### PR TITLE
CODENVY-606: fix NPE in DockerInstanceStopDetector

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/Actor.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/Actor.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+/**
+ * Represents Actor field of {@link Event}.
+ *
+ * @author Mykola Morhun
+ */
+public class Actor {
+    @SerializedName("ID")
+    private String             id;
+    @SerializedName("Attributes")
+    private Map<String,String> attributes;
+
+    public String getId() {
+        return id;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public Actor withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public Actor withAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Actor{" +
+               "id='" + id + '\'' +
+               ", attributes=" + attributes +
+               '}';
+    }
+
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/Event.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/Event.java
@@ -10,16 +10,30 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.client.json;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Docker event.
  *
  * @author Alexander Garagatyi
+ * @author Mykola Morhun
  */
 public class Event {
+    @SerializedName("status")
     private String status;
+    @SerializedName("id")
     private String id;
+    @SerializedName("from")
     private String from;
+    @SerializedName("Type")
+    private String type;
+    @SerializedName("Action")
+    private String action;
+    @SerializedName("Actor")
+    private Actor  actor;
+    @SerializedName("time")
     private long   time;
+    @SerializedName("timeNano")
     private long   timeNano;
 
     public long getTime() {
@@ -36,6 +50,18 @@ public class Event {
 
     public String getStatus() {
         return status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public Actor getActor() {
+        return actor;
     }
 
     public long getTimeNano() {
@@ -57,6 +83,21 @@ public class Event {
         return this;
     }
 
+    public Event withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public Event withAction(String action) {
+        this.action = action;
+        return this;
+    }
+
+    public Event withActor(Actor actor) {
+        this.actor = actor;
+        return this;
+    }
+
     public Event withTime(long time) {
         this.time = time;
         return this;
@@ -73,6 +114,9 @@ public class Event {
                "status='" + status + '\'' +
                ", id='" + id + '\'' +
                ", from='" + from + '\'' +
+               ", type='" + type + '\'' +
+               ", action='" + action + '\'' +
+               ", actor='" + actor + '\'' +
                ", time=" + time +
                ", timeNano=" + timeNano +
                '}';


### PR DESCRIPTION
We had NPE in `DockerInstanceStopDetector` because of new format of docker response to `get events` method and bug in docker swarm which do not filter events.
This PR adapts expected format of `get events` response and adds check for event type in response processing.
