### PR TITLE
Add Push to Gerrit functionality

### DIFF
--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/PushResponse.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/PushResponse.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.api.git.shared;
 
 import org.eclipse.che.dto.shared.DTO;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Info received from push response
@@ -27,4 +29,12 @@ public interface PushResponse {
     String getCommandOutput();
 
     PushResponse withCommandOutput(String commandOutput);
+
+    /** set list of push updates */
+    void setUpdates(List<Map<String, String>> updates);
+
+    /** @return list of push updates */
+    List<Map<String, String>> getUpdates();
+
+    PushResponse withUpdates(List<Map<String, String>> updates);
 }

--- a/wsagent/che-core-api-git/src/test/java/org/eclipse/che/git/impl/PushTest.java
+++ b/wsagent/che-core-api-git/src/test/java/org/eclipse/che/git/impl/PushTest.java
@@ -103,7 +103,6 @@ public class PushTest {
         assertEquals(branchesAfter - 1, branchesBefore);
     }
 
-
     @Test(dataProvider = "GitConnectionFactory", dataProviderClass = GitConnectionFactoryProvider.class,
             expectedExceptions = GitException.class, expectedExceptionsMessageRegExp = "No remote repository specified.  " +
             "Please, specify either a URL or a remote name from which new revisions should be fetched in request.")

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConfigImpl.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConfigImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.git.GitException;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,7 @@ import static java.lang.System.lineSeparator;
  * @author Tareq Sharafy (tareq.sha@sap.com)
  */
 class JGitConfigImpl extends Config {
+
     private final Repository repository;
 
     JGitConfigImpl(Repository repository) throws GitException {
@@ -96,6 +98,11 @@ class JGitConfigImpl extends Config {
     public Config set(String name, String value) throws GitException {
         ConfigKey key = parseName(name);
         repository.getConfig().setString(key.section, key.subsection, key.name, value);
+        try {
+            this.repository.getConfig().save();
+        } catch (IOException e) {
+            throw new GitException(e.getMessage(), e);
+        }
         return this;
     }
 
@@ -108,6 +115,11 @@ class JGitConfigImpl extends Config {
     public Config unset(String name) throws GitException {
         ConfigKey key = parseName(name);
         repository.getConfig().unset(key.section, key.subsection, key.name);
+        try {
+            this.repository.getConfig().save();
+        } catch (IOException e) {
+            throw new GitException(e.getMessage(), e);
+        }
         return this;
     }
 


### PR DESCRIPTION
1. Fix storing issue in JGitConfigImpl
2. Commit command scenario - Get gerrit changid property from configuration
   and set the commit command to set insert change ID to work with Gerrit
3. Push command scenario - Create PushResponse with details regarding updates
   and refs and use it in push command

Signed-off-by: Offer Shostak offershostak@gmail.com
