### PR TITLE
CHE-1231. Show/hide error messages after updating pom.xml

### DIFF
--- a/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/core/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -33,7 +33,6 @@ import org.eclipse.che.ide.api.editor.EditorRegistry;
 import org.eclipse.che.ide.api.editor.OpenEditorCallbackImpl;
 import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
-import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
 import org.eclipse.che.ide.api.event.FileEvent;
 import org.eclipse.che.ide.api.event.FileEvent.FileOperation;
 import org.eclipse.che.ide.api.event.FileEventHandler;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcilerStrategy.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcilerStrategy.java
@@ -60,7 +60,7 @@ public class JavaReconcilerStrategy implements ReconcilingStrategy {
 
         handlerRegistration = eventBus.addHandler(DependencyUpdatedEvent.TYPE, new DependencyUpdatedEventHandler() {
             @Override
-            public void onDependencyUpdated(DependencyUpdatedEvent event) {
+            public void onDependencyUpdated() {
                 parse();
             }
         });

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/event/DependencyUpdatedEvent.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/event/DependencyUpdatedEvent.java
@@ -21,16 +21,6 @@ public class DependencyUpdatedEvent extends GwtEvent<DependencyUpdatedEventHandl
 
     public static final Type<DependencyUpdatedEventHandler> TYPE = new Type<>();
 
-    private final String channel;
-
-    public DependencyUpdatedEvent(String channel) {
-        this.channel = channel;
-    }
-
-    public String getChannel() {
-        return channel;
-    }
-
     @Override
     public Type<DependencyUpdatedEventHandler> getAssociatedType() {
         return TYPE;
@@ -38,6 +28,6 @@ public class DependencyUpdatedEvent extends GwtEvent<DependencyUpdatedEventHandl
 
     @Override
     protected void dispatch(DependencyUpdatedEventHandler handler) {
-        handler.onDependencyUpdated(this);
+        handler.onDependencyUpdated();
     }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/event/DependencyUpdatedEventHandler.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/event/DependencyUpdatedEventHandler.java
@@ -12,12 +12,10 @@ package org.eclipse.che.ide.ext.java.client.event;
 
 import com.google.gwt.event.shared.EventHandler;
 
-import org.eclipse.che.ide.api.event.EditorDirtyStateChangedEvent;
-
 /**
- * Handle {@link EditorDirtyStateChangedEvent}
+ * Handle {@link DependencyUpdatedEvent}
  * @author Alexander Andrienko
  */
 public interface DependencyUpdatedEventHandler extends EventHandler {
-    void onDependencyUpdated(DependencyUpdatedEvent event);
+    void onDependencyUpdated();
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/dependenciesupdater/LogsOutputHandlerTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/dependenciesupdater/LogsOutputHandlerTest.java
@@ -12,7 +12,6 @@ package org.eclipse.che.ide.ext.java.client.dependenciesupdater;
 
 import com.google.web.bindery.event.shared.EventBus;
 
-import org.eclipse.che.ide.ext.java.client.event.DependencyUpdatedEvent;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.OutputsContainerPresenter;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandConsoleFactory;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.DefaultOutputConsole;
@@ -55,8 +54,6 @@ public class LogsOutputHandlerTest {
     private MessageBus             messageBus;
     @Mock
     private DefaultOutputConsole   console;
-    @Mock
-    private DependencyUpdatedEvent event;
 
     private LogsOutputHandler logsOutputHandler;
 
@@ -64,23 +61,16 @@ public class LogsOutputHandlerTest {
     public void setUp() {
         when(messageBusProvider.getMachineMessageBus()).thenReturn(messageBus);
         when(consoleFactory.create(TAB_NAME)).thenReturn(console);
-        when(event.getChannel()).thenReturn(CHANNEL);
 
         logsOutputHandler = new LogsOutputHandler(consoleFactory, outputsContainerPresenter, eventBus, messageBusProvider);
     }
 
     @Test
-    public void dependencyUpdatedEventShouldBeAdded() {
-        verify(eventBus).addHandler(DependencyUpdatedEvent.TYPE, logsOutputHandler);
-    }
-
-    @Test
-    public void dependencyUpdatedEventShouldBeCaughtAndMessageBusShouldBeUnsubscribed() throws Exception {
+    public void messageBusShouldBeUnsubscribed() throws Exception {
         logsOutputHandler.subscribeToOutput(CHANNEL, TAB_NAME);
 
-        logsOutputHandler.onDependencyUpdated(event);
+        logsOutputHandler.unsubscribe(CHANNEL);
 
-        verify(event).getChannel();
         verify(messageBus).unsubscribe(eq(CHANNEL), Matchers.<MessageHandler>anyObject());
     }
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/dto/Problem.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/dto/Problem.java
@@ -33,6 +33,8 @@ public interface Problem {
 
     void setOriginatingFileName(String originatingFileName);
 
+    Problem withOriginatingFileName(String originatingFileName);
+
     /**
      * Answer a localized, human-readable message string which describes the problem.
      *
@@ -41,6 +43,8 @@ public interface Problem {
     String getMessage();
 
     void setMessage(String message);
+
+    Problem withMessage(String message);
 
     /**
      * Returns the problem id
@@ -51,6 +55,8 @@ public interface Problem {
 
     void setID(int ID);
 
+    Problem withID(int ID);
+
     /**
      * Answer back the original arguments recorded into the problem.
      *
@@ -59,6 +65,8 @@ public interface Problem {
     List<String> getArguments();
 
     void setArguments(List<String> arguments);
+
+    Problem withArguments(List<String> arguments);
 
     /**
      * Answer the start position of the problem (inclusive), or -1 if unknown.
@@ -69,6 +77,8 @@ public interface Problem {
 
     void setSourceStart(int start);
 
+    Problem withSourceStart(int start);
+
     /**
      * Answer the end position of the problem (inclusive), or -1 if unknown.
      *
@@ -77,6 +87,8 @@ public interface Problem {
     int getSourceEnd();
 
     void setSourceEnd(int end);
+
+    Problem withSourceEnd(int end);
 
     /**
      * Answer the line number in source where the problem begins.
@@ -87,6 +99,8 @@ public interface Problem {
 
     void setSourceLineNumber(int lineNumber);
 
+    Problem withSourceLineNumber(int lineNumber);
+
     /**
      * Checks the severity to see if the Error bit is set.
      *
@@ -96,6 +110,8 @@ public interface Problem {
 
     void setError(boolean isError);
 
+    Problem withError(boolean isError);
+
     /**
      * Checks the severity to see if the Error bit is not set.
      *
@@ -104,4 +120,6 @@ public interface Problem {
     boolean isWarning();
 
     void setWarning(boolean isWarning);
+
+    Problem withWarning(boolean isWarning);
 }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenExtension.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.che.ide.api.filetypes.FileType;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.project.type.wizard.PreSelectedProjectTypeManager;
 import org.eclipse.che.plugin.maven.client.actions.GetEffectivePomAction;
-import org.eclipse.che.plugin.maven.client.actions.MavenActionsConstants;
 import org.eclipse.che.plugin.maven.client.actions.ReimportMavenDependenciesAction;
 import org.eclipse.che.plugin.maven.client.comunnication.MavenMessagesHandler;
 import org.eclipse.che.plugin.maven.client.comunnication.progressor.background.DependencyResolverAction;
@@ -105,7 +104,7 @@ public class MavenExtension {
                                   MavenResources mavenResources,
                                   EditorRegistry editorRegistry,
                                   PomEditorProvider editorProvider) {
-        FileType pomFile = new FileType(mavenResources.maven(), "pom.xml");
+        FileType pomFile = new FileType(mavenResources.maven(), "pom.xml", "pom\\.xml");
         fileTypeRegistry.registerFileType(pomFile);
         editorRegistry.register(pomFile, editorProvider);
     }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/MavenMessagesHandler.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/MavenMessagesHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.collections.Jso;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.ext.java.client.event.DependencyUpdatedEvent;
 import org.eclipse.che.plugin.maven.client.comunnication.progressor.background.BackgroundLoaderPresenter;
 import org.eclipse.che.plugin.maven.shared.MavenAttributes;
 import org.eclipse.che.plugin.maven.shared.MessageType;
@@ -135,6 +136,7 @@ public class MavenMessagesHandler {
         if (dto.isStart()) {
             dependencyResolver.show();
         } else {
+            eventBus.fireEvent(new DependencyUpdatedEvent());
             dependencyResolver.hide();
         }
     }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/PomEditorReconciler.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/PomEditorReconciler.java
@@ -19,7 +19,7 @@ import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.reconciler.Reconciler;
 import org.eclipse.che.ide.api.editor.reconciler.ReconcilingStrategy;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
-import org.eclipse.che.plugin.maven.client.editor.PomReconsilingStrategy;
+import org.eclipse.che.plugin.maven.client.editor.PomReconcilingStrategy;
 
 import java.util.HashSet;
 import java.util.List;
@@ -54,8 +54,8 @@ public class PomEditorReconciler {
                             final Reconciler reconciler = ((TextEditor)openedEditor).getConfiguration().getReconciler();
                             if (reconciler != null) {
                                 final ReconcilingStrategy strategy = reconciler.getReconcilingStrategy(DEFAULT_CONTENT_TYPE);
-                                if (strategy instanceof PomReconsilingStrategy) {
-                                    ((PomReconsilingStrategy)strategy).doReconcile();
+                                if (strategy instanceof PomReconcilingStrategy) {
+                                    ((PomReconcilingStrategy)strategy).doReconcile();
                                 }
                             }
                         }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomEditorConfiguration.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomEditorConfiguration.java
@@ -35,10 +35,10 @@ public class PomEditorConfiguration extends AutoSaveTextEditorConfiguration {
     @Inject
     public PomEditorConfiguration(Provider<DocumentPositionMap> docPositionMapProvider,
                                   JavaAnnotationModelFactory javaAnnotationModelFactory,
-                                  PomReconsilingStrategyFactory reconsilingStrategyFactory,
+                                  PomReconcilingStrategyFactory reconcilingStrategyFactory,
                                   @Assisted @NotNull final TextEditorPresenter<?> editor) {
         annotationModel = javaAnnotationModelFactory.create(docPositionMapProvider.get());
-        PomReconsilingStrategy reconsilingStrategy = reconsilingStrategyFactory.create(annotationModel, editor);
+        PomReconcilingStrategy reconsilingStrategy = reconcilingStrategyFactory.create(annotationModel, editor);
         Reconciler reconciler = getReconciler();
         reconciler.addReconcilingStrategy(DEFAULT_CONTENT_TYPE, reconsilingStrategy);
     }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomReconcilingStrategy.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomReconcilingStrategy.java
@@ -36,17 +36,15 @@ import java.util.List;
  *
  * @author Evgen Vidolob
  */
-public class PomReconsilingStrategy implements ReconcilingStrategy {
+public class PomReconcilingStrategy implements ReconcilingStrategy {
 
     private final AnnotationModel          annotationModel;
-    private final TextEditorPresenter<?>
-                                           editor;
+    private final TextEditorPresenter<?>   editor;
     private final MavenServerServiceClient client;
     private       String                   pomPath;
-    private       String                   projectPath;
 
     @Inject
-    public PomReconsilingStrategy(@Assisted AnnotationModel annotationModel,
+    public PomReconcilingStrategy(@Assisted AnnotationModel annotationModel,
                                   @Assisted @NotNull final TextEditorPresenter<?> editor,
                                   MavenServerServiceClient client) {
         this.annotationModel = annotationModel;
@@ -57,7 +55,6 @@ public class PomReconsilingStrategy implements ReconcilingStrategy {
     @Override
     public void setDocument(Document document) {
         pomPath = document.getFile().getPath();
-        projectPath = document.getFile().getProject().getProjectConfig().getPath();
     }
 
     @Override

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomReconcilingStrategyFactory.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomReconcilingStrategyFactory.java
@@ -14,11 +14,11 @@ import org.eclipse.che.ide.api.editor.annotation.AnnotationModel;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditorPresenter;
 
 /**
- * Factory class for creating PomReconsiligStrategy
+ * Factory class for creating PomReconcilingStrategy
  *
  * @author Evgen Vidolob
  */
-public interface PomReconsilingStrategyFactory {
+public interface PomReconcilingStrategyFactory {
 
-    PomReconsilingStrategy create(AnnotationModel annotationModel, TextEditorPresenter<?> editor);
+    PomReconcilingStrategy create(AnnotationModel annotationModel, TextEditorPresenter<?> editor);
 }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/inject/MavenGinModule.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/inject/MavenGinModule.java
@@ -20,7 +20,7 @@ import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar;
 import org.eclipse.che.ide.extension.machine.client.command.CommandType;
 import org.eclipse.che.plugin.maven.client.command.MavenCommandType;
 import org.eclipse.che.plugin.maven.client.editor.PomEditorConfigurationFactory;
-import org.eclipse.che.plugin.maven.client.editor.PomReconsilingStrategyFactory;
+import org.eclipse.che.plugin.maven.client.editor.PomReconcilingStrategyFactory;
 import org.eclipse.che.plugin.maven.client.project.MavenContentRootInterceptor;
 import org.eclipse.che.plugin.maven.client.project.MavenExternalLibrariesInterceptor;
 import org.eclipse.che.plugin.maven.client.project.PomNodeInterceptor;
@@ -45,7 +45,7 @@ public class MavenGinModule extends AbstractGinModule {
         GinMultibinder.newSetBinder(binder(), NodeInterceptor.class).addBinding().to(MavenExternalLibrariesInterceptor.class);
         GinMultibinder.newSetBinder(binder(), NodeInterceptor.class).addBinding().to(PomNodeInterceptor.class);
 
-        install(new GinFactoryModuleBuilder().build(PomReconsilingStrategyFactory.class));
+        install(new GinFactoryModuleBuilder().build(PomReconcilingStrategyFactory.class));
         install(new GinFactoryModuleBuilder().build(PomEditorConfigurationFactory.class));
     }
 }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/service/MavenServerServiceClientImpl.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/service/MavenServerServiceClientImpl.java
@@ -95,7 +95,7 @@ public class MavenServerServiceClientImpl implements MavenServerServiceClient {
 
     @Override
     public Promise<List<Problem>> reconcilePom(String pomPath) {
-        final String url = appContext.getDevMachine().getWsAgentBaseUrl() + servicePath + "pom/reconsile?pompath=" + pomPath;
+        final String url = appContext.getDevMachine().getWsAgentBaseUrl() + servicePath + "pom/reconcile?pompath=" + pomPath;
         Unmarshallable<List<Problem>> unmarshallable = dtoUnmarshallerFactory.newListUnmarshaller(Problem.class);
         return asyncRequestFactory.createGetRequest(url)
                                   .send(unmarshallable);

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenProject.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenProject.java
@@ -254,6 +254,7 @@ public class MavenProject {
     private MavenProjectModifications setInfo(Info newInfo) {
         MavenProjectModifications modifications = info.generateChanges(newInfo);
         info = newInfo;
+        info.problemsCache = null; //info has been changed, so we must to clean cache
         return modifications;
     }
 

--- a/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/BaseTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/BaseTest.java
@@ -63,8 +63,9 @@ import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_ID;
  */
 public abstract class BaseTest {
 
-    protected static final String wsPath     = "target/workspace";
-    protected final static String INDEX_PATH = "target/fs_index";
+    protected static final String wsPath       = "target/workspace";
+    protected final static String INDEX_PATH   = "target/fs_index";
+    protected final static String PROJECT_NAME = "testProject";
 
     protected static Map<String, String> options      = new HashMap<>();
     protected static EventService        eventService = new EventService();
@@ -72,17 +73,19 @@ public abstract class BaseTest {
     protected static JavaPlugin        javaPlugin        = new JavaPlugin(wsPath + "/set", null, null);
     protected static FileBuffersPlugin fileBuffersPlugin = new FileBuffersPlugin();
     protected static TestWorkspaceHolder workspaceHolder;
+
     private final String mavenServerPath = BaseTest.class.getResource("/maven-server").getPath();
-    protected File root;
-    protected ProjectManager pm;
+
+    protected File                           root;
+    protected ProjectManager                 pm;
     protected LocalVirtualFileSystemProvider vfsProvider;
-    protected ProjectRegistry projectRegistry;
+    protected ProjectRegistry                projectRegistry;
     protected FileWatcherNotificationHandler fileWatcherNotificationHandler;
-    protected FileTreeWatcher fileTreeWatcher;
-    protected ProjectTypeRegistry projectTypeRegistry;
-    protected ProjectHandlerRegistry projectHandlerRegistry;
-    protected ProjectImporterRegistry importerRegistry;
-    protected MavenServerManager mavenServerManager;
+    protected FileTreeWatcher                fileTreeWatcher;
+    protected ProjectTypeRegistry            projectTypeRegistry;
+    protected ProjectHandlerRegistry         projectHandlerRegistry;
+    protected ProjectImporterRegistry        importerRegistry;
+    protected MavenServerManager             mavenServerManager;
 
     public BaseTest() {
         options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);

--- a/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/PomReconcilerTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/PomReconcilerTest.java
@@ -10,21 +10,39 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.maven.server;
 
+import com.google.gson.JsonObject;
+import com.google.inject.Provider;
+
 import org.eclipse.che.api.project.server.FolderEntry;
+import org.eclipse.che.api.project.server.ProjectRegistry;
 import org.eclipse.che.api.project.server.VirtualFileEntry;
 import org.eclipse.che.ide.ext.java.shared.dto.Problem;
 import org.eclipse.che.plugin.maven.server.core.EclipseWorkspaceProvider;
+import org.eclipse.che.plugin.maven.server.core.MavenCommunication;
+import org.eclipse.che.plugin.maven.server.core.MavenExecutorService;
 import org.eclipse.che.plugin.maven.server.core.MavenProjectManager;
+import org.eclipse.che.plugin.maven.server.core.MavenWorkspace;
+import org.eclipse.che.plugin.maven.server.core.classpath.ClasspathManager;
+import org.eclipse.che.plugin.maven.server.core.project.MavenProject;
 import org.eclipse.che.plugin.maven.server.rest.MavenServerService;
 import org.eclipse.che.plugin.maven.server.rmi.MavenServerManagerTest;
 import org.eclipse.che.maven.server.MavenTerminal;
+import org.eclipse.che.plugin.maven.shared.MessageType;
+import org.eclipse.che.plugin.maven.shared.dto.NotificationMessage;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.rmi.RemoteException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Evgen Vidolob
@@ -33,9 +51,12 @@ public class PomReconcilerTest extends BaseTest {
 
 
     private MavenProjectManager projectManager;
+    private MavenWorkspace      mavenWorkspace;
 
     @BeforeMethod
     public void setUp() throws Exception {
+        Provider<ProjectRegistry> projectRegistryProvider = (Provider<ProjectRegistry>)mock(Provider.class);
+        when(projectRegistryProvider.get()).thenReturn(projectRegistry);
         MavenServerManagerTest.MyMavenServerProgressNotifier mavenNotifier = new MavenServerManagerTest.MyMavenServerProgressNotifier();
         MavenTerminal terminal = new MavenTerminal() {
             @Override
@@ -46,8 +67,36 @@ public class PomReconcilerTest extends BaseTest {
                 }
             }
         };
+
+        File localRepository = new File(new File("target/localRepo").getAbsolutePath());
+        localRepository.mkdirs();
+        mavenServerManager.setLocalRepository(localRepository);
+
         MavenWrapperManager wrapperManager = new MavenWrapperManager(mavenServerManager);
-        projectManager = new MavenProjectManager(wrapperManager, mavenServerManager, terminal, mavenNotifier, new EclipseWorkspaceProvider());
+        projectManager =
+                new MavenProjectManager(wrapperManager, mavenServerManager, terminal, mavenNotifier, new EclipseWorkspaceProvider());
+
+
+        ClasspathManager classpathManager =
+                new ClasspathManager(root.getAbsolutePath(), wrapperManager, projectManager, terminal, mavenNotifier);
+
+        mavenWorkspace = new MavenWorkspace(projectManager, mavenNotifier, new MavenExecutorService(), projectRegistryProvider,
+                                            new MavenCommunication() {
+                                                @Override
+                                                public void sendUpdateMassage(Set<MavenProject> updated, List<MavenProject> removed) {
+
+                                                }
+
+                                                @Override
+                                                public void sendNotification(NotificationMessage message) {
+                                                    System.out.println(message.toString());
+                                                }
+
+                                                @Override
+                                                public void send(JsonObject object, MessageType type) {
+
+                                                }
+                                            }, classpathManager, eventService, new EclipseWorkspaceProvider());
 
     }
 
@@ -59,12 +108,122 @@ public class PomReconcilerTest extends BaseTest {
         String newContent = getPomContent("<ss");
         child.getVirtualFile().updateContent(newContent);
 
-        List<Problem> problems = serverService.reconsilePom("/A/pom.xml");
+        List<Problem> problems = serverService.reconcilePom("/A/pom.xml");
         assertThat(problems).isNotEmpty();
         Problem problem = problems.get(0);
 
         assertThat(problem.getSourceStart()).isEqualTo(newContent.indexOf("<ss") + 3);
         assertThat(problem.getSourceEnd()).isEqualTo(newContent.indexOf("<ss") + 4);
 
+    }
+
+    @Test
+    public void testReconcilePomWhenMavenProjectIsNotFound() throws Exception {
+        MavenServerService serverService = new MavenServerService(null, projectRegistry, pm, projectManager, null, null);
+        FolderEntry testProject = createTestProject(PROJECT_NAME, "");
+        VirtualFileEntry pom = testProject.getChild("pom.xml");
+
+        List<Problem> problems = serverService.reconcilePom(String.format("/%s/pom.xml", PROJECT_NAME));
+
+        assertThat(problems).isEmpty();
+        assertThat(pom).isNotNull();
+    }
+
+    @Test
+    public void testReconcilePomWhenPomContainsCorrectDependency() throws Exception {
+        String dependency = "    <dependency>\n" +
+                            "        <groupId>junit</groupId>\n" +
+                            "        <artifactId>junit</artifactId>\n" +
+                            "        <version>3.8.1</version>\n" +
+                            "        <scope>test</scope>\n" +
+                            "    </dependency>\n";
+        MavenServerService serverService = new MavenServerService(null, projectRegistry, pm, projectManager, null, null);
+        FolderEntry testProject = createTestProject(PROJECT_NAME, getPomContentWithDependency(dependency));
+        VirtualFileEntry pom = testProject.getChild("pom.xml");
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+        mavenWorkspace.update(Collections.singletonList(project));
+        mavenWorkspace.waitForUpdate();
+
+        List<Problem> problems = serverService.reconcilePom(String.format("/%s/pom.xml", PROJECT_NAME));
+
+        assertThat(problems).isEmpty();
+        assertThat(pom).isNotNull();
+    }
+
+    @Test
+    public void testReconcilePomWhenPomContainsDependecyWithIncorrectVersion() throws Exception {
+        String brokenDependency = "    <dependency>\n" +
+                                  "        <groupId>junit</groupId>\n" +
+                                  "        <artifactId>junit</artifactId>\n" +
+                                  "        <version>33333333.8.1</version>\n" +
+                                  "        <scope>test</scope>\n" +
+                                  "    </dependency>\n";
+        MavenServerService serverService = new MavenServerService(null, projectRegistry, pm, projectManager, null, null);
+        FolderEntry testProject = createTestProject(PROJECT_NAME, getPomContentWithDependency(brokenDependency));
+        VirtualFileEntry pom = testProject.getChild("pom.xml");
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+        mavenWorkspace.update(Collections.singletonList(project));
+        mavenWorkspace.waitForUpdate();
+
+        List<Problem> problems = serverService.reconcilePom(String.format("/%s/pom.xml", PROJECT_NAME));
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0).isError()).isTrue();
+        assertThat(pom).isNotNull();
+    }
+
+    @Test
+    public void testReconcilePomWhenPomContainsDependecyWithIncorrectGroupId() throws Exception {
+        String brokenDependency = "    <dependency>\n" +
+                                  "        <groupId>junittttt</groupId>\n" +
+                                  "        <artifactId>junit</artifactId>\n" +
+                                  "        <version>3.8.1</version>\n" +
+                                  "        <scope>test</scope>\n" +
+                                  "    </dependency>\n";
+        MavenServerService serverService = new MavenServerService(null, projectRegistry, pm, projectManager, null, null);
+        FolderEntry testProject = createTestProject(PROJECT_NAME, getPomContentWithDependency(brokenDependency));
+        VirtualFileEntry pom = testProject.getChild("pom.xml");
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+        mavenWorkspace.update(Collections.singletonList(project));
+        mavenWorkspace.waitForUpdate();
+
+        List<Problem> problems = serverService.reconcilePom(String.format("/%s/pom.xml", PROJECT_NAME));
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0).isError()).isTrue();
+        assertThat(pom).isNotNull();
+    }
+
+    @Test
+    public void testReconcilePomWhenPomContainsDependecyWithIncorrectAtrifactId() throws Exception {
+        String brokenDependency = "    <dependency>\n" +
+                                  "        <groupId>junit</groupId>\n" +
+                                  "        <artifactId>jjjjjjjunit</artifactId>\n" +
+                                  "        <version>3.8.1</version>\n" +
+                                  "        <scope>test</scope>\n" +
+                                  "    </dependency>\n";
+        MavenServerService serverService = new MavenServerService(null, projectRegistry, pm, projectManager, null, null);
+        FolderEntry testProject = createTestProject(PROJECT_NAME, getPomContentWithDependency(brokenDependency));
+        VirtualFileEntry pom = testProject.getChild("pom.xml");
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+        mavenWorkspace.update(Collections.singletonList(project));
+        mavenWorkspace.waitForUpdate();
+
+        List<Problem> problems = serverService.reconcilePom(String.format("/%s/pom.xml", PROJECT_NAME));
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0).isError()).isTrue();
+        assertThat(pom).isNotNull();
+    }
+
+    private String getPomContentWithDependency(String dependency) {
+        return String.format("<groupId>org.eclipse.che.examples</groupId>\n" +
+                             "<artifactId>web-java-spring</artifactId>\n" +
+                             "<packaging>war</packaging>\n" +
+                             "<version>1.0-SNAPSHOT</version>\n" +
+                             "<name>SpringDemo</name>" +
+                             "<dependencies>\n" +
+                             "%s" +
+                             "</dependencies>", dependency);
     }
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/pom.xml
+++ b/plugins/plugin-orion/che-plugin-orion-editor/pom.xml
@@ -41,6 +41,10 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-elemental</artifactId>
         </dependency>


### PR DESCRIPTION
1. Display/hide error messages in the pom-file and opened java files after updating pom.xml
2. Fix showing duplicate error message in the pom.xml when a dependency is not found
3. Fix showing old error message in the pom.xml (problems with caching )

@vparfonov @evidolob please review

Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com
