### PR TITLE
Added .dockerignore file to speed up Che Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!assembly/assembly-main/target/eclipse-che-*
+assembly/assembly-main/target/eclipse-che-*.tar.gz
+assembly/assembly-main/target/eclipse-che-*.zip


### PR DESCRIPTION
Currently the complete eclipse/che repository (>1GB) was sent to the Docker daemon:
![image](https://cloud.githubusercontent.com/assets/606959/16038457/4f4a5ba8-3225-11e6-962a-59f8f53da350.png)

Adding a .dockerignore file makes the build context 10 times smaller:
![image](https://cloud.githubusercontent.com/assets/606959/16038545/b292a7a6-3225-11e6-8045-aae6c1792516.png)
