### PR TITLE
CHE-866: wrap fileWatcher.startup() with try..catch.

### DIFF
--- a/agent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/agent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -117,7 +117,12 @@ public final class ProjectManager {
             }
         };
         fileWatchNotifier.addNotificationListener(defaultListener);
-        fileWatcher.startup();
+        try {
+            fileWatcher.startup();
+        } catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+            fileWatchNotifier.removeNotificationListener(defaultListener);
+        }
     }
 
     @PreDestroy


### PR DESCRIPTION
Avoid failing ProjectManager startup

Signed-off-by: Vitaly Parfonov vparfonov@codenvy.com
