### PR TITLE
CHE-605: Extend Workspace API with new post/pre operations

### DIFF
--- a/core/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClient.java
+++ b/core/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClient.java
@@ -38,7 +38,7 @@ public interface WorkspaceServiceClient {
      * @param account
      *         the account id related to this operation
      * @return a promise that resolves to the {@link WorkspaceDto}, or rejects with an error
-     * @see WorkspaceService#create(WorkspaceConfigDto, List, String)
+     * @see WorkspaceService#create(WorkspaceConfigDto, List, Boolean, String)
      */
     Promise<WorkspaceDto> create(WorkspaceConfigDto newWorkspace, String account);
 
@@ -106,7 +106,7 @@ public interface WorkspaceServiceClient {
      * @param envName
      *         the name of the workspace environment that should be used for start
      * @return a promise that resolves to the {@link WorkspaceDto}, or rejects with an error
-     * @see WorkspaceService#startById(String, String, String)
+     * @see WorkspaceService#startById(String, String, Boolean, String)
      */
     Promise<WorkspaceDto> startById(String id, String envName);
 
@@ -116,7 +116,7 @@ public interface WorkspaceServiceClient {
      * @param wsId
      *         workspace ID
      * @return a promise that will resolve when the workspace has been stopped, or rejects with an error
-     * @see WorkspaceService#stop(String)
+     * @see WorkspaceService#stop(String, Boolean)
      */
     Promise<Void> stop(String wsId);
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -129,7 +129,7 @@ public class WorkspaceImpl implements Workspace {
     }
 
     @Override
-    public WorkspaceRuntime getRuntime() {
+    public WorkspaceRuntimeImpl getRuntime() {
         return runtime;
     }
 


### PR DESCRIPTION
Add post workspace create operation which allows to start workspace immediately after workspace is created, `start-after-create=true` query parameter is responsible for that.
Add new `auto-snapshot` and `auto-restore` query parameters which go with stop and start requests, if its value is `true` then:
- A snapshot of the workspace will be created before workspace stop is performed.
  If snapshot creation failed then workspace will be stopped anyway.
- Workspace will be recovered from the snapshot if starting with `auto-restore=true` query parameter and snapshot exists. If snapshot doesn't exist the wokrpsace will be regularly started.

@skabashnyuk, @akorneta, @garagatyi please review
