### PR TITLE
CHE-605: Use auto_snapshot/auto_restore attributes instead of params

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -304,11 +304,6 @@ public class WorkspaceService extends Service {
                                   @ApiParam("The name of the workspace environment that should be used for start")
                                   @QueryParam("environment")
                                   String envName,
-                                  @ApiParam("Whether the workspace should be recovered " +
-                                            "from the snapshot if the snapshot exists")
-                                  @QueryParam("auto-restore")
-                                  @DefaultValue("false")
-                                  Boolean autoRestore,
                                   @ApiParam("The account id related to this operation")
                                   @QueryParam("accountId")
                                   String accountId) throws ServerException,
@@ -323,13 +318,7 @@ public class WorkspaceService extends Service {
         params.put("workspaceId", workspaceId);
         permissionManager.checkPermission(START_WORKSPACE, getCurrentUserId(), params);
 
-        final WorkspaceImpl workspace;
-        if (autoRestore && snapshotExists(workspaceId)) {
-            workspace = workspaceManager.recoverWorkspace(workspaceId, envName, accountId);
-        } else {
-            workspace = workspaceManager.startWorkspace(workspaceId, envName, accountId);
-        }
-        return injectLinks(asDto(workspace));
+        return injectLinks(asDto(workspaceManager.startWorkspace(workspaceId, envName, accountId)));
     }
 
     @POST
@@ -416,18 +405,12 @@ public class WorkspaceService extends Service {
                    @ApiResponse(code = 404, message = "The workspace with specified id doesn't exist"),
                    @ApiResponse(code = 403, message = "The user is not workspace owner"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
-    public void stop(@ApiParam("The workspace id")
-                     @PathParam("id")
-                     String id,
-                     @ApiParam("Whether workspace snapshot should be created before stop")
-                     @QueryParam("auto-snapshot")
-                     @DefaultValue("false")
-                     Boolean autoSnapshot) throws ForbiddenException,
-                                                  NotFoundException,
-                                                  ServerException,
-                                                  ConflictException {
+    public void stop(@ApiParam("The workspace id") @PathParam("id") String id) throws ForbiddenException,
+                                                                                      NotFoundException,
+                                                                                      ServerException,
+                                                                                      ConflictException {
         ensureUserIsWorkspaceOwner(id);
-        workspaceManager.stopWorkspace(id, autoSnapshot);
+        workspaceManager.stopWorkspace(id);
     }
 
     @POST
@@ -978,15 +961,6 @@ public class WorkspaceService extends Service {
                                                       APPLICATION_JSON,
                                                       LINK_REL_SELF);
         return snapshotDto.withLinks(asList(machineLink, workspaceLink, workspaceSnapshotLink));
-    }
-
-    private boolean snapshotExists(String workspaceId) throws ServerException {
-        try {
-            workspaceManager.getSnapshot(workspaceId);
-            return true;
-        } catch (NotFoundException e) {
-            return false;
-        }
     }
 
     private static Map<String, String> parseAttrs(List<String> attributes) throws BadRequestException {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -20,6 +20,8 @@ import org.eclipse.che.api.core.rest.permission.Operation;
 public final class Constants {
 
     public static final String WORKSPACE_STOPPED_BY           = "stopped_by";
+    public static final String AUTO_CREATE_SNAPSHOT           = "auto_snapshot";
+    public static final String AUTO_RESTORE_FROM_SNAPSHOT     = "auto_restore";
     public static final String LINK_REL_GET_WORKSPACES        = "get workspaces";
     public static final String LINK_REL_CREATE_WORKSPACE      = "create workspace";
     public static final String LINK_REL_REMOVE_WORKSPACE      = "remove workspace";


### PR DESCRIPTION
@skabashnyuk, @akorneta i made these changes according to the [comment](https://jira.codenvycorp.com/browse/CHE-605? focusedCommentId=274077&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-274077) please review.

Workspace attributes contain `auto_snapshot=true` workspace will be snapshoted before stop operation is perfmored, Workspace attributes contain `auto_restore=true & workspace snapshot exists`, then workspace will be restored from that snapshot.

Note that these changes won't affect default behavior of the Workspace API, and also these changes do not add general configuration parameters, as mentioned in [this comment](https://jira.codenvycorp.com/browse/CHE-605?focusedCommentId=274034&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-274034).
