### PR TITLE
Remove the usage of license years property and use inceptionYear

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -24,9 +24,7 @@
     <version>4.0.0-RC4-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Eclipse Che Dashboard :: Web App</name>
-    <properties>
-        <license_years>2015-2016</license_years>
-    </properties>
+    <inceptionYear>2015</inceptionYear>
     <build>
         <finalName>dashboard-war</finalName>
         <plugins>


### PR DESCRIPTION
This allows to get correct start date without having to specify the end date.
In this case we reuse the top level currentYear property

Change-Id: I3b63e90eb99589d0432f2cffe05ec522f1a96866
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
