### PR TITLE
Extracting superclass

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
@@ -205,6 +205,7 @@ import org.eclipse.che.ide.ui.toolbar.ToolbarView;
 import org.eclipse.che.ide.ui.toolbar.ToolbarViewImpl;
 import org.eclipse.che.ide.ui.zeroclipboard.ClipboardButtonBuilder;
 import org.eclipse.che.ide.ui.zeroclipboard.ClipboardButtonBuilderImpl;
+import org.eclipse.che.ide.upload.BasicUploadPresenter;
 import org.eclipse.che.ide.upload.file.UploadFileView;
 import org.eclipse.che.ide.upload.file.UploadFileViewImpl;
 import org.eclipse.che.ide.upload.folder.UploadFolderFromZipView;
@@ -419,6 +420,8 @@ public class CoreGinModule extends AbstractGinModule {
         bind(HotKeysDialogView.class).to(HotKeysDialogViewImpl.class).in(Singleton.class);
 
         bind(RecentFileList.class).to(RecentFileStore.class).in(Singleton.class);
+
+        bind(BasicUploadPresenter.class);
         install(new GinFactoryModuleBuilder().build(RecentFileActionFactory.class));
     }
 

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/newresource/AbstractNewResourceAction.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/newresource/AbstractNewResourceAction.java
@@ -40,6 +40,7 @@ import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 import org.eclipse.che.ide.ui.dialogs.InputCallback;
 import org.eclipse.che.ide.ui.dialogs.input.InputDialog;
 import org.eclipse.che.ide.ui.dialogs.input.InputValidator;
+import org.eclipse.che.ide.upload.BasicUploadPresenter;
 import org.eclipse.che.ide.util.NameUtils;
 import org.eclipse.che.ide.websocket.WebSocketException;
 import org.eclipse.che.ide.websocket.rest.RequestCallback;
@@ -79,6 +80,8 @@ public abstract class AbstractNewResourceAction extends AbstractPerspectiveActio
     private NotificationManager      notificationManager;
     @Inject
     private CoreLocalizationConstant localizationConstant;
+    @Inject
+    private BasicUploadPresenter     basicUploadPresenter;
 
     /**
      * Creates new action.
@@ -244,30 +247,7 @@ public abstract class AbstractNewResourceAction extends AbstractPerspectiveActio
     /** Returns parent for creating new item or {@code null} if resource can not be created. */
     @Nullable
     protected ResourceBasedNode<?> getResourceBasedNode() {
-        Selection<?> selection = projectExplorer.getSelection();
-
-        //we should be sure that user selected single element to work with it
-        if (selection == null || selection.isEmpty()) {
-            return null;
-        }
-
-        Object o = selection.getHeadElement();
-
-        if (o instanceof ResourceBasedNode<?>) {
-            ResourceBasedNode<?> node = (ResourceBasedNode<?>)o;
-            //it may be file node, so we should take parent node
-            if (node.isLeaf() && isResourceAndStorableNode(node.getParent())) {
-                return (ResourceBasedNode<?>)node.getParent();
-            }
-
-            return isResourceAndStorableNode(node) ? node : null;
-        }
-
-        return null;
-    }
-
-    protected boolean isResourceAndStorableNode(@Nullable Node node) {
-        return node != null && node instanceof ResourceBasedNode<?> && node instanceof HasStorablePath;
+        return basicUploadPresenter.getResourceBasedNode();
     }
 
     @Inject

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/BasicUploadPresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/BasicUploadPresenter.java
@@ -1,0 +1,64 @@
+package org.eclipse.che.ide.upload;
+
+import com.google.inject.Inject;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.ide.api.project.node.HasStorablePath;
+import org.eclipse.che.ide.api.project.node.Node;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.project.node.ResourceBasedNode;
+
+import java.util.List;
+
+/**
+ * Provides common functionality for upload classes
+ *
+ * @author  Alex Vengrovsk.
+ */
+public class BasicUploadPresenter {
+
+    private final ProjectExplorerPresenter projectExplorer;
+
+    @Inject
+    public BasicUploadPresenter(ProjectExplorerPresenter projectExplorer) {
+        this.projectExplorer = projectExplorer;
+    }
+
+    public ResourceBasedNode<?> getResourceBasedNode() {
+        List<?> selection = projectExplorer.getSelection().getAllElements();
+        //we should be sure that user selected single element to work with it
+        if (selection == null || selection.size() != 1) {
+            return null;
+        }
+
+        Object o = selection.get(0);
+
+        if (o instanceof ResourceBasedNode<?>) {
+            ResourceBasedNode<?> node = (ResourceBasedNode<?>)o;
+            //it may be file node, so we should take parent node
+            if (node.isLeaf() && isResourceAndStorableNode(node.getParent())) {
+                return (ResourceBasedNode<?>)node.getParent();
+            }
+
+            return isResourceAndStorableNode(node) ? node : null;
+        }
+
+        return null;
+    }
+
+    protected String parseMessage(String message) {
+        int startIndex = 0;
+        int endIndex = message.indexOf("</pre>");
+
+        if (message.contains("<pre>message:")) {
+            startIndex = message.indexOf("<pre>message:") + "<pre>message:".length();
+        } else if (message.contains("<pre>")) {
+            startIndex = message.indexOf("<pre>") + "<pre>".length();
+        }
+
+        return (endIndex != -1) ? message.substring(startIndex, endIndex) : message.substring(startIndex);
+    }
+
+    private boolean isResourceAndStorableNode(@Nullable Node node) {
+        return node != null && node instanceof ResourceBasedNode<?> && node instanceof HasStorablePath;
+    }
+}

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/file/UploadFilePresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/file/UploadFilePresenter.java
@@ -14,18 +14,14 @@ import com.google.gwt.user.client.ui.FormPanel;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
-import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.project.node.HasStorablePath;
-import org.eclipse.che.ide.api.project.node.Node;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
-import org.eclipse.che.ide.project.node.ResourceBasedNode;
-
-import java.util.List;
+import org.eclipse.che.ide.upload.BasicUploadPresenter;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 
@@ -34,7 +30,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMod
  *
  * @author Roman Nikitenko.
  */
