### PR TITLE
Changed <title> from Codenvy to Eclipse Che

### DIFF
--- a/assembly-sdk-war/src/main/webapp/IDE.jsp
+++ b/assembly-sdk-war/src/main/webapp/IDE.jsp
@@ -15,7 +15,7 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta name="mobile-web-app-capable" content="yes">		
-    <title>Codenvy Developer Environment</title>
+    <title>Eclipse Che</title>
     <link rel="shortcut icon" href="/che/_app/favicon.ico"/>
     <link href="http://fonts.googleapis.com/css?family=Droid+Sans+Mono" rel="stylesheet" type="text/css" />
 


### PR DESCRIPTION
To review if change is ok.  The <title> text is what appears when Che loads.
