### PR TITLE
Poject & Factory & GitServiceClient improvements

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -200,7 +200,6 @@ public class AppContextImpl implements AppContext, SelectionChangedHandler, WsAg
             final HasProjectConfig hasProjectConfig = (HasProjectConfig)headElement;
             final ProjectConfigDto module = (hasProjectConfig).getProjectConfig();
             currentProject.setProjectConfig(module);
-            eventBus.fireEvent(new CurrentProjectChangedEvent(module));
         }
 
         if (headElement instanceof Node) {
@@ -211,6 +210,8 @@ public class AppContextImpl implements AppContext, SelectionChangedHandler, WsAg
             currentProject.setRootProject(rootConfig);
             browserQueryFieldRenderer.setProjectName(rootConfig.getName());
         }
+
+        eventBus.fireEvent(new CurrentProjectChangedEvent(currentProject.getProjectConfig()));
     }
 
     @Override

--- a/core/platform-api-client-gwt/che-core-client-gwt-git/src/main/java/org/eclipse/che/api/git/gwt/client/GitServiceClient.java
+++ b/core/platform-api-client-gwt/che-core-client-gwt-git/src/main/java/org/eclipse/che/api/git/gwt/client/GitServiceClient.java
@@ -595,8 +595,21 @@ public interface GitServiceClient {
      * @param project
      *         project (root of GIT repository)
      * @param callback
+     * @deprecated use {@link #status(String, ProjectConfigDto)}
      */
+    @Deprecated
     void status(String workspaceId, ProjectConfigDto project, AsyncRequestCallback<Status> callback);
+
+    /**
+     * Returns the current working tree status.
+     *
+     * @param workspaceId
+     *         id of the workspace
+     * @param project
+     *         the project.
+     * @return the promise which either resolves working tree status or rejects with an error
+     */
+    Promise<Status> status(String workspaceId, ProjectConfigDto project);
 
     /**
      * Get the Git ReadOnly Url for the pointed item's location.

--- a/core/platform-api-client-gwt/che-core-client-gwt-git/src/main/java/org/eclipse/che/api/git/gwt/client/GitServiceClientImpl.java
+++ b/core/platform-api-client-gwt/che-core-client-gwt-git/src/main/java/org/eclipse/che/api/git/gwt/client/GitServiceClientImpl.java
@@ -155,7 +155,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void cloneRepository(String workspaceId, 
+    public void cloneRepository(String workspaceId,
                                 ProjectConfigDto project,
                                 String remoteUri,
                                 String remoteName,
@@ -206,7 +206,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void add(String workspaceId, 
+    public void add(String workspaceId,
                     ProjectConfigDto project,
                     boolean update,
                     @Nullable List<String> filePattern,
@@ -229,7 +229,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void commit(String workspaceId, 
+    public void commit(String workspaceId,
                        ProjectConfigDto project,
                        String message,
                        boolean all,
@@ -245,7 +245,7 @@ public class GitServiceClientImpl implements GitServiceClient{
     }
 
     @Override
-    public void commit(final String workspaceId, 
+    public void commit(final String workspaceId,
                        final ProjectConfigDto project,
                        final String message,
                        final List<String> files,
@@ -263,7 +263,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void config(String workspaceId, 
+    public void config(String workspaceId,
                        ProjectConfigDto project,
                        @Nullable List<String> entries,
                        boolean all,
@@ -278,7 +278,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void push(String workspaceId, 
+    public void push(String workspaceId,
                      ProjectConfigDto project,
                      List<String> refSpec,
                      String remote,
@@ -291,7 +291,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void remoteList(String workspaceId, 
+    public void remoteList(String workspaceId,
                            ProjectConfigDto project,
                            @Nullable String remoteName,
                            boolean verbose,
@@ -319,13 +319,24 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void branchList(String workspaceId, 
+    public void branchList(String workspaceId,
                            ProjectConfigDto project,
                            @Nullable String remoteMode,
                            AsyncRequestCallback<List<Branch>> callback) {
         BranchListRequest branchListRequest = dtoFactory.createDto(BranchListRequest.class).withListMode(remoteMode);
         String url = extPath + "/git/" + workspaceId + BRANCH_LIST + "?projectPath=" + project.getPath();
         asyncRequestFactory.createPostRequest(url, branchListRequest).send(callback);
+    }
+
+    @Override
+    public Promise<Status> status(String workspaceId, ProjectConfigDto project) {
+        final String params = "?projectPath=" + project.getPath() + "&format=" + PORCELAIN;
+        final String url = extPath + "/git/" + workspaceId + STATUS + params;
+        return asyncRequestFactory.createPostRequest(url, null)
+                                  .loader(loader)
+                                  .header(CONTENTTYPE, APPLICATION_JSON)
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .send(dtoUnmarshallerFactory.newUnmarshaller(Status.class));
     }
 
     /** {@inheritDoc} */
@@ -341,7 +352,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void branchDelete(String workspaceId, 
+    public void branchDelete(String workspaceId,
                              ProjectConfigDto project,
                              String name,
                              boolean force,
@@ -353,7 +364,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void branchRename(String workspaceId,  
+    public void branchRename(String workspaceId,
                              ProjectConfigDto project,
                              String oldName,
                              String newName,
@@ -375,7 +386,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void checkout(String workspaceId, 
+    public void checkout(String workspaceId,
                          ProjectConfigDto project,
                          CheckoutRequest checkoutRequest,
                          AsyncRequestCallback<String> callback) {
@@ -385,7 +396,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void remove(String workspaceId, 
+    public void remove(String workspaceId,
                        ProjectConfigDto project,
                        List<String> items,
                        boolean cached,
@@ -397,7 +408,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void reset(String workspaceId, 
+    public void reset(String workspaceId,
                       ProjectConfigDto project,
                       String commit,
                       @Nullable ResetRequest.ResetType resetType,
@@ -428,7 +439,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void remoteAdd(String workspaceId, 
+    public void remoteAdd(String workspaceId,
                           ProjectConfigDto project,
                           String name,
                           String repositoryURL,
@@ -440,7 +451,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void remoteDelete(String workspaceId, 
+    public void remoteDelete(String workspaceId,
                              ProjectConfigDto project,
                              String name,
                              AsyncRequestCallback<String> callback) {
@@ -450,7 +461,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void fetch(String workspaceId, 
+    public void fetch(String workspaceId,
                       ProjectConfigDto project,
                       String remote,
                       List<String> refspec,
@@ -472,7 +483,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void pull(String workspaceId, 
+    public void pull(String workspaceId,
                      ProjectConfigDto project,
                      String refSpec,
                      String remote,
@@ -484,7 +495,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void diff(String workspaceId, 
+    public void diff(String workspaceId,
                      ProjectConfigDto project,
                      List<String> fileFilter,
                      DiffRequest.DiffType type,
@@ -505,7 +516,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void showFileContent(String workspaceId, 
+    public void showFileContent(String workspaceId,
                                 @NotNull ProjectConfigDto project,
                                 String file,
                                 String version,
@@ -517,7 +528,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void diff(String workspaceId, 
+    public void diff(String workspaceId,
                      ProjectConfigDto project,
                      List<String> fileFilter,
                      DiffRequest.DiffType type,
@@ -553,7 +564,7 @@ public class GitServiceClientImpl implements GitServiceClient{
 
     /** {@inheritDoc} */
     @Override
-    public void merge(String workspaceId, 
+    public void merge(String workspaceId,
                       ProjectConfigDto project,
                       String commit,
                       AsyncRequestCallback<MergeResult> callback) {

--- a/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/AttributeFilter.java
+++ b/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/AttributeFilter.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.project.server;
 
+import com.google.common.base.MoreObjects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -22,6 +23,7 @@ import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.api.project.server.type.Variable;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -179,7 +181,7 @@ public class AttributeFilter {
             if (factory == null) {
                 List<String> value = projectConfig.getAttributes().get(attribute.getName());
 
-                persistentAttributes.put(variable.getName(), value);
+                persistentAttributes.put(variable.getName(), MoreObjects.firstNonNull(value, new ArrayList<>()));
             }
         }
 


### PR DESCRIPTION
Publish `CurrentProjectChangedEvent` when root project is already set.
Exclude projects without location when creating factory from workspace.
Force `AttributesFilter` to use empty list instead of `null`.
Add `status` method to `GitServiceClient` which returns promise.

@vparfonov, @skabashnyuk  please review
