### PR TITLE
createMachineLogsDir fix for issue #366

### DIFF
--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
@@ -884,7 +884,8 @@ public class MachineManager {
     }
 
     private void createMachineLogsDir(String machineId) throws MachineException {
-        if (!new File(machineLogsDir, machineId).mkdirs()) {
+        File dir = new File(machineLogsDir, machineId);
+        if (!dir.exists() && !dir.mkdirs()) {
             throw new MachineException("Can't create folder for the logs of machine");
         }
     }


### PR DESCRIPTION
The following change fixes one of the failing tests for issue #366. The mkdirs() function in File returns false when the file already exists which caused the test to throw an exception. To fix this problem I added a check to see if the directory already exists before throwing the exception.

This change does not fix all of the issues when trying to build Eclipse Che on Windows.

Signed-off-by: Nicholas Lu ndlu2@illinois.edu
