### PR TITLE
Fixing usage of DataOutputStream and ObjectOutputStream 

### DIFF
--- a/core/commons/che-core-commons-schedule/src/test/java/org/eclipse/che/commons/schedule/executor/CronExpressionTest.java
+++ b/core/commons/che-core-commons-schedule/src/test/java/org/eclipse/che/commons/schedule/executor/CronExpressionTest.java
@@ -132,6 +132,7 @@ public class CronExpressionTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(cronExpression);
+        oos.flush();
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         ObjectInputStream ois = new ObjectInputStream(bais);
         CronExpression newExpression = (CronExpression)ois.readObject();

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/LocalVirtualFileTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/LocalVirtualFileTest.java
@@ -1784,6 +1784,7 @@ public class LocalVirtualFileTest {
         ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
         DataOutputStream dataOutput = new DataOutputStream(byteOutput);
         new FileMetadataSerializer().write(dataOutput, properties);
+        dataOutput.flush();
         return byteOutput.toByteArray();
     }
 


### PR DESCRIPTION
When a `DataOutputStream` or an `ObjectOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance, it is recommended to flush or close the DataOutputStream and ObjectOutputStream before invoking the  underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a `flush` method before calling toByteArray().

Signed-off-by: Wajih ul hassan wajih.lums@gmail.com
