### PR TITLE
Disappear JsOauthWindow after action is performed

### DIFF
--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/security/oauth/JsOAuthWindow.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/security/oauth/JsOAuthWindow.java
@@ -76,7 +76,7 @@ public class JsOAuthWindow {
 
                     if (href) {
                         var path = popupWindow.location.pathname;
-                        if (path == (authUrl.substring(authUrl.lastIndexOf("/ws"))) || path == "/dashboard/") {
+                        if (path.startsWith("/ws/") || path.startsWith("/dashboard/")) {
                             instance.@org.eclipse.che.security.oauth.JsOAuthWindow::setAuthenticationStatus(I)(3);
                             popupWindow.close();
                             popupWindow = null;


### PR DESCRIPTION
**_2 Upvotes**_ The problem is that if url was `/ws/wss` then it wouldn't work.

@vparfonov, @azatsarynnyy, @vzhukovskii  please review
