### PR TITLE
Add HTTP Host header to support Docker v1.12

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/TcpConnection.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/TcpConnection.java
@@ -67,6 +67,12 @@ public class TcpConnection extends DockerConnection {
         for (Pair<String, ?> header : headers) {
             connection.setRequestProperty(header.first, String.valueOf(header.second));
         }
+        String host = url.getHost();
+        if (url.getPort() != -1) {
+            host += ":" + Integer.toString(url.getPort());
+        }
+        // Host header is mandatory in HTTP 1.1
+        connection.setRequestProperty("Host", host);
         if (entity != null) {
             connection.setDoOutput(true);
             try (OutputStream output = connection.getOutputStream()) {

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/UnixSocketConnection.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/UnixSocketConnection.java
@@ -94,7 +94,8 @@ public class UnixSocketConnection extends DockerConnection {
             writer.write(String.valueOf(header.second));
             writer.write("\r\n");
         }
-        writer.write("\r\n");
+        // Host header is mandatory in HTTP 1.1
+        writer.write("Host: \r\n\r\n");
         writer.flush();
     }
 


### PR DESCRIPTION
`Host` is a mandatory header in [HTTP 1.1 specifications](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html). In previous versions of Docker that header wasn't required but release v1.12 use [golang 1.6.2](https://github.com/docker/docker/pull/22840) that makes this header mandatory. 

Therefore Docker v1.12 daemon doesn't accept HTTP 1.1 requests with no `Host` header set (you can find some references to the discussions [here](https://github.com/docker/swarm/issues/2332)).

This works:
`echo -e "GET /containers/json HTTP/1.1\r\nHost: \r\n\r\n"  | netcat -U /var/run/docker.sock`

This doesn't work:
`echo -e "GET /containers/json HTTP/1.1\r\n\r\n"  | netcat -U /var/run/docker.sock`

As a consequence in Che we had this nasty error message whenever we tried to create a new workspace: 

> org.eclipse.che.api.machine.server.exception.MachineException: Failed writing 8192 bytes

This PR is related to #1482 and #745.
