### PR TITLE
CHE-648. Try to restore websocket connection when this one has closed

### DIFF
--- a/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/MachineManager.java
+++ b/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/MachineManager.java
@@ -12,7 +12,6 @@ package org.eclipse.che.ide.api.machine;
 
 import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
-import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.promises.client.Promise;
 
 /**
@@ -79,14 +78,5 @@ public interface MachineManager {
      *         contains information about machine state
      */
     void restartMachine(final Machine machine);
-
-    /**
-     * Checks if the the status for dev machine is tracked by machine manager.
-     *
-     * @param machine
-     *         contains information about machine state
-     * @return {@code true} if status for dev machine is tracked by machine manager and {@code false} - otherwise.
-     */
-    boolean isDevMachineStatusTracked(MachineDto machine);
 
 }

--- a/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentStateController.java
+++ b/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentStateController.java
@@ -42,6 +42,8 @@ import org.eclipse.che.ide.websocket.events.WebSocketClosedEvent;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.che.ide.api.machine.WsAgentState.STARTED;
+import static org.eclipse.che.ide.api.machine.WsAgentState.STOPPED;
 import static org.eclipse.che.ide.ui.loaders.initialization.InitialLoadingInfo.Operations.WS_AGENT_BOOTING;
 import static org.eclipse.che.ide.ui.loaders.initialization.OperationInfo.Status.IN_PROGRESS;
 import static org.eclipse.che.ide.ui.loaders.initialization.OperationInfo.Status.SUCCESS;
@@ -84,7 +86,7 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
 
     public void initialize(DevMachine devMachine) {
         this.devMachine = devMachine;
-        this.state = WsAgentState.STOPPED;
+        this.state = STOPPED;
         initialLoadingInfo.setOperationStatus(WS_AGENT_BOOTING.getValue(), IN_PROGRESS);
         checkHttpConnection();
     }
@@ -92,8 +94,8 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
     @Override
     public void onClose(WebSocketClosedEvent event) {
         Log.info(getClass(), "Test WS connection closed with code " + event.getCode() + " reason: " + event.getReason());
-        if (state.equals(WsAgentState.STARTED)) {
-            state = WsAgentState.STOPPED;
+        if (state.equals(STARTED)) {
+            state = STOPPED;
             eventBus.fireEvent(WsAgentStateEvent.createWsAgentStoppedEvent());
         }
     }
@@ -101,8 +103,8 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
     @Override
     public void onError() {
         Log.info(getClass(), "Test WS connection error");
-        if (state.equals(WsAgentState.STARTED)) {
-            state = WsAgentState.STOPPED;
+        if (state.equals(STARTED)) {
+            state = STOPPED;
             eventBus.fireEvent(WsAgentStateEvent.createWsAgentStoppedEvent());
         }
     }
@@ -126,7 +128,7 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
     }
 
     private void started() {
-        state = WsAgentState.STARTED;
+        state = STARTED;
         initialLoadingInfo.setOperationStatus(WS_AGENT_BOOTING.getValue(), SUCCESS);
         loader.hide();
 
@@ -226,7 +228,7 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
         }
         messageBus = messageBusProvider.createMachineMessageBus(devMachine.getWsAgentWebSocketUrl());
         messageBus.addOnCloseHandler(this);
-        messageBus.addOnCloseHandler(this);
+        messageBus.addOnErrorHandler(this);
         messageBus.addOnOpenHandler(this);
     }
 }


### PR DESCRIPTION
1. The first problem is - we have double method call and code execution for initialization of WsAgentStateController: 
   - when a workspace has started: https://github.com/eclipse/che/blob/master/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/BootstrapController.java#L105
   - when a dev machine has started: https://github.com/eclipse/che/blob/master/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImpl.java#L298
     This causes incorrect behavior to tracking of websocket connection state.
2. Next problem - Che loses connection with WS agent after the several hours of inactivity. My suggestion is try to restore connection when connection has closed or when we have some errors related to websocket connection. So we will have 5 attempts to restore connection (reconnection period is 2ms) and notify corresponding listeners only after these attempts. For example, I've tested it on the use case when session timeout has been reached: connection was restored in 2 ms without some problems.
