### PR TITLE
[Issue #1178] Added hook to register content type and highlighting in orion

### DIFF
--- a/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
+++ b/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
@@ -45,6 +45,13 @@ public class ExtensionFileTypeIdentifier implements FileTypeIdentifier {
         }
         return null;
     }
+    
+    public void registerNewExtension(String extension, List<String> contentTypes) {
+        if (mappings.containsKey(extension)) {
+            Log.warn(ExtensionFileTypeIdentifier.class, "Replacing content types for extension '" + extension +"'.");
+        }
+        mappings.put(extension, contentTypes);
+    }
 
     /** Prepares the know extension registry. */
     public void init() {

--- a/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/MultipleMethodFileIdentifier.java
+++ b/core/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/MultipleMethodFileIdentifier.java
@@ -13,6 +13,8 @@ package org.eclipse.che.ide.api.editor.filetype;
 import org.eclipse.che.ide.api.project.tree.VirtualFile;
 import org.eclipse.che.ide.util.loging.Log;
 
+import com.google.inject.Singleton;
+
 import java.util.List;
 
 /**
@@ -20,12 +22,17 @@ import java.util.List;
  *
  * @author "Mickaël Leduque"
  */
+@Singleton
 public class MultipleMethodFileIdentifier implements FileTypeIdentifier {
 
     private final FileNameFileTypeIdentifier  fileNameFileTypeIdentifier  = new FileNameFileTypeIdentifier();
     private final ExtensionFileTypeIdentifier extensionFileTypeIdentifier = new ExtensionFileTypeIdentifier();
     private final FirstLineFileTypeIdentifier firstLineFileTypeIdentifier = new FirstLineFileTypeIdentifier();
 
+    public void registerNewExtension(String extension, List<String> contentTypes) {
+        extensionFileTypeIdentifier.registerNewExtension(extension, contentTypes);
+    }
+    
     @Override
     public List<String> identifyType(final VirtualFile file) {
         Log.debug(MultipleMethodFileIdentifier.class, "Try identification by file name.");

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionContentTypeRegistrant.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionContentTypeRegistrant.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import org.eclipse.che.ide.api.editor.filetype.MultipleMethodFileIdentifier;
+import org.eclipse.che.ide.api.editor.texteditor.EditorModule.EditorModuleReadyCallback;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionCodeEditWidgetOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionContentTypeOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionHighlightingConfigurationOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionServiceRegistryOverlay;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class OrionContentTypeRegistrant {
+
+    final MultipleMethodFileIdentifier fileTypeIdentifier;
+    final Provider<OrionCodeEditWidgetOverlay> codeEditWidgetProvider;
+    final OrionEditorModule editorModule;
+    
+    @Inject
+    public OrionContentTypeRegistrant(
+            final MultipleMethodFileIdentifier fileTypeIdentifier,
+            final Provider<OrionCodeEditWidgetOverlay> codeEditWidgetProvider,
+            final OrionEditorModule editorModule) {
+        this.fileTypeIdentifier = fileTypeIdentifier;
+        this.codeEditWidgetProvider = codeEditWidgetProvider;
+        this.editorModule = editorModule;
+    }
+
+    public void registerFileType(final OrionContentTypeOverlay contentType, final OrionHighlightingConfigurationOverlay config) {
+        // register content type and configure orion
+        JsArrayString extensions = contentType.getExtensions();
+        for (int i = 0; i < extensions.length(); i++) {
+            String extension = extensions.get(i);
+            fileTypeIdentifier.registerNewExtension(extension, newArrayList(contentType.getId()));
+        }
+        
+        editorModule.waitReady(new EditorModuleReadyCallback() {
+            
+            @Override
+            public void onEditorModuleReady() {
+                OrionServiceRegistryOverlay serviceRegistry = codeEditWidgetProvider.get().getServiceRegistry();
+                serviceRegistry.doRegisterService("orion.core.contenttype", JavaScriptObject.createObject(), contentType.toServiceObject());
+                serviceRegistry.doRegisterService("orion.edit.highlighter", JavaScriptObject.createObject(), config);
+            }
+            
+            @Override
+            public void onEditorModuleError() {
+            }
+        });
+        
+    }
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionContentTypeRegistrant.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionContentTypeRegistrant.java
@@ -24,6 +24,11 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
+/**
+ * Component to register new content types and corresponding highlighting configuration.
+ * 
+ * @author Sven Efftinge (typefox.io)
+ */
 public class OrionContentTypeRegistrant {
 
     final MultipleMethodFileIdentifier fileTypeIdentifier;

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionCodeEditWidgetOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionCodeEditWidgetOverlay.java
@@ -43,4 +43,13 @@ public class OrionCodeEditWidgetOverlay extends JavaScriptObject {
         options.parent = element;
         return this.create(options);
     }-*/;
+    
+    /**
+     * Provides Access to Orion's service registry.
+     * 
+     * @return the service registry
+     */
+    public final native OrionServiceRegistryOverlay getServiceRegistry() /*-{
+        return this.serviceRegistry;
+    }-*/;
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionContentTypeOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionContentTypeOverlay.java
@@ -13,6 +13,12 @@ package org.eclipse.che.ide.editor.orion.client.jso;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 
+/**
+ * The "Service attributes" for registering orion 'orion.core.contenttype' service.
+ * See <a href="https://wiki.eclipse.org/Orion/Documentation/Developer_Guide/Plugging_into_the_editor#orion.core.contenttype">Orion documentation</a> for details.
+ * 
+ * @author Sven Efftinge
+ */
 public class OrionContentTypeOverlay extends JavaScriptObject {
 
     protected OrionContentTypeOverlay() {

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionContentTypeOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionContentTypeOverlay.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+
+public class OrionContentTypeOverlay extends JavaScriptObject {
+
+    protected OrionContentTypeOverlay() {
+    }
+    
+    public final static native OrionContentTypeOverlay create() /*-{
+        return {};
+    }-*/;
+    
+    public final native JavaScriptObject toServiceObject()  /*-{
+        return { contentTypes : [this] };
+    }-*/;
+    
+    public final native void setId(String theId) /*-{
+        this.id = theId;
+    }-*/;
+    
+    public final native void setName(String theName) /*-{
+        this.name = theName;
+    }-*/;
+    
+    public final void setExtension(String ...fileExtensions) {
+        JsArrayString arr = JavaScriptObject.createArray().cast();
+        for (String value : fileExtensions) {
+            arr.push(value);
+        }
+        setExtension(arr);
+    }
+    
+    public final void setFileName(String... fileNames) {
+        JsArrayString arr = JavaScriptObject.createArray().cast();
+        for (String value : fileNames) {
+            arr.push(value);
+        }
+        setFileName(arr);
+    }
+    
+    public final native void setExtension(JsArrayString fileExtensions) /*-{
+        this.extension = fileExtensions;
+    }-*/;
+    
+    public final native void setFileName(JsArrayString fileNames) /*-{
+        this.fileName = fileNames;
+    }-*/;
+    
+    public final native void setExtends(String parentContentType) /*-{
+        this["extends"] = parentContentType;
+    }-*/;
+    
+    public final native void setImage(String imageURL) /*-{
+        this.image = imageURL;
+    }-*/;
+    
+    public final native void setImageClass(String theImageClass) /*-{
+        this.imageClass = theImageClass;
+    }-*/;
+    
+    public final native String getId() /*-{
+        return this.id;
+    }-*/;
+    
+    public final native String getName() /*-{
+        return this.name;
+    }-*/;
+    
+    public final native JsArrayString getExtensions() /*-{
+        return this.extension;
+    }-*/;
+    
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionHighlightingConfigurationOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionHighlightingConfigurationOverlay.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+
+public class OrionHighlightingConfigurationOverlay extends JavaScriptObject {
+    
+    protected OrionHighlightingConfigurationOverlay() {
+    }
+    
+    public static native OrionHighlightingConfigurationOverlay create() /*-{
+        return {};
+    }-*/;
+
+    public final native void setId(String newValue) /*-{
+        this.id = newValue;
+    }-*/;
+    
+    public final void setContentTypes(String ... theContentTypes) {
+        JsArrayString arr = JavaScriptObject.createArray().cast();
+        for (String value : theContentTypes) {
+            arr.push(value);
+        }
+        setContentTypes(arr);
+    }
+    
+    protected final native void setContentTypes(JsArrayString theContentTypes) /*-{
+        this.contentTypes = theContentTypes;
+    }-*/;
+    
+    public final native void setPatterns(String patternsAsJsonArray) /*-{
+        this.patterns = eval(patternsAsJsonArray);
+    }-*/;
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionHighlightingConfigurationOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionHighlightingConfigurationOverlay.java
@@ -13,6 +13,12 @@ package org.eclipse.che.ide.editor.orion.client.jso;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 
+/**
+ * The "Service attributes" for registering orion 'orion.edit.highlight' service.
+ * See <a href="https://wiki.eclipse.org/Orion/Documentation/Developer_Guide/Plugging_into_the_editor#orion.edit.highlighter">Orion documentation</a> for details.
+ * 
+ * @author Sven Efftinge
+ */
 public class OrionHighlightingConfigurationOverlay extends JavaScriptObject {
     
     protected OrionHighlightingConfigurationOverlay() {
@@ -38,6 +44,12 @@ public class OrionHighlightingConfigurationOverlay extends JavaScriptObject {
         this.contentTypes = theContentTypes;
     }-*/;
     
+    /**
+     * The proper grammar description. 
+     * See <a href="https://wiki.eclipse.org/Orion/Documentation/Developer_Guide/Plugging_into_the_editor#Pattern_objects">Orion documentation</a> for details.  
+     *  
+     * @param patternsAsJsonArray
+     */
     public final native void setPatterns(String patternsAsJsonArray) /*-{
         this.patterns = eval(patternsAsJsonArray);
     }-*/;

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionServiceRegistryOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionServiceRegistryOverlay.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * JavaScript overlay over Orion Service Registry.
+ *
+ * @author Sven Efftinge
+ */
+public class OrionServiceRegistryOverlay extends JavaScriptObject {
+
+    protected OrionServiceRegistryOverlay() {}
+    /**
+     * @name registerService
+     * @description Registers a service with this registry. This function will notify clients registered
+     * for <code>registered</code> service events.
+     * @function
+     * @public
+     * @param the name of the service being registered
+     * @param service The service implementation
+     * @param properties A JSON collection of declarative service properties
+     * 
+     * @see orion.serviceregistry.ServiceEvent
+     */
+    public final native void doRegisterService(String name, JavaScriptObject service, JavaScriptObject properties) /*-{
+        this.registerService(name, service, properties);
+    }-*/;
+}


### PR DESCRIPTION
Fixes #1178.
With this change you can configure arbitrary new contentTypes and corresponding highlight configuration. 
Here's a usage example:

```
@Inject
    protected void configureContentType(final OrionContentTypeRegistrant contentTypeRegistrant) {
        // register content type and configure orion
        final String contentTypeId = "text/x-testlang";

        OrionContentTypeOverlay contentType = OrionContentTypeOverlay.create();
        contentType.setId(contentTypeId);
        contentType.setName("Test Language");
        contentType.setExtension("testlang");
        contentType.setExtends("text/plain");

        // highlighting
        OrionHighlightingConfigurationOverlay config = OrionHighlightingConfigurationOverlay.create();
        config.setId("testlang.highlighting");
        config.setContentTypes(contentTypeId);
        config.setPatterns(
                "[\n" + 
                        "  {include: \"orion.lib#string_doubleQuote\"},\n" + 
                        "  {include: \"orion.lib#string_singleQuote\"},\n" + 
                        "  {include: \"orion.lib#brace_open\"},\n" + 
                        "  {include: \"orion.lib#brace_close\"},\n" + 
                        "  {include: \"orion.lib#bracket_open\"},\n" + 
                        "  {include: \"orion.lib#bracket_close\"},\n" + 
                        "  {include: \"orion.lib#parenthesis_open\"},\n" + 
                        "  {include: \"orion.lib#parenthesis_close\"},\n" + 
                        "  {include: \"orion.lib#number_decimal\"},\n" + 
                        "  {include: \"orion.lib#number_hex\"},\n" + 
                        "  {\n" + 
                        "    match: \"\\\\b(?:false|true)\\\\b\",\n" + 
                        "    name: \"keyword.json\"\n" + 
                        "  }\n" + 
                "]");

        contentTypeRegistrant.registerFileType(contentType, config);
    }
```
