### PR TITLE
CHE-260 Rename some factory parameters

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenter.java
@@ -127,12 +127,12 @@ public class GitImporterPagePresenter extends AbstractWizardPage<ProjectConfigDt
         view.enableDirectoryNameField(keepDirectory);
 
         if (keepDirectory) {
-            projectParameters().put("keepDirectory", view.getDirectoryName());
+            projectParameters().put("keepDir", view.getDirectoryName());
             dataObject.withType("blank");
             view.highlightDirectoryNameField(!NameUtils.checkProjectName(view.getDirectoryName()));
             view.focusDirectoryNameFiend();
         } else {
-            projectParameters().remove("keepDirectory");
+            projectParameters().remove("keepDir");
             dataObject.withType(null);
             view.highlightDirectoryNameField(false);
         }
@@ -141,11 +141,11 @@ public class GitImporterPagePresenter extends AbstractWizardPage<ProjectConfigDt
     @Override
     public void keepDirectoryNameChanged(@NotNull String directoryName) {
         if (view.keepDirectory()) {
-            projectParameters().put("keepDirectory", directoryName);
+            projectParameters().put("keepDir", directoryName);
             dataObject.withType("blank");
             view.highlightDirectoryNameField(!NameUtils.checkProjectName(view.getDirectoryName()));
         } else {
-            projectParameters().remove("keepDirectory");
+            projectParameters().remove("keepDir");
             dataObject.withType(null);
             view.highlightDirectoryNameField(false);
         }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenterTest.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenterTest.java
@@ -264,7 +264,7 @@ public class GitImporterPagePresenterTest {
     @Test
     public void keepDirectoryUnSelectedTest() {
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("keepDirectory", "directory");
+        parameters.put("keepDir", "directory");
         when(source.getParameters()).thenReturn(parameters);
 
         presenter.keepDirectorySelected(false);

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
@@ -170,12 +170,12 @@ public class GithubImporterPagePresenter extends AbstractWizardPage<ProjectConfi
         view.enableDirectoryNameField(keepDirectory);
 
         if (keepDirectory) {
-            projectParameters().put("keepDirectory", view.getDirectoryName());
+            projectParameters().put("keepDir", view.getDirectoryName());
             dataObject.withType("blank");
             view.highlightDirectoryNameField(!NameUtils.checkProjectName(view.getDirectoryName()));
             view.focusDirectoryNameFiend();
         } else {
-            projectParameters().remove("keepDirectory");
+            projectParameters().remove("keepDir");
             dataObject.withType(null);
             view.highlightDirectoryNameField(false);
         }
@@ -184,11 +184,11 @@ public class GithubImporterPagePresenter extends AbstractWizardPage<ProjectConfi
     @Override
     public void keepDirectoryNameChanged(@NotNull String directoryName) {
         if (view.keepDirectory()) {
-            projectParameters().put("keepDirectory", directoryName);
+            projectParameters().put("keepDir", directoryName);
             dataObject.withType("blank");
             view.highlightDirectoryNameField(!NameUtils.checkProjectName(view.getDirectoryName()));
         } else {
-            projectParameters().remove("keepDirectory");
+            projectParameters().remove("keepDir");
             dataObject.withType(null);
             view.highlightDirectoryNameField(false);
         }

--- a/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
@@ -404,7 +404,7 @@ public class GithubImporterPagePresenterTest {
 
         presenter.keepDirectorySelected(true);
 
-        assertEquals("directory", parameters.get("keepDirectory"));
+        assertEquals("directory", parameters.get("keepDir"));
         verify(dataObject).withType("blank");
         verify(view).highlightDirectoryNameField(eq(false));
         verify(view).focusDirectoryNameFiend();
@@ -413,7 +413,7 @@ public class GithubImporterPagePresenterTest {
     @Test
     public void keepDirectoryUnSelectedTest() {
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("keepDirectory", "directory");
+        parameters.put("keepDir", "directory");
         when(source.getParameters()).thenReturn(parameters);
 
         presenter.keepDirectorySelected(false);
@@ -432,7 +432,7 @@ public class GithubImporterPagePresenterTest {
 
         presenter.keepDirectoryNameChanged("directory");
 
-        assertEquals("directory", parameters.get("keepDirectory"));
+        assertEquals("directory", parameters.get("keepDir"));
         verify(dataObject, never()).setPath(any());
         verify(dataObject).withType(eq("blank"));
         verify(view).highlightDirectoryNameField(eq(false));
@@ -441,7 +441,7 @@ public class GithubImporterPagePresenterTest {
     @Test
     public void keepDirectoryNameChangedAndKeepDirectoryUnSelectedTest() {
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("keepDirectory", "directory");
+        parameters.put("keepDir", "directory");
         when(source.getParameters()).thenReturn(parameters);
         when(view.keepDirectory()).thenReturn(false);
 

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
@@ -111,13 +111,13 @@ public class GitProjectImporter implements ProjectImporter {
             // For factory: checkout particular commit after clone
             String commitId = null;
             // For factory: github pull request feature
-            String remoteOriginFetch = null;
+            String fetch = null;
             String branch = null;
             String startPoint = null;
             // For factory or probably for our projects templates:
             // If git repository contains more than one project need clone all repository but after cloning keep just
-            // sub-project that is specified in parameter "keepDirectory".
-            String keepDirectory = null;
+            // sub-project that is specified in parameter "keepDir".
+            String keepDir = null;
             // For factory and for our projects templates:
             // Keep all info related to the vcs. In case of Git: ".git" directory and ".gitignore" file.
             // Delete vcs info if false.
@@ -129,8 +129,8 @@ public class GitProjectImporter implements ProjectImporter {
                 commitId = parameters.get("commitId");
                 branch = parameters.get("branch");
                 startPoint = parameters.get("startPoint");
-                remoteOriginFetch = parameters.get("remoteOriginFetch");
-                keepDirectory = parameters.get("keepDirectory");
+                fetch = parameters.get("fetch");
+                keepDir = parameters.get("keepDir");
                 if (parameters.containsKey("keepVcs")) {
                     keepVcs = Boolean.parseBoolean(parameters.get("keepVcs"));
                 }
@@ -141,11 +141,11 @@ public class GitProjectImporter implements ProjectImporter {
             final DtoFactory dtoFactory = DtoFactory.getInstance();
             final String location = storage.getLocation();
             final String projectName = baseFolder.getName();
-            if (keepDirectory != null) {
+            if (keepDir != null) {
                 final File temp = Files.createTempDirectory(null).toFile();
                 try {
                     git = gitConnectionFactory.getConnection(temp, consumerFactory);
-                    sparsecheckout(git, projectName, location, branch == null ? "master" : branch, startPoint, keepDirectory, dtoFactory);
+                    sparsecheckout(git, projectName, location, branch == null ? "master" : branch, startPoint, keepDir, dtoFactory);
                     // Copy content of directory to the project folder.
                     final File projectDir = new File(localPath);
                     IoUtil.copy(temp, projectDir, IoUtil.ANY_FILTER);
@@ -159,8 +159,8 @@ public class GitProjectImporter implements ProjectImporter {
                     cloneRepository(git, "origin", location, dtoFactory);
                     if (commitId != null) {
                         checkoutCommit(git, commitId, dtoFactory);
-                    } else if (remoteOriginFetch != null) {
-                        git.getConfig().add("remote.origin.fetch", remoteOriginFetch);
+                    } else if (fetch != null) {
+                        git.getConfig().add("remote.origin.fetch", fetch);
                         fetch(git, "origin", dtoFactory);
                         if (branch != null) {
                             checkoutBranch(git, projectName, branch, startPoint, dtoFactory);
@@ -174,8 +174,8 @@ public class GitProjectImporter implements ProjectImporter {
                     if (commitId != null) {
                         fetchBranch(git, "origin", branch == null ? "*" : branch, dtoFactory);
                         checkoutCommit(git, commitId, dtoFactory);
-                    } else if (remoteOriginFetch != null) {
-                        git.getConfig().add("remote.origin.fetch", remoteOriginFetch);
+                    } else if (fetch != null) {
+                        git.getConfig().add("remote.origin.fetch", fetch);
                         fetch(git, "origin", dtoFactory);
                         if (branch != null) {
                             checkoutBranch(git, projectName, branch, startPoint, dtoFactory);
@@ -312,7 +312,7 @@ public class GitProjectImporter implements ProjectImporter {
         $ git init
         $ git remote add origin <URL>
         $ git config core.sparsecheckout true
-        $ echo keepDirectory >> .git/info/sparse-checkout
+        $ echo keepDir >> .git/info/sparse-checkout
         $ git pull origin master
         */
         initRepository(git, dtoFactory);

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/SourceStorageParametersValidator.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/SourceStorageParametersValidator.java
@@ -40,8 +40,8 @@ public class SourceStorageParametersValidator implements FactoryParameterValidat
                         break;
                     case "branch":
                     case "commitId":
-                    case "keepDirectory":
-                    case "remoteOriginFetch":
+                    case "keepDir":
+                    case "fetch":
                     case "branchMerge":
                         break;
                     default:

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/impl/SourceProjectParametersValidatorTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/impl/SourceProjectParametersValidatorTest.java
@@ -38,8 +38,8 @@ public class SourceProjectParametersValidatorTest {
                                           put("branch", "master");
                                           put("commitId", "123456");
                                           put("keepVcs", "true");
-                                          put("remoteOriginFetch", "12345");
-                                          put("keepDirectory", "/src");
+                                          put("fetch", "12345");
+                                          put("keepDir", "/src");
                                       }
                                   });
     }


### PR DESCRIPTION
Rename the following project source parameters:
"project.source.parameters.keepDirectory" to "project.source.parameters.keepDir".
"project.source.parameters.remoteOriginFetch" to "project.source.parameters.fetch"

The old parameter names are not going to work anymore, so all existing workspaces with such projects should be updated
