### PR TITLE
Fixing 'StaticAccessedFromInstance' warnings

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/ide/ext/debugger/client/configuration/EditDebugConfigurationsViewImpl.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/ide/ext/debugger/client/configuration/EditDebugConfigurationsViewImpl.java
@@ -340,7 +340,7 @@ public class EditDebugConfigurationsViewImpl extends Window implements EditDebug
                 delegate.onSaveClicked();
             }
         });
-        saveButton.addStyleName(this.resources.windowCss().primaryButton());
+        saveButton.addStyleName(Window.resources.windowCss().primaryButton());
         overFooter.add(saveButton);
 
         cancelButton = createButton(coreLocale.cancel(), "window-edit-debug-configurations-cancel", new ClickHandler() {

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/ide/ext/debugger/client/debug/DebuggerTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/ide/ext/debugger/client/debug/DebuggerTest.java
@@ -166,7 +166,7 @@ public class DebuggerTest extends BaseTest {
         doReturn(messageBus).when(messageBusProvider).getMachineMessageBus();
 
         doReturn(localStorage).when(localStorageProvider).get();
-        doReturn(DEBUG_INFO).when(localStorage).getItem(debugger.LOCAL_STORAGE_DEBUGGER_KEY);
+        doReturn(DEBUG_INFO).when(localStorage).getItem(AbstractDebugger.LOCAL_STORAGE_DEBUGGER_KEY);
         doReturn(debuggerInfo).when(dtoFactory).createDtoFromJson(DEBUG_INFO, DebuggerInfo.class);
 
         doReturn(fgnResolver).when(fqnResolverFactory).getResolver(anyString());


### PR DESCRIPTION
According to [Error Prone](http://errorprone.info/bugpattern/StaticAccessedFromInstance) website

> A static variable or method should never be accessed from an instance. This hides the fact that the variable or method is static and does not depend on the value of the object instance on which this variable or method is being invoked.

This pull request fixes this issue/warning.

Signed-off-by: Wajih ul hassan wajih.lums@gmail.com
