### PR TITLE
CHE-120. Should not set default size for parts when user has sized the panel

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkBenchPartController.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkBenchPartController.java
@@ -36,6 +36,17 @@ public interface WorkBenchPartController {
     void setSize(double size);
 
     /**
+     * Sets the minimum allowable size for the part.
+     * <p/>
+     * The splitter cannot be dragged to a position that would make the part
+     * smaller than this size.
+     *
+     * @param minSize
+     *         the minimum size for the part
+     */
+    void setMinSize(int minSize);
+
+    /**
      * Show/hide part stack.
      *
      * @param hidden

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkBenchPartControllerImpl.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkBenchPartControllerImpl.java
@@ -34,7 +34,6 @@ public class WorkBenchPartControllerImpl implements WorkBenchPartController {
         this.widget = widget;
 
         splitLayoutPanel.setWidgetToggleDisplayAllowed(widget, true);
-        splitLayoutPanel.setWidgetMinSize(widget, 100);
         splitLayoutPanel.setWidgetHidden(widget, true);
         splitLayoutPanel.forceLayout();
     }
@@ -61,6 +60,12 @@ public class WorkBenchPartControllerImpl implements WorkBenchPartController {
 
         splitLayoutPanel.setWidgetSize(widget, hidden ? 0 : getSize());
         splitLayoutPanel.animate(DURATION);
+
+    }
+
+    @Override
+    public void setMinSize(int minSize) {
+        splitLayoutPanel.setWidgetMinSize(widget, minSize);
     }
 
 }

--- a/core/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/PartStackPresenterTest.java
+++ b/core/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/PartStackPresenterTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -54,6 +55,7 @@ import static org.mockito.Mockito.when;
 public class PartStackPresenterTest {
 
     private static final String SOME_TEXT = "someText";
+    private static final double PART_SIZE = 170;
 
     //constructor mocks
     @Mock
@@ -249,11 +251,40 @@ public class PartStackPresenterTest {
 
     @Test
     public void onTabShouldBeClicked() {
+        reset(workBenchPartController);
         presenter.addPart(partPresenter);
 
         presenter.onTabClicked(partButton);
 
         verify(workBenchPartController).setSize(anyDouble());
+        verify(workBenchPartController).setHidden(false);
+
+        verify(view).selectTab(partPresenter);
+    }
+
+    @Test
+    public void shouldSetCurrentSizeForPart() {
+        reset(workBenchPartController);
+        presenter.addPart(partPresenter);
+        when(workBenchPartController.getSize()).thenReturn(0d);
+
+        presenter.onTabClicked(partButton);
+
+        verify(workBenchPartController).setSize(eq(presenter.currentSize));
+        verify(workBenchPartController).setHidden(false);
+
+        verify(view).selectTab(partPresenter);
+    }
+
+    @Test
+    public void shouldSetInitialSizeForPart() {
+        reset(workBenchPartController);
+        presenter.addPart(partPresenter);
+        when(workBenchPartController.getSize()).thenReturn(PART_SIZE);
+
+        presenter.onTabClicked(partButton);
+
+        verify(workBenchPartController).setSize(eq(PART_SIZE));
         verify(workBenchPartController).setHidden(false);
 
         verify(view).selectTab(partPresenter);


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com

Set default size for parts if size of pats < minimum part size only
Reduce default part size from 285 to 260
