### PR TITLE
CHE-1160: Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,18 +10,18 @@
 # Set to "<proto>://<user>:<pass>@<host>:<port>"
 $http_proxy  = ""
 $https_proxy = ""
-$che_version = "latest"
-$ip          = "192.168.28.30"
+$che_version = "nightly"
+$ip          = "192.168.28.111"
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "centos71-docker-java-v1.0"
-  config.vm.box_url = "https://install.codenvycorp.com/centos71-docker-java-v1.0.box"
+  config.vm.box = "boxcutter/centos72-docker"
   config.vm.box_download_insecure = true
   config.ssh.insert_key = false
   config.vm.network :private_network, ip: $ip
   config.vm.synced_folder ".", "/home/vagrant/.che"
   config.vm.define "che" do |che|
   end
+
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"
     vb.name = "eclipse-che-vm"
@@ -31,7 +31,6 @@ Vagrant.configure(2) do |config|
     HTTP_PROXY=$1
     HTTPS_PROXY=$2
     CHE_VERSION=$3
-    IP=$4
 
     if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
 	    echo "-------------------------------------"
@@ -45,8 +44,24 @@ Vagrant.configure(2) do |config|
 	    echo "HTTP PROXY set to: $HTTP_PROXY"
 	    echo "HTTPS PROXY set to: $HTTPS_PROXY"
     fi
+
     # Add the user in the VM to the docker group
+    echo "------------------------------------"
+    echo "ECLIPSE CHE: UPGRADING DOCKER ENGINE"
+    echo "------------------------------------"
+    echo 'y' | sudo yum update docker-engine &>/dev/null &
+    PROC_ID=$!
+    while kill -0 "$PROC_ID" >/dev/null 2>&1; do
+      printf "#"
+      sleep 5
+    done
+
+ 
+    # Add the 'vagrant' user to the 'docker' group
     usermod -aG docker vagrant &>/dev/null
+
+    # We need write access to this file to enable Che container to create other containers
+    sudo chmod 777 /var/run/docker.sock &>/dev/null
 
     # Configure Docker daemon with the proxy
     if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
@@ -64,93 +79,58 @@ Vagrant.configure(2) do |config|
         systemctl restart docker
     fi
 
-    echo "------------------------------------"
-    echo "."
-    echo "ECLIPSE CHE: DOWNLOADING ECLIPSE CHE"
-    echo "."
-    echo "------------------------------------"
-    curl -O "https://install.codenvycorp.com/che/eclipse-che-$CHE_VERSION.tar.gz"
-    tar xvfz eclipse-che-$CHE_VERSION.tar.gz &>/dev/null
-    sudo chown -R vagrant:vagrant * &>/dev/null
-    export JAVA_HOME=/usr &>/dev/null
-
-    # exporting CHE_LOCAL_CONF_DIR, reconfiguring Che to store workspaces, projects and prefs outside the Tomcat
-    export CHE_LOCAL_CONF_DIR=/home/vagrant/.che &>/dev/null
-    cp /home/vagrant/eclipse-che-*/conf/che.properties /home/vagrant/.che/che.properties
-    sed -i 's|${catalina.base}/temp/local-storage|/home/vagrant/.che|' /home/vagrant/.che/che.properties
-    sed -i 's|${che.home}/workspaces|/home/vagrant/.che|' /home/vagrant/.che/che.properties
-    echo 'export CHE_LOCAL_CONF_DIR=/home/vagrant/.che' >> /home/vagrant/.bashrc
-    source /home/vagrant/.bashrc
-
-    echo "----------------------------------------"
-    echo "."
-    echo "ECLIPSE CHE: DOWNLOADING DOCKER REGISTRY"
-    echo "             50MB: SILENT OUTPUT        "
-    echo "."
-    echo "----------------------------------------"
-    docker pull registry:2 &>/dev/null
-    echo "---------------------------------"
-    echo "."
-    echo "ECLIPSE CHE: PREPPING SERVER ~10s"
-    echo "."
-    echo "---------------------------------"
-    if [ -n "$HTTP_PROXY" ]; then
-        sed -i "s|http.proxy=|http.proxy=${HTTP_PROXY}|" /home/vagrant/eclipse-che-*/conf/che.properties
-    fi
-    if [ -n "$HTTPS_PROXY" ]; then
-        sed -i "s|https.proxy=|https.proxy=${HTTPS_PROXY}|"  /home/vagrant/eclipse-che-*/conf/che.properties
-    fi
-    echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:${IP} --skip:client -g start &>/dev/null
-  SHELL
-
-  config.vm.provision "shell" do |s|
-  	s.inline = $script
-  	s.args = [$http_proxy, $https_proxy, $che_version, $ip]
-  end
-  
-  $script2 = <<-SHELL
-    IP=$1
-    counter=0
-    while [ true ]; do
-      curl -v http://${IP}:8080/dashboard &>/dev/null
-      exitcode=$?
-      if [ $exitcode == "0" ]; then
-        echo "----------------------------------------"
-        echo "."
-        echo "ECLIPSE CHE: SERVER BOOTED AND REACHABLE"
-        echo "AVAILABLE: http://${IP}:8080  "
-        echo "."
-        echo "----------------------------------------"
-        exit 0
-      fi 
-      # If we are not awake after 60 seconds, restart server
-      if [ $counter == "11" ]; then
-        echo "------------------------------------------------"
-        echo "."
-        echo "ECLIPSE CHE: SERVER NOT RESPONSIVE -- RESTARTING"
-        echo "."
-        echo "------------------------------------------------"
-        export JAVA_HOME=/usr &>/dev/null
-        echo vagrant | sudo -S -E -u vagrant /home/vagrant/eclipse-che-*/bin/che.sh --remote:${IP} --skip:client -g start &>/dev/null
-      fi
-      # If we are not awake after 180 seconds, exit with failure
-      if [ $counter == "35" ]; then
-        echo "---------------------------------------------"
-        echo "."
-        echo "ECLIPSE CHE: SERVER NOT RESPONSIVE -- EXITING"
-        echo "             CONTACT SUPPORT FOR ASSISTANCE  "
-        echo "."
-        echo "---------------------------------------------"
-        exit 0
-      fi
-      let counter=counter+1
+    echo "-------------------------------------------------"
+    echo "ECLIPSE CHE: DOWNLOADING ECLIPSE CHE DOCKER IMAGE"
+    echo "-------------------------------------------------"
+    docker pull codenvy/che:${CHE_VERSION} &>/dev/null &
+    PROC_ID=$!
+ 
+    while kill -0 "$PROC_ID" >/dev/null 2>&1; do
+      printf "#"
       sleep 5
     done
   SHELL
 
