### PR TITLE
IDEX-4137: fix "Internal Server Error" error message in "Evaluate Expression" popup

### DIFF
--- a/assembly-machine-war/src/main/java/org/eclipse/che/ide/ext/java/server/MachineModule.java
+++ b/assembly-machine-war/src/main/java/org/eclipse/che/ide/ext/java/server/MachineModule.java
@@ -16,6 +16,7 @@ import com.google.inject.name.Names;
 
 import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.core.notification.WSocketEventBusClient;
+import org.eclipse.che.api.core.rest.ApiExceptionMapper;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.api.core.rest.CoreRestModule;
 import org.eclipse.che.api.git.GitConnectionFactory;
@@ -87,6 +88,7 @@ public class MachineModule extends AbstractModule {
 
         bind(ArchetypeGenerator.class);
         bind(DebuggerService.class);
+        bind(ApiExceptionMapper.class);
         
         bind(GitUserResolver.class).to(LocalGitUserResolver.class);
         bind(GitConnectionFactory.class).to(NativeGitConnectionFactory.class);


### PR DESCRIPTION
IDEX-4137: fix "Internal Server Error" error message in "Evaluate Expression" popup. Now it is displays actual message about  error, like "Unknown local variable or field someVar" 
