### PR TITLE
Improvements to set the right API endpoint URL  

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfiguration.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfiguration.java
@@ -37,9 +37,14 @@ import static java.io.File.separatorChar;
  */
 public class DockerConnectorConfiguration {
     /**
-     * Docker bridge name on Linux.
+     * Default Docker bridge name on Linux.
      */
     protected static final String BRIDGE_LINUX_INTERFACE_NAME = "docker0";
+
+    /**
+     * Default network interface name (Linux system).
+     */
+    protected static final String DEFAULT_LINUX_INTERFACE_NAME = "eth0";
 
     /**
      * Default ip of docker host (Linux system).
@@ -249,9 +254,14 @@ public class DockerConnectorConfiguration {
     protected String getDockerHostIp(final boolean isLinux, @NotNull final Map<String, String> env) {
         if (isLinux) {
             // search "docker0" bridge
-            Optional<InetAddress> dockerHostInetAddress = networkFinder.getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
-            if (dockerHostInetAddress.isPresent()) {
-                return dockerHostInetAddress.get().getHostAddress();
+            Optional<InetAddress> dockerBridgeInetAddress = networkFinder.getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
+            if (dockerBridgeInetAddress.isPresent()) {
+                return dockerBridgeInetAddress.get().getHostAddress();
+            }
+            // Che server is probably running in a Docker container: get its internal IP
+            Optional<InetAddress> cheServerInetAddress = networkFinder.getIPAddress(DEFAULT_LINUX_INTERFACE_NAME);
+            if (cheServerInetAddress.isPresent()) {
+                return cheServerInetAddress.get().getHostAddress();
             }
             // return default Docker host ip address
             return DEFAULT_LINUX_DOCKER_HOST_IP;

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/DockerConnection.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/DockerConnection.java
@@ -99,7 +99,7 @@ public abstract class DockerConnection implements Closeable {
                                               String path,
                                               String query,
                                               List<Pair<String, ?>> headers,
-                                              Entity entity) throws IOException;
+                                              Entity<?> entity) throws IOException;
 
     public abstract void close();
 

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/TcpConnection.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/TcpConnection.java
@@ -50,7 +50,7 @@ public class TcpConnection extends DockerConnection {
     }
 
     @Override
-    protected DockerResponse request(String method, String path, String query, List<Pair<String, ?>> headers, Entity entity)
+    protected DockerResponse request(String method, String path, String query, List<Pair<String, ?>> headers, Entity<?> entity)
             throws IOException {
         final String requestUri = path + (Strings.isNullOrEmpty(query) ? "" : "?" + query);
         final URL url = baseUri.resolve(requestUri).toURL();

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/UnixSocketConnection.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/connection/UnixSocketConnection.java
@@ -44,7 +44,7 @@ public class UnixSocketConnection extends DockerConnection {
     }
 
     @Override
-    protected DockerResponse request(String method, String path, String query, List<Pair<String, ?>> headers, Entity entity)
+    protected DockerResponse request(String method, String path, String query, List<Pair<String, ?>> headers, Entity<?> entity)
             throws IOException {
         fd = connect();
         final OutputStream output = new BufferedOutputStream(openOutputStream(fd));

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -59,6 +59,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -191,12 +193,13 @@ public class DockerInstanceProvider implements InstanceProvider {
         envVariablesForDevMachine.addAll(devMachineEnvVariables);
         this.devMachineEnvVariables = envVariablesForDevMachine;
 
-        // always add the docker host
-        String dockerHost = DockerInstanceRuntimeInfo.CHE_HOST.concat(":").concat(dockerConnectorConfiguration.getDockerHostIp());
+        // always add Che server to hosts list
+        String cheHost = dockerConnectorConfiguration.getDockerHostIp();
+        String cheHostAlias = DockerInstanceRuntimeInfo.CHE_HOST.concat(":").concat(cheHost);
         if (isNullOrEmpty(allMachinesExtraHosts)) {
-            this.allMachinesExtraHosts = new String[] {dockerHost};
+            this.allMachinesExtraHosts = new String[] {cheHostAlias};
         } else {
-            this.allMachinesExtraHosts = ObjectArrays.concat(allMachinesExtraHosts.split(","), dockerHost);
+            this.allMachinesExtraHosts = ObjectArrays.concat(allMachinesExtraHosts.split(","), cheHostAlias);
         }
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
@@ -26,7 +26,7 @@ public class DockerMachineModule extends AbstractModule {
     protected void configure() {
         bind(org.eclipse.che.plugin.docker.machine.cleaner.DockerContainerCleaner.class);
 
-        Multibinder<String> debMachineEnvVars = Multibinder.newSetBinder(binder(),
+        Multibinder<String> devMachineEnvVars = Multibinder.newSetBinder(binder(),
                                                                          String.class,
                                                                          Names.named("machine.docker.dev_machine.machine_env"))
                                                            .permitDuplicates();

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/ApiEndpointEnvVariableProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/ApiEndpointEnvVariableProvider.java
@@ -12,6 +12,8 @@ package org.eclipse.che.plugin.docker.machine.ext.provider;
 
 import org.eclipse.che.plugin.docker.machine.DockerInstanceRuntimeInfo;
 
+import com.google.common.base.Strings;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -30,6 +32,11 @@ public class ApiEndpointEnvVariableProvider implements Provider<String> {
 
     @Override
     public String get() {
+        String apiEndpointEnvVar = System.getenv(DockerInstanceRuntimeInfo.API_ENDPOINT_URL_VARIABLE);
+        if (Strings.isNullOrEmpty(apiEndpoint) &&
+            !Strings.isNullOrEmpty(apiEndpointEnvVar)) {
+            apiEndpoint = apiEndpointEnvVar;
+        }
         return DockerInstanceRuntimeInfo.API_ENDPOINT_URL_VARIABLE + '=' + apiEndpoint;
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
@@ -60,11 +60,11 @@ public class LocalDockerModule extends AbstractModule {
 
         bind(org.eclipse.che.plugin.docker.client.DockerRegistryChecker.class).asEagerSingleton();
 
-        Multibinder<String> debMachineEnvVars = Multibinder.newSetBinder(binder(),
+        Multibinder<String> devMachineEnvVars = Multibinder.newSetBinder(binder(),
                                                                          String.class,
                                                                          Names.named("machine.docker.dev_machine.machine_env"))
                                                            .permitDuplicates();
-        debMachineEnvVars.addBinding()
+        devMachineEnvVars.addBinding()
                          .toProvider(org.eclipse.che.plugin.docker.machine.local.provider.DockerApiHostEnvVariableProvider.class);
 
         install(new org.eclipse.che.plugin.docker.machine.DockerMachineModule());


### PR DESCRIPTION
This PR introduce two improvements and is related to #1482: 
- The endpoint URL can be set using an environment variable
- When Che server is running inside a container the alias in wsagents /etc/hosts is set its internal IP
