### PR TITLE
CHE-1057: GDB Debugger UX Improvements

### DIFF
--- a/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/debug/DebugConfigurationsManager.java
+++ b/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/debug/DebugConfigurationsManager.java
@@ -55,6 +55,14 @@ public interface DebugConfigurationsManager {
     /** Remove the given listener. */
     void removeConfigurationsChangedListener(ConfigurationChangedListener listener);
 
+    /**
+     * Apply configuration. Establish connection with configured debugger.
+     *
+     * @param debugConfiguration
+     *      the debug configuration to use
+     */
+    void apply(DebugConfiguration debugConfiguration);
+
     /** Listener that will be called when debug configuration has been changed. */
     interface ConfigurationChangedListener {
         void onConfigurationAdded(DebugConfiguration configuration);

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerExtension.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerExtension.java
@@ -96,17 +96,17 @@ public class DebuggerExtension {
         actionManager.registerAction(SHOW_HIDE_DEBUGGER_PANEL_ID, showHideDebuggerPanelAction);
 
         // create group for selecting (changing) debug configurations
-        final DefaultActionGroup debugConfigurationsGroup = new DefaultActionGroup(localizationConstants.debugConfigurationsActionTitle(),
-                                                                                   true,
-                                                                                   actionManager);
-        debugConfigurationsGroup.add(editConfigurationsAction);
-        debugConfigurationsGroup.addSeparator();
-        debugConfigurationsGroup.add(configurationsGroup);
+        final DefaultActionGroup debugActionGroup = new DefaultActionGroup(localizationConstants.debugActionTitle(),
+                                                                           true,
+                                                                           actionManager);
+        debugActionGroup.add(debugAction);
+        debugActionGroup.addSeparator();
+        debugActionGroup.add(configurationsGroup);
 
         // add actions in main menu
         runMenu.addSeparator();
-        runMenu.add(debugConfigurationsGroup, LAST);
-        runMenu.add(debugAction, LAST);
+        runMenu.add(debugActionGroup, LAST);
+        runMenu.add(editConfigurationsAction, LAST);
         runMenu.add(disconnectDebuggerAction, LAST);
         runMenu.addSeparator();
         runMenu.add(stepIntoAction, LAST);

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.java
@@ -18,9 +18,6 @@ package org.eclipse.che.plugin.debugger.ide;
 public interface DebuggerLocalizationConstant extends com.google.gwt.i18n.client.Messages {
 
     /* actions */
-    @Key("debugConfigurationsActionTitle")
-    String debugConfigurationsActionTitle();
-
     @Key("editDebugConfigurationsActionTitle")
     String editDebugConfigurationsActionTitle();
 

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebugAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebugAction.java
@@ -14,22 +14,14 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
 import org.eclipse.che.ide.api.debug.DebugConfigurationsManager;
-import org.eclipse.che.ide.debug.Debugger;
-import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
 import org.eclipse.che.plugin.debugger.ide.DebuggerResources;
-import org.eclipse.che.ide.api.dialogs.DialogFactory;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
@@ -42,15 +34,11 @@ import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspect
 public class DebugAction extends AbstractPerspectiveAction {
 
     private final DebuggerLocalizationConstant localizationConstants;
-    private final DebuggerManager              debuggerManager;
-    private final DialogFactory                dialogFactory;
     private final DebugConfigurationsManager   configurationsManager;
 
     @Inject
     public DebugAction(DebuggerLocalizationConstant localizationConstants,
                        DebuggerResources resources,
-                       DebuggerManager debuggerManager,
-                       DialogFactory dialogFactory,
                        DebugConfigurationsManager debugConfigurationsManager) {
         super(Collections.singletonList(PROJECT_PERSPECTIVE_ID),
               localizationConstants.debugActionTitle(),
@@ -58,8 +46,6 @@ public class DebugAction extends AbstractPerspectiveAction {
               null,
               resources.debug());
         this.localizationConstants = localizationConstants;
-        this.debuggerManager = debuggerManager;
-        this.dialogFactory = dialogFactory;
         this.configurationsManager = debugConfigurationsManager;
     }
 
@@ -69,9 +55,10 @@ public class DebugAction extends AbstractPerspectiveAction {
 
         event.getPresentation().setEnabled(configurationOptional.isPresent());
         if (configurationOptional.isPresent()) {
+            event.getPresentation().setVisible(true);
             event.getPresentation().setText(localizationConstants.debugActionTitle() + " '" + configurationOptional.get().getName() + "'");
         } else {
-            event.getPresentation().setText(localizationConstants.debugActionTitle());
+            event.getPresentation().setVisible(false);
         }
     }
 
@@ -79,33 +66,7 @@ public class DebugAction extends AbstractPerspectiveAction {
     public void actionPerformed(ActionEvent actionEvent) {
         Optional<DebugConfiguration> configurationOptional = configurationsManager.getCurrentDebugConfiguration();
         if (configurationOptional.isPresent()) {
-            connect(configurationOptional.get());
-        }
-    }
-
-    private void connect(DebugConfiguration debugConfiguration) {
-        if (debuggerManager.getActiveDebugger() != null) {
-            dialogFactory.createMessageDialog(localizationConstants.connectToRemote(),
-                                              localizationConstants.debuggerAlreadyConnected(),
-                                              null).show();
-            return;
-        }
-
-        final Debugger debugger = debuggerManager.getDebugger(debugConfiguration.getType().getId());
-        if (debugger != null) {
-            debuggerManager.setActiveDebugger(debugger);
-
-            Map<String, String> connectionProperties = new HashMap<>(2 + debugConfiguration.getConnectionProperties().size());
-            connectionProperties.put("HOST", debugConfiguration.getHost());
-            connectionProperties.put("PORT", String.valueOf(debugConfiguration.getPort()));
-            connectionProperties.putAll(debugConfiguration.getConnectionProperties());
-
-            debugger.connect(connectionProperties).catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    debuggerManager.setActiveDebugger(null);
-                }
-            });
+            configurationsManager.apply(configurationOptional.get());
         }
     }
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebugAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebugAction.java
@@ -53,12 +53,9 @@ public class DebugAction extends AbstractPerspectiveAction {
     public void updateInPerspective(ActionEvent event) {
         Optional<DebugConfiguration> configurationOptional = configurationsManager.getCurrentDebugConfiguration();
 
-        event.getPresentation().setEnabled(configurationOptional.isPresent());
+        event.getPresentation().setEnabledAndVisible(configurationOptional.isPresent());
         if (configurationOptional.isPresent()) {
-            event.getPresentation().setVisible(true);
             event.getPresentation().setText(localizationConstants.debugActionTitle() + " '" + configurationOptional.get().getName() + "'");
-        } else {
-            event.getPresentation().setVisible(false);
         }
     }
 

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationAction.java
@@ -50,11 +50,9 @@ public class DebugConfigurationAction extends AbstractPerspectiveAction {
     @Override
     public void updateInPerspective(ActionEvent event) {
         Optional<DebugConfiguration> configurationOptional = configurationsManager.getCurrentDebugConfiguration();
-        if (configurationOptional.isPresent() && configuration.equals(configurationOptional.get())) {
-            event.getPresentation().setVisible(false);
-        } else {
-            event.getPresentation().setVisible(true);
-        }
+        boolean isCurrentConfig = configurationOptional.isPresent() && configuration.equals(configurationOptional.get());
+
+        event.getPresentation().setEnabledAndVisible(!isCurrentConfig);
     }
 
     @Override

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationAction.java
@@ -31,8 +31,6 @@ import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspect
  */
 public class DebugConfigurationAction extends AbstractPerspectiveAction {
 
-    private static final String TICK = "> ";
-
     private final DebugConfigurationsManager configurationsManager;
     private final DebugConfiguration         configuration;
 
@@ -53,14 +51,15 @@ public class DebugConfigurationAction extends AbstractPerspectiveAction {
     public void updateInPerspective(ActionEvent event) {
         Optional<DebugConfiguration> configurationOptional = configurationsManager.getCurrentDebugConfiguration();
         if (configurationOptional.isPresent() && configuration.equals(configurationOptional.get())) {
-            event.getPresentation().setText(TICK + configuration.getName());
+            event.getPresentation().setVisible(false);
         } else {
-            event.getPresentation().setText(configuration.getName());
+            event.getPresentation().setVisible(true);
         }
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         configurationsManager.setCurrentDebugConfiguration(configuration);
+        configurationsManager.apply(configuration);
     }
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImpl.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImpl.java
@@ -13,17 +13,25 @@ package org.eclipse.che.plugin.debugger.ide.configuration;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
 import org.eclipse.che.ide.api.debug.DebugConfigurationType;
 import org.eclipse.che.ide.api.debug.DebugConfigurationsManager;
+import org.eclipse.che.ide.api.dialogs.DialogFactory;
+import org.eclipse.che.ide.debug.Debugger;
+import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
 import org.eclipse.che.plugin.debugger.ide.configuration.dto.DebugConfigurationDto;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.ide.util.storage.LocalStorage;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,15 +53,24 @@ public class DebugConfigurationsManagerImpl implements DebugConfigurationsManage
     private final Optional<LocalStorage>            localStorageOptional;
     private final Set<ConfigurationChangedListener> configurationChangedListeners;
     private final List<DebugConfiguration>          configurations;
+    private final DebuggerManager                   debuggerManager;
+    private final DialogFactory                     dialogFactory;
+    private final DebuggerLocalizationConstant      localizationConstants;
 
     private DebugConfiguration currentDebugConfiguration;
 
     @Inject
     public DebugConfigurationsManagerImpl(LocalStorageProvider localStorageProvider,
                                           DtoFactory dtoFactory,
-                                          DebugConfigurationTypeRegistry debugConfigurationTypeRegistry) {
+                                          DebugConfigurationTypeRegistry debugConfigurationTypeRegistry,
+                                          DebuggerManager debuggerManager,
+                                          DialogFactory dialogFactory,
+                                          DebuggerLocalizationConstant localizationConstants) {
         this.dtoFactory = dtoFactory;
-        configurationTypeRegistry = debugConfigurationTypeRegistry;
+        this.configurationTypeRegistry = debugConfigurationTypeRegistry;
+        this.debuggerManager = debuggerManager;
+        this.dialogFactory = dialogFactory;
+        this.localizationConstants = localizationConstants;
         localStorageOptional = Optional.fromNullable(localStorageProvider.get());
         configurationChangedListeners = new HashSet<>();
         configurations = new ArrayList<>();
@@ -198,6 +215,33 @@ public class DebugConfigurationsManagerImpl implements DebugConfigurationsManage
     @Override
     public void removeConfigurationsChangedListener(ConfigurationChangedListener listener) {
         configurationChangedListeners.remove(listener);
+    }
+
+    @Override
+    public void apply(DebugConfiguration debugConfiguration) {
+        if (debuggerManager.getActiveDebugger() != null) {
+            dialogFactory.createMessageDialog(localizationConstants.connectToRemote(),
+                                              localizationConstants.debuggerAlreadyConnected(),
+                                              null).show();
+            return;
+        }
+
+        final Debugger debugger = debuggerManager.getDebugger(debugConfiguration.getType().getId());
+        if (debugger != null) {
+            debuggerManager.setActiveDebugger(debugger);
+
+            Map<String, String> connectionProperties = new HashMap<>(2 + debugConfiguration.getConnectionProperties().size());
+            connectionProperties.put("HOST", debugConfiguration.getHost());
+            connectionProperties.put("PORT", String.valueOf(debugConfiguration.getPort()));
+            connectionProperties.putAll(debugConfiguration.getConnectionProperties());
+
+            debugger.connect(connectionProperties).catchError(new Operation<PromiseError>() {
+                @Override
+                public void apply(PromiseError arg) throws OperationException {
+                    debuggerManager.setActiveDebugger(null);
+                }
+            });
+        }
     }
 
     private void fireConfigurationAdded(DebugConfiguration configuration) {

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImpl.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImpl.java
@@ -219,6 +219,10 @@ public class DebugConfigurationsManagerImpl implements DebugConfigurationsManage
 
     @Override
     public void apply(DebugConfiguration debugConfiguration) {
+        if (debugConfiguration == null) {
+            return;
+        }
+
         if (debuggerManager.getActiveDebugger() != null) {
             dialogFactory.createMessageDialog(localizationConstants.connectToRemote(),
                                               localizationConstants.debuggerAlreadyConnected(),

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/resources/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.properties
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/resources/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.properties
@@ -10,7 +10,6 @@
 #
 
 ##### Actions #####
-debugConfigurationsActionTitle=Debug Configurations
 editDebugConfigurationsActionTitle=Edit Debug Configurations...
 breakpoints = Breakpoints
 debug = Debug

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/actions/DebugActionTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/actions/DebugActionTest.java
@@ -12,18 +12,15 @@ package org.eclipse.che.plugin.debugger.ide.actions;
 
 import com.google.common.base.Optional;
 
-import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
 import org.eclipse.che.ide.api.debug.DebugConfigurationType;
 import org.eclipse.che.ide.api.debug.DebugConfigurationsManager;
-import org.eclipse.che.ide.debug.Debugger;
+import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
 import org.eclipse.che.plugin.debugger.ide.DebuggerResources;
-import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -31,9 +28,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,19 +74,8 @@ public class DebugActionTest {
         when(configurationOptional.get()).thenReturn(debugConfiguration);
         when(debugConfigurationsManager.getCurrentDebugConfiguration()).thenReturn(configurationOptional);
 
-        Debugger debugger = mock(Debugger.class);
-        when(debugger.connect(anyMap())).thenReturn(mock(Promise.class));
-        when(debuggerManager.getDebugger(anyString())).thenReturn(debugger);
-
         action.actionPerformed(null);
 
-        ArgumentCaptor<Map> mapArgumentCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(debugger).connect(mapArgumentCaptor.capture());
-
-        Map actualConnectionProperties = mapArgumentCaptor.getValue();
-        assertEquals("localhost", actualConnectionProperties.get("HOST"));
-        assertEquals("8000", actualConnectionProperties.get("PORT"));
-        assertEquals("val1", actualConnectionProperties.get("prop1"));
-        assertEquals("val2", actualConnectionProperties.get("prop2"));
+        verify(debugConfigurationsManager).apply(debugConfiguration);
     }
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationActionTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationActionTest.java
@@ -67,7 +67,7 @@ public class DebugConfigurationActionTest {
 
         action.updateInPerspective(event);
 
-        verify(presentation).setVisible(true);
+        verify(presentation).setEnabledAndVisible(true);
     }
 
     @Test

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationActionTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationActionTest.java
@@ -51,7 +51,7 @@ public class DebugConfigurationActionTest {
     }
 
     @Test
-    public void shouldSetTitleOnUpdate() {
+    public void shouldBeVisibleOnUpdate() {
         String confName = "test_conf";
         when(debugConfiguration.getName()).thenReturn(confName);
 
@@ -67,13 +67,14 @@ public class DebugConfigurationActionTest {
 
         action.updateInPerspective(event);
 
-        verify(presentation).setText(eq(confName));
+        verify(presentation).setVisible(true);
     }
 
     @Test
-    public void shouldSetCurrentConfigurationOnActionPerformed() {
+    public void shouldSetCurrentConfigurationAndApplyOnActionPerformed() {
         action.actionPerformed(null);
 
         verify(debugConfigurationsManager).setCurrentDebugConfiguration(eq(debugConfiguration));
+        verify(debugConfigurationsManager).apply(eq(debugConfiguration));
     }
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImplTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImplTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.debugger.ide.configuration;
+
+import junit.framework.TestCase;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.ide.api.debug.DebugConfiguration;
+import org.eclipse.che.ide.api.debug.DebugConfigurationType;
+import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
+import org.eclipse.che.ide.api.dialogs.DialogFactory;
+import org.eclipse.che.ide.api.dialogs.MessageDialog;
+import org.eclipse.che.ide.debug.Debugger;
+import org.eclipse.che.ide.debug.DebuggerManager;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.util.storage.LocalStorageProvider;
+import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Anatoliy Bazko
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DebugConfigurationsManagerImplTest extends TestCase {
+
+    @Mock
+    private LocalStorageProvider           localStorageProvider;
+    @Mock
+    private DtoFactory                     dtoFactory;
+    @Mock
+    private DebuggerManager                debuggerManager;
+    @Mock
+    private DebugConfigurationTypeRegistry debugConfigurationTypeRegistry;
+    @Mock
+    private DialogFactory                  dialogFactory;
+    @Mock
+    private DebuggerLocalizationConstant   localizationConstants;
+    @Mock
+    private DebugConfiguration             debugConfiguration;
+    @Mock
+    private DebugConfigurationType         debugConfigurationType;
+    @Mock
+    private Debugger                       debugger;
+
+    @InjectMocks
+    private DebugConfigurationsManagerImpl debugConfigurationsManager;
+
+    @Test
+    public void testShouldNotApplyConfigurationIfActiveDebuggerExists() throws Exception {
+        when(debuggerManager.getActiveDebugger()).thenReturn(mock(Debugger.class));
+        when(dialogFactory.createMessageDialog(anyString(), anyString(), (ConfirmCallback)isNull())).thenReturn(mock(MessageDialog.class));
+
+        debugConfigurationsManager.apply(debugConfiguration);
+
+        verify(debuggerManager, never()).setActiveDebugger(any(Debugger.class));
+    }
+
+    @Test
+    public void testShouldApplyNewConfiguration() throws Exception {
+        final String debugId = "debug";
+        final String host = "localhost";
+        final int port = 9000;
+
+        when(debugConfiguration.getConnectionProperties()).thenReturn(ImmutableMap.of("prop", "value"));
+        when(debugConfigurationType.getId()).thenReturn(debugId);
+        when(debugConfiguration.getHost()).thenReturn(host);
+        when(debugConfiguration.getPort()).thenReturn(port);
+        when(debugConfiguration.getType()).thenReturn(debugConfigurationType);
+        when(debuggerManager.getDebugger(debugId)).thenReturn(debugger);
+        when(debugger.connect(anyMap())).thenReturn(mock(Promise.class));
+
+        ArgumentCaptor<Map> properties = ArgumentCaptor.forClass(Map.class);
+
+        debugConfigurationsManager.apply(debugConfiguration);
+
+        verify(debuggerManager).setActiveDebugger(debugger);
+        verify(debugger).connect(properties.capture());
+
+        Map<String, String> m = properties.getValue();
+        assertEquals(m.get("HOST"), host);
+        assertEquals(m.get("PORT"), String.valueOf(port));
+        assertEquals(m.get("prop"), "value");
+    }
+}

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbLocalizationConstant.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbLocalizationConstant.java
@@ -26,4 +26,7 @@ public interface GdbLocalizationConstant extends com.google.gwt.i18n.client.Mess
 
     @Key("view.gdbConfigurationPage.binPathLabel")
     String gdbConfigurationPageViewBinPathLabel();
+
+    @Key("view.gdbConfigurationPage.binPathDescription")
+    String gdbConfigurationPageViewBinPathDescription();
 }

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenter.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenter.java
@@ -29,12 +29,10 @@ import org.eclipse.che.ide.api.machine.RecipeServiceClient;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.extension.machine.client.command.valueproviders.CurrentProjectPathProvider;
 import org.eclipse.che.ide.json.JsonHelper;
-import org.eclipse.che.ide.util.Pair;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Page allows to edit GDB debug configuration.
@@ -78,10 +76,17 @@ public class GdbConfigurationPagePresenter implements GdbConfigurationPageView.A
     }
 
     private String getBinaryPath(DebugConfiguration debugConfiguration) {
+        if (debugConfiguration == null) {
+            return getDefaultBinaryPath();
+        }
+
         Map<String, String> connectionProperties = debugConfiguration.getConnectionProperties();
         String binaryPath = connectionProperties.get(BIN_PATH_CONNECTION_PROPERTY);
-        return binaryPath == null ? currentProjectPathProvider.getKey() + "/" + DEFAULT_EXECUTABLE_TARGET_NAME
-                                  : binaryPath;
+        return binaryPath == null ? getDefaultBinaryPath() : binaryPath;
+    }
+
+    private String getDefaultBinaryPath() {
+        return currentProjectPathProvider.getKey() + "/" + DEFAULT_EXECUTABLE_TARGET_NAME;
     }
 
     @Override
@@ -126,7 +131,7 @@ public class GdbConfigurationPagePresenter implements GdbConfigurationPageView.A
         Promises.all(recipePromises).then(new Operation<JsArrayMixed>() {
             @Override
             public void apply(JsArrayMixed recipes) throws OperationException {
-                Set<Pair<String, String>> hosts = new HashSet<>();
+                Map<String, String> hosts = new HashMap<>();
 
                 for (int i = 0; i < recipes.length(); i++) {
                     String recipeJson = recipes.getObject(i).toString();
@@ -142,7 +147,7 @@ public class GdbConfigurationPagePresenter implements GdbConfigurationPageView.A
                         host = "localhost";
                     }
                     String description = host + " (" + machines.get(i).getConfig().getName() + ")";
-                    hosts.add(new Pair<>(description, host));
+                    hosts.put(host, description);
                 }
 
                 view.setHostsList(hosts);

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageView.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageView.java
@@ -11,6 +11,9 @@
 package org.eclipse.che.plugin.gdb.ide.configuration;
 
 import org.eclipse.che.ide.api.mvp.View;
+import org.eclipse.che.ide.util.Pair;
+
+import java.util.Collection;
 
 /**
  * The view of {@link GdbConfigurationPagePresenter}.
@@ -36,6 +39,14 @@ public interface GdbConfigurationPageView extends View<GdbConfigurationPageView.
 
     /** Sets path to the binary. */
     void setBinaryPath(String path);
+
+    /**
+     * Sets the list of hosts to help user to choose an appropriate one.
+     *
+     * @param hosts
+     *         the hosts list to set into the view
+     */
+    void setHostsList(Collection<Pair<String, String>> hosts);
 
     /** Action handler for the view's controls. */
     interface ActionDelegate {

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageView.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageView.java
@@ -11,9 +11,8 @@
 package org.eclipse.che.plugin.gdb.ide.configuration;
 
 import org.eclipse.che.ide.api.mvp.View;
-import org.eclipse.che.ide.util.Pair;
 
-import java.util.Collection;
+import java.util.Map;
 
 /**
  * The view of {@link GdbConfigurationPagePresenter}.
@@ -46,7 +45,7 @@ public interface GdbConfigurationPageView extends View<GdbConfigurationPageView.
      * @param hosts
      *         the hosts list to set into the view
      */
-    void setHostsList(Collection<Pair<String, String>> hosts);
+    void setHostsList(Map<String, String> hosts);
 
     /** Action handler for the view's controls. */
     interface ActionDelegate {

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageViewImpl.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageViewImpl.java
@@ -20,9 +20,8 @@ import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.eclipse.che.ide.ui.listbox.CustomComboBox;
-import org.eclipse.che.ide.util.Pair;
 
-import java.util.Collection;
+import java.util.Map;
 
 /**
  * The implementation of {@link GdbConfigurationPageView}.
@@ -89,10 +88,10 @@ public class GdbConfigurationPageViewImpl implements GdbConfigurationPageView {
     }
 
     @Override
-    public void setHostsList(Collection<Pair<String, String>> hosts) {
+    public void setHostsList(Map<String, String> hosts) {
         host.clear();
-        for (Pair<String, String> entry : hosts) {
-            host.addItem(entry.first, entry.second);
+        for (Map.Entry<String, String> entry : hosts.entrySet()) {
+            host.addItem(entry.getValue(), entry.getKey());
         }
     }
 

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageViewImpl.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageViewImpl.java
@@ -19,6 +19,11 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
+import org.eclipse.che.ide.ui.listbox.CustomComboBox;
+import org.eclipse.che.ide.util.Pair;
+
+import java.util.Collection;
+
 /**
  * The implementation of {@link GdbConfigurationPageView}.
  *
@@ -31,11 +36,11 @@ public class GdbConfigurationPageViewImpl implements GdbConfigurationPageView {
     private final FlowPanel rootElement;
 
     @UiField
-    TextBox host;
+    CustomComboBox host;
     @UiField
-    TextBox port;
+    TextBox        port;
     @UiField
-    TextBox binaryPath;
+    TextBox        binaryPath;
 
     private ActionDelegate delegate;
 
@@ -81,6 +86,14 @@ public class GdbConfigurationPageViewImpl implements GdbConfigurationPageView {
     @Override
     public void setBinaryPath(String path) {
         this.binaryPath.setValue(path);
+    }
+
+    @Override
+    public void setHostsList(Collection<Pair<String, String>> hosts) {
+        host.clear();
+        for (Pair<String, String> entry : hosts) {
+            host.addItem(entry.first, entry.second);
+        }
     }
 
     @UiHandler({"host"})

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageViewImpl.ui.xml
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPageViewImpl.ui.xml
@@ -11,14 +11,16 @@
 
 -->
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:che='urn:import:org.eclipse.che.ide.ui.listbox'>
     <ui:with field='locale' type='org.eclipse.che.plugin.gdb.ide.GdbLocalizationConstant'/>
 
     <g:FlowPanel debugId="gdbDebugConfigurationPageView-mainPanel">
         <g:Label text="{locale.gdbConfigurationPageViewHostLabel}"/>
-        <g:TextBox ui:field="host"/>
+        <che:CustomComboBox ui:field="host"/>
         <g:Label text="Port"/>
         <g:TextBox ui:field="port"/>
+        <g:Label text="{locale.gdbConfigurationPageViewBinPathDescription}"/>
         <g:Label text="{locale.gdbConfigurationPageViewBinPathLabel}"/>
         <g:TextBox ui:field="binaryPath"/>
     </g:FlowPanel>

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/resources/org/eclipse/che/plugin/gdb/ide/GdbLocalizationConstant.properties
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/resources/org/eclipse/che/plugin/gdb/ide/GdbLocalizationConstant.properties
@@ -13,3 +13,4 @@
 view.gdbConfigurationPage.hostLabel=Host
 view.gdbConfigurationPage.portLabel=Port
 view.gdbConfigurationPage.binPathLabel=Binary Path
+view.gdbConfigurationPage.binPathDescription=If you compile project with no '-o $binaryName' argument provided, 'a.out' is the default name. If required, you may need to change your binary file name.

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/test/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenterTest.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/test/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenterTest.java
@@ -12,8 +12,13 @@ package org.eclipse.che.plugin.gdb.ide.configuration;
 
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
 import org.eclipse.che.ide.api.debug.DebugConfigurationPage;
+import org.eclipse.che.ide.api.machine.MachineServiceClient;
+import org.eclipse.che.ide.api.machine.RecipeServiceClient;
+import org.eclipse.che.ide.extension.machine.client.command.valueproviders.CurrentProjectPathProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,9 +46,17 @@ public class GdbConfigurationPagePresenterTest {
     private static final int    PORT = 8000;
 
     @Mock
-    private GdbConfigurationPageView pageView;
+    private GdbConfigurationPageView   pageView;
     @Mock
-    private DebugConfiguration       configuration;
+    private DebugConfiguration         configuration;
+    @Mock
+    private CurrentProjectPathProvider currentProjectPathProvider;
+    @Mock
+    private AppContext                 appContext;
+    @Mock
+    private RecipeServiceClient        recipeServiceClient;
+    @Mock
+    private MachineServiceClient       machineServiceClient;
 
     @InjectMocks
     private GdbConfigurationPagePresenter pagePresenter;
@@ -66,6 +79,7 @@ public class GdbConfigurationPagePresenterTest {
     @Test
     public void testGo() throws Exception {
         AcceptsOneWidget container = Mockito.mock(AcceptsOneWidget.class);
+        when(machineServiceClient.getMachines(appContext.getWorkspaceId())).thenReturn(mock(Promise.class));
 
         pagePresenter.go(container);
 


### PR DESCRIPTION
- Provides list of hosts of running machines to chose.
- Set default binary path to `a.out`
- Run menu:
  Run
  Debug > (sub-menu below)
  Debug Config1
  Debug Config 2
  Edit Debug Configurations [CTRL-SHFT-F9]
- Actions in the menu items should be changed:
  Clicking on Edit Debug Configurations will open the current Edit Debugger Config panel.
  Clicking on Debug opens a submenu with the available configured debuggers.
  Clicking on the debugger should start the debug session.
  The last debugger should be runnable with the SHIFT-F9 command.

@vparfonov 
@azatsarynnyy 
@vzhukovskii 
