### PR TITLE
CODENVY-584: Add terminal link into each machine instance

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/Machine.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/Machine.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.che.ide.extension.machine.client.machine;
 
-import com.google.gwt.user.client.Window;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
 import org.eclipse.che.api.core.model.machine.MachineStatus;
+import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.machine.shared.Constants;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
@@ -22,6 +22,7 @@ import org.eclipse.che.api.machine.shared.dto.ServerDto;
 import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
 import org.eclipse.che.ide.extension.machine.client.inject.factories.EntityFactory;
 import org.eclipse.che.ide.extension.machine.client.perspective.widgets.machine.appliance.server.Server;
+import org.eclipse.che.ide.util.loging.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ public class Machine {
 
     private final MachineDto    descriptor;
     private final EntityFactory entityFactory;
+    private final List<Link>    machineLinks;
 
     private String activeTabName;
 
@@ -46,7 +48,7 @@ public class Machine {
                    @Assisted MachineDto descriptor) {
         this.entityFactory = entityFactory;
         this.descriptor = descriptor;
-
+        this.machineLinks = descriptor.getLinks();
         this.activeTabName = locale.tabInfo();
     }
 
@@ -107,18 +109,9 @@ public class Machine {
     }
 
     public String getTerminalUrl() {
-        Map<String, ServerDto> serverDescriptors = descriptor.getRuntime().getServers();
-
-        for (ServerDto descriptor : serverDescriptors.values()) {
-            if (Constants.TERMINAL_REFERENCE.equals(descriptor.getRef())) {
-                String terminalUrl = descriptor.getUrl();
-
-                String uriWithoutProtocol = terminalUrl.substring(terminalUrl.indexOf(':'), terminalUrl.length());
-                String protocol = Window.Location.getProtocol().equals("https:") ? "wss" : "ws";
-
-                return protocol +
-                       uriWithoutProtocol +
-                       (terminalUrl.endsWith("/") ? "pty" : "/pty");
+        for (Link link : machineLinks) {
+            if (Constants.TERMINAL_REFERENCE.equals(link.getRel())) {
+                return link.getHref();
             }
         }
 

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/Constants.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     public static final String LINK_REL_SEARCH_RECIPES             = "search recipes";
     public static final String LINK_REL_UPDATE_RECIPE              = "update recipe";
 
+    public static final String LINK_REL_SELF                       = "self link";
     public static final String LINK_REL_GET_MACHINE                = "get machine";
     public static final String LINK_REL_GET_MACHINES               = "get machines";
     public static final String LINK_REL_DESTROY_MACHINE            = "destroy machine";

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineServiceLinksInjector.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineServiceLinksInjector.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server;
+
+import com.google.common.collect.Lists;
+
+import org.eclipse.che.api.core.rest.ServiceContext;
+import org.eclipse.che.api.core.rest.shared.dto.Link;
+import org.eclipse.che.api.core.rest.shared.dto.LinkParameter;
+import org.eclipse.che.api.machine.shared.Constants;
+import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
+import org.eclipse.che.api.machine.shared.dto.MachineDto;
+import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
+import org.eclipse.che.api.machine.shared.dto.ServerDto;
+import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
+
+import javax.inject.Singleton;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.eclipse.che.api.core.util.LinksHelper.createLink;
+import static org.eclipse.che.api.machine.shared.Constants.TERMINAL_REFERENCE;
+import static org.eclipse.che.dto.server.DtoFactory.cloneDto;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
+/**
+ * Helps to inject {@link MachineService} related links.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class MachineServiceLinksInjector {
+
+    public MachineDto injectLinks(MachineDto machine, ServiceContext serviceContext) {
+        final UriBuilder uriBuilder = serviceContext.getServiceUriBuilder();
+        final List<Link> links = new ArrayList<>();
+
+        links.add(createLink(HttpMethod.GET,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "getMachineById")
+                                       .build(machine.getId())
+                                       .toString(),
+                             APPLICATION_JSON,
+                             "self link"));
+        links.add(createLink(HttpMethod.GET,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "getMachines")
+                                       .build()
+                                       .toString(),
+                             null,
+                             APPLICATION_JSON,
+                             Constants.LINK_REL_GET_MACHINES,
+                             newDto(LinkParameter.class).withName("workspace")
+                                                        .withRequired(true)
+                                                        .withDefaultValue(machine.getWorkspaceId())));
+        links.add(createLink(HttpMethod.DELETE,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "destroyMachine")
+                                       .build(machine.getId())
+                                       .toString(),
+                             Constants.LINK_REL_DESTROY_MACHINE));
+        links.add(createLink(HttpMethod.GET,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "getSnapshots")
+                                       .build()
+                                       .toString(),
+                             null,
+                             APPLICATION_JSON,
+                             Constants.LINK_REL_GET_SNAPSHOTS,
+                             newDto(LinkParameter.class).withName("workspace")
+                                                        .withRequired(true)
+                                                        .withDefaultValue(machine.getWorkspaceId())));
+        links.add(createLink(HttpMethod.POST,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "saveSnapshot")
+                                       .build(machine.getId())
+                                       .toString(),
+                             APPLICATION_JSON,
+                             APPLICATION_JSON,
+                             Constants.LINK_REL_SAVE_SNAPSHOT));
+        links.add(createLink(HttpMethod.POST,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "executeCommandInMachine")
+                                       .build(machine.getId())
+                                       .toString(),
+                             APPLICATION_JSON,
+                             APPLICATION_JSON,
+                             Constants.LINK_REL_EXECUTE_COMMAND,
+                             newDto(LinkParameter.class).withName("outputChannel")
+                                                        .withRequired(false)));
+        links.add(createLink(HttpMethod.GET,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "getProcesses")
+                                       .build(machine.getId())
+                                       .toString(),
+                             APPLICATION_JSON,
+                             Constants.LINK_REL_GET_PROCESSES));
+        final URI getLogsUri = uriBuilder.clone()
+                                         .path(MachineService.class, "getMachineLogs")
+                                         .build(machine.getId());
+        links.add(createLink(HttpMethod.GET, getLogsUri.toString(), TEXT_PLAIN, Constants.LINK_REL_GET_MACHINE_LOGS));
+
+        injectTerminalLink(machine, serviceContext, links);
+
+        // add links to websocket channels
+        final Link machineChannelLink = createLink("GET",
+                                                   serviceContext.getBaseUriBuilder()
+                                                                 .path("ws")
+                                                                 .path(machine.getWorkspaceId())
+                                                                 .scheme("https".equals(getLogsUri.getScheme()) ? "wss" : "ws")
+                                                                 .build()
+                                                                 .toString(),
+                                                   null);
+        final LinkParameter channelParameter = newDto(LinkParameter.class).withName("channel")
+                                                                          .withRequired(true);
+
+        injectMachineChannelsLinks(machine.getConfig(),
+                                   machine.getWorkspaceId(),
+                                   machine.getEnvName(),
+                                   machineChannelLink,
+                                   channelParameter);
+
+        return machine.withLinks(links);
+    }
+
+    protected void injectTerminalLink(MachineDto machine, ServiceContext serviceContext, List<Link> links) {
+        final String scheme = serviceContext.getBaseUriBuilder().build().getScheme();
+        final Collection<ServerDto> servers = machine.getRuntime().getServers().values();
+        servers.stream()
+               .filter(server -> TERMINAL_REFERENCE.equals(server.getRef()))
+               .findAny()
+               .ifPresent(terminal -> links.add(createLink("GET",
+                                                           UriBuilder.fromUri(terminal.getUrl())
+                                                                     .scheme("https".equals(scheme) ? "wss"
+                                                                                                    : "ws")
+                                                                     .path("/pty")
+                                                                     .build()
+                                                                     .toString(),
+                                                           TERMINAL_REFERENCE)));
+    }
+
+    public void injectMachineChannelsLinks(MachineConfigDto machineConfig,
+                                           String workspaceId,
+                                           String envName,
+                                           Link machineChannelLink,
+                                           LinkParameter channelParameter) {
+        final ChannelsImpl channels = MachineManager.getMachineChannels(machineConfig.getName(),
+                                                                        workspaceId,
+                                                                        envName);
+        final Link getLogsLink = cloneDto(machineChannelLink)
+                .withRel(org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_MACHINE_LOGS_CHANNEL)
+                .withParameters(singletonList(cloneDto(channelParameter).withDefaultValue(channels.getOutput())));
+
+        final Link getStatusLink = cloneDto(machineChannelLink)
+                .withRel(org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_MACHINE_STATUS_CHANNEL)
+                .withParameters(singletonList(cloneDto(channelParameter).withDefaultValue(channels.getStatus())));
+
+        machineConfig.withLinks(asList(getLogsLink, getStatusLink));
+    }
+
+    public MachineProcessDto injectLinks(MachineProcessDto process, String machineId, ServiceContext serviceContext) {
+        final UriBuilder uriBuilder = serviceContext.getServiceUriBuilder();
+        final List<Link> links = Lists.newArrayListWithExpectedSize(3);
+
+        links.add(createLink(HttpMethod.DELETE,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "stopProcess")
+                                       .build(machineId, process.getPid())
+                                       .toString(),
+                             Constants.LINK_REL_STOP_PROCESS));
+        links.add(createLink(HttpMethod.GET,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "getProcessLogs")
+                                       .build(machineId, process.getPid())
+                                       .toString(),
+                             TEXT_PLAIN,
+                             Constants.LINK_REL_GET_PROCESS_LOGS));
+        links.add(createLink(HttpMethod.GET,
+                             uriBuilder.clone()
+                                       .path(MachineService.class, "getProcesses")
+                                       .build(machineId)
+                                       .toString(),
+                             APPLICATION_JSON,
+                             Constants.LINK_REL_GET_PROCESSES));
+
+        return process.withLinks(links);
+    }
+
+    public SnapshotDto injectLinks(SnapshotDto snapshot, ServiceContext serviceContext) {
+        final UriBuilder uriBuilder = serviceContext.getServiceUriBuilder();
+        return snapshot.withLinks(singletonList(createLink(HttpMethod.DELETE,
+                                                           uriBuilder.clone()
+                                                                     .path(MachineService.class, "removeSnapshot")
+                                                                     .build(snapshot.getId())
+                                                                     .toString(),
+                                                           Constants.LINK_REL_REMOVE_SNAPSHOT)));
+    }
+}

--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineServiceLinksInjectorTest.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineServiceLinksInjectorTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import org.eclipse.che.api.core.rest.ServiceContext;
+import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
+import org.eclipse.che.api.machine.shared.dto.MachineDto;
+import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
+import org.eclipse.che.api.machine.shared.dto.MachineRuntimeInfoDto;
+import org.eclipse.che.api.machine.shared.dto.ServerDto;
+import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.everrest.core.impl.uri.UriBuilderImpl;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.UriBuilder;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_DESTROY_MACHINE;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_EXECUTE_COMMAND;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_MACHINES;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_MACHINE_LOGS;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_PROCESSES;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_PROCESS_LOGS;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_SNAPSHOTS;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_REMOVE_SNAPSHOT;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_SAVE_SNAPSHOT;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_SELF;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_STOP_PROCESS;
+import static org.eclipse.che.api.machine.shared.Constants.TERMINAL_REFERENCE;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for {@link MachineServiceLinksInjector}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class MachineServiceLinksInjectorTest {
+    private static final String URI_BASE = "http://localhost:8080";
+
+    @Mock
+    private ServiceContext        serviceContextMock;
+    @Mock
+    private MachineRuntimeInfoDto machineRuntimeInfoDtoMock;
+    @Mock
+    private MachineConfigDto      machineConfigDtoMock;
+    @Mock
+    private ServerDto             serverDtoMock;
+
+    private MachineServiceLinksInjector machineLinksInjector;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        machineLinksInjector = new MachineServiceLinksInjector();
+        final UriBuilder uriBuilder = new UriBuilderImpl();
+        uriBuilder.uri(URI_BASE);
+        when(serviceContextMock.getServiceUriBuilder()).thenReturn(uriBuilder);
+        when(serviceContextMock.getBaseUriBuilder()).thenReturn(uriBuilder);
+    }
+
+    @Test
+    public void shouldInjectLinksIntoMachineDto() {
+        when(serverDtoMock.getRef()).thenReturn(TERMINAL_REFERENCE);
+        when(serverDtoMock.getUrl()).thenReturn(URI_BASE + "/pty");
+        when(machineRuntimeInfoDtoMock.getServers()).thenReturn(ImmutableMap.of("", serverDtoMock));
+        final MachineDto machineDto = DtoFactory.newDto(MachineDto.class)
+                                                .withId("id")
+                                                .withWorkspaceId("wsId")
+                                                .withConfig(machineConfigDtoMock)
+                                                .withRuntime(machineRuntimeInfoDtoMock);
+        machineLinksInjector.injectLinks(machineDto, serviceContextMock);
+        final Set<Pair<String, String>> links = machineDto.getLinks()
+                                                          .stream()
+                                                          .map(link -> Pair.of(link.getMethod(), link.getRel()))
+                                                          .collect(Collectors.toSet());
+        final Set<Pair<String, String>> expectedLinks = new HashSet<>(asList(Pair.of("GET", TERMINAL_REFERENCE),
+                                                                             Pair.of("GET", LINK_REL_SELF),
+                                                                             Pair.of("GET", LINK_REL_GET_MACHINES),
+                                                                             Pair.of("POST", LINK_REL_EXECUTE_COMMAND),
+                                                                             Pair.of("DELETE", LINK_REL_DESTROY_MACHINE),
+                                                                             Pair.of("GET", LINK_REL_GET_SNAPSHOTS),
+                                                                             Pair.of("GET", LINK_REL_GET_PROCESSES),
+                                                                             Pair.of("POST", LINK_REL_SAVE_SNAPSHOT),
+                                                                             Pair.of("GET", LINK_REL_GET_MACHINE_LOGS)));
+
+        assertEquals(links, expectedLinks, "Difference " + Sets.symmetricDifference(links, expectedLinks) + "\n");
+    }
+
+    @Test
+    public void shouldInjectLinksIntoMachineProcessDto() {
+        final MachineProcessDto machineProcessDto = DtoFactory.newDto(MachineProcessDto.class);
+        machineLinksInjector.injectLinks(machineProcessDto, "machineId", serviceContextMock);
+        final Set<Pair<String, String>> links = machineProcessDto.getLinks()
+                                                                 .stream()
+                                                                 .map(link -> Pair.of(link.getMethod(), link.getRel()))
+                                                                 .collect(Collectors.toSet());
+        final Set<Pair<String, String>> expectedLinks = ImmutableSet.of(Pair.of("DELETE", LINK_REL_STOP_PROCESS),
+                                                                        Pair.of("GET", LINK_REL_GET_PROCESS_LOGS),
+                                                                        Pair.of("GET", LINK_REL_GET_PROCESSES));
+
+        assertEquals(links, expectedLinks, "Difference " + Sets.symmetricDifference(links, expectedLinks) + "\n");
+    }
+
+    @Test
+    public void shouldInjectLinksIntoSnapshotDto() {
+        final SnapshotDto snapshotDto = DtoFactory.newDto(SnapshotDto.class)
+                                                  .withId("id");
+        machineLinksInjector.injectLinks(snapshotDto, serviceContextMock);
+        final Set<Pair<String, String>> links = snapshotDto.getLinks()
+                                                           .stream()
+                                                           .map(link -> Pair.of(link.getMethod(), link.getRel()))
+                                                           .collect(Collectors.toSet());
+        final Set<Pair<String, String>> expectedLinks = ImmutableSet.of(Pair.of("DELETE", LINK_REL_REMOVE_SNAPSHOT));
+
+        assertEquals(links, expectedLinks, "Difference " + Sets.symmetricDifference(links, expectedLinks) + "\n");
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.core.rest.Service;
 import org.eclipse.che.api.core.rest.annotations.GenerateLink;
 import org.eclipse.che.api.machine.server.MachineManager;
 import org.eclipse.che.api.machine.server.MachineService;
+import org.eclipse.che.api.machine.server.MachineServiceLinksInjector;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
@@ -83,7 +84,6 @@ public class WorkspaceService extends Service {
     private final WorkspaceManager   workspaceManager;
     private final WorkspaceValidator validator;
     private final MachineManager     machineManager;
-
     private final WorkspaceServiceLinksInjector linksInjector;
 
     @Context
@@ -726,8 +726,8 @@ public class WorkspaceService extends Service {
                                                                       workspace.getRuntime().getActiveEnv());
 
         return Response.status(201)
-                       .entity(MachineService.injectLinks(org.eclipse.che.api.machine.server.DtoConverter.asDto(machine),
-                                                          getServiceContext()))
+                       .entity(linksInjector.injectMachineLinks(org.eclipse.che.api.machine.server.DtoConverter.asDto(machine),
+                                                                getServiceContext()))
                        .build();
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceLinksInjector.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceLinksInjector.java
@@ -13,7 +13,7 @@ package org.eclipse.che.api.workspace.server;
 import org.eclipse.che.api.core.rest.ServiceContext;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.rest.shared.dto.LinkParameter;
-import org.eclipse.che.api.machine.server.MachineService;
+import org.eclipse.che.api.machine.server.MachineServiceLinksInjector;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.ServerDto;
@@ -62,11 +62,14 @@ public class WorkspaceServiceLinksInjector {
 
     //TODO: we need keep IDE context in some property to have possibility configure it because context is different in Che and Hosted packaging
     //TODO: not good solution do it here but critical for this task  https://jira.codenvycorp.com/browse/IDEX-3619
-    private final String ideContext;
+    private final String                      ideContext;
+    private final MachineServiceLinksInjector machineLinksInjector;
 
     @Inject
-    public WorkspaceServiceLinksInjector(@Named("che.ide.context") String ideContext) {
+    public WorkspaceServiceLinksInjector(@Named("che.ide.context") String ideContext,
+                                         MachineServiceLinksInjector machineLinksInjector) {
         this.ideContext = ideContext;
+        this.machineLinksInjector = machineLinksInjector;
     }
 
     public WorkspaceDto injectLinks(WorkspaceDto workspace, ServiceContext serviceContext) {
@@ -229,17 +232,20 @@ public class WorkspaceServiceLinksInjector {
         }
     }
 
+    public MachineDto injectMachineLinks(MachineDto machine, ServiceContext serviceContext) {
+        return machineLinksInjector.injectLinks(machine, serviceContext);
+    }
+    
     private void injectMachineChannelsLinks(EnvironmentDto environmentDto,
                                             String workspaceId,
                                             Link machineChannelLink,
                                             LinkParameter channelParameter) {
-
         for (MachineConfigDto machineConfigDto : environmentDto.getMachineConfigs()) {
-            MachineService.injectMachineChannelsLinks(machineConfigDto,
-                                                      workspaceId,
-                                                      environmentDto.getName(),
-                                                      machineChannelLink,
-                                                      channelParameter);
+            machineLinksInjector.injectMachineChannelsLinks(machineConfigDto,
+                                                            workspaceId,
+                                                            environmentDto.getName(),
+                                                            machineChannelLink,
+                                                            channelParameter);
         }
     }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.core.rest.ApiExceptionMapper;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.api.machine.server.MachineManager;
+import org.eclipse.che.api.machine.server.MachineServiceLinksInjector;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
@@ -127,7 +128,10 @@ public class WorkspaceServiceTest {
 
     @BeforeMethod
     public void setup() {
-        service = new WorkspaceService(wsManager, machineManager, validator, new WorkspaceServiceLinksInjector(IDE_CONTEXT));
+        service = new WorkspaceService(wsManager,
+                                       machineManager,
+                                       validator,
+                                       new WorkspaceServiceLinksInjector(IDE_CONTEXT, new MachineServiceLinksInjector()));
     }
 
     @Test


### PR DESCRIPTION
Since the websocket terminal link now used for each machine separately, so it is nessesary to add the formation mechanism for these links like we did for the dev machine.
@skabashnyuk, @garagatyi 
