### PR TITLE
CHE-815. Remove project folder if import of project is failed

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -323,7 +323,7 @@ public class ProjectService extends Service {
                                                                      ServerException,
                                                                      NotFoundException,
                                                                      BadRequestException {
-        projectManager.importProject(path, sourceStorage);
+        projectManager.importProject(path, sourceStorage, force);
     }
 
     @POST


### PR DESCRIPTION
1. Throw ConflictException when project already exists at importing  
2. Remove project folder if import of project is failed

@vparfonov 
