### PR TITLE
CHE-676. Keep focus on dialog when user uses tab button

### DIFF
--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogFooter.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogFooter.java
@@ -16,7 +16,8 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -24,11 +25,11 @@ import org.eclipse.che.ide.ui.window.Window;
 
 /**
  * The footer show on choice dialogs.
- * 
+ *
  * @author Mickaël Leduque
  * @author Artem Zatsarynnyi
  */
-public class ChoiceDialogFooter extends Composite {
+public class ChoiceDialogFooter implements IsWidget {
 
     private static final Window.Resources           resources = GWT.create(Window.Resources.class);
     /** The UI binder instance. */
@@ -36,19 +37,18 @@ public class ChoiceDialogFooter extends Composite {
 
     @UiField
     Button firstChoiceButton;
-
     @UiField
     Button secondChoiceButton;
-
     @UiField
     Button thirdChoiceButton;
+    HTMLPanel rootPanel;
 
     /** The action delegate. */
     private ChoiceDialogView.ActionDelegate actionDelegate;
 
     @Inject
     public ChoiceDialogFooter() {
-        initWidget(uiBinder.createAndBindUi(this));
+        rootPanel = uiBinder.createAndBindUi(this);
 
         firstChoiceButton.addStyleName(resources.windowCss().primaryButton());
         firstChoiceButton.getElement().setId("ask-dialog-first");
@@ -73,7 +73,8 @@ public class ChoiceDialogFooter extends Composite {
     /**
      * Handler set on the first button.
      *
-     * @param event the event that triggers the handler call
+     * @param event
+     *         the event that triggers the handler call
      */
     @UiHandler("firstChoiceButton")
     public void handleFirstChoiceClick(final ClickEvent event) {
@@ -83,7 +84,8 @@ public class ChoiceDialogFooter extends Composite {
     /**
      * Handler set on the second button.
      *
-     * @param event the event that triggers the handler call
+     * @param event
+     *         the event that triggers the handler call
      */
     @UiHandler("secondChoiceButton")
     public void handleSecondChoiceClick(final ClickEvent event) {
@@ -93,14 +95,20 @@ public class ChoiceDialogFooter extends Composite {
     /**
      * Handler set on the third button.
      *
-     * @param event the event that triggers the handler call
+     * @param event
+     *         the event that triggers the handler call
      */
     @UiHandler("thirdChoiceButton")
     public void handleThirdChoiceClick(final ClickEvent event) {
         this.actionDelegate.thirdChoiceClicked();
     }
 
+    @Override
+    public Widget asWidget() {
+        return rootPanel;
+    }
+
     /** The UI binder interface for this component. */
-    interface ChoiceDialogFooterUiBinder extends UiBinder<Widget, ChoiceDialogFooter> {
+    interface ChoiceDialogFooterUiBinder extends UiBinder<HTMLPanel, ChoiceDialogFooter> {
     }
 }

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogFooter.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogFooter.java
@@ -11,13 +11,15 @@
 package org.eclipse.che.ide.ui.dialogs.confirm;
 
 import org.eclipse.che.ide.ui.UILocalizationConstant;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -31,7 +33,7 @@ import javax.validation.constraints.NotNull;
  * @author Mickaël Leduque
  * @author Artem Zatsarynnyi
  */
-public class ConfirmDialogFooter extends Composite {
+public class ConfirmDialogFooter implements IsWidget {
 
     private static final Window.Resources            resources = GWT.create(Window.Resources.class);
     /** The UI binder instance. */
@@ -43,13 +45,15 @@ public class ConfirmDialogFooter extends Composite {
     Button                 okButton;
     @UiField
     Button                 cancelButton;
+    HTMLPanel rootPanel;
+
     /** The action delegate. */
     private ConfirmDialogView.ActionDelegate actionDelegate;
 
     @Inject
     public ConfirmDialogFooter(final @NotNull UILocalizationConstant messages) {
         this.messages = messages;
-        initWidget(uiBinder.createAndBindUi(this));
+        rootPanel = uiBinder.createAndBindUi(this);
 
         okButton.addStyleName(resources.windowCss().primaryButton());
         okButton.getElement().setId("ask-dialog-ok");
@@ -60,7 +64,8 @@ public class ConfirmDialogFooter extends Composite {
     /**
      * Overwrites label of Ok button
      *
-     * @param label new label
+     * @param label
+     *         new label
      */
     public void setOkButtonLabel(String label) {
         okButton.setText(label);
@@ -69,7 +74,8 @@ public class ConfirmDialogFooter extends Composite {
     /**
      * Overwrites label of Cancel button
      *
-     * @param label new label
+     * @param label
+     *         new label
      */
     public void setCancelButtonLabel(String label) {
         cancelButton.setText(label);
@@ -107,7 +113,12 @@ public class ConfirmDialogFooter extends Composite {
         this.actionDelegate.cancelled();
     }
 
+    @Override
+    public Widget asWidget() {
+        return rootPanel;
+    }
+
     /** The UI binder interface for this component. */
-    interface ConfirmDialogFooterUiBinder extends UiBinder<Widget, ConfirmDialogFooter> {
+    interface ConfirmDialogFooterUiBinder extends UiBinder<HTMLPanel, ConfirmDialogFooter> {
     }
 }

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogFooter.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogFooter.java
@@ -11,13 +11,15 @@
 package org.eclipse.che.ide.ui.dialogs.input;
 
 import org.eclipse.che.ide.ui.UILocalizationConstant;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -32,7 +34,7 @@ import static org.eclipse.che.ide.ui.window.Window.Resources;
  * @author Mickaël Leduque
  * @author Artem Zatsarynnyi
  */
-public class InputDialogFooter extends Composite {
+public class InputDialogFooter implements IsWidget {
 
     private static final Resources                   resources = GWT.create(Resources.class);
     /** The UI binder instance. */
@@ -44,13 +46,16 @@ public class InputDialogFooter extends Composite {
     Button                 okButton;
     @UiField
     Button                 cancelButton;
+
+    HTMLPanel rootPanel;
+
     /** The action delegate. */
     private ActionDelegate actionDelegate;
 
     @Inject
     public InputDialogFooter(final @NotNull UILocalizationConstant messages) {
         this.messages = messages;
-        initWidget(uiBinder.createAndBindUi(this));
+        rootPanel = uiBinder.createAndBindUi(this);
 
         okButton.addStyleName(resources.windowCss().primaryButton());
         okButton.getElement().setId("askValue-dialog-ok");
@@ -94,7 +99,12 @@ public class InputDialogFooter extends Composite {
         return okButton;
     }
 
+    @Override
+    public Widget asWidget() {
+        return rootPanel;
+    }
+
     /** The UI binder interface for this component. */
-    interface ConfirmWindowFooterUiBinder extends UiBinder<Widget, InputDialogFooter> {
+    interface ConfirmWindowFooterUiBinder extends UiBinder<HTMLPanel, InputDialogFooter> {
     }
 }

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/View.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/View.java
@@ -20,6 +20,8 @@ import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.MouseDownEvent;
@@ -41,6 +43,8 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.eclipse.che.ide.util.UIUtil;
+
+import java.util.List;
 
 /**
  * The view that renders the {@link Window}. The View consists of a glass
@@ -78,7 +82,7 @@ class View extends Composite {
     private int               dragStartX;
     private int               dragStartY;
     private String            transition;
-    private FocusWidget lastFocused;
+    private FocusWidget       lastFocused;
 
     private BlurHandler blurHandler = new BlurHandler() {
         @Override
@@ -102,6 +106,16 @@ class View extends Composite {
             contentContainer.add(footer);
         }
         handleEvents();
+
+        FocusPanel dummyFocusElement = new FocusPanel();
+        dummyFocusElement.setTabIndex(0);
+        dummyFocusElement.addFocusHandler(new FocusHandler() {
+            @Override
+            public void onFocus(FocusEvent event) {
+                setFocus();
+            }
+        });
+        contentContainer.add(dummyFocusElement);
     }
 
     /**
@@ -292,11 +306,36 @@ class View extends Composite {
     }
 
     /**
-     * Set focus on the specific children element if such exists.
+     * Sets focus on the last focused child element if such exists.
      */
-    public void focusView() {
+    public void focusLastFocusedElement() {
         if (lastFocused != null) {
             lastFocused.setFocus(true);
         }
+    }
+
+    /**
+     * Sets focus on the first child of content panel if such exists.
+     * Otherwise sets focus on first child of footer
+     */
+    public void setFocus() {
+        if (!setFocusOnChildOf(content)) {
+            setFocusOnChildOf(footer);
+        }
+    }
+
+    /**
+     * Sets focus on the first focusable child if such exists.
+     * @return <code>true</code> if the focus was set
+     */
+    private boolean setFocusOnChildOf(Widget widget) {
+        List<FocusWidget> focusableChildren = UIUtil.getFocusableChildren(widget);
+        for (FocusWidget focusableWidget : focusableChildren) {
+            if (focusableWidget.isVisible()) {
+                focusableWidget.setFocus(true);
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
@@ -188,7 +188,14 @@ public abstract class Window implements IsWidget {
 
     /** Set focus to current window. */
     public void focus() {
-        view.focusView();
+        view.setFocus();
+    }
+
+    /**
+     * Sets focus on the last focused child element if such exists.
+     */
+    public void focusLastFocusedElement() {
+        view.focusLastFocusedElement();
     }
 
     /**

--- a/core/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogViewTest.java
+++ b/core/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogViewTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.ide.ui.dialogs.confirm;
 
 import org.eclipse.che.ide.ui.dialogs.BaseTest;
-import com.google.gwt.user.client.Element;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -19,9 +18,7 @@ import org.mockito.Mock;
 
 import static org.eclipse.che.ide.ui.dialogs.confirm.ConfirmDialogView.ActionDelegate;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Testing {@link ConfirmDialogViewImpl} functionality.
@@ -39,7 +36,6 @@ public class ConfirmDialogViewTest extends BaseTest {
     @Override
     public void setUp() {
         super.setUp();
-        when(footer.getElement()).thenReturn(mock(Element.class));
         view = new ConfirmDialogViewImpl(footer);
     }
 

--- a/core/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogViewTest.java
+++ b/core/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogViewTest.java
@@ -12,19 +12,13 @@ package org.eclipse.che.ide.ui.dialogs.input;
 
 import org.eclipse.che.ide.ui.UILocalizationConstant;
 import org.eclipse.che.ide.ui.dialogs.BaseTest;
-import com.google.gwt.user.client.Element;
 
-import org.eclipse.che.ide.ui.UILocalizationConstant;
-import org.eclipse.che.ide.ui.dialogs.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static org.eclipse.che.ide.ui.dialogs.input.InputDialogView.ActionDelegate;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Testing {@link InputDialogViewImpl} functionality.
@@ -44,7 +38,6 @@ public class InputDialogViewTest extends BaseTest {
     @Override
     public void setUp() {
         super.setUp();
-        when(footer.getElement()).thenReturn(mock(Element.class));
         view = new InputDialogViewImpl(footer, uiLocalizationConstant);
     }
 


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com
1. Keep focus on dialog when user uses tab button
2. Change behavior for focus() for org.eclipse.che.ide.ui.window.Window: https://github.com/eclipse/che/blob/master/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java#L190
   Now it set focus on last focused element if such exist: https://github.com/eclipse/che/blob/master/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/View.java#L298
   But if you display dialog, last focused elemet = null, so it's impossible to set focus in this use case.
   After my changes it will set focus on the first child of content panel if such exists. Otherwise it will set focus on first child of footer
