### PR TITLE
Separate logic of showing dialog on workspace stop

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/DefaultWorkspaceComponent.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/DefaultWorkspaceComponent.java
@@ -110,7 +110,7 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent implements Com
                         for (WorkspaceDto workspace : workspaces) {
                             if (wsNameFromBrowser.equals(workspace.getConfig().getName())) {
                                 Log.info(getClass(), "Starting workspace " + workspace.getConfig().getName());
-                                startWorkspaceById(workspace);
+                                startWorkspaceById(workspace, callback);
                                 return;
                             }
                         }
@@ -138,7 +138,7 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent implements Com
         } else {
             for(WorkspaceDto workspace : workspaces) {
                 if (workspace.getId().equals(recentWorkspaceId)) {
-                    startWorkspaceById(workspace);
+                    startWorkspaceById(workspace, callback);
                     return;
                 }
             }

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/FactoryWorkspaceComponent.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/FactoryWorkspaceComponent.java
@@ -60,9 +60,9 @@ public class FactoryWorkspaceComponent extends WorkspaceComponent implements Com
 
     @Inject
     public FactoryWorkspaceComponent(WorkspaceServiceClient workspaceServiceClient,
-                                     FactoryServiceClient factoryServiceClient,
                                      CreateWorkspacePresenter createWorkspacePresenter,
                                      StartWorkspacePresenter startWorkspacePresenter,
+                                     FactoryServiceClient factoryServiceClient,
                                      CoreLocalizationConstant locale,
                                      DtoUnmarshallerFactory dtoUnmarshallerFactory,
                                      EventBus eventBus,

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -177,8 +177,11 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
      *
      * @param workspace
      *         workspace which will be started
+     * @param callback
+     *         callback to be executed
      */
-    public void startWorkspaceById(final WorkspaceDto workspace) {
+    public void startWorkspaceById(final WorkspaceDto workspace, final Callback<Component, Exception> callback) {
+        this.callback = callback;
         loader.show(initialLoadingInfo);
         initialLoadingInfo.setOperationStatus(WORKSPACE_BOOTING.getValue(), IN_PROGRESS);
 
@@ -304,12 +307,6 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
                             break;
 
                         case STOPPED:
-                            workspaceServiceClient.getWorkspaces(SKIP_COUNT, MAX_COUNT).then(new Operation<List<WorkspaceDto>>() {
-                                @Override
-                                public void apply(List<WorkspaceDto> workspaces) throws OperationException {
-                                    startWorkspacePresenter.show(workspaces, callback);
-                                }
-                            });
                             unSubscribeWorkspace(statusEvent.getWorkspaceId(), this);
                             notificationManager.notify(locale.extServerStopped(), StatusNotification.Status.SUCCESS, true);
                             eventBus.fireEvent(new WorkspaceStoppedEvent(workspace));
@@ -369,7 +366,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
         return new Operation<WorkspaceDto>() {
             @Override
             public void apply(WorkspaceDto workspaceToStart) throws OperationException {
-                startWorkspaceById(workspaceToStart);
+                startWorkspaceById(workspaceToStart, callback);
             }
         };
     }

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenter.java
@@ -94,8 +94,6 @@ public class CreateWorkspacePresenter implements CreateWorkspaceView.ActionDeleg
     /**
      * Shows special dialog window which allows set up workspace which will be created.
      *
-     * @param callback
-     *         callback which is necessary to notify that workspace component started or failed
      * @param workspaces
      *         list of existing workspaces
      */
@@ -214,7 +212,7 @@ public class CreateWorkspacePresenter implements CreateWorkspaceView.ActionDeleg
             @Override
             public void apply(WorkspaceDto workspace) throws OperationException {
                 DefaultWorkspaceComponent component = wsComponentProvider.get();
-                component.startWorkspaceById(workspace);
+                component.startWorkspaceById(workspace, callback);
             }
         }).catchError(new Operation<PromiseError>() {
             @Override

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspacePresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspacePresenter.java
@@ -117,7 +117,7 @@ public class StartWorkspacePresenter implements StartWorkspaceView.ActionDelegat
 
             workspaceComponent.setCurrentWorkspace(workspace);
 
-            workspaceComponent.startWorkspaceById(workspace);
+            workspaceComponent.startWorkspaceById(workspace, callback);
 
             view.hide();
         }
@@ -136,7 +136,7 @@ public class StartWorkspacePresenter implements StartWorkspaceView.ActionDelegat
     public void onStartWorkspaceClicked() {
         DefaultWorkspaceComponent workspaceComponent = wsComponentProvider.get();
 
-        workspaceComponent.startWorkspaceById(selectedWorkspace);
+        workspaceComponent.startWorkspaceById(selectedWorkspace, callback);
 
         view.hide();
     }

--- a/core/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/core/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -266,9 +266,11 @@ placeholder.find.by.tags=Input tag to find recipe
 ############# Start Workspace Dialog ##########
 start.ws.title=Start Workspace
 start.ws.button=Start
+
 start.ws.select.to.start=Workspace to start:
 placeholder.select.ws.to.start=Click to select workspace to start
 started.ws=Workspace is running
+stopped.ws=Workspace is not running
 ext.server.started=Workspace agent started
 ext.server.stopped=Workspace agent stopped
 workspace.start.failed=Failed to start workspace

--- a/core/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenterTest.java
+++ b/core/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenterTest.java
@@ -337,7 +337,7 @@ public class CreateWorkspacePresenterTest {
         callApplyCreateWorkspaceMethod();
 
         verify(wsComponentProvider).get();
-        verify(workspaceComponent).startWorkspaceById(usersWorkspaceDto);
+        verify(workspaceComponent).startWorkspaceById(usersWorkspaceDto, componentCallback);
     }
 
     private void callApplyCreateWorkspaceMethod() throws Exception {
@@ -361,7 +361,7 @@ public class CreateWorkspacePresenterTest {
 
         callApplyCreateWorkspaceMethod();
 
-        verify(workspaceComponent).startWorkspaceById(usersWorkspaceDto);
+        verify(workspaceComponent).startWorkspaceById(usersWorkspaceDto, componentCallback);
     }
 
     @Test

--- a/core/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/start/StartWorkspacePresenterTest.java
+++ b/core/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/start/StartWorkspacePresenterTest.java
@@ -116,7 +116,7 @@ public class StartWorkspacePresenterTest {
         presenter.onStartWorkspaceClicked();
 
         verify(wsComponentProvider).get();
-        verify(workspaceComponent).startWorkspaceById(workspaceDto);
+        verify(workspaceComponent).startWorkspaceById(workspaceDto, callback);
         verify(view).hide();
     }
 
@@ -175,7 +175,7 @@ public class StartWorkspacePresenterTest {
 
         verify(wsComponentProvider).get();
 
-        verify(workspaceComponent).startWorkspaceById(workspaceDto);
+        verify(workspaceComponent).startWorkspaceById(workspaceDto, callback);
 
         verify(view).hide();
     }

--- a/plugins/plugin-nodejs/che-plugin-nodejs-lang-shared/pom.xml
+++ b/plugins/plugin-nodejs/che-plugin-nodejs-lang-shared/pom.xml
@@ -11,18 +11,15 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>che-plugin-nodejs-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
         <version>4.1.0-RC1-SNAPSHOT</version>
     </parent>
-
     <artifactId>che-plugin-nodejs-lang-shared</artifactId>
     <name>Che Plugin :: NodeJs :: Extension Shared</name>
-
     <build>
         <resources>
             <resource>

--- a/plugins/plugin-nodejs/pom.xml
+++ b/plugins/plugin-nodejs/pom.xml
@@ -11,8 +11,7 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>che-plugin-parent</artifactId>
@@ -20,7 +19,6 @@
         <version>4.1.0-RC1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-
     <artifactId>che-plugin-nodejs-parent</artifactId>
     <packaging>pom</packaging>
     <name>Che Plugin :: NodeJs :: Parent</name>

--- a/plugins/plugin-sdk/che-plugin-sdk-env-local/pom.xml
+++ b/plugins/plugin-sdk/che-plugin-sdk-env-local/pom.xml
@@ -43,11 +43,27 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-client-gwt-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-gwt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-ide-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-app</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-sdk/che-plugin-sdk-env-local/src/main/java/org/eclipse/che/env/local/client/CheWorkspaceStoppedHandler.java
+++ b/plugins/plugin-sdk/che-plugin-sdk-env-local/src/main/java/org/eclipse/che/env/local/client/CheWorkspaceStoppedHandler.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.env.local.client;
+
+import com.google.gwt.core.client.Callback;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.workspace.gwt.client.WorkspaceServiceClient;
+import org.eclipse.che.api.workspace.gwt.client.event.WorkspaceStoppedEvent;
+import org.eclipse.che.api.workspace.gwt.client.event.WorkspaceStoppedHandler;
+import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
+import org.eclipse.che.ide.api.component.Component;
+import org.eclipse.che.ide.workspace.start.StartWorkspacePresenter;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.List;
+
+/**
+ * Shows dialog after workspace stopped event.
+ *
+ * @author Mihail Kuznyetsov
+ */
+@Singleton
+public class CheWorkspaceStoppedHandler implements WorkspaceStoppedHandler {
+
+    private final static int SKIP_COUNT = 0;
+    private final static int MAX_COUNT  = 10;
+
+    private final Provider<StartWorkspacePresenter> startWorkspacePresenterProvider;
+    private final WorkspaceServiceClient            workspaceServiceClient;
+    private final Callback<Component, Exception>    callback;
+
+    @Inject
+    public CheWorkspaceStoppedHandler(Provider<StartWorkspacePresenter> startWorkspacePresenterProvider,
+                                      WorkspaceServiceClient workspaceServiceClient,
+                                      EventBus eventBus) {
+        this.startWorkspacePresenterProvider = startWorkspacePresenterProvider;
+        this.workspaceServiceClient = workspaceServiceClient;
+
+        this.callback = new Callback<Component, Exception>() {
+            @Override
+            public void onFailure(Exception reason) {
+            }
+
+            @Override
+            public void onSuccess(Component result) {
+            }
+        };
+        eventBus.addHandler(WorkspaceStoppedEvent.TYPE, this);
+    }
+
+    @Override
+    public void onWorkspaceStopped(WorkspaceStoppedEvent event) {
+        workspaceServiceClient.getWorkspace(event.getWorkspace().getId()).then(new Operation<WorkspaceDto>() {
+            @Override
+            public void apply(WorkspaceDto workspace) throws OperationException {
+                workspaceServiceClient.getWorkspaces(SKIP_COUNT, MAX_COUNT)
+                                      .then(new Operation<List<WorkspaceDto>>() {
+                                          @Override
+                                          public void apply(List<WorkspaceDto> workspaces) throws OperationException {
+                                              startWorkspacePresenterProvider.get().show(workspaces, callback);
+                                          }
+                                      });
+            }
+        });
+    }
+}

--- a/plugins/plugin-sdk/che-plugin-sdk-env-local/src/main/java/org/eclipse/che/env/local/client/inject/LocalEnvironmentGinModule.java
+++ b/plugins/plugin-sdk/che-plugin-sdk-env-local/src/main/java/org/eclipse/che/env/local/client/inject/LocalEnvironmentGinModule.java
@@ -15,6 +15,7 @@ import com.google.inject.Singleton;
 
 import org.eclipse.che.env.local.client.CheConnectionClosedInformer;
 import org.eclipse.che.env.local.client.CheProductInfoDataProvider;
+import org.eclipse.che.env.local.client.CheWorkspaceStoppedHandler;
 import org.eclipse.che.ide.api.ConnectionClosedInformer;
 import org.eclipse.che.ide.api.ProductInfoDataProvider;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
@@ -28,5 +29,6 @@ public class LocalEnvironmentGinModule extends AbstractGinModule {
     protected void configure() {
         bind(ProductInfoDataProvider.class).to(CheProductInfoDataProvider.class).in(Singleton.class);
         bind(ConnectionClosedInformer.class).to(CheConnectionClosedInformer.class).in(Singleton.class);
+        bind(CheWorkspaceStoppedHandler.class).asEagerSingleton();
     }
 }


### PR DESCRIPTION
Dialog showing logic is moved to separate workspace stop handler, so it can be overriden in non-local environment.
