### PR TITLE
Adds mobile-web-app-capable meta tag. Enables fullscreen for mobile

### DIFF
--- a/assembly-sdk-war/src/main/webapp/IDE.jsp
+++ b/assembly-sdk-war/src/main/webapp/IDE.jsp
@@ -32,6 +32,7 @@
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="mobile-web-app-capable" content="yes">		
     <title>Codenvy Developer Environment</title>
     <link rel="shortcut icon" href="/che/_app/favicon.ico"/>
     <link href="http://fonts.googleapis.com/css?family=Droid+Sans+Mono" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Safari on iOS and Chrome 31+ on Android support the
mobile-web-app-capable meta tag. This allow a bookmark to be created
on the home screen of the device which opens a new browser window
without the window chrome or tabs. This provides a significantly better
experience when using che on a tablet
