### PR TITLE
IDEX-3670: Bind RemotePreferenceDao

### DIFF
--- a/assembly-machine-war/src/main/java/org/eclipse/che/ide/ext/java/server/MachineModule.java
+++ b/assembly-machine-war/src/main/java/org/eclipse/che/ide/ext/java/server/MachineModule.java
@@ -19,7 +19,6 @@ import org.eclipse.che.api.core.notification.WSocketEventBusClient;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.api.core.rest.CoreRestModule;
 import org.eclipse.che.api.git.GitConnectionFactory;
-import org.eclipse.che.api.local.LocalPreferenceDaoImpl;
 import org.eclipse.che.api.local.LocalUserDaoImpl;
 import org.eclipse.che.api.project.server.BaseProjectModule;
 import org.eclipse.che.api.user.server.dao.PreferenceDao;
@@ -63,7 +62,7 @@ public class MachineModule extends AbstractModule {
 
         //TODO it's temporary solution. Ext war should not have binding for DAO.
         bind(UserDao.class).to(LocalUserDaoImpl.class);
-        bind(PreferenceDao.class).to(LocalPreferenceDaoImpl.class);
+        bind(PreferenceDao.class).to(org.eclipse.che.api.local.RemotePreferenceDao.class);
 
         bind(LocalFSMountStrategy.class).to(MachineFSMountStrategy.class);
         bind(VirtualFileSystemRegistry.class).to(AutoMountVirtualFileSystemRegistry.class);


### PR DESCRIPTION
Use `RemotePreferenceDao` for ext-server instead of using `LocalPreferenceDao`.

@skabashnyuk please review
