### PR TITLE
CHE-1143: fixed synchronization issue during removal of several projects

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/LocalVirtualFileSystem.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/LocalVirtualFileSystem.java
@@ -243,7 +243,7 @@ public class LocalVirtualFileSystem implements VirtualFileSystem {
         return newArrayList(path.elements()).contains(".vfs");
     }
 
-    List<VirtualFile> getChildren(LocalVirtualFile parent, VirtualFileFilter filter) throws ServerException {
+    synchronized List<VirtualFile> getChildren(LocalVirtualFile parent, VirtualFileFilter filter) throws ServerException {
         if (parent.isFolder()) {
             final List<VirtualFile> children = doGetChildren(parent, DOT_VFS_DIR_FILTER, filter);
             Collections.sort(children);


### PR DESCRIPTION
**_1 Upvote**_ Hi,

Recently I was working on some bugs in Eclipse Che project management infrastructure. The report itself looks like:

When we delete several projects simultaneously (in the same running workspace with project api):
1. We get `204` status on each request however projects are not deleted
2. In some cases we get `500` status combined with `java.util.ConcurrentModificationException`

The first point is a separate question and there are several ideological problems that should be solved first. As far as I know, the discussion is not yet complete.

And for the second item I created a dedicated test to cover the bug. Though the bug is not reproduced anymore most likely thanks to [this commit](https://github.com/eclipse/che/commit/658410556f8d0d5c91316890111ff7dc9d57cba1#diff-9414b806e2941cc99a2d071cd5b982fc), I've spotted another problem. We rarely get exception:  

```
java.lang.AssertionError: Error: Comparison method violates its general contract! expected [204] but found [500]
        at org.testng.Assert.fail(Assert.java:94)
        at org.testng.Assert.failNotEquals(Assert.java:494)
        at org.testng.Assert.assertEquals(Assert.java:123)
        at org.testng.Assert.assertEquals(Assert.java:370)
        at org.eclipse.che.api.project.server.ProjectServiceTest.testDeleteProjectsConcurrently(ProjectServiceTest.java:981)
```

when we try to simultaneously remove 100 projects (in 100 threads), while it is always reproduced for 1k+ threads.

I assume that the problem is the following. At some point of project deletion we are to get its filesystem parent's sorted children list, the process is a set of two operations: get and sort the list. These operations are not synchronized so sometimes it happens to change somehow state of children collections by another thread. This results in a following exception: 

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
    at java.util.ComparableTimSort.mergeHi(ComparableTimSort.java:835)
    at java.util.ComparableTimSort.mergeAt(ComparableTimSort.java:453)
    at java.util.ComparableTimSort.mergeForceCollapse(ComparableTimSort.java:392)
    at java.util.ComparableTimSort.sort(ComparableTimSort.java:191)
    at java.util.ComparableTimSort.sort(ComparableTimSort.java:146)
    at java.util.Arrays.sort(Arrays.java:472)
    at java.util.Collections.sort(Collections.java:155)
```

That basically happens when arrays of children that are to be merged are indeed not sorted (because of impact of the other thread: there are changes of some elements' state or elements themselves after they are already sorted) or elements are sorted but children's compareTo method cannot fulfill its contract (e.g. does not provide transitivity).

My suggestion is to synchronize those two operations, which should not have great impact on performance (taking into account the kind of operations that we have here) and at the same time we will not impact general logic of such a low level component as file system.
