### PR TITLE
CHE-1353: Add possibility to configure specific docker api version

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -73,6 +73,7 @@ machine.docker.unused_containers_cleanup_period_min=60
 #docker.registry.auth.your_registry_name.username=user-name
 #docker.registry.auth.your_registry_name.password=user-password
 
+docker.api.version=1.20
 docker.connection.tcp.connection_timeout_ms=600000
 docker.connection.tcp.read_timeout_ms=600000
 

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerApiVersionPathPrefixProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerApiVersionPathPrefixProvider.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+/**
+ * This class provides docker api version path prefix that should be used in Docker API calls. See {@link DockerConnector}.
+ *
+ * @author Alexander Andrienko
+ */
+@Singleton
+public class DockerApiVersionPathPrefixProvider implements Provider<String> {
+
+    //Supports docker api version value in format: '1', '1.18' etc.
+    private static final Pattern VERSION_API_PATTERN    = Pattern.compile("([0-9]+)(\\.[0-9]+)?");
+    private static final String  VALID_PROPERTY_EXAMPLE =
+            "Valid docker api version contains digits which can be separated by symbol '.'. For example: '1', '1.18'";
+
+    public static final String MACHINE_DOCKER_API_VERSION = "docker.api.version";
+
+    private final String apiVersionPrefixPath;
+
+    @Inject
+    public DockerApiVersionPathPrefixProvider(@Named(MACHINE_DOCKER_API_VERSION) String apiVersion) {
+        if (apiVersion.isEmpty()) {
+            this.apiVersionPrefixPath = "";
+            return;
+        }
+        Matcher matcher = VERSION_API_PATTERN.matcher(apiVersion);
+        if (matcher.matches()) {
+            this.apiVersionPrefixPath = "/v" + apiVersion;
+            return;
+        }
+        throw new IllegalArgumentException(format("Invalid property format: '%s'. %s", MACHINE_DOCKER_API_VERSION, VALID_PROPERTY_EXAMPLE));
+    }
+
+    @Override
+    public String get() {
+        return apiVersionPrefixPath;
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/InitialAuthConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/InitialAuthConfig.java
@@ -106,7 +106,7 @@ public class InitialAuthConfig {
 
         String propertyIdentifier = parts[1];
         if (!URL.equals(propertyIdentifier) && !USER_NAME.equals(propertyIdentifier) && !PASSWORD.equals(propertyIdentifier)) {
-            LOG.warn("Set unused property: {}.", propertyName);
+            LOG.warn("Set unused property: '{}'.", propertyName);
         }
 
         return CONFIG_PREFIX + parts[0] + ".";

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerApiVersionPathPrefixProviderTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerApiVersionPathPrefixProviderTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client;
+
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test for {@link DockerApiVersionPathPrefixProvider}
+ *
+ * @author Alexander Andrienko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class DockerApiVersionPathPrefixProviderTest {
+
+    private static DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider;
+
+    @DataProvider(name = "validApiVersionValues")
+    public static Object[][] validApiVersionValues() {
+        return new Object[][] {
+            {"", ""},
+            {"1", "/v1"},
+            {"1.18", "/v1.18"}
+        };
+    }
+
+    @Test(dataProvider = "validApiVersionValues")
+    public void apiVersionPrefixShouldBeEmpty(String apiVersion, String expectedApiVersionPrefix) {
+        dockerApiVersionPathPrefixProvider = new DockerApiVersionPathPrefixProvider(apiVersion);
+
+        assertEquals(dockerApiVersionPathPrefixProvider.get(), expectedApiVersionPrefix);
+    }
+
+    @DataProvider(name = "invalidApiVersionValues")
+    public static Object[][] invalidApiVersionValues() {
+        return new Object[][] {
+                {"invalid"},
+                {"1 .18"},
+                {".1.18"},
+                {"1..18"},
+                {"1-18"},
+                {"1$18"},
+                {"1%18"},
+                {"1*18"},
+                {"1_18"},
+                {"1   18"},
+                {"1,,18"},
+                {".1"},
+                {",1"},
+                {"1."},
+                {".1."},
+                {",1,"},
+                {"1,18 "},
+                {"1a18 "},
+                {"1B18 "},
+                {"a1"},
+                {"1a"},
+                {"Ab"},
+                {"1.18a"}
+        };
+    }
+
+    @Test(dataProvider = "invalidApiVersionValues",
+          expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = "Invalid property format: '.*'. Valid docker api version contains digits " +
+                                            "which can be separated by symbol '.'. For example: '1', '1.18'")
+    public void apiVersionPrefixShouldBeEmpty(String apiVersion) {
+        dockerApiVersionPathPrefixProvider = new DockerApiVersionPathPrefixProvider(apiVersion);
+    }
+}
+

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/integration/DockerProcessTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/integration/DockerProcessTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.model.machine.Command;
 import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
+import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
 import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
@@ -53,7 +54,8 @@ public class DockerProcessTest {
                                                                         new DefaultNetworkFinder());
         docker = new DockerConnector(dockerConnectorConfiguration,
                                      new DockerConnectionFactory(dockerConnectorConfiguration),
-                                     new DockerRegistryAuthResolver(null));
+                                     new DockerRegistryAuthResolver(null),
+                                     new DockerApiVersionPathPrefixProvider("1.18"));
 
         final ContainerCreated containerCreated = docker.createContainer(
                 CreateContainerParams.create(new ContainerConfig().withImage("ubuntu")
@@ -91,7 +93,8 @@ public class DockerProcessTest {
                                                                             new DefaultNetworkFinder());
             docker = new DockerConnector(dockerConnectorConfiguration,
                                          new DockerConnectionFactory(dockerConnectorConfiguration),
-                                         new DockerRegistryAuthResolver(null));
+                                         new DockerRegistryAuthResolver(null),
+                                         new DockerApiVersionPathPrefixProvider(""));
         }
         Command command = new CommandImpl("tailf", "tail -f /dev/null", "mvn");
         final DockerProcess dockerProcess = new DockerProcess(docker,


### PR DESCRIPTION
Add possibility to configure api version by che.properties. Set minimum default docker api version 1.20.
