### PR TITLE
CHE-176. Set 'accept' button in the focus for Choice dialog and Confirm dialog

### DIFF
--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogView.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogView.java
@@ -23,7 +23,10 @@ public interface ChoiceDialogView {
     /** Sets the action delegate. */
     void setDelegate(ActionDelegate delegate);
 
-    /** Displays the dialog window. */
+    /**
+     * Displays the dialog window.
+     * Sets "first-choice" button in the focus.
+     */
     void showDialog();
 
     /** Closes the dialog window. */

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogViewImpl.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogViewImpl.java
@@ -59,7 +59,7 @@ public class ChoiceDialogViewImpl extends Window implements ChoiceDialogView {
 
     @Override
     public void showDialog() {
-        this.show();
+        this.show(footer.firstChoiceButton);
     }
 
     @Override

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogView.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogView.java
@@ -23,7 +23,10 @@ public interface ConfirmDialogView {
     /** Sets the action delegate. */
     void setDelegate(ActionDelegate delegate);
 
-    /** Displays the dialog window. */
+    /**
+     * Displays the dialog window.
+     * Sets "accept" button in the focus.
+     */
     void showDialog();
 
     /** Closes the dialog window. */

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogViewImpl.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogViewImpl.java
@@ -64,7 +64,7 @@ public class ConfirmDialogViewImpl extends Window implements ConfirmDialogView {
 
     @Override
     public void showDialog() {
-        this.show();
+        this.show(footer.okButton);
     }
 
     @Override

--- a/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
+++ b/core/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
@@ -230,20 +230,21 @@ public abstract class Window implements IsWidget {
             RootLayoutPanel.get().add(view);
         }
 
-        // Start the animation after the element is attached.
-        Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-            @Override
-            public void execute() {
-                // The popup may have been hidden before this timer executes.
-                if (isShowing) {
-                    popup.getStyle().removeProperty("visibility");
+        // The popup may have been hidden before this timer executes.
+        if (isShowing) {
+            popup.getStyle().removeProperty("visibility");
+            // Start the animation after the element is attached.
+            Scheduler.get().scheduleDeferred(new ScheduledCommand() {
+                @Override
+                public void execute() {
+                    // The popup may have been hidden before this timer executes.
                     view.setShowing(true);
                     if (selectAndFocusElement != null) {
                         selectAndFocusElement.setFocus(true);
                     }
                 }
-            }
-        });
+            });
+        }
     }
 
     private void handleViewEvents() {


### PR DESCRIPTION
1. Set 'accept' button in the focus for Choice and Confirm dialogs.
2. Fix method show() of org.eclipse.che.ide.ui.window.Window 
   for correct setting focus on focusable element.  
