### PR TITLE
CHE-167: Improve java debugger for opening java files from external project modules.

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/ActiveFileHandler.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/ActiveFileHandler.java
@@ -13,8 +13,7 @@ package org.eclipse.che.plugin.debugger.ide.debug;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import org.eclipse.che.ide.api.resources.VirtualFile;
-
-import java.util.List;
+import org.eclipse.che.api.debug.shared.model.Location;
 
 /**
  * Responsible to open files in editor when debugger stopped at breakpoint.
@@ -23,7 +22,13 @@ import java.util.List;
  */
 public interface ActiveFileHandler {
 
-    void openFile(final List<String> filePaths,
-                  final String className,
-                  final int lineNumber,
-                  final AsyncCallback<VirtualFile> callback);}
+    /**
+     * Open file, scroll to the debug line and do some actions from {@code callback}
+     *
+     * @param location
+     *         location to the source file. See more {@link Location}
+     * @param callback
+     *         some action which should be performed after opening file
+     */
+    void openFile(Location location, AsyncCallback<VirtualFile> callback);
+}

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenterTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenterTest.java
@@ -35,7 +35,6 @@ import org.eclipse.che.ide.ui.toolbar.ToolbarPresenter;
 import org.eclipse.che.plugin.debugger.ide.BaseTest;
 import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
 import org.eclipse.che.plugin.debugger.ide.DebuggerResources;
