### PR TITLE
Set correct dependency scope

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
@@ -63,10 +63,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-project</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-user</artifactId>
         </dependency>
         <dependency>
@@ -150,6 +146,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-project</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Classes from che-core-api-project used only in test so buld skip test fail according dependency convergence
@skabashnyuk 
Signed-off-by: Vitaly Parfonov vparfonov@codenvy.com
