### PR TITLE
Improve handling of ws agent started event

### DIFF
--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/ApiEndpointAccessibilityChecker.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/ApiEndpointAccessibilityChecker.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
+package org.eclipse.che.wsagent.server;
 
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;

--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/ApiEndpointProvider.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/ApiEndpointProvider.java
@@ -8,27 +8,23 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
+package org.eclipse.che.wsagent.server;
+
+import com.google.common.base.Strings;
 
 import javax.inject.Provider;
-import java.net.URI;
 
 /**
- * Provides URI of Che API endpoint for usage inside machine to be able to connect to host machine using docker host IP.
+ * Provides value of Che API endpoint URL for usage inside machine to be able to connect to host machine using docker host IP.
  *
- * @author Alexander Garagatyi
+ * @author Artem Zatsarynnyi
  */
-public class UriApiEndpointProvider implements Provider<URI> {
+public class ApiEndpointProvider implements Provider<String> {
 
     public static final String API_ENDPOINT_URL_VARIABLE = "CHE_API_ENDPOINT";
 
     @Override
-    public URI get() {
-        try {
-            return new URI(System.getenv(API_ENDPOINT_URL_VARIABLE));
-        } catch (Exception e) {
-            throw new RuntimeException("System variable CHE_API_ENDPOINT contain invalid value of Che api endpoint:" +
-                                       System.getenv(API_ENDPOINT_URL_VARIABLE));
-        }
+    public String get() {
+        return Strings.nullToEmpty(System.getenv(API_ENDPOINT_URL_VARIABLE));
     }
 }

--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/ApiServletModule.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/ApiServletModule.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
+package org.eclipse.che.wsagent.server;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.servlet.ServletModule;

--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/EventBusURLProvider.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/EventBusURLProvider.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
+package org.eclipse.che.wsagent.server;
 
 import javax.inject.Inject;
 import javax.inject.Named;

--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/MachineModule.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/MachineModule.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
+package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -101,7 +101,7 @@ public class MachineModule extends AbstractModule {
         bind(WSocketEventBusClient.class).asEagerSingleton();
 
         bind(String.class).annotatedWith(Names.named("event.bus.url")).toProvider(EventBusURLProvider.class);
-        bind(org.eclipse.che.ide.ext.java.server.ApiEndpointAccessibilityChecker.class);
+        bind(ApiEndpointAccessibilityChecker.class);
     }
 
     //it's need for WSocketEventBusClient and in the future will be replaced with the property

--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/UriApiEndpointProvider.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/UriApiEndpointProvider.java
@@ -8,23 +8,27 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
-
-import com.google.common.base.Strings;
+package org.eclipse.che.wsagent.server;
 
 import javax.inject.Provider;
+import java.net.URI;
 
 /**
- * Provides value of Che API endpoint URL for usage inside machine to be able to connect to host machine using docker host IP.
+ * Provides URI of Che API endpoint for usage inside machine to be able to connect to host machine using docker host IP.
  *
- * @author Artem Zatsarynnyi
+ * @author Alexander Garagatyi
  */
-public class ApiEndpointProvider implements Provider<String> {
+public class UriApiEndpointProvider implements Provider<URI> {
 
     public static final String API_ENDPOINT_URL_VARIABLE = "CHE_API_ENDPOINT";
 
     @Override
-    public String get() {
-        return Strings.nullToEmpty(System.getenv(API_ENDPOINT_URL_VARIABLE));
+    public URI get() {
+        try {
+            return new URI(System.getenv(API_ENDPOINT_URL_VARIABLE));
+        } catch (Exception e) {
+            throw new RuntimeException("System variable CHE_API_ENDPOINT contain invalid value of Che api endpoint:" +
+                                       System.getenv(API_ENDPOINT_URL_VARIABLE));
+        }
     }
 }

--- a/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/UserTokenProvider.java
+++ b/assembly/assembly-machine-war/src/main/java/org/eclipse/che/wsagent/server/UserTokenProvider.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.java.server;
+package org.eclipse.che.wsagent.server;
 
 import com.google.inject.Provider;
 

--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/rest/RestServiceInfo.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/rest/RestServiceInfo.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.rest;
+
+/**
+ * Describe information available service like fqn of class and path.
+ *
+ * @author Vitalii Parfonov
+ */
+public class RestServiceInfo {
+
+    private String fqn;
+
+    private String regex;
+
+    private String path;
+
+    public RestServiceInfo(String fqn, String regex, String path) {
+        this.fqn = fqn;
+        this.regex = regex;
+        this.path = path;
+    }
+
+    /**
+     * FQN of REST service class
+     * @return fqn
+     */
+    public String getFqn() {
+        return fqn;
+    }
+
+    /**
+     * Regular expressions for URI pattern.
+     * @return
+     */
+    public String getRegex() {
+        return regex;
+    }
+
+    /**
+     * Describe the Path annotation, see {@link javax.ws.rs.Path}
+     * @return
+     */
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+         return "RestServiceInfo{" +
+                "fqn='" + fqn + '\'' +
+                ", regex='" + regex + '\'' +
+                ", path='" + path + '\'' +
+                   '}';
+    }
+
+}

--- a/core/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/WsAgentStateController.java
+++ b/core/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/WsAgentStateController.java
@@ -10,28 +10,39 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.gwt.client;
 
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.machine.gwt.client.events.WsAgentStateEvent;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper;
+import org.eclipse.che.ide.rest.AsyncRequestCallback;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.RestServiceInfo;
+import org.eclipse.che.ide.rest.StringUnmarshaller;
 import org.eclipse.che.ide.ui.loaders.initialization.InitialLoadingInfo;
 import org.eclipse.che.ide.ui.loaders.initialization.LoaderPresenter;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.ide.websocket.MessageBus;
 import org.eclipse.che.ide.websocket.MessageBusProvider;
-import org.eclipse.che.ide.websocket.WebSocket;
 import org.eclipse.che.ide.websocket.events.ConnectionClosedHandler;
 import org.eclipse.che.ide.websocket.events.ConnectionErrorHandler;
 import org.eclipse.che.ide.websocket.events.ConnectionOpenedHandler;
 import org.eclipse.che.ide.websocket.events.WebSocketClosedEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.che.api.machine.gwt.client.WsAgentState.STARTED;
+import static org.eclipse.che.api.machine.gwt.client.WsAgentState.STOPPED;
 import static org.eclipse.che.ide.ui.loaders.initialization.InitialLoadingInfo.Operations.WS_AGENT_BOOTING;
-import static org.eclipse.che.ide.ui.loaders.initialization.OperationInfo.Status.ERROR;
 import static org.eclipse.che.ide.ui.loaders.initialization.OperationInfo.Status.IN_PROGRESS;
 import static org.eclipse.che.ide.ui.loaders.initialization.OperationInfo.Status.SUCCESS;
 
@@ -42,72 +53,88 @@ import static org.eclipse.che.ide.ui.loaders.initialization.OperationInfo.Status
 @Singleton
 public class WsAgentStateController implements ConnectionOpenedHandler, ConnectionClosedHandler, ConnectionErrorHandler {
 
-    private final Timer              retryConnectionTimer;
-    private final EventBus           eventBus;
-    private final MessageBusProvider messageBusProvider;
-    private final InitialLoadingInfo initialLoadingInfo;
-    private final LoaderPresenter    loader;
+    private final EventBus                 eventBus;
+    private final MessageBusProvider       messageBusProvider;
+    private final InitialLoadingInfo       initialLoadingInfo;
+    private final LoaderPresenter          loader;
+    private final AsyncRequestFactory      asyncRequestFactory;
+    private final String                   extPath;
 
-    private MessageBus                messageBus;
-    private WsAgentState              state;
-    private String                    wsUrl;
-    private int                       countRetry;
-    private AsyncCallback<MessageBus> messageBusCallback;
-    private WebSocket                 testConnection; //use it only for testing state of ext-service
+    //not used now added it for future if it we will have possibility check that service available for client call
+    private final List<RestServiceInfo>    availableServices;
+
+    private MessageBus                     messageBus;
+    private WsAgentState                   state;
+    private String                         wsUrl;
+    private String                         wsId;
+    private AsyncCallback<MessageBus>      messageBusCallback;
 
     @Inject
     public WsAgentStateController(EventBus eventBus,
                                   LoaderPresenter loader,
                                   MessageBusProvider messageBusProvider,
+                                  AsyncRequestFactory asyncRequestFactory,
+                                  @Named("cheExtensionPath") String extPath,
                                   InitialLoadingInfo initialLoadingInfo) {
         this.loader = loader;
         this.eventBus = eventBus;
         this.messageBusProvider = messageBusProvider;
+        this.asyncRequestFactory = asyncRequestFactory;
+        this.extPath = extPath;
         this.initialLoadingInfo = initialLoadingInfo;
-
-        retryConnectionTimer = new Timer() {
-            @Override
-            public void run() {
-                connect();
-                countRetry--;
-            }
-        };
+        availableServices = new ArrayList<>();
     }
 
-    public void initialize(String wsUrl) {
-        this.wsUrl = wsUrl;
-        this.countRetry = 50;
-        this.state = WsAgentState.STOPPED;
-
+    public void initialize(String wsUrl, String wsId) {
+        this.wsUrl = wsUrl + "/" + wsId;
+        this.wsId = wsId;
+        this.state = STOPPED;
         initialLoadingInfo.setOperationStatus(WS_AGENT_BOOTING.getValue(), IN_PROGRESS);
-        connect();
-
-
+        checkHttpConnection();
     }
 
     @Override
     public void onClose(WebSocketClosedEvent event) {
-        Log.info(getClass(), "Test WS connection closed with code " + event.getCode() + " reason: " + event.getReason() +
-                             " workspace agent started well ");
+        Log.info(getClass(), "Test WS connection closed with code " + event.getCode() + " reason: " + event.getReason());
+        if (state.equals(STARTED)) {
+            state = STOPPED;
+            eventBus.fireEvent(WsAgentStateEvent.createWsAgentStoppedEvent());
+        }
     }
 
     @Override
     public void onError() {
-        if (countRetry > 0) {
-            retryConnectionTimer.schedule(1000);
-        } else {
-            state = WsAgentState.STOPPED;
-            initialLoadingInfo.setOperationStatus(WS_AGENT_BOOTING.getValue(), ERROR);
-            loader.hide();
+        Log.info(getClass(), "Test WS connection error");
+        if (state.equals(STARTED)) {
+            state = STOPPED;
             eventBus.fireEvent(WsAgentStateEvent.createWsAgentStoppedEvent());
         }
     }
 
     @Override
     public void onOpen() {
-        testConnection.close(); //close testing connection now we know ws-agent already start
-        messageBus = messageBusProvider.createMachineMessageBus(wsUrl);
-        state = WsAgentState.STARTED;
+        messageBus.removeOnOpenHandler(this);
+        MessageBus.ReadyState readyState = messageBus.getReadyState();
+        Log.info(getClass(), readyState.toString());
+        //need to make sure ready state equals 1 (OPEN) in same situations after opening it still equals 0 (CONNECTING)
+        if (!readyState.equals(MessageBus.ReadyState.OPEN)) {
+            new Timer() {
+                @Override
+                public void run() {
+                    Log.info(getClass(), messageBus.getReadyState());
+                    if (messageBus.getReadyState().equals(MessageBus.ReadyState.OPEN)) {
+                        cancel();
+                        started();
+                    }
+                }
+            }.scheduleRepeating(100);
+        } else {
+            started();
+        }
+    }
+
+    private void started() {
+        state = STARTED;
         initialLoadingInfo.setOperationStatus(WS_AGENT_BOOTING.getValue(), SUCCESS);
         loader.hide();
 
@@ -116,6 +143,8 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
         }
         eventBus.fireEvent(WsAgentStateEvent.createWsAgentStartedEvent());
     }
+
+
 
     public WsAgentState getState() {
         return state;
@@ -134,10 +163,48 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
         });
     }
 
-    private void connect() {
-        testConnection = WebSocket.create(wsUrl);
-        testConnection.setOnOpenHandler(this);
-        testConnection.setOnCloseHandler(this);
-        testConnection.setOnErrorHandler(this);
+    /**
+     * Goto checking HTTP connection via getting all registered REST Services
+     */
+    private void checkHttpConnection() {
+        asyncRequestFactory.createGetRequest(extPath + "/" + wsId + "/").send(new AsyncRequestCallback<String>(new StringUnmarshaller()) {
+            @Override
+            protected void onSuccess(String result) {
+                JSONObject object = JSONParser.parseStrict(result).isObject();
+                if (object.containsKey("rootResources")) {
+                    JSONArray rootResources = object.get("rootResources").isArray();
+                    for (int i = 0; i < rootResources.size(); i++) {
+                        JSONObject rootResource = rootResources.get(i).isObject();
+                        String regex = rootResource.get("regex").isString().stringValue();
+                        String fqn = rootResource.get("fqn").isString().stringValue();
+                        String path = rootResource.get("path").isString().stringValue();
+                        availableServices.add(new RestServiceInfo(fqn,regex,path));
+                    }
+                    checkWsConnection();
+                }
+            }
+
+            @Override
+            protected void onFailure(Throwable exception) {
+                Log.error(getClass(), exception.getMessage());
+                new Timer() {
+                    @Override
+                    public void run() {
+                        checkHttpConnection();
+                    }
+                }.schedule(1000);
+            }
+        });
+    }
+
+    /**
+     * Try to connect via WebSocket connection
+     */
+    private void checkWsConnection() {
+        messageBus = messageBusProvider.createMachineMessageBus(wsUrl);
+        messageBus.addOnCloseHandler(this);
+        messageBus.addOnCloseHandler(this);
+        messageBus.addOnOpenHandler(this);
+
     }
 }

--- a/core/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/proxy/MachineExtensionProxyServletTest.java
+++ b/core/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/proxy/MachineExtensionProxyServletTest.java
@@ -220,6 +220,32 @@ public class MachineExtensionProxyServletTest {
     }
 
     @Test
+    public void shouldBeAbleToProxyWithout() throws Exception {
+        final String path = "/api/ext/" + WORKSPACE_ID + "/";
+
+        final String defaultContextPath = contextHandler.getContextPath();
+        try {
+            contextHandler.setContextPath("/api/ext/");
+
+            MockHttpServletRequest mockRequest =
+                    new MockHttpServletRequest(PROXY_ENDPOINT + path,
+                                               new ByteArrayInputStream(new byte[0]),
+                                               0,
+                                               "GET",
+                                               defaultHeaders);
+
+            MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+
+            proxyServlet.service(mockRequest, mockResponse);
+
+            assertEquals(mockResponse.getStatus(), 200);
+            assertEquals(extensionApiRequest.uri, "/api/ext/");
+        } finally {
+            contextHandler.setContextPath(defaultContextPath);
+        }
+    }
+
+    @Test
     public void shouldProxyWithQueryString() throws Exception {
         final String query = "key1=value1&key2=value2&key2=value3";
 

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImpl.java
@@ -281,7 +281,7 @@ public class MachineManagerImpl implements MachineManager, WorkspaceStoppedHandl
                 appContext.setDevMachineId(machineId);
                 appContext.setProjectsRoot(machineDto.getRuntime().projectsRoot());
                 devMachine = entityFactory.createMachine(machineDto);
-                wsAgentStateController.initialize(devMachine.getWsServerExtensionsUrl() + "/" + appContext.getWorkspaceId());
+                wsAgentStateController.initialize(devMachine.getWsServerExtensionsUrl(), appContext.getWorkspaceId());
             }
         });
     }


### PR DESCRIPTION
Signed-off-by: Vitaly Parfonov vparfonov@codenvy.com

Add checking on ready state for websocket connection.
Make it possible rout  org.eclipse.che.api.core.rest.ApiInfoService on wsAgent form MachineExtensionProxyServlet.
Renamee package in assembly-machine-war to more accurate for it  
