### PR TITLE
Allow factory to contain projects with keepDir function

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -333,6 +333,12 @@ public final class ProjectManager {
         List<? extends ProjectConfig> projects = workspaceConfig.getProjects();
         for (ProjectConfig project : projects) {
             if (normalizePath.equals(project.getPath())) {
+                // TODO Needed for factory project importing with keepDir. It needs to find more appropriate solution
+                List<String> innerProjects = projectRegistry.getProjects(normalizePath);
+                for (String innerProject : innerProjects) {
+                    RegisteredProject registeredProject = projectRegistry.getProject(innerProject);
+                    projectRegistry.putProject(registeredProject, asFolder(registeredProject.getPath()), true, false);
+                }
                 return projectRegistry.putProject(project, folder, true, false);
             }
         }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/FactoryBaseValidator.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/FactoryBaseValidator.java
@@ -73,19 +73,24 @@ public abstract class FactoryBaseValidator {
                                               "digits or these following special characters -._.");
             }
 
-            final String location = project.getSource().getLocation();
-            final String parameterLocationName = "project.storage.location";
-            if (isNullOrEmpty(location)) {
-                throw new BadRequestException(format(FactoryConstants.PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE,
-                                                     parameterLocationName,
-                                                     location));
-            }
-            try {
-                URLDecoder.decode(location, "UTF-8");
-            } catch (IllegalArgumentException | UnsupportedEncodingException e) {
-                throw new BadRequestException(format(FactoryConstants.PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE,
-                                                     parameterLocationName,
-                                                     location));
+            if (project.getPath().indexOf('/', 1) == -1) {
+
+                final String location = project.getSource().getLocation();
+                final String parameterLocationName = "project.source.location";
+
+                if (isNullOrEmpty(location)) {
+                    throw new BadRequestException(format(FactoryConstants.PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE,
+                                                         parameterLocationName,
+                                                         location));
+                }
+
+                try {
+                    URLDecoder.decode(location, "UTF-8");
+                } catch (IllegalArgumentException | UnsupportedEncodingException e) {
+                    throw new BadRequestException(format(FactoryConstants.PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE,
+                                                         parameterLocationName,
+                                                         location));
+                }
             }
         }
     }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
@@ -963,11 +963,13 @@ public class FactoryServiceTest {
         wsConfig.setProjects(Arrays.asList(dto.createDto(ProjectConfigDto.class)
                                               .withSource(dto.createDto(SourceStorageDto.class)
                                                        .withType("git")
-                                                       .withLocation("location")),
+                                                       .withLocation("location"))
+                                              .withPath("path"),
                                            dto.createDto(ProjectConfigDto.class)
                                               .withSource(dto.createDto(SourceStorageDto.class)
                                                        .withType("git")
-                                                       .withLocation("location"))));
+                                                       .withLocation("location"))
+                                              .withPath("path")));
         wsConfig.setName("wsname");
         wsConfig.setDefaultEnv("env1");
         wsConfig.setEnvironments(Collections.singletonList(dto.createDto(EnvironmentDto.class).withName("env1")));

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/dto/ProjectConfigDto.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/dto/ProjectConfigDto.java
@@ -77,7 +77,7 @@ public interface ProjectConfigDto extends ProjectConfig {
     ProjectConfigDto withAttributes(Map<String, List<String>> attributes);
 
     @Override
-    @FactoryParameter(obligation = MANDATORY)
+    @FactoryParameter(obligation = OPTIONAL)
     SourceStorageDto getSource();
 
     void setSource(SourceStorageDto source);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/dto/SourceStorageDto.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/dto/SourceStorageDto.java
@@ -20,12 +20,14 @@ import static org.eclipse.che.api.core.factory.FactoryParameter.Obligation.MANDA
 import static org.eclipse.che.api.core.factory.FactoryParameter.Obligation.OPTIONAL;
 
 /**
+ * TODO Type and location are optional in case it is a subproject, that has an empty source.
+ *
  * @author Alexander Garagatyi
  */
 @DTO
 public interface SourceStorageDto extends SourceStorage {
     @Override
-    @FactoryParameter(obligation = MANDATORY)
+    @FactoryParameter(obligation = OPTIONAL)
     String getType();
 
     void setType(String type);
@@ -33,7 +35,7 @@ public interface SourceStorageDto extends SourceStorage {
     SourceStorageDto withType(String type);
 
     @Override
-    @FactoryParameter(obligation = MANDATORY)
+    @FactoryParameter(obligation = OPTIONAL)
     String getLocation();
 
     void setLocation(String location);


### PR DESCRIPTION
Projects that are created with keepDir option have no source type or location.
So the source validation or project in factory will be omitted, if such project is located in another project
