### PR TITLE
Interface and default implementation for promises

### DIFF
--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/api/promises/client/PromiseProvider.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/api/promises/client/PromiseProvider.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.promises.client;
+
+import elemental.util.ArrayOf;
+
+import com.google.common.annotations.Beta;
+import com.google.gwt.core.client.JsArrayMixed;
+import com.google.inject.ImplementedBy;
+
+import org.eclipse.che.api.promises.client.js.Executor;
+import org.eclipse.che.api.promises.client.js.JsPromiseProvider;
+
+/**
+ * A smattering of useful methods to work with Promises.
+ *
+ * @author Vlad Zhukovskyi
+ * @since 4.3.0
+ */
+@Beta
+@ImplementedBy(JsPromiseProvider.class)
+public interface PromiseProvider {
+
+    /**
+     * Creates a new promise using the provided executor.
+     *
+     * @param executor
+     *         the executor
+     * @param <V>
+     *         the type of the promised value
+     * @return a promise
+     */
+    <V> Promise<V> create(Executor<V> executor);
+
+    /**
+     * Creates a promise that resolves as soon as all the promises used as parameters are resolved or
+     * rejected as soon as the first rejection happens on one of the included promises.
+     * This is useful for aggregating results of multiple promises together.
+     *
+     * @param promises
+     *         the included promises
+     * @return a promise with an array of unit values as fulfillment value
+     */
+    Promise<JsArrayMixed> all(ArrayOf<Promise<?>> promises);
+
+    /** @see {@link #all(ArrayOf)} */
+    Promise<JsArrayMixed> all(final Promise<?>... promises);
+
+    /**
+     * Returns a promise that is rejected with the given reason.
+     *
+     * @param reason
+     *         the reason of promise rejection
+     * @param <U>
+     *         the type of the returned promise
+     * @return a promise
+     */
+    <U> Promise<U> reject(PromiseError reason);
+
+    /**
+     * Returns a promise that is rejected with the given reason.
+     *
+     * @param message
+     *         the reason of promise rejection
+     * @param <U>
+     *         the type of the returned promise
+     * @return a promise
+     */
+    <U> Promise<U> reject(String message);
+
+    /**
+     * Returns a promise that is rejected with the given reason.
+     *
+     * @param reason
+     *         the reason of promise rejection
+     * @param <U>
+     *         the type of the returned promise
+     * @return a promise
+     */
+    <U> Promise<U> reject(Throwable reason);
+
+    /**
+     * Returns a promise that is resolved with the given {@code value}.
+     *
+     * @param value
+     *         the 'promised' value
+     * @param <U>
+     *         the type of the returned promise
+     * @return a promise that is resolved with the specified value
+     */
+    <U> Promise<U> resolve(U value);
+}

--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/api/promises/client/js/JsPromiseProvider.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/api/promises/client/js/JsPromiseProvider.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.promises.client.js;
+
+import elemental.js.util.JsArrayOf;
+import elemental.util.ArrayOf;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayMixed;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+
+/**
+ * Default implementation of {@link PromiseProvider}.
+ *
+ * @author Vlad Zhukovskyi
+ * @see PromiseProvider
+ */
+public class JsPromiseProvider implements PromiseProvider {
+
+    /** {@inheritDoc} */
+    @Override
+    public native <V> Promise<V> create(Executor<V> executor) /*-{
+        return new Promise(executor);
+    }-*/;
+
+    /** {@inheritDoc} */
+    @Override
+    public native Promise<JsArrayMixed> all(ArrayOf<Promise<?>> promises) /*-{
+        return Promise.all(promises);
+    }-*/;
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<JsArrayMixed> all(Promise<?>... promises) {
+        final JsArrayOf<Promise<?>> promisesArray = JavaScriptObject.createArray().cast();
+        for (final Promise<?> promise : promises) {
+            promisesArray.push(promise);
+        }
+        return all(promisesArray);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public native <U> Promise<U> reject(String message) /*-{
+        return Promise.reject(new Error(message));
+    }-*/;
+
+    /** {@inheritDoc} */
+    @Override
+    public native <U> Promise<U> resolve(U value) /*-{
+        return Promise.resolve(value);
+    }-*/;
+
+    /** {@inheritDoc} */
+    @Override
+    public <U> Promise<U> reject(Throwable reason) {
+        return reject(JsPromiseError.create(reason));
+    }
+
+    /** {@inheritDoc} */
+    public final native <U> JsPromise<U> reject(PromiseError reason) /*-{
+        return Promise.reject(reason);
+    }-*/;
+}


### PR DESCRIPTION
There is a proposal to add interface and default implementation for client side promises to allow use it in unit tests.

This PR is part of #1383.
@vparfonov @skabashnyuk please, review it.

Related issue: CHE-907

Signed-off-by: Vladyslav Zhukovskii vzhukovskii@codenvy.com
