### PR TITLE
[Not for merge] CHE-1368: rework machine's output/statuses events subscribing

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/AbstractLineConsumer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/AbstractLineConsumer.java
@@ -10,18 +10,17 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.util;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * Consumes text line by line for analysing, writing, storing, etc.
+ * No-op implementation of {@link LineConsumer}
  *
- * @author andrew00x
- * @see AbstractLineConsumer
+ * @author Alexander Garagatyi
  */
-public interface LineConsumer extends Closeable {
-    /** Consumes single line. */
-    void writeLine(String line) throws IOException;
+public abstract class AbstractLineConsumer implements LineConsumer {
+    @Override
+    public void writeLine(String line) throws IOException {}
 
-    LineConsumer DEV_NULL = new AbstractLineConsumer() {};
+    @Override
+    public void close() throws IOException {}
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/AbstractMessageConsumer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/AbstractMessageConsumer.java
@@ -10,18 +10,17 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.util;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * Consumes text line by line for analysing, writing, storing, etc.
+ * No-op implementation of {@link MessageConsumer}
  *
- * @author andrew00x
- * @see AbstractLineConsumer
+ * @author Alexander Garagatyi
  */
-public interface LineConsumer extends Closeable {
-    /** Consumes single line. */
-    void writeLine(String line) throws IOException;
+public class AbstractMessageConsumer<T> implements MessageConsumer<T> {
+    @Override
+    public void consume(T message) throws IOException {}
 
-    LineConsumer DEV_NULL = new AbstractLineConsumer() {};
+    @Override
+    public void close() throws IOException {}
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/MessageConsumer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/MessageConsumer.java
@@ -14,14 +14,10 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * Consumes text line by line for analysing, writing, storing, etc.
+ * Consumes messages one by one for analysing, writing, storing, etc.
  *
- * @author andrew00x
- * @see AbstractLineConsumer
+ * @author Alexander Garagatyi
  */
-public interface LineConsumer extends Closeable {
-    /** Consumes single line. */
-    void writeLine(String line) throws IOException;
-
-    LineConsumer DEV_NULL = new AbstractLineConsumer() {};
+public interface MessageConsumer<T> extends Closeable {
+    void consume(T message) throws IOException;
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/WebsocketLineConsumer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/WebsocketLineConsumer.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.util;
 
-import org.everrest.core.impl.provider.json.JsonUtils;
 import org.everrest.websockets.WSConnectionContext;
 import org.everrest.websockets.message.ChannelBroadcastMessage;
 import org.slf4j.Logger;
@@ -36,7 +35,7 @@ public class WebsocketLineConsumer implements LineConsumer {
     public void writeLine(String line) throws IOException {
         final ChannelBroadcastMessage bm = new ChannelBroadcastMessage();
         bm.setChannel(channel);
-        bm.setBody(JsonUtils.getJsonString(line));
+        bm.setBody(line);
         try {
             WSConnectionContext.sendMessage(bm);
         } catch (Exception e) {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/WebsocketMessageConsumer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/WebsocketMessageConsumer.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+
+/**
+ * Message consumer that sends messages to specified websocket channel
+ *
+ * @author Alexander Garagatyi
+ */
+public class WebsocketMessageConsumer<T> extends AbstractMessageConsumer<T> {
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+    private final LineConsumer messageSender;
+
+    public WebsocketMessageConsumer(String channel) {
+        this.messageSender = new WebsocketLineConsumer(channel);
+    }
+
+    @Override
+    public void consume(T message) throws IOException {
+        messageSender.writeLine(GSON.toJson(message));
+    }
+}

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/MachineLogMessage.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/MachineLogMessage.java
@@ -8,20 +8,21 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.core.util;
-
-import java.io.Closeable;
-import java.io.IOException;
+package org.eclipse.che.api.core.model.machine;
 
 /**
- * Consumes text line by line for analysing, writing, storing, etc.
+ * Represents log message from machine
  *
- * @author andrew00x
- * @see AbstractLineConsumer
+ * @author Alexander Garagatyi
  */
-public interface LineConsumer extends Closeable {
-    /** Consumes single line. */
-    void writeLine(String line) throws IOException;
+public interface MachineLogMessage {
+    /**
+     * Content of log message
+     */
+    String getContent();
 
-    LineConsumer DEV_NULL = new AbstractLineConsumer() {};
+    /**
+     * Machine name
+     */
+    String getMachineName();
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/CommandOutputMessageUnmarshaller.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/CommandOutputMessageUnmarshaller.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.machine;
 
-import com.google.gwt.json.client.JSONParser;
-import com.google.gwt.json.client.JSONString;
-
 import org.eclipse.che.ide.websocket.Message;
 import org.eclipse.che.ide.websocket.rest.Unmarshallable;
 
@@ -32,8 +29,7 @@ public class CommandOutputMessageUnmarshaller implements Unmarshallable<String> 
 
     @Override
     public void unmarshal(Message message) {
-        final JSONString jsonString = JSONParser.parseStrict(message.getBody()).isString();
-        payload = jsonString.stringValue();
+        payload = message.getBody();
 
         if (payload.startsWith("[STDOUT]")) {
             payload = payload.substring(9);

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/OutputMessageUnmarshaller.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/OutputMessageUnmarshaller.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.machine;
 
-import com.google.gwt.json.client.JSONParser;
-import com.google.gwt.json.client.JSONString;
-
 import org.eclipse.che.ide.websocket.Message;
 import org.eclipse.che.ide.websocket.rest.Unmarshallable;
 
@@ -26,9 +23,7 @@ public class OutputMessageUnmarshaller implements Unmarshallable<String> {
 
     @Override
     public void unmarshal(Message message) {
-        final JSONString jsonString = JSONParser.parseStrict(message.getBody()).isString();
-        payload = jsonString.stringValue();
-
+        payload = message.getBody();
         if (payload.startsWith("[STDOUT]") || payload.startsWith("[STDERR]")) {
             payload = payload.substring(9);
         }

--- a/plugins/plugin-ssh-machine/src/main/java/org/eclipse/che/plugin/machine/ssh/SshMachineImplTerminalLauncher.java
+++ b/plugins/plugin-ssh-machine/src/main/java/org/eclipse/che/plugin/machine/ssh/SshMachineImplTerminalLauncher.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.plugin.machine.ssh;
 
 import org.eclipse.che.api.core.ConflictException;
-import org.eclipse.che.api.core.util.LineConsumer;
+import org.eclipse.che.api.core.util.AbstractLineConsumer;
 import org.eclipse.che.api.core.util.ListLineConsumer;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
@@ -164,14 +164,11 @@ public class SshMachineImplTerminalLauncher implements MachineImplSpecificTermin
                                                                               null),
                                                               null);
 
-        startTerminal.start(new LineConsumer() {
+        startTerminal.start(new AbstractLineConsumer() {
             @Override
             public void writeLine(String line) throws IOException {
                 machine.getLogger().writeLine("[Terminal] " + line);
             }
-
-            @Override
-            public void close() throws IOException {}
         });
     }
 }

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/Constants.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/Constants.java
@@ -40,6 +40,11 @@ public class Constants {
     public static final String WSAGENT_WEBSOCKET_REFERENCE         = "wsagent.websocket";
     public static final String WSAGENT_DEBUG_REFERENCE             = "wsagent.debug";
 
+    public static final String LINK_REL_ENVIRONMENT_OUTPUT_CHANNEL = "environment.output_channel";
+    public static final String ENVIRONMENT_OUTPUT_CHANNEL_TEMPLATE = "workspace:%s:environment_output";
+    public static final String LINK_REL_ENVIRONMENT_STATUS_CHANNEL = "environment.status_channel";
+    public static final String ENVIRONMENT_STATUS_CHANNEL_TEMPLATE = "workspace:%s:machines_statuses";
+
     public static final String TERMINAL_REFERENCE = "terminal";
 
     public static final String WS_AGENT_PORT = "4401/tcp";

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineLogMessageDto.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineLogMessageDto.java
@@ -8,20 +8,21 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.core.util;
+package org.eclipse.che.api.machine.shared.dto;
 
-import java.io.Closeable;
-import java.io.IOException;
+import org.eclipse.che.api.core.model.machine.MachineLogMessage;
+import org.eclipse.che.dto.shared.DTO;
 
 /**
- * Consumes text line by line for analysing, writing, storing, etc.
- *
- * @author andrew00x
- * @see AbstractLineConsumer
+ * @author Alexander Garagatyi
  */
-public interface LineConsumer extends Closeable {
-    /** Consumes single line. */
-    void writeLine(String line) throws IOException;
+@DTO
+public interface MachineLogMessageDto extends MachineLogMessage {
+    void setContent(String content);
 
-    LineConsumer DEV_NULL = new AbstractLineConsumer() {};
+    MachineLogMessageDto withContent(String content);
+
+    void setMachineName(String machineName);
+
+    MachineLogMessageDto withMachineName(String machineName);
 }

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
@@ -14,6 +14,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
@@ -135,6 +136,8 @@ public class MachineManager {
      *         id of the workspace the created machine will belong to
      * @param environmentName
      *         environment name the created machine will belongs to
+     * @param outputConsumer
+     *         output consumer of machine
      * @return new machine
      * @throws NotFoundException
      *         if machine type from recipe is unsupported
@@ -153,7 +156,8 @@ public class MachineManager {
      */
     public MachineImpl createMachineSync(MachineConfig machineConfig,
                                          final String workspaceId,
-                                         final String environmentName)
+                                         final String environmentName,
+                                         LineConsumer outputConsumer)
             throws NotFoundException,
                    SnapshotException,
                    ConflictException,
@@ -167,7 +171,8 @@ public class MachineManager {
                                                   workspaceId,
                                                   environmentName,
                                                   this::createInstance,
-                                                  null);
+                                                  null,
+                                                  outputConsumer);
         LOG.info("Machine [ws = {}: env = {}: machine = {}] was successfully created, its id is '{}'",
                  workspaceId,
                  environmentName,
@@ -186,6 +191,8 @@ public class MachineManager {
      *         workspace id
      * @param envName
      *         name of environment
+     * @param outputConsumer
+     *         output consumer of machine
      * @return machine instance
      * @throws NotFoundException
      *         when snapshot doesn't exist
@@ -198,11 +205,15 @@ public class MachineManager {
      * @throws BadRequestException
      *         when either machineConfig or workspace id, or environment name is not valid
      */
-    public MachineImpl recoverMachine(MachineConfig machineConfig, String workspaceId, String envName) throws NotFoundException,
-                                                                                                              SnapshotException,
-                                                                                                              MachineException,
-                                                                                                              ConflictException,
-                                                                                                              BadRequestException {
+    public MachineImpl recoverMachine(MachineConfig machineConfig,
+                                      String workspaceId,
+                                      String envName,
+                                      LineConsumer outputConsumer) throws NotFoundException,
+                                                                          SnapshotException,
+                                                                          MachineException,
+                                                                          ConflictException,
+                                                                          BadRequestException {
+
         final SnapshotImpl snapshot = snapshotDao.getSnapshot(workspaceId, envName, machineConfig.getName());
 
         LOG.info("Recovering machine [ws = {}: env = {}: machine = {}] from snapshot", workspaceId, envName, machineConfig.getName());
@@ -210,7 +221,8 @@ public class MachineManager {
                                                   workspaceId,
                                                   envName,
                                                   this::createInstance,
-                                                  snapshot);
+                                                  snapshot,
+                                                  outputConsumer);
         LOG.info("Machine [ws = {}: env = {}: machine = {}] was successfully recovered, its id '{}'",
                  workspaceId,
                  envName,
@@ -229,6 +241,8 @@ public class MachineManager {
      *         id of the workspace the created machine will belong to
      * @param environmentName
      *         environment name the created machine will belongs to
+     * @param outputConsumer
+     *         output consumer of machine
      * @return new machine
      * @throws NotFoundException
      *         if machine type from recipe is unsupported
@@ -247,7 +261,8 @@ public class MachineManager {
      */
     public MachineImpl createMachineAsync(MachineConfig machineConfig,
                                           final String workspaceId,
-                                          final String environmentName)
+                                          final String environmentName,
+                                          LineConsumer outputConsumer)
             throws NotFoundException,
                    SnapshotException,
                    ConflictException,
@@ -269,14 +284,16 @@ public class MachineManager {
                                              // todo what should we do in that case?
                                          }
                                      })),
-                             null);
+                             null,
+                             outputConsumer);
     }
 
     private MachineImpl createMachine(MachineConfigImpl machineConfig,
                                       String workspaceId,
                                       String environmentName,
                                       MachineInstanceCreator instanceCreator,
-                                      SnapshotImpl snapshot)
+                                      SnapshotImpl snapshot,
+                                      LineConsumer outputConsumer)
             throws NotFoundException,
                    SnapshotException,
                    ConflictException,
@@ -329,38 +346,43 @@ public class MachineManager {
                                                     null);
 
         createMachineLogsDir(machineId);
-        final LineConsumer machineLogger = getMachineLogger(machineId, getMachineChannels(machine.getConfig().getName(),
-                                                                                          machine.getWorkspaceId(),
-                                                                                          machine.getEnvName())
-                .getOutput());
+        final LineConsumer machineLogger = getMachineLogger(machineId, outputConsumer);
 
         try {
+            machineRegistry.addMachine(machine);
             try {
-                machineRegistry.addMachine(machine);
                 instanceCreator.createInstance(instanceProvider, machine, machineLogger);
             } catch (MachineException ex) {
                 if (snapshot == null) {
                     throw ex;
                 }
                 if (ex.getCause() instanceof SourceNotFoundException) {
-                    final LineConsumer logger = getMachineLogger(machineId,
-                                                                 getMachineChannels(machine.getConfig().getName(),
-                                                                                    machine.getWorkspaceId(),
-                                                                                    machine.getEnvName()).getOutput());
                     LOG.error("Image of snapshot for machine " + machineConfig.getName() + " not found. " +
                               "Machine will be created from origin source");
                     machine.getConfig().setSource(sourceCopy);
+                    try {
+                        machineRegistry.remove(machineId);
+                    } catch (NotFoundException ignored) {
+                        // machine is already removed, should never happen
+                    }
                     machineRegistry.addMachine(machine);
-                    instanceCreator.createInstance(instanceProvider, machine, logger);
+                    instanceCreator.createInstance(instanceProvider, machine, outputConsumer);
                 }
             }
             return machine;
-        } catch (ConflictException e) {
+        } catch (ApiException apiEx) {
             try {
                 machineLogger.close();
-            } catch (IOException ignored) {
+            } catch (IOException ioEx) {
+                LOG.error(ioEx.getLocalizedMessage(), ioEx);
             }
-            throw new MachineException(e.getLocalizedMessage(), e);
+            try {
+                machineRegistry.remove(machineId);
+            } catch (NotFoundException ignored) {
+                // machine is already removed
+            }
+
+            throw new MachineException(apiEx.getLocalizedMessage(), apiEx);
         }
     }
 
@@ -393,27 +415,28 @@ public class MachineManager {
                                            .withWorkspaceId(machine.getWorkspaceId())
                                            .withMachineName(machine.getConfig().getName()));
 
-        } catch (ServerException | InterruptedException e) {
-            if (instance != null) {
-                instance.destroy();
-            }
-
+        } catch (ServerException | InterruptedException creationEx) {
             eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
                                            .withEventType(MachineStatusEvent.EventType.ERROR)
                                            .withMachineId(machine.getId())
                                            .withDev(machine.getConfig().isDev())
                                            .withWorkspaceId(machine.getWorkspaceId())
                                            .withMachineName(machine.getConfig().getName())
-                                           .withError(e.getLocalizedMessage()));
+                                           .withError(creationEx.getLocalizedMessage()));
+            try {
+                machineLogger.writeLine(String.format("[ERROR] %s", creationEx.getLocalizedMessage()));
+            } catch (IOException ioEx) {
+                LOG.error(ioEx.getLocalizedMessage());
+            }
 
             try {
-                machineRegistry.remove(machine.getId());
-                machineLogger.writeLine(String.format("[ERROR] %s", e.getLocalizedMessage()));
-                machineLogger.close();
-            } catch (IOException | NotFoundException e1) {
-                LOG.error(e1.getLocalizedMessage());
+                if (instance != null) {
+                    instance.destroy();
+                }
+            } catch (MachineException destroyingEx) {
+                LOG.error(destroyingEx.getLocalizedMessage(), destroyingEx);
             }
-            throw new MachineException(e.getLocalizedMessage(), e);
+            throw new MachineException(creationEx.getLocalizedMessage(), creationEx);
         }
     }
 
@@ -930,8 +953,8 @@ public class MachineManager {
     }
 
     @VisibleForTesting
-    LineConsumer getMachineLogger(String machineId, String outputChannel) throws MachineException {
-        return getLogger(getMachineFileLogger(machineId), outputChannel);
+    LineConsumer getMachineLogger(String machineId, LineConsumer outputConsumer) throws MachineException {
+        return new CompositeLineConsumer(getMachineFileLogger(machineId), outputConsumer);
     }
 
     @VisibleForTesting
@@ -944,11 +967,6 @@ public class MachineManager {
             return new CompositeLineConsumer(fileLogger, new WebsocketLineConsumer(outputChannel));
         }
         return fileLogger;
-    }
-
-    static ChannelsImpl getMachineChannels(String machineName, String workspaceId, String envName) {
-        return new ChannelsImpl(workspaceId + ':' + envName + ':' + machineName,
-                                "machine:status:" + workspaceId + ':' + machineName);
     }
 
     // cleanup machine if event about instance failure comes

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/event/MachineStateMessenger.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/event/MachineStateMessenger.java
@@ -24,6 +24,9 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import static java.lang.String.format;
+import static org.eclipse.che.api.machine.shared.Constants.ENVIRONMENT_STATUS_CHANNEL_TEMPLATE;
+
 /**
  * Send machine state events using websocket channel to the clients
  *
@@ -44,7 +47,7 @@ public class MachineStateMessenger implements EventSubscriber<MachineStatusEvent
     public void onEvent(MachineStatusEvent event) {
         try {
             final ChannelBroadcastMessage bm = new ChannelBroadcastMessage();
-            bm.setChannel("machine:status:" + event.getWorkspaceId() + ':' + event.getMachineName());
+            bm.setChannel(format(ENVIRONMENT_STATUS_CHANNEL_TEMPLATE, event.getWorkspaceId()));
             bm.setBody(DtoFactory.getInstance().toJson(event));
             WSConnectionContext.sendMessage(bm);
         } catch (Exception e) {

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineLogMessageImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineLogMessageImpl.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server.model.impl;
+
+import org.eclipse.che.api.core.model.machine.MachineLogMessage;
+
+import java.util.Objects;
+
+/**
+ * @author Alexander Garagatyi
+ */
+public class MachineLogMessageImpl implements MachineLogMessage {
+    private String machineName;
+    private String content;
+
+    public MachineLogMessageImpl() {}
+
+    public MachineLogMessageImpl(String machineName, String content) {
+        this.machineName = machineName;
+        this.content = content;
+    }
+
+    @Override
+    public String getMachineName() {
+        return machineName;
+    }
+
+    public void setMachineName(String machine) {
+        this.machineName = machine;
+    }
+
+    @Override
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MachineLogMessageImpl)) return false;
+        MachineLogMessageImpl that = (MachineLogMessageImpl)o;
+        return Objects.equals(machineName, that.machineName) &&
+               Objects.equals(content, that.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(machineName, content);
+    }
+
+    @Override
+    public String toString() {
+        return "MachineLogMessageImpl{machineName='" + machineName +
+               "', content='" + content + "'}";
+    }
+}

--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineServiceLinksInjectorTest.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineServiceLinksInjectorTest.java
@@ -36,6 +36,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_ENVIRONMENT_OUTPUT_CHANNEL;
+import static org.eclipse.che.api.machine.shared.Constants.ENVIRONMENT_STATUS_CHANNEL_TEMPLATE;
 import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_DESTROY_MACHINE;
 import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_EXECUTE_COMMAND;
 import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_GET_MACHINES;
@@ -103,7 +105,9 @@ public class MachineServiceLinksInjectorTest {
                                                                              Pair.of("GET", LINK_REL_GET_SNAPSHOTS),
                                                                              Pair.of("GET", LINK_REL_GET_PROCESSES),
                                                                              Pair.of("POST", LINK_REL_SAVE_SNAPSHOT),
-                                                                             Pair.of("GET", LINK_REL_GET_MACHINE_LOGS)));
+                                                                             Pair.of("GET", LINK_REL_GET_MACHINE_LOGS),
+                                                                             Pair.of("GET", LINK_REL_ENVIRONMENT_OUTPUT_CHANNEL),
+                                                                             Pair.of("GET", ENVIRONMENT_STATUS_CHANNEL_TEMPLATE)));
 
         assertEquals(links, expectedLinks, "Difference " + Sets.symmetricDifference(links, expectedLinks) + "\n");
     }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -73,6 +73,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_ENVIRONMENT_OUTPUT_CHANNEL;
+import static org.eclipse.che.api.machine.shared.Constants.LINK_REL_ENVIRONMENT_STATUS_CHANNEL;
 import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
 import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_WEBSOCKET_REFERENCE;
 import static org.eclipse.che.api.workspace.shared.Constants.GET_ALL_USER_WORKSPACES;
@@ -127,7 +129,6 @@ public class WorkspaceServiceTest {
     @BeforeMethod
     public void setup() {
         service = new WorkspaceService(wsManager,
-                                       machineManager,
                                        validator,
                                        new WorkspaceServiceLinksInjector(new MachineServiceLinksInjector()));
     }
@@ -295,7 +296,7 @@ public class WorkspaceServiceTest {
                                          .delete(SECURE_PATH + "/workspace/" + workspace.getId());
 
         assertEquals(response.getStatusCode(), 204);
-        verify(machineManager).removeSnapshots(NAMESPACE, workspace.getId());
+        verify(wsManager).removeSnapshots(workspace.getId());
         verify(wsManager).removeWorkspace(workspace.getId());
     }
 
@@ -681,7 +682,9 @@ public class WorkspaceServiceTest {
                                                               LINK_REL_GET_SNAPSHOT,
                                                               LINK_REL_GET_WORKSPACE_EVENTS_CHANNEL,
                                                               LINK_REL_IDE_URL,
-                                                              LINK_REL_SELF));
+                                                              LINK_REL_SELF,
+                                                              LINK_REL_ENVIRONMENT_OUTPUT_CHANNEL,
+                                                              LINK_REL_ENVIRONMENT_STATUS_CHANNEL));
         assertTrue(actualRels.equals(expectedRels), format("Links difference: '%s'. \n" +
                                                            "Returned links: '%s', \n" +
                                                            "Expected links: '%s'.",


### PR DESCRIPTION
This PR is a part of contribution that change the way of streaming logs/statuses of machines of active environment in a workspace. This PR introduces changes on server side and require changes in UD and IDE clients to be merged in master.

Rework output/status events of machine to be per workspace as a
part of implementation of new multi-machine environments.
Get rid of usage of machine manager in workspace service
Refactor code of machine manager.
