### PR TITLE
Improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"
-    vb.name = "eclipse-che-vm2"
+    vb.name = "eclipse-che-vm"
   end
 
   $script = <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -138,7 +138,7 @@ Vagrant.configure(2) do |config|
         export JAVA_HOME=/usr &>/dev/null
         echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:${IP} --skip:client -g start &>/dev/null
       fi
-      # If we are not awake after 180 seconds, restart server
+      # If we are not awake after 180 seconds, exit with failure
       if [ $counter == "35" ]; then
         echo "---------------------------------------------"
         echo "."

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,17 +1,8 @@
-# Copyright (c) 2012-2016 Codenvy, S.A.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#   Codenvy, S.A. - initial API and implementation
-
 # Set to "<proto>://<user>:<pass>@<host>:<port>"
 $http_proxy  = ""
 $https_proxy = ""
 $che_version = "latest"
-$ip          = "192.168.28.30"
+$ip          = "192.168.28.28"
 
 Vagrant.configure(2) do |config|
   config.vm.box = "centos71-docker-java-v1.0"
@@ -20,11 +11,16 @@ Vagrant.configure(2) do |config|
   config.ssh.insert_key = false
   config.vm.network :private_network, ip: $ip
   config.vm.synced_folder ".", "/home/vagrant/.che"
-  config.vm.define "che" do |che|
+  config.vm.define "artik" do |artik|
   end
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"
-    vb.name = "eclipse-che-vm"
+    vb.name = "artik-ide-vm"
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbehci", "on"]
+    vb.customize ["usbfilter", "add", "0",
+                  "--target", :id,
+                  "--name", "Artik"]
   end
 
   $script = <<-SHELL
@@ -34,11 +30,11 @@ Vagrant.configure(2) do |config|
     IP=$4
 
     if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
-	    echo "-------------------------------------"
+	    echo "-----------------------------------"
 	    echo "."
-	    echo "ECLIPSE CHE: CONFIGURING SYSTEM PROXY"
+	    echo "ARTIK IDE: CONFIGURING SYSTEM PROXY"
 	    echo "."
-	    echo "-------------------------------------"
+	    echo "-----------------------------------"
 	    echo 'export HTTP_PROXY="'$HTTP_PROXY'"' >> /home/vagrant/.bashrc
 	    echo 'export HTTPS_PROXY="'$HTTPS_PROXY'"' >> /home/vagrant/.bashrc
 	    source /home/vagrant/.bashrc
@@ -65,38 +61,44 @@ Vagrant.configure(2) do |config|
         systemctl restart docker
     fi
 
-    echo "------------------------------------"
+    echo "--------------------------------"
     echo "."
-    echo "ECLIPSE CHE: DOWNLOADING ECLIPSE CHE"
+    echo "ARTIK IDE: DOWNLOADING ARTIK IDE"
     echo "."
-    echo "------------------------------------"
-    curl -O "https://install.codenvycorp.com/che/eclipse-che-$CHE_VERSION.tar.gz"
-    tar xvfz eclipse-che-$CHE_VERSION.tar.gz &>/dev/null
+    echo "--------------------------------"
+    curl -O "https://install.codenvycorp.com/artik/samsung-artik-ide-${CHE_VERSION}.tar.gz"
+    tar xvfz samsung-artik-ide-${CHE_VERSION}.tar.gz &>/dev/null
     sudo chown -R vagrant:vagrant * &>/dev/null
     export JAVA_HOME=/usr &>/dev/null
 
     # exporting CHE_LOCAL_CONF_DIR, reconfiguring Che to store workspaces, projects and prefs outside the Tomcat
     export CHE_LOCAL_CONF_DIR=/home/vagrant/.che &>/dev/null
-    cp /home/vagrant/eclipse-che-*/conf/che.properties /home/vagrant/.che/che.properties
+    cp /home/vagrant/eclipse-che-*/conf/che.properties /home/vagrant/.che/
     sed -i 's|${catalina.base}/temp/local-storage|/home/vagrant/.che|' /home/vagrant/.che/che.properties
     sed -i 's|${che.home}/workspaces|/home/vagrant/.che|' /home/vagrant/.che/che.properties
     echo 'export CHE_LOCAL_CONF_DIR=/home/vagrant/.che' >> /home/vagrant/.bashrc
