### PR TITLE
CHE-139: add 'Organize Imports' functionality

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/pom.xml
@@ -121,6 +121,10 @@
             <artifactId>org.eclipse.search</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.equinox</groupId>
+            <artifactId>preferences</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.search</groupId>
             <artifactId>org.eclipse.search</artifactId>
         </dependency>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/main/java/org/eclipse/che/jdt/rest/CodeAssistService.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/main/java/org/eclipse/che/jdt/rest/CodeAssistService.java
@@ -11,15 +11,18 @@
 
 package org.eclipse.che.jdt.rest;
 
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.ide.ext.java.shared.dto.Problem;
 import org.eclipse.che.ide.ext.java.shared.dto.ProposalApplyResult;
 import org.eclipse.che.ide.ext.java.shared.dto.Proposals;
+import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
 import org.eclipse.che.jdt.CodeAssist;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.JavaModel;
 import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jface.text.BadLocationException;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -30,6 +33,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
 
@@ -69,9 +73,9 @@ public class CodeAssistService {
     @Produces("application/json")
     @Consumes("application/json")
     public Proposals computeAssistProposals(@QueryParam("projectpath") String projectPath,
-                                                @QueryParam("fqn") String fqn,
-                                                @QueryParam("offset") int offset,
-                                                List<Problem> problems) throws CoreException {
+                                            @QueryParam("fqn") String fqn,
+                                            @QueryParam("offset") int offset,
+                                            List<Problem> problems) throws CoreException {
         IJavaProject javaProject = model.getJavaProject(projectPath);
         return codeAssist.computeAssistProposals(javaProject, fqn, offset, problems);
 
@@ -84,6 +88,48 @@ public class CodeAssistService {
                              @QueryParam("index") int index, @Context UriInfo uriInfo) {
 
         return codeAssist.getJavaDoc(sessionId, index);
+    }
+
+    /**
+     * Organizes the imports of a compilation unit.
+     *
+     * @param projectPath
+     *         path to the project
+     * @param fqn
+     *         fully qualified name of the java file
+     * @return list of imports which have conflicts
+     */
+    @POST
+    @Path("/organize-imports")
+    @Produces({MediaType.APPLICATION_JSON})
+    public List<ConflictImportDTO> organizeImports(@QueryParam("projectpath") String projectPath,
+                                                   @QueryParam("fqn") String fqn) throws NotFoundException,
+                                                                                        CoreException,
+                                                                                        BadLocationException {
+        IJavaProject project = model.getJavaProject(projectPath);
+        return codeAssist.organizeImports(project, fqn);
+    }
+
+    /**
+     * Applies chosen imports after resolving conflicts.
+     *
+     * @param projectPath
+     *         path to the project
+     * @param fqn
+     *         fully qualified name of the java file
+     * @param  chosen
+     *          list of chosen imports from conflicts which needed to add to all imports.
+     */
+    @POST
+    @Path("/apply-imports")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void applyChosenImports(@QueryParam("projectpath") String projectPath,
+                                   @QueryParam("fqn") String fqn,
+                                   ConflictImportDTO chosen) throws NotFoundException,
+                                                                    CoreException,
+                                                                    BadLocationException {
+        IJavaProject project = model.getJavaProject(projectPath);
+        codeAssist.applyChosenImports(project, fqn, chosen.getTypeMatches());
     }
 
 }

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/test/java/org/eclipse/che/jdt/core/CoreTests.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/test/java/org/eclipse/che/jdt/core/CoreTests.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.jdt.core;
+
+import org.eclipse.che.ide.ext.java.BaseTest;
+import org.eclipse.che.jdt.testplugin.*;
+import org.eclipse.che.jdt.testplugin.ProjectTestSetup;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class CoreTests extends BaseTest {
+
+	private org.eclipse.che.jdt.testplugin.ProjectTestSetup setup;
+
+	public CoreTests(ProjectTestSetup setup) {
+		this.setup = setup;
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		setup.setUp();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		setup.tearDown();
+	}
+
+	public static void assertEqualString(String actual, String expected) {
+		StringAsserts.assertEqualString(actual, expected);
+	}
+
+	public static void assertEqualStringIgnoreDelim(String actual, String expected) throws IOException {
+		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
+	}
+
+	public static void assertEqualStringsIgnoreOrder(String[] actuals, String[] expecteds) {
+		StringAsserts.assertEqualStringsIgnoreOrder(actuals, expecteds);
+	}
+
+	public static void assertNumberOf(String name, int is, int expected) {
+		assertTrue("Wrong number of " + name + ", is: " + is + ", expected: " + expected, is == expected);
+	}
+
+	protected ImportRewrite newImportsRewrite(ICompilationUnit cu, String[] order, int normalThreshold, int staticThreshold, boolean restoreExistingImports) throws CoreException {
+		ImportRewrite rewrite= StubUtility.createImportRewrite(cu, restoreExistingImports);
+		rewrite.setImportOrder(order);
+		rewrite.setOnDemandImportThreshold(normalThreshold);
+		rewrite.setStaticOnDemandImportThreshold(staticThreshold);
+		return rewrite;
+	}
+
+	protected ImportRewrite newImportsRewrite(CompilationUnit cu, String[] order, int normalThreshold, int staticThreshold, boolean restoreExistingImports) {
+		ImportRewrite rewrite= ImportRewrite.create(cu, restoreExistingImports);
+		rewrite.setImportOrder(order);
+		rewrite.setOnDemandImportThreshold(normalThreshold);
+		rewrite.setStaticOnDemandImportThreshold(staticThreshold);
+		return rewrite;
+	}
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/test/java/org/eclipse/che/jdt/core/ImportOrganizeTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/test/java/org/eclipse/che/jdt/core/ImportOrganizeTest.java
@@ -1,0 +1,3287 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.jdt.core;
+
+import org.eclipse.che.jdt.search.JUnitSourceSetup;
+import org.eclipse.che.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.che.jdt.testplugin.ProjectTestSetup;
+import org.eclipse.che.jdt.testplugin.TestOptions;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IImportDeclaration;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.core.search.TypeNameMatch;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.corext.codemanipulation.OrganizeImportsOperation;
+import org.eclipse.jdt.internal.corext.codemanipulation.OrganizeImportsOperation.IChooseImportQuery;
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Hashtable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class ImportOrganizeTest extends CoreTests {
+
+	private static final Class THIS= ImportOrganizeTest.class;
+
+	private IJavaProject fJProject1;
+
+	public ImportOrganizeTest() {
+		super(new org.eclipse.che.jdt.testplugin.ProjectTestSetup());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		fJProject1= ProjectTestSetup.getProject();
+
+		Hashtable options= TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_NUMBER_OF_EMPTY_LINES_TO_PRESERVE, String.valueOf(99));
+		JavaCore.setOptions(options);
+	}
+
+    @After
+	public void tearDown() throws Exception {
+		super.tearDown();
+		setOrganizeImportSettings(null, 99, 99, fJProject1);
+		JavaProjectHelper.clear(fJProject1, ProjectTestSetup.getDefaultClasspath());
+
+		JavaModelManager.getIndexManager().indexAll(fJProject1.getProject());
+	}
+
+	protected IChooseImportQuery createQuery(final String name, final String[] choices, final int[] nEntries) {
+		return new IChooseImportQuery() {
+			public TypeNameMatch[] chooseImports(TypeNameMatch[][] openChoices, ISourceRange[] ranges) {
+				assertTrue(name + "-query-nchoices1", choices.length == openChoices.length);
+				assertTrue(name + "-query-nchoices2", nEntries.length == openChoices.length);
+				for (int i= 0; i < nEntries.length; i++) {
+					assertTrue(name + "-query-cnt" + i, openChoices[i].length == nEntries[i]);
+				}
+				TypeNameMatch[] res= new TypeNameMatch[openChoices.length];
+				for (int i= 0; i < openChoices.length; i++) {
+					TypeNameMatch[] selection= openChoices[i];
+					assertNotNull(name + "-query-setset" + i, selection);
+					assertTrue(name + "-query-setlen" + i, selection.length > 0);
+					TypeNameMatch found= null;
+					for (int k= 0; k < selection.length; k++) {
+						if (selection[k].getFullyQualifiedName().equals(choices[i])) {
+							found= selection[k];
+						}
+					}
+					assertNotNull(name + "-query-notfound" + i, found);
+					res[i]= found;
+				}
+				return res;
+			}
+		};
+	}
+
+	private void assertImports(ICompilationUnit cu, String[] imports) throws Exception {
+		IImportDeclaration[] desc= cu.getImports();
+		assertEquals(cu.getElementName() + "-count", imports.length, desc.length);
+		for (int i= 0; i < imports.length; i++) {
+			assertEquals(cu.getElementName() + "-cmpentries" + i, desc[i].getElementName(), imports[i]);
+		}
+	}
+
+	@Test
+	public void test1() throws Exception {
+		File junitSrcArchive= new File(JUnitSourceSetup.class.getClassLoader().getResource(JavaProjectHelper.JUNIT_SRC_381.toOSString()).getFile());
+		assertTrue("junit src not found", junitSrcArchive != null && junitSrcArchive.exists());
+
+		JavaProjectHelper.addSourceContainerWithImport(fJProject1, "src", junitSrcArchive, JavaProjectHelper.JUNIT_SRC_ENCODING);
+
+		ICompilationUnit cu= (ICompilationUnit) fJProject1.findElement(new Path("junit/runner/BaseTestRunner.java"));
+		assertNotNull("BaseTestRunner.java", cu);
+
+		IPackageFragmentRoot root= (IPackageFragmentRoot)cu.getParent().getParent();
+		IPackageFragment pack= root.createPackageFragment("mytest", true, null);
+
+		ICompilationUnit colidingCU= pack.getCompilationUnit("TestListener.java");
+		colidingCU.createType("public abstract class TestListener {\n}\n", null, true, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("BaseTestRunner", new String[] { "junit.framework.TestListener" }, new int[] { 2 });
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+			"java.io.BufferedReader",
+			"java.io.File",
+			"java.io.FileInputStream",
+			"java.io.FileOutputStream",
+			"java.io.IOException",
+			"java.io.InputStream",
+			"java.io.PrintWriter",
+			"java.io.StringReader",
+			"java.io.StringWriter",
+			"java.lang.reflect.InvocationTargetException",
+			"java.lang.reflect.Method",
+			"java.lang.reflect.Modifier",
+			"java.text.NumberFormat",
+			"java.util.Properties",
+			"junit.framework.AssertionFailedError",
+			"junit.framework.Test",
+			"junit.framework.TestListener",
+			"junit.framework.TestSuite"
+		});
+	}
+
+	@Test
+	public void test1WithOrder() throws Exception {
+		File junitSrcArchive= new File(JUnitSourceSetup.class.getClassLoader().getResource(JavaProjectHelper.JUNIT_SRC_381.toOSString()).getFile());
+		assertTrue("junit src not found", junitSrcArchive != null && junitSrcArchive.exists());
+
+		JavaProjectHelper.addSourceContainerWithImport(fJProject1, "src", junitSrcArchive, JavaProjectHelper.JUNIT_SRC_ENCODING);
+
+		ICompilationUnit cu= (ICompilationUnit) fJProject1.findElement(new Path("junit/runner/BaseTestRunner.java"));
+		assertNotNull("BaseTestRunner.java", cu);
+
+		IPackageFragmentRoot root= (IPackageFragmentRoot)cu.getParent().getParent();
+		IPackageFragment pack= root.createPackageFragment("mytest", true, null);
+
+		ICompilationUnit colidingCU= pack.getCompilationUnit("TestListener.java");
+		colidingCU.createType("public abstract class TestListener {\n}\n", null, true, null);
+
+
+		String[] order= new String[] { "junit", "java.text", "java.io", "java" };
+		IChooseImportQuery query= createQuery("BaseTestRunner", new String[] { "junit.framework.TestListener" }, new int[] { 2 });
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+			"junit.framework.AssertionFailedError",
+			"junit.framework.Test",
+			"junit.framework.TestListener",
+			"junit.framework.TestSuite",
+			"java.text.NumberFormat",
+			"java.io.BufferedReader",
+			"java.io.File",
+			"java.io.FileInputStream",
+			"java.io.FileOutputStream",
+			"java.io.IOException",
+			"java.io.InputStream",
+			"java.io.PrintWriter",
+			"java.io.StringReader",
+			"java.io.StringWriter",
+			"java.lang.reflect.InvocationTargetException",
+			"java.lang.reflect.Method",
+			"java.lang.reflect.Modifier",
+			"java.util.Properties"
+		});
+	}
+
+    @Test
+	public void test2() throws Exception {
+		File junitSrcArchive= new File(JUnitSourceSetup.class.getClassLoader().getResource(JavaProjectHelper.JUNIT_SRC_381.toOSString()).getFile());
+		assertTrue("junit src not found", junitSrcArchive != null && junitSrcArchive.exists());
+
+		JavaProjectHelper.addSourceContainerWithImport(fJProject1, "src", junitSrcArchive, JavaProjectHelper.JUNIT_SRC_ENCODING);
+
+		ICompilationUnit cu= (ICompilationUnit) fJProject1.findElement(new Path("junit/runner/LoadingTestCollector.java"));
+		assertNotNull("LoadingTestCollector.java", cu);
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("LoadingTestCollector", new String[] { }, new int[] { });
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+			"java.lang.reflect.Modifier",
+			"junit.framework.Test",
+			"junit.framework.TestSuite",
+		});
+	}
+
+	@Test
+	public void test3() throws Exception {
+		File junitSrcArchive= new File(JUnitSourceSetup.class.getClassLoader().getResource(JavaProjectHelper.JUNIT_SRC_381.toOSString()).getFile());
+		assertTrue("junit src not found", junitSrcArchive != null && junitSrcArchive.exists());
+
+		JavaProjectHelper.addSourceContainerWithImport(fJProject1, "src", junitSrcArchive, JavaProjectHelper.JUNIT_SRC_ENCODING);
+
+		ICompilationUnit cu= (ICompilationUnit) fJProject1.findElement(new Path("junit/runner/TestCaseClassLoader.java"));
+		assertNotNull("TestCaseClassLoader.java", cu);
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("TestCaseClassLoader", new String[] { }, new int[] { });
+
+		OrganizeImportsOperation op= createOperation(cu, order, 3, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+			"java.io.*",
+			"java.net.URL",
+			"java.util.*",
+			"java.util.zip.ZipEntry",
+			"java.util.zip.ZipFile",
+		});
+	}
+
+	@Test
+	public void test4() throws Exception {
+		File junitSrcArchive= new File(JUnitSourceSetup.class.getClassLoader().getResource(JavaProjectHelper.JUNIT_SRC_381.toOSString()).getFile());
+		assertTrue("junit src not found", junitSrcArchive != null && junitSrcArchive.exists());
+
+		JavaProjectHelper.addSourceContainerWithImport(fJProject1, "src", junitSrcArchive, JavaProjectHelper.JUNIT_SRC_ENCODING);
+
+		ICompilationUnit cu= (ICompilationUnit) fJProject1.findElement(new Path("junit/textui/TestRunner.java"));
+		assertNotNull("TestRunner.java", cu);
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("TestRunner", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+			"java.io.PrintStream",
+			"junit.framework.Test",
+			"junit.framework.TestResult",
+			"junit.framework.TestSuite",
+			"junit.runner.BaseTestRunner",
+			"junit.runner.StandardTestSuiteLoader",
+			"junit.runner.TestSuiteLoader",
+			"junit.runner.Version"
+		});
+	}
+
+	@Test
+	public void testVariousTypeReferences() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack= sourceFolder.createPackageFragment("test", false, null);
+		for (int ch= 'A'; ch < 'M'; ch++) {
+			String name= String.valueOf((char) ch);
+			ICompilationUnit cu= pack.getCompilationUnit(name + ".java");
+			String content= "public class " + name + " {}";
+			cu.createType(content, null, false, null);
+		}
+		for (int ch= 'A'; ch < 'M'; ch++) {
+			String name= "I" + String.valueOf((char) ch);
+			ICompilationUnit cu= pack.getCompilationUnit(name + ".java");
+			String content= "public interface " + name + " {}";
+			cu.createType(content, null, false, null);
+		}
+
+		StringBuffer buf= new StringBuffer();
+		buf.append("public class ImportTest extends A implements IA, IB {\n");
+		buf.append("  private B fB;\n");
+		buf.append("  private Object fObj= new C();\n");
+		buf.append("  public IB foo(IC c, ID d) throws IOException {\n");
+		buf.append("   Object local= (D) fObj;\n");
+		buf.append("   if (local instanceof E) {};\n");
+		buf.append("   return null;\n");
+		buf.append("  }\n");
+		buf.append("}\n");
+
+		pack= sourceFolder.createPackageFragment("other", false, null);
+		ICompilationUnit cu= pack.getCompilationUnit("ImportTest.java");
+		cu.createType(buf.toString(), null, false, null);
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("ImportTest", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+				"java.io.IOException",
+				"test.A",
+				"test.B",
+				"test.C",
+				"test.D",
+				"test.E",
+				"test.IA",
+				"test.IB",
+				"test.IC",
+				"test.ID",
+				});
+	}
+
+	@Test
+	public void testInnerClassVisibility() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("public class C {\n");
+		buf.append("  public static class C1 {\n");
+		buf.append("    public static class C2 {\n");
+		buf.append("    }\n");
+		buf.append("  }\n");
+		buf.append("}\n");
+		pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("test2", false, null);
+
+		buf= new StringBuffer();
+		buf.append("package test2;\n");
+
+		buf.append("import test2.A.A1;\n");
+		buf.append("import test2.A.A1.A2;\n");
+		buf.append("import test2.A.A1.A2.A3;\n");
+		buf.append("import test2.A.B1;\n");
+		buf.append("import test2.A.B1.B2;\n");
+		buf.append("import test1.C;\n");
+		buf.append("import test1.C.C1.C2;\n");
+
+		buf.append("public class A {\n");
+		buf.append("    public static class A1 {\n");
+		buf.append("        public static class A2 {\n");
+		buf.append("            public static class A3 {\n");
+		buf.append("            }\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+
+		buf.append("    public static class B1 {\n");
+		buf.append("        public static class B2 {\n");
+		buf.append("        }\n");
+
+		buf.append("        public static class B3 {\n");
+		buf.append("            public static class B4 extends C {\n");
+		buf.append("                B4 b4;\n");
+		buf.append("                B3 b3;\n");
+		buf.append("                B2 b2;\n");
+		buf.append("                B1 b1;\n");
+		buf.append("                A1 a1;\n");
+		buf.append("                A2 a2;\n");
+		buf.append("                A3 a3;\n");
+		buf.append("                C1 c1;\n");
+		buf.append("                C2 c2;\n");
+		buf.append("            }\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu2= pack2.createCompilationUnit("A.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("A", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu2, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu2, new String[] {
+			"test1.C",
+			"test1.C.C1.C2",
+			"test2.A.A1.A2",
+			"test2.A.A1.A2.A3"
+		});
+	}
+
+
+	@Test
+	public void testClearImports() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("public class C {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("public class C {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testNewImports() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testReplaceImports() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testClearImportsNoPackage() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.getPackageFragment("");
+		StringBuffer buf= new StringBuffer();
+		buf.append("import java.util.Vector;\n");
+		buf.append("public class C {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("public class C {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testNewImportsNoPackage() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.getPackageFragment("");
+		StringBuffer buf= new StringBuffer();
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testReplaceImportsNoPackage() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.getPackageFragment("");
+		StringBuffer buf= new StringBuffer();
+		buf.append("import java.util.Set;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testCommentAfterImport() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\r\n");
+		buf.append("\r\n");
+		buf.append("import x;\r\n");
+		buf.append("import java.util.Vector; //comment\n");
+		buf.append("\r\n");
+		buf.append("public class C {\r\n");
+		buf.append("    Vector v;\r\n");
+		buf.append("}\r\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\r\n");
+		buf.append("\r\n");
+		buf.append("import java.util.Vector; //comment\n");
+		buf.append("\r\n");
+		buf.append("public class C {\r\n");
+		buf.append("    Vector v;\r\n");
+		buf.append("}\r\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportToStar() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v5;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v5;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportToStarWithComments() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("// comment 1\n");
+		buf.append("/*lead 1*/import java.util.Set;//test1\n");
+		buf.append("/*lead 2*/ import java.util.Vector;/*test2*/\n");
+		buf.append("/**lead 3*/import java.util.Map; //test3\n");
+		buf.append("/**comment 2*/\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v5;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("// comment 1\n");
+		buf.append("/*lead 1*//*lead 2*/ /**lead 3*/import java.util.*; //test3\n");
+		buf.append("//test1/*test2*/\n");
+		buf.append("");
+		buf.append("\n");
+		buf.append("/**comment 2*/\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v5;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportToStarWithExplicit() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List2 {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List2.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("import pack.List2;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    List2 v5;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("import pack.*;\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    List2 v5;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportToStarWithExplicit2() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportToStarWithExplicit3() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class Set {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("Set.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 1, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportToStarWithExplicit4() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+		IPackageFragment pack3= sourceFolder.createPackageFragment("pack3", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack3;\n");
+		buf.append("public class List {\n");
+		buf.append("}\n");
+		pack3.createCompilationUnit("List.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 1, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("import pack.List;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List v4;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+
+	@Test
+	public void testImportToStarWithExplicit5() throws Exception {
+		// unrelated project, to fill the all types cache
+		IJavaProject project2 = JavaProjectHelper.createJavaProject("TestProject2", "bin");
+		try {
+			assertTrue("rt not found", JavaProjectHelper.addRTJar(project2) != null);
+			IPackageFragmentRoot sourceFolder2= JavaProjectHelper.addSourceContainer(project2, "src");
+
+			IPackageFragment pack22= sourceFolder2.createPackageFragment("packx", false, null);
+			StringBuffer buf= new StringBuffer();
+			buf.append("package pack;\n");
+			buf.append("public class Vector {\n");
+			buf.append("}\n");
+			pack22.createCompilationUnit("List.java", buf.toString(), false, null);
+
+			buf= new StringBuffer();
+			buf.append("package pack;\n");
+			buf.append("public class Set {\n");
+			buf.append("}\n");
+			pack22.createCompilationUnit("Set.java", buf.toString(), false, null);
+
+			IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+			IPackageFragment pack2= sourceFolder.createPackageFragment("pack", false, null);
+			buf= new StringBuffer();
+			buf.append("package pack;\n");
+			buf.append("public class List {\n");
+			buf.append("}\n");
+			pack2.createCompilationUnit("List.java", buf.toString(), false, null);
+
+			IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+			buf= new StringBuffer();
+			buf.append("package pack1;\n");
+			buf.append("\n");
+			buf.append("import java.util.Set;\n");
+			buf.append("import java.util.Vector;\n");
+			buf.append("import java.util.Map;\n");
+			buf.append("\n");
+			buf.append("import pack.List;\n");
+			buf.append("\n");
+			buf.append("public class C {\n");
+			buf.append("    Vector v;\n");
+			buf.append("    Set v2;\n");
+			buf.append("    Map v3;\n");
+			buf.append("    List v4;\n");
+			buf.append("    String v6;\n");
+			buf.append("}\n");
+			ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+			String[] order= new String[] { "java", "pack" };
+			IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+			OrganizeImportsOperation op= createOperation(cu, order, 1, false, true, true, query);
+			op.run(null);
+
+			buf= new StringBuffer();
+			buf.append("package pack1;\n");
+			buf.append("\n");
+			buf.append("import java.util.*;\n");
+			buf.append("\n");
+			buf.append("import pack.List;\n");
+			buf.append("\n");
+			buf.append("public class C {\n");
+			buf.append("    Vector v;\n");
+			buf.append("    Set v2;\n");
+			buf.append("    Map v3;\n");
+			buf.append("    List v4;\n");
+			buf.append("    String v6;\n");
+			buf.append("}\n");
+			assertEqualString(cu.getSource(), buf.toString());
+		} finally {
+			JavaProjectHelper.delete(project2);
+		}
+	}
+
+	@Test
+	public void testGroups1() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public class List1 {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List1.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    File f;\n");
+		buf.append("    IOException f1;\n");
+		buf.append("    RandomAccessFile f2;\n");
+		buf.append("    ArrayList f3;\n");
+		buf.append("    List1 f4;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "java.io", "java.util" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("import java.io.IOException;\n");
+		buf.append("import java.io.RandomAccessFile;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("import pack0.List1;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    File f;\n");
+		buf.append("    IOException f1;\n");
+		buf.append("    RandomAccessFile f2;\n");
+		buf.append("    ArrayList f3;\n");
+		buf.append("    List1 f4;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportFromDefault() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("public class List1 {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List1.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List1 v4;\n");
+		buf.append("    String v5;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");  // no imports from default in compatibility >= 1.4
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List1 v4;\n");
+		buf.append("    String v5;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportFromDefaultWithStar() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("public class List1 {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List1.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("public class List2 {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List2.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Set;\n");  // no imports from default in compatibility >= 1.4
+		buf.append("import java.util.Vector;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List1 v4;\n");
+		buf.append("    List2 v5;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    Vector v;\n");
+		buf.append("    Set v2;\n");
+		buf.append("    Map v3;\n");
+		buf.append("    List1 v4;\n");
+		buf.append("    List2 v5;\n");
+		buf.append("    String v6;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportOfMemberFromLocal() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        class Local {\n");
+		buf.append("            class LocalMember {\n");
+		buf.append("            }\n");
+		buf.append("            LocalMember x;\n");
+		buf.append("            Vector v;\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        class Local {\n");
+		buf.append("            class LocalMember {\n");
+		buf.append("            }\n");
+		buf.append("            LocalMember x;\n");
+		buf.append("            Vector v;\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testBaseGroups1() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public class List1 {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("List1.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    File f;\n");
+		buf.append("    IOException f1;\n");
+		buf.append("    RandomAccessFile f2;\n");
+		buf.append("    ArrayList f3;\n");
+		buf.append("    List1 f4;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "java.io" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("import java.io.IOException;\n");
+		buf.append("import java.io.RandomAccessFile;\n");
+		buf.append("\n");
+		buf.append("import pack0.List1;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    File f;\n");
+		buf.append("    IOException f1;\n");
+		buf.append("    RandomAccessFile f2;\n");
+		buf.append("    ArrayList f3;\n");
+		buf.append("    List1 f4;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug26746() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public interface MyInterface {\n");
+		buf.append("	public interface MyInnerInterface {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("MyInterface.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import pack0.MyInterface.MyInnerInterface;\n");
+		buf.append("public class MyClass implements MyInterface {\n");
+		buf.append("	public MyInnerInterface myMethod() {\n");
+		buf.append("		return null;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("MyClass.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("public class MyClass implements MyInterface {\n");
+		buf.append("	public MyInnerInterface myMethod() {\n");
+		buf.append("		return null;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug37299a() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("public class ClusterSingletonStepped {\n");
+		buf.append("	public interface SingletonStep {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack1.createCompilationUnit("ClusterSingletonStepped.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack0", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import pack1.ClusterSingletonStepped;\n");
+		buf.append("import pack1.ClusterSingletonStepped.SingletonStep;\n");
+		buf.append("\n");
+		buf.append("public class TestFile extends ClusterSingletonStepped implements SingletonStep {\n");
+		buf.append("    SingletonStep step;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("TestFile.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("TestFile", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import pack1.ClusterSingletonStepped;\n");
+		buf.append("import pack1.ClusterSingletonStepped.SingletonStep;\n");
+		buf.append("\n");
+		buf.append("public class TestFile extends ClusterSingletonStepped implements SingletonStep {\n");
+		buf.append("    SingletonStep step;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug37299b() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("public class ClusterSingletonStepped {\n");
+		buf.append("	public interface SingletonStep {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack1.createCompilationUnit("ClusterSingletonStepped.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack0", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import pack1.ClusterSingletonStepped;\n");
+		buf.append("import pack1.ClusterSingletonStepped.SingletonStep;\n");
+		buf.append("\n");
+		buf.append("public class TestFile extends ClusterSingletonStepped {\n");
+		buf.append("    SingletonStep step;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("TestFile.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("TestFile", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import pack1.ClusterSingletonStepped;\n");
+		buf.append("\n");
+		buf.append("public class TestFile extends ClusterSingletonStepped {\n");
+		buf.append("    SingletonStep step;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug56704() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public class A {\n");
+		buf.append("	public class AX {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import pack0.A.AX;\n");
+		buf.append("public class B extends A {\n");
+		buf.append("	public class BX extends AX {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("B.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("public class B extends A {\n");
+		buf.append("	public class BX extends AX {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug67644() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("public class A {\n");
+		buf.append("	public class AX {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack2", false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("\n");
+		buf.append("import pack1.A;\n");
+		buf.append("import pack1.AX;\n");
+		buf.append("public class B {\n");
+		buf.append("	public void foo() {\n");
+		buf.append("	  Object x= new A().new AX();\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("B.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testVisibility_bug67644", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("\n");
+		buf.append("import pack1.A;\n");
+		buf.append("public class B {\n");
+		buf.append("	public void foo() {\n");
+		buf.append("	  Object x= new A().new AX();\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug85831() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack2", false, null);
+
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("\n");
+		buf.append("class A {\n");
+		buf.append("	public class AX {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		buf.append("public class B {\n");
+		buf.append("	Object x= new A().new AX();\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("B.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testVisibility_bug85831", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("\n");
+		buf.append("class A {\n");
+		buf.append("	public class AX {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		buf.append("public class B {\n");
+		buf.append("	Object x= new A().new AX();\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug79174() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("public interface A<X> {\n");
+		buf.append("	public interface AX<Y> {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack2", false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("\n");
+		buf.append("import pack1.A;\n");
+		buf.append("import pack1.AX;\n");
+		buf.append("public class B implements A<String> {\n");
+		buf.append("	public void foo(AX<String> a) {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("B.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testVisibility_bug79174", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("\n");
+		buf.append("import pack1.A;\n");
+		buf.append("public class B implements A<String> {\n");
+		buf.append("	public void foo(AX<String> a) {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testVisibility_bug131305() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment packUtil= sourceFolder.createPackageFragment("util", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package util;\n");
+		buf.append("\n");
+		buf.append("public interface Map \n");
+		buf.append("        public static interface Entry {\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		packUtil.createCompilationUnit("Map.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package util;\n");
+		buf.append("\n");
+		buf.append("public interface HashMap implements Map {\n");
+		buf.append("        private static interface Entry {\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		packUtil.createCompilationUnit("HashMap.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import util.HashMap;\n");
+		buf.append("import util.Map;\n");
+		buf.append("import util.Map.Entry;\n");
+		buf.append("\n");
+		buf.append("public class A extends HashMap {\n");
+		buf.append("        public A(Map m, Entry e) {\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testVisibility_bug131305", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertEqualString(cu.getSource(), buf.toString()); // no changes, import for Entry is required
+	}
+
+	@Test
+	public void testVisibility_bug159638() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public abstract class Parent<E> {\n");
+		buf.append("    public static class Inner {\n");
+		buf.append("    }\n");
+		buf.append("    public @interface Tag{\n");
+		buf.append("        String value();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("Parent.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.Parent;\n");
+		buf.append("import pack0.Parent.Inner;\n");
+		buf.append("import pack0.Parent.Tag;\n");
+		buf.append("\n");
+		buf.append("@Tag(\"foo\")\n");
+		buf.append("public class Child extends Parent<Inner> {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Child.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testVisibility_bug159638", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertEqualString(cu.getSource(), buf.toString()); // no changes, imports for Inner and tag are required
+	}
+
+	@Test
+	public void test5() throws Exception {
+
+		String[] types= new String[] {
+			"org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader",
+			"org.eclipse.core.resources.IContainer",
+			"org.eclipse.core.runtime.IPath",
+			"org.eclipse.core.runtime.CoreException",
+			"org.eclipse.core.resources.IResource",
+			"org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer"
+		};
+		String[] order= new String[] { "org.eclipse.jdt", "org.eclipse" };
+
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		for (int i= 0; i < types.length; i++) {
+			String pack= Signature.getQualifier(types[i]);
+			String name= Signature.getSimpleName(types[i]);
+
+			IPackageFragment pack2= sourceFolder.createPackageFragment(pack, false, null);
+			StringBuffer buf= new StringBuffer();
+			buf.append("package "); buf.append(pack); buf.append(";\n");
+			buf.append("public class "); buf.append(name); buf.append(" {\n");
+			buf.append("}\n");
+			pack2.createCompilationUnit(name + ".java", buf.toString(), false, null);
+		}
+
+		StringBuffer body= new StringBuffer();
+		body.append("public class C {\n");
+		for (int i= 0; i < types.length; i++) {
+			String name= Signature.getSimpleName(types[i]);
+			body.append(name); body.append(" a"); body.append(i); body.append(";\n");
+		}
+		body.append("}\n");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append(body.toString());
+
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;\n");
+		buf.append("import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;\n");
+		buf.append("\n");
+		buf.append("import org.eclipse.core.resources.IContainer;\n");
+		buf.append("import org.eclipse.core.resources.IResource;\n");
+		buf.append("import org.eclipse.core.runtime.CoreException;\n");
+		buf.append("import org.eclipse.core.runtime.IPath;\n");
+		buf.append("\n");
+		buf.append(body.toString());
+
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_bug25773() throws Exception {
+
+		String[] types= new String[] {
+			"java.util.Vector",
+			"java.util.Map",
+			"java.util.Set",
+			"org.eclipse.gef.X1",
+			"org.eclipse.gef.X2",
+			"org.eclipse.gef.X3",
+			"org.eclipse.core.runtime.IAdaptable",
+			"org.eclipse.draw2d.IFigure",
+			"org.eclipse.draw2d.LayoutManager",
+			"org.eclipse.draw2d.geometry.Point",
+			"org.eclipse.draw2d.geometry.Rectangle",
+			"org.eclipse.swt.accessibility.ACC",
+			"org.eclipse.swt.accessibility.AccessibleControlEvent"
+		};
+
+		String[] order= new String[] { "java", "org.eclipse", "org.eclipse.gef", "org.eclipse.draw2d", "org.eclipse.gef.examples" };
+		int threshold= 3;
+
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		for (int i= 0; i < types.length; i++) {
+			String pack= Signature.getQualifier(types[i]);
+			if (!pack.startsWith("java.")) {
+				String name= Signature.getSimpleName(types[i]);
+
+				IPackageFragment pack2= sourceFolder.createPackageFragment(pack, false, null);
+				StringBuffer buf= new StringBuffer();
+				buf.append("package "); buf.append(pack); buf.append(";\n");
+				buf.append("public class "); buf.append(name); buf.append(" {\n");
+				buf.append("}\n");
+				pack2.createCompilationUnit(name + ".java", buf.toString(), false, null);
+			}
+		}
+
+		StringBuffer body= new StringBuffer();
+		body.append("public class C {\n");
+		for (int i= 0; i < types.length; i++) {
+			String name= Signature.getSimpleName(types[i]);
+			body.append(name); body.append(" a"); body.append(i); body.append(";\n");
+		}
+		body.append("}\n");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append(body.toString());
+
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, threshold, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("import org.eclipse.core.runtime.IAdaptable;\n");
+		buf.append("import org.eclipse.swt.accessibility.ACC;\n");
+		buf.append("import org.eclipse.swt.accessibility.AccessibleControlEvent;\n");
+		buf.append("\n");
+		buf.append("import org.eclipse.gef.*;\n");
+		buf.append("\n");
+		buf.append("import org.eclipse.draw2d.IFigure;\n");
+		buf.append("import org.eclipse.draw2d.LayoutManager;\n");
+		buf.append("import org.eclipse.draw2d.geometry.Point;\n");
+		buf.append("import org.eclipse.draw2d.geometry.Rectangle;\n");
+		buf.append("\n");
+		buf.append(body.toString());
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_bug25113() throws Exception {
+
+		String[] types= new String[] {
+			"com.mycompany.Class1",
+			"com.foreigncompany.Class2",
+			"com.foreigncompany.Class3",
+			"com.mycompany.Class4",
+			"com.misc.Class5"
+		};
+
+		String[] order= new String[] { "com", "com.foreigncompany", "com.mycompany" };
+		int threshold= 99;
+
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		for (int i= 0; i < types.length; i++) {
+			String pack= Signature.getQualifier(types[i]);
+			if (!pack.startsWith("java.")) {
+				String name= Signature.getSimpleName(types[i]);
+
+				IPackageFragment pack2= sourceFolder.createPackageFragment(pack, false, null);
+				StringBuffer buf= new StringBuffer();
+				buf.append("package "); buf.append(pack); buf.append(";\n");
+				buf.append("public class "); buf.append(name); buf.append(" {\n");
+				buf.append("}\n");
+				pack2.createCompilationUnit(name + ".java", buf.toString(), false, null);
+			}
+		}
+
+		StringBuffer body= new StringBuffer();
+		body.append("public class C {\n");
+		for (int i= 0; i < types.length; i++) {
+			String name= Signature.getSimpleName(types[i]);
+			body.append(name); body.append(" a"); body.append(i); body.append(";\n");
+		}
+		body.append("}\n");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append(body.toString());
+
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, threshold, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import com.misc.Class5;\n");
+		buf.append("\n");
+		buf.append("import com.foreigncompany.Class2;\n");
+		buf.append("import com.foreigncompany.Class3;\n");
+		buf.append("\n");
+		buf.append("import com.mycompany.Class1;\n");
+		buf.append("import com.mycompany.Class4;\n");
+		buf.append("\n");
+		buf.append(body.toString());
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports1() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import static java.lang.System.out;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public int foo() {\n");
+		buf.append("        out.print(File.separator);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack", "#java" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("\n");
+		buf.append("import static java.lang.System.out;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public int foo() {\n");
+		buf.append("        out.print(File.separator);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports2() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import static java.io.File.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public String foo() {\n");
+		buf.append("        return pathSeparator + separator + File.separator;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "#java.io.File", "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import static java.io.File.pathSeparator;\n");
+		buf.append("import static java.io.File.separator;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public String foo() {\n");
+		buf.append("        return pathSeparator + separator + File.separator;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug78585() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public class Test1 {\n");
+		buf.append("	public static final <T> void assertNotEquals(final String msg, final T expected, final T toCheck) {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("Test1.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.Test1;\n");
+		buf.append("import java.util.List;\n");
+		buf.append("\n");
+		buf.append("public class Test2 extends Test1 {\n");
+		buf.append("	public void testMe() {\n");
+		buf.append("	    assertNotEquals(\"A\", \"B\", \"C\");\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Test2.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.Test1;\n"); // no static import for 'assertNotEquals'
+		buf.append("\n");
+		buf.append("public class Test2 extends Test1 {\n");
+		buf.append("	public void testMe() {\n");
+		buf.append("	    assertNotEquals(\"A\", \"B\", \"C\");\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug90556() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public class BasePanel<T extends Number> {\n");
+		buf.append("	public static void add2panel(String... s) {\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("Test1.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("public class ManufacturerMainPanel<T extends Number> extends BasePanel<T>{\n");
+		buf.append("	public void testMe() {\n");
+		buf.append("	    add2panel(null, null);\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack0.createCompilationUnit("ManufacturerMainPanel.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("ManufacturerMainPanel", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("public class ManufacturerMainPanel<T extends Number> extends BasePanel<T>{\n");
+		buf.append("	public void testMe() {\n");
+		buf.append("	    add2panel(null, null);\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug113770() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public abstract class Test<M>\n");
+		buf.append("{\n");
+		buf.append("        private static Map<Object, Object[]> facetMap;\n");
+		buf.append("\n");
+		buf.append("        public void getFacets() {\n");
+		buf.append("                facetMap.get(null);\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack0.createCompilationUnit("Test.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("Test", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("public abstract class Test<M>\n");
+		buf.append("{\n");
+		buf.append("        private static Map<Object, Object[]> facetMap;\n");
+		buf.append("\n");
+		buf.append("        public void getFacets() {\n");
+		buf.append("                facetMap.get(null);\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug81589() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public enum E {\n");
+		buf.append("	A, B, C;\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.E;\n");
+		buf.append("import static pack0.E.A;\n");
+		buf.append("\n");
+		buf.append("public class Test2 {\n");
+		buf.append("	public void testMe(E e) {\n");
+		buf.append("	    switch (e) {\n");
+		buf.append("	      case A:\n");
+		buf.append("	    }\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Test2.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.E;\n"); // no import for E.A
+		buf.append("\n");
+		buf.append("public class Test2 {\n");
+		buf.append("	public void testMe(E e) {\n");
+		buf.append("	    switch (e) {\n");
+		buf.append("	      case A:\n");
+		buf.append("	    }\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	public void testStaticImports_bug159424() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import java.util.List;\n");
+		buf.append("\n");
+		buf.append("public abstract class B {\n");
+		buf.append("    private static List logger;\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("B.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.List;\n");
+		buf.append("import pack0.B;\n");
+		buf.append("\n");
+		buf.append("public abstract class A {\n");
+		buf.append("    private static List logger;\n");
+		buf.append("\n");
+		buf.append("    protected class BSubClass extends B {\n");
+		buf.append("        public void someMethod() {\n");
+		buf.append("            logger.toString();\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testStaticImports_bug159424", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertEqualString(cu.getSource(), buf.toString()); // no changes, don't add 'logger' as static import
+	}
+
+	@Test
+	public void testStaticImports_bug175498() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		IPackageFragment pack1= sourceFolder.createPackageFragment("p", false, null);
+
+		StringBuffer buf= new StringBuffer();
+		buf.append("package p;\n");
+		buf.append("public class Test<T> {\n");
+		buf.append("        public static enum TestEnum {\n");
+		buf.append("                V1,\n");
+		buf.append("                V2\n");
+		buf.append("        }\n");
+		buf.append("\n");
+		buf.append("        public void test(final TestEnum value) {\n");
+		buf.append("                switch (value) {\n");
+		buf.append("                        case V1:\n");
+		buf.append("                        case V2:\n");
+		buf.append("                }\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("testStaticImports_bug175498", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertEqualString(cu.getSource(), buf.toString()); // no changes, don't add 'V1' and 'V2' as static import
+	}
+
+	@Test
+	public void testStaticImports_bug181895() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import static java.lang.Math.max;\n");
+		buf.append("\n");
+		buf.append("public class Test {\n");
+		buf.append("        /**\n");
+		buf.append("         * @see #max\n");
+		buf.append("         */\n");
+		buf.append("        public void doFoo() {\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack0.createCompilationUnit("Test.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("Test", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("\n");
+		buf.append("public class Test {\n");
+		buf.append("        /**\n");
+		buf.append("         * @see #max\n");
+		buf.append("         */\n");
+		buf.append("        public void doFoo() {\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug187004a() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("b", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package b;\n");
+		buf.append("\n");
+		buf.append("abstract public class Parent<T> {\n");
+		buf.append("        protected static final int CONSTANT = 42;\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("Parent.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("a", false, null);
+		buf= new StringBuffer();
+		buf.append("package a;\n");
+		buf.append("\n");
+		buf.append("import b.Parent;\n");
+		buf.append("\n");
+		buf.append("public class Child extends Parent<String> {\n");
+		buf.append("        public Child() {\n");
+		buf.append("                System.out.println(CONSTANT);\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Child.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("Child", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package a;\n");
+		buf.append("\n");
+		buf.append("import b.Parent;\n"); 		// no static import for CONSTANT
+		buf.append("\n");
+		buf.append("public class Child extends Parent<String> {\n");
+		buf.append("        public Child() {\n");
+		buf.append("                System.out.println(CONSTANT);\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug187004b() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("b", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package b;\n");
+		buf.append("\n");
+		buf.append("abstract public class Parent<T> {\n");
+		buf.append("        protected static final int CONSTANT() { return 42; }\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("Parent.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("a", false, null);
+		buf= new StringBuffer();
+		buf.append("package a;\n");
+		buf.append("\n");
+		buf.append("import b.Parent;\n");
+		buf.append("\n");
+		buf.append("public class Child extends Parent<String> {\n");
+		buf.append("        public Child() {\n");
+		buf.append("                System.out.println(CONSTANT());\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Child.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("Child", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package a;\n");
+		buf.append("\n");
+		buf.append("import b.Parent;\n"); 		// no static import for CONSTANT()
+		buf.append("\n");
+		buf.append("public class Child extends Parent<String> {\n");
+		buf.append("        public Child() {\n");
+		buf.append("                System.out.println(CONSTANT());\n");
+		buf.append("        }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testStaticImports_bug230067() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("a", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package a;\n");
+		buf.append("\n");
+		buf.append("class Test<T> {\n");
+		buf.append("    private static String TEST = \"constant\";\n");
+		buf.append("\n");
+		buf.append("    static class Inner extends Test<String> {\n");
+		buf.append("        public void test() {\n");
+		buf.append("            TEST.concat(\"access\");\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("Test", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package a;\n");
+		buf.append("\n");                            // no static import for 'TEST'
+		buf.append("class Test<T> {\n");
+		buf.append("    private static String TEST = \"constant\";\n");
+		buf.append("\n");
+		buf.append("    static class Inner extends Test<String> {\n");
+		buf.append("        public void test() {\n");
+		buf.append("            TEST.concat(\"access\");\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testImportCountAddNew() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(0, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountAddandRemove() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(1, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountAddandRemoveWithComments() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("/**comment1*/\n");
+		buf.append("/*lead1*/import java.util.*;// trail 1\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("/**comment1*/\n");
+		buf.append("/*lead1*/");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;// trail 1\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(1, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountKeepOne() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(1, op.getNumberOfImportsAdded());
+		assertEquals(0, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountKeepStar() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("        Collection c;\n");
+		buf.append("        Socket s;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 2, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.net.Socket;\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("        Collection c;\n");
+		buf.append("        Socket s;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(1, op.getNumberOfImportsAdded());
+		assertEquals(0, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountAddTwoRemoveOne() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.BitSet;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(1, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountReplaceStar() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.BitSet;\n");
+		buf.append("import java.util.Calendar;\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(3, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountRemoveStatic() throws Exception {
+	    IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.BitSet;\n");
+		buf.append("// some comment;\n");
+		buf.append("import java.util.Calendar; /*another comment*/\n");
+		buf.append("import static java.io.File.pathSeparator;\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("// some comment;\n");
+		buf.append("/*another comment*/\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(4, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void testImportCountKeepStatic() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.BitSet;\n");
+		buf.append("// some comment;\n");
+		buf.append("import java.util.Calendar; /*another comment*/\n");
+		buf.append("import static java.io.File.pathSeparator;\n");
+		buf.append("import java.util.*;\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String s= pathSeparator;\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[] { "java", "pack", "#" };
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("import static java.io.File.pathSeparator;\n");
+		buf.append("// some comment;\n");
+		buf.append("/*another comment*/\n");
+		buf.append("\n");
+		buf.append("public class C {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String s= pathSeparator;\n");
+		buf.append("        HashMap m;\n");
+		buf.append("        ArrayList l;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+
+		assertEquals(2, op.getNumberOfImportsAdded());
+		assertEquals(3, op.getNumberOfImportsRemoved());
+	}
+
+	@Test
+	public void test_bug78397() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("import java.util.Collection;\n");
+		buf.append("public class A {\n");
+		buf.append("    Collection<java.sql.Date> foo;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("import java.util.Collection;\n");
+		buf.append("public class A {\n");
+		buf.append("    Collection<java.sql.Date> foo;\n"); // no import for Date
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_bug78533() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public class A {\n");
+		buf.append("    public <T extends Collection> void method1() { }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("\n");
+		buf.append("import java.util.Collection;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		buf.append("    public <T extends Collection> void method1() { }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_bug78716() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public enum MyEnum {\n");
+		buf.append("	A, B, C\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("MyEnum.java", buf.toString(), false, null);
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.MyEnum;\n");
+		buf.append("import static pack0.MyEnum.*;\n");
+		buf.append("\n");
+		buf.append("public class Test2 {\n");
+		buf.append("	MyEnum e= A;\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Test2.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#"};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.MyEnum;\n");
+		buf.append("\n");
+		buf.append("import static pack0.MyEnum.A;\n");
+		buf.append("\n");
+		buf.append("public class Test2 {\n");
+		buf.append("	MyEnum e= A;\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_bug135122() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class Foo extends Bar {\n");
+		buf.append("  public static final int MYCONSTANT= 9;\n");
+		buf.append("\n");
+		buf.append("  public void anotherMethod() {\n");
+		buf.append("    super.testMethod(MYCONSTANT);\n");
+		buf.append("  }\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("class Bar {\n");
+		buf.append("    public void testMethod(int something) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Foo.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#"};
+		IChooseImportQuery query= createQuery("Foo", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class Foo extends Bar {\n");
+		buf.append("  public static final int MYCONSTANT= 9;\n");
+		buf.append("\n");
+		buf.append("  public void anotherMethod() {\n");
+		buf.append("    super.testMethod(MYCONSTANT);\n");
+		buf.append("  }\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("class Bar {\n");
+		buf.append("    public void testMethod(int something) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_PackageInfoBug157541a() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("@Foo\n");
+		buf.append("package pack1;");
+		ICompilationUnit cu= pack1.createCompilationUnit("package-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack2", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("public @interface Foo {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("Foo.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#" };
+		IChooseImportQuery query= createQuery("Foo", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("@Foo\n");
+		buf.append("package pack1;\n");
+		buf.append("import pack2.Foo;\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_PackageInfoBug157541b() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("@Foo @Bar\n");
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack2.Foo;\n");
+		buf.append("\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("package-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack2", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("public @interface Foo {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("Foo.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("public @interface Bar {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("Bar.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#" };
+		IChooseImportQuery query= createQuery("Foo", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("@Foo @Bar\n");
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack2.Bar;\n");
+		buf.append("import pack2.Foo;\n");
+		buf.append("\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void test_PackageInfoBug216432() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("/**\n");
+		buf.append(" * @see Bar\n");
+		buf.append(" */\n");
+		buf.append("@Foo\n");
+		buf.append("package pack1;");
+		ICompilationUnit cu= pack1.createCompilationUnit("package-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack2= sourceFolder.createPackageFragment("pack2", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("public @interface Foo {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("Foo.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack2;\n");
+		buf.append("public @interface Bar {\n");
+		buf.append("}\n");
+		pack2.createCompilationUnit("Bar.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#" };
+		IChooseImportQuery query= createQuery("test_PackageInfoBug216432", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("/**\n");
+		buf.append(" * @see Bar\n");
+		buf.append(" */\n");
+		buf.append("@Foo\n");
+		buf.append("package pack1;\n");
+		buf.append("import pack2.Foo;\n"); // no import for Bar
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testTypeArgumentImports() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("public class B {\n");
+		buf.append("	   public B() {\n");
+		buf.append("        <File> this(null);\n"); // constructor invocation
+		buf.append("    }\n");
+		buf.append("    public <T> B(T t) {\n");
+		buf.append("    }\n");
+		buf.append("    public <T> void foo(T t) {\n");
+		buf.append("        this.<Socket> foo(null);\n");  // method invocation
+		buf.append("        new<URL> B(null);\n");  // class instance creation
+		buf.append("    }\n");
+		buf.append("    class C extends B {\n");
+		buf.append("        public C() {\n");
+		buf.append("            <Vector> super(null);\n");  // super constructor invocation
+		buf.append("            super.<HashMap> foo(null);\n"); // super method invocation
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("B.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#"};
+		IChooseImportQuery query= createQuery("B", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("import java.net.Socket;\n");
+		buf.append("import java.net.URL;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class B {\n");
+		buf.append("	   public B() {\n");
+		buf.append("        <File> this(null);\n");
+		buf.append("    }\n");
+		buf.append("    public <T> B(T t) {\n");
+		buf.append("    }\n");
+		buf.append("    public <T> void foo(T t) {\n");
+		buf.append("        this.<Socket> foo(null);\n");
+		buf.append("        new<URL> B(null);\n");
+		buf.append("    }\n");
+		buf.append("    class C extends B {\n");
+		buf.append("        public C() {\n");
+		buf.append("            <Vector> super(null);\n");
+		buf.append("            super.<HashMap> foo(null);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testAnnotationImports1() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public @interface MyAnnot1 {\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("MyAnnot1.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public @interface MyAnnot2 {\n");
+		buf.append("    int value();\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("MyAnnot2.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public @interface MyAnnot3 {\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("MyAnnot3.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("@MyAnnot3 public class Test2 {\n");
+		buf.append("    @MyAnnot1 Object e;\n");
+		buf.append("    @MyAnnot2(1) void foo() {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Test2.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import pack0.MyAnnot1;\n");
+		buf.append("import pack0.MyAnnot2;\n");
+		buf.append("import pack0.MyAnnot3;\n");
+		buf.append("\n");
+		buf.append("@MyAnnot3 public class Test2 {\n");
+		buf.append("    @MyAnnot1 Object e;\n");
+		buf.append("    @MyAnnot2(1) void foo() {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testAnnotationImports2() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack0= sourceFolder.createPackageFragment("pack0", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public @interface MyAnnot1 {\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("MyAnnot1.java", buf.toString(), false, null);
+
+		buf= new StringBuffer();
+		buf.append("package pack0;\n");
+		buf.append("public @interface MyAnnot2 {\n");
+		buf.append("    char value();\n");
+		buf.append("}\n");
+		pack0.createCompilationUnit("MyAnnot2.java", buf.toString(), false, null);
+
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("@MyAnnot1()\n");
+		buf.append("@MyAnnot2(File.separatorChar)\n");
+		buf.append("public @interface Test2 {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("Test2.java", buf.toString(), false, null);
+
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("MyClass", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuffer();
+		buf.append("package pack1;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("\n");
+		buf.append("import pack0.MyAnnot1;\n");
+		buf.append("import pack0.MyAnnot2;\n");
+		buf.append("\n");
+		buf.append("@MyAnnot1()\n");
+		buf.append("@MyAnnot2(File.separatorChar)\n");
+		buf.append("public @interface Test2 {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testJavadocImports_bug319860() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		
+		IPackageFragment pack0= sourceFolder.createPackageFragment("p", false, null);
+		StringBuffer buf= new StringBuffer();
+		buf.append("package p;\n");
+		buf.append("\n");
+		buf.append("import p.Main.I;\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * {@link I}.\n");
+		buf.append(" * @see C\n");
+		buf.append(" */\n");
+		buf.append("public class Main {\n");
+		buf.append("    public interface I {\n");
+		buf.append("    }\n");
+		buf.append("    public class C {}\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack0.createCompilationUnit("Main.java", buf.toString(), false, null);
+		
+		String[] order= new String[] {};
+		IChooseImportQuery query= createQuery("JavadocImports_bug319860", new String[] {}, new int[] {});
+		
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+		
+		buf= new StringBuffer();
+		buf.append("package p;\n");
+		buf.append("\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * {@link I}.\n");
+		buf.append(" * @see C\n");
+		buf.append(" */\n");
+		buf.append("public class Main {\n");
+		buf.append("    public interface I {\n");
+		buf.append("    }\n");
+		buf.append("    public class C {}\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	protected OrganizeImportsOperation createOperation(ICompilationUnit cu, String[] order, int threshold, boolean ignoreLowerCaseNames, boolean save, boolean allowSyntaxErrors, IChooseImportQuery chooseImportQuery) {
+		setOrganizeImportSettings(order, threshold, threshold, cu.getJavaProject());
+		return new OrganizeImportsOperation(cu, null, ignoreLowerCaseNames, save, allowSyntaxErrors, null, chooseImportQuery);
+	}
+
+	protected void setOrganizeImportSettings(String[] order, int threshold, int staticThreshold, IJavaProject project) {
+		IEclipsePreferences scope= new ProjectScope(project.getProject()).getNode("org.eclipse.jdt.ui");
+		if (order == null) {
+			scope.remove(PreferenceConstants.ORGIMPORTS_IMPORTORDER);
+			scope.remove(PreferenceConstants.ORGIMPORTS_ONDEMANDTHRESHOLD);
+		} else {
+			StringBuffer buf= new StringBuffer();
+			for (int i= 0; i < order.length; i++) {
+				buf.append(order[i]);
+				buf.append(';');
+			}
+			scope.put(PreferenceConstants.ORGIMPORTS_IMPORTORDER, buf.toString());
+			scope.put(PreferenceConstants.ORGIMPORTS_ONDEMANDTHRESHOLD, String.valueOf(threshold));
+			scope.put(PreferenceConstants.ORGIMPORTS_STATIC_ONDEMANDTHRESHOLD, String.valueOf(staticThreshold));
+		}
+	}
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/test/java/org/eclipse/che/jdt/quickfix/AssistQuickFixTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/src/test/java/org/eclipse/che/jdt/quickfix/AssistQuickFixTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
 import org.eclipse.jdt.internal.corext.template.java.CodeTemplateContextType;
@@ -6376,6 +6377,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 	@Test
 	public void testConvertAnonymousToNested2() throws Exception {
+		JavaModelManager.getIndexManager().indexAll(fJProject1.getProject());
 //		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
 		fJProject1.setOption(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
 		fJProject1.setOption(JavaCore.CODEASSIST_LOCAL_PREFIXES, "l");

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/internal/corext/codemanipulation/OrganizeImportsOperation.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/internal/corext/codemanipulation/OrganizeImportsOperation.java
@@ -1,0 +1,595 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p/>
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.corext.codemanipulation;
+
+import org.eclipse.che.jdt.util.JavaModelUtil;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.SourceRange;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.TypeNameMatch;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
+import org.eclipse.jdt.internal.corext.util.Messages;
+import org.eclipse.jdt.internal.corext.util.Strings;
+import org.eclipse.jdt.internal.corext.util.TypeNameMatchCollector;
+import org.eclipse.jdt.internal.ui.text.correction.ASTResolving;
+import org.eclipse.jdt.internal.ui.text.correction.SimilarElementsRequestor;
+import org.eclipse.jdt.internal.ui.viewsupport.BasicElementLabels;
+import org.eclipse.jdt.ui.SharedASTProvider;
+import org.eclipse.text.edits.TextEdit;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class OrganizeImportsOperation implements IWorkspaceRunnable {
+    public static interface IChooseImportQuery {
+        /**
+         * Selects imports from a list of choices.
+         *
+         * @param openChoices
+         *         From each array, a type reference has to be selected
+         * @param ranges
+         *         For each choice the range of the corresponding  type reference.
+         * @return Returns <code>null</code> to cancel the operation, or the
+         * selected imports.
+         */
+        TypeNameMatch[] chooseImports(TypeNameMatch[][] openChoices, ISourceRange[] ranges);
+    }
+
+
+    private static class TypeReferenceProcessor {
+
+        private static class UnresolvedTypeData {
+            final SimpleName          ref;
+            final int                 typeKinds;
+            final List<TypeNameMatch> foundInfos;
+
+            public UnresolvedTypeData(SimpleName ref) {
+                this.ref = ref;
+                this.typeKinds = ASTResolving.getPossibleTypeKinds(ref, true);
+                this.foundInfos = new ArrayList<TypeNameMatch>(3);
+            }
+
+            public void addInfo(TypeNameMatch info) {
+                for (int i = this.foundInfos.size() - 1; i >= 0; i--) {
+                    TypeNameMatch curr = this.foundInfos.get(i);
+                    if (curr.getTypeContainerName().equals(info.getTypeContainerName())) {
+                        return; // not added. already contains type with same name
+                    }
+                }
+                foundInfos.add(info);
+            }
+        }
+
+        private Set<String> fOldSingleImports;
+        private Set<String> fOldDemandImports;
+
+        private Set<String> fImplicitImports;
+
+        private ImportRewrite fImpStructure;
+
+        private boolean fDoIgnoreLowerCaseNames;
+
+        private IPackageFragment fCurrPackage;
+
+        private ScopeAnalyzer fAnalyzer;
+        private boolean       fAllowDefaultPackageImports;
+
+        private Map<String, UnresolvedTypeData> fUnresolvedTypes;
+        private Set<String>                     fImportsAdded;
+        private TypeNameMatch[][]               fOpenChoices;
+        private SourceRange[]                   fSourceRanges;
+
+
+        public TypeReferenceProcessor(Set<String> oldSingleImports, Set<String> oldDemandImports, CompilationUnit root,
+                                      ImportRewrite impStructure, boolean ignoreLowerCaseNames) {
+            fOldSingleImports = oldSingleImports;
+            fOldDemandImports = oldDemandImports;
+            fImpStructure = impStructure;
+            fDoIgnoreLowerCaseNames = ignoreLowerCaseNames;
+
+            ICompilationUnit cu = impStructure.getCompilationUnit();
+
+            fImplicitImports = new HashSet<String>(3);
+            fImplicitImports.add(""); //$NON-NLS-1$
+            fImplicitImports.add("java.lang"); //$NON-NLS-1$
+            fImplicitImports.add(cu.getParent().getElementName());
+
+            fAnalyzer = new ScopeAnalyzer(root);
+
+            fCurrPackage = (IPackageFragment)cu.getParent();
+
+            fAllowDefaultPackageImports = cu.getJavaProject().getOption(JavaCore.COMPILER_SOURCE, true).equals(JavaCore.VERSION_1_3);
+
+            fImportsAdded = new HashSet<String>();
+            fUnresolvedTypes = new HashMap<String, UnresolvedTypeData>();
+        }
+
+        private boolean needsImport(ITypeBinding typeBinding, SimpleName ref) {
+            if (!typeBinding.isTopLevel() && !typeBinding.isMember() || typeBinding.isRecovered()) {
+                return false; // no imports for anonymous, local, primitive types or parameters types
+            }
+            int modifiers = typeBinding.getModifiers();
+            if (Modifier.isPrivate(modifiers)) {
+                return false; // imports for privates are not required
+            }
+            ITypeBinding currTypeBinding = Bindings.getBindingOfParentType(ref);
+            if (currTypeBinding == null) {
+                if (ASTNodes.getParent(ref, ASTNode.PACKAGE_DECLARATION) != null) {
+                    return true; // reference in package-info.java
+                }
+                return false; // not in a type
+            }
+            if (!Modifier.isPublic(modifiers)) {
+                if (!currTypeBinding.getPackage().getName().equals(typeBinding.getPackage().getName())) {
+                    return false; // not visible
+                }
+            }
+
+            ASTNode parent = ref.getParent();
+            while (parent instanceof Type) {
+                parent = parent.getParent();
+            }
+            if (parent instanceof AbstractTypeDeclaration && parent.getParent() instanceof CompilationUnit) {
+                return true;
+            }
+
+            if (typeBinding.isMember()) {
+                if (fAnalyzer.isDeclaredInScope(typeBinding, ref, ScopeAnalyzer.TYPES | ScopeAnalyzer.CHECK_VISIBILITY))
+                    return false;
+            }
+            return true;
+        }
+
+
+        /**
+         * Tries to find the given type name and add it to the import structure.
+         *
+         * @param ref
+         *         the name node
+         */
+        public void add(SimpleName ref) {
+            String typeName = ref.getIdentifier();
+
+            if (fImportsAdded.contains(typeName)) {
+                return;
+            }
+
+            IBinding binding = ref.resolveBinding();
+            if (binding != null) {
+                if (binding.getKind() != IBinding.TYPE) {
+                    return;
+                }
+                ITypeBinding typeBinding = (ITypeBinding)binding;
+                if (typeBinding.isArray()) {
+                    typeBinding = typeBinding.getElementType();
+                }
+                typeBinding = typeBinding.getTypeDeclaration();
+                if (!typeBinding.isRecovered()) {
+                    if (needsImport(typeBinding, ref)) {
+                        fImpStructure.addImport(typeBinding);
+                        fImportsAdded.add(typeName);
+                    }
+                    return;
+                }
+            } else {
+                if (fDoIgnoreLowerCaseNames && typeName.length() > 0) {
+                    char ch = typeName.charAt(0);
+                    if (Strings.isLowerCase(ch) && Character.isLetter(ch)) {
+                        return;
+                    }
+                }
+            }
+            fImportsAdded.add(typeName);
+            fUnresolvedTypes.put(typeName, new UnresolvedTypeData(ref));
+        }
+
+        public boolean process(IProgressMonitor monitor) throws JavaModelException {
+            try {
+                int nUnresolved = fUnresolvedTypes.size();
+                if (nUnresolved == 0) {
+                    return false;
+                }
+                char[][] allTypes = new char[nUnresolved][];
+                int i = 0;
+                for (Iterator<String> iter = fUnresolvedTypes.keySet().iterator(); iter.hasNext(); ) {
+                    allTypes[i++] = iter.next().toCharArray();
+                }
+                final ArrayList<TypeNameMatch> typesFound = new ArrayList<TypeNameMatch>();
+                final IJavaProject project = fCurrPackage.getJavaProject();
+                IJavaSearchScope scope = SearchEngine.createJavaSearchScope(new IJavaElement[]{project});
+                TypeNameMatchCollector collector = new TypeNameMatchCollector(typesFound);
+                new SearchEngine()
+                        .searchAllTypeNames(null, allTypes, scope, collector, IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH, monitor);
+
+                boolean is50OrHigher = JavaModelUtil.is50OrHigher(project);
+
+                for (i = 0; i < typesFound.size(); i++) {
+                    TypeNameMatch curr = typesFound.get(i);
+                    UnresolvedTypeData data = fUnresolvedTypes.get(curr.getSimpleTypeName());
+                    if (data != null && isVisible(curr) && isOfKind(curr, data.typeKinds, is50OrHigher)) {
+                        if (fAllowDefaultPackageImports || curr.getPackageName().length() > 0) {
+                            data.addInfo(curr);
+                        }
+                    }
+                }
+
+                ArrayList<TypeNameMatch[]> openChoices = new ArrayList<TypeNameMatch[]>(nUnresolved);
+                ArrayList<SourceRange> sourceRanges = new ArrayList<SourceRange>(nUnresolved);
+                for (Iterator<UnresolvedTypeData> iter = fUnresolvedTypes.values().iterator(); iter.hasNext(); ) {
+                    UnresolvedTypeData data = iter.next();
+                    TypeNameMatch[] openChoice = processTypeInfo(data.foundInfos);
+                    if (openChoice != null) {
+                        openChoices.add(openChoice);
+                        sourceRanges.add(new SourceRange(data.ref.getStartPosition(), data.ref.getLength()));
+                    }
+                }
+                if (openChoices.isEmpty()) {
+                    return false;
+                }
+                fOpenChoices = openChoices.toArray(new TypeNameMatch[openChoices.size()][]);
+                fSourceRanges = sourceRanges.toArray(new SourceRange[sourceRanges.size()]);
+                return true;
+            } finally {
+                monitor.done();
+            }
+        }
+
+        private TypeNameMatch[] processTypeInfo(List<TypeNameMatch> typeRefsFound) {
+            int nFound = typeRefsFound.size();
+            if (nFound == 0) {
+                // nothing found
+                return null;
+            } else if (nFound == 1) {
+                TypeNameMatch typeRef = typeRefsFound.get(0);
+                fImpStructure.addImport(typeRef.getFullyQualifiedName());
+                return null;
+            } else {
+                String typeToImport = null;
+                boolean ambiguousImports = false;
+
+                // multiple found, use old imports to find an entry
+                for (int i = 0; i < nFound; i++) {
+                    TypeNameMatch typeRef = typeRefsFound.get(i);
+                    String fullName = typeRef.getFullyQualifiedName();
+                    String containerName = typeRef.getTypeContainerName();
+                    if (fOldSingleImports.contains(fullName)) {
+                        // was single-imported
+                        fImpStructure.addImport(fullName);
+                        return null;
+                    } else if (fOldDemandImports.contains(containerName) || fImplicitImports.contains(containerName)) {
+                        if (typeToImport == null) {
+                            typeToImport = fullName;
+                        } else {  // more than one import-on-demand
+                            ambiguousImports = true;
+                        }
+                    }
+                }
+
+                if (typeToImport != null && !ambiguousImports) {
+                    fImpStructure.addImport(typeToImport);
+                    return null;
+                }
+                // return the open choices
+                return typeRefsFound.toArray(new TypeNameMatch[nFound]);
+            }
+        }
+
+        private boolean isOfKind(TypeNameMatch curr, int typeKinds, boolean is50OrHigher) {
+            int flags = curr.getModifiers();
+            if (Flags.isAnnotation(flags)) {
+                return is50OrHigher && (typeKinds & SimilarElementsRequestor.ANNOTATIONS) != 0;
+            }
+            if (Flags.isEnum(flags)) {
+                return is50OrHigher && (typeKinds & SimilarElementsRequestor.ENUMS) != 0;
+            }
+            if (Flags.isInterface(flags)) {
+                return (typeKinds & SimilarElementsRequestor.INTERFACES) != 0;
+            }
+            return (typeKinds & SimilarElementsRequestor.CLASSES) != 0;
+        }
+
+        private boolean isVisible(TypeNameMatch curr) {
+            int flags = curr.getModifiers();
+            if (Flags.isPrivate(flags)) {
+                return false;
+            }
+            if (Flags.isPublic(flags) || Flags.isProtected(flags)) {
+                return true;
+            }
+            return curr.getPackageName().equals(fCurrPackage.getElementName());
+        }
+
+        public TypeNameMatch[][] getChoices() {
+            return fOpenChoices;
+        }
+
+        public ISourceRange[] getChoicesSourceRanges() {
+            return fSourceRanges;
+        }
+    }
+
+    private boolean fDoSave;
+
+    private boolean fIgnoreLowerCaseNames;
+
+    private IChooseImportQuery fChooseImportQuery;
+
+    private int fNumberOfImportsAdded;
+    private int fNumberOfImportsRemoved;
+
+    private IProblem         fParsingError;
+    private ICompilationUnit fCompilationUnit;
+
+    private CompilationUnit        fASTRoot;
+    private TextEdit               edit;
+    private TypeReferenceProcessor processor;
+    private boolean                hasOpenChoices;
+
+    private TypeNameMatch[][] choices;
+    private List<String>      chosenFQN;
+
+    private final boolean fAllowSyntaxErrors;
+
+    public OrganizeImportsOperation(ICompilationUnit cu,
+                                    CompilationUnit astRoot,
+                                    boolean ignoreLowerCaseNames,
+                                    boolean save,
+                                    boolean allowSyntaxErrors,
+                                    List<String> chosen,
+                                    IChooseImportQuery chooseImportQuery) {
+        fCompilationUnit = cu;
+        fASTRoot = astRoot;
+
+        fDoSave = save;
+        fIgnoreLowerCaseNames = ignoreLowerCaseNames;
+        fAllowSyntaxErrors = allowSyntaxErrors;
+        fChooseImportQuery = chooseImportQuery;
+
+        fNumberOfImportsAdded = 0;
+        fNumberOfImportsRemoved = 0;
+
+        fParsingError = null;
+
+        chosenFQN = chosen;
+    }
+
+    /**
+     * Runs the operation.
+     *
+     * @param monitor
+     *         the progress monitor
+     * @throws CoreException
+     *         thrown when the operation failed
+     * @throws OperationCanceledException
+     *         Runtime error thrown when operation is canceled.
+     */
+    public void run(IProgressMonitor monitor) throws CoreException, OperationCanceledException {
+        if (monitor == null) {
+            monitor = new NullProgressMonitor();
+        }
+        try {
+            monitor.beginTask(Messages.format(CodeGenerationMessages.OrganizeImportsOperation_description,
+                                              BasicElementLabels.getFileName(fCompilationUnit)), 10);
+
+            edit = createTextEdit(new SubProgressMonitor(monitor, 9));
+            if (edit == null)
+                return;
+
+            JavaModelUtil.applyEdit(fCompilationUnit, edit, fDoSave, new SubProgressMonitor(monitor, 1));
+        } finally {
+            monitor.done();
+        }
+    }
+
+    public void applyChanges(TextEdit edit, IProgressMonitor monitor) throws CoreException {
+        if (edit == null) {
+            return;
+        }
+
+        JavaModelUtil.applyEdit(fCompilationUnit, edit, fDoSave, new SubProgressMonitor(monitor, 1));
+    }
+
+    public TextEdit createTextEdit(IProgressMonitor monitor) throws CoreException, OperationCanceledException {
+        if (monitor == null) {
+            monitor = new NullProgressMonitor();
+        }
+        try {
+            fNumberOfImportsAdded = 0;
+            fNumberOfImportsRemoved = 0;
+
+            monitor.beginTask(Messages.format(CodeGenerationMessages.OrganizeImportsOperation_description,
+                                              BasicElementLabels.getFileName(fCompilationUnit)), 9);
+
+            CompilationUnit astRoot = fASTRoot;
+            if (astRoot == null) {
+                astRoot = SharedASTProvider.getAST(fCompilationUnit, SharedASTProvider.WAIT_YES, new SubProgressMonitor(monitor, 2));
+                if (monitor.isCanceled())
+                    throw new OperationCanceledException();
+            } else {
+                monitor.worked(2);
+            }
+
+            ImportRewrite importsRewrite = StubUtility.createImportRewrite(astRoot, false);
+
+            Set<String> oldSingleImports = new HashSet<>();
+            Set<String> oldDemandImports = new HashSet<>();
+            List<SimpleName> typeReferences = new ArrayList<>();
+            List<SimpleName> staticReferences = new ArrayList<>();
+
+            if (!collectReferences(astRoot, typeReferences, staticReferences, oldSingleImports, oldDemandImports))
+                return null;
+
+            monitor.worked(1);
+
+            processor = new TypeReferenceProcessor(oldSingleImports, oldDemandImports, astRoot, importsRewrite, fIgnoreLowerCaseNames);
+
+            Iterator<SimpleName> refIterator = typeReferences.iterator();
+            while (refIterator.hasNext()) {
+                SimpleName typeRef = refIterator.next();
+                processor.add(typeRef);
+            }
+
+            hasOpenChoices = processor.process(new SubProgressMonitor(monitor, 3));
+            addStaticImports(staticReferences, importsRewrite);
+
+            if (hasOpenChoices) {
+                choices = processor.getChoices();
+                ISourceRange[] ranges = processor.getChoicesSourceRanges();
+                if (fChooseImportQuery != null) {
+                    TypeNameMatch[] chosen = fChooseImportQuery.chooseImports(choices, ranges);
+                    for (int i = 0; i < chosen.length; i++) {
+                        TypeNameMatch typeInfo = chosen[i];
+                        importsRewrite.addImport(typeInfo.getFullyQualifiedName());
+                    }
+                } else if (chosenFQN != null) {
+                    chosenFQN.forEach(importsRewrite::addImport);
+                }
+            }
+
+            TextEdit result = importsRewrite.rewriteImports(new SubProgressMonitor(monitor, 3));
+
+            determineImportDifferences(importsRewrite, oldSingleImports, oldDemandImports);
+
+            return result;
+        } finally {
+            monitor.done();
+        }
+    }
+
+    public TypeNameMatch[][] getChoices() {
+        return choices;
+    }
+
+    private void determineImportDifferences(ImportRewrite importsStructure, Set<String> oldSingleImports, Set<String> oldDemandImports) {
+        ArrayList<String> importsAdded = new ArrayList<String>();
+        importsAdded.addAll(Arrays.asList(importsStructure.getCreatedImports()));
+        importsAdded.addAll(Arrays.asList(importsStructure.getCreatedStaticImports()));
+
+        Object[] content = oldSingleImports.toArray();
+        for (int i = 0; i < content.length; i++) {
+            String importName = (String)content[i];
+            if (importsAdded.remove(importName))
+                oldSingleImports.remove(importName);
+        }
+        content = oldDemandImports.toArray();
+        for (int i = 0; i < content.length; i++) {
+            String importName = (String)content[i];
+            if (importsAdded.remove(importName + ".*")) //$NON-NLS-1$
+                oldDemandImports.remove(importName);
+        }
+        fNumberOfImportsAdded = importsAdded.size();
+        fNumberOfImportsRemoved = oldSingleImports.size() + oldDemandImports.size();
+    }
+
+
+    private void addStaticImports(List<SimpleName> staticReferences, ImportRewrite importsStructure) {
+        for (int i = 0; i < staticReferences.size(); i++) {
+            Name name = staticReferences.get(i);
+            IBinding binding = name.resolveBinding();
+            if (binding != null) { // paranoia check
+                importsStructure.addStaticImport(binding);
+            }
+        }
+    }
+
+
+    // find type references in a compilation unit
+    private boolean collectReferences(CompilationUnit astRoot, List<SimpleName> typeReferences, List<SimpleName> staticReferences,
+                                      Set<String> oldSingleImports, Set<String> oldDemandImports) {
+        if (!fAllowSyntaxErrors) {
+            IProblem[] problems = astRoot.getProblems();
+            for (int i = 0; i < problems.length; i++) {
+                IProblem curr = problems[i];
+                if (curr.isError() && (curr.getID() & IProblem.Syntax) != 0) {
+                    fParsingError = problems[i];
+                    return false;
+                }
+            }
+        }
+        List<ImportDeclaration> imports = astRoot.imports();
+        for (int i = 0; i < imports.size(); i++) {
+            ImportDeclaration curr = imports.get(i);
+            String id = ASTResolving.getFullName(curr.getName());
+            if (curr.isOnDemand()) {
+                oldDemandImports.add(id);
+            } else {
+                oldSingleImports.add(id);
+            }
+        }
+
+        IJavaProject project = fCompilationUnit.getJavaProject();
+        ImportReferencesCollector.collect(astRoot, project, null, typeReferences, staticReferences);
+
+        return true;
+    }
+
+    /**
+     * After executing the operation, returns <code>null</code> if the operation has been executed successfully or
+     * the range where parsing failed.
+     *
+     * @return returns the parse error
+     */
+    public IProblem getParseError() {
+        return fParsingError;
+    }
+
+    public int getNumberOfImportsAdded() {
+        return fNumberOfImportsAdded;
+    }
+
+    public int getNumberOfImportsRemoved() {
+        return fNumberOfImportsRemoved;
+    }
+
+    /**
+     * @return Returns the scheduling rule for this operation
+     */
+    public ISchedulingRule getScheduleRule() {
+        return fCompilationUnit.getResource();
+    }
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui;
 
+import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -36,6 +37,8 @@ import java.util.StringTokenizer;
  * @noextend This class is not intended to be subclassed by clients.
   */
 public class PreferenceConstants {
+
+	public static final String ID_PLUGIN = "org.eclipse.jdt.ui";
 
 	private PreferenceConstants() {
 	}
@@ -4083,18 +4086,17 @@ public class PreferenceConstants {
 	 * @since 3.1
 	 */
 	public static String getPreference(String key, IJavaProject project) {
-//		String val;
-//		if (project != null) {
-//			val = new ProjectScope(project.getProject()).getNode(JavaUI.ID_PLUGIN).get(key, null);
-//			if (val != null) {
-//				return val;
-//			}
-//		}
-//		val = InstanceScope.INSTANCE.getNode(JavaUI.ID_PLUGIN).get(key, null);
-//		if (val != null) {
-//			return val;
-//		}
-//		return DefaultScope.INSTANCE.getNode(JavaUI.ID_PLUGIN).get(key, null);
+		String val;
+		if (project != null) {
+			val = new ProjectScope(project.getProject()).getNode(ID_PLUGIN).get(key, null);
+			if (val != null && !val.isEmpty()) {
+				return val;
+			}
+		}
+		val = InstanceScope.INSTANCE.getNode(ID_PLUGIN).get(key, null);
+		if (val != null) {
+			return val;
+		}
 		return getPreferenceStore().getString(key);
 	}
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaExtension.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaExtension.java
@@ -24,13 +24,14 @@ import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.KeyBuilder;
+import org.eclipse.che.ide.ext.java.client.action.FileStructureAction;
 import org.eclipse.che.ide.ext.java.client.action.FindUsagesAction;
 import org.eclipse.che.ide.ext.java.client.action.NewJavaSourceFileAction;
 import org.eclipse.che.ide.ext.java.client.action.NewPackageAction;
 import org.eclipse.che.ide.ext.java.client.action.OpenDeclarationAction;
 import org.eclipse.che.ide.ext.java.client.action.OpenImplementationAction;
+import org.eclipse.che.ide.ext.java.client.action.OrganizeImportsAction;
 import org.eclipse.che.ide.ext.java.client.action.QuickDocumentationAction;
-import org.eclipse.che.ide.ext.java.client.action.FileStructureAction;
 import org.eclipse.che.ide.ext.java.client.refactoring.move.CutJavaSourceAction;
 import org.eclipse.che.ide.ext.java.client.refactoring.move.MoveAction;
 import org.eclipse.che.ide.ext.java.client.refactoring.rename.RenameRefactoringAction;
@@ -72,6 +73,7 @@ public class JavaExtension {
                                 MoveAction moveAction,
                                 CutJavaSourceAction cutAction,
                                 FileStructureAction fileStructureAction,
+                                OrganizeImportsAction organizeImportsAction,
                                 RenameRefactoringAction renameRefactoringAction,
                                 QuickDocumentationAction quickDocumentationAction,
                                 OpenDeclarationAction openDeclarationAction,
@@ -106,9 +108,11 @@ public class JavaExtension {
         actionManager.registerAction("javaCutRefactoring", cutAction);
         actionManager.registerAction("javaFindUsages", findUsagesAction);
         actionManager.registerAction("javaClassStructure", fileStructureAction);
+        actionManager.registerAction("organizeImports", organizeImportsAction);
 
         assistantGroup.add(quickDocumentationAction, new Constraints(Anchor.BEFORE, GROUP_ASSISTANT_REFACTORING));
         assistantGroup.add(openDeclarationAction, new Constraints(Anchor.BEFORE, GROUP_ASSISTANT_REFACTORING));
+        assistantGroup.add(organizeImportsAction, new Constraints(Anchor.BEFORE, GROUP_ASSISTANT_REFACTORING));
         assistantGroup.add(openImplementationAction, new Constraints(Anchor.BEFORE, GROUP_ASSISTANT_REFACTORING));
         assistantGroup.add(fileStructureAction, new Constraints(Anchor.BEFORE, GROUP_ASSISTANT_REFACTORING));
         assistantGroup.add(findUsagesAction, new Constraints(Anchor.BEFORE, GROUP_ASSISTANT_REFACTORING));
@@ -117,10 +121,12 @@ public class JavaExtension {
             keyBinding.getGlobal().addKey(new KeyBuilder().alt().control().charCode('b').build(), "openImplementation");
             keyBinding.getGlobal().addKey(new KeyBuilder().control().charCode('j').build(), "showQuickDoc");
             keyBinding.getGlobal().addKey(new KeyBuilder().control().charCode(KeyCodeMap.F12).build(), "javaClassStructure");
+            keyBinding.getGlobal().addKey(new KeyBuilder().alt().control().charCode('o').build(), "organizeImports");
         } else {
             keyBinding.getGlobal().addKey(new KeyBuilder().alt().action().charCode('b').build(), "openImplementation");
             keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('q').build(), "showQuickDoc");
             keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode(KeyCodeMap.F12).build(), "javaClassStructure");
+            keyBinding.getGlobal().addKey(new KeyBuilder().alt().action().charCode('o').build(), "organizeImports");
         }
         keyBinding.getGlobal().addKey(new KeyBuilder().none().charCode(KeyCodeMap.F4).build(), "openJavaDeclaration");
         keyBinding.getGlobal().addKey(new KeyBuilder().shift().charCode(KeyCodeMap.F6).build(), "javaRenameRefactoring");

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.java
@@ -129,6 +129,27 @@ public interface JavaLocalizationConstant extends Messages {
     @Key("file.structure.action.description")
     String fileStructureActionDescription();
 
+    @Key("organize.imports.name")
+    String organizeImportsName();
+
+    @Key("organize.imports.description")
+    String organizeImportsDescription();
+
+    @Key("organize.imports.failed.title")
+    String failedToProcessOrganizeImports();
+
+    @Key("organize.imports.button.finish")
+    String organizeImportsButtonFinish();
+
+    @Key("organize.imports.button.cancel")
+    String organizeImportsButtonCancel();
+
+    @Key("organize.imports.button.next")
+    String organizeImportsButtonNext();
+
+    @Key("organize.imports.button.back")
+    String organizeImportsButtonBack();
+
     @Key("show.inherited.members.label")
     String showInheritedMembersLabel();
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/OrganizeImportsAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/OrganizeImportsAction.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.action;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
+import org.eclipse.che.ide.ext.java.client.organizeimports.OrganizeImportsPresenter;
+
+/**
+ * Organizes the imports of a compilation unit.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class OrganizeImportsAction extends JavaEditorAction implements ProposalAction {
+    public final static String JAVA_ORGANIZE_IMPORT_ID = "javaOrganizeImports";
+
+    private final EditorAgent              editorAgent;
+    private final OrganizeImportsPresenter organizeImportsPresenter;
+
+    @Inject
+    public OrganizeImportsAction(JavaLocalizationConstant locale,
+                                 EditorAgent editorAgent,
+                                 OrganizeImportsPresenter organizeImportsPresenter) {
+        super(locale.organizeImportsName(), locale.organizeImportsDescription(), null, editorAgent);
+        this.editorAgent = editorAgent;
+        this.organizeImportsPresenter = organizeImportsPresenter;
+    }
+
+    @Override
+    public void performAsProposal() {
+        actionPerformed(null);
+    }
+
+    @Override
+    public String getId() {
+        return JAVA_ORGANIZE_IMPORT_ID;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        final EditorPartPresenter editor = editorAgent.getActiveEditor();
+        organizeImportsPresenter.organizeImports(editor);
+    }
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/ProposalAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/ProposalAction.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.action;
+
+/**
+ * This interface is a general type for all completion proposal actions.
+ * You must implement the interface when you add new completion action.
+ *
+ * @author Valeriy Svydenko
+ */
+public interface ProposalAction {
+    /** Implement this method to provide proposal action handler */
+    void performAsProposal();
+
+    /** Returns action id */
+    String getId();
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/ActionCompletionProposal.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/ActionCompletionProposal.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.ext.java.client.editor;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.eclipse.che.ide.api.icon.Icon;
+import org.eclipse.che.ide.ext.java.client.action.ProposalAction;
 import org.eclipse.che.ide.jseditor.client.codeassist.CompletionProposal;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -21,13 +22,15 @@ import org.eclipse.che.ide.util.loging.Log;
  */
 public class ActionCompletionProposal implements CompletionProposal {
 
-    private final String               display;
-    private final String               actionId;
-    private final Icon                 icon;
+    private final String         display;
+    private final String         actionId;
+    private final ProposalAction action;
+    private final Icon           icon;
 
-    public ActionCompletionProposal(String display, String actionId, Icon icon) {
+    public ActionCompletionProposal(String display, String actionId, ProposalAction action, Icon icon) {
         this.display = display;
         this.actionId = actionId;
+        this.action = action;
         this.icon = icon;
     }
 
@@ -48,6 +51,10 @@ public class ActionCompletionProposal implements CompletionProposal {
 
     @Override
     public void getCompletion(CompletionCallback callback) {
-        Log.error(getClass(), "Can't run Action " + actionId);
+        if (action == null) {
+            Log.error(getClass(), "Can't run Action " + actionId);
+        } else {
+            action.performAsProposal();
+        }
     }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/inject/JavaGinModule.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/inject/JavaGinModule.java
@@ -26,6 +26,8 @@ import org.eclipse.che.ide.api.project.node.settings.SettingsProvider;
 import org.eclipse.che.ide.api.reference.FqnProvider;
 import org.eclipse.che.ide.ext.java.client.CurrentClassFQNProvider;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
+import org.eclipse.che.ide.ext.java.client.action.OrganizeImportsAction;
+import org.eclipse.che.ide.ext.java.client.action.ProposalAction;
 import org.eclipse.che.ide.ext.java.client.dependenciesupdater.JavaClasspathServiceClient;
 import org.eclipse.che.ide.ext.java.client.dependenciesupdater.JavaClasspathServiceClientImpl;
 import org.eclipse.che.ide.ext.java.client.documentation.QuickDocPresenter;
@@ -50,6 +52,8 @@ import org.eclipse.che.ide.ext.java.client.settings.property.PropertyWidgetImpl;
 import org.eclipse.che.ide.extension.machine.client.command.valueproviders.CommandPropertyValueProvider;
 import org.eclipse.che.ide.settings.common.SettingsPagePresenter;
 
+import static org.eclipse.che.ide.ext.java.client.action.OrganizeImportsAction.JAVA_ORGANIZE_IMPORT_ID;
+
 /**
  * @author Evgen Vidolob
  * @author Artem Zatsarynnyi
@@ -60,6 +64,9 @@ public class JavaGinModule extends AbstractGinModule {
     /** {@inheritDoc} */
     @Override
     protected void configure() {
+        GinMapBinder<String, ProposalAction> proposalActionMapBinder = GinMapBinder.newMapBinder(binder(), String.class, ProposalAction.class);
+        proposalActionMapBinder.addBinding(JAVA_ORGANIZE_IMPORT_ID).to(OrganizeImportsAction.class);
+
         bind(NewJavaSourceFileView.class).to(NewJavaSourceFileViewImpl.class).in(Singleton.class);
         bind(QuickDocumentation.class).to(QuickDocPresenter.class).in(Singleton.class);
         bind(JavaNavigationService.class).to(JavaNavigationServiceImpl.class);

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
@@ -1,0 +1,250 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.organizeimports;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.project.gwt.client.ProjectServiceClient;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+import org.eclipse.che.ide.api.texteditor.HandlesUndoRedo;
+import org.eclipse.che.ide.api.texteditor.UndoableEditor;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
+import org.eclipse.che.ide.ext.java.client.editor.JavaCodeAssistClient;
+import org.eclipse.che.ide.ext.java.client.projecttree.JavaSourceFolderUtil;
+import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+import org.eclipse.che.ide.jseditor.client.document.Document;
+import org.eclipse.che.ide.jseditor.client.texteditor.TextEditor;
+import org.eclipse.che.ide.rest.AsyncRequestCallback;
+import org.eclipse.che.ide.rest.StringUnmarshaller;
+import org.eclipse.che.ide.util.loging.Log;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
+
+/**
+ * The class that manages conflicts with organize imports if if they occur.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDelegate {
+    private final OrganizeImportsView      view;
+    private final JavaCodeAssistClient     javaCodeAssistClient;
+    private final AppContext               appContext;
+    private final DtoFactory               dtoFactory;
+    private final JavaLocalizationConstant locale;
+    private final NotificationManager      notificationManager;
+
+    private int                     page;
+    private List<ConflictImportDTO> choices;
+    private Map<Integer, String>    selected;
+    private VirtualFile             file;
+    private ProjectServiceClient    projectService;
+    private Document                document;
+    private EditorPartPresenter     editor;
+
+    @Inject
+    public OrganizeImportsPresenter(OrganizeImportsView view,
+                                    AppContext appContext,
+                                    ProjectServiceClient projectService,
+                                    JavaCodeAssistClient javaCodeAssistClient,
+                                    DtoFactory dtoFactory,
+                                    JavaLocalizationConstant locale,
+                                    NotificationManager notificationManager) {
+        this.view = view;
+        this.projectService = projectService;
+        this.javaCodeAssistClient = javaCodeAssistClient;
+        this.view.setDelegate(this);
+
+        this.appContext = appContext;
+        this.dtoFactory = dtoFactory;
+        this.locale = locale;
+        this.notificationManager = notificationManager;
+    }
+
+    /**
+     * Make Organize imports operation. If the operation doesn't have conflicts all imports will be applied
+     * otherwise a special window will be showed for resolving conflicts.
+     *
+     * @param editor
+     *         current active editor
+     */
+    public void organizeImports(EditorPartPresenter editor) {
+        this.editor = editor;
+        this.document = ((TextEditor)editor).getDocument();
+        this.file = editor.getEditorInput().getFile();
+
+
+        final String projectPath = file.getProject().getProjectConfig().getPath();
+        final String fqn = JavaSourceFolderUtil.getFQNForFile(file);
+
+        javaCodeAssistClient.organizeImports(projectPath, fqn)
+                            .then(new Operation<List<ConflictImportDTO>>() {
+                                @Override
+                                public void apply(List<ConflictImportDTO> choices) throws OperationException {
+                                    if (!choices.isEmpty()) {
+                                        show(choices);
+                                    } else {
+                                        applyChanges(file);
+                                    }
+                                }
+                            })
+                            .catchError(new Operation<PromiseError>() {
+                                @Override
+                                public void apply(PromiseError arg) throws OperationException {
+                                    notificationManager.notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, true);
+                                }
+                            });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onNextButtonClicked() {
+        selected.put(page++, view.getSelectedImport());
+        if (!selected.containsKey(page)) {
+            String newSelection = choices.get(page).getTypeMatches().get(0);
+            selected.put(page, newSelection);
+        }
+        view.setSelectedImport(selected.get(page));
+        view.changePage(choices.get(page));
+        updateButtonsState();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onBackButtonClicked() {
+        selected.put(page--, view.getSelectedImport());
+        view.setSelectedImport(selected.get(page));
+        view.changePage(choices.get(page));
+        updateButtonsState();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onFinishButtonClicked() {
+        selected.put(page, view.getSelectedImport());
+
+        ConflictImportDTO result = dtoFactory.createDto(ConflictImportDTO.class).withTypeMatches(new ArrayList<>(selected.values()));
+
+        String projectPath = file.getProject().getProjectConfig().getPath();
+        String fqn = JavaSourceFolderUtil.getFQNForFile(file);
+
+        javaCodeAssistClient.applyChosenImports(projectPath, fqn, result)
+                            .then(new Operation<Void>() {
+                                @Override
+                                public void apply(Void arg) throws OperationException {
+                                    applyChanges(file);
+                                    view.hide();
+                                    ((TextEditor)editor).setFocus();
+                                }
+                            })
+                            .catchError(new Operation<PromiseError>() {
+                                @Override
+                                public void apply(PromiseError arg) throws OperationException {
+                                    notificationManager.notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, true);
+                                }
+                            });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onCancelButtonClicked() {
+        ((TextEditor)editor).setFocus();
+    }
+
+    /** Show Organize Imports panel with the special information. */
+    private void show(List<ConflictImportDTO> choices) {
+        if (choices == null || choices.isEmpty()) {
+            return;
+        }
+
+        this.choices = choices;
+
+        page = 0;
+        selected = new HashMap<>(choices.size());
+
+        String selection = choices.get(0).getTypeMatches().get(0);
+        selected.put(page, selection);
+        view.setSelectedImport(selection);
+
+        updateButtonsState();
+
+        view.show(choices.get(page));
+    }
+
+    /**
+     * Update content of the file.
+     *
+     * @param file
+     *         current file
+     */
+    private void applyChanges(VirtualFile file) {
+        HandlesUndoRedo undoRedo = null;
+        if (editor instanceof UndoableEditor) {
+            undoRedo = ((UndoableEditor)editor).getUndoRedo();
+        }
+        try {
+            if (undoRedo != null) {
+                undoRedo.beginCompoundChange();
+            }
+            replaceContent(file, document);
+        } catch (final Exception e) {
+            Log.error(getClass(), e);
+        } finally {
+            if (undoRedo != null) {
+                undoRedo.endCompoundChange();
+            }
+        }
+    }
+
+    private void replaceContent(VirtualFile file, final Document document) {
+        projectService.getFileContent(appContext.getWorkspaceId(),
+                                      file.getPath(),
+                                      new AsyncRequestCallback<String>(new StringUnmarshaller()) {
+                                          @Override
+                                          protected void onSuccess(String result) {
+                                              document.replace(0, document.getContents().length(), result);
+                                          }
+
+                                          @Override
+                                          protected void onFailure(Throwable exception) {
+                                              Log.error(getClass(), exception);
+                                          }
+                                      });
+    }
+
+    private void updateButtonsState() {
+        view.setEnableBackButton(!isFirstPage());
+        view.setEnableNextButton(!isLastPage());
+        view.setEnableFinishButton(selected.size() == choices.size());
+    }
+
+    private boolean isFirstPage() {
+        return page == 0;
+    }
+
+    private boolean isLastPage() {
+        return (choices.size() - 1) == page;
+    }
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsView.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsView.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.organizeimports;
+
+import com.google.inject.ImplementedBy;
+
+import org.eclipse.che.ide.api.mvp.View;
+import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+
+/**
+ * The visual part of Organize Imports wizard that has an ability to resolve import conflicts.
+ *
+ * @author Valeriy Svydenko
+ */
+@ImplementedBy(OrganizeImportsViewImpl.class)
+interface OrganizeImportsView extends View<OrganizeImportsView.ActionDelegate> {
+
+    /** Show Organize Imports panel with the list of conflict imports. */
+    void show(ConflictImportDTO match);
+
+    /** Hide Organize Imports panel. */
+    void hide();
+
+    /** @return selected import for current view page. */
+    String getSelectedImport();
+
+    /**
+     * Selects an import into current view page.
+     *
+     * @param fqn
+     *         import which need to select
+     */
+    void setSelectedImport(String fqn);
+
+    /**
+     * Show new view page for choosing necessary import.
+     *
+     * @param match
+     *         conflict object with possible options to choose
+     */
+    void changePage(ConflictImportDTO match);
+
+    /**
+     * Setts enable scope of the Finish button.
+     *
+     * @param isEnable
+     *         enable state of scope property
+     */
+    void setEnableFinishButton(boolean isEnable);
+
+    /**
+     * Setts enable scope of the Next button.
+     *
+     * @param isEnable
+     *         enable state of scope property
+     */
+    void setEnableNextButton(boolean isEnable);
+
+    /**
+     * Setts enable scope of the Back button.
+     *
+     * @param isEnable
+     *         enable state of scope property
+     */
+    void setEnableBackButton(boolean isEnable);
+
+    interface ActionDelegate {
+        /** Performs some actions in response to user's clicking on the 'Next' button. */
+        void onNextButtonClicked();
+
+        /** Performs some actions in response to user's clicking on the 'Back' button. */
+        void onBackButtonClicked();
+
+        /** Performs some actions in response to user's clicking on the 'Finish' button. */
+        void onFinishButtonClicked();
+
+        /** Performs some actions in response to user's clicking on the 'Cancel' button. */
+        void onCancelButtonClicked();
+    }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsViewImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsViewImpl.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.organizeimports;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
+import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+import org.eclipse.che.ide.ui.window.Window;
+
+import java.util.List;
+
+import static com.google.gwt.dom.client.Style.Cursor.POINTER;
+import static org.eclipse.che.ide.api.theme.Style.getEditorSelectionColor;
+import static org.eclipse.che.ide.api.theme.Style.getMainFontColor;
+
+/**
+ * Implements of {@link OrganizeImportsView}.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+final class OrganizeImportsViewImpl extends Window implements OrganizeImportsView {
+    interface OrganizeImportsViewImplUiBinder extends UiBinder<Widget, OrganizeImportsViewImpl> {
+    }
+
+    private static OrganizeImportsViewImplUiBinder UI_BINDER = GWT.create(OrganizeImportsViewImplUiBinder.class);
+
+    @UiField
+    VerticalPanel container;
+
+    @UiField(provided = true)
+    final JavaLocalizationConstant locale;
+
+    private ActionDelegate delegate;
+    private Button         next;
+    private Button         back;
+    private Button         finish;
+
+    private String      selectedImport;
+    private Label       selectedLabel;
+
+    @Inject
+    public OrganizeImportsViewImpl(JavaLocalizationConstant locale) {
+        this.locale = locale;
+        setTitle(locale.organizeImportsName());
+        setWidget(UI_BINDER.createAndBindUi(this));
+
+        createButtons(locale);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setDelegate(ActionDelegate delegate) {
+        this.delegate = delegate;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void show(ConflictImportDTO match) {
+        container.clear();
+        List<String> matches = match.getTypeMatches();
+        for (String fqn : matches) {
+            final Label label = new Label(fqn);
+            if (fqn.equals(selectedImport)) {
+                selectedLabel = label;
+                selectedLabel.getElement().getStyle().setBackgroundColor(getEditorSelectionColor());
+            }
+            label.getElement().getStyle().setColor(getMainFontColor());
+            label.getElement().getStyle().setCursor(POINTER);
+            label.addClickHandler(new ClickHandler() {
+                @Override
+                public void onClick(ClickEvent clickEvent) {
+                    selectedLabel.getElement().getStyle().setBackgroundColor("initial");
+                    selectedLabel = label;
+                    label.getElement().getStyle().setBackgroundColor(getEditorSelectionColor());
+                }
+            });
+
+            container.add(label);
+        }
+
+        super.show();
+    }
+
+    /** {@inheritDoc} */
+    public String getSelectedImport() {
+        return selectedLabel.getText();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setSelectedImport(String fqn) {
+        this.selectedImport = fqn;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void changePage(ConflictImportDTO match) {
+        show(match);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setEnableFinishButton(boolean isEnable) {
+        finish.setEnabled(isEnable);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setEnableNextButton(boolean isEnable) {
+        next.setEnabled(isEnable);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setEnableBackButton(boolean isEnable) {
+        back.setEnabled(isEnable);
+    }
+
+    private void createButtons(JavaLocalizationConstant locale) {
+        back = createButton(locale.organizeImportsButtonBack(), "imports-back-button", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                delegate.onBackButtonClicked();
+            }
+        });
+
+        next = createButton(locale.organizeImportsButtonNext(), "imports-next-button", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                delegate.onNextButtonClicked();
+            }
+        });
+
+        Button cancel = createButton(locale.organizeImportsButtonCancel(), "imports-cancel-button", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                hide();
+                delegate.onCancelButtonClicked();
+            }
+        });
+
+        finish = createPrimaryButton(locale.organizeImportsButtonFinish(), "imports-finish-button", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                delegate.onFinishButtonClicked();
+            }
+        });
+
+        addButtonToFooter(finish);
+        addButtonToFooter(cancel);
+        addButtonToFooter(next);
+        addButtonToFooter(back);
+    }
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsViewImpl.ui.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsViewImpl.ui.xml
@@ -1,0 +1,33 @@
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g="urn:import:com.google.gwt.user.client.ui">
+    <ui:with field="locale" type="org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant"/>
+
+    <ui:style>
+        .main {
+            width: 515px;
+            float: left;
+            height: 200px;
+        }
+    </ui:style>
+
+    <g:SimplePanel addStyleNames="{style.main}">
+        <g:ScrollPanel width="100%" height="100%">
+
+            <g:VerticalPanel ui:field="container" width="100%" height="100%"/>
+
+        </g:ScrollPanel>
+    </g:SimplePanel>
+
+</ui:UiBinder>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MoveViewImpl.ui.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MoveViewImpl.ui.xml
@@ -21,7 +21,7 @@
 
         .label {
             float: left;
-            margin-left: 6px;
+            margin-left: 3px;
             margin-top: 6px;
         }
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.properties
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.properties
@@ -125,6 +125,15 @@ file.structure.action.description = Open File Structure Window
 show.inherited.members.label = Press 'Ctrl+F12' to show inherited members
 hide.inherited.members.label = Press 'Ctrl+F12' to hide inherited members
 
+##### Organize Imports #####
+organize.imports.name = Organize Imports
+organize.imports.description = Organize Imports action generates the import statements in a compilation unit
+organize.imports.failed.title = Failed to process organize imports
+organize.imports.button.finish=Finish
+organize.imports.button.cancel=Cancel
+organize.imports.button.back=< Back
+organize.imports.button.next=Next >
+
 ##### Open Implementation #####
 open.implementation.action.name = Implementation(s)
 open.implementation.action.description = Open Implementation(s)

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/action/OrganizeImportsActionTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/action/OrganizeImportsActionTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.action;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
+import org.eclipse.che.ide.ext.java.client.organizeimports.OrganizeImportsPresenter;
+import org.eclipse.che.ide.jseditor.client.texteditor.EmbeddedTextEditorPresenter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link OrganizeImportsAction}.
+ *
+ * @author Valeriy Svydenko
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class OrganizeImportsActionTest {
+    @Mock
+    private OrganizeImportsPresenter organizeImportsPresenter;
+    @Mock
+    private EditorAgent              editorAgent;
+    @Mock
+    private ActionEvent              actionEvent;
+
+    @Mock
+    private EmbeddedTextEditorPresenter editor;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private JavaLocalizationConstant locale;
+
+    @InjectMocks
+    OrganizeImportsAction action;
+
+    @Before
+    public void setUp() throws Exception {
+        when(editorAgent.getActiveEditor()).thenReturn(editor);
+    }
+
+    public void prepareAction() throws Exception {
+        verify(locale).organizeImportsName();
+        verify(locale).organizeImportsDescription();
+    }
+
+    @Test
+    public void actionShouldBePerformed() {
+        action.actionPerformed(actionEvent);
+
+        verify(organizeImportsPresenter).organizeImports(editor);
+    }
+
+    @Test
+    public void actionShouldBePerformedAsProposal() {
+        action.performAsProposal();
+
+        verify(organizeImportsPresenter).organizeImports(editor);
+    }
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenterTest.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.organizeimports;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.api.project.gwt.client.ProjectServiceClient;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.editor.EditorInput;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.project.node.HasProjectConfig;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
+import org.eclipse.che.ide.ext.java.client.editor.JavaCodeAssistClient;
+import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+import org.eclipse.che.ide.jseditor.client.document.Document;
+import org.eclipse.che.ide.jseditor.client.texteditor.TextEditor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Valeriy Svydenko
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class OrganizeImportsPresenterTest {
+    private final static String PATH  = "/project/a/b/A.java";
+    private final static String WS_ID = "wsId";
+
+    @Mock
+    private OrganizeImportsView      view;
+    @Mock
+    private AppContext               appContext;
+    @Mock
+    private ProjectServiceClient     projectService;
+    @Mock
+    private JavaCodeAssistClient     javaCodeAssistClient;
+    @Mock
+    private DtoFactory               dtoFactory;
+    @Mock
+    private JavaLocalizationConstant locale;
+    @Mock
+    private NotificationManager      notificationManager;
+
+    private OrganizeImportsPresenter presenter;
+
+    @Mock
+    private VirtualFile      file;
+    @Mock
+    private EditorInput      editorInput;
+    @Mock
+    private HasProjectConfig hasProjectConfig;
+    @Mock
+    private ProjectConfigDto projectConfigDto;
+    @Mock
+    private TextEditor       editor;
+    @Mock
+    private Document         document;
+
+    @Mock
+    private Promise<List<ConflictImportDTO>> importsPromise;
+    @Mock
+    private Promise<Void>                    resolveConflictsPromise;
+
+    @Captor
+    private ArgumentCaptor<Operation<List<ConflictImportDTO>>> importsOperation;
+    @Captor
+    private ArgumentCaptor<Operation<Void>>                    resolveConflictsOperation;
+
+    private ConflictImportDTO conflict1;
+    private ConflictImportDTO conflict2;
+
+
+    @Before
+    public void setUp() throws Exception {
+        when(editor.getEditorInput()).thenReturn(editorInput);
+        when(editorInput.getFile()).thenReturn(file);
+        when(file.getProject()).thenReturn(hasProjectConfig);
+        when(hasProjectConfig.getProjectConfig()).thenReturn(projectConfigDto);
+        when(projectConfigDto.getPath()).thenReturn(PATH);
+        when(file.getName()).thenReturn("A.java");
+        when(file.getPath()).thenReturn(PATH);
+
+        when(appContext.getWorkspaceId()).thenReturn(WS_ID);
+
+        when(javaCodeAssistClient.organizeImports(anyString(), anyString())).thenReturn(importsPromise);
+        when(importsPromise.then(Matchers.<Operation<List<ConflictImportDTO>>>anyObject())).thenReturn(importsPromise);
+
+        presenter = new OrganizeImportsPresenter(view,
+                                                 appContext,
+                                                 projectService,
+                                                 javaCodeAssistClient,
+                                                 dtoFactory,
+                                                 locale,
+                                                 notificationManager);
+
+        prepareConflicts();
+
+    }
+
+    @Test
+    public void organizeImportsShouldBeDoneWithoutConflicts() throws Exception {
+        presenter.organizeImports(editor);
+
+        verify(javaCodeAssistClient).organizeImports(PATH, "A");
+        verify(importsPromise).then(importsOperation.capture());
+        importsOperation.getValue().apply(Collections.emptyList());
+    }
+
+    private void prepareConflicts() {
+        conflict1 = Mockito.mock(ConflictImportDTO.class);
+        conflict2 = Mockito.mock(ConflictImportDTO.class);
+
+        List<String> imports1 = Arrays.asList("import1", "import2");
+        List<String> imports2 = Arrays.asList("import3", "import4");
+
+        when(conflict1.getTypeMatches()).thenReturn(imports1);
+        when(conflict2.getTypeMatches()).thenReturn(imports2);
+
+    }
+
+    @Test
+    public void openWindowForResolvingConflicts() throws Exception {
+        showOrganizeImportsWindow();
+
+        verify(view).setSelectedImport("import1");
+
+        verify(view).setEnableBackButton(false);
+        verify(view).setEnableFinishButton(false);
+        verify(view).setEnableNextButton(true);
+
+        verify(view).show(conflict1);
+    }
+
+    private void showOrganizeImportsWindow() throws Exception {
+        presenter.organizeImports(editor);
+
+        List<ConflictImportDTO> result = Arrays.asList(conflict1, conflict2);
+
+        verify(javaCodeAssistClient).organizeImports(PATH, "A");
+        verify(importsPromise).then(importsOperation.capture());
+        importsOperation.getValue().apply(result);
+    }
+
+    @Test
+    public void showNextConflictPage() throws Exception {
+        when(view.getSelectedImport()).thenReturn("import1");
+
+        showOrganizeImportsWindow();
+        presenter.onNextButtonClicked();
+
+        verify(view).getSelectedImport();
+        verify(view).setSelectedImport("import3");
+        verify(view).changePage(conflict2);
+
+        verify(view).setEnableBackButton(true);
+        verify(view).setEnableFinishButton(true);
+        verify(view).setEnableNextButton(false);
+    }
+
+    @Test
+    public void showPreviousConflictPage() throws Exception {
+        when(view.getSelectedImport()).thenReturn("import4");
+
+        showOrganizeImportsWindow();
+        presenter.onNextButtonClicked();
+        reset(view);
+        presenter.onBackButtonClicked();
+
+        verify(view).getSelectedImport();
+        verify(view).setSelectedImport("import4");
+        verify(view).changePage(conflict1);
+
+        verify(view).setEnableBackButton(false);
+        verify(view).setEnableFinishButton(true);
+        verify(view).setEnableNextButton(true);
+    }
+
+    @Test
+    public void focusShouldBeSetAfterClosingWindow() throws Exception {
+        showOrganizeImportsWindow();
+        presenter.onCancelButtonClicked();
+
+        verify(editor).setFocus();
+    }
+
+    @Test
+    public void focusShouldBeSetAfterApplyingConflicts() throws Exception {
+        when(view.getSelectedImport()).thenReturn("import1");
+        when(dtoFactory.createDto(ConflictImportDTO.class)).thenReturn(conflict1);
+        when(conflict1.withTypeMatches(Matchers.<List<String>>anyObject())).thenReturn(conflict1);
+        when(javaCodeAssistClient.applyChosenImports(anyString(), anyString(), any())).thenReturn(resolveConflictsPromise);
+        when(resolveConflictsPromise.then(Matchers.<Operation<Void>>anyObject())).thenReturn(resolveConflictsPromise);
+
+        showOrganizeImportsWindow();
+        presenter.onFinishButtonClicked();
+
+        verify(resolveConflictsPromise).then(resolveConflictsOperation.capture());
+        resolveConflictsOperation.getValue().apply(null);
+
+        verify(editor).setFocus();
+        verify(view).hide();
+    }
+
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/dto/ConflictImportDTO.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/dto/ConflictImportDTO.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+import java.util.List;
+
+/**
+ * DTO represents the information about the imports for the organize imports process.
+ *
+ * @author Valeriy Svydenko
+ */
+@DTO
+public interface ConflictImportDTO {
+    /** Returns list of the possible imports for the current conflict. */
+    List<String> getTypeMatches();
+
+    void setTypeMatches(List<String> typeMatches);
+
+    ConflictImportDTO withTypeMatches(List<String> typeMatches);
+}


### PR DESCRIPTION
Added an ability to organize the import declarations in your source code. You can choose **Organize Imports** from the **Assistant** menu or click **Ctrl + Alt + O**. 
You can also choose this action from Proposals if you have some troubles with imports.
