### PR TITLE
Add text for the Delete key code

### DIFF
--- a/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/util/input/KeyCodeMap.java
+++ b/core/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/util/input/KeyCodeMap.java
@@ -262,6 +262,7 @@ public class KeyCodeMap {
             case ARROW_RIGHT: return "→";
             case ARROW_UP: return "↑";
             case ARROW_DOWN: return "↓";
+            case DELETE: return "Delete";
             //todo add others keys
         }
 


### PR DESCRIPTION
This PR is part of https://github.com/eclipse/che/pull/1383.

The purpose of current changes is add key text for the `Delete` key code into general mappings.

Related issue: CHE-907

@vparfonov please, review it.
