### PR TITLE
CHE-75: Cut long names in editor tab

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
@@ -28,13 +28,13 @@ import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStackView.TabItem;
 import org.eclipse.che.ide.api.parts.PropertyListener;
 import org.eclipse.che.ide.api.project.tree.VirtualFile;
-import org.eclipse.che.ide.part.widgets.TabItemFactory;
 import org.eclipse.che.ide.part.PartStackPresenter;
 import org.eclipse.che.ide.part.PartsComparator;
 import org.eclipse.che.ide.part.editor.event.CloseNonPinnedEditorsEvent;
 import org.eclipse.che.ide.part.editor.event.CloseNonPinnedEditorsEvent.CloseNonPinnedEditorsHandler;
 import org.eclipse.che.ide.part.editor.event.PinEditorTabEvent;
 import org.eclipse.che.ide.part.editor.event.PinEditorTabEvent.PinEditorTabEventHandler;
+import org.eclipse.che.ide.part.widgets.TabItemFactory;
 import org.eclipse.che.ide.part.widgets.editortab.EditorTab;
 import org.eclipse.che.ide.part.widgets.listtab.ListButton;
 import org.eclipse.che.ide.part.widgets.listtab.ListItem;
@@ -218,6 +218,8 @@ public class EditorPartStackPresenter extends PartStackPresenter implements Edit
     @Override
     public void onTabClose(@NotNull TabItem tab) {
         removeItemFromList(tab);
+
+        eventBus.fireEvent(new FileEvent(((EditorTab)tab).getFile(), CLOSE));
     }
 
     /** {@inheritDoc} */

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.ui.xml
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.ui.xml
@@ -78,6 +78,9 @@
             font-size: 11px;
             font-family: "Helvetica Neue", "Myriad Pro", arial, Verdana, Verdana, sans-serif;
             line-height: 22px;
+            max-width: 250px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .closeTabPanel {
@@ -211,7 +214,7 @@
         <g:Label ui:field="title" styleName="{style.titlePanel}" />
         <g:FlowPanel styleName="{style.closeTabPanel}">
             <g:FlowPanel ui:field="closeButton" styleName="{style.closeTabButton}">
-                <svg:SVGImage resource="{resources.closeIcon}"></svg:SVGImage>
+                <svg:SVGImage resource="{resources.closeIcon}"/>
             </g:FlowPanel>
         </g:FlowPanel>
     </g:FlowPanel>

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/listtab/ListItemWidget.ui.xml
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/listtab/ListItemWidget.ui.xml
@@ -49,6 +49,9 @@
             float: left;
             padding-left: 4px;
             cursor: default;
+            max-width: 250px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .close {


### PR DESCRIPTION
@vparfonov 
After changes it looks like this 
![cut_names](https://cloud.githubusercontent.com/assets/7605230/13392246/d772e55a-dee1-11e5-85ea-34b7cb401bee.png)
