### PR TITLE
Add an ability to get pull requests by repo, owner and head

### DIFF
--- a/plugins/plugin-github/che-plugin-github-ext-github/src/main/java/org/eclipse/che/ide/ext/github/client/GitHubClientService.java
+++ b/plugins/plugin-github/che-plugin-github-ext-github/src/main/java/org/eclipse/che/ide/ext/github/client/GitHubClientService.java
@@ -151,6 +151,18 @@ public interface GitHubClientService {
     Promise<GitHubPullRequestList> getPullRequests(@NotNull String owner, @NotNull String repository);
 
     /**
+     * Get pull requests for given repository.
+     *
+     * @param owner
+     *         the repository owner.
+     * @param repository
+     *         the repository name.
+     * @param head
+     *         user and branch name in the format of user:ref-name
+     */
+    Promise<GitHubPullRequestList> getPullRequests(String owner, String repository, String head);
+
+    /**
      * Get a pull request by id for a given repository.
      *
      * @param owner

--- a/plugins/plugin-github/che-plugin-github-ext-github/src/main/java/org/eclipse/che/ide/ext/github/client/GitHubClientServiceImpl.java
+++ b/plugins/plugin-github/che-plugin-github-ext-github/src/main/java/org/eclipse/che/ide/ext/github/client/GitHubClientServiceImpl.java
@@ -151,6 +151,14 @@ public class GitHubClientServiceImpl implements GitHubClientService {
     }
 
     @Override
+    public Promise<GitHubPullRequestList> getPullRequests(String owner, String repository, String head) {
+        final String url = baseUrl + PULL_REQUESTS + '/' + owner + '/' + repository + "?head=" + head;
+        return asyncRequestFactory.createGetRequest(url)
+                                  .loader(loader)
+                                  .send(dtoUnmarshallerFactory.newUnmarshaller(GitHubPullRequestList.class));
+    }
+
+    @Override
     public void getPullRequest(final String owner, final String repository, final String pullRequestId,
                                final AsyncRequestCallback<GitHubPullRequest> callback) {
         String url = baseUrl + PULL_REQUESTS + "/" + owner + "/" + repository + "/" + pullRequestId;


### PR DESCRIPTION
Provides an ability to get a pull request from `user1/repo` to `user2/repo` instead of getting pull request by number. The client of this method(such as contribution plugin) needs this improvement because the only way of getting the pull request from one repository to another is getting all the pull requests and then matching them. In that case when repository has 10+ open pull requests it takes some time to get all of the pull requests and parse those into dtos, on the other hand `GitService` client makes the same request to get all the pull requests returned by server. As a result we had 2 huge requests.

I think here is the only one way for adding additional query parameter to the `kohsuke` github client -  it's custom `HttpConnector` which adds `head` query parameter directly to the url and delegates connect call to the `DEFAULT` implementation.

Here is [api ref](https://developer.github.com/v3/pulls/#list-pull-requests), koksuke library doesn't allow to put head param.

@skabashnyuk please review
