### PR TITLE
Fetch module config directly from item reference

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/node/NodeManager.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/node/NodeManager.java
@@ -67,8 +67,6 @@ public class NodeManager {
     protected final AppContext             appContext;
     protected final String                 workspaceId;
 
-    private ModuleNode moduleNode;
-
     @Inject
     public NodeManager(NodeFactory nodeFactory,
                        ProjectServiceClient projectService,
@@ -184,33 +182,10 @@ public class NodeManager {
         }
 
         if ("module".equals(itemType)) {
-            moduleNode = null;
-
-            for (ProjectConfigDto moduleConfigDto : configDto.getModules()) {
-                createModuleNode(itemReference, moduleConfigDto, settings);
-
-                if (moduleNode != null) {
-                    return moduleNode;
-                }
-            }
+            return nodeFactory.newModuleNode(itemReference.getProjectConfig(), settings);
         }
 
         return null;
-    }
-
-    private void createModuleNode(ItemReference itemReference,
-                                  ProjectConfigDto moduleConfig,
-                                  NodeSettings settings) {
-
-        if (itemReference.getName().equals(moduleConfig.getName())) {
-            moduleNode = nodeFactory.newModuleNode(moduleConfig, settings);
-
-            return;
-        }
-
-        for (ProjectConfigDto configDto : moduleConfig.getModules()) {
-            createModuleNode(itemReference, configDto, settings);
-        }
     }
 
     @NotNull
@@ -219,20 +194,6 @@ public class NodeManager {
             @Override
             public List<Node> apply(PromiseError arg) throws FunctionException {
                 return Collections.emptyList();
-            }
-        };
-    }
-
-    /** Project Reference operations ********************* */
-    public Promise<ProjectConfigDto> getProjectDescriptor(String path) {
-        return AsyncPromiseHelper.createFromAsyncRequest(getProjectDescriptoRC(path));
-    }
-
-    private RequestCall<ProjectConfigDto> getProjectDescriptoRC(final String path) {
-        return new RequestCall<ProjectConfigDto>() {
-            @Override
-            public void makeCall(AsyncCallback<ProjectConfigDto> callback) {
-                projectService.getProject(workspaceId, path, _callback(callback, dtoUnmarshaller.newUnmarshaller(ProjectConfigDto.class)));
             }
         };
     }

--- a/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/AttributeFilter.java
+++ b/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/AttributeFilter.java
@@ -120,36 +120,6 @@ public class AttributeFilter {
                                                                                                                          parentFolder);
             projectConfig.getAttributes().putAll(attributes);
         }
-
-        for (ProjectConfigDto configDto : projectConfig.getModules()) {
-            FolderEntry module = findModuleByPath(parentFolder, configDto.getPath());
-
-            addAttributesToProject(configDto, module, attributeType);
-        }
-    }
-
-    private FolderEntry findModuleByPath(FolderEntry parent, String path) throws ServerException, ForbiddenException {
-        if (!path.contains("/")) {
-            return parent;
-        }
-
-        //module which is located in module or project
-        FolderEntry module = (FolderEntry)parent.getChild(path.substring(path.lastIndexOf("/")));
-
-        if (module == null) {
-            //module which is located in simple folder
-            module = (FolderEntry)parent.getChild(definePathToModule(path));
-        }
-
-        return module == null ? parent : module;
-    }
-
-    private String definePathToModule(String path) {
-        if (path.startsWith("/")) {
-            path = path.substring(1);
-        }
-
-        return path.substring(path.indexOf("/"));
     }
 
     private ProjectTypes getProjectTypes(FolderEntry module, ProjectConfig moduleConfig) throws ProjectTypeConstraintException,

--- a/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
+++ b/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
@@ -21,9 +21,9 @@ import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.project.ProjectConfig;
 import org.eclipse.che.api.core.model.project.type.Attribute;
 import org.eclipse.che.api.core.model.project.type.ProjectType;
-import org.eclipse.che.api.core.model.project.ProjectConfig;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
@@ -425,7 +425,7 @@ public final class DefaultProjectManager implements ProjectManager {
                                                                   NotFoundException {
         ProjectConfigDto projectConfigDto = getProjectFromWorkspace(project.getWorkspace(), project.getPath());
         if (projectConfigDto == null) {
-            projectConfigDto = newDto(ProjectConfigDto.class);
+            projectConfigDto = findModule(project);
         }
 
         FolderEntry projectFolder = project.getBaseFolder();
@@ -436,6 +436,25 @@ public final class DefaultProjectManager implements ProjectManager {
         attributeFilter.addRuntimeAttributesToProject(projectConfigDto, projectFolder);
 
         return projectConfigDto;
+    }
+
+    private ProjectConfigDto findModule(Project project) throws ServerException {
+        String path = project.getPath();
+        if (!path.contains("/")){
+            return newDto(ProjectConfigDto.class);
+        }
+
+        String[] parts = path.split("/");
+
+        int projectNameIndex = 1;
+
+        ProjectConfigDto projectConfig = getProjectFromWorkspace(project.getWorkspace(), "/" + parts[projectNameIndex]);
+
+        if (projectConfig == null) {
+            return newDto(ProjectConfigDto.class);
+        } else {
+            return projectConfig.findModule(project.getPath());
+        }
     }
 
     @Override

--- a/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/ItemReference.java
+++ b/core/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/ItemReference.java
@@ -12,6 +12,8 @@ package org.eclipse.che.api.project.shared.dto;
 
 import org.eclipse.che.api.core.rest.shared.dto.Hyperlinks;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
+import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.dto.shared.DTO;
 
 import java.util.List;
@@ -89,4 +91,9 @@ public interface ItemReference extends Hyperlinks {
 
     ItemReference withContentLength(long length);
 
+    /** The method can return {@code null} value. {@link ProjectConfigDto} exist only for project and modules in other cases it is null. */
+    @Nullable
+    ProjectConfigDto getProjectConfig();
+
+    void setProjectConfig(ProjectConfigDto config);
 }


### PR DESCRIPTION
Get children operation _(on the server side, project service)_ is returning item reference with project configuration for the module if such exists. Client based on this information may faster construct module node instead of making additional request for the configuration.
###### Note: temporary solution will be alive before new changes will be merged (related to new project type with server side vfs refactorings)

Related issue: [CHE-660](https://jira.codenvycorp.com/browse/CHE-660)

@vparfonov @dimasnurenko review this PR.

Squashed commit of the following:

commit e86d058795c7bd1cb30221b6e79b376d662ad191
Merge: 32caa18 7b6bb02
Author: Vladyslav Zhukovskii vzhukovskii@codenvy.com
Date:   Tue Mar 1 17:42:55 2016 +0200

```
Merge branch 'master' into CHE-660
```

commit 32caa185e3cd18cbe71fa644a733abaaacc9562a
Author: Vladyslav Zhukovskii vzhukovskii@codenvy.com
Date:   Tue Mar 1 17:37:36 2016 +0200

```
Fetch module config directly from item reference
```

commit 04513ae3c58624028405e3b62edfacf7e13807ef
Author: Dmitry Shnurenko dshnurenko@codenvy.com
Date:   Tue Mar 1 17:06:12 2016 +0200

```
CHE-660: Add java doc
```

commit 20e99f884e434b726cd2066b4f3663b86c77e455
Author: Dmitry Shnurenko dshnurenko@codenvy.com
Date:   Tue Mar 1 16:57:56 2016 +0200

```
CHE-660: Improve server side code to less time of getting project
```

Signed-off-by: Vladyslav Zhukovskii vzhukovskii@codenvy.com
