### PR TITLE
Add JPA implementions of UserDao/ProfileDao

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/security/PBKDF2PasswordEncryptor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/security/PBKDF2PasswordEncryptor.java
@@ -67,7 +67,7 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
             return false;
         }
         // retrieve salt, password hash and iterations count from hash
-        final Integer iterations = tryParse(firstNonNull(matcher.group("iterations"), ""));
+        final Integer iterations = tryParse(matcher.group("iterations"));
         final String salt = matcher.group("saltHash");
         final String pwdHash = matcher.group("pwdHash");
         // compute password's hash and test whether it matches to given hash

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/security/PBKDF2PasswordEncryptor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/security/PBKDF2PasswordEncryptor.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.security;
+
+import com.google.common.hash.HashCode;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.primitives.Ints.tryParse;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Encrypts password using <a href="https://en.wikipedia.org/wiki/PBKDF2">Password-based-Key-Derivative-Function</a>
+ * with <b>SHA512</b> as pseudorandom function.
+ * See <a href="https://www.ietf.org/rfc/rfc2898.txt">rfc2898</a>.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
+
+    private static final String  PWD_FMT   = "%s:%s:%d";
+    private static final Pattern PWD_REGEX = Pattern.compile("(?<pwdHash>\\w+):(?<saltHash>\\w+):(?<iterations>[0-9]+)");
+
+    private static final String       SECRET_KEY_FACTORY_NAME = "PBKDF2WithHmacSHA512";
+    private static final SecureRandom SECURE_RANDOM           = new SecureRandom();
+    /**
+     * Minimum number of iterations required is 1_000(rfc2898),
+     * pick greater as potentially safer in the case of brute-force attacks .
+     */
+    private static final int          ITERATIONS_COUNT        = 10_000;
+    /** 64bit salt length based on the rfc2898 spec . */
+    private static final int          SALT_LENGTH             = 64 / 8;
+
+    @Override
+    public String encrypt(String password) {
+        requireNonNull(password, "Required non-null password");
+        final byte[] salt = new byte[SALT_LENGTH];
+        SECURE_RANDOM.nextBytes(salt);
+        final HashCode hash = computeHash(password.toCharArray(), salt, ITERATIONS_COUNT);
+        final HashCode saltHash = HashCode.fromBytes(salt);
+        return format(PWD_FMT, hash, saltHash, ITERATIONS_COUNT);
+    }
+
+    @Override
+    public boolean test(String password, String encryptedPassword) {
+        requireNonNull(password, "Required non-null password");
+        requireNonNull(password, "Required non-null encrypted password");
+        final Matcher matcher = PWD_REGEX.matcher(encryptedPassword);
+        if (!matcher.matches()) {
+            return false;
+        }
+        // retrieve salt, password hash and iterations count from hash
+        final Integer iterations = tryParse(firstNonNull(matcher.group("iterations"), ""));
+        final String salt = matcher.group("saltHash");
+        final String pwdHash = matcher.group("pwdHash");
+        // compute password's hash and test whether it matches to given hash
+        final HashCode hash = computeHash(password.toCharArray(), HashCode.fromString(salt).asBytes(), iterations);
+        return hash.toString().equals(pwdHash);
+    }
+
+    private HashCode computeHash(char[] password, byte[] salt, int iterations) {
+        try {
+            final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(SECRET_KEY_FACTORY_NAME);
+            final KeySpec keySpec = new PBEKeySpec(password, salt, iterations, 512);
+            return HashCode.fromBytes(keyFactory.generateSecret(keySpec).getEncoded());
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException x) {
+            throw new RuntimeException(x.getMessage(), x);
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/security/PasswordEncryptor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/security/PasswordEncryptor.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.security;
+
+/**
+ * Encrypts password in implementation specific way.
+ *
+ * @author Yevhenii Voevodin
+ */
+public interface PasswordEncryptor {
+
+    /**
+     * Encrypts the given {@code password}.
+     *
+     * @param password
+     *         the plain password to be encrypted
+     * @return the encrypted password
+     * @throws NullPointerException
+     *         when the password is null
+     * @throws RuntimeException
+     *         when any error occurs during password encryption
+     */
+    String encrypt(String password);
+
+    /**
+     * Tests whether given {@code password} is {@code encryptedPassword}.
+     *
+     * @param encryptedPassword
+     *         encrypted password
+     * @param password
+     *         the password to check
+     * @return true if given {@code password} is {@code encryptedPassword}
+     * @throws NullPointerException
+     *         when either of arguments is null
+     * @throws RuntimeException
+     *         when any error occurs during test
+     */
+    boolean test(String password, String encryptedPassword);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/security/SHA512PasswordEncryptor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/security/SHA512PasswordEncryptor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.security;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+
+import java.nio.charset.Charset;
+import java.security.SecureRandom;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * SHA-512 based encryptor {@code hash = sha512(password + salt) + salt}.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class SHA512PasswordEncryptor implements PasswordEncryptor {
+
+    /** 64 bit salt length is based on the <a href="https://www.ietf.org/rfc/rfc2898.txt">source</a>. */
+    private static final int          SALT_BYTES_LENGTH               = 64 / 8;
+    /** SHA-512 produces 512 bits. */
+    private static final int          ENCRYPTED_PASSWORD_BYTES_LENGTH = 512 / 8;
+    private static final SecureRandom SECURE_RANDOM                   = new SecureRandom();
+    private static final Charset      PWD_CHARSET                     = Charset.forName("UTF-8");
+
+    @Override
+    public String encrypt(String password) {
+        requireNonNull(password, "Required non-null password");
+        // generate salt
+        final byte[] salt = new byte[SALT_BYTES_LENGTH];
+        SECURE_RANDOM.nextBytes(salt);
+        // sha512(password + salt)
+        final HashCode hash = Hashing.sha512().hashBytes(Bytes.concat(password.getBytes(PWD_CHARSET), salt));
+        final HashCode saltHash = HashCode.fromBytes(salt);
+        // add salt to the hash, result length (512 / 8) * 2 + (64 / 8) * 2 = 144
+        return hash.toString() + saltHash.toString();
+    }
+
+    @Override
+    public boolean test(String password, String passwordHash) {
+        requireNonNull(password, "Required non-null password");
+        requireNonNull(passwordHash, "Required non-null password's hash");
+        // retrieve salt from the hash
+        final int passwordHashLength = ENCRYPTED_PASSWORD_BYTES_LENGTH * 2;
+        if (passwordHash.length() < passwordHashLength + SALT_BYTES_LENGTH * 2) {
+            return false;
+        }
+        final HashCode saltHash = HashCode.fromString(passwordHash.substring(passwordHashLength));
+        // sha1(password + salt)
+        final HashCode hash = Hashing.sha512().hashBytes(Bytes.concat(password.getBytes(PWD_CHARSET), saltHash.asBytes()));
+        // test sha1(password + salt) + salt == passwordHash
+        return (hash.toString() + saltHash.toString()).equals(passwordHash);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/security/PasswordEncryptorsTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/security/PasswordEncryptorsTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.security;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class PasswordEncryptorsTest {
+
+    @Test(dataProvider = "encryptorsProvider")
+    public void testEncryption(PasswordEncryptor encryptor) throws Exception {
+        final String password = "password";
+
+        final String hash = encryptor.encrypt(password);
+        assertNotNull(hash, "encrypted password's hash");
+
+        assertTrue(encryptor.test(password, hash), "password test");
+    }
+
+    @DataProvider(name = "encryptorsProvider")
+    public Object[][] encryptorsProvider() {
+        return new Object[][] {
+                {new SHA512PasswordEncryptor()},
+                {new PBKDF2PasswordEncryptor()}
+        };
+    }
+}

--- a/core/che-core-api-jdbc-vendor-h2/pom.xml
+++ b/core/che-core-api-jdbc-vendor-h2/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-core-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>4.5.0-RC1-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-core-api-jdbc-vendor-h2</artifactId>
+    <name>Che Core :: API :: JDBC Vendor H2</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/che-core-api-jdbc-vendor-h2/src/main/java/org/eclipse/che/api/core/h2/jdbc/jpa/eclipselink/H2ExceptionHandler.java
+++ b/core/che-core-api-jdbc-vendor-h2/src/main/java/org/eclipse/che/api/core/h2/jdbc/jpa/eclipselink/H2ExceptionHandler.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink;
+
+import org.eclipse.che.api.core.jdbc.jpa.DuplicateKeyException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.exceptions.ExceptionHandler;
+
+import java.sql.SQLException;
+
+/**
+ * Rethrows vendor specific exceptions as common exceptions.
+ * See <a href="http://www.h2database.com/javadoc/org/h2/api/ErrorCode.html">H2 error codes</a>.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class H2ExceptionHandler implements ExceptionHandler {
+
+    public Object handleException(RuntimeException exception) {
+        if (exception instanceof DatabaseException && exception.getCause() instanceof SQLException) {
+            final SQLException sqlEx = (SQLException)exception.getCause();
+            if (sqlEx.getErrorCode() == 23505) {
+                throw new DuplicateKeyException(exception.getMessage(), exception);
+            }
+        }
+        throw exception;
+    }
+}

--- a/core/che-core-api-jdbc/pom.xml
+++ b/core/che-core-api-jdbc/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-core-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>4.5.0-RC1-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-core-api-jdbc</artifactId>
+    <name>Che Core :: API :: JDBC</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/DBErrorCode.java
+++ b/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/DBErrorCode.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jdbc;
+
+/**
+ * Defines common database error codes which should
+ * be used throughout the application in preference to
+ * vendor specific error codes.
+ *
+ * @author Yevhenii Voevodin
+ */
+public enum DBErrorCode {
+
+    /**
+     * When database error can't be described with one
+     * of the other values of this enumeration.
+     */
+    UNDEFINED(-1),
+
+    /**
+     * When any of the unique constraints is violated
+     * e.g. duplicate key or unique index violation.
+     */
+    DUPLICATE_KEY(1);
+
+    private final int code;
+
+    DBErrorCode(int code) {
+        this.code = code;
+    }
+
+    /**
+     * Returns the code of this error.
+     */
+    public int getCode() {
+        return code;
+    }
+}

--- a/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/DetailedRollbackException.java
+++ b/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/DetailedRollbackException.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jdbc.jpa;
+
+import org.eclipse.che.api.core.jdbc.DBErrorCode;
+
+import javax.persistence.RollbackException;
+
+/**
+ * Extends the standard {@link RollbackException} with an error code from {@link DBErrorCode}.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class DetailedRollbackException extends RollbackException {
+
+    private DBErrorCode code;
+
+    public DetailedRollbackException(String message, Throwable cause, DBErrorCode code) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    public DBErrorCode getCode() {
+        return code;
+    }
+}

--- a/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/DuplicateKeyException.java
+++ b/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/DuplicateKeyException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jdbc.jpa;
+
+import org.eclipse.che.api.core.jdbc.DBErrorCode;
+
+/**
+ * Thrown when data couldn't be updated/stored due to unique constrain violation.
+ *
+ * @author Yevhenii Voevodin
+ * @see DBErrorCode#DUPLICATE_KEY
+ */
+public class DuplicateKeyException extends DetailedRollbackException {
+
+    public DuplicateKeyException(String message, Throwable cause) {
+        super(message, cause, DBErrorCode.DUPLICATE_KEY);
+    }
+}

--- a/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/AbstractTestListener.java
+++ b/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/AbstractTestListener.java
@@ -15,18 +15,31 @@ import org.testng.ITestListener;
 import org.testng.ITestResult;
 
 /**
- * Listener representing fake db server url injection for testing "attributes sharing"
- * using {@link ITestContext} test suite instance.
+ * Skeletal implementation of the {@link ITestListener}.
+ * In most cases only 2 methods are needed {@link #onStart(ITestContext)} and {@link #onFinish(ITestContext)}.
  *
  * @author Yevhenii Voevodin
  */
-public class DBServerListener extends AbstractTestListener {
-
-    public static final String DB_SERVER_URL_ATTRIBUTE_NAME = "db_server_url";
-    public static final String DB_SERVER_URL                = "localhost:12345";
+public abstract class AbstractTestListener implements ITestListener {
 
     @Override
-    public void onStart(ITestContext context) {
-        context.setAttribute(DB_SERVER_URL_ATTRIBUTE_NAME, DB_SERVER_URL);
-    }
+    public void onTestStart(ITestResult result) {}
+
+    @Override
+    public void onTestSuccess(ITestResult result) {}
+
+    @Override
+    public void onTestFailure(ITestResult result) {}
+
+    @Override
+    public void onTestSkipped(ITestResult result) {}
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {}
+
+    @Override
+    public void onStart(ITestContext context) {}
+
+    @Override
+    public void onFinish(ITestContext context) {}
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,5 +30,7 @@
         <module>che-core-api-dto-maven-plugin</module>
         <module>che-core-api-core</module>
         <module>che-core-api-model</module>
+        <module>che-core-api-jdbc</module>
+        <module>che-core-api-jdbc-vendor-h2</module>
     </modules>
 </project>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-ui-ide/src/main/java/org/eclipse/ui/wizards/datatransfer/ImportOperation.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-ui-ide/src/main/java/org/eclipse/ui/wizards/datatransfer/ImportOperation.java
@@ -441,7 +441,7 @@ public class ImportOperation extends WorkspaceModifyOperation {
      *
      * @param resource resource to cast/adapt
      * @return the resource either casted to or adapted to an IFile.
-     * 	<code>null</code> if the resource does not adapt to IFile 
+     * 	<code>null</code> if the resource does not adapt to IFile
      */
     IFile getFile(IResource resource) {
         if (resource instanceof IFile) {
@@ -460,7 +460,7 @@ public class ImportOperation extends WorkspaceModifyOperation {
      *
      * @param resource resource to cast/adapt
      * @return the resource either casted to or adapted to an IFolder.
-     * 	<code>null</code> if the resource does not adapt to IFolder 
+     * 	<code>null</code> if the resource does not adapt to IFolder
      */
     IFolder getFolder(IResource resource) {
         if (resource instanceof IFolder) {

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,18 @@
     <properties>
         <che.lib.version>4.5.0-RC1-SNAPSHOT</che.lib.version>
         <che.version>4.5.0-RC1-SNAPSHOT</che.version>
+        <com.h2database.version>1.4.186</com.h2database.version>
+        <org.eclipse.persistence.eclipselink.version>2.6.2</org.eclipse.persistence.eclipselink.version>
+        <org.eclipse.persistence.version>2.1.1</org.eclipse.persistence.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${com.h2database.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
@@ -140,6 +148,16 @@
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-infrastructure-local</artifactId>
                 <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-jdbc-vendor-h2</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -684,6 +702,22 @@
                 <groupId>org.eclipse.che.sample</groupId>
                 <artifactId>che-sample-plugin-json-shared</artifactId>
                 <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>eclipselink</artifactId>
+                <version>${org.eclipse.persistence.eclipselink.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commonj.sdo</artifactId>
+                        <groupId>org.eclipse.persistence</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>javax.persistence</artifactId>
+                <version>${org.eclipse.persistence.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>

--- a/wsmaster/che-core-api-user/pom.xml
+++ b/wsmaster/che-core-api-user/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>
@@ -69,8 +73,23 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -80,7 +99,17 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc-vendor-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -114,16 +143,6 @@
     </dependencies>
     <build>
         <plugins>
-            <!-- Skip tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/spi/tck/*.*</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
             <!-- Create the test jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/JpaProfileDao.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/JpaProfileDao.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jdbc.jpa.DuplicateKeyException;
+import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
+import org.eclipse.che.api.user.server.spi.ProfileDao;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@Singleton
+public class JpaProfileDao implements ProfileDao {
+
+    @Inject
+    private EntityManagerFactory factory;
+
+    @Override
+    public void create(ProfileImpl profile) throws ServerException, ConflictException {
+        requireNonNull(profile, "Required non-null profile");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            manager.getTransaction().begin();
+            manager.persist(profile);
+            manager.getTransaction().commit();
+        } catch (DuplicateKeyException x) {
+            throw new ConflictException(format("Profile for user with id '%s' already exists", profile.getUserId()));
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            if (manager.getTransaction().isActive()) {
+                manager.getTransaction().rollback();
+            }
+            manager.close();
+        }
+    }
+
+    @Override
+    public void update(ProfileImpl profile) throws NotFoundException, ServerException {
+        requireNonNull(profile, "Required non-null profile");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            manager.getTransaction().begin();
+            if (manager.find(ProfileImpl.class, profile.getUserId()) == null) {
+                throw new NotFoundException(format("Couldn't update profile, because profile for user with id '%s' doesn't exist",
+                                                   profile.getUserId()));
+            }
+            manager.merge(profile);
+            manager.getTransaction().commit();
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            if (manager.getTransaction().isActive()) {
+                manager.getTransaction().rollback();
+            }
+            manager.close();
+        }
+    }
+
+    @Override
+    public void remove(String id) throws ServerException {
+        requireNonNull(id, "Required non-null id");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            manager.getTransaction().begin();
+            final ProfileImpl profile = manager.find(ProfileImpl.class, id);
+            if (profile != null) {
+                manager.remove(profile);
+            }
+            manager.getTransaction().commit();
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            if (manager.getTransaction().isActive()) {
+                manager.getTransaction().rollback();
+            }
+            manager.close();
+        }
+    }
+
+    @Override
+    public ProfileImpl getById(String userId) throws NotFoundException, ServerException {
+        requireNonNull(userId, "Required non-null id");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            final ProfileImpl profile = manager.find(ProfileImpl.class, userId);
+            if (profile == null) {
+                throw new NotFoundException(format("Couldn't find profile for user with id '%s'", userId));
+            }
+            manager.refresh(profile);
+            return profile;
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            manager.close();
+        }
+    }
+}

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/JpaUserDao.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/JpaUserDao.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jdbc.jpa.DuplicateKeyException;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.user.server.spi.UserDao;
+import org.eclipse.che.security.PasswordEncryptor;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class JpaUserDao implements UserDao {
+
+    @Inject
+    private EntityManagerFactory factory;
+    @Inject
+    private PasswordEncryptor    encryptor;
+
+    @Override
+    public UserImpl getByAliasAndPassword(String emailOrAliasOrName, String password) throws NotFoundException, ServerException {
+        requireNonNull(emailOrAliasOrName, "Required non-null alias");
+        requireNonNull(password, "Required non-null password");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            final UserImpl user = manager.createQuery("SELECT distinct(u) " +
+                                                      "FROM User u " +
+                                                      "WHERE u.name = :alias OR u.email = :alias OR :alias MEMBER OF u.aliases",
+                                                      UserImpl.class)
+                                         .setParameter("alias", emailOrAliasOrName)
+                                         .getSingleResult();
+            if (!encryptor.test(password, user.getPassword())) {
+                throw new NotFoundException(format("User with alias '%s' and given password doesn't exist", emailOrAliasOrName));
+            }
+            return user;
+        } catch (NoResultException x) {
+            throw new NotFoundException(format("User with alias '%s' and given password doesn't exist", emailOrAliasOrName));
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        }
+    }
+
+    @Override
+    public void create(UserImpl user) throws ConflictException, ServerException {
+        requireNonNull(user, "Required non-null user");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            manager.getTransaction().begin();
+            manager.persist(user);
+            manager.getTransaction().commit();
+        } catch (DuplicateKeyException x) {
+            // TODO make more concrete
+            throw new ConflictException("User with such id/name/email/alias already exists");
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            if (manager.getTransaction().isActive()) {
+                manager.getTransaction().rollback();
+            }
+            manager.close();
+        }
+    }
+
+    @Override
+    public void update(UserImpl update) throws NotFoundException, ServerException, ConflictException {
+        requireNonNull(update, "Required non-null update");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            manager.getTransaction().begin();
+            if (manager.find(UserImpl.class, update.getId()) == null) {
+                throw new NotFoundException(format("Couldn't update user with id '%s' because it doesn't exist", update.getId()));
+            }
+            manager.merge(update);
+            manager.getTransaction().commit();
+        } catch (DuplicateKeyException x) {
+            // TODO make more concrete
+            throw new ConflictException("User with such name/email/alias already exists");
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            if (manager.getTransaction().isActive()) {
+                manager.getTransaction().rollback();
+            }
+            manager.close();
+        }
+    }
+
+    @Override
+    public void remove(String id) throws ServerException, ConflictException {
+        requireNonNull(id, "Required non-null id");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            manager.getTransaction().begin();
+            final UserImpl user = manager.find(UserImpl.class, id);
+            if (user != null) {
+                manager.remove(user);
+            }
+            manager.getTransaction().commit();
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            if (manager.getTransaction().isActive()) {
+                manager.getTransaction().rollback();
+            }
+            manager.close();
+        }
+    }
+
+    @Override
+    public UserImpl getByAlias(String alias) throws NotFoundException, ServerException {
+        requireNonNull(alias, "Required non-null alias");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            return manager.createQuery("SELECT u FROM User u WHERE :alias MEMBER OF u.aliases", UserImpl.class)
+                          .setParameter("alias", alias)
+                          .getSingleResult();
+        } catch (NoResultException x) {
+            throw new NotFoundException(format("User with alias '%s' doesn't exist", alias));
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Override
+    public UserImpl getById(String id) throws NotFoundException, ServerException {
+        requireNonNull(id, "Required non-null id");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            final UserImpl user = manager.find(UserImpl.class, id);
+            if (user == null) {
+                throw new NotFoundException(format("User with id '%s' doesn't exist", id));
+            }
+            return user;
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Override
+    public UserImpl getByName(String name) throws NotFoundException, ServerException {
+        requireNonNull(name, "Required non-null name");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            return manager.createQuery("SELECT u FROM User u WHERE u.name = :name", UserImpl.class)
+                          .setParameter("name", name)
+                          .getSingleResult();
+        } catch (NoResultException x) {
+            throw new NotFoundException(format("User with name '%s' doesn't exist", name));
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Override
+    public UserImpl getByEmail(String email) throws NotFoundException, ServerException {
+        requireNonNull(email, "Required non-null email");
+        final EntityManager manager = factory.createEntityManager();
+        try {
+            return manager.createQuery("SELECT u FROM User u WHERE u.email = :email", UserImpl.class)
+                          .setParameter("email", email)
+                          .getSingleResult();
+        } catch (NoResultException x) {
+            throw new NotFoundException(format("User with email '%s' doesn't exist", email));
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        } finally {
+            manager.close();
+        }
+    }
+}

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/ProfileImpl.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/ProfileImpl.java
@@ -12,6 +12,15 @@ package org.eclipse.che.api.user.server.model.impl;
 
 import org.eclipse.che.api.core.model.user.Profile;
 
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.UniqueConstraint;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -21,17 +30,30 @@ import java.util.Objects;
  *
  * @author Yevhenii Voevodin
  */
+@Entity(name = "Profile")
 public class ProfileImpl implements Profile {
 
-    private String              id;
+    @Id
+    private String userId;
+
+    @PrimaryKeyJoinColumn
+    private UserImpl user;
+
+    @ElementCollection
+    @MapKeyColumn(name = "name")
+    @Column(name = "value")
+    @CollectionTable(joinColumns = @JoinColumn(name = "user_id"),
+                     uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "name"}))
     private Map<String, String> attributes;
 
-    public ProfileImpl(String id) {
-        this.id = id;
+    public ProfileImpl() {}
+
+    public ProfileImpl(String userId) {
+        this.userId = userId;
     }
 
-    public ProfileImpl(String id, Map<String, String> attributes) {
-        this.id = id;
+    public ProfileImpl(String userId, Map<String, String> attributes) {
+        this.userId = userId;
         if (attributes != null) {
             this.attributes = new HashMap<>(attributes);
         }
@@ -41,9 +63,18 @@ public class ProfileImpl implements Profile {
         this(profile.getUserId(), profile.getAttributes());
     }
 
+    public ProfileImpl(ProfileImpl profile) {
+        this(profile.getUserId(), profile.getAttributes());
+        this.user = profile.user;
+    }
+
     @Override
     public String getUserId() {
-        return id;
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
     @Override
@@ -52,6 +83,10 @@ public class ProfileImpl implements Profile {
             this.attributes = new HashMap<>();
         }
         return attributes;
+    }
+
+    public UserImpl getUser() {
+        return user;
     }
 
     public void setAttributes(Map<String, String> attributes) {
@@ -67,13 +102,13 @@ public class ProfileImpl implements Profile {
             return false;
         }
         final ProfileImpl that = (ProfileImpl)obj;
-        return Objects.equals(id, that.id) && getAttributes().equals(that.getAttributes());
+        return Objects.equals(userId, that.userId) && getAttributes().equals(that.getAttributes());
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(userId);
         hash = 31 * hash + getAttributes().hashCode();
         return hash;
     }
@@ -81,7 +116,7 @@ public class ProfileImpl implements Profile {
     @Override
     public String toString() {
         return "ProfileImpl{" +
-               "id='" + id + '\'' +
+               "userId='" + userId + '\'' +
                ", attributes=" + attributes +
                '}';
     }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
@@ -12,6 +12,13 @@ package org.eclipse.che.api.user.server.model.impl;
 
 import org.eclipse.che.api.core.model.user.User;
 
+import javax.persistence.Basic;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -22,13 +29,27 @@ import java.util.Objects;
  *
  * @author Yevhenii Voevodin
  */
+@Entity(name = "User")
 public class UserImpl implements User {
 
-    private String       id;
-    private String       email;
-    private String       name;
-    private String       password;
+    @Id
+    private String id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @Basic
+    private String password;
+
+    @ElementCollection
+    @Column(name = "alias", nullable = false, unique = true)
+    @CollectionTable(name = "user_aliases", joinColumns = @JoinColumn(name = "user_id"))
     private List<String> aliases;
+
+    public UserImpl() {}
 
     public UserImpl(String id) {
         this.id = id;
@@ -63,6 +84,10 @@ public class UserImpl implements User {
     @Override
     public String getId() {
         return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     @Override

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/spi/UserDao.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/spi/UserDao.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.user.server.spi;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 
 /**
@@ -33,22 +32,21 @@ import org.eclipse.che.api.user.server.model.impl.UserImpl;
 public interface UserDao {
 
     /**
-     * // TODO remove this method from spi
-     * Authenticates user.
+     * Gets user by alias and password
      *
      * @param emailOrAliasOrName
-     *         one of the user identifiers such as email/name/alias
+     *         one of user aliases such as email/name/alias(but not id)
      * @param password
      *         password
      * @return user identifier
      * @throws NullPointerException
      *         when either {@code emailOrAliasOrName} or {@code password} is null
-     * @throws UnauthorizedException
-     *         when user with such {@code aliasOrName} and {@code password} doesn't exist
+     * @throws NotFoundException
+     *         when user with such {@code emailOrAliasOrName} and {@code password} doesn't exist
      * @throws ServerException
      *         when any other error occurs
      */
-    String authenticate(String emailOrAliasOrName, String password) throws UnauthorizedException, ServerException;
+    UserImpl getByAliasAndPassword(String emailOrAliasOrName, String password) throws NotFoundException, ServerException;
 
     /**
      * Creates a new user.

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/H2DBServerListener.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/H2DBServerListener.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import org.eclipse.che.commons.test.tck.AbstractTestListener;
+import org.eclipse.persistence.config.TargetServer;
+import org.testng.ITestContext;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import java.util.HashMap;
+import java.util.Map;
+
+import static javax.persistence.spi.PersistenceUnitTransactionType.RESOURCE_LOCAL;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.EXCEPTION_HANDLER_CLASS;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_DRIVER;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_PASSWORD;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_URL;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_USER;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.TARGET_SERVER;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.TRANSACTION_TYPE;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class H2DBServerListener extends AbstractTestListener {
+
+    public static final String ENTITY_MANAGER_FACTORY_ATTR_NAME = "entityManagerFactory";
+
+    private EntityManagerFactory managerFactory;
+
+    @Override
+    public void onStart(ITestContext context) {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(TRANSACTION_TYPE, RESOURCE_LOCAL.name());
+        properties.put(JDBC_DRIVER, "org.h2.Driver");
+        properties.put(JDBC_URL, "jdbc:h2:mem:;DB_CLOSE_DELAY=0;MVCC=true;TRACE_LEVEL_FILE=4;TRACE_LEVEL_SYSTEM_OUT=4");
+        properties.put(JDBC_USER, "");
+        properties.put(JDBC_PASSWORD, "");
+        properties.put(TARGET_SERVER, TargetServer.None);
+        properties.put(EXCEPTION_HANDLER_CLASS, "org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler");
+
+        managerFactory = Persistence.createEntityManagerFactory("main", properties);
+        context.setAttribute(ENTITY_MANAGER_FACTORY_ATTR_NAME, managerFactory);
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+        managerFactory.close();
+    }
+}

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/JpaTckModule.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/JpaTckModule.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import com.google.common.reflect.Reflection;
+import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+
+import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.user.server.spi.ProfileDao;
+import org.eclipse.che.api.user.server.spi.UserDao;
+import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.security.PasswordEncryptor;
+import org.eclipse.che.security.SHA512PasswordEncryptor;
+
+import javax.persistence.EntityManagerFactory;
+
+import static org.eclipse.che.api.user.server.jpa.H2DBServerListener.ENTITY_MANAGER_FACTORY_ATTR_NAME;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class JpaTckModule extends TckModule {
+
+    @Override
+    protected void configure() {
+        final EntityManagerFactory factoryProxy = Reflection.newProxy(EntityManagerFactory.class, (proxy, method, args) -> {
+            if (method.getName().startsWith("createEntityManager")) {
+                final EntityManagerFactory factory = (EntityManagerFactory)getTestContext().getAttribute(ENTITY_MANAGER_FACTORY_ATTR_NAME);
+                return factory.createEntityManager();
+            }
+            return null;
+        });
+        bind(EntityManagerFactory.class).toInstance(factoryProxy);
+
+        bind(new TypeLiteral<TckRepository<UserImpl>>() {}).to(UserJpaTckRepository.class);
+        bind(new TypeLiteral<TckRepository<ProfileImpl>>() {}).to(ProfileJpaTckRepository.class);
+
+        bind(UserDao.class).to(JpaUserDao.class);
+        bind(ProfileDao.class).to(JpaProfileDao.class);
+        // SHA-512 ecnryptor is faster than PBKDF2 so it is better for testing
+        bind(PasswordEncryptor.class).to(SHA512PasswordEncryptor.class).in(Singleton.class);
+    }
+}

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/ProfileJpaTckRepository.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/ProfileJpaTckRepository.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import java.util.Collection;
+
+import static java.util.Collections.emptyList;
+
+public class ProfileJpaTckRepository implements TckRepository<ProfileImpl> {
+
+    @Inject
+    private EntityManagerFactory factory;
+
+    @Override
+    public void createAll(Collection<? extends ProfileImpl> entities) throws TckRepositoryException {
+        final EntityManager manager = factory.createEntityManager();
+        manager.getTransaction().begin();
+        for (ProfileImpl profile : entities) {
+            manager.persist(new UserImpl(profile.getUserId(),
+                                         profile.getUserId() + "@eclipse.org",
+                                         profile.getUserId(),
+                                         "password",
+                                         emptyList()));
+            manager.persist(profile);
+        }
+        manager.getTransaction().commit();
+        manager.close();
+    }
+
+    @Override
+    public void removeAll() throws TckRepositoryException {
+        final EntityManager manager = factory.createEntityManager();
+        manager.getTransaction().begin();
+        manager.createQuery("DELETE FROM Profile").executeUpdate();
+        manager.createQuery("DELETE FROM User").executeUpdate();
+        manager.getTransaction().commit();
+        manager.close();
+    }
+}

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/UserJpaTckRepository.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/UserJpaTckRepository.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
+import org.eclipse.che.security.PasswordEncryptor;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import java.util.Collection;
+
+public class UserJpaTckRepository implements TckRepository<UserImpl> {
+
+    @Inject
+    private EntityManagerFactory factory;
+
+    @Inject
+    private PasswordEncryptor encryptor;
+
+    @Override
+    public void createAll(Collection<? extends UserImpl> entities) throws TckRepositoryException {
+        final EntityManager manager = factory.createEntityManager();
+        manager.getTransaction().begin();
+        entities.stream()
+                .map(user -> new UserImpl(user.getId(),
+                                          user.getEmail(),
+                                          user.getName(),
+                                          encryptor.encrypt(user.getPassword()),
+                                          user.getAliases()))
+                .forEach(manager::persist);
+        manager.getTransaction().commit();
+        manager.close();
+    }
+
+    @Override
+    public void removeAll() throws TckRepositoryException {
+        final EntityManager manager = factory.createEntityManager();
+        manager.getTransaction().begin();
+        manager.createQuery("DELETE FROM User").executeUpdate();
+        manager.getTransaction().commit();
+        manager.close();
+    }
+}

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/ProfileDaoTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/ProfileDaoTest.java
@@ -92,16 +92,14 @@ public class ProfileDaoTest {
         profileDao.getById(null);
     }
 
-    @Test(dependsOnMethods = "shouldGetProfileById")
+    @Test(dependsOnMethods = {"shouldGetProfileById", "shouldRemoveProfile"})
     public void shouldCreateProfile() throws Exception {
-        final ProfileImpl newProfile = new ProfileImpl("user123",
-                                                       ImmutableMap.of("attribute1", "value1",
-                                                                       "attribute2", "value2",
-                                                                       "attribute3", "value3"));
+        final ProfileImpl profile = profiles[0];
 
-        profileDao.create(newProfile);
+        profileDao.remove(profile.getUserId());
+        profileDao.create(profile);
 
-        assertEquals(profileDao.getById(newProfile.getUserId()), newProfile);
+        assertEquals(profileDao.getById(profile.getUserId()), profile);
     }
 
     @Test(expectedExceptions = ConflictException.class)

--- a/wsmaster/che-core-api-user/src/test/resources/META-INF/persistence.xml
+++ b/wsmaster/che-core-api-user/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" version="1.0">
+    <persistence-unit name="main" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.che.api.user.server.model.impl.UserImpl</class>
+        <class>org.eclipse.che.api.user.server.model.impl.ProfileImpl</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="database"/>
+
+            <!-- Logging configuration. -->
+            <property name="eclipselink.logging.logger" value="DefaultLogger"/>
+            <property name="eclipselink.logging.level" value="INFO"/>
+            <!--property name="eclipselink.logging.sql" value="FINEST"/>
+            <property name="eclipselink.logging.level.sql" value="FINEST"/>
+            <property name="eclipselink.logging.parameters" value="true"/-->
+        </properties>
+
+    </persistence-unit>
+</persistence>

--- a/wsmaster/che-core-api-user/src/test/resources/META-INF/services/org.eclipse.che.commons.test.tck.TckModule
+++ b/wsmaster/che-core-api-user/src/test/resources/META-INF/services/org.eclipse.che.commons.test.tck.TckModule
@@ -1,0 +1,1 @@
+org.eclipse.che.api.user.server.jpa.JpaTckModule

--- a/wsmaster/che-core-api-user/src/test/resources/META-INF/services/org.testng.ITestNGListener
+++ b/wsmaster/che-core-api-user/src/test/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,1 @@
+org.eclipse.che.api.user.server.jpa.H2DBServerListener

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalProfileDaoImpl.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalProfileDaoImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.che.api.local.storage.LocalStorageFactory;
 import org.eclipse.che.api.core.model.user.Profile;
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.spi.ProfileDao;
-import org.eclipse.che.api.user.server.spi.UserDao;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalUserDaoImpl.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalUserDaoImpl.java
@@ -17,7 +17,6 @@ import com.google.common.reflect.TypeToken;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.local.storage.LocalStorage;
 import org.eclipse.che.api.local.storage.LocalStorageFactory;
@@ -91,7 +90,7 @@ public class LocalUserDaoImpl implements UserDao {
     }
 
     @Override
-    public String authenticate(String aliasOrNameOrEmail, String password) throws UnauthorizedException, ServerException {
+    public UserImpl getByAliasAndPassword(String aliasOrNameOrEmail, String password) throws ServerException, NotFoundException {
         requireNonNull(aliasOrNameOrEmail);
         requireNonNull(password);
         rwLock.readLock().lock();
@@ -103,9 +102,9 @@ public class LocalUserDaoImpl implements UserDao {
                                                                     || user.getAliases().contains(aliasOrNameOrEmail))
                                                     .findAny();
             if (!userOpt.isPresent() || !userOpt.get().getPassword().equals(password)) {
-                throw new UnauthorizedException(format("Authentication failed for user '%s'", aliasOrNameOrEmail));
+                throw new NotFoundException(format("User '%s' doesn't exist", aliasOrNameOrEmail));
             }
-            return userOpt.get().getId();
+            return userOpt.get();
         } finally {
             rwLock.readLock().unlock();
         }


### PR DESCRIPTION
Along with JPA implementations i added 2 password encryptors _SHA-512_ and _PBKDF2_.
`JpaUserDao` and `JpaProfileDao` pass all the TCK prepared before. 

@skabashnyuk, @sleshchenko, @garagatyi, @akorneta  can you please review.
Please note that this will be merged into the `jpa-integration` branch which will be merged to the master when all the DAOs are migrated to JPA.