-import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolverFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -80,8 +79,6 @@ public class DebuggerPresenterTest extends BaseTest {
     @Mock
     @DebuggerToolbar
     private ToolbarPresenter             debuggerToolbar;
-    @Mock
-    private FqnResolverFactory           fqnResolverFactory;
     @Mock
     private DtoFactory                   dtoFactory;
     @Mock

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
@@ -36,12 +36,11 @@ import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
-import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.debug.Breakpoint;
 import org.eclipse.che.ide.api.debug.BreakpointManager;
 import org.eclipse.che.ide.api.debug.DebuggerServiceClient;
 import org.eclipse.che.ide.api.filetypes.FileType;
-import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
 import org.eclipse.che.ide.api.resources.VirtualFile;
@@ -54,8 +53,6 @@ import org.eclipse.che.ide.util.storage.LocalStorageProvider;
 import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.ide.websocket.rest.SubscriptionHandler;
 import org.eclipse.che.plugin.debugger.ide.BaseTest;
-import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolver;
-import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolverFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,7 +61,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -109,13 +105,9 @@ public class DebuggerTest extends BaseTest {
     @Mock
     private EventBus              eventBus;
     @Mock
-    private AppContext            appContext;
-    @Mock
     private ActiveFileHandler     activeFileHandler;
     @Mock
     private DebuggerManager       debuggerManager;
-    @Mock
-    private FileTypeRegistry      fileTypeRegistry;
     @Mock
     private BreakpointManager     breakpointManager;
 
@@ -129,8 +121,6 @@ public class DebuggerTest extends BaseTest {
     @Mock
     private VirtualFile        file;
     @Mock
-    private FqnResolverFactory fqnResolverFactory;
-    @Mock
     private LocalStorage       localStorage;
     @Mock
     private DebuggerObserver   observer;
@@ -138,8 +128,6 @@ public class DebuggerTest extends BaseTest {
     private LocationDto        locationDto;
     @Mock
     private BreakpointDto      breakpointDto;
-    @Mock
-    private FqnResolver        fgnResolver;
 
     @Captor
     private ArgumentCaptor<WsAgentStateHandler>             extServerStateHandlerCaptor;
@@ -178,13 +166,10 @@ public class DebuggerTest extends BaseTest {
         doReturn(DEBUG_INFO).when(localStorage).getItem(AbstractDebugger.LOCAL_STORAGE_DEBUGGER_SESSION_KEY);
         doReturn(debugSessionDto).when(dtoFactory).createDtoFromJson(anyString(), eq(DebugSessionDto.class));
 
-        doReturn(fgnResolver).when(fqnResolverFactory).getResolver(anyString());
-        doReturn(FQN).when(fgnResolver).resolveFqn(file);
-
         doReturn(PATH).when(file).getPath();
 
-        debugger = new TestDebugger(service, dtoFactory, localStorageProvider, messageBusProvider, eventBus, fqnResolverFactory,
-                                    activeFileHandler, debuggerManager, fileTypeRegistry, "id");
+        debugger = new TestDebugger(service, dtoFactory, localStorageProvider, messageBusProvider, eventBus,
+                                    activeFileHandler, debuggerManager, "id");
         doReturn(promiseInfo).when(service).getSessionInfo(SESSION_ID);
         doReturn(promiseInfo).when(promiseInfo).then(any(Operation.class));
 
@@ -196,7 +181,6 @@ public class DebuggerTest extends BaseTest {
 
         FileType fileType = mock(FileType.class);
         doReturn("java").when(fileType).getExtension();
-        doReturn(fileType).when(fileTypeRegistry).getFileTypeByFile(eq(file));
     }
 
     @Test
@@ -567,29 +551,26 @@ public class DebuggerTest extends BaseTest {
                             LocalStorageProvider localStorageProvider,
                             MessageBusProvider messageBusProvider,
                             EventBus eventBus,
-                            FqnResolverFactory fqnResolverFactory,
                             ActiveFileHandler activeFileHandler,
                             DebuggerManager debuggerManager,
-                            FileTypeRegistry fileTypeRegistry,
                             String id) {
             super(service,
                   dtoFactory,
                   localStorageProvider,
                   messageBusProvider,
                   eventBus,
-                  fqnResolverFactory,
                   activeFileHandler,
                   debuggerManager,
-                  fileTypeRegistry,
                   breakpointManager,
                   id);
         }
 
         @Override
-        protected List<String> fqnToPath(@NotNull Location location) {
-            return Collections.emptyList();
+        protected String fqnToPath(Location location) {
+            return PATH;
         }
 
+        @Nullable
         @Override
         protected String pathToFqn(VirtualFile file) {
             return FQN;

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbDebugger.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbDebugger.java
@@ -14,11 +14,11 @@ import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.debug.shared.model.Location;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.app.CurrentProject;
 import org.eclipse.che.ide.api.debug.BreakpointManager;
 import org.eclipse.che.ide.api.debug.DebuggerServiceClient;
-import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
@@ -26,11 +26,8 @@ import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
 import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.plugin.debugger.ide.debug.AbstractDebugger;
-import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolverFactory;
 
 import javax.validation.constraints.NotNull;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.che.plugin.gdb.ide.GdbDebugger.ConnectionProperties.HOST;
@@ -53,10 +50,8 @@ public class GdbDebugger extends AbstractDebugger {
                        LocalStorageProvider localStorageProvider,
                        MessageBusProvider messageBusProvider,
                        EventBus eventBus,
-                       FqnResolverFactory fqnResolverFactory,
                        GdbDebuggerFileHandler activeFileHandler,
                        DebuggerManager debuggerManager,
-                       FileTypeRegistry fileTypeRegistry,
                        BreakpointManager breakpointManager,
                        AppContext appContext) {
 
@@ -65,27 +60,23 @@ public class GdbDebugger extends AbstractDebugger {
               localStorageProvider,
               messageBusProvider,
               eventBus,
-              fqnResolverFactory,
               activeFileHandler,
               debuggerManager,
-              fileTypeRegistry,
               breakpointManager,
               ID);
         this.appContext = appContext;
     }
 
     @Override
-    protected List<String> fqnToPath(@NotNull Location location) {
+    protected String fqnToPath(@NotNull Location location) {
         CurrentProject currentProject = appContext.getCurrentProject();
         if (currentProject == null) {
-            return Collections.singletonList(location.getTarget());
+            return location.getTarget();
         }
-
-        String projectPath = currentProject.getProjectConfig().getPath();
-        String path = projectPath + "/" + location.getTarget();
-        return Collections.singletonList(path);
+        return currentProject.getProjectConfig().getPath() + "/" + location.getTarget();
     }
 
+    @Nullable
     @Override
     protected String pathToFqn(VirtualFile file) {
         return file.getName();

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbDebuggerFileHandler.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbDebuggerFileHandler.java
@@ -15,11 +15,15 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
+import org.eclipse.che.api.debug.shared.model.Location;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.app.CurrentProject;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.event.FileEvent;
 import org.eclipse.che.ide.api.project.node.HasStorablePath;
 import org.eclipse.che.ide.api.data.tree.Node;
@@ -27,12 +31,8 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.plugin.debugger.ide.debug.ActiveFileHandler;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
-import org.eclipse.che.ide.api.editor.texteditor.TextEditorPresenter;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.project.node.FileReferenceNode;
-
-import javax.validation.constraints.NotNull;
-import java.util.List;
 
 import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.OPEN;
 
@@ -46,87 +46,66 @@ public class GdbDebuggerFileHandler implements ActiveFileHandler {
     private final EditorAgent              editorAgent;
     private final EventBus                 eventBus;
     private final ProjectExplorerPresenter projectExplorer;
+    private final AppContext               appContext;
 
     @Inject
     public GdbDebuggerFileHandler(EditorAgent editorAgent,
+                                  ProjectExplorerPresenter projectExplorer,
                                   EventBus eventBus,
-                                  ProjectExplorerPresenter projectExplorer) {
+                                  AppContext appContext) {
         this.editorAgent = editorAgent;
         this.eventBus = eventBus;
         this.projectExplorer = projectExplorer;
+        this.appContext = appContext;
     }
 
     @Override
-    public void openFile(final List<String> filePaths,
-                         final String className,
-                         final int lineNumber,
-                         final AsyncCallback<VirtualFile> callback) {
+    public void openFile(final Location location, final AsyncCallback<VirtualFile> callback) {
+        CurrentProject currentProject = appContext.getCurrentProject();
+        if (currentProject == null) {
+            return;
+        }
+        String filePath = currentProject.getProjectConfig().getPath() + "/" + location.getTarget();
         VirtualFile activeFile = null;
         final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
         if (activeEditor != null) {
             activeFile = activeEditor.getEditorInput().getFile();
         }
 
-        if (activeFile == null || !filePaths.contains(activeFile.getPath())) {
-            openFile(className, filePaths, 0, new AsyncCallback<VirtualFile>() {
-                @Override
-                public void onSuccess(VirtualFile result) {
-                    scrollEditorToExecutionPoint((TextEditorPresenter)editorAgent.getActiveEditor(), lineNumber);
-                    callback.onSuccess(result);
-                }
-
-                @Override
-                public void onFailure(Throwable caught) {
-                    callback.onFailure(caught);
-                }
-            });
+        if (activeEditor == null || !activeFile.getPath().equals(filePath)) {
+            doOpenFile(filePath, location.getLineNumber(), callback);
         } else {
-            scrollEditorToExecutionPoint((TextEditorPresenter)activeEditor, lineNumber);
-            callback.onSuccess(activeFile);
+            scrollEditorToExecutionPoint((TextEditor)activeEditor, location.getLineNumber());
+            callback.onSuccess(activeEditor.getEditorInput().getFile());
         }
     }
 
-    /**
-     * Tries to open file from the project.
-     * If fails then method will try to find resource from external dependencies.
-     */
-    private void openFile(@NotNull final String className,
-                          final List<String> filePaths,
-                          final int pathNumber,
-                          final AsyncCallback<VirtualFile> callback) {
-        if (pathNumber == filePaths.size()) {
-            callback.onFailure(new IllegalArgumentException("Can't open resource " + className));
-            return;
-        }
-
-        String filePath = filePaths.get(pathNumber);
-
+    private void doOpenFile(final String filePath, final int lineNumber, final AsyncCallback<VirtualFile> callback) {
         projectExplorer.getNodeByPath(new HasStorablePath.StorablePath(filePath)).then(new Operation<Node>() {
             @Override
             public void apply(final Node node) throws OperationException {
                 if (!(node instanceof FileReferenceNode)) {
                     return;
                 }
-
-                handleActivateFile((VirtualFile)node, callback);
+                handleActivatedFile((VirtualFile)node, callback, lineNumber);
                 eventBus.fireEvent(new FileEvent((VirtualFile)node, OPEN));
             }
         }).catchError(new Operation<PromiseError>() {
             @Override
             public void apply(PromiseError error) throws OperationException {
-                // try another path
-                openFile(className, filePaths, pathNumber + 1, callback);
+                callback.onFailure(error.getCause());
             }
         });
     }
 
-    public void handleActivateFile(final VirtualFile virtualFile, final AsyncCallback<VirtualFile> callback) {
+    public void handleActivatedFile(final VirtualFile virtualFile, final AsyncCallback<VirtualFile> callback, final int debugLine) {
         editorAgent.openEditor(virtualFile, new EditorAgent.OpenEditorCallback() {
             @Override
             public void onEditorOpened(EditorPartPresenter editor) {
                 new Timer() {
                     @Override
                     public void run() {
+                        scrollEditorToExecutionPoint((TextEditor)editorAgent.getActiveEditor(), debugLine);
                         callback.onSuccess(virtualFile);
                     }
                 }.schedule(300);
@@ -137,6 +116,7 @@ public class GdbDebuggerFileHandler implements ActiveFileHandler {
                 new Timer() {
                     @Override
                     public void run() {
+                        scrollEditorToExecutionPoint((TextEditor)editorAgent.getActiveEditor(), debugLine);
                         callback.onSuccess(virtualFile);
                     }
                 }.schedule(300);
@@ -149,7 +129,7 @@ public class GdbDebuggerFileHandler implements ActiveFileHandler {
         });
     }
 
-    private void scrollEditorToExecutionPoint(TextEditorPresenter editor, int lineNumber) {
+    private void scrollEditorToExecutionPoint(TextEditor editor, int lineNumber) {
         Document document = editor.getDocument();
 
         if (document != null) {

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebugger.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebugger.java
@@ -14,8 +14,7 @@ import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.debug.shared.model.Location;
-import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.app.CurrentProject;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.debug.BreakpointManager;
 import org.eclipse.che.ide.api.debug.DebuggerServiceClient;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
@@ -23,7 +22,8 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
-import org.eclipse.che.ide.ext.java.client.projecttree.JavaSourceFolderUtil;
+import org.eclipse.che.ide.ext.java.client.project.node.JavaFileNode;
+import org.eclipse.che.ide.ext.java.client.project.node.jar.JarFileNode;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
 import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.plugin.debugger.ide.debug.AbstractDebugger;
@@ -31,9 +31,6 @@ import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolver;
 import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolverFactory;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.che.plugin.jdb.ide.debug.JavaDebugger.ConnectionProperties.HOST;
@@ -49,7 +46,8 @@ public class JavaDebugger extends AbstractDebugger {
 
     public static final String ID = "jdb";
 
-    private final AppContext appContext;
+    public final FqnResolverFactory fqnResolverFactory;
+    public final FileTypeRegistry   fileTypeRegistry;
 
     @Inject
     public JavaDebugger(DebuggerServiceClient service,
@@ -61,45 +59,36 @@ public class JavaDebugger extends AbstractDebugger {
                         JavaDebuggerFileHandler javaDebuggerFileHandler,
                         DebuggerManager debuggerManager,
                         FileTypeRegistry fileTypeRegistry,
-                        BreakpointManager breakpointManager,
-                        AppContext appContext) {
+                        BreakpointManager breakpointManager) {
         super(service,
               dtoFactory,
               localStorageProvider,
               messageBusProvider,
               eventBus,
-              fqnResolverFactory,
               javaDebuggerFileHandler,
               debuggerManager,
-              fileTypeRegistry,
               breakpointManager,
               ID);
-        this.appContext = appContext;
+        this.fqnResolverFactory = fqnResolverFactory;
+        this.fileTypeRegistry = fileTypeRegistry;
     }
 
     @Override
-    protected List<String> fqnToPath(@NotNull Location location) {
-        CurrentProject currentProject = appContext.getCurrentProject();
-
-        if (currentProject == null) {
-            return Collections.emptyList();
-        }
-
-        String pathSuffix = location.getTarget().replace(".", "/") + ".java";
-
-        List<String> sourceFolders = JavaSourceFolderUtil.getSourceFolders(currentProject);
-        List<String> filePaths = new ArrayList<>(sourceFolders.size() + 1);
-
-        for (String sourceFolder : sourceFolders) {
-            filePaths.add(sourceFolder + pathSuffix);
-        }
-        filePaths.add(location.getTarget());
-
-        return filePaths;
+    protected String fqnToPath(@NotNull Location location) {
+        String resourcePath = location.getResourcePath();
+        return  resourcePath != null ? resourcePath : location.getTarget();
     }
 
+    @Nullable
     @Override
     protected String pathToFqn(VirtualFile file) {
+        if (file instanceof JavaFileNode) {
+            return ((JavaFileNode)file).getFqn();
+        }
+        if (file instanceof JarFileNode) {
+            return file.getPath();
+        }
+
         String fileExtension = fileTypeRegistry.getFileTypeByFile(file).getExtension();
 
         FqnResolver resolver = fqnResolverFactory.getResolver(fileExtension);

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebuggerFileHandler.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebuggerFileHandler.java
@@ -14,33 +14,40 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
+import com.google.web.bindery.event.shared.HandlerRegistration;
 
+import org.eclipse.che.api.debug.shared.model.Location;
+import org.eclipse.che.api.promises.client.Function;
+import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.data.tree.settings.NodeSettings;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
+import org.eclipse.che.ide.api.event.EditorDirtyStateChangedEvent;
+import org.eclipse.che.ide.api.event.EditorDirtyStateChangedHandler;
 import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.project.ProjectServiceClient;
 import org.eclipse.che.ide.api.project.node.HasStorablePath;
 import org.eclipse.che.ide.api.data.tree.Node;
 import org.eclipse.che.ide.api.resources.VirtualFile;
-import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
-import org.eclipse.che.plugin.debugger.ide.debug.ActiveFileHandler;
+import org.eclipse.che.ide.ext.java.client.project.node.JavaNodeFactory;
 import org.eclipse.che.ide.ext.java.client.project.node.JavaNodeManager;
 import org.eclipse.che.ide.ext.java.client.project.node.jar.JarFileNode;
 import org.eclipse.che.ide.ext.java.shared.JarEntry;
-import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.text.TextPosition;
-import org.eclipse.che.ide.api.editor.texteditor.TextEditorPresenter;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.project.node.FileReferenceNode;
-
-import javax.validation.constraints.NotNull;
-import java.util.List;
+import org.eclipse.che.plugin.debugger.ide.debug.ActiveFileHandler;
 
 import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.OPEN;
+import static org.eclipse.che.ide.ext.java.shared.JarEntry.JarEntryType.CLASS_FILE;
 
 /**
  * Responsible to open files in editor when debugger stopped at breakpoint.
@@ -49,128 +56,157 @@ import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.OPEN;
  */
 public class JavaDebuggerFileHandler implements ActiveFileHandler {
 
-    private final DebuggerManager          debuggerManager;
     private final EditorAgent              editorAgent;
     private final DtoFactory               dtoFactory;
     private final AppContext               appContext;
     private final EventBus                 eventBus;
     private final JavaNodeManager          javaNodeManager;
     private final ProjectExplorerPresenter projectExplorer;
+    private final ProjectServiceClient     projectService;
+
+    private HandlerRegistration handler;
 
     @Inject
-    public JavaDebuggerFileHandler(DebuggerManager debuggerManager,
-                                   EditorAgent editorAgent,
+    public JavaDebuggerFileHandler(EditorAgent editorAgent,
                                    DtoFactory dtoFactory,
                                    AppContext appContext,
                                    EventBus eventBus,
                                    JavaNodeManager javaNodeManager,
-                                   ProjectExplorerPresenter projectExplorer) {
-        this.debuggerManager = debuggerManager;
+                                   ProjectExplorerPresenter projectExplorer,
+                                   ProjectServiceClient projectService) {
         this.editorAgent = editorAgent;
         this.dtoFactory = dtoFactory;
         this.appContext = appContext;
         this.eventBus = eventBus;
         this.javaNodeManager = javaNodeManager;
         this.projectExplorer = projectExplorer;
+        this.projectService = projectService;
     }
 
     @Override
-    public void openFile(final List<String> filePaths,
-                         final String className,
-                         final int lineNumber,
-                         final AsyncCallback<VirtualFile> callback) {
-        if (debuggerManager.getActiveDebugger() != debuggerManager.getDebugger(JavaDebugger.ID)) {
-            callback.onFailure(null);
-            return;
-        }
-
+    public void openFile(Location location, AsyncCallback<VirtualFile> callback) {
         VirtualFile activeFile = null;
+        String activePath = null;
         final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
         if (activeEditor != null) {
-            activeFile = activeEditor.getEditorInput().getFile();
+            activeFile = editorAgent.getActiveEditor().getEditorInput().getFile();
+            activePath = activeFile.getPath();
         }
-
-        if (activeFile == null || !filePaths.contains(activeFile.getPath())) {
-            openFile(className, filePaths, 0, new AsyncCallback<VirtualFile>() {
-                @Override
-                public void onSuccess(VirtualFile result) {
-                    scrollEditorToExecutionPoint((TextEditorPresenter)editorAgent.getActiveEditor(), lineNumber);
-                    callback.onSuccess(result);
-                }
-
-                @Override
-                public void onFailure(Throwable caught) {
-                    callback.onFailure(caught);
-                }
-            });
+        if (activePath != null && !activePath.equals(location.getTarget()) && !activePath.equals(location.getResourcePath())) {
+            if (location.isExternalResource()) {
+                openExternalResource(location, callback);
+            } else {
+                doOpenFile(location, callback);
+            }
         } else {
-            scrollEditorToExecutionPoint((TextEditorPresenter)activeEditor, lineNumber);
+            scrollEditorToExecutionPoint((TextEditor)activeEditor, location.getLineNumber());
             callback.onSuccess(activeFile);
         }
     }
 
-    /**
-     * Tries to open file from the project.
-     * If fails then method will try to find resource from external dependencies.
-     */
-    private void openFile(@NotNull final String className,
-                          final List<String> filePaths,
-                          final int pathNumber,
-                          final AsyncCallback<VirtualFile> callback) {
-        if (pathNumber == filePaths.size()) {
-            callback.onFailure(new IllegalArgumentException("Can't open resource " + className));
-            return;
-        }
-
-        String filePath = filePaths.get(pathNumber);
-
-        if (!filePath.startsWith("/")) {
-            openExternalResource(className, callback);
-            return;
-        }
-
-        projectExplorer.getNodeByPath(new HasStorablePath.StorablePath(filePath)).then(new Operation<Node>() {
+    private void doOpenFile(final Location location, final AsyncCallback<VirtualFile> callback) {
+        projectExplorer.getNodeByPath(new HasStorablePath.StorablePath(location.getResourcePath())).then(new Operation<Node>() {
             @Override
             public void apply(final Node node) throws OperationException {
                 if (!(node instanceof FileReferenceNode)) {
                     return;
                 }
 
-                handleActivateFile((VirtualFile)node, callback);
+                handleActivatedFile((VirtualFile)node, callback, location.getLineNumber());
                 eventBus.fireEvent(new FileEvent((VirtualFile)node, OPEN));
             }
         }).catchError(new Operation<PromiseError>() {
             @Override
             public void apply(PromiseError error) throws OperationException {
-                // try another path
-                openFile(className, filePaths, pathNumber + 1, callback);
+                callback.onFailure(error.getCause());
             }
         });
     }
 
-    private void openExternalResource(String className, final AsyncCallback<VirtualFile> callback) {
-        JarEntry jarEntry = dtoFactory.createDto(JarEntry.class);
+    private void openExternalResource(final Location location, final AsyncCallback<VirtualFile> callback) {
+        final NodeSettings nodeSettings = javaNodeManager.getJavaSettingsProvider().getSettings();
+        final JavaNodeFactory javaNodeFactory = javaNodeManager.getJavaNodeFactory();
+
+        String className = extractOuterClassFqn(location.getTarget());
+        final JarEntry jarEntry = dtoFactory.createDto(JarEntry.class);
         jarEntry.setPath(className);
         jarEntry.setName(className.substring(className.lastIndexOf(".") + 1) + ".class");
-        jarEntry.setType(JarEntry.JarEntryType.CLASS_FILE);
+        jarEntry.setType(CLASS_FILE);
 
-        final JarFileNode jarFileNode = javaNodeManager.getJavaNodeFactory()
-                                                       .newJarFileNode(jarEntry,
-                                                                       null,
-                                                                       appContext.getCurrentProject().getProjectConfig(),
-                                                                       javaNodeManager.getJavaSettingsProvider().getSettings());
+        final String projectPath = location.getResourceProjectPath();
+        projectService.getProject(appContext.getDevMachine(), projectPath)
+                      .then(new Function<ProjectConfigDto, JarFileNode>() {
+                          @Override
+                          public JarFileNode apply(ProjectConfigDto projectConfigDto) throws FunctionException {
+                              return javaNodeFactory.newJarFileNode(jarEntry, null, projectConfigDto, nodeSettings);
+                          }
+                      })
+                      .then(new Operation<JarFileNode>() {
+                          @Override
+                          public void apply(final JarFileNode jarFileNode) throws OperationException {
+                              AsyncCallback<VirtualFile> downloadSourceCallback = new AsyncCallback<VirtualFile>() {
+                                  @Override
+                                  public void onSuccess(final VirtualFile result) {
+                                      if (jarFileNode.isContentGenerated()) {
+                                          handleContentGeneratedResource(result, location, callback);
+                                      } else {
+                                          handleActivatedFile(jarFileNode, callback, location.getLineNumber());
+                                      }
+                                  }
 
-        handleActivateFile(jarFileNode, callback);
-        eventBus.fireEvent(new FileEvent(jarFileNode, OPEN));
+                                  @Override
+                                  public void onFailure(Throwable caught) {
+                                      callback.onFailure(caught);
+                                  }
+                              };
+                              handleActivatedFile(jarFileNode, downloadSourceCallback, location.getLineNumber());
+                          }
+                      })
+                      .catchError(new Operation<PromiseError>() {
+                          @Override
+                          public void apply(PromiseError arg) throws OperationException {
+                              callback.onFailure(arg.getCause());
+                          }
+                      });
     }
 
-    public void handleActivateFile(final VirtualFile virtualFile, final AsyncCallback<VirtualFile> callback) {
+    private String extractOuterClassFqn(String fqn) {
+        //handle fqn in case nested classes
+        if (fqn.contains("$")) {
+            return fqn.substring(0, fqn.indexOf("$"));
+        }
+        //handle fqn in case lambda expressions
+        if (fqn.contains("$$")) {
+            return fqn.substring(0, fqn.indexOf("$$"));
+        }
+        return fqn;
+    }
+
+    private void handleContentGeneratedResource(final VirtualFile file,
+                                                final Location location,
+                                                final AsyncCallback<VirtualFile> callback) {
+        if (handler != null) {
+            handler.removeHandler();
+        }
+        handler = eventBus.addHandler(EditorDirtyStateChangedEvent.TYPE, new EditorDirtyStateChangedHandler() {
+            @Override
+            public void onEditorDirtyStateChanged(EditorDirtyStateChangedEvent event) {
+                if (file.equals(event.getEditor().getEditorInput().getFile())) {
+                    handleActivatedFile(file, callback, location.getLineNumber());
+                    handler.removeHandler();
+                }
+            }
+        });
+    }
+
+    public void handleActivatedFile(final VirtualFile virtualFile, final AsyncCallback<VirtualFile> callback, final int debugLine) {
         editorAgent.openEditor(virtualFile, new EditorAgent.OpenEditorCallback() {
             @Override
             public void onEditorOpened(EditorPartPresenter editor) {
                 new Timer() {
                     @Override
                     public void run() {
+                        scrollEditorToExecutionPoint((TextEditor)editorAgent.getActiveEditor(), debugLine);
                         callback.onSuccess(virtualFile);
                     }
                 }.schedule(300);
@@ -181,6 +217,7 @@ public class JavaDebuggerFileHandler implements ActiveFileHandler {
                 new Timer() {
                     @Override
                     public void run() {
+                        scrollEditorToExecutionPoint((TextEditor)editorAgent.getActiveEditor(), debugLine);
                         callback.onSuccess(virtualFile);
                     }
                 }.schedule(300);
@@ -193,7 +230,7 @@ public class JavaDebuggerFileHandler implements ActiveFileHandler {
         });
     }
 
-    private void scrollEditorToExecutionPoint(TextEditorPresenter editor, int lineNumber) {
+    private void scrollEditorToExecutionPoint(TextEditor editor, int lineNumber) {
         Document document = editor.getDocument();
 
         if (document != null) {

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>antlr-runtime</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.birt.runtime</groupId>
+            <artifactId>org.eclipse.equinox.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-debug</artifactId>
         </dependency>
@@ -54,6 +58,20 @@
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-java-jdt-core-repack</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.eclipse.jdt.core</artifactId>
+                    <groupId>org.eclipse.tycho</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -62,6 +80,31 @@
             <artifactId>tools</artifactId>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockitong</groupId>
+            <artifactId>mockitong</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/utils/JavaDebuggerUtils.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/utils/JavaDebuggerUtils.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.jdb.server.utils;
+
+import com.sun.istack.internal.NotNull;
+
+import org.eclipse.che.api.debug.shared.model.Location;
+import org.eclipse.che.api.debug.shared.model.impl.LocationImpl;
+import org.eclipse.che.api.debugger.server.exceptions.DebuggerException;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.TypeNameMatch;
+import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.jdt.core.search.SearchEngine.createWorkspaceScope;
+
+/**
+ * Class uses for find and handle important information from the Java Model.
+ *
+ * @author Alexander Andrienko
+ */
+public class JavaDebuggerUtils {
+
+    /**
+     * Returns Location for current debugger resource.
+     *
+     * @param location
+     *         location type from JVM
+     * @throws DebuggerException
+     *         in case {@link org.eclipse.jdt.core.JavaModelException} or if Java {@link org.eclipse.jdt.core.IType}
+     *         was not find
+     */
+    public Location getLocation(com.sun.jdi.Location location) throws DebuggerException {
+        String fqn = location.declaringType().name();
+
+        List<IType> types;
+        try {
+            Pair<char[][], char[][]> fqnPair = prepareFqnToSearch(fqn);
+
+            types = findTypeByFqn(fqnPair.first, fqnPair.second, createWorkspaceScope());
+        } catch (JavaModelException e) {
+            throw new DebuggerException("Can't find class models by fqn: " + fqn, e);
+        }
+
+        if (types.isEmpty()) {
+            throw new DebuggerException("Type with fully qualified name: " + fqn + " was not found");
+        }
+
+        IType type = types.get(0);//TODO we need handle few result! It's temporary solution.
+        String typeProjectPath = type.getJavaProject().getPath().toOSString();
+        if (type.isBinary()) {
+            IClassFile classFile = type.getClassFile();
+            int libId = classFile.getAncestor(IPackageFragmentRoot.PACKAGE_FRAGMENT_ROOT).hashCode();
+            return new LocationImpl(fqn, location.lineNumber(), null, true, libId, typeProjectPath);
+        } else {
+            ICompilationUnit compilationUnit = type.getCompilationUnit();
+            typeProjectPath = type.getJavaProject().getPath().toOSString();
+            String resourcePath = compilationUnit.getPath().toOSString();
+            return new LocationImpl(fqn, location.lineNumber(), resourcePath, false, -1, typeProjectPath);
+        }
+    }
+
+    private Pair<char[][], char[][]> prepareFqnToSearch(@NotNull String fqn) {
+        String outerClassFqn = extractOuterClassFqn(fqn);
+        int lastDotIndex = outerClassFqn.trim().lastIndexOf('.');
+
+        char[][] packages;
+        char[][] names;
+        if (lastDotIndex == -1) {
+            packages = new char[0][];
+            names = new char[][]{outerClassFqn.toCharArray()};
+        } else {
+            String packageLine = fqn.substring(0, lastDotIndex);
+            packages = new char[][]{packageLine.toCharArray()};
+
+            String nameLine = fqn.substring(lastDotIndex + 1, outerClassFqn.length());
+            names = new char[][]{nameLine.toCharArray()};
+        }
+        return new Pair<>(packages, names);
+    }
+
+    private String extractOuterClassFqn(String fqn) {
+        //handle fqn in case nested classes
+        if (fqn.contains("$")) {
+            return fqn.substring(0, fqn.indexOf("$"));
+        }
+        //handle fqn in case lambda expressions
+        if (fqn.contains("$$")) {
+            return fqn.substring(0, fqn.indexOf("$$"));
+        }
+        return fqn;
+    }
+
+    private List<IType> findTypeByFqn(char[][] packages, char[][] names, IJavaSearchScope scope) throws JavaModelException {
+        List<IType> result = new ArrayList<>();
+
+        SearchEngine searchEngine = new SearchEngine();
+
+        searchEngine.searchAllTypeNames(packages,
+                                        names,
+                                        scope,
+                                        new TypeNameMatchRequestor() {
+                                            @Override
+                                            public void acceptTypeNameMatch(TypeNameMatch typeNameMatch) {
+                                                result.add(typeNameMatch.getType());
+                                            }
+                                        },
+                                        IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH,
+                                        new NullProgressMonitor());
+        return result;
+    }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/JarEntry.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/JarEntry.java
@@ -17,7 +17,7 @@ import org.eclipse.che.dto.shared.DTO;
  */
 @DTO
 public interface JarEntry {
-    public enum JarEntryType {
+    enum JarEntryType {
         PACKAGE, FOLDER, CLASS_FILE, FILE
     }
 

--- a/wsagent/che-core-api-debug-shared/src/main/java/org/eclipse/che/api/debug/shared/dto/LocationDto.java
+++ b/wsagent/che-core-api-debug-shared/src/main/java/org/eclipse/che/api/debug/shared/dto/LocationDto.java
@@ -16,15 +16,27 @@ import org.eclipse.che.dto.shared.DTO;
 /** @author andrew00x */
 @DTO
 public interface LocationDto extends Location {
-    String getTarget();
-
     void setTarget(String target);
 
     LocationDto withTarget(String target);
 
-    int getLineNumber();
-
     void setLineNumber(int lineNumber);
 
     LocationDto withLineNumber(int lineNumber);
+
+    void setExternalResource(boolean externalResource);
+
+    void setResourcePath(String resourcePath);
+
+    LocationDto withResourcePath(String resourcePath);
+
+    LocationDto withExternalResource(boolean externalResource);
+
+    void setExternalResourceId(int externalResourceId);
+
+    LocationDto withExternalResourceId(int externalResourceId);
+
+    void setResourceProjectPath(String resourceProjectPath);
+
+    LocationDto withResourceProjectPath(String resourceProjectPath);
 }

--- a/wsagent/che-core-api-debug-shared/src/main/java/org/eclipse/che/api/debug/shared/model/Location.java
+++ b/wsagent/che-core-api-debug-shared/src/main/java/org/eclipse/che/api/debug/shared/model/Location.java
@@ -23,4 +23,24 @@ public interface Location {
      * The line number in a file or in a class.
      */
     int getLineNumber();
+
+    /**
+     * Returns path to the resource.
+     */
+    String getResourcePath();
+
+    /**
+     * Returns true if breakpoint resource is external resource, or false otherwise.
+     */
+    boolean isExternalResource();
+
+    /**
+     * Returns external resource id in case if {@link #isExternalResource()} return true.
+     */
+    int getExternalResourceId();
+
+    /**
+     * Returns project path, for resource which we are debugging now.
+     */
+    String getResourceProjectPath();
 }

--- a/wsagent/che-core-api-debug-shared/src/main/java/org/eclipse/che/api/debug/shared/model/impl/LocationImpl.java
+++ b/wsagent/che-core-api-debug-shared/src/main/java/org/eclipse/che/api/debug/shared/model/impl/LocationImpl.java
@@ -12,20 +12,39 @@ package org.eclipse.che.api.debug.shared.model.impl;
 
 import org.eclipse.che.api.debug.shared.model.Location;
 
+import java.util.Objects;
+
 /**
  * @author Anatoliy Bazko
  */
 public class LocationImpl implements Location {
-    private final String target;
-    private final int    lineNumber;
+    private final String  target;
+    private final int     lineNumber;
+    private final String  resourcePath;
+    private final boolean externalResource;
+    private final int     externalResourceId;
+    private final String  resourceProjectPath;
 
-    public LocationImpl(String target, int lineNumber) {
+    public LocationImpl(String target,
+                        int lineNumber,
+                        String resourcePath,
+                        boolean externalResource,
+                        int externalResourceId,
+                        String resourceProjectPath) {
         this.target = target;
         this.lineNumber = lineNumber;
+        this.resourcePath = resourcePath;
+        this.externalResource = externalResource;
+        this.externalResourceId = externalResourceId;
+        this.resourceProjectPath = resourceProjectPath;
+    }
+
+    public LocationImpl(String target, int lineNumber) {
+        this(target, lineNumber, null, false, 0, null);
     }
 
     public LocationImpl(String target) {
-        this(target, 0);
+        this(target, 0, null, false, 0, null);
     }
 
     @Override
@@ -39,21 +58,49 @@ public class LocationImpl implements Location {
     }
 
     @Override
+    public String getResourcePath() {
+        return resourcePath;
+    }
+
+    @Override
+    public boolean isExternalResource() {
+        return externalResource;
+    }
+
+    @Override
+    public int getExternalResourceId() {
+        return externalResourceId;
+    }
+
+    @Override
+    public String getResourceProjectPath() {
+        return resourceProjectPath;
+    }
+
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof LocationImpl)) return false;
 
         LocationImpl location = (LocationImpl)o;
 
-        if (lineNumber != location.lineNumber) return false;
-        return !(target != null ? !target.equals(location.target) : location.target != null);
-
+        return lineNumber == location.lineNumber &&
+               externalResourceId == location.externalResourceId &&
+               externalResource == location.externalResource &&
+               Objects.equals(resourcePath ,location.resourcePath) &&
+               Objects.equals(resourceProjectPath, location.resourceProjectPath) &&
+               !(target != null ? !target.equals(location.target) : location.target != null);
     }
 
     @Override
     public int hashCode() {
         int result = target != null ? target.hashCode() : 0;
         result = 31 * result + lineNumber;
+        result = 31 * result + externalResourceId;
+        result = 31 * result + Objects.hashCode(resourcePath);
+        result = 31 * result + (externalResource ? 1 : 0);
+        result = 31 * result + Objects.hashCode(resourceProjectPath);
         return result;
     }
 }

--- a/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DtoConverter.java
+++ b/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DtoConverter.java
@@ -77,7 +77,11 @@ public final class DtoConverter {
 
     public static LocationDto asDto(Location location) {
         return newDto(LocationDto.class).withTarget(location.getTarget())
-                                        .withLineNumber(location.getLineNumber());
+                                        .withLineNumber(location.getLineNumber())
+                                        .withExternalResourceId(location.getExternalResourceId())
+                                        .withResourcePath(location.getResourcePath())
+                                        .withResourceProjectPath(location.getResourceProjectPath())
+                                        .withExternalResource(location.isExternalResource());
     }
 
     public static SimpleValueDto asDto(SimpleValue value) {


### PR DESCRIPTION
Add possibility find source file from another module or external java project and open it in time of debugging. For realizing this search we use JDT on the server side (Earlier we used project attributes and look over potential file location in the client side). 
Fix opening java file in case if we debug inner classes or lyambda.
Fix render debug line for java classes from external jar after click to download source link.

Signed-off-by: Aleksandr Andrienko aandrienko@codenvy.com
