### PR TITLE
Fixing random number contention

### DIFF
--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/util/UUID.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/util/UUID.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.ide.util;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 /**
  * Generate a random UUID.
  *
@@ -50,7 +52,7 @@ public class UUID {
         char[] uuid = new char[len];
         // Compact form
         for (int i = 0; i < len; i++) {
-            uuid[i] = CHARS[(int)(Math.random() * radix)];
+            uuid[i] = CHARS[ThreadLocalRandom.current().nextInt(radix)];
         }
         return new String(uuid);
     }
@@ -71,7 +73,7 @@ public class UUID {
         // per rfc4122, sec. 4.1.5
         for (int i = 0; i < 36; i++) {
             if (uuid[i] == 0) {
-                r = (int)(Math.random() * 16);
+                r = ThreadLocalRandom.current().nextInt(16);
                 uuid[i] = CHARS[(i == 19) ? (r & 0x3) | 0x8 : r & 0xf];
             }
         }

--- a/core/commons/che-core-commons-gwt/src/test/java/org/eclipse/che/ide/util/UUIDTest.java
+++ b/core/commons/che-core-commons-gwt/src/test/java/org/eclipse/che/ide/util/UUIDTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test of UUID generator
+ */
+
+public class UUIDTest {
+
+    @Test
+    public void testUUIDLength() {
+        String uuid = UUID.uuid(15);
+        Assert.assertEquals(15, uuid.length());
+    }
+
+    @Test
+    public void testUUIDRadix() {
+        String uuid1 = UUID.uuid(6,2);
+        Assert.assertTrue(uuid1.matches("[0-1]{6}"));
+	String uuid2 = UUID.uuid(8,10);
+        Assert.assertTrue(uuid2.matches("[0-9]{8}"));
+    }
+
+    @Test
+    public void testUUIDRFC4122() {
+        String uuid = UUID.uuid();
+        Assert.assertTrue(uuid.matches("^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"));
+    }
+
+}


### PR DESCRIPTION
In `UUID.java`, `Math.random()` is used for random number generation and multiple threads use this UUID generator in eclipse che .
According to [Java API](http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#random--) , in multi-threaded environment, it is suggested that each thread has their own random number generator to reduce contention. 
This pull request replaces `Math.random()` with `ThreadLocalRandom`, which has a Random instance per thread and safeguards against contention. Also, I added tests for UUID generator. 
Let me know if I need to change or add something.

Signed-off-by: Wajih ul hassan wajih.lums@gmail.com
