### PR TITLE
Optimazing builder's implementation

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/parser/DockerImageIdentifier.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/parser/DockerImageIdentifier.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * <br>my_private_registry:15800/my_image1:latest
  * <br>my_private_registry:15800/my_image1@sha256:6b019df8c73bb42e606225ef935760b9c428521eba4ad2519ef3ff4cdb3dbd69
  *
- * @author Alexander Garaagtyi
+ * @author Alexander Garagatyi
  */
 public class DockerImageIdentifier {
     private final String  registry;
@@ -37,10 +37,10 @@ public class DockerImageIdentifier {
     private final String  tag;
     private final String  digest;
 
-    public DockerImageIdentifier(String registry,
-                                 String repository,
-                                 String tag,
-                                 String digest) {
+    private DockerImageIdentifier(String registry,
+                                  String repository,
+                                  String tag,
+                                  String digest) {
         this.registry = registry;
         this.repository = repository;
         this.tag = tag;


### PR DESCRIPTION
Signed-off-by: alextrentton@gmail.com

Maybe I get it all wrong, but it seems to me, that when builder is provided for creation an instance of the  _DockerImageIdentifier_  it is not a very good idea to make a constructor of this class public. Otherwise, what is a reason to do all this overhead work with builder implementation?

With changes from this PR, the instance of the _DockerImageIdentifier_  can be created this way:

```
DockerImageIdentifier dockerImageIdentifier = DockerImageIdentifier.builder()
                                                                   .setDigest("digest")
                                                                   .setRegistry("registry")
                                                                   .setRepository("repository")
                                                                   .setTag("tag")
                                                                   .build(); 
```
