### PR TITLE
Fixing wildcard import

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ValueHelper.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ValueHelper.java
@@ -10,7 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.factory.server;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * @author Sergii Kabashniuk


### PR DESCRIPTION
According to [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html#s3.3.1-wildcard-imports), wildcard imports should not be used because they make code difficult to reason about. 
This pull request fixes this issue in ValueHelper.java.

Signed-off-by: Wajih ul hassan wajih.lums@gmail.com
