### PR TITLE
CHE-783: add Python plugin

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -238,6 +238,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-python-lang-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-python-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-sdk-env-local</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-ide-war/src/main/resources/org/eclipse/che/ide/IDE.gwt.xml
+++ b/assembly/assembly-ide-war/src/main/resources/org/eclipse/che/ide/IDE.gwt.xml
@@ -55,6 +55,7 @@
     <inherits name='org.eclipse.che.env.local.LocalEnvironment'/>
     <inherits name='org.eclipse.che.ide.ext.plugins.PluginsDevelopment'/>
 
+    <inherits name='org.eclipse.che.plugin.python.Python'/>
     <inherits name='org.eclipse.che.plugin.docker.client.dto.Dto'/>
 
     <!-- Platform API GWT client dependencies                       -->

--- a/assembly/assembly-machine-war/pom.xml
+++ b/assembly/assembly-machine-war/pom.xml
@@ -127,6 +127,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-python-lang-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-python-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-sdk-env-local</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/che-jdt-ext-machine/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-project</artifactId>
         </dependency>
         <dependency>
@@ -155,11 +159,6 @@
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-model</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-resources/src/main/java/org/eclipse/che/core/internal/resources/Project.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-resources/src/main/java/org/eclipse/che/core/internal/resources/Project.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.content.IContentTypeMatcher;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -136,7 +137,12 @@ public class Project extends Container implements IProject {
 
             @Override
             public String[] getNatureIds() {
-                return new String[]{"org.eclipse.jdt.core.javanature"};
+                Map<String, List<String>> attributes = workspace.getProjectRegistry().getProject(path.toString()).getAttributes();
+                String language = "";
+                if (attributes.containsKey("language")) {
+                    language = attributes.get("language").get(0);
+                }
+                return "java".equals(language) ? new String[]{"org.eclipse.jdt.core.javanature"} : new String[]{language};
             }
 
             @Override
@@ -146,6 +152,12 @@ public class Project extends Container implements IProject {
 
             @Override
             public boolean hasNature(String s) {
+                String[] natureIds = getNatureIds();
+                for (String id : natureIds) {
+                    if (s.equals(id)) {
+                        return true;
+                    }
+                }
                 return false;
             }
 
@@ -251,12 +263,7 @@ public class Project extends Container implements IProject {
 
     @Override
     public boolean hasNature(String s) throws CoreException {
-        //TODO we suppose that now only java projects
-        if(s.equals("org.eclipse.jdt.core.javanature")){
-            return true;
-        } else {
-            throw new UnsupportedOperationException();
-        }
+        return getDescription().hasNature(s);
     }
 
     @Override

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/internal/core/JavaProject.java
@@ -200,15 +200,14 @@ public class JavaProject extends Openable implements IJavaProject, SuffixConstan
      * @return boolean
      */
     public static boolean hasJavaNature(IProject project) {
-//        try {
-//            return project.hasNature(JavaCore.NATURE_ID);
-//        } catch (CoreException e) {
-//            if (ExternalJavaProject.EXTERNAL_PROJECT_NAME.equals(project.getName()))
-//                return true;
-//            // project does not exist or is not open
-//        }
-//        return false;
-        return true;
+        try {
+            return project.hasNature(JavaCore.NATURE_ID);
+        } catch (CoreException e) {
+            if (ExternalJavaProject.EXTERNAL_PROJECT_NAME.equals(project.getName()))
+                return true;
+            // project does not exist or is not open
+        }
+        return false;
     }
 
     public static boolean areClasspathsEqual(

--- a/plugins/plugin-python/che-plugin-python-lang-ide/pom.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-python-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.1.0-RC1-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-python-lang-ide</artifactId>
+    <packaging>jar</packaging>
+    <name>Che Plugin :: Python :: IDE</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.gwt.inject</groupId>
+            <artifactId>gin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-app</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-jseditor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-python-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.vectomatic</groupId>
+            <artifactId>lib-gwt-svg</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonExtension.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonExtension.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.DefaultActionGroup;
+import org.eclipse.che.ide.api.constraints.Constraints;
+import org.eclipse.che.ide.api.extension.Extension;
+import org.eclipse.che.ide.api.filetypes.FileType;
+import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
+import org.eclipse.che.ide.api.icon.Icon;
+import org.eclipse.che.ide.api.icon.IconRegistry;
+import org.eclipse.che.plugin.python.ide.action.CreatePythonFileAction;
+
+import static org.eclipse.che.ide.api.action.IdeActions.GROUP_FILE_NEW;
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_CATEGORY;
+
+/**
+ * Python extension entry point.
+ *
+ * @author Valeriy Svydenko
+ */
+@Extension(title = "Python")
+public class PythonExtension {
+    @Inject
+    public PythonExtension(FileTypeRegistry fileTypeRegistry,
+                           CreatePythonFileAction createPythonFileAction,
+                           ActionManager actionManager,
+                           PythonResources pythonResources,
+                           IconRegistry iconRegistry,
+                           @Named("PythonFileType") FileType pythonFile) {
+        fileTypeRegistry.registerFileType(pythonFile);
+
+        DefaultActionGroup newGroup = (DefaultActionGroup)actionManager.getAction(GROUP_FILE_NEW);
+        actionManager.registerAction("pythonFile", createPythonFileAction);
+        newGroup.add(createPythonFileAction, Constraints.FIRST);
+
+        iconRegistry.registerIcon(new Icon(PYTHON_CATEGORY + ".samples.category.icon", pythonResources.category()));
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonJsEditorExtension.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonJsEditorExtension.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide;
+
+import com.google.inject.name.Named;
+
+import org.eclipse.che.ide.api.editor.EditorRegistry;
+import org.eclipse.che.ide.api.extension.Extension;
+import org.eclipse.che.ide.api.filetypes.FileType;
+import org.eclipse.che.plugin.python.ide.editor.PythonEditorProvider;
+
+import javax.inject.Inject;
+
+/** @author Valeriy Svydenko */
+@Extension(title = "Python JS Editor")
+public class PythonJsEditorExtension {
+
+    @Inject
+    public PythonJsEditorExtension(final EditorRegistry editorRegistry,
+                                   final @Named("PythonFileType") FileType pythonFile,
+                                   final PythonEditorProvider pythonEditorProvider) {
+        editorRegistry.registerDefaultEditor(pythonFile, pythonEditorProvider);
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonLocalizationConstant.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonLocalizationConstant.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide;
+
+import com.google.gwt.i18n.client.Messages;
+
+/**
+ * Localization constants. Interface to represent the constants defined in resource bundle:
+ * 'PythonLocalizationConstant.properties'.
+ *
+ * @author Valeriy Svydenko
+ */
+public interface PythonLocalizationConstant extends Messages {
+    @Key("python.action.create.file.title")
+    String createPythonFileActionTitle();
+
+    @Key("python.action.create.file.description")
+    String createPythonFileActionDescription();
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonResources.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/PythonResources.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.ClientBundle;
+
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+/**
+ * @author Valeriy Svydenko
+ */
+public interface PythonResources extends ClientBundle {
+    PythonResources INSTANCE = GWT.create(PythonResources.class);
+
+    @Source("svg/python.svg")
+    SVGResource pythonFile();
+
+    @Source("svg/python.svg")
+    SVGResource category();
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/action/CreatePythonFileAction.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/action/CreatePythonFileAction.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide.action;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.app.CurrentProject;
+import org.eclipse.che.ide.newresource.AbstractNewResourceAction;
+import org.eclipse.che.plugin.python.ide.PythonLocalizationConstant;
+import org.eclipse.che.plugin.python.ide.PythonResources;
+
+import javax.validation.constraints.NotNull;
+
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_EXT;
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_ID;
+
+/**
+ * Action to create new Python source file.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class CreatePythonFileAction extends AbstractNewResourceAction {
+    private final AppContext appContext;
+
+    @Inject
+    public CreatePythonFileAction(PythonLocalizationConstant localizationConstant,
+                                  PythonResources pythonResources,
+                                  AppContext appContext) {
+        super(localizationConstant.createPythonFileActionTitle(),
+              localizationConstant.createPythonFileActionDescription(),
+              pythonResources.pythonFile());
+        this.appContext = appContext;
+    }
+
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent event) {
+        CurrentProject currentProject = appContext.getCurrentProject();
+        if (currentProject == null) {
+            return;
+        }
+        ProjectConfigDto projectConfig = currentProject.getProjectConfig();
+        String type = projectConfig.getType();
+        event.getPresentation().setEnabledAndVisible(PYTHON_ID.equals(type));
+    }
+
+    @Override
+    protected String getExtension() {
+        return PYTHON_EXT;
+    }
+
+    @Override
+    protected String getDefaultContent() {
+        return "";
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/editor/PythonEditorProvider.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/editor/PythonEditorProvider.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide.editor;
+
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.EditorProvider;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.jseditor.client.defaulteditor.DefaultEditorProvider;
+import org.eclipse.che.ide.jseditor.client.editorconfig.AutoSaveTextEditorConfiguration;
+import org.eclipse.che.ide.jseditor.client.texteditor.EmbeddedTextEditorPresenter;
+
+import javax.inject.Inject;
+
+
+/**
+ * EditorProvider that provides a text editor configured for Python source files.
+ *
+ * @author Valeriy Svydenko
+ */
+public class PythonEditorProvider implements EditorProvider {
+    private final DefaultEditorProvider editorProvider;
+    private final NotificationManager   notificationManager;
+
+    @Inject
+    public PythonEditorProvider(final DefaultEditorProvider editorProvider,
+                                final NotificationManager notificationManager) {
+        this.editorProvider = editorProvider;
+        this.notificationManager = notificationManager;
+    }
+
+    @Override
+    public String getId() {
+        return "PythonEditor";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Python Editor";
+    }
+
+    @Override
+    public EditorPartPresenter getEditor() {
+        final EditorPartPresenter textEditor = editorProvider.getEditor();
+        if (textEditor instanceof EmbeddedTextEditorPresenter) {
+            EmbeddedTextEditorPresenter<?> editor = (EmbeddedTextEditorPresenter<?>)textEditor;
+            editor.initialize(new AutoSaveTextEditorConfiguration(), notificationManager);
+        }
+        return textEditor;
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/inject/PythonGinModule.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/inject/PythonGinModule.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide.inject;
+
+import com.google.gwt.inject.client.AbstractGinModule;
+import com.google.gwt.inject.client.multibindings.GinMultibinder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+
+import org.eclipse.che.ide.MimeType;
+import org.eclipse.che.ide.api.extension.ExtensionGinModule;
+import org.eclipse.che.ide.api.filetypes.FileType;
+import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar;
+import org.eclipse.che.plugin.python.ide.PythonResources;
+import org.eclipse.che.plugin.python.ide.project.PythonProjectWizardRegistrar;
+
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_EXT;
+
+/**
+ * @author Valeriy Svydenko
+ */
+@ExtensionGinModule
+public class PythonGinModule extends AbstractGinModule {
+
+    @Override
+    protected void configure() {
+        GinMultibinder.newSetBinder(binder(), ProjectWizardRegistrar.class).addBinding().to(PythonProjectWizardRegistrar.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named("PythonFileType")
+    protected FileType providePythonFile() {
+        return new FileType("Python", PythonResources.INSTANCE.pythonFile(), MimeType.TEXT_X_PYTHON, PYTHON_EXT);
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/project/PythonProjectWizardRegistrar.java
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/java/org/eclipse/che/plugin/python/ide/project/PythonProjectWizardRegistrar.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.ide.project;
+
+import com.google.inject.Provider;
+
+import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
+import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar;
+import org.eclipse.che.ide.api.wizard.WizardPage;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_CATEGORY;
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_ID;
+
+/**
+ * Provides information for registering Python project type into project wizard.
+ *
+ * @author Valeriy Svydenko
+ */
+public class PythonProjectWizardRegistrar implements ProjectWizardRegistrar {
+    private final List<Provider<? extends WizardPage<ProjectConfigDto>>> wizardPages;
+
+    public PythonProjectWizardRegistrar() {
+        wizardPages = new ArrayList<>();
+    }
+
+    @NotNull
+    public String getProjectTypeId() {
+        return PYTHON_ID;
+    }
+
+    @NotNull
+    public String getCategory() {
+        return PYTHON_CATEGORY;
+    }
+
+    @NotNull
+    public List<Provider<? extends WizardPage<ProjectConfigDto>>> getWizardPages() {
+        return wizardPages;
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/resources/org/eclipse/che/plugin/python/Python.gwt.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/resources/org/eclipse/che/plugin/python/Python.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
+<module>
+    <inherits name="com.google.gwt.user.User"/>
+    <inherits name="com.google.gwt.http.HTTP"/>
+    <inherits name="com.google.gwt.i18n.I18N"/>
+    <inherits name="com.google.gwt.json.JSON"/>
+    <inherits name='org.eclipse.che.ide.Api'/>
+    <inherits name='org.eclipse.che.ide.ui.CodenvyUI'/>
+    <inherits name="com.google.gwt.inject.Inject"/>
+    <inherits name="org.eclipse.che.api.Project"/>
+    <inherits name="org.eclipse.che.ide.Core"/>
+    <inherits name="org.eclipse.che.ide.jseditor.JsEditor"/>
+
+    <source path="ide"/>
+    <source path="shared"/>
+</module>

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/resources/org/eclipse/che/plugin/python/ide/PythonLocalizationConstant.properties
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/resources/org/eclipse/che/plugin/python/ide/PythonLocalizationConstant.properties
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2012-2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
+##### Action #####
+python.action.create.file.title = Python File
+python.action.create.file.description = Create Python File

--- a/plugins/plugin-python/che-plugin-python-lang-ide/src/main/resources/org/eclipse/che/plugin/python/ide/svg/python.svg
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/src/main/resources/org/eclipse/che/plugin/python/ide/svg/python.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
+	 height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<g id="Python">
+	<path fill-rule="evenodd" clip-rule="evenodd" fill="#3193D4" d="M18.158,21.344c0.4,0,0.724,0.327,0.724,0.732
+		c0,0.406-0.323,0.737-0.724,0.737c-0.397,0-0.724-0.331-0.724-0.737C17.435,21.671,17.761,21.344,18.158,21.344L18.158,21.344z
+		 M13.817,9.096c0.399,0,0.725,0.331,0.725,0.737c0,0.406-0.325,0.733-0.725,0.733s-0.723-0.327-0.723-0.733
+		C13.095,9.427,13.418,9.096,13.817,9.096L13.817,9.096z M15.905,7.912c-0.66,0.003-1.29,0.059-1.844,0.158
+		c-1.634,0.288-1.93,0.892-1.93,2.005v1.471h3.858v0.49h-5.307c-1.122,0-2.104,0.674-2.411,1.957c-0.354,1.47-0.37,2.387,0,3.921
+		c0.274,1.144,0.93,1.957,2.051,1.957h1.326v-1.763c0-1.274,1.104-2.398,2.412-2.398h3.854c1.074,0,1.93-0.883,1.93-1.961v-3.675
+		c0-1.046-0.882-1.832-1.93-2.005C17.253,7.959,16.564,7.909,15.905,7.912L15.905,7.912z M20.326,12.037v1.714
+		c0,1.329-1.126,2.447-2.411,2.447h-3.854c-1.057,0-1.93,0.903-1.93,1.962v3.674c0,1.046,0.909,1.661,1.93,1.961
+		c1.221,0.359,2.393,0.425,3.854,0c0.972-0.281,1.93-0.847,1.93-1.961v-1.471H15.99v-0.49h5.784c1.122,0,1.539-0.782,1.93-1.957
+		c0.402-1.208,0.386-2.371,0-3.921c-0.277-1.116-0.807-1.957-1.93-1.957H20.326z"/>
+</g>
+</svg>

--- a/plugins/plugin-python/che-plugin-python-lang-server/pom.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-server/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-python-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.1.0-RC1-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-python-lang-server</artifactId>
+    <name>Che Plugin :: Python :: Extension Server</name>
+    <properties>
+        <findbugs.failonerror>false</findbugs.failonerror>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-project</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-python-lang-shared</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/generator/PythonProjectGenerator.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/generator/PythonProjectGenerator.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.generator;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.project.server.FolderEntry;
+import org.eclipse.che.api.project.server.handlers.CreateProjectHandler;
+import org.eclipse.che.api.project.server.type.AttributeValue;
+import org.eclipse.che.plugin.python.shared.ProjectAttributes;
+
+import java.util.Map;
+
+/**
+ * @author Valeriy Svydenko
+ */
+public class PythonProjectGenerator implements CreateProjectHandler {
+    @Override
+    public void onCreateProject(FolderEntry baseFolder, Map<String, AttributeValue> attributes, Map<String, String> options)
+            throws ForbiddenException, ConflictException, ServerException {
+    }
+
+    @Override
+    public String getProjectType() {
+        return ProjectAttributes.PYTHON_ID;
+    }
+}

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/inject/PythonModule.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/inject/PythonModule.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.inject;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+import org.eclipse.che.api.project.server.handlers.ProjectHandler;
+import org.eclipse.che.api.project.server.type.ProjectTypeDef;
+import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.plugin.python.generator.PythonProjectGenerator;
+import org.eclipse.che.plugin.python.projecttype.PythonProjectType;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+/**
+ * @author Valeriy Svydenko
+ */
+@DynaModule
+public class PythonModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder<ProjectTypeDef> projectTypeMultibinder = newSetBinder(binder(), ProjectTypeDef.class);
+        projectTypeMultibinder.addBinding().to(PythonProjectType.class);
+
+        Multibinder<ProjectHandler> projectHandlerMultibinder = newSetBinder(binder(), ProjectHandler.class);
+        projectHandlerMultibinder.addBinding().to(PythonProjectGenerator.class);
+    }
+}

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/projecttype/PythonProjectType.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/projecttype/PythonProjectType.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.projecttype;
+
+import com.google.inject.Inject;
+
+import org.eclipse.che.api.project.server.type.ProjectTypeDef;
+
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.LANGUAGE;
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_ID;
+import static org.eclipse.che.plugin.python.shared.ProjectAttributes.PYTHON_NAME;
+
+
+/**
+ * Python  project type.
+ *
+ * @author Valeriy Svydenko
+ */
+public class PythonProjectType extends ProjectTypeDef {
+    @Inject
+    public PythonProjectType() {
+        super(PYTHON_ID, PYTHON_NAME, true, false, true);
+        addConstantDefinition(LANGUAGE, LANGUAGE, PYTHON_ID);
+    }
+
+}

--- a/plugins/plugin-python/che-plugin-python-lang-shared/pom.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-shared/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-python-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.1.0-RC1-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-python-lang-shared</artifactId>
+    <name>che-plugin-python-lang-shared</name>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/plugins/plugin-python/che-plugin-python-lang-shared/src/main/java/org/eclipse/che/plugin/python/shared/ProjectAttributes.java
+++ b/plugins/plugin-python/che-plugin-python-lang-shared/src/main/java/org/eclipse/che/plugin/python/shared/ProjectAttributes.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.python.shared;
+
+/**
+ * The utility class for constants.
+ *
+ * @author Valeriy Svydenko
+ */
+public final class ProjectAttributes {
+    public static String LANGUAGE             = "language";
+    public static String PYTHON_ID            = "python";
+    public static String PYTHON_NAME          = "Python Project";
+    public static String PYTHON_CATEGORY      = "Python";
+    public static String PYTHON_EXT           = "py";
+
+    private ProjectAttributes() {
+        throw new UnsupportedOperationException("Unused constructor.");
+    }
+
+}

--- a/plugins/plugin-python/pom.xml
+++ b/plugins/plugin-python/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.1.0-RC1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>che-plugin-python-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Che Plugin :: Python :: Parent</name>
+    <modules>
+        <module>che-plugin-python-lang-shared</module>
+        <module>che-plugin-python-lang-server</module>
+        <module>che-plugin-python-lang-ide</module>
+    </modules>
+</project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -36,5 +36,6 @@
         <module>plugin-github</module>
         <module>plugin-dashboard</module>
         <module>plugin-gwt</module>
+        <module>plugin-python</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,21 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-python-lang-ide</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-python-lang-server</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-python-lang-shared</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-sdk-env-local</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -343,7 +343,8 @@ public class ProjectService extends Service {
         final FileEntry newFile = parent.createFile(fileName, content);
 
         eventService.publish(new ProjectItemModifiedEvent(ProjectItemModifiedEvent.EventType.CREATED,
-                                                          workspace, projectPath(newFile.getPath().toString()),
+                                                          workspace,
+                                                          newFile.getProject(),
                                                           newFile.getPath().toString(),
                                                           false));
 
@@ -379,7 +380,7 @@ public class ProjectService extends Service {
 
         eventService.publish(new ProjectItemModifiedEvent(ProjectItemModifiedEvent.EventType.CREATED,
                                                           workspace,
-                                                          projectPath(newFolder.getPath().toString()),
+                                                          newFolder.getProject(),
                                                           newFolder.getPath().toString(),
                                                           true));
 
@@ -486,7 +487,7 @@ public class ProjectService extends Service {
 
         eventService.publish(new ProjectItemModifiedEvent(ProjectItemModifiedEvent.EventType.UPDATED,
                                                           workspace,
-                                                          projectPath(file.getPath().toString()),
+                                                          file.getProject(),
                                                           file.getPath().toString(),
                                                           false));
 
@@ -581,7 +582,7 @@ public class ProjectService extends Service {
 
         eventService.publish(new ProjectItemModifiedEvent(ProjectItemModifiedEvent.EventType.MOVED,
                                                           workspace,
-                                                          projectPath(entry.getPath().toString()),
+                                                          entry.getProject(),
                                                           entry.getPath().toString(),
                                                           entry.isFolder(),
                                                           path));
@@ -908,15 +909,6 @@ public class ProjectService extends Service {
                  projectType,
                  EnvironmentContext.getCurrent().getWorkspaceId(),
                  EnvironmentContext.getCurrent().getUser().getId());
-    }
-
-    private String projectPath(String path) {
-        int end = path.indexOf("/");
-        if (end == -1) {
-            return path;
-        }
-
-        return path.substring(0, end);
     }
 
     private VirtualFileEntry getVirtualFile(String path, boolean force) throws ServerException,


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko vsvydenko@codenvy.com

Add new plugin for supporting python projects. 
Register new project type 'python' and the editor with supporting a python syntax highlighter.
Now java model is filtering all projects from the workspace and is skipping projects if they don't support java language.

@vparfonov @evidolob 
