### PR TITLE
IDEX-3396: Add ability to save workspace's snapshot 

### DIFF
--- a/assembly-sdk-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java
+++ b/assembly-sdk-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java
@@ -114,7 +114,7 @@ public class ApiModule extends AbstractModule {
         machineServers.addBinding().toInstance(new ServerConf("extensions-debug", "4403", "http"));
 
         bindConstant().annotatedWith(Names.named(DockerMachineExtServerLauncher.START_EXT_SERVER_COMMAND))
-                      .to("mkdir -p ~/che && unzip /mnt/che/ext-server.zip -d ~/che/ext-server && " +
+                      .to("mkdir -p ~/che && unzip -n /mnt/che/ext-server.zip -d ~/che/ext-server && " +
                           "export JPDA_ADDRESS=\"4403\" && ~/che/ext-server/bin/catalina.sh jpda start");
 
         install(new org.eclipse.che.plugin.docker.machine.ext.LocalStorageModule());

--- a/assembly-sdk-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly-sdk-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -55,8 +55,13 @@ local.storage.path=${catalina.base}/temp/local-storage
 schedule.core_pool_size=10
 
 machine.logs.location=${catalina.base}/logs
-machine.docker.registry=http://localhost:5000
+machine.docker.registry=localhost:5000
 machine.docker.local.projects=${catalina.base}/temp
+
+docker.registry.auth.url=http://localhost:5000
+docker.registry.auth.username=user1
+docker.registry.auth.password=pass
+docker.registry.auth.email=user1@email.com
 
 # machine extensions server archive
 machine.server.ext.archive=${catalina.base}/ext-server/ext-server.zip


### PR DESCRIPTION
Changed unzip behaviour, when workspace is created from snapshot _unzip_ doesn't have to unzip extension server.
Changed _docker.registry.auth._\* properties to be able to work with local registry

@skabashnyuk, @garagatyi, @akorneta, @sleshchenko please take a look
