### PR TITLE
IDEX-4232: Support windows directories with spaces

### DIFF
--- a/assembly-main/src/assembly/bin/che.bat
+++ b/assembly-main/src/assembly/bin/che.bat
@@ -15,6 +15,9 @@ REM Check to ensure bash is installed
 CALL bash --help > nul 2>&1
 IF %ERRORLEVEL% NEQ 0 goto setup
 
+REM IDEX-4232 change windows long directories to DOS 8.3 format to handle directories with spaces
+FOR %%i in ("%~dp0..") do set "CHE_WINDOWS_SHORT_DIR=%%~Si"
+
 REM Launch Che and any associated docker machines, if necessary
 CALL bash --login -i "%~dp0\che.sh" %*
 

--- a/assembly-main/src/assembly/bin/che.sh
+++ b/assembly-main/src/assembly/bin/che.sh
@@ -217,10 +217,11 @@ function set_environment_variables {
   ### Use values set by user, unless they are broken, then fix them
   # The base directory of Che
   if [ -z "${CHE_HOME}" ]; then
-    export CHE_HOME="$(dirname "$(cd "$(dirname "${0}")" && pwd -P)")"
-    #export CHE_HOME="/c/PROGRA~1/eclipse-che-4.0.0-RC1-SNAPSHOT"
-    #export CHE_HOME=/c/Program\ Files/eclipse-che-4.0.0-RC1-SNAPSHOT
-    echo $CHE_HOME
+    if [ "${WIN}" == "true" ]; then
+      export CHE_HOME="${CHE_WINDOWS_SHORT_DIR}"
+    else 
+      export CHE_HOME="$(dirname "$(cd "$(dirname "${0}")" && pwd -P)")"
+    fi
   fi
 
   if [[ "${CHE_IP}" != "" ]]; then


### PR DESCRIPTION
1. In che.bat, convert directory of batch script to short form name using batch uitilies.
2. Set this variable to CHE_WINDOWS_SHORT_NAME
3. If on windows, use this short form instead of bash directory name look up.
