### PR TITLE
CHE-1 Fixed swagger service deployment

### DIFF
--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java
@@ -35,8 +35,8 @@ import org.eclipse.che.api.workspace.server.WorkspaceService;
 import org.eclipse.che.api.workspace.server.event.MachineStateListener;
 import org.eclipse.che.api.workspace.server.event.WorkspaceMessenger;
 import org.eclipse.che.everrest.CodenvyAsynchronousJobPool;
-import org.eclipse.che.everrest.EverrestDownloadFileResponseFilter;
 import org.eclipse.che.everrest.ETagResponseFilter;
+import org.eclipse.che.everrest.EverrestDownloadFileResponseFilter;
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.plugin.docker.machine.ServerConf;
 import org.eclipse.che.plugin.docker.machine.ext.DockerExtServerModule;
@@ -103,6 +103,7 @@ public class ApiModule extends AbstractModule {
 
         install(new DockerExtServerModule());
         install(new org.eclipse.che.plugin.docker.machine.ext.DockerTerminalModule());
+        install(new org.eclipse.che.swagger.deploy.DocsModule());
 
         bind(DockerMachineExtServerChecker.class);
         bind(DockerMachineTerminalChecker.class);

--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/api/deploy/ApiServletModule.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/api/deploy/ApiServletModule.java
@@ -17,7 +17,6 @@ import org.eclipse.che.api.local.CheGuiceEverrestServlet;
 import org.eclipse.che.api.machine.server.proxy.MachineExtensionProxyServlet;
 import org.eclipse.che.env.local.server.SingleEnvironmentFilter;
 import org.eclipse.che.inject.DynaModule;
-import org.eclipse.che.swagger.deploy.BasicSwaggerConfigurationModule;
 import org.everrest.websockets.WSConnectionTracker;
 
 import javax.inject.Singleton;
@@ -55,6 +54,6 @@ public class ApiServletModule extends ServletModule {
         filter("/*").through(SingleEnvironmentFilter.class);
         serve("/ext/*").with(MachineExtensionProxyServlet.class);
         serveRegex("^/api((?!(/(ws|eventbus)($|/.*)))/.*)").with(CheGuiceEverrestServlet.class);
-        install(new BasicSwaggerConfigurationModule());
+        install(new org.eclipse.che.swagger.deploy.BasicSwaggerConfigurationModule());
     }
 }

--- a/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CodenvyJsonProvider.java
+++ b/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CodenvyJsonProvider.java
@@ -57,7 +57,7 @@ public class CodenvyJsonProvider<T> implements MessageBodyReader<T>, MessageBody
     private final JsonEntityProvider delegate = new JsonEntityProvider<>();
 
     @Inject
-    public CodenvyJsonProvider(@Nullable @Named("codenvy.json.ignored_classes") Set<Class> ignoredClasses) {
+    public CodenvyJsonProvider(@Nullable @Named("che.json.ignored_classes") Set<Class> ignoredClasses) {
         this.ignoredClasses = ignoredClasses == null ? new LinkedHashSet<Class>() : new LinkedHashSet<>(ignoredClasses);
     }
 

--- a/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
+++ b/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
@@ -22,6 +22,6 @@ public class CoreRestModule extends AbstractModule {
     protected void configure() {
         bind(CodenvyJsonProvider.class);
         bind(ApiExceptionMapper.class);
-        Multibinder.newSetBinder(binder(), Class.class, Names.named("codenvy.json.ignored_classes"));
+        Multibinder.newSetBinder(binder(), Class.class, Names.named("che.json.ignored_classes"));
     }
 }

--- a/core/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystemModule.java
+++ b/core/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystemModule.java
@@ -26,7 +26,7 @@ public class VirtualFileSystemModule extends AbstractModule {
         bind(VirtualFileSystemRegistryPlugin.class);
         // Avoid writing ContentStream with common JSON writer.
         // ContentStream should be serialized with dedicated MessageBodyWriter
-        Multibinder.newSetBinder(binder(), Class.class, Names.named("codenvy.json.ignored_classes"))
+        Multibinder.newSetBinder(binder(), Class.class, Names.named("che.json.ignored_classes"))
                    .addBinding().toInstance(ContentStream.class);
         bind(ContentStreamWriter.class);
         bind(RequestValidator.class).toProvider(Providers.<RequestValidator>of(null));


### PR DESCRIPTION
**_1 Upvote**_ During migration to eclipse infrastructure I've changed a couple of things in swagger services in che-lib
1. Renamed property codenvy.json.ignored_classes to che.json.ignored_classes
2. I've made org.eclipse.che.swagger.deploy.BasicSwaggerConfigurationModule not a  Dynoamodule ( to remove dependency on commons-inject)

This pr contains changes to make che working with corresponding changes in che-lib

Signed-off-by: Sergii Kabashniuk skabashnyuk@codenvy.com
