### PR TITLE
Set memory_swap_multiplier -1 to disable swap limit

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -124,9 +124,9 @@ machine.docker.local_node_host=NULL
 machine.docker.snapshot_use_registry=false
 
 # Allows to adjust machine swap memory by multiplication current machnine memory on provided value.
-# default is 0 which means disabled swap, if set multiplier value equal to 0.5 machine swap will be
-# configured with size that equal to half of current machine memory.
-machine.docker.memory_swap_multiplier=0
+# default is -1 which means unlimited swap, if set multiplier value equal to 0.5 machine swap will be
+# configured with size that equal to half of current machine memory, to disable swap set it to 0.
+machine.docker.memory_swap_multiplier=-1
 
 # URL path to api service.  
 # Browser clients use this to initiate REST communications with workspace master


### PR DESCRIPTION
@garagatyi @vparfonov @skabashnyuk  Please take a look.
We should disable swap limits to workaround docker bug on some debian systems.
More info: https://github.com/docker/docker/issues/16256
