### PR TITLE
Fix problems with installing npm packages on Windows

### DIFF
--- a/assembly-main/src/assembly/templates/samples.json
+++ b/assembly-main/src/assembly/templates/samples.json
@@ -127,7 +127,7 @@
       {
         "name": "install dependencies",
         "type": "custom",
-        "commandLine": "cd ${current.project.path} && npm install && bower install",
+        "commandLine": "cd ${current.project.path} && npm install --no-bin-links && bower install",
         "attributes": {
           "previewUrl": ""
         }


### PR DESCRIPTION
with adding --no-bin-links flag to the npm install command