-    source /home/vagrant/.bashrc
 
-    echo "----------------------------------------"
+    echo "------------------------------------------"
     echo "."
-    echo "ECLIPSE CHE: DOWNLOADING DOCKER REGISTRY"
-    echo "             50MB: SILENT OUTPUT        "
+    echo "ARTIK IDE: DOWNLOADING ARTIK RUNTIME IMAGE"
+    echo "           950MB: SILENT OUTPUT           "
     echo "."
-    echo "----------------------------------------"
+    echo "------------------------------------------"
+    docker pull codenvy/artik &>/dev/null
+
+    echo "--------------------------------------"
+    echo "."
+    echo "ARTIK IDE: DOWNLOADING DOCKER REGISTRY"
+    echo "           50MB: SILENT OUTPUT        "
+    echo "."
+    echo "--------------------------------------"
     docker pull registry:2 &>/dev/null
 
-    echo "---------------------------------"
+    echo "-------------------------------"
     echo "."
-    echo "ECLIPSE CHE: PREPPING SERVER ~10s"
+    echo "ARTIK IDE: PREPPING SERVER ~10s"
     echo "."
-    echo "---------------------------------"
-
+    echo "-------------------------------"
     if [ -n "$HTTP_PROXY" ]; then
         sed -i "s|http.proxy=|http.proxy=${HTTP_PROXY}|" /home/vagrant/eclipse-che-*/conf/che.properties
     fi
@@ -113,30 +115,42 @@ Vagrant.configure(2) do |config|
 
   $script2 = <<-SHELL
     IP=$1
+
     counter=0
     while [ true ]; do
       curl -v http://${IP}:8080/dashboard &>/dev/null
       exitcode=$?
 
       if [ $exitcode == "0" ]; then
-        echo "----------------------------------------"
+        echo "--------------------------------------"
         echo "."
-        echo "ECLIPSE CHE: SERVER BOOTED AND REACHABLE"
-        echo "AVAILABLE:   http://$IP:8080  "
+        echo "ARTIK IDE: SERVER BOOTED AND REACHABLE"
+        echo "AVAILABLE: http://${IP}:8080  "
         echo "."
-        echo "----------------------------------------"
+        echo "--------------------------------------"
         exit 0
       fi 
 
-      # If we are not awake after 30 seconds, restart server
-      if [ $counter == "5" ]; then
-        echo "-----------------------------------------------"
+      # If we are not awake after 60 seconds, restart server
+      if [ $counter == "11" ]; then
+        echo "---------------------------------------------"
         echo "."
-        echo "ECLIPSE IDE: SERVER NOT RESPONSIVE -- REBOOTING"
+        echo "ARTIK IDE: SERVER NOT RESPONSIVE -- REBOOTING"
         echo "."
-        echo "-----------------------------------------------"
+        echo "---------------------------------------------"
         export JAVA_HOME=/usr &>/dev/null
-        echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:$IP --skip:client -g start &>/dev/null
+        echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:${IP} --skip:client -g start &>/dev/null
+      fi
+
+      # If we are not awake after 180 seconds, restart server
+      if [ $counter == "35" ]; then
+        echo "-------------------------------------------"
+        echo "."
+        echo "ARTIK IDE: SERVER NOT RESPONSIVE -- EXITING"
+        echo "           CONTACT SUPPORT FOR ASSISTANCE  "
+        echo "."
+        echo "-------------------------------------------"
+        exit 0
       fi
 
       let counter=counter+1
@@ -144,10 +158,7 @@ Vagrant.configure(2) do |config|
     done
   SHELL
 
-   config.vm.provision "shell", run: "always", inline: <<-SHELL
-  SHELL
-
-  config.vm.provision "shell" do |s|
+  config.vm.provision "shell", run: "always" do |s|
     s.inline = $script2
     s.args = [$ip]
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,44 +115,39 @@ Vagrant.configure(2) do |config|
 
   $script2 = <<-SHELL
     IP=$1
-
     counter=0
     while [ true ]; do
       curl -v http://${IP}:8080/dashboard &>/dev/null
       exitcode=$?
-
       if [ $exitcode == "0" ]; then
-        echo "--------------------------------------"
+        echo "----------------------------------------"
         echo "."
