### PR TITLE
Remove wrong required parameters in DockerConnector methods params

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -1407,8 +1407,8 @@ public class DockerConnector {
         try (DockerConnection connection = connectionFactory.openConnection(dockerDaemonUri)
                                                             .method("POST")
                                                             .path("/commit")
-                                                            .query("container", params.getContainer())
-                                                            .query("repo", params.getRepository())) {
+                                                            .query("container", params.getContainer())) {
+            addQueryParamIfNotNull(connection, "repo", params.getRepository());
             addQueryParamIfNotNull(connection, "tag", params.getTag());
             addQueryParamIfNotNull(connection, "comment", (params.getComment() == null) ?
                                                           null : URLEncoder.encode(params.getComment(), "UTF-8"));

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/CommitParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/CommitParams.java
@@ -39,10 +39,25 @@ public class CommitParams {
      * @return arguments holder with required parameters
      * @throws NullPointerException
      *         if {@code container} or {@code repository} is null
+     * @deprecated use {@link CommitParams#create(String)} instead
      */
+    @Deprecated
     public static CommitParams create(@NotNull String container, @NotNull String repository) {
         return new CommitParams().withContainer(container)
                                  .withRepository(repository);
+    }
+
+    /**
+     * Creates arguments holder with required parameters.
+     *
+     * @param container
+     *         id or name of container
+     * @return arguments holder with required parameters
+     * @throws NullPointerException
+     *         if {@code container} is null
+     */
+    public static CommitParams create(@NotNull String container) {
+        return new CommitParams().withContainer(container);
     }
 
     private CommitParams() {}
@@ -68,11 +83,8 @@ public class CommitParams {
      * @param repository
      *         full repository name
      * @return this params instance
-     * @throws NullPointerException
-     *         if {@code repository} is null
      */
-    public CommitParams withRepository(@NotNull String repository) {
-        requireNonNull(repository);
+    public CommitParams withRepository(String repository) {
         this.repository = repository;
         return this;
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/params/CommitParamsTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/params/CommitParamsTest.java
@@ -31,16 +31,16 @@ public class CommitParamsTest {
 
     @BeforeMethod
     private void prepare() {
-        commitParams = CommitParams.create(CONTAINER, REPOSITORY);
+        commitParams = CommitParams.create(CONTAINER);
     }
 
     @Test
     public void shouldCreateParamsObjectWithRequiredParameters() {
-        commitParams = CommitParams.create(CONTAINER, REPOSITORY);
+        commitParams = CommitParams.create(CONTAINER);
 
         assertEquals(commitParams.getContainer(), CONTAINER);
-        assertEquals(commitParams.getRepository(), REPOSITORY);
 
+        assertNull(commitParams.getRepository());
         assertNull(commitParams.getTag());
         assertNull(commitParams.getComment());
         assertNull(commitParams.getAuthor());
@@ -48,10 +48,11 @@ public class CommitParamsTest {
 
     @Test
     public void shouldCreateParamsObjectWithAllPossibleParameters() {
-        commitParams = CommitParams.create(CONTAINER, REPOSITORY)
-                                                .withTag(TAG)
-                                                .withComment(COMMENT)
-                                                .withAuthor(AUTHOR);
+        commitParams = CommitParams.create(CONTAINER)
+                                   .withRepository(REPOSITORY)
+                                   .withTag(TAG)
+                                   .withComment(COMMENT)
+                                   .withAuthor(AUTHOR);
 
         assertEquals(commitParams.getContainer(), CONTAINER);
         assertEquals(commitParams.getRepository(), REPOSITORY);
@@ -62,22 +63,12 @@ public class CommitParamsTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIfContainerRequiredParameterIsNull() {
-        commitParams = CommitParams.create(null, REPOSITORY);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNullPointerExceptionIfRepositoryRequiredParameterIsNull() {
-        commitParams = CommitParams.create(CONTAINER, null);
+        commitParams = CommitParams.create(null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void shouldThrowNullPointerExceptionIfContainerRequiredParameterResetWithNull() {
         commitParams.withContainer(null);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNullPointerExceptionIfRepositoryRequiredParameterResetWithNull() {
-        commitParams.withRepository(null);
     }
 
     @Test
@@ -89,8 +80,18 @@ public class CommitParamsTest {
     }
 
     @Test
+    public void repositoryParameterShouldEqualsNullIfItNotSet() {
+        commitParams.withComment(COMMENT)
+                    .withTag(TAG)
+                    .withAuthor(AUTHOR);
+
+        assertNull(commitParams.getRepository());
+    }
+
+    @Test
     public void commentParameterShouldEqualsNullIfItNotSet() {
-        commitParams.withTag(TAG)
+        commitParams.withContainer(CONTAINER)
+                    .withTag(TAG)
                     .withAuthor(AUTHOR);
 
         assertNull(commitParams.getComment());
@@ -98,7 +99,8 @@ public class CommitParamsTest {
 
     @Test
     public void authorParameterShouldEqualsNullIfItNotSet() {
-        commitParams.withTag(TAG)
+        commitParams.withContainer(CONTAINER)
+                    .withTag(TAG)
                     .withComment(COMMENT);
 
         assertNull(commitParams.getAuthor());


### PR DESCRIPTION
We had parameters in some methods of `DockerConnector` which is used in API requests even if they wasn't really required. Now we should remove they from required list.
