### PR TITLE
CHE-137. Improve full text searching

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -657,6 +657,12 @@ public interface CoreLocalizationConstant extends Messages {
 
     String search();
 
+    @Key("text.search.scope.label")
+    String textSearchScopeLabel();
+
+    @Key("text.search.fileFilter.label")
+    String textSearchFileFilterLabel();
+
     @Key("text.search.content.label")
     String textSearchContentLabel();
 

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchPresenter.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchPresenter.java
@@ -30,9 +30,12 @@ import java.util.List;
  * Presenter for full text search.
  *
  * @author Valeriy Svydenko
+ * @author Roman Nikitenko
  */
 @Singleton
 public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegate {
+    private static final String URL_ENCODED_BACKSLASH = "%5C";
+    private static final String AND_OPERATOR          = "AND";
 
     private final FullTextSearchView   view;
     private final FindResultPresenter  findResultPresenter;
@@ -69,7 +72,7 @@ public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegat
     @Override
     public void search(final String text) {
         QueryExpression queryExpression = new QueryExpression();
-        queryExpression.setText(text + '*');
+        queryExpression.setText(prepareQuery(text));
         if (!view.getFileMask().isEmpty()) {
             queryExpression.setName(view.getFileMask());
         }
@@ -89,6 +92,51 @@ public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegat
                 view.showErrorMessage(dtoFactory.createDtoFromJson(arg.getMessage(), ServiceError.class).getMessage());
             }
         });
+    }
+
+    private String prepareQuery(String text) {
+        StringBuilder sb = new StringBuilder();
+        for (char character : text.toCharArray()) {
+            // Escape those characters that QueryParser expects to be escaped
+            if (character == '\\' ||
+                character == '+' ||
+                character == '-' ||
+                character == '!' ||
+                character == '(' ||
+                character == ')' ||
+                character == ':' ||
+                character == '^' ||
+                character == '[' ||
+                character == ']' ||
+                character == '\"' ||
+                character == '{' ||
+                character == '}' ||
+                character == '~' ||
+                character == '*' ||
+                character == '?' ||
+                character == '|' ||
+                character == '&' ||
+                character == '/') {
+                sb.append(URL_ENCODED_BACKSLASH);
+            }
+            sb.append(character);
+        }
+        String escapedText = sb.toString();
+
+        String[] items = escapedText.trim().split("\\s+");
+        int numberItem = items.length;
+        if (numberItem == 1) {
+            return items[0] + '*';
+        }
+
+        String lastItem = items[numberItem - 1];
+        sb = new StringBuilder();
+        sb.append('"');
+        sb.append(escapedText.substring(0, escapedText.lastIndexOf(lastItem)));
+        sb.append("\" " + AND_OPERATOR + " ");
+        sb.append(lastItem);
+        sb.append('*');
+        return sb.toString();
     }
 
     @Override

--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.ui.xml
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.ui.xml
@@ -23,80 +23,88 @@
             margin: 6px;
         }
 
-        .spacingContainer {
-            margin-top: 5px;
-            margin-bottom: 8px;
-        }
-
-        .labelMargin {
-            margin: 5px 5px;
-        }
-
-        .containerPanel {
-            width: 100%;
-            height: 27px;
-        }
-
         .checkBox {
             float: left;
-            margin-left: 6px;
-            margin-top: 6px;
+            margin-top: 4px;
+        }
+
+        .label {
+            float: left;
+            margin-bottom: 0;
+        }
+
+        .checkBoxLabel {
+            margin-left: 3px;
+        }
+
+        .promtLabel {
+            float: right;
+            margin-right: 28px;
+            margin-bottom: 0;
         }
 
         .selectDirectoryButton {
             min-width: 25px;
-            margin-left: 2px;
-            border-radius: 5px;
-            padding: 0 7px;
+            margin-left: 3px;
+            padding: 2px 7px;
         }
 
         .selectDirectoryButton:hover,
         .selectDirectoryButton:focus {
+            float: left;
             box-shadow: 0 0 0 1px buttonHoverBorderColor, 0 0 0 2px buttonHoverBackground;
             border-color: transparent;
         }
 