-        echo "ARTIK IDE: SERVER BOOTED AND REACHABLE"
+        echo "ECLIPSE CHE: SERVER BOOTED AND REACHABLE"
         echo "AVAILABLE: http://${IP}:8080  "
         echo "."
-        echo "--------------------------------------"
+        echo "----------------------------------------"
         exit 0
       fi 
-
       # If we are not awake after 60 seconds, restart server
       if [ $counter == "11" ]; then
-        echo "---------------------------------------------"
+        echo "-----------------------------------------------"
         echo "."
-        echo "ARTIK IDE: SERVER NOT RESPONSIVE -- REBOOTING"
+        echo "ECLIPSE CHE: SERVER NOT RESPONSIVE -- REBOOTING"
         echo "."
-        echo "---------------------------------------------"
+        echo "-----------------------------------------------"
         export JAVA_HOME=/usr &>/dev/null
         echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:${IP} --skip:client -g start &>/dev/null
       fi
-
       # If we are not awake after 180 seconds, restart server
       if [ $counter == "35" ]; then
-        echo "-------------------------------------------"
+        echo "---------------------------------------------"
         echo "."
-        echo "ARTIK IDE: SERVER NOT RESPONSIVE -- EXITING"
-        echo "           CONTACT SUPPORT FOR ASSISTANCE  "
+        echo "ECLIPSE CHE: SERVER NOT RESPONSIVE -- EXITING"
+        echo "           CONTACT SUPPORT FOR ASSISTANCE    "
         echo "."
-        echo "-------------------------------------------"
+        echo "---------------------------------------------"
         exit 0
       fi
-
       let counter=counter+1
       sleep 5
     done

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,31 +10,35 @@
 # Set to "<proto>://<user>:<pass>@<host>:<port>"
 $http_proxy  = ""
 $https_proxy = ""
+$che_version = "latest"
+$ip          = "192.168.28.30"
 
 Vagrant.configure(2) do |config|
   config.vm.box = "centos71-docker-java-v1.0"
   config.vm.box_url = "https://install.codenvycorp.com/centos71-docker-java-v1.0.box"
   config.vm.box_download_insecure = true
   config.ssh.insert_key = false
-  config.vm.network :private_network, ip: "192.168.28.30"
+  config.vm.network :private_network, ip: $ip
   config.vm.synced_folder ".", "/home/vagrant/.che"
   config.vm.define "che" do |che|
   end
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"
-    vb.name = "eclipse-che-vm"
+    vb.name = "eclipse-che-vm2"
   end
 
   $script = <<-SHELL
     HTTP_PROXY=$1
     HTTPS_PROXY=$2
+    CHE_VERSION=$3
+    IP=$4
 
     if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
-	    echo "."
+	    echo "-------------------------------------"
 	    echo "."
 	    echo "ECLIPSE CHE: CONFIGURING SYSTEM PROXY"
 	    echo "."
-	    echo "."
+	    echo "-------------------------------------"
 	    echo 'export HTTP_PROXY="'$HTTP_PROXY'"' >> /home/vagrant/.bashrc
 	    echo 'export HTTPS_PROXY="'$HTTPS_PROXY'"' >> /home/vagrant/.bashrc
 	    source /home/vagrant/.bashrc
@@ -61,27 +65,37 @@ Vagrant.configure(2) do |config|
         systemctl restart docker
     fi
 
-    echo "."
+    echo "------------------------------------"
     echo "."
     echo "ECLIPSE CHE: DOWNLOADING ECLIPSE CHE"
     echo "."
-    echo "."
-    curl -O "https://install.codenvycorp.com/che/eclipse-che-latest.tar.gz"
-    tar xvfz eclipse-che-latest.tar.gz &>/dev/null
+    echo "------------------------------------"
+    curl -O "https://install.codenvycorp.com/che/eclipse-che-$CHE_VERSION.tar.gz"
+    tar xvfz eclipse-che-$CHE_VERSION.tar.gz &>/dev/null
     sudo chown -R vagrant:vagrant * &>/dev/null
     export JAVA_HOME=/usr &>/dev/null
 
     # exporting CHE_LOCAL_CONF_DIR, reconfiguring Che to store workspaces, projects and prefs outside the Tomcat
     export CHE_LOCAL_CONF_DIR=/home/vagrant/.che &>/dev/null
     cp /home/vagrant/eclipse-che-*/conf/che.properties /home/vagrant/.che/che.properties
