### PR TITLE
Adds Eclipse Che to command prompt

### DIFF
--- a/che.bat
+++ b/che.bat
@@ -16,6 +16,7 @@ for /F %%i in ("%FILE%") do (set VERSION=%%~nxi)
 set CATALINA_HOME=%DIRNAME%assembly-sdk\target\%VERSION%\%VERSION%
 set ASSEMBLY_BIN_DIR=%CATALINA_HOME%\bin
 IF exist %ASSEMBLY_BIN_DIR% (
+    TITLE "Eclipse Che"
     call %ASSEMBLY_BIN_DIR%\che.bat %1 %2 %3 %4 %5 %6 %7 %8
 ) else (
     echo The command 'mvn clean install' needs to be run first. This will build the Eclipse Che assembly.


### PR DESCRIPTION
Updates the command console that is created in windows to have its title be "Eclipse Che" instead of Tomcat.
