### PR TITLE
Avoid NPE if event don't has EventOrigin annotation

### DIFF
--- a/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/EventOriginClientPropagationPolicy.java
+++ b/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/EventOriginClientPropagationPolicy.java
@@ -58,6 +58,6 @@ public class EventOriginClientPropagationPolicy implements ClientEventPropagatio
     public boolean shouldPropagated(URI uri, Object event) {
         final EventOrigin eventOrigin = event.getClass().getAnnotation(EventOrigin.class);
         final Set<String> set = forPropagation.get(uri);
-        return set != null && set.contains(eventOrigin.value());
+        return set != null && eventOrigin != null && set.contains(eventOrigin.value());
     }
 }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov vparfonov@codenvy.com
@skabashnyuk 