-    sed -i "s/\${catalina.base}\/temp\/local-storage/\/home\/vagrant\/.che/g" /home/vagrant/.che/che.properties
-    sed -i "s|\${che.home}/workspaces|/home/vagrant/.che|" /home/vagrant/.che/che.properties
+    sed -i 's|${catalina.base}/temp/local-storage|/home/vagrant/.che|' /home/vagrant/.che/che.properties
+    sed -i 's|${che.home}/workspaces|/home/vagrant/.che|' /home/vagrant/.che/che.properties
     echo 'export CHE_LOCAL_CONF_DIR=/home/vagrant/.che' >> /home/vagrant/.bashrc
+    source /home/vagrant/.bashrc
+
+    echo "----------------------------------------"
     echo "."
+    echo "ECLIPSE CHE: DOWNLOADING DOCKER REGISTRY"
+    echo "             50MB: SILENT OUTPUT        "
     echo "."
-    echo "ECLIPSE CHE: PREPPING SERVER"
+    echo "----------------------------------------"
+    docker pull registry:2 &>/dev/null
+
+    echo "---------------------------------"
     echo "."
+    echo "ECLIPSE CHE: PREPPING SERVER ~10s"
     echo "."
+    echo "---------------------------------"
 
     if [ -n "$HTTP_PROXY" ]; then
         sed -i "s|http.proxy=|http.proxy=${HTTP_PROXY}|" /home/vagrant/eclipse-che-*/conf/che.properties
@@ -89,21 +103,53 @@ Vagrant.configure(2) do |config|
     if [ -n "$HTTPS_PROXY" ]; then
         sed -i "s|https.proxy=|https.proxy=${HTTPS_PROXY}|"  /home/vagrant/eclipse-che-*/conf/che.properties
     fi
-    echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:192.168.28.30 --skip:client -g start
+    echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:${IP} --skip:client -g start &>/dev/null
   SHELL
 
   config.vm.provision "shell" do |s|
   	s.inline = $script
-  	s.args = [$http_proxy, $https_proxy]
+  	s.args = [$http_proxy, $https_proxy, $che_version, $ip]
   end
 
-   config.vm.provision "shell", run: "always", inline: <<-SHELL
-    echo "."
-    echo "."
-    echo "ECLIPSE CHE: SERVER BOOTING ~10s"
-    echo "AVAILABLE: http://192.168.28.30:8080"
-    echo "."
-    echo "."
+  $script2 = <<-SHELL
+    IP=$1
+    counter=0
+    while [ true ]; do
+      curl -v http://${IP}:8080/dashboard &>/dev/null
+      exitcode=$?
+
+      if [ $exitcode == "0" ]; then
+        echo "----------------------------------------"
+        echo "."
+        echo "ECLIPSE CHE: SERVER BOOTED AND REACHABLE"
+        echo "AVAILABLE:   http://$IP:8080  "
+        echo "."
+        echo "----------------------------------------"
+        exit 0
+      fi 
+
+      # If we are not awake after 30 seconds, restart server
+      if [ $counter == "5" ]; then
+        echo "-----------------------------------------------"
+        echo "."
+        echo "ECLIPSE IDE: SERVER NOT RESPONSIVE -- REBOOTING"
+        echo "."
+        echo "-----------------------------------------------"
+        export JAVA_HOME=/usr &>/dev/null
+        echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:$IP --skip:client -g start &>/dev/null
+      fi
+
+      let counter=counter+1
+      sleep 5
+    done
   SHELL
+
+   config.vm.provision "shell", run: "always", inline: <<-SHELL
+  SHELL
+
+  config.vm.provision "shell" do |s|
+    s.inline = $script2
+    s.args = [$ip]
+  end
 
 end


### PR DESCRIPTION
1. Fixed errors with command substitution of the che properties file.
2. Added in logic to reboot che server if VM was poorly suspended.
3. Allow users to choose latest vs. nightly vs. tagged version with flag in Vagrantfile
4. Allow users to change the IP address used in the Vagrantfile

@eivantsov - please check.  Authored in response to GitHub issue CHE-1207
