### PR TITLE
Add mandatory check for JAVA_HOME

### DIFF
--- a/assembly-main/src/assembly/bin/che.sh
+++ b/assembly-main/src/assembly/bin/che.sh
@@ -102,9 +102,7 @@ function usage {
 
 function error_exit {
   echo
-  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$1"
-  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$WRONG $CHE_VARIABLES $USAGE"
   JUMP_TO_END=true
 }
@@ -459,7 +457,6 @@ function call_catalina {
       error_exit "Che requires Java version 1.8 or higher. We found a lower version."
       return
   fi
-echo "here"
 
   ### Cannot add this in setenv.sh.
   ### We do the port mapping here, and this gets inserted into server.xml when tomcat boots

--- a/assembly-main/src/assembly/bin/che.sh
+++ b/assembly-main/src/assembly/bin/che.sh
@@ -102,7 +102,9 @@ function usage {
 
 function error_exit {
   echo
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$1"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$WRONG $CHE_VARIABLES $USAGE"
   JUMP_TO_END=true
 }
@@ -439,19 +441,25 @@ function call_catalina {
     return
   fi
 
+  if [ -z "${JAVA_HOME}" ]; then
+    error_exit "JAVA_HOME is not set. Please set to directory of JVM or JRE."
+    return
+  fi
+
   # Test to see that Java is installed and working
-  java &>/dev/null || JAVA_EXIT=$? || true
+  "${JAVA_HOME}"/bin/java &>/dev/null || JAVA_EXIT=$? || true
   if [ "${JAVA_EXIT}" != "1" ]; then
     error_exit "We could not find a working Java JVM. java command fails."
     return
   fi
 
   # Che requires Java version 1.8 or higher. 
-  JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  JAVA_VERSION=$(eval "${JAVA_HOME}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ "$JAVA_VERSION" < "1.8" ]]; then
       error_exit "Che requires Java version 1.8 or higher. We found a lower version."
       return
   fi
+echo "here"
 
   ### Cannot add this in setenv.sh.
   ### We do the port mapping here, and this gets inserted into server.xml when tomcat boots
@@ -561,7 +569,7 @@ function launch_che_server {
     echo -e "Launching Che app server inside the container named ${GREEN}che${NC}."
 
     # For some reason, launching tomcat with the start option in a docker container does not run successfully - only launch with run action
-    "${DOCKER}" exec -it che bash -c 'true && export CHE_HOME=/home/user/che && /home/user/che/bin/che.sh -s run' || DOCKER_EXIT=$? || true    
+    "${DOCKER}" exec -it che bash -c 'true && export CHE_HOME=/home/user/che && /home/user/che/bin/che.sh --skip:client run' || DOCKER_EXIT=$? || true    
   fi
 }
 


### PR DESCRIPTION
1. Make JAVA_HOME checks mandatory.
2. Use JAVA_HOME to do java and java -version check -- solves problem with windows path having double quotes in path name
3. Updated docker start command to use latest --skip:client syntax
