### PR TITLE
CHE-169: Git mixin should not appear if project is not under Git vcs

### DIFF
--- a/core/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
+++ b/core/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
@@ -64,7 +64,7 @@ public class GitValueProviderFactory implements ValueProviderFactory {
                              gitConnectionFactory.getConnection(resolveLocalPathByPath(folder.getPath(), folder.getWorkspace()))) {
                     //check whether the folder belongs to git repository
                     if (!gitConnection.isInsideWorkTree()) {
-                        return Collections.EMPTY_LIST;
+                        throw new ValueStorageException("Not a Git repository.");
                     }
                     switch (attributeName) {
                         case VCS_PROVIDER_NAME:


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi azatsarynnyy@codenvy.com
@vparfonov 
