### PR TITLE
bunch of fixes for ext scripts

### DIFF
--- a/assembly-sdk/src/assembly/extInstall.bat
+++ b/assembly-sdk/src/assembly/extInstall.bat
@@ -23,7 +23,7 @@ SET "EXT_RES_WORK_DIR_REL_PATH=sdk-resources\temp"
 
 rem Install every 3rd-party extension into local Maven repository
 for /R %EXT_DIR_REL_PATH% %%f in (*.jar) do (
-if exist %%f call mvn org.apache.maven.plugins:maven-install-plugin:2.5.1:install-file -Dfile=%%f
+if exist %%f call mvn org.apache.maven.plugins:maven-install-plugin:2.5.1:install-file -Dpackaging=jar -Dfile=%%f
 )
 
 rem Prepare to re-build Codenvy IDE
@@ -31,9 +31,12 @@ call java -cp "sdk-tools\che-plugin-sdk-tools.jar" org.eclipse.che.ide.sdk.tools
 
 rem Re-build Codenvy IDE
 cd %EXT_RES_WORK_DIR_REL_PATH%
-call mvn clean package -Dskip-validate-sources=true
-cd ../..
-1>nul  2>&1 copy /B /Y "%EXT_RES_WORK_DIR_REL_PATH%\target\*.war" "webapps\che.war"
-1>nul  2>&1 rmdir /S /Q webapps\che
-
-echo Restart Codenvy IDE if it is currently running
+call mvn -B clean package -Dskip-validate-sources=true
+if %ERRORLEVEL% == 0 (
+  cd ../..
+  1>nul  2>&1 copy /B /Y "%EXT_RES_WORK_DIR_REL_PATH%\target\*.war" "webapps\che.war"
+  echo Restart Codenvy IDE if it is currently running
+) else (
+  echo Compilation Failed
+  exit /b 1
+)

--- a/assembly-sdk/src/assembly/extInstall.sh
+++ b/assembly-sdk/src/assembly/extInstall.sh
@@ -26,7 +26,7 @@ EXT_RES_WORK_DIR_REL_PATH="sdk-resources/temp"
 for file in $EXT_DIR_REL_PATH/*.jar
 do
     if [ -f $file ]; then
-        mvn org.apache.maven.plugins:maven-install-plugin:2.5.1:install-file -Dfile=$file
+        mvn org.apache.maven.plugins:maven-install-plugin:2.5.1:install-file -Dpackaging=jar -Dfile=$file
     fi
 done
 
@@ -35,9 +35,11 @@ java -cp "sdk-tools/che-plugin-sdk-tools.jar" org.eclipse.che.ide.sdk.tools.Inst
 
 # Re-build Codenvy IDE
 cd $EXT_RES_WORK_DIR_REL_PATH
-mvn clean package -Dskip-validate-sources=true
+mvn -B clean package -Dskip-validate-sources=true
+if [ "$?" -ne 0 ]; then
+    echo "Build of che assembly failed"
+    exit 1
+fi
 cd ../..
 cp $EXT_RES_WORK_DIR_REL_PATH/target/*.war webapps/che.war
-rm -rf webapps/che
-
 echo Restart Codenvy IDE if it is currently running


### PR DESCRIPTION
- Use of batch mode for maven command (script launch)
- If mvn operation fails, exit script immediately, do not try to continue
- Do not delete unasked folder. (it is automatically recreated when Che is restarted)

Change-Id: If20a8ba1169362be9df4def63261dd6a82d81a86
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