+  config.vm.provision "shell" do |s| 
+  	s.inline = $script
+  	s.args = [$http_proxy, $https_proxy, $che_version]
+  end
+
+  $script2 = <<-SHELL
+    CHE_VERSION=$1
+    IP=$2
+
+    echo "---------------------------------------"
+    echo "ECLIPSE CHE: BOOTING ECLIPSE CHE SERVER"
+    echo "---------------------------------------"
+
+    docker run --net=host --name=che --restart=always --detach `
+              `-v /var/run/docker.sock:/var/run/docker.sock `
+              `-v /home/user/che/lib:/home/user/che/lib-copy `
+              `-v /home/user/che/workspaces:/home/user/che/workspaces `
+              `-v /home/user/che/storage:/home/user/che/tomcat/temp/local-storage `
+              `codenvy/che:${CHE_VERSION} --remote:${IP} run &>/dev/null
+            
+    while [ true ]; do
+      printf "#"
+      curl -v http://${IP}:8080/dashboard &>/dev/null
+      exitcode=$?
+      if [ $exitcode == "0" ]; then
+        echo "----------------------------------------"
+        echo "ECLIPSE CHE: SERVER BOOTED AND REACHABLE"
+        echo "AVAILABLE: http://${IP}:8080  "
+        echo "----------------------------------------"
+        exit 0
+      fi 
+      sleep 5
+
+    done
+
+  SHELL
+
   config.vm.provision "shell", run: "always" do |s|
     s.inline = $script2
-    s.args = [$ip]
+    s.args = [$che_version, $ip]
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
   config.ssh.insert_key = false
   config.vm.network :private_network, ip: $ip
   config.vm.network "forwarded_port", guest: 8080, host: $port
-  config.vm.synced_folder ".", "/home/vagrant/.che"
+  config.vm.synced_folder ".", "/home/user/che"
   config.vm.define "che" do |che|
   end
 
@@ -48,25 +48,21 @@ Vagrant.configure(2) do |config|
     HTTPS_PROXY=$2
     NO_PROXY=$3
     CHE_VERSION=$4
-
     if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
