### PR TITLE
Fix NPE at cleaning selections in processes panel

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelView.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelView.java
@@ -54,7 +54,7 @@ public interface ConsolesPanelView extends View<ConsolesPanelView.ActionDelegate
     void setProcessesData(@NotNull ProcessTreeNode root);
 
     /** Select given process node */
-    void selectNode(@NotNull ProcessTreeNode node);
+    void selectNode(ProcessTreeNode node);
 
     /** Displays output for process with given ID */
     void showProcessOutput(String processId);

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelViewImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelViewImpl.java
@@ -284,11 +284,12 @@ public class ConsolesPanelViewImpl extends BaseView<ConsolesPanelView.ActionDele
     }
 
     @Override
-    public void selectNode(final @NotNull ProcessTreeNode node) {
+    public void selectNode(final ProcessTreeNode node) {
         SelectionModel<ProcessTreeNode> selectionModel = processTree.getSelectionModel();
 
         if (node == null) {
             selectionModel.clearSelections();
+            return;
         } else {
             selectionModel.setTreeActive(true);
             selectionModel.clearSelections();


### PR DESCRIPTION
We have NPE when workspace is stopped and we clear selections in processes panel.
@vparfonov 

Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com