-public class UploadFilePresenter implements UploadFileView.ActionDelegate {
+public class UploadFilePresenter extends BasicUploadPresenter implements UploadFileView.ActionDelegate {
 
     private final UploadFileView           view;
     private final String                   workspaceId;
@@ -51,6 +47,7 @@ public class UploadFilePresenter implements UploadFileView.ActionDelegate {
                                NotificationManager notificationManager,
                                ProjectExplorerPresenter projectExplorer,
                                CoreLocalizationConstant locale) {
+        super(projectExplorer);
         this.appContext = appContext;
         this.workspaceId = appContext.getWorkspace().getId();
         this.eventBus = eventBus;
@@ -105,47 +102,5 @@ public class UploadFilePresenter implements UploadFileView.ActionDelegate {
         String fileName = view.getFileName();
         boolean enabled = !fileName.isEmpty();
         view.setEnabledUploadButton(enabled);
-    }
-
-    protected ResourceBasedNode<?> getResourceBasedNode() {
-        List<?> selection = projectExplorer.getSelection().getAllElements();
-        //we should be sure that user selected single element to work with it
-        if (selection != null && selection.isEmpty() || selection.size() > 1) {
-            return null;
-        }
-
-        Object o = selection.get(0);
-
-        if (o instanceof ResourceBasedNode<?>) {
-            ResourceBasedNode<?> node = (ResourceBasedNode<?>)o;
-            //it may be file node, so we should take parent node
-            if (node.isLeaf() && isResourceAndStorableNode(node.getParent())) {
-                return (ResourceBasedNode<?>)node.getParent();
-            }
-
-            return isResourceAndStorableNode(node) ? node : null;
-        }
-
-        return null;
-    }
-
-    protected boolean isResourceAndStorableNode(@Nullable Node node) {
-        return node != null && node instanceof ResourceBasedNode<?> && node instanceof HasStorablePath;
-    }
-
-    private String parseMessage(String message) {
-        int startIndex = 0;
-        int endIndex = -1;
-
-        if (message.contains("<pre>message:")) {
-            startIndex = message.indexOf("<pre>message:") + "<pre>message:".length();
-        } else if (message.contains("<pre>")) {
-            startIndex = message.indexOf("<pre>") + "<pre>".length();
-        }
-
-        if (message.contains("</pre>")) {
-            endIndex = message.indexOf("</pre>");
-        }
-        return (endIndex != -1) ? message.substring(startIndex, endIndex) : message.substring(startIndex);
     }
 }

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/file/UploadFileViewImpl.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/file/UploadFileViewImpl.java
@@ -143,9 +143,11 @@ public class UploadFileViewImpl extends Window implements UploadFileView {
     @NotNull
     public String getFileName() {
         String fileName = file.getFilename();
-        if (fileName.contains("/") || fileName.contains("\\")) {
-            int index = fileName.contains("\\") ? fileName.lastIndexOf("\\") + 1 : fileName.lastIndexOf("/") + 1;
-            fileName = fileName.substring(index);
+        if (fileName.contains("/")) {
+            return fileName.substring(fileName.lastIndexOf("/") + 1);
+        }
+        if (fileName.contains("\\")) {
+            return fileName.substring(fileName.lastIndexOf("\\") + 1);
         }
         return fileName;
     }

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/folder/UploadFolderFromZipPresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/folder/UploadFolderFromZipPresenter.java
@@ -25,6 +25,7 @@ import org.eclipse.che.ide.api.project.node.HasStorablePath;
 import org.eclipse.che.ide.api.project.node.Node;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.project.node.ResourceBasedNode;
+import org.eclipse.che.ide.upload.BasicUploadPresenter;
 
 import java.util.List;
 
@@ -36,7 +37,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  *
  * @author Roman Nikitenko.
  */
-public class UploadFolderFromZipPresenter implements UploadFolderFromZipView.ActionDelegate {
+public class UploadFolderFromZipPresenter extends BasicUploadPresenter implements UploadFolderFromZipView.ActionDelegate {
 
     private final UploadFolderFromZipView  view;
     private final ProjectExplorerPresenter projectExplorer;
@@ -54,6 +55,7 @@ public class UploadFolderFromZipPresenter implements UploadFolderFromZipView.Act
                                         NotificationManager notificationManager,
                                         ProjectExplorerPresenter projectExplorer,
                                         CoreLocalizationConstant locale) {
+        super(projectExplorer);
         this.appContext = appContext;
         this.editorAgent = editorAgent;
         this.eventBus = eventBus;
@@ -110,48 +112,6 @@ public class UploadFolderFromZipPresenter implements UploadFolderFromZipView.Act
         String fileName = view.getFileName();
         boolean enabled = !fileName.isEmpty() && fileName.contains(".zip");
         view.setEnabledUploadButton(enabled);
-    }
-
-    protected ResourceBasedNode<?> getResourceBasedNode() {
-        List<?> selection = projectExplorer.getSelection().getAllElements();
-        //we should be sure that user selected single element to work with it
-        if (selection != null && selection.isEmpty() || selection.size() > 1) {
-            return null;
-        }
-
-        Object o = selection.get(0);
-
-        if (o instanceof ResourceBasedNode<?>) {
-            ResourceBasedNode<?> node = (ResourceBasedNode<?>)o;
-            //it may be file node, so we should take parent node
-            if (node.isLeaf() && isResourceAndStorableNode(node.getParent())) {
-                return (ResourceBasedNode<?>)node.getParent();
-            }
-
-            return isResourceAndStorableNode(node) ? node : null;
-        }
-
-        return null;
-    }
-
-    protected boolean isResourceAndStorableNode(@Nullable Node node) {
-        return node != null && node instanceof ResourceBasedNode<?> && node instanceof HasStorablePath;
-    }
-
-    private String parseMessage(String message) {
-        int startIndex = 0;
-        int endIndex = -1;
-
-        if (message.contains("<pre>message:")) {
-            startIndex = message.indexOf("<pre>message:") + "<pre>message:".length();
-        } else if (message.contains("<pre>")) {
-            startIndex = message.indexOf("<pre>") + "<pre>".length();
-        }
-
-        if (message.contains("</pre>")) {
-            endIndex = message.indexOf("</pre>");
-        }
-        return (endIndex != -1) ? message.substring(startIndex, endIndex) : message.substring(startIndex);
     }
 
     private void updateOpenedEditors() {

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/folder/UploadFolderFromZipViewImpl.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/folder/UploadFolderFromZipViewImpl.java
@@ -161,9 +161,11 @@ public class UploadFolderFromZipViewImpl extends Window implements UploadFolderF
     @NotNull
     public String getFileName() {
         String fileName = file.getFilename();
-        if (fileName.contains("/") || fileName.contains("\\")) {
-            int index = fileName.contains("\\") ? fileName.lastIndexOf("\\") + 1 : fileName.lastIndexOf("/") + 1;
-            fileName = fileName.substring(index);
+        if (fileName.contains("/")) {
+            return fileName.substring(fileName.lastIndexOf("/") + 1);
+        }
+        if (fileName.contains("\\")) {
+            return fileName.substring(fileName.lastIndexOf("\\") + 1);
         }
         return fileName;
     }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/remove/RemoveFromIndexPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/remove/RemoveFromIndexPresenter.java
@@ -36,6 +36,7 @@ import org.eclipse.che.ide.project.node.FolderReferenceNode;
 import org.eclipse.che.ide.project.node.ResourceBasedNode;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.rest.AsyncRequestCallback;
+import org.eclipse.che.ide.upload.BasicUploadPresenter;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -50,7 +51,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  *
  * @author Ann Zhuleva
  */
-public class RemoveFromIndexPresenter implements RemoveFromIndexView.ActionDelegate {
+public class RemoveFromIndexPresenter extends BasicUploadPresenter implements RemoveFromIndexView.ActionDelegate {
     public static final String REMOVE_FROM_INDEX_COMMAND_NAME = "Git remove from index";
 
     private final RemoveFromIndexView      view;
@@ -88,6 +89,7 @@ public class RemoveFromIndexPresenter implements RemoveFromIndexView.ActionDeleg
                                     ProjectExplorerPresenter projectExplorer,
                                     GitOutputConsoleFactory gitOutputConsoleFactory,
                                     ConsolesPanelPresenter consolesPanelPresenter) {
+        super(projectExplorer);
         this.view = view;
         this.eventBus = eventBus;
         this.projectExplorer = projectExplorer;
@@ -183,31 +185,6 @@ public class RemoveFromIndexPresenter implements RemoveFromIndexView.ActionDeleg
                        }
                       );
         view.close();
-    }
-
-    @Nullable
-    protected ResourceBasedNode<?> getResourceBasedNode() {
-        List<?> selection = projectExplorer.getSelection().getAllElements();
-        //we should be sure that user selected single element to work with it
-        if (selection != null && !selection.isEmpty()) {
-
-            Object o = selection.get(0);
-
-            if (o instanceof ResourceBasedNode<?>) {
-                ResourceBasedNode<?> node = (ResourceBasedNode<?>)o;
-                //it may be file node, so we should take parent node
-                if (node.isLeaf() && isResourceAndStorableNode(node.getParent())) {
-                    return (ResourceBasedNode<?>)node.getParent();
-                }
-
-                return isResourceAndStorableNode(node) ? node : null;
-            }
-        }
-        return null;
-    }
-
-    protected boolean isResourceAndStorableNode(@Nullable Node node) {
-        return node != null && node instanceof ResourceBasedNode<?> && node instanceof HasStorablePath;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: alextrentton@gmail.com

If-check in the `getResourceBasedNode()` method can be simplified. This change allows to exclude one check and protect method from `NullPointerException`. But this method still can throw this exception in line 
`Object o = selection.get(0);`
I wasn't shure is it expected behaviour, so, didn't chenge anything there.

In the `parseMessage()` method it is posible to exclude the last if-check, because method `indexOf()` will return index or -1 if there is no searching sequence in the String. 

One more question - both changed classes have identical methods with identical bodies: `getResourceBasedNode()`, `isResourceAndStorableNode()`, `parseMessage()`. Maybe, it would be better to create some utility class (for example - `UploadUtil`) with this methods and to use this class for both `UploadFilePresenter` and `UploadFolderFromZipPresenter`? 
The same story about methods `addFile()` (from `UploadFileViewImpl`) and `addFileUploadForm()` (from `UploadFolderFromZipViewImpl`).
