### PR TITLE
Remove Command and Machine selectors from project explorer context menu

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineExtension.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineExtension.java
@@ -192,11 +192,6 @@ public class MachineExtension {
         actionManager.registerAction(GROUP_COMMANDS_LIST, commandList);
         commandList.add(editCommandsAction, FIRST);
 
-        final DefaultActionGroup runContextGroup = (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_RUN_CONTEXT_MENU);
-        runContextGroup.add(machinesList);
-        runContextGroup.add(commandList);
-        runContextGroup.addSeparator();
-
         // Define hot-keys
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.F12).build(), "newTerminal");
 


### PR DESCRIPTION
**_1 Upvote**_ Signed-off-by: Vitaliy Guliy vguliy@codenvy.com
