### PR TITLE
fix check of docker accessability on old bash versions

### DIFF
--- a/assembly-main/src/assembly/bin/che.sh
+++ b/assembly-main/src/assembly/bin/che.sh
@@ -339,7 +339,7 @@ function get_docker_ready {
     LINUX_UID=$(id -u "${LINUX_USER}")
 
     if [[ "${CHECK_DOCKER_UID}" == "true" ]] ; then
-      if [[ "${LINUX_GROUPS}" =~ "docker" ]] ; then
+      if echo "${LINUX_GROUPS}" | grep "docker" &>/dev/null; then
 
         if [[ "${LINUX_UID}" != "1000" ]] ; then
           error_exit "!!! This Linux user was launched with a UID != 1000. Che must run under UID 1000. See https://eclipse-che.readme.io/docs/usage#section-cannot-create-projects"


### PR DESCRIPTION
@skabashnyuk @vparfonov @TylerJewell 

Operator `=~` is invalid on some bash versions. I workaround it with grep.
