### PR TITLE
Fix Che on OSX

### DIFF
--- a/assembly-sdk-war/src/main/java/org/eclipse/che/api/deploy/ApiEndpointProvider.java
+++ b/assembly-sdk-war/src/main/java/org/eclipse/che/api/deploy/ApiEndpointProvider.java
@@ -1,0 +1,21 @@
+package org.eclipse.che.api.deploy;
+
+import org.eclipse.che.api.core.util.SystemInfo;
+
+import javax.inject.Provider;
+
+/**
+ * Provider api.endpoint url. This is used to make calls to che api from containers.
+ * It may depend if we use boot2docker or not.
+ *
+ * @author Sergii Kabashniuk
+ */
+public class ApiEndpointProvider implements Provider<String> {
+    @Override
+    public String get() {
+        if (SystemInfo.isMacOS()) {
+            return "http://192.168.99.1:8080/che/api";
+        }
+        return "http://172.17.42.1:8080/che/api";
+    }
+}

--- a/assembly-sdk-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java
+++ b/assembly-sdk-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java
@@ -45,9 +45,6 @@ import org.everrest.core.impl.async.AsynchronousJobPool;
 import org.everrest.core.impl.async.AsynchronousJobService;
 import org.everrest.guice.ServiceBindingHelper;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 /** @author andrew00x */
 @DynaModule
 public class ApiModule extends AbstractModule {
@@ -112,6 +109,6 @@ public class ApiModule extends AbstractModule {
 
         install(new org.eclipse.che.plugin.docker.machine.ext.LocalStorageModule());
 
-        bindConstant().annotatedWith(Names.named("machine.docker.che_api.endpoint")).to("http://172.17.42.1:8080/che/api");
+        bind(String.class).annotatedWith(Names.named("machine.docker.che_api.endpoint")).toProvider(new ApiEndpointProvider());
     }
 }


### PR DESCRIPTION
Fixed work of che on OSX with boot2docker. Before the we use direct ip to host to access api from container
On OSX we need to use boot2docker to start docker containers and the old link is not working. Instead of that
we will use direct ip address of host

Signed-off-by: Sergii Kabashniuk skabashnyuk@codenvy.com
