### PR TITLE
Add docker group IDs for boot2docker and Docker for Mac Beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && apt-get -y install curl sudo procps wget && \
     useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
     echo "secret\nsecret" | passwd user && \
     curl -sSL https://get.docker.com/ | sh && \
-    usermod -aG docker user && sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    # Add user to docker group: 100 and 50 are this gIDs in boot2docker and Docker for Mac
+    usermod -aG docker,100,50 user && \
+    sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER user
 


### PR DESCRIPTION
This is related to #1482. When running Che server inside a container, adding user to the local docker group (gid=999) is not enough. User should be added to the Docker host group too. 

And in Docker for Mac Beta VM docker gid is 50, in boot2docker 100. 

It worked accidentally on boot2docker because container `user` group and Docker host `docker` group had the same gid. But it did not work on Docker for Mac Beta.    

Signed-off-by: Mario Loriedo mario.loriedo@gmail.com