-	    echo "-------------------------------------"
-	    echo "."
-	    echo "ECLIPSE CHE: CONFIGURING SYSTEM PROXY"
-	    echo "."
-	    echo "-------------------------------------"
-	    echo 'export HTTP_PROXY="'$HTTP_PROXY'"' >> /home/vagrant/.bashrc
-	    echo 'export HTTPS_PROXY="'$HTTPS_PROXY'"' >> /home/vagrant/.bashrc
-	    source /home/vagrant/.bashrc
-
+      echo "-------------------------------------"
+      echo "."
+      echo "ECLIPSE CHE: CONFIGURING SYSTEM PROXY"
+      echo "."
+      echo "-------------------------------------"
+      echo 'export HTTP_PROXY="'$HTTP_PROXY'"' >> /home/vagrant/.bashrc
+      echo 'export HTTPS_PROXY="'$HTTPS_PROXY'"' >> /home/vagrant/.bashrc
+      source /home/vagrant/.bashrc
       echo 'http.proxy="'$HTTP_PROXY'"' >> /home/user/che/che.properties
       echo 'https.proxy="'$HTTPS_PROXY'"' >> /home/user/che/che.properties
-
-	    echo "HTTP PROXY set to: $HTTP_PROXY"
-	    echo "HTTPS PROXY set to: $HTTPS_PROXY"
+      echo "HTTP PROXY set to: $HTTP_PROXY"
+      echo "HTTPS PROXY set to: $HTTPS_PROXY"
       more /home/vagrant/che.properties
     fi
-
     # Add the user in the VM to the docker group
     echo "------------------------------------"
     echo "ECLIPSE CHE: UPGRADING DOCKER ENGINE"
@@ -77,14 +73,11 @@ Vagrant.configure(2) do |config|
       printf "#"
       sleep 5
     done
-
  
     # Add the 'vagrant' user to the 'docker' group
     usermod -aG docker vagrant &>/dev/null
-
     # We need write access to this file to enable Che container to create other containers
     sudo chmod 777 /var/run/docker.sock &>/dev/null
-
     # Configure Docker daemon with the proxy
     if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
         mkdir /etc/systemd/system/docker.service.d
@@ -101,7 +94,6 @@ Vagrant.configure(2) do |config|
         systemctl daemon-reload
         systemctl restart docker
     fi
-
     echo "-------------------------------------------------"
     echo "ECLIPSE CHE: DOWNLOADING ECLIPSE CHE DOCKER IMAGE"
     echo "-------------------------------------------------"
@@ -115,19 +107,17 @@ Vagrant.configure(2) do |config|
   SHELL
 
   config.vm.provision "shell" do |s| 
-  	s.inline = $script
-  	s.args = [$http_proxy, $https_proxy, $no_proxy, $che_version]
+    s.inline = $script
+    s.args = [$http_proxy, $https_proxy, $no_proxy, $che_version]
   end
 
   $script2 = <<-SHELL
     CHE_VERSION=$1
     IP=$2
     PORT=$3
-
     echo "---------------------------------------"
     echo "ECLIPSE CHE: BOOTING ECLIPSE CHE SERVER"
     echo "---------------------------------------"
-
     docker run --net=host --name=che --restart=always --detach `
               `-v /var/run/docker.sock:/var/run/docker.sock `
               `-v /home/user/che/lib:/home/user/che/lib-copy `
@@ -149,9 +139,7 @@ Vagrant.configure(2) do |config|
         exit 0
       fi 
       sleep 5
-
     done
-
   SHELL
 
   config.vm.provision "shell", run: "always" do |s|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,7 +132,7 @@ Vagrant.configure(2) do |config|
               `-v /var/run/docker.sock:/var/run/docker.sock `
               `-v /home/user/che/lib:/home/user/che/lib-copy `
               `-v /home/user/che/workspaces:/home/user/che/workspaces `
-              `-v /home/user/che/storage:/home/user/che/tomcat/temp/local-storage `
+              `-v /home/user/che/storage:/home/user/che/storage `
               `-v /home/user/che/che.properties:/container/che.properties `
               `-e CHE_LOCAL_CONF_DIR=/container `
               `codenvy/che:${CHE_VERSION} --remote:${IP} run &>/dev/null


### PR DESCRIPTION
Moved the Vagrantfile to now launch the Che Docker container instead of Che as a server.  Simpler syntax, more reliable, and operates as a Daemon by default "--restart=always" syntax.  Also adds in better checks for Vagrant plugin configuration.  Maps Che workspaces and projects into the Vagrant image sync'd folder.  Also now lets the user set the port that the image is listening on.

Updated 4.3 documentation:  https://eclipse-che.readme.io/v4.3/docs/usage-vagrant
@eivantsov @riuvshin - please approve.
