### PR TITLE
Change default machine name to che

### DIFF
--- a/assembly/assembly-main/src/assembly/bin/che.sh
+++ b/assembly/assembly-main/src/assembly/bin/che.sh
@@ -346,7 +346,11 @@ get_docker_ready () {
       fi
     else
       if [ ! -z "${VBOX_MSI_INSTALL_PATH}" ]; then
-        VBOXMANAGE=${VBOX_MSI_INSTALL_PATH}VBoxManage.exe
+        # Convert this directory to its short form name on Windows
+        if [ "${WIN}" == "true" ]; then
+          export VBOX_MSI_INSTALL_PATH=`(cd "${VBOX_MSI_INSTALL_PATH}" && cmd //C 'FOR %i in (.) do @echo %~Si')`\\
+      fi
+        VBOXMANAGE="${VBOX_MSI_INSTALL_PATH}"VBoxManage.exe
       else
         VBOXMANAGE=/usr/local/bin/VBoxManage
       fi
@@ -367,7 +371,6 @@ get_docker_ready () {
     # Test to see if the VM we need is already running
     # Added || true to not fail due to set -e
     ${VM_CHECK_CMD} &> /dev/null || VM_EXISTS_CODE=$? || true
-
     if [ "${VM_EXISTS_CODE}" == "1" ]; then
       echo -e "Could not find an existing docker machine named ${GREEN}${VM}${NC}."
       echo -e "Creating docker machine named ${GREEN}${VM}${NC}... Please be patient, this takes a couple minutes the first time."

--- a/assembly/assembly-main/src/assembly/bin/che.sh
+++ b/assembly/assembly-main/src/assembly/bin/che.sh
@@ -32,7 +32,7 @@ init_global_variables () {
 Usage:
   che [OPTIONS] [COMMAND]
      -v,        --vmware                Use the docker-machine VMware driver (instead of VirtualBox)
-     -m:name,   --machine:name          For Win & Mac, sets the docker-machine VM name; default=default
+     -m:name,   --machine:name          For Win & Mac, sets the docker-machine VM name; default=che
      -a:driver, --machine-driver:driver For Win & Mac, specifies the docker-machine driver to use; default=vbox
      -p:port,   --port:port             Port that Che server will use for HTTP requests; default=8080
      -r:ip,     --remote:ip             If Che clients are not localhost, set to IP address of Che server
@@ -72,7 +72,7 @@ https://eclipse-che.readme.io/docs/networking."
   CHE_IP=
   USE_HELP=false
   CHE_SERVER_ACTION=run
-  VM=${CHE_DOCKER_MACHINE_NAME:-default}
+  VM=${CHE_DOCKER_MACHINE_NAME:-che}
   MACHINE_DRIVER=virtualbox
   CONTAINER=${CHE_CONTAINER_NAME:-che}
   USE_DEBUG=false
@@ -369,7 +369,7 @@ get_docker_ready () {
     ${VM_CHECK_CMD} &> /dev/null || VM_EXISTS_CODE=$? || true
 
     if [ "${VM_EXISTS_CODE}" == "1" ]; then
-      echo "Could not find an existing docker machine."
+      echo -e "Could not find an existing docker machine named ${GREEN}${VM}${NC}."
       echo -e "Creating docker machine named ${GREEN}${VM}${NC}... Please be patient, this takes a couple minutes the first time."
       "${DOCKER_MACHINE}" rm -f ${VM} &> /dev/null || true
       rm -rf ~/.docker/machine/machines/${VM}

--- a/assembly/assembly-main/src/assembly/bin/che.sh
+++ b/assembly/assembly-main/src/assembly/bin/che.sh
@@ -356,7 +356,7 @@ get_docker_ready () {
       fi
       VM_CHECK_CMD="${VBOXMANAGE} showvminfo ${VM}"
       DOCKER_MACHINE_DRIVER=virtualbox
-      DOCKER_MACHINE_DRIVER_OPTIONS=--virtualbox-host-dns-resolver
+      DOCKER_MACHINE_DRIVER_OPTIONS='--virtualbox-host-dns-resolver --virtualbox-memory 2048 --virtualbox-cpu-count 2'
       if [ ! -f "${VBOXMANAGE}" ]; then
         error_exit "Could not find VirtualBox. Win: VBOX_MSI_INSTALL_PATH env variable not set. Add it or rerun Docker Toolbox installation. Mac: Expected Virtual Box at /usr/local/bin/VBoxManage."
       return


### PR DESCRIPTION
Improved an error message and changed the default docker-machine to be named "che". This solves some issues with Windows systems that have previously run a docker machine named "default".
