### PR TITLE
Fix url encoding in DefaultHttpJsonRequest

### DIFF
--- a/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
+++ b/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
@@ -42,13 +42,12 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Objects.requireNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Simple implementation of {@link HttpJsonRequest} based on {@link HttpURLConnection}.
@@ -62,7 +61,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  * @see DefaultHttpJsonRequestFactory
  */
 public class DefaultHttpJsonRequest implements HttpJsonRequest {
- 
+
     private static final int      DEFAULT_QUERY_PARAMS_LIST_SIZE = 5;
     private static final Object[] EMPTY_ARRAY                    = new Object[0];
 
@@ -186,12 +185,12 @@ public class DefaultHttpJsonRequest implements HttpJsonRequest {
                                       Object body,
                                       List<Pair<String, ?>> parameters,
                                       String authorizationHeaderValue) throws IOException,
-                                                                               ServerException,
-                                                                               ForbiddenException,
-                                                                               NotFoundException,
-                                                                               UnauthorizedException,
-                                                                               ConflictException,
-                                                                               BadRequestException {
+                                                                              ServerException,
+                                                                              ForbiddenException,
+                                                                              NotFoundException,
+                                                                              UnauthorizedException,
+                                                                              ConflictException,
+                                                                              BadRequestException {
         final String authToken = getAuthenticationToken();
         final boolean hasQueryParams = parameters != null && !parameters.isEmpty();
         if (hasQueryParams || authToken != null) {
@@ -201,11 +200,7 @@ public class DefaultHttpJsonRequest implements HttpJsonRequest {
 
             if (hasQueryParams) {
                 for (Pair<String, ?> parameter : parameters) {
-                    String name = URLEncoder.encode(parameter.first, "UTF-8");
-                    String value = parameter.second == null ?
-                                   null :
-                                   URLEncoder.encode(String.valueOf(parameter.second), "UTF-8");
-                    ub.queryParam(name, value);
+                    ub.queryParam(parameter.first, parameter.second);
                 }
             }
             url = ub.build().toString();

--- a/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
+++ b/core/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
@@ -431,10 +431,7 @@ public class HttpJsonHelper {
 
                 if (parameters != null && parameters.length > 0) {
                     for (Pair<String, ?> parameter : parameters) {
-                        String name = URLEncoder.encode(parameter.first, "UTF-8");
-                        String value = parameter.second == null ? null : URLEncoder
-                                .encode(String.valueOf(parameter.second), "UTF-8");
-                        ub.replaceQueryParam(name, value);
+                        ub.queryParam(parameter.first, parameter.second);
                     }
                 }
                 url = ub.build().toString();

--- a/core/platform-api/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
+++ b/core/platform-api/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
@@ -57,7 +57,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -256,8 +255,20 @@ public class DefaultHttpJsonRequestTest {
     public void shouldReadJsonObjectBodyAsString(ITestContext ctx) throws Exception {
         final DefaultHttpJsonRequest request = new DefaultHttpJsonRequest(getUrl(ctx) + "/application-json");
         request.useGetMethod();
-        
+
         assertEquals(request.request().asString(), TestService.JSON_OBJECT);
+    }
+
+    @Test
+    public void shouldEncodeRequestUrlInDefaultHttpJsonRequestAndDecodeInService(ITestContext ctx) throws Exception {
+        final String base = getUrl(ctx) + "/decode";
+        final HttpJsonResponse response = new DefaultHttpJsonRequest(base).addQueryParam("query", "some white spaces !!")
+                                                                          .useGetMethod()
+                                                                          .request();
+
+        final String url = base + "?query=some white spaces !!";
+
+        assertEquals(url, response.asString());
     }
 
     @Test

--- a/core/platform-api/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/TestService.java
+++ b/core/platform-api/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/TestService.java
@@ -17,17 +17,19 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.dto.server.JsonArrayImpl;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-
+import javax.ws.rs.core.UriInfo;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,5 +102,13 @@ public class TestService {
         if (!EnvironmentContext.getCurrent().getUser().getToken().equals(token)) {
             throw new UnauthorizedException("Token '" + token + "' it is different from token in EnvironmentContext");
         }
+    }
+
+    @GET
+    @Path("/decode")
+    @Produces(APPLICATION_JSON)
+    public String getUriInfo(@QueryParam("query") String query,
+                             @Context UriInfo uriInfo) {
+        return URLDecoder.decode(uriInfo.getRequestUri().toString());
     }
 }


### PR DESCRIPTION
@skabashnyuk @evoevodin 
UriBuilder.build()  performs encode it was necessary to get rid of second encoding of query params
