### PR TITLE
CHE-1276: Add exception handler during creation machine from snapshot

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/DockerException.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/DockerException.java
@@ -8,14 +8,14 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.plugin.docker.client;
+package org.eclipse.che.plugin.docker.client.exception;
 
 import java.io.IOException;
 
 /**
  * @author andrew00x
  */
-public final class DockerException extends IOException {
+public class DockerException extends IOException {
     private final int    status;
     private final String originError;
 

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/ImageNotFoundException.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/ImageNotFoundException.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.exception;
+
+/**
+ * Occurs when docker image is not found.
+ *
+ * @author Anton Korneta
+ */
+public class ImageNotFoundException extends DockerException {
+
+    public ImageNotFoundException(String message) {
+        super(message, 404);
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -23,6 +23,7 @@ import org.eclipse.che.plugin.docker.client.connection.DockerConnectionFactory;
 import org.eclipse.che.plugin.docker.client.connection.DockerResponse;
 import org.eclipse.che.plugin.docker.client.dto.AuthConfig;
 import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
+import org.eclipse.che.plugin.docker.client.exception.DockerException;
 import org.eclipse.che.plugin.docker.client.json.ContainerCommitted;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.json.ContainerCreated;

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
@@ -33,10 +33,12 @@ import org.eclipse.che.api.machine.server.dao.SnapshotDao;
 import org.eclipse.che.api.machine.server.event.InstanceStateEvent;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.exception.SnapshotException;
+import org.eclipse.che.api.machine.server.exception.SourceNotFoundException;
 import org.eclipse.che.api.machine.server.exception.UnsupportedRecipeException;
 import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.server.spi.InstanceProcess;
@@ -277,6 +279,7 @@ public class MachineManager {
                    ConflictException,
                    BadRequestException,
                    MachineException {
+        final MachineSourceImpl sourceCopy = machineConfig.getSource();
         final InstanceProvider instanceProvider = machineInstanceProviders.getProvider(machineConfig.getType());
 
         // Backward compatibility for source type 'Recipe'.
@@ -329,10 +332,25 @@ public class MachineManager {
                 .getOutput());
 
         try {
-            machineRegistry.addMachine(machine);
-
-            instanceCreator.createInstance(instanceProvider, machine, machineLogger);
-
+            try {
+                machineRegistry.addMachine(machine);
+                instanceCreator.createInstance(instanceProvider, machine, machineLogger);
+            } catch (MachineException ex) {
+                if (snapshot == null) {
+                    throw ex;
+                }
+                if (ex.getCause() instanceof SourceNotFoundException) {
+                    final LineConsumer logger = getMachineLogger(machineId,
+                                                                 getMachineChannels(machine.getConfig().getName(),
+                                                                                    machine.getWorkspaceId(),
+                                                                                    machine.getEnvName()).getOutput());
+                    LOG.error("Image of snapshot for machine " + machineConfig.getName() + " not found. " +
+                              "Machine will be created from origin source");
+                    machine.getConfig().setSource(sourceCopy);
+                    machineRegistry.addMachine(machine);
+                    instanceCreator.createInstance(instanceProvider, machine, logger);
+                }
+            }
             return machine;
         } catch (ConflictException e) {
             try {

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/exception/SourceNotFoundException.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/exception/SourceNotFoundException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server.exception;
+
+import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
+
+/**
+ * Occurs when machine sources is not found or is not available.
+ *
+ * @author Anton Korneta
+ */
+public class SourceNotFoundException extends MachineException {
+    public SourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public SourceNotFoundException(ServiceError serviceError) {
+        super(serviceError);
+    }
+
+    public SourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public SourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/spi/InstanceProvider.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/spi/InstanceProvider.java
@@ -18,6 +18,7 @@ import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.exception.InvalidRecipeException;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.exception.SnapshotException;
+import org.eclipse.che.api.machine.server.exception.SourceNotFoundException;
 import org.eclipse.che.api.machine.server.exception.UnsupportedRecipeException;
 
 import java.util.Set;
@@ -65,6 +66,7 @@ public interface InstanceProvider {
     Instance createInstance(Machine machine,
                             LineConsumer creationLogsOutput) throws UnsupportedRecipeException,
                                                                     InvalidRecipeException,
+                                                                    SourceNotFoundException,
                                                                     NotFoundException,
                                                                     MachineException;
 


### PR DESCRIPTION
When docker image is not exist and snapshot is not null then in case of creating   machine instance from this config, docker client will throw an exception, to avoid this situation we should handle this error. It is proposed to create machine instance  form incoming config(recipe).
@skabashnyuk @vparfonov @garagatyi
