### PR TITLE
IDEX-2929: Change creator id  in docker recipe from "codenvy" to "che" for Che

### DIFF
--- a/assembly-sdk-war/src/main/resources/predefined-recipes.json
+++ b/assembly-sdk-war/src/main/resources/predefined-recipes.json
@@ -1,6 +1,6 @@
 [
   {
-    "creator": "codenvy",
+    "creator": "che",
     "tags": [
       "java",
       "ubuntu",
@@ -28,7 +28,7 @@
     "script": "FROM codenvy/ubuntu_jdk8"
   },
   {
-    "creator": "codenvy",
+    "creator": "che",
     "tags": [
       "debian",
       "java",


### PR DESCRIPTION
It is needed to select docker recipe when user id is "che" in Che
