### PR TITLE
CHE-909, CHE-386: Synchronize machine stop/start with related runtime workspace environment

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -75,7 +75,7 @@ public class WsMasterModule extends AbstractModule {
         bind(org.eclipse.che.api.workspace.server.WorkspaceValidator.class)
                 .to(org.eclipse.che.api.workspace.server.DefaultWorkspaceValidator.class);
 
-        bind(org.eclipse.che.api.workspace.server.event.MachineStateListener.class).asEagerSingleton();
+        bind(org.eclipse.che.api.workspace.server.event.StopWorkspaceOnDestroyDevMachine.class).asEagerSingleton();
 
         bind(org.eclipse.che.api.machine.server.wsagent.WsAgentLauncher.class)
                 .to(org.eclipse.che.api.machine.server.wsagent.WsAgentLauncherImpl.class);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/StopWorkspaceOnDestroyDevMachine.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/StopWorkspaceOnDestroyDevMachine.java
@@ -30,28 +30,27 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.machine.shared.dto.event.MachineStatusEvent.EventType.DESTROYED;
 
 /**
- * The class listens changing of machine status and perform some actions when status is changed.
+ * The class listens changing of machine status and perform stop workspace if ws-machine is destroyed.
  *
  * @author Dmitry Shnurenko
  */
 @Singleton
-public class MachineStateListener implements EventSubscriber<MachineStatusEvent> {
-    private static final Logger LOG = LoggerFactory.getLogger(MachineStateListener.class);
+public class StopWorkspaceOnDestroyDevMachine implements EventSubscriber<MachineStatusEvent> {
+    private static final Logger LOG = LoggerFactory.getLogger(StopWorkspaceOnDestroyDevMachine.class);
 
     private final WorkspaceManager workspaceManager;
     private final EventService     eventService;
 
     @Inject
-    public MachineStateListener(WorkspaceManager workspaceManager, EventService eventService) {
+    public StopWorkspaceOnDestroyDevMachine(WorkspaceManager workspaceManager, EventService eventService) {
         this.workspaceManager = workspaceManager;
         this.eventService = eventService;
     }
 
     @Override
     public void onEvent(MachineStatusEvent event) {
-        String workspaceId = event.getWorkspaceId();
-
-        if (event.isDev() && DESTROYED.equals(event.getEventType())) {
+        if (DESTROYED.equals(event.getEventType()) && event.isDev()) {
+            String workspaceId = event.getWorkspaceId();
             try {
                 WorkspaceImpl currentWorkspace = workspaceManager.getWorkspace(workspaceId);
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceRuntimeImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceRuntimeImpl.java
@@ -47,9 +47,11 @@ public class WorkspaceRuntimeImpl implements WorkspaceRuntime {
         if (devMachine != null) {
             this.devMachine = new MachineImpl(devMachine);
         }
-        this.machines = machines.stream()
-                                .map(MachineImpl::new)
-                                .collect(toList());
+        if (machines != null) {
+            this.machines = machines.stream()
+                                    .map(MachineImpl::new)
+                                    .collect(toList());
+        }
     }
 
     public WorkspaceRuntimeImpl(WorkspaceRuntime runtime) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/event/StopWorkspaceOnDestroyDevMachineTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/event/StopWorkspaceOnDestroyDevMachineTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
  * @author Dmitry Shnurenko
  */
 @Listeners(MockitoTestNGListener.class)
-public class MachineStateListenerTest {
+public class StopWorkspaceOnDestroyDevMachineTest {
 
     @Mock
     private WorkspaceManager workspaceManager;
@@ -45,7 +45,7 @@ public class MachineStateListenerTest {
     private WorkspaceImpl      workspace;
 
     @InjectMocks
-    private MachineStateListener listener;
+    private StopWorkspaceOnDestroyDevMachine listener;
 
     @Test
     public void workspaceShouldNotBeStoppedWhenStoppedMachineIsNotDev() throws Exception {


### PR DESCRIPTION
We do not track temporary machines in API. As a consequence this additional machines is not stopped after stop of their workspace.
