### PR TITLE
CODENVY-608: Close output consumer on destroy machine

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -246,6 +246,11 @@ public class DockerInstance extends AbstractInstance {
 
     @Override
     public void destroy() throws MachineException {
+        try {
+            outputConsumer.close();
+        } catch (IOException ignored) {
+        }
+
         machineProcesses.clear();
         processesCleaner.untrackProcesses(getId());
         dockerInstanceStopDetector.stopDetection(container);

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceTest.java
@@ -78,6 +78,8 @@ public class DockerInstanceTest {
     private DockerConnector            dockerConnectorMock;
     @Mock
     private DockerInstanceStopDetector dockerInstanceStopDetectorMock;
+    @Mock
+    private LineConsumer               outputConsumer;
 
     private DockerInstance dockerInstance;
 
@@ -160,6 +162,13 @@ public class DockerInstanceTest {
     }
 
     @Test
+    public void shouldCloseOutputConsumerOnDestroy() throws Exception {
+        dockerInstance.destroy();
+
+        verify(outputConsumer).close();
+    }
+
+    @Test
     public void shouldSaveDockerInstanceStateIntoRepository() throws Exception {
         final String digest = "image12";
         dockerInstance = getDockerInstance(getMachine(), REGISTRY, CONTAINER, IMAGE, true);
@@ -206,7 +215,7 @@ public class DockerInstanceTest {
                                   container,
                                   image,
                                   mock(DockerNode.class),
-                                  mock(LineConsumer.class),
+                                  outputConsumer,
                                   dockerInstanceStopDetectorMock,
                                   mock(DockerInstanceProcessesCleaner.class),
                                   snapshotUseRegistry);

--- a/plugins/plugin-ssh-machine/src/main/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstance.java
+++ b/plugins/plugin-ssh-machine/src/main/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstance.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.machine.server.spi.impl.AbstractInstance;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
@@ -146,6 +147,11 @@ public class SshMachineInstance extends AbstractInstance {
 
     @Override
     public void destroy() throws MachineException {
+        try {
+            outputConsumer.close();
+        } catch (IOException ignored) {
+        }
+
         // session destroying stops all processes
         // todo kill all processes started by code, we should get parent pid of session and kill all children
         sshClient.stop();

--- a/plugins/plugin-ssh-machine/src/test/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstanceTest.java
+++ b/plugins/plugin-ssh-machine/src/test/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstanceTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.machine.ssh;
+
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.util.LineConsumer;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for{@link SshMachineInstance}
+ *
+ * @author Igor Vinokur
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SshMachineInstanceTest {
+    @Mock
+    private Machine      machine;
+    @Mock
+    private SshClient    sshClient;
+    @Mock
+    private LineConsumer outputConsumer;
+
+    private SshMachineInstance sshMachineInstance;
+
+    @BeforeMethod
+    public void setUp() {
+        when(machine.getConfig()).thenReturn(mock(MachineConfig.class));
+        when(machine.getEnvName()).thenReturn("EnvName");
+        when(machine.getId()).thenReturn("Id");
+        when(machine.getOwner()).thenReturn("Owner");
+        when(machine.getRuntime()).thenReturn(mock(MachineRuntimeInfo.class));
+        when(machine.getWorkspaceId()).thenReturn("WorkspaceId");
+
+        sshMachineInstance = new SshMachineInstance(machine,
+                                                    sshClient,
+                                                    outputConsumer,
+                                                    mock(SshMachineFactory.class),
+                                                    new HashSet<>());
+    }
+
+    @Test
+    public void shouldCloseOutputConsumerAndStopClientOnDestroy() throws Exception {
+        sshMachineInstance.destroy();
+
+        verify(outputConsumer).close();
+        verify(sshClient).stop();
+    }
+
+}

--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineManagerTest.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineManagerTest.java
@@ -11,9 +11,12 @@
 package org.eclipse.che.api.machine.server;
 
 import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.model.machine.Command;
 import org.eclipse.che.api.core.model.machine.Limits;
 import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.MachineSource;
 import org.eclipse.che.api.core.model.machine.MachineStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.util.LineConsumer;
@@ -26,6 +29,7 @@ import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
+import org.eclipse.che.api.machine.server.spi.InstanceProcess;
 import org.eclipse.che.api.machine.server.spi.InstanceProvider;
 import org.eclipse.che.api.machine.server.wsagent.WsAgentLauncher;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -45,6 +49,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -84,6 +89,12 @@ public class MachineManagerTest {
     private Instance                 instance;
     @Mock
     private Limits                   limits;
+    @Mock
+    private Command                  command;
+    @Mock
+    private InstanceProcess          instanceProcess;
+    @Mock
+    private LineConsumer             processLogger;
 
     private MachineManager manager;
 
@@ -108,6 +119,7 @@ public class MachineManagerTest {
         RecipeImpl recipe = new RecipeImpl().withScript("script").withType("Dockerfile");
 //        doNothing().when(manager).createMachineLogsDir(anyString());
         doReturn(MACHINE_ID).when(manager).generateMachineId();
+        doReturn(processLogger).when(manager).getProcessLogger(MACHINE_ID, 111, "outputChannel");
         when(machineInstanceProviders.getProvider(anyString())).thenReturn(instanceProvider);
         HashSet<String> recipeTypes = new HashSet<>();
         recipeTypes.add("test type 1");
@@ -115,6 +127,12 @@ public class MachineManagerTest {
         when(instanceProvider.getRecipeTypes()).thenReturn(recipeTypes);
         when(instanceProvider.createInstance(any(Machine.class), any(LineConsumer.class))).thenReturn(instance);
         when(machineRegistry.getInstance(anyString())).thenReturn(instance);
+        when(command.getCommandLine()).thenReturn("CommandLine");
+        when(command.getName()).thenReturn("CommandName");
+        when(command.getType()).thenReturn("CommandType");
+        when(machineRegistry.getInstance(MACHINE_ID)).thenReturn(instance);
+        when(instance.createProcess(command, "outputChannel")).thenReturn(instanceProcess);
+        when(instanceProcess.getPid()).thenReturn(111);
     }
 
     @AfterMethod
@@ -196,6 +214,54 @@ public class MachineManagerTest {
             manager.destroy(MACHINE_ID, false);
         } catch (Exception e) {
             verify(machineRegistry).remove(MACHINE_ID);
+        }
+    }
+
+    @Test
+    public void shouldCloseProcessLoggerIfExecIsSuccess() throws Exception {
+        //when
+        manager.exec(MACHINE_ID, command, "outputChannel");
+        waitForExecutorIsCompletedTask();
+
+        //then
+        verify(processLogger).close();
+    }
+
+    @Test
+    public void shouldCloseProcessLoggerIfExecFails() throws Exception {
+        //given
+        doThrow(Exception.class).when(instanceProcess).start();
+
+        //when
+        manager.exec(MACHINE_ID, command, "outputChannel");
+        waitForExecutorIsCompletedTask();
+
+        //then
+        verify(processLogger).close();
+    }
+
+    @Test(expectedExceptions = MachineException.class)
+    public void shouldCloseMachineLoggerIfMachineCreationFails() throws Exception {
+        //given
+        MachineConfig machineConfig = mock(MachineConfig.class);
+        MachineSource machineSource = mock(MachineSource.class);
+        LineConsumer machineLogger = mock(LineConsumer.class);
+        doReturn(machineLogger).when(manager).getMachineLogger(MACHINE_ID, "outputChannel");
+        when(machineConfig.getSource()).thenReturn(machineSource);
+        when(machineConfig.getName()).thenReturn("Name");
+        when(machineSource.getType()).thenReturn("dockerfile");
+        doThrow(ConflictException.class).when(machineRegistry).addMachine(any());
+
+        //when
+        manager.createMachineSync(machineConfig, "workspaceId", "environmentName");
+
+        //then
+        verify(machineLogger).close();
+    }
+
+    private void waitForExecutorIsCompletedTask() throws Exception {
+        for (int i = 0; ((ThreadPoolExecutor)manager.executor).getCompletedTaskCount() == 0 && i < 10; i++) {
+            Thread.sleep(300);
         }
     }
 


### PR DESCRIPTION
This fixes too many opened file descriptors related to machine logs issue
@garagatyi @skabashnyuk please reviw
