### PR TITLE
CODENVY-301; do not check source storage types on creating factory

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/SourceStorageParametersValidator.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/SourceStorageParametersValidator.java
@@ -28,28 +28,26 @@ import static java.lang.String.format;
 public class SourceStorageParametersValidator implements FactoryParameterValidator<SourceStorage> {
     @Override
     public void validate(SourceStorage source, FactoryParameter.Version version) throws ConflictException {
-        if ("git".equals(source.getType()) || "esbwso2".equals(source.getType())) {
-            for (Map.Entry<String, String> entry : source.getParameters().entrySet()) {
-                switch (entry.getKey()) {
-                    case "keepVcs":
-                        final String keepVcs = entry.getValue();
-                        if (!"true".equals(keepVcs) && !"false".equals(keepVcs)) {
-                            throw new ConflictException(
-                                    format(PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE, "source.project.parameters.keepVcs", entry.getValue()));
-                        }
-                        break;
-                    case "branch":
-                    case "commitId":
-                    case "keepDir":
-                    case "fetch":
-                    case "branchMerge":
-                        break;
-                    default:
-                        throw new ConflictException(format(PARAMETRIZED_INVALID_PARAMETER_MESSAGE, "source.project.parameters." + entry.getKey(), version));
-                }
+        for (Map.Entry<String, String> entry : source.getParameters().entrySet()) {
+            switch (entry.getKey()) {
+                case "keepVcs":
+                    final String keepVcs = entry.getValue();
+                    if (!"true".equals(keepVcs) && !"false".equals(keepVcs)) {
+                        throw new ConflictException(
+                                format(PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE, "source.project.parameters.keepVcs",
+                                       entry.getValue()));
+                    }
+                    break;
+                case "branch":
+                case "commitId":
+                case "keepDir":
+                case "fetch":
+                case "branchMerge":
+                    break;
+                default:
+                    throw new ConflictException(
+                            format(PARAMETRIZED_INVALID_PARAMETER_MESSAGE, "source.project.parameters." + entry.getKey(), version));
             }
-        } else {
-            throw new ConflictException(format(PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE, "source.project.type", source.getType()));
         }
     }
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/impl/SourceProjectParametersValidatorTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/impl/SourceProjectParametersValidatorTest.java
@@ -57,12 +57,6 @@ public class SourceProjectParametersValidatorTest {
     }
 
     @Test(expectedExceptions = ConflictException.class,
-          expectedExceptionsMessageRegExp = "The parameter .* has a value submitted .* with a value.*")
-    public void shouldThrowExceptionIfTypeIsNotGit() throws Exception {
-        validator.validate(sourceStorage.withType("zip"), FactoryParameter.Version.V4_0);
-    }
-
-    @Test(expectedExceptions = ConflictException.class,
           expectedExceptionsMessageRegExp = "You have provided an invalid parameter .* for this version of Factory parameters.*")
     public void shouldThrowExceptionIfUnknownParameterIsUsed() throws Exception {
         sourceStorage.getParameters().put("other", "value");


### PR DESCRIPTION
In general, at the moment of factory creation or accepting, we can't know all source types we support, because they are pluggable and deployed on agent and also can be subject to change. 
