### PR TITLE
Fix UD transitive dependency of gulp-angular-templatecache 

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,6 +23,7 @@
     "gulp-eslint": "~1.0.0",
     "gulp-filter": "~3.0.1",
     "gulp-flatten": "~0.2.0",
+    "gulp-header": "1.8.2",
     "gulp-iconfont": "2.0.0",
     "gulp-iconfont-css": "0.0.9",
     "gulp-inject": "~1.5.0",


### PR DESCRIPTION
that is not working with 1.8.3 version of gulp-header

Change-Id: I5c01e6c3ecd5e57eca4e1bcdea2ea76f4ca27c26
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
