### PR TITLE
Allow character based key bindings 

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/keymap/KeyBinding.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/keymap/KeyBinding.java
@@ -22,8 +22,12 @@ public class KeyBinding {
     private final boolean alt;
     /** Is the cmd key pressed? */
     private final boolean cmd;
-    /** The key code. */
-    private final int keycode;
+    /** The key code of this key binding. */
+    private final Integer keyCodeNumber;
+    /** The character of this key binding. */
+    private final String character;
+    /** The key event type. */
+    private final String type;
     /** The action taken on the key binding. */
     private final KeyBindingAction action;
 
@@ -33,9 +37,23 @@ public class KeyBinding {
         this.shift = shift;
         this.alt = alt;
         this.cmd = cmd;
-        this.keycode = keycode;
+        this.keyCodeNumber = keycode;
+        this.character = null;
         this.action = action;
+        this.type = "keydown";
     }
+    
+    public KeyBinding(final boolean control, final boolean shift, final boolean alt,
+            final boolean cmd, final char character, final KeyBindingAction action) {
+    	this.control = control;
+		this.shift = shift;
+		this.alt = alt;
+		this.cmd = cmd;
+		this.keyCodeNumber = null;
+		this.character = String.valueOf(character);
+		this.action = action;
+		this.type = "keypress";
+	}
 
     /**
      * Whether the control key is hold during the key binding.
@@ -70,11 +88,35 @@ public class KeyBinding {
     }
 
     /**
-     * Returns the keycode of the bey binding.
+     * Returns the keycode of the key binding.
      * @return the keycode
      */
-    public int getKeyCode() {
-        return this.keycode;
+    public Integer getKeyCodeNumber() {
+        return this.keyCodeNumber;
+    }
+
+    /**
+     * Returns the keycode of the key binding.
+     * @return the keycode
+     */
+    public String getCharacter() {
+        return this.character;
+    }
+
+    /**
+     * Whether the key binding is character based. 
+     * @return true iff the binding uses a character
+     */
+    public boolean isCharacterBinding() {
+        return getCharacter() != null;
+    }
+
+    /**
+     * Returns the event type of the key binding.
+     * @return the event type
+     */
+    public String getType() {
+        return type;
     }
 
     /**

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/keymap/KeyBindingAction.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/keymap/KeyBindingAction.java
@@ -16,5 +16,5 @@ package org.eclipse.che.ide.api.editor.keymap;
 public interface KeyBindingAction {
 
     /** The triggered action. */
-    void action();
+    boolean action();
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorInit.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorInit.java
@@ -202,8 +202,9 @@ public class TextEditorInit<T extends EditorWidget> {
 
             final KeyBindingAction action = new KeyBindingAction() {
                 @Override
-                public void action() {
+                public boolean action() {
                     showCompletion(codeAssistant);
+                    return true;
                 }
             };
             final HasKeyBindings hasKeyBindings = this.textEditor.getHasKeybindings();
@@ -219,8 +220,9 @@ public class TextEditorInit<T extends EditorWidget> {
         } else {
             final KeyBindingAction action = new KeyBindingAction() {
                 @Override
-                public void action() {
+                public boolean action() {
                     showCompletion();
+                    return true;
                 }
             };
             final HasKeyBindings hasKeyBindings = this.textEditor.getHasKeybindings();
@@ -283,11 +285,12 @@ public class TextEditorInit<T extends EditorWidget> {
         if (this.quickAssist != null) {
             final KeyBindingAction action = new KeyBindingAction() {
                 @Override
-                public void action() {
+                public boolean action() {
                     final PositionConverter positionConverter = textEditor.getPositionConverter();
                     if (positionConverter != null) {
                         textEditor.showQuickAssist();
                     }
+                    return true;
                 }
             };
             final HasKeyBindings hasKeyBindings = this.textEditor.getHasKeybindings();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorPresenter.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorPresenter.java
@@ -258,9 +258,10 @@ public class TextEditorPresenter<T extends EditorWidget> extends AbstractEditorP
         });
         this.editorWidget.addKeyBinding(new KeyBinding(true, false, false, false, KeyCodes.KEY_F8, new KeyBindingAction() {
             @Override
-            public void action() {
+            public boolean action() {
                 int currentLine = editorWidget.getDocument().getCursorPosition().getLine();
                 breakpointManager.changeBreakpointState(currentLine);
+                return true;
             }
         }), TOGGLE_LINE_BREAKPOINT);
     }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/Action.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/Action.java
@@ -12,5 +12,5 @@ package org.eclipse.che.ide.editor.orion.client;
 
 public interface Action {
 
-    void onAction();
+    boolean onAction();
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -247,64 +247,73 @@ public class ContentAssistWidget implements EventListener {
         // add key event listener on popup
         textEditor.getTextView().setAction("cheContentAssistCancel", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 hide();
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistApply", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 validateItem(true);
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistPreviousProposal", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 selectPrevious();
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistNextProposal", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 selectNext();
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistNextPage", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 selectNext(listElement.getParentElement().getOffsetHeight() / listElement.getFirstElementChild().getOffsetHeight() - 1);
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistPreviousPage", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 selectPrevious(listElement.getParentElement().getOffsetHeight() / listElement.getFirstElementChild().getOffsetHeight() - 1);
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistEnd", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 selectElement(listElement.getLastElementChild());
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistHome", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 selectElement(listElement.getFirstElementChild());
+                return true;
             }
         });
 
         textEditor.getTextView().setAction("cheContentAssistTab", new Action() {
             @Override
-            public void onAction() {
+            public boolean onAction() {
                 validateItem(false);
+                return true;
             }
         });
 

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorWidget.java
@@ -512,29 +512,25 @@ public class OrionEditorWidget extends CompositeEditorWidget implements HasChang
     @Override
     public void addKeyBinding(final KeyBinding keyBinding, String actionDescription) {
         OrionKeyStrokeOverlay strokeOverlay;
-        if (UserAgent.isMac()) {
-            strokeOverlay = OrionKeyStrokeOverlay.create(keyBinding.getKeyCode(),
-                                                         keyBinding.isCmd(),
-                                                         keyBinding.isShift(),
-                                                         keyBinding.isAlt(),
-                                                         keyBinding.isControl(),
-                                                         "keydown",
-                                                         moduleHolder.getModule("OrionKeyBinding").cast());
+        JavaScriptObject keyBindingModule = moduleHolder.getModule("OrionKeyBinding").cast();
+        String type = keyBinding.getType();
+        boolean modifier1 = UserAgent.isMac() ? keyBinding.isCmd() : keyBinding.isControl();
+        boolean modifier2 = keyBinding.isShift();
+        boolean modifier3 = keyBinding.isAlt();
+        boolean modifier4 = UserAgent.isMac() ? keyBinding.isControl() : false;
+        if (keyBinding.isCharacterBinding()) {
+			strokeOverlay = OrionKeyStrokeOverlay.create(keyBinding.getCharacter(), modifier1, modifier2, modifier3,
+					modifier4, type, keyBindingModule);
         } else {
-            strokeOverlay = OrionKeyStrokeOverlay.create(keyBinding.getKeyCode(),
-                                                         keyBinding.isControl(),
-                                                         keyBinding.isShift(),
-                                                         keyBinding.isAlt(),
-                                                         false,
-                                                         "keydown",
-                                                         moduleHolder.getModule("OrionKeyBinding").cast());
+			strokeOverlay = OrionKeyStrokeOverlay.create(keyBinding.getKeyCodeNumber(), modifier1, modifier2, modifier3,
+					modifier4, type, keyBindingModule);
         }
         String actionId = "che-action-" + keyBinding.getAction().toString();
         editorOverlay.getTextView().setKeyBinding(strokeOverlay, actionId);
         editorOverlay.getTextView().setAction(actionId, new Action() {
             @Override
-            public void onAction() {
-                keyBinding.getAction().action();
+            public boolean onAction() {
+                return keyBinding.getAction().action();
             }
         }, actionDescription);
     }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionKeyStrokeOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionKeyStrokeOverlay.java
@@ -31,14 +31,41 @@ public class OrionKeyStrokeOverlay extends JavaScriptObject {
      * @param modifier4
      *         the fourth modifier (usually Control on the Mac).
      * @param type
-     *         the type of event that the keybinding matches; either "keydown" or "keypress".
+     *         the type of event that the key binding matches; either "keydown" or "keypress".
      */
     public static final native OrionKeyStrokeOverlay create(int keyCode,
                                                             boolean modifier1,
                                                             boolean modifier2,
                                                             boolean modifier3,
                                                             boolean modifier4,
-                                                            String type, JavaScriptObject keyBindingModule) /*-{
+                                                            String type, 
+                                                            JavaScriptObject keyBindingModule) /*-{
         return new keyBindingModule.KeyStroke(keyCode, modifier1, modifier2, modifier3, modifier4, type);
+    }-*/;
+    
+    /**
+     * Constructs a new key stroke with the given character, modifiers and event type.
+     *
+     * @param character
+     *         the character of the key binding.
+     * @param modifier1
+     *         the primary modifier (usually Command on Mac and Control on other platforms).
+     * @param modifier2
+     *         the secondary modifier (usually Shift).
+     * @param modifier3
+     *         the third modifier (usually Alt).
+     * @param modifier4
+     *         the fourth modifier (usually Control on the Mac).
+     * @param type
+     *         the type of event that the key binding matches; either "keydown" or "keypress".
+     */
+    public static final native OrionKeyStrokeOverlay create(String character,
+                                                            boolean modifier1,
+                                                            boolean modifier2,
+                                                            boolean modifier3,
+                                                            boolean modifier4,
+                                                            String type, 
+                                                            JavaScriptObject keyBindingModule) /*-{
+        return new keyBindingModule.KeyStroke(character, modifier1, modifier2, modifier3, modifier4, type);
     }-*/;
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewOverlay.java
@@ -148,8 +148,7 @@ public class OrionTextViewOverlay extends JavaScriptObject {
 
     public final native void setAction(String actionId, Action action) /*-{
         this.setAction(actionId, function () {
-            action.@org.eclipse.che.ide.editor.orion.client.Action::onAction()();
-            return true;
+            return action.@org.eclipse.che.ide.editor.orion.client.Action::onAction()();
         });
     }-*/;
 
@@ -166,8 +165,7 @@ public class OrionTextViewOverlay extends JavaScriptObject {
     public final native void setAction(String actionId, Action action, String description) /*-{
         var actionDescription = {name: description};
         this.setAction(actionId, function () {
-            action.@org.eclipse.che.ide.editor.orion.client.Action::onAction()();
-            return true;
+            return action.@org.eclipse.che.ide.editor.orion.client.Action::onAction()();
         }, actionDescription);
     }-*/;
 


### PR DESCRIPTION
We need to be add (or replace) editor-specific key bindings not only for key codes but also for characters.

Therefore I've extended `OrionKeyStrokeOverlay`, `OrionEditorWidget`, `Action`, and `KeyBinding` to be able to add/repalce character based key bindings.

Signed-off-by: Alex Tugarev alex.tugarev@typefox.io
