### PR TITLE
CHE-1316: Temporary fix for to avoid cyclic dependencies of components

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/jdt/internal/core/JavaProject.java
@@ -1024,19 +1024,22 @@ public class JavaProject extends Openable implements IJavaProject, SuffixConstan
             // when a project is imported, we get a first delta for the addition of the .project, but the .classpath is not accessible
             // so default to using java.io.File
             // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=96258
-            URI location = rscFile.getLocationURI();
-            if (location == null)
-                throw new IOException("Cannot obtain a location URI for " + rscFile); //$NON-NLS-1$
-            File file = Util.toLocalFile(location, null/*no progress monitor available*/);
-            if (file == null)
-                throw new IOException("Unable to fetch file from " + location); //$NON-NLS-1$
-            try {
-                bytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(file);
-            } catch (IOException e) {
-                if (!file.exists())
-                    return new IClasspathEntry[][]{defaultClasspath(), ClasspathEntry.NO_ENTRIES};
-                throw e;
-            }
+
+            // temporary fix for release 4.3
+            // TODO: should fix Resource#getProjects()
+//            URI location = rscFile.getLocationURI();
+//            if (location == null)
+            throw new IOException("Cannot obtain a location URI for " + rscFile); //$NON-NLS-1$
+//            File file = Util.toLocalFile(location, null/*no progress monitor available*/);
+//            if (file == null)
+//                throw new IOException("Unable to fetch file from " + location); //$NON-NLS-1$
+//            try {
+//                bytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(file);
+//            } catch (IOException e) {
+//                if (!file.exists())
+//                    return new IClasspathEntry[][]{defaultClasspath(), ClasspathEntry.NO_ENTRIES};
+//                throw e;
+//            }
         }
         if (hasUTF8BOM(bytes)) { // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=240034
             int length = bytes.length- IContentDescription.BOM_UTF_8.length;


### PR DESCRIPTION
During the initialization of the projects we have :
IllegalStateException with message "Projects are not initialized yet", to avoid this situation we comment the code that depends on component which initialize project because the workspace agent must always start even if there are any problems with projects.
@vparfonov, @skabashnyuk please review
