### PR TITLE
IDEX-3281: Increase session timeout

### DIFF
--- a/assembly-machine-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly-machine-war/src/main/webapp/WEB-INF/web.xml
@@ -44,4 +44,8 @@
         <description>the user role</description>
         <role-name>developer</role-name>
     </security-role>
+
+    <session-config>
+        <session-timeout>180</session-timeout>
+    </session-config>
 </web-app>


### PR DESCRIPTION
Project Tree becomes disappeared, IDE thinks that extension server is stopped after 30 minutes because session with extension server is expired. It was decided to increase session timeout to 180 minutes + ping extension server from client. Ping logic will be done by another issue!
