### PR TITLE
Moved win short directory conversion into bash

### DIFF
--- a/assembly/assembly-main/src/assembly/bin/che.bat
+++ b/assembly/assembly-main/src/assembly/bin/che.bat
@@ -15,9 +15,6 @@ REM Check to ensure bash is installed
 CALL bash --help > nul 2>&1
 IF %ERRORLEVEL% NEQ 0 goto setup
 
-REM IDEX-4232 change windows long directories to DOS 8.3 format to handle directories with spaces
-FOR %%i in ("%~dp0..") do set "CHE_WINDOWS_SHORT_DIR=%%~Si"
-
 REM Launch Che and any associated docker machines, if necessary
 CALL bash --login -i "%~dp0\che.sh" %*
 


### PR DESCRIPTION
Signed-off-by: Tyler Jewell tjewell@codenvy.com

Two sets of changes:
1. Moved CHE_HOME short directory conversion of windows from che.bat into che.sh.  Thanks @SamHasler.
2. Convert JAVA_HOME to short directory if on Windows.
