### PR TITLE
CHE-528: Resize git Merge and History icons to fit them in line

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/controls/branches.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/controls/branches.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="12px"
+	 height="12px" viewBox="8 8 16 16" enable-background="new 8 8 16 16" xml:space="preserve">
 <g id="_x31_1">
 	<path id="_x3C_Path_x3E__23_" fill-rule="evenodd" clip-rule="evenodd" fill="#808080" d="M20.01,15h-9.009c-0.55,0-1,0.452-1,1
 		v4.637l-0.594-0.593c-0.176-0.176-0.462-0.176-0.637,0l-0.638,0.638c-0.176,0.175-0.176,0.461,0,0.637l2.55,2.55l0,0l0.008,0.008

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/controls/checkoutReference.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/controls/checkoutReference.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="12px"
+	 height="12px" viewBox="8 8 16 16" enable-background="new 8 8 16 16" xml:space="preserve">
 <g id="_x31_3_1_">
 	<path id="_x3C_Path_x3E__25_" fill-rule="evenodd" clip-rule="evenodd" fill="#808080" d="M20.001,10c1.104,0,2,1.078,2,2
 		s-0.402,1.386-1,1.732V16c0,2.199-1.801,4-4,4H13v0.268c0.598,0.347,1,0.992,1,1.732c0,1.104-0.896,2-2,2s-2-0.896-2-2

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/controls/remote.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/controls/remote.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="12px"
+	 height="12px" viewBox="8 8 16 16" enable-background="new 8 8 16 16" xml:space="preserve">
 <g id="_x32_2_1_">
 	<g>
 		<path fill-rule="evenodd" clip-rule="evenodd" fill="#808080" d="M8,23.318h6.034C14.106,23.133,14.288,23,14.5,23h1v-1

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/diff_index.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/diff_index.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px"
+	 height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="_x30_1">
 	<g>
 		<path id="_x3C_Path_x3E__3_" fill-rule="evenodd" clip-rule="evenodd" fill="#808080" d="M22,8h-1v6h0.448

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/diff_prev_version.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/diff_prev_version.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px"
+	 height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="_x30_2">
 	<g>
 		<path id="_x3C_Path_x3E__7_" fill-rule="evenodd" clip-rule="evenodd" fill="#808080" d="M11,8h-1v6h0.449

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/diff_working_dir.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/diff_working_dir.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px"
+	 height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="_x30_3">
 	<g>
 		<path id="_x3C_Path_x3E__10_" fill-rule="evenodd" clip-rule="evenodd" fill="#3193D4" d="M19.155,12.5h2.293

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/project_level.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/project_level.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px"
+	 height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="_x30_5">
 	<g>
 		<path id="_x3C_Path_x3E__15_" fill-rule="evenodd" clip-rule="evenodd" fill="#808080" d="M19.5,24v-5.106h1V24H19.5L19.5,24z

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/refresh.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/refresh.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px"
+	 height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="_x30_6">
 	<g>
 		<path fill-rule="evenodd" clip-rule="evenodd" fill="#4D4D4D" d="M12.465,19.536c1.953,1.952,5.119,1.952,7.071,0

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/resource_level.svg
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/history/resource_level.svg
@@ -12,8 +12,8 @@
 
 -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
-	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px"
+	 height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="_x30_6">
 	<g>
 		<path id="_x3C_Path_x3E__18_" fill-rule="evenodd" clip-rule="evenodd" fill="#3193D4" d="M19.155,12.5h2.293


### PR DESCRIPTION
![history](https://cloud.githubusercontent.com/assets/7668752/13629446/dd88403c-e5e1-11e5-990a-498b873cedb8.png)
![merge](https://cloud.githubusercontent.com/assets/7668752/13629467/00c687de-e5e2-11e5-9a59-316adc6e5431.png)
@vparfonov please review
