### PR TITLE
Fix error 'removal of the recipe file' in the console log

### DIFF
--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/util/RecipeDownloader.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/util/RecipeDownloader.java
@@ -78,7 +78,7 @@ public class RecipeDownloader {
                                               machineConfig.getSource().getLocation(),
                                               e.getLocalizedMessage()));
         } finally {
-            if (file != null && file.delete()) {
+            if (file != null && !file.delete()) {
                 LOG.error(String.format("Removal of recipe file %s failed.", file.getAbsolutePath()));
             }
         }


### PR DESCRIPTION
When file was delete succesfully then file.delete() == true.
@garagatyi @skabashnyuk review please
