### PR TITLE
IDEX-4235 provide minimal JVM config to build che

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx2048m -Xms1024m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Dgwt.compiler.localWorkers=1


### PR DESCRIPTION
This config provide lowest memory profile setting to make sure that more people can compile che for sure.
