### PR TITLE
CHE-730. Fix problems related to refusing WebSocket connection when machine is restarted.

### DIFF
--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/websocket/AbstractMessageBus.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/websocket/AbstractMessageBus.java
@@ -139,6 +139,13 @@ abstract class AbstractMessageBus implements MessageBus {
         };
     }
 
+    public void cancelReconnection() {
+        frequentlyReconnectionAttemptsCounter = MAX_FREQUENTLY_RECONNECTION_ATTEMPTS;
+        seldomReconnectionAttemptsCounter = MAX_SELDOM_RECONNECTION_ATTEMPTS;
+        frequentlyReconnectionTimer.cancel();
+        seldomReconnectionTimer.cancel();
+    }
+
     private void initialize() {
         ws = WebSocket.create(wsConnectionUrl);
         wsListener = new WsListener();
@@ -329,7 +336,6 @@ abstract class AbstractMessageBus implements MessageBus {
      *         e.g.: WebSocket is not supported by browser, WebSocket connection is not opened
      */
     private void send(String message) throws WebSocketException {
-//        checkWebSocketConnectionState();
         if (getReadyState() != ReadyState.OPEN) {
             messages2send.add(message);
             return;

--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/websocket/MessageBus.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/websocket/MessageBus.java
@@ -183,4 +183,9 @@ public interface MessageBus extends MessageReceivedHandler {
      * @return <code>true</code> if handler subscribed to channel and <code>false</code> if not
      */
     boolean isHandlerSubscribed(MessageHandler handler, String channel);
+
+    /**
+     * Cancels attempts to reconnect by WebSocket
+     */
+    void cancelReconnection();
 }

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -182,6 +182,9 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
         loader.show(initialLoadingInfo);
         initialLoadingInfo.setOperationStatus(WORKSPACE_BOOTING.getValue(), IN_PROGRESS);
 
+        if (messageBus != null) {
+            messageBus.cancelReconnection();
+        }
         messageBus = messageBusProvider.createMessageBus(workspace.getId());
 
         messageBus.addOnOpenHandler(new ConnectionOpenedHandler() {

--- a/core/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineManager.java
+++ b/core/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineManager.java
@@ -27,6 +27,14 @@ public interface MachineManager {
     }
 
     /**
+     * Performs some actions when dev machine is creating.
+     *
+     * @param machineConfig
+     *         contains information about dev machine configuration
+     */
+    void onDevMachineCreating(MachineConfigDto machineConfig);
+
+    /**
      * Performs some actions when machine is running.
      *
      * @param machineId
@@ -72,10 +80,12 @@ public interface MachineManager {
     void restartMachine(final MachineDto machine);
 
     /**
-     * Performs some actions when dev machine is creating.
+     * Checks if the the status for dev machine is tracked by machine manager.
      *
-     * @param machineConfig
-     *         contains information about dev machine configuration
+     * @param machine
+     *         contains information about machine state
+     * @return {@code true} if status for dev machine is tracked by machine manager and {@code false} - otherwise.
      */
-    void onDevMachineCreating(MachineConfigDto machineConfig);
+    boolean isDevMachineStatusTracked(MachineDto machine);
+
 }

--- a/core/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/WsAgentStateController.java
+++ b/core/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/WsAgentStateController.java
@@ -201,10 +201,13 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
      * Try to connect via WebSocket connection
      */
     private void checkWsConnection() {
+        if (messageBus != null) {
+            messageBus.cancelReconnection();
+        }
         messageBus = messageBusProvider.createMachineMessageBus(wsUrl);
+
         messageBus.addOnCloseHandler(this);
         messageBus.addOnCloseHandler(this);
         messageBus.addOnOpenHandler(this);
-
     }
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineComponent.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineComponent.java
@@ -62,9 +62,11 @@ public class MachineComponent implements WsAgentComponent {
 
                     if (isDev && status == RUNNING) {
                         callback.onSuccess(MachineComponent.this);
-
                         appContext.setDevMachineId(descriptor.getId());
-                        machineManager.onMachineRunning(descriptor.getId());
+
+                        if (!machineManager.isDevMachineStatusTracked(descriptor)) {
+                            machineManager.onMachineRunning(descriptor.getId());
+                        }
                         break;
                     }
                     if (isDev && status == CREATING) {


### PR DESCRIPTION
1. We create new instance of  MachineMessageBus and try to connect via WebSocket connection when machine is started.
   But old instance tries to reconnect at this moment by timer, so we need to cancel all attempts to reconnect.
2. We have double method call and code execution when we restart machine https://github.com/eclipse/che/blob/master/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImpl.java#L277:
   - from machine component
   - from handler in machine manager

It causes to create new WebSocket connection twice and creates bugs related to refusing connection.
So we need to check it to avoid these bugs.
