### PR TITLE
IDEX-3737. Fix errors after Git checkout operation

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectUpdater.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectUpdater.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.event.ConfigureProjectEvent;
 import org.eclipse.che.ide.api.event.project.CreateProjectEvent;
+import org.eclipse.che.ide.api.event.project.ProjectUpdatedEvent;
 import org.eclipse.che.ide.api.project.wizard.ProjectNotificationSubscriber;
 import org.eclipse.che.ide.api.wizard.Wizard.CompleteCallback;
 import org.eclipse.che.ide.projectimport.ErrorMessageUtils;
@@ -69,7 +70,7 @@ public class ProjectUpdater {
     public void updateProject(@NotNull final CompleteCallback callback,
                               @NotNull ProjectConfigDto projectConfig,
                               final boolean isConfigurationRequired) {
-        String projectPath = projectConfig.getPath();
+        final String projectPath = projectConfig.getPath();
 
         Unmarshallable<ProjectConfigDto> unmarshaller = dtoUnmarshallerFactory.newUnmarshaller(ProjectConfigDto.class);
         projectService.updateProject(workspaceId,
@@ -78,12 +79,16 @@ public class ProjectUpdater {
                                      new AsyncRequestCallback<ProjectConfigDto>(unmarshaller) {
                                          @Override
                                          protected void onSuccess(final ProjectConfigDto result) {
+                                             if (result.getProblems().isEmpty() && !isConfigurationRequired) {
+                                                 eventBus.fireEvent(new ProjectUpdatedEvent(projectPath, result));
+                                                 projectNotificationSubscriber.onSuccess();
+                                                 callback.onCompleted();
+                                                 return;
+                                             }
                                              eventBus.fireEvent(new CreateProjectEvent(result));
+                                             eventBus.fireEvent(new ConfigureProjectEvent(result));
                                              projectNotificationSubscriber.onSuccess();
                                              callback.onCompleted();
-                                             if (!result.getProblems().isEmpty() || isConfigurationRequired) {
-                                                 eventBus.fireEvent(new ConfigureProjectEvent(result));
-                                             }
                                          }
 
                                          @Override

--- a/plugins/plugin-git/che-plugin-git-ext-git/pom.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/pom.xml
@@ -63,6 +63,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-project</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace</artifactId>
         </dependency>
         <dependency>
@@ -139,11 +143,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-project</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchPresenter.java
@@ -21,12 +21,18 @@ import org.eclipse.che.api.git.gwt.client.GitServiceClient;
 import org.eclipse.che.api.git.shared.Branch;
 import org.eclipse.che.api.git.shared.CheckoutRequest;
 import org.eclipse.che.api.project.gwt.client.ProjectServiceClient;
+import org.eclipse.che.api.project.shared.dto.ItemReference;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.app.CurrentProject;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
+import org.eclipse.che.ide.api.event.FileEvent;
 import org.eclipse.che.ide.api.event.project.ProjectUpdatedEvent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.project.tree.VirtualFile;
@@ -35,9 +41,9 @@ import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.outputconsole.GitOutputConsole;
 import org.eclipse.che.ide.ext.git.client.outputconsole.GitOutputConsoleFactory;
 import org.eclipse.che.ide.extension.machine.client.processes.ConsolesPanelPresenter;
-import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.rest.AsyncRequestCallback;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
+import org.eclipse.che.ide.rest.Unmarshallable;
 import org.eclipse.che.ide.ui.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 import org.eclipse.che.ide.ui.dialogs.InputCallback;
@@ -61,24 +67,23 @@ public class BranchPresenter implements BranchView.ActionDelegate {
     public static final String BRANCH_CREATE_COMMAND_NAME   = "Git create branch";
     public static final String BRANCH_LIST_COMMAND_NAME     = "Git list of branches";
 
-    private final DtoFactory               dtoFactory;
-    private final DtoUnmarshallerFactory   dtoUnmarshallerFactory;
-    private final BranchView               view;
-    private final ProjectServiceClient     projectService;
-    private final GitOutputConsoleFactory  gitOutputConsoleFactory;
-    private final ConsolesPanelPresenter   consolesPanelPresenter;
-    private final DialogFactory            dialogFactory;
-    private final ProjectExplorerPresenter projectExplorer;
-    private final EventBus                 eventBus;
-    private final GitServiceClient         service;
-    private final GitLocalizationConstant  constant;
-    private final EditorAgent              editorAgent;
-    private final AppContext               appContext;
-    private final NotificationManager      notificationManager;
-    private final String                   workspaceId;
+    private final DtoFactory              dtoFactory;
+    private final DtoUnmarshallerFactory  dtoUnmarshallerFactory;
+    private final BranchView              view;
+    private final ProjectServiceClient    projectService;
+    private final GitOutputConsoleFactory gitOutputConsoleFactory;
+    private final ConsolesPanelPresenter  consolesPanelPresenter;
+    private final DialogFactory           dialogFactory;
+    private final EventBus                eventBus;
+    private final GitServiceClient        service;
+    private final GitLocalizationConstant constant;
+    private final EditorAgent             editorAgent;
+    private final AppContext              appContext;
+    private final NotificationManager     notificationManager;
+    private final String                  workspaceId;
 
-    private CurrentProject project;
-    private Branch         selectedBranch;
+    private CurrentProject      project;
+    private Branch              selectedBranch;
 
     /** Create presenter. */
     @Inject
@@ -94,7 +99,6 @@ public class BranchPresenter implements BranchView.ActionDelegate {
                            GitOutputConsoleFactory gitOutputConsoleFactory,
                            ConsolesPanelPresenter consolesPanelPresenter,
                            DialogFactory dialogFactory,
-                           ProjectExplorerPresenter projectExplorer,
                            EventBus eventBus) {
         this.view = view;
         this.dtoFactory = dtoFactory;
@@ -102,7 +106,6 @@ public class BranchPresenter implements BranchView.ActionDelegate {
         this.gitOutputConsoleFactory = gitOutputConsoleFactory;
         this.consolesPanelPresenter = consolesPanelPresenter;
         this.dialogFactory = dialogFactory;
-        this.projectExplorer = projectExplorer;
         this.eventBus = eventBus;
         this.view.setDelegate(this);
         this.editorAgent = editorAgent;
@@ -225,25 +228,23 @@ public class BranchPresenter implements BranchView.ActionDelegate {
             checkoutRequest.setName(selectedBranch.getDisplayName());
         }
 
-        final String path = project.getRootProject().getPath();
+        final ProjectConfigDto root = project.getRootProject();
+        final String path = root.getPath();
+        final String projectType = root.getType();
 
-        service.checkout(workspaceId, project.getRootProject(), checkoutRequest, new AsyncRequestCallback<String>() {
+        service.checkout(workspaceId, root, checkoutRequest, new AsyncRequestCallback<String>() {
             @Override
             protected void onSuccess(String result) {
                 getBranches();
                 //In this case we can have unconfigured state of the project,
                 //so we must repeat the logic which is performed when we open a project
-                projectExplorer.reloadChildren();
-
-                updateOpenedFiles();
-
-                //refresh project
                 projectService.getProject(workspaceId, path,
                                           new AsyncRequestCallback<ProjectConfigDto>(
                                                   dtoUnmarshallerFactory.newUnmarshaller(ProjectConfigDto.class)) {
                                               @Override
                                               protected void onSuccess(ProjectConfigDto result) {
-                                                  eventBus.fireEvent(new ProjectUpdatedEvent(path, result));
+                                                  result.setType(projectType);
+                                                  updateProject(result);
                                               }
 
                                               @Override
@@ -263,11 +264,41 @@ public class BranchPresenter implements BranchView.ActionDelegate {
         });
     }
 
+    private void updateProject(final ProjectConfigDto projectToUpdate) {
+        Promise<ProjectConfigDto> updateProjectPromise = projectService.updateProject(workspaceId, projectToUpdate.getPath(), projectToUpdate);
+        updateProjectPromise.then(new Operation<ProjectConfigDto>() {
+            @Override
+            public void apply(ProjectConfigDto arg) throws OperationException {
+                updateOpenedFiles();
+                eventBus.fireEvent(new ProjectUpdatedEvent(arg.getPath(), arg));
+            }
+        }).catchError(new Operation<PromiseError>() {
+            @Override
+            public void apply(PromiseError arg) throws OperationException {
+                notificationManager.notify(arg.getMessage(), FAIL, true, projectToUpdate);
+            }
+        });
+    }
+
     private void updateOpenedFiles() {
         for (EditorPartPresenter editorPartPresenter : editorAgent.getOpenedEditors().values()) {
-            VirtualFile file = editorPartPresenter.getEditorInput().getFile();
+            final VirtualFile file = editorPartPresenter.getEditorInput().getFile();
+            final String filePath = file.getPath();
+            Unmarshallable<ItemReference> unmarshaller = dtoUnmarshallerFactory.newUnmarshaller(ItemReference.class);
 
-            eventBus.fireEvent(new FileContentUpdateEvent(file.getPath()));
+            projectService.getItem(workspaceId, filePath,
+                                   new AsyncRequestCallback<org.eclipse.che.api.project.shared.dto.ItemReference>(unmarshaller) {
+                                       @Override
+                                       protected void onSuccess(ItemReference itemReference) {
+                                           eventBus.fireEvent(new FileContentUpdateEvent(filePath));
+                                       }
+
+                                       @Override
+                                       protected void onFailure(Throwable throwable) {
+                                           eventBus.fireEvent(new FileEvent(file, FileEvent.FileOperation.CLOSE));
+                                       }
+                                   });
+
         }
     }
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/branch/BranchPresenterTest.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/branch/BranchPresenterTest.java
@@ -24,7 +24,6 @@ import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.project.tree.VirtualFile;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.git.client.BaseTest;
-import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.rest.AsyncRequestCallback;
 import org.eclipse.che.ide.ui.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.ui.dialogs.DialogFactory;
@@ -104,8 +103,6 @@ public class BranchPresenterTest extends BaseTest {
     @Mock
     private DtoFactory                dtoFactory;
     @Mock
-    private ProjectExplorerPresenter  projectExplorer;
-    @Mock
     private CheckoutRequest           checkoutRequest;
     @Mock
     private ProjectServiceClient      projectService;
@@ -129,7 +126,6 @@ public class BranchPresenterTest extends BaseTest {
                                         gitOutputConsoleFactory,
                                         consolesPanelPresenter,
                                         dialogFactory,
-                                        projectExplorer,
                                         eventBus);
 
         NavigableMap<String, EditorPartPresenter> partPresenterMap = new TreeMap<>();


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com

Configure project in the background after git checkout operation.
Don't close project tree after project configuration.
Refresh opened files only when they exist.
Close opened file when this one doesn't exist.
