### PR TITLE
Added plugin extension examples for users

### DIFF
--- a/assembly-main/src/assembly/plugins/examples/che-ide-extension-client-server.txt
+++ b/assembly-main/src/assembly/plugins/examples/che-ide-extension-client-server.txt
@@ -1,0 +1,36 @@
+<!--
+
+    Copyright (c) 2012-2015 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+
+###################################################
+###
+### Che IDE Extension Talking to Server Example
+###
+###################################################
+
+WHAT:     Creates a new IDE clickable action that prints server resposne as IDE notification popup.
+DOCS:     https://eclipse-che.readme.io/docs/developing-extensions#ide-extension-example
+SOURCE:   http://github.com/che-samples/che-ide-extension.git   BRANCH: client-server
+PRE-REQS: Java 1.8, Maven, Git, and a clone of Che's assembly repo @ http://github.com/codenvy/che.
+
+STEPS:    1. git clone http://github.com/che-samples/che-ide-extension
+          2. cd che-ide-extension
+          3. git checkout client-server
+          4. mvn clean install
+          5. Add new extension as dependency to /che/assembly-ide-war/pom.xml
+          6. Add new extension as GWT inheritance to /che/assembly-ide-war/src/main/resources/org/eclipse/che/ide/IDE.gwt.xml
+          7. Add new extension as a dependency to /che/pom.xml
+          8. Create new IDE with your extension: `mvn clean install` in /che/assembly-ide-war module
+          9. Create new Che assembly with new IDE: `mvn clean install` in /che/assembly-main module
+          10. In /che/assembly-main/target/eclipse-che-{version}/bin, run `che run` to launch new Che assembly.
+          11. Create a workspace in Che.
+          12. In the IDE, there will be a new menu with your action.

--- a/assembly-main/src/assembly/plugins/examples/che-ide-extension-simple.txt
+++ b/assembly-main/src/assembly/plugins/examples/che-ide-extension-simple.txt
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (c) 2012-2015 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+
+###################################################
+###
+### Che IDE Extension Example
+###
+###################################################
+
+WHAT:     Creates a new IDE clickable action that prints "It's My Action!" as an event in the event console.
+DOCS:     https://eclipse-che.readme.io/docs/developing-extensions#ide-extension-example
+SOURCE:   http://github.com/che-samples/che-ide-extension.git
+PRE-REQS: Java 1.8, Maven, Git, and a clone of Che's assembly repo @ http://github.com/codenvy/che.
+
+STEPS:    1. git clone http://github.com/che-samples/che-ide-extension
+          2. cd che-ide-extension
+          3. mvn clean install
+          4. Add new extension as dependency to /che/assembly-ide-war/pom.xml
+          5. Add new extension as GWT inheritance to /che/assembly-ide-war/src/main/resources/org/eclipse/che/ide/IDE.gwt.xml
+          6. Add new extension as a dependency to /che/pom.xml
+          7. Create new IDE with your extension: `mvn clean install` in /che/assembly-ide-war module
+          8. Create new Che assembly with new IDE: `mvn clean install` in /che/assembly-main module
+          9. In /che/assembly-main/target/eclipse-che-{version}/bin, run `che run` to launch new Che assembly.
+          10. Create a workspace in Che.
+          11. In the IDE, there will be a new menu with your action.

--- a/assembly-main/src/assembly/plugins/examples/che-server-extension.txt
+++ b/assembly-main/src/assembly/plugins/examples/che-server-extension.txt
@@ -1,0 +1,30 @@
+<!--
+
+    Copyright (c) 2012-2015 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+
+###################################################
+###
+### Che Server-Side Extension Example
+###
+###################################################
+
+DOCS:     https://eclipse-che.readme.io/docs/developing-extensions
+SOURCE:   http://github.com/che-samples/che-server-extension.git
+PRE-REQS: Java 1.8, Maven, Git, and a clone of Che's assembly repo @ http://github.com/codenvy/che.
+
+STEPS:    1. git clone http://github.com/che-samples/che-server-extension
+          2. cd che-server-extension
+          3. mvn clean install
+          4. Add new extension as dependency to /che/assembly-machine-war/pom.xml
+          5. Add new extension as dependency to /che/pom.xml
+          6. Create new che assembly: `mvn clean install` in /che directory
+          7. In /che/assembly-main/target/eclipse-che-{version}/bin, run `che run` to launch new Che assembly.


### PR DESCRIPTION
Added instructions into the /plugins/examples directory for the extension samples that are now documented on eclipse.org/che.