-        .floating {
+        .section {
             float: left;
+            line-height: 22px;
+            margin-left: 4px;
+        }
+
+        .sectionContent {
+            margin-left: 15px;
+            margin-bottom: 5px;
         }
 
         .inputTextBox {
+            float: left;
             margin-bottom: 2px;
-        }
-
-        .box {
+            margin-left: 6px;
             -moz-box-sizing: border-box;
             box-sizing: border-box;
             -webkit-box-sizing: border-box;
         }
     </ui:style>
-    <g:FlowPanel width="400px" height="135px" addStyleNames="{style.emptyBorder}" debugId="text-search-mainPanel">
-        <g:FlowPanel addStyleNames="{style.emptyBorder} {style.spacingContainer} {style.containerPanel} {style.floating}">
-            <g:Label addStyleNames="{style.labelMargin} {style.floating}" text="{locale.textSearchContentLabel}"/>
-            <g:TextBox ui:field="text" width="310px" addStyleNames="{style.box} {style.floating} {style.inputTextBox}"
+    <g:FlowPanel width="400px" addStyleNames="{style.emptyBorder}" debugId="text-search-mainPanel">
+        <g:FlowPanel addStyleNames="{style.section}">
+            <g:Label addStyleNames="{style.label}" text="{locale.textSearchContentLabel}"/>
+            <g:TextBox ui:field="text" width="322px" addStyleNames="{style.inputTextBox}"
                        debugId="text-search-text"/>
         </g:FlowPanel>
 
-        <g:FlowPanel addStyleNames="{style.emptyBorder} {style.spacingContainer} {style.containerPanel} {style.floating}">
-            <g:CheckBox ui:field="isUseDirectory" addStyleNames="{style.checkBox}" value="false"/>
-            <g:Label addStyleNames="{style.labelMargin} {style.floating}" text="{locale.textSearchDirectory}"/>
-            <g:TextBox enabled="false" ui:field="directory" width="257px" addStyleNames="{style.box} {style.floating}"
+        <g:FlowPanel addStyleNames="{style.section}">
+            <g:Label text="{locale.textSearchScopeLabel}" width="100%" addStyleNames="{style.label}"/>
+            <g:CheckBox ui:field="isUseDirectory" addStyleNames="{style.checkBox} {style.sectionContent}" value="false"/>
+            <g:Label addStyleNames="{style.label} {style.checkBoxLabel}" text="{locale.textSearchDirectory}"/>
+            <g:TextBox enabled="false" ui:field="directory" width="257px" addStyleNames="{style.inputTextBox}"
                        debugId="text-search-directory"/>
-            <g:Button enabled="false" ui:field="selectPathButton" text="..." addStyleNames="{style.floating} {style.selectDirectoryButton}"
+            <g:Button enabled="false" ui:field="selectPathButton" text="..." addStyleNames="{style.selectDirectoryButton}"
                       debugId="text-search-directory-button"/>
         </g:FlowPanel>
 
-        <g:FlowPanel addStyleNames="{style.emptyBorder} {style.spacingContainer} {style.containerPanel} {style.floating}">
-            <g:CheckBox ui:field="isUseFileMask" addStyleNames="{style.checkBox}" value="false"/>
-            <g:Label addStyleNames="{style.labelMargin} {style.floating}" text="{locale.textSearchFileMask}"/>
-            <g:TextBox enabled="false" ui:field="filesMask" width="296px" addStyleNames="{style.box} {style.floating}"
+        <g:FlowPanel addStyleNames="{style.section}">
+            <g:Label text="{locale.textSearchFileFilterLabel}" width="100%" addStyleNames="{style.label}"/>
+            <g:CheckBox ui:field="isUseFileMask" value="false" addStyleNames="{style.checkBox} {style.sectionContent}"/>
+            <g:Label text="{locale.textSearchFileMask}" width="62px" addStyleNames="{style.label} {style.checkBoxLabel}"/>
+            <g:TextBox enabled="false" ui:field="filesMask" width="284px" addStyleNames="{style.inputTextBox}"
                        debugId="text-search-files"/>
-            <g:Label width="100%" addStyleNames="{style.labelMargin} {res.coreCss.greyFontColor}"
+            <g:Label addStyleNames="{res.coreCss.greyFontColor} {style.promtLabel}"
                      text="{locale.navigateToFileViewFileFieldPrompt}"/>
         </g:FlowPanel>
 
-        <g:SimplePanel addStyleNames="{style.emptyBorder} {style.spacingContainer} {style.containerPanel} {style.floating}">
-            <g:Label ui:field="errLabel" width="100%" addStyleNames="{style.labelMargin} {res.coreCss.errorFont}"/>
+        <g:SimplePanel addStyleNames="{style.section}">
+            <g:Label ui:field="errLabel" width="100%" direction="LTR" addStyleNames="{res.coreCss.errorFont}"/>
         </g:SimplePanel>
     </g:FlowPanel>
 </ui:UiBinder>

--- a/core/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/core/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -303,6 +303,8 @@ error.configuration.content=Do you want configure project as BLANK? You can re-c
 ############### full-text-search###################
 action.full.text.search=Find
 action.full.text.search.description=Find Text In Path
+text.search.scope.label=Scope
+text.search.fileFilter.label=File name filter
 text.search.content.label=Text to find:
 text.search.title=Find Text
 text.search.file.mask=File mask:

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -131,6 +131,14 @@ public class ProjectServiceTest {
     protected final static String FS_PATH    = "target/fss";
     protected final static String INDEX_PATH = "target/fss_index";
 
+    private static final String URL_ENCODED_QUOTES            = "%22";
+    private static final String URL_ENCODED_SPACE             = "%20";
+    private static final String URL_ENCODED_BACKSLASH         = "%5C";
+    private static final String URL_ENCODED_ASTERISK          = "%2A";
+
+    private static final String AND_OPERATOR = "AND";
+    private static final String NOT_OPERATOR = "NOT";
+
     private ProjectManager         pm;
     private ResourceLauncher       launcher;
     private ProjectHandlerRegistry phRegistry;
@@ -142,7 +150,7 @@ public class ProjectServiceTest {
     @Mock
     private UserDao                userDao;
     @Mock
-    private WorkspaceDto      usersWorkspaceMock;
+    private WorkspaceDto           usersWorkspaceMock;
     @Mock
     private WorkspaceConfigDto     workspaceConfigMock;
     @Mock
@@ -1890,6 +1898,137 @@ public class ProjectServiceTest {
         Set<String> paths = new LinkedHashSet<>(1);
         paths.addAll(result.stream().map(ItemReference::getPath).collect(Collectors.toList()));
         Assert.assertTrue(paths.contains("/my_project/x/y/__test.txt"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSearchParticularSequenceWords() throws Exception {
+        String queryToSearch = "?text=" + URL_ENCODED_QUOTES +
+                               "To" + URL_ENCODED_SPACE +
+                               "be" + URL_ENCODED_SPACE +
+                               "or" + URL_ENCODED_SPACE +
+                               "not" + URL_ENCODED_SPACE +
+                               "to" + URL_ENCODED_SPACE +
+                               "be" + URL_ENCODED_QUOTES;
+        RegisteredProject myProject = pm.getProject("my_project");
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "Pay attention! To be or to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("c").createFile("_test", "Pay attention! To be or to not be that is the question".getBytes());
+
+        ContainerResponse response =
+                launcher.service(GET, String.format("http://localhost:8080/api/project/%s/search/my_project", workspace) + queryToSearch,
+                                 "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        List<ItemReference> result = (List<ItemReference>)response.getEntity();
+        assertEquals(result.size(), 1);
+        Set<String> paths = new LinkedHashSet<>(1);
+        paths.addAll(result.stream().map(ItemReference::getPath).collect(Collectors.toList()));
+        Assert.assertTrue(paths.contains("/my_project/x/y/containsSearchText.txt"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSearchParticularSequenceWordsWithAnyEnding() throws Exception {
+        String queryToSearch = "?text=" + URL_ENCODED_QUOTES +
+                               "that" + URL_ENCODED_SPACE +
+                               "is" + URL_ENCODED_SPACE +
+                               "the" + URL_ENCODED_QUOTES + URL_ENCODED_SPACE + AND_OPERATOR + URL_ENCODED_SPACE +
+                               "question" + URL_ENCODED_ASTERISK;
+        RegisteredProject myProject = pm.getProject("my_project");
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("a/b")
+                 .createFile("containsSearchTextAlso.txt", "Pay attention! To be or not to be that is the questionS".getBytes());
+        myProject.getBaseFolder().createFolder("c")
+                 .createFile("notContainsSearchText", "Pay attention! To be or to not be that is the questEon".getBytes());
+
+        ContainerResponse response =
+                launcher.service(GET, String.format("http://localhost:8080/api/project/%s/search/my_project", workspace) + queryToSearch,
+                                 "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        List<ItemReference> result = (List<ItemReference>)response.getEntity();
+        assertEquals(result.size(), 2);
+        Set<String> paths = new LinkedHashSet<>(2);
+        paths.addAll(result.stream().map(ItemReference::getPath).collect(Collectors.toList()));
+        Assert.assertTrue(paths.contains("/my_project/x/y/containsSearchText.txt"));
+        Assert.assertTrue(paths.contains("/my_project/a/b/containsSearchTextAlso.txt"));
+        Assert.assertFalse(paths.contains("/my_project/c/notContainsSearchText.txt"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSearchWordWithAnyEnding() throws Exception {
+        String queryToSearch = "?text=" +
+                               "question" + URL_ENCODED_ASTERISK;
+        RegisteredProject myProject = pm.getProject("my_project");
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("a/b")
+                 .createFile("containsSearchTextAlso.txt", "Pay attention! To be or not to be that is the questionS".getBytes());
+        myProject.getBaseFolder().createFolder("c")
+                 .createFile("notContainsSearchText", "Pay attention! To be or to not be that is the questEon".getBytes());
+
+        ContainerResponse response =
+                launcher.service(GET, String.format("http://localhost:8080/api/project/%s/search/my_project", workspace) + queryToSearch,
+                                 "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        List<ItemReference> result = (List<ItemReference>)response.getEntity();
+        assertEquals(result.size(), 2);
+        Set<String> paths = new LinkedHashSet<>(2);
+        paths.addAll(result.stream().map(ItemReference::getPath).collect(Collectors.toList()));
+        Assert.assertTrue(paths.contains("/my_project/x/y/containsSearchText.txt"));
+        Assert.assertTrue(paths.contains("/my_project/a/b/containsSearchTextAlso.txt"));
+        Assert.assertFalse(paths.contains("/my_project/c/notContainsSearchText.txt"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSearchTextWhenExcludeSomeText() throws Exception {
+        String queryToSearch = "?text=" +
+                               "question" + URL_ENCODED_SPACE + NOT_OPERATOR + URL_ENCODED_SPACE + URL_ENCODED_QUOTES +
+                               "attention!" + URL_ENCODED_QUOTES;
+        RegisteredProject myProject = pm.getProject("my_project");
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("b")
+                 .createFile("notContainsSearchText", "Pay attention! To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("c").createFile("alsoNotContainsSearchText", "To be or to not be that is the ...".getBytes());
+
+        ContainerResponse response =
+                launcher.service(GET, String.format("http://localhost:8080/api/project/%s/search/my_project", workspace) + queryToSearch,
+                                 "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        List<ItemReference> result = (List<ItemReference>)response.getEntity();
+        assertEquals(result.size(), 1);
+        Set<String> paths = new LinkedHashSet<>(1);
+        paths.addAll(result.stream().map(ItemReference::getPath).collect(Collectors.toList()));
+        Assert.assertTrue(paths.contains("/my_project/x/y/containsSearchText.txt"));
+        Assert.assertFalse(paths.contains("/my_project/b/notContainsSearchText.txt"));
+        Assert.assertFalse(paths.contains("/my_project/c/alsoContainsSearchText"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSearchTextWithEscapedCharachters() throws Exception {
+        String queryToSearch = "?text=http" +
+                               URL_ENCODED_BACKSLASH + ':' +
+                               URL_ENCODED_BACKSLASH + '/' +
+                               URL_ENCODED_BACKSLASH + '/' + "localhost" +
+                               URL_ENCODED_BACKSLASH + ':' + "8080" +
+                               URL_ENCODED_BACKSLASH + '/' + "ide" +
+                               URL_ENCODED_BACKSLASH + '/' + "dev6" +
+                               URL_ENCODED_BACKSLASH + '?' + "action=createProject" +
+                               URL_ENCODED_BACKSLASH + ':' + "projectName=test";
+        RegisteredProject myProject = pm.getProject("my_project");
+        myProject.getBaseFolder().createFolder("x/y")
+                 .createFile("test.txt", "http://localhost:8080/ide/dev6?action=createProject:projectName=test".getBytes());
+
+        ContainerResponse response = launcher.service(GET, String.format("http://localhost:8080/api/project/%s/search/my_project",
+                                                                         workspace) + queryToSearch,
+                                                      "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        List<ItemReference> result = (List<ItemReference>)response.getEntity();
+        assertEquals(result.size(), 1);
+        Set<String> paths = new LinkedHashSet<>(1);
+        paths.addAll(result.stream().map(ItemReference::getPath).collect(Collectors.toList()));
+        Assert.assertTrue(paths.contains("/my_project/x/y/test.txt"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
1. Escape those characters that QueryParser expects to be escaped to correct search
2. Change behavior of full text searching: 
   - old mode: on server side some text for searching splited on separate words and you get all files which contain at least one of the word 
   - new mode - we will find only text for searching as particular sequence of words
3. Change UI for 'Find text' window:
   before my changes
   ![search_text_before](https://cloud.githubusercontent.com/assets/5676062/15147462/70cdc156-16c9-11e6-80fb-3cefa3c8a13c.png)
   after my changes

![search_text_after](https://cloud.githubusercontent.com/assets/5676062/15247748/da13ceba-191e-11e6-80ad-ee9b60ba08c4.png)

@skabashnyuk @vparfonov @slemeur 
