### PR TITLE
CHE-903: Runtime links to workspace

### DIFF
--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/shared/Constants.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/shared/Constants.java
@@ -37,6 +37,7 @@ public class Constants {
     public static final String LINK_REL_GET_MACHINE_STATUS_CHANNEL = "get machine status channel";
 
     public static final String WSAGENT_REFERENCE                   = "wsagent";
+    public static final String WSAGENT_WEBSOCKET_REFERENCE         = "wsagent.websocket";
     public static final String WSAGENT_DEBUG_REFERENCE             = "wsagent.debug";
 
     public static final String TERMINAL_REFERENCE                  = "terminal";

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -80,6 +80,7 @@ import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.util.LinksHelper.createLink;
 import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
+import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_WEBSOCKET_REFERENCE;
 import static org.eclipse.che.api.workspace.shared.Constants.GET_ALL_USER_WORKSPACES;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_CREATE_WORKSPACE;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_GET_SNAPSHOT;
@@ -891,15 +892,21 @@ public class WorkspaceService extends Service {
                          .stream()
                          .filter(server -> WSAGENT_REFERENCE.equals(server.getRef()))
                          .findAny()
-                         .ifPresent(wsAgent -> workspace.getRuntime()
-                                                        .getLinks()
-                                                        .add(createLink("GET",
-                                                                        UriBuilder.fromUri(wsAgent.getUrl())
-                                                                                  .scheme("https".equals(ideUri.getScheme()) ? "wss"
-                                                                                                                             : "ws")
-                                                                                  .build()
-                                                                                  .toString(),
-                                                                        WSAGENT_REFERENCE)));
+                         .ifPresent(wsAgent -> {
+                             workspace.getRuntime()
+                                      .getLinks()
+                                      .add(createLink("GET",
+                                                      wsAgent.getUrl(),
+                                                      WSAGENT_REFERENCE));
+                             workspace.getRuntime()
+                                      .getLinks()
+                                      .add(createLink("GET",
+                                                      UriBuilder.fromUri(wsAgent.getUrl())
+                                                                .scheme("https".equals(ideUri.getScheme()) ? "wss" : "ws")
+                                                                .build()
+                                                                .toString(),
+                                                      WSAGENT_WEBSOCKET_REFERENCE));
+                         });
             }
         }
         return workspace.withLinks(links);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -73,6 +73,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
+import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_WEBSOCKET_REFERENCE;
 import static org.eclipse.che.api.workspace.shared.Constants.GET_ALL_USER_WORKSPACES;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_GET_SNAPSHOT;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_GET_WORKSPACE_EVENTS_CHANNEL;
@@ -637,6 +638,7 @@ public class WorkspaceServiceTest {
                                                            expectedRels.toString()));
         assertNotNull(workspaceDto.getRuntime().getLink(LINK_REL_STOP_WORKSPACE), "Runtime doesn't contain stop link");
         assertNotNull(workspaceDto.getRuntime().getLink(WSAGENT_REFERENCE), "Runtime doesn't contain wsagent link");
+        assertNotNull(workspaceDto.getRuntime().getLink(WSAGENT_WEBSOCKET_REFERENCE), "Runtime doesn't contain wsagent.websocket link");
     }
 
     private static String unwrapError(Response response) {


### PR DESCRIPTION
CHE-903: Runtime links to workspace agent should contain both types of protocol: http and ws
