### PR TITLE
CHE-1303: add .swf path location using ngClipProvider

### DIFF
--- a/dashboard/gulp/build.js
+++ b/dashboard/gulp/build.js
@@ -102,6 +102,12 @@ gulp.task('brandingassets', function () {
     .pipe(gulp.dest(conf.paths.dist + '/assets/branding/'));
 });
 
+gulp.task('zeroclipboardassets', function () {
+  return gulp.src($.mainBowerFiles().concat('bower_components/zeroclipboard/dist/**/*'))
+    .pipe($.filter('**/*.swf'))
+    .pipe($.flatten())
+    .pipe(gulp.dest(conf.paths.dist + '/assets/zeroclipboard/'));
+});
 
 gulp.task('existingfonts', function () {
   return gulp.src(conf.paths.src + '/assets/fonts/*')
@@ -175,4 +181,4 @@ gulp.task('clean', function () {
 });
 
 
-gulp.task('build', ['html', 'images', 'htmlassets', 'brandingassets', 'fonts', 'other']);
+gulp.task('build', ['html', 'images', 'htmlassets', 'brandingassets', 'zeroclipboardassets', 'fonts', 'other']);

--- a/dashboard/src/app/index.module.js
+++ b/dashboard/src/app/index.module.js
@@ -85,9 +85,9 @@ initModule.config(['$routeProvider', ($routeProvider) => {
 var DEV = false;
 
 
-// config routes
-initModule.config(['$routeProvider', ($routeProvider) => {
-  // add demo page
+// configs
+initModule.config(['$routeProvider', 'ngClipProvider', ($routeProvider, ngClipProvider) => {
+  // config routes (add demo page)
   if (DEV) {
     $routeProvider.accessWhen('/demo-components', {
       templateUrl: 'app/demo-components/demo-components.html',
@@ -95,7 +95,9 @@ initModule.config(['$routeProvider', ($routeProvider) => {
       controllerAs: 'demoComponentsCtrl'
     });
   }
-
+  //add .swf path location using ngClipProvider
+  let ngClipProviderPath = DEV ? 'bower_components/zeroclipboard/dist/ZeroClipboard.swf' : 'assets/zeroclipboard/ZeroClipboard.swf';
+  ngClipProvider.setPath(ngClipProviderPath);
 }]);
 
 
@@ -190,7 +192,6 @@ initModule.factory('ETagInterceptor', ($window, $cookies, $q) => {
     }
   };
 });
-
 
 initModule.config(($mdThemingProvider, jsonColors) => {
 


### PR DESCRIPTION
Signed-off-by: Oleksii Orel oorel@codenvy.com

@benoitf  WDYT?

```
https://github.com/zeroclipboard/ZeroClipboard/blob/master/docs/instructions.md#a-note-on-the-allowscriptaccess-option
-
ZeroClipboard was intentionally configured to not allow the SWF to be served from a secure domain (HTTPS) but scripted by an insecure domain (HTTP).
...
1.Serve the SWF over HTTP instead of HTTPS. If the page's protocol can vary (e.g. authorized/unauthorized, staging/production, etc.), you should include add the SWF with a relative protocol (//s3.amazonaws.com/blah/ZeroClipboard.swf) instead of an absolute protocol (https://s3.amazonaws.com/blah/ZeroClipboard.swf).
2.Serve the page over HTTPS instead of HTTP. If the page's protocol can vary, see the note on the previous option (1).
3. Fork ZeroClipboard and update "src/flash/ZeroClipboard.as" to call the allowInsecureDomain method as needed, then recompile the SWF with your custom changes.
-
```
