### PR TITLE
Improve docker client

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
@@ -15,6 +15,7 @@ import org.eclipse.che.plugin.docker.client.json.container.NetworkingConfig;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /** @author andrew00x */
 public class ContainerConfig {
@@ -359,6 +360,71 @@ public class ContainerConfig {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ContainerConfig)) {
+            return false;
+        }
+        final ContainerConfig that = (ContainerConfig)obj;
+        return cpuShares == that.cpuShares
+               && attachStdin == that.attachStdin
+               && attachStdout == that.attachStdout
+               && attachStderr == that.attachStderr
+               && tty == that.tty
+               && openStdin == that.openStdin
+               && stdinOnce == that.stdinOnce
+               && networkDisabled == that.networkDisabled
+               && Objects.equals(domainName, that.domainName)
+               && Objects.equals(cpuset, that.cpuset)
+               && Arrays.equals(env, that.env)
+               && Arrays.equals(cmd, that.cmd)
+               && Arrays.equals(entrypoint, that.entrypoint)
+               && Objects.equals(image, that.image)
+               && Objects.equals(macAddress, that.macAddress)
+               && Arrays.equals(securityOpts, that.securityOpts)
+               && Objects.equals(hostConfig, that.hostConfig)
+               && Objects.equals(networkingConfig, that.networkingConfig)
+               && getExposedPorts().equals(that.getExposedPorts())
+               && Objects.equals(user, that.user)
+               && Objects.equals(hostname, that.hostname)
+               && Objects.equals(workingDir, that.workingDir)
+               && getVolumes().equals(that.getVolumes())
+               && getLabels().equals(that.getLabels());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(domainName);
+        hash = 31 * hash + cpuShares;
+        hash = 31 * hash + Objects.hashCode(cpuset);
+        hash = 31 * hash + Boolean.hashCode(attachStdin);
+        hash = 31 * hash + Boolean.hashCode(attachStdout);
+        hash = 31 * hash + Boolean.hashCode(attachStderr);
+        hash = 31 * hash + Boolean.hashCode(tty);
+        hash = 31 * hash + Boolean.hashCode(openStdin);
+        hash = 31 * hash + Boolean.hashCode(stdinOnce);
+        hash = 31 * hash + Arrays.hashCode(env);
+        hash = 31 * hash + Arrays.hashCode(cmd);
+        hash = 31 * hash + Arrays.hashCode(entrypoint);
+        hash = 31 * hash + Objects.hashCode(image);
+        hash = 31 * hash + Boolean.hashCode(networkDisabled);
+        hash = 31 * hash + Objects.hashCode(macAddress);
+        hash = 31 * hash + Arrays.hashCode(securityOpts);
+        hash = 31 * hash + Objects.hashCode(hostConfig);
+        hash = 31 * hash + Objects.hashCode(networkingConfig);
+        hash = 31 * hash + getExposedPorts().hashCode();
+        hash = 31 * hash + Objects.hashCode(user);
+        hash = 31 * hash + Objects.hashCode(hostname);
+        hash = 31 * hash + Objects.hashCode(workingDir);
+        hash = 31 * hash + getVolumes().hashCode();
+        hash = 31 * hash + getLabels().hashCode();
+        return hash;
+    }
+
+    @Override
     public String toString() {
         return "ContainerConfig{" +
                "domainName='" + domainName + '\'' +
@@ -372,19 +438,19 @@ public class ContainerConfig {
                ", stdinOnce=" + stdinOnce +
                ", env=" + Arrays.toString(env) +
                ", cmd=" + Arrays.toString(cmd) +
-               ", entrypoint='" + Arrays.toString(entrypoint) + '\'' +
+               ", entrypoint=" + Arrays.toString(entrypoint) +
                ", image='" + image + '\'' +
                ", networkDisabled=" + networkDisabled +
                ", macAddress='" + macAddress + '\'' +
                ", securityOpts=" + Arrays.toString(securityOpts) +
                ", hostConfig=" + hostConfig +
+               ", networkingConfig=" + networkingConfig +
                ", exposedPorts=" + exposedPorts +
                ", user='" + user + '\'' +
                ", hostname='" + hostname + '\'' +
                ", workingDir='" + workingDir + '\'' +
                ", volumes=" + volumes +
                ", labels=" + labels +
-               ", networkingConfig=" + networkingConfig +
                '}';
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
@@ -10,29 +10,32 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.client.json;
 
+import org.eclipse.che.plugin.docker.client.json.container.NetworkingConfig;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 /** @author andrew00x */
 public class ContainerConfig {
-    private String     domainName;
-    private int        cpuShares;
-    private String     cpuset;
-    private boolean    attachStdin;
-    private boolean    attachStdout;
-    private boolean    attachStderr;
-    private boolean    tty;
-    private boolean    openStdin;
-    private boolean    stdinOnce;
-    private String[]   env;
-    private String[]   cmd;
-    private String     entrypoint;
-    private String     image;
-    private boolean    networkDisabled;
-    private String     macAddress;
-    private String[]   securityOpts;
-    private HostConfig hostConfig;
+    private String           domainName;
+    private int              cpuShares;
+    private String           cpuset;
+    private boolean          attachStdin;
+    private boolean          attachStdout;
+    private boolean          attachStderr;
+    private boolean          tty;
+    private boolean          openStdin;
+    private boolean          stdinOnce;
+    private String[]         env;
+    private String[]         cmd;
+    private String[]         entrypoint;
+    private String           image;
+    private boolean          networkDisabled;
+    private String           macAddress;
+    private String[]         securityOpts;
+    private HostConfig       hostConfig;
+    private NetworkingConfig networkingConfig;
 
     // from docs for 1.15 API https://docs.docker.com/reference/api/docker_remote_api_v1.15/#create-a-container
     // An object mapping ports to an empty object in the form of: "ExposedPorts": { "<port>/<tcp|udp>: {}" }
@@ -127,7 +130,7 @@ public class ContainerConfig {
         return cmd;
     }
 
-    public void setCmd(String[] cmd) {
+    public void setCmd(String... cmd) {
         this.cmd = cmd;
     }
 
@@ -277,15 +280,15 @@ public class ContainerConfig {
         return this;
     }
 
-    public String getEntrypoint() {
+    public String[] getEntrypoint() {
         return entrypoint;
     }
 
-    public void setEntrypoint(String entrypoint) {
+    public void setEntrypoint(String[] entrypoint) {
         this.entrypoint = entrypoint;
     }
 
-    public ContainerConfig withEntrypoint(String entrypoint) {
+    public ContainerConfig withEntrypoint(String[] entrypoint) {
         this.entrypoint = entrypoint;
         return this;
     }
@@ -342,6 +345,19 @@ public class ContainerConfig {
         return this;
     }
 
+    public NetworkingConfig getNetworkingConfig() {
+        return networkingConfig;
+    }
+
+    public void setNetworkingConfig(NetworkingConfig networkingConfig) {
+        this.networkingConfig = networkingConfig;
+    }
+
+    public ContainerConfig withNetworkingConfig(NetworkingConfig networkingConfig) {
+        this.networkingConfig = networkingConfig;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ContainerConfig{" +
@@ -356,7 +372,7 @@ public class ContainerConfig {
                ", stdinOnce=" + stdinOnce +
                ", env=" + Arrays.toString(env) +
                ", cmd=" + Arrays.toString(cmd) +
-               ", entrypoint='" + entrypoint + '\'' +
+               ", entrypoint='" + Arrays.toString(entrypoint) + '\'' +
                ", image='" + image + '\'' +
                ", networkDisabled=" + networkDisabled +
                ", macAddress='" + macAddress + '\'' +
@@ -368,6 +384,7 @@ public class ContainerConfig {
                ", workingDir='" + workingDir + '\'' +
                ", volumes=" + volumes +
                ", labels=" + labels +
+               ", networkingConfig=" + networkingConfig +
                '}';
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/NetworkCreated.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/NetworkCreated.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json;
+
+import java.util.Objects;
+
+/**
+ * Represents response from docker API on successful creation of network.
+ *
+ * author Alexander Garagatyi
+ */
+public class NetworkCreated {
+    private String id;
+    private String warning;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public NetworkCreated withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getWarning() {
+        return warning;
+    }
+
+    public void setWarning(String warning) {
+        this.warning = warning;
+    }
+
+    public NetworkCreated withWarning(String warning) {
+        this.warning = warning;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NetworkCreated)) return false;
+        NetworkCreated that = (NetworkCreated)o;
+        return Objects.equals(id, that.id) &&
+               Objects.equals(warning, that.warning);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, warning);
+    }
+
+    @Override
+    public String toString() {
+        return "NetworkCreated{" +
+               "id='" + id + '\'' +
+               ", warning='" + warning + '\'' +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/NetworkCreated.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/NetworkCreated.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 /**
  * Represents response from docker API on successful creation of network.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class NetworkCreated {
     private String id;
@@ -48,17 +48,24 @@ public class NetworkCreated {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof NetworkCreated)) return false;
-        NetworkCreated that = (NetworkCreated)o;
-        return Objects.equals(id, that.id) &&
-               Objects.equals(warning, that.warning);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NetworkCreated)) {
+            return false;
+        }
+        final NetworkCreated that = (NetworkCreated)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(warning, that.warning);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, warning);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(warning);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/container/NetworkingConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/container/NetworkingConfig.java
@@ -13,12 +13,11 @@ package org.eclipse.che.plugin.docker.client.json.container;
 import org.eclipse.che.plugin.docker.client.json.network.EndpointConfig;
 
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Represents description of network inside {@link org.eclipse.che.plugin.docker.client.json.ContainerConfig}
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class NetworkingConfig {
     private Map<String, EndpointConfig> endpointsConfig;
@@ -37,16 +36,22 @@ public class NetworkingConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof NetworkingConfig)) return false;
-        NetworkingConfig that = (NetworkingConfig)o;
-        return Objects.equals(endpointsConfig, that.endpointsConfig);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NetworkingConfig)) {
+            return false;
+        }
+        final NetworkingConfig that = (NetworkingConfig)obj;
+        return getEndpointsConfig().equals(that.getEndpointsConfig());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(endpointsConfig);
+        int hash = 7;
+        hash = 31 * hash + getEndpointsConfig().hashCode();
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/container/NetworkingConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/container/NetworkingConfig.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.container;
+
+import org.eclipse.che.plugin.docker.client.json.network.EndpointConfig;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents description of network inside {@link org.eclipse.che.plugin.docker.client.json.ContainerConfig}
+ *
+ * author Alexander Garagatyi
+ */
+public class NetworkingConfig {
+    private Map<String, EndpointConfig> endpointsConfig;
+
+    public Map<String, EndpointConfig> getEndpointsConfig() {
+        return endpointsConfig;
+    }
+
+    public void setEndpointsConfig(Map<String, EndpointConfig> endpointsConfig) {
+        this.endpointsConfig = endpointsConfig;
+    }
+
+    public NetworkingConfig withEndpointsConfig(Map<String, EndpointConfig> endpointsConfig) {
+        this.endpointsConfig = endpointsConfig;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NetworkingConfig)) return false;
+        NetworkingConfig that = (NetworkingConfig)o;
+        return Objects.equals(endpointsConfig, that.endpointsConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpointsConfig);
+    }
+
+    @Override
+    public String toString() {
+        return "NetworkingConfig{" +
+               "endpointsConfig=" + endpointsConfig +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ConnectContainer.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ConnectContainer.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Objects;
+
+/**
+ * Represents configuration that should be passed to docker API to connect container to network.
+ *
+ * author Alexander Garagatyi
+ */
+public class ConnectContainer {
+    private String         container;
+    private EndpointConfig endpointConfig;
+
+    public String getContainer() {
+        return container;
+    }
+
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    public ConnectContainer withContainer(String container) {
+        this.container = container;
+        return this;
+    }
+
+    public EndpointConfig getEndpointConfig() {
+        return endpointConfig;
+    }
+
+    public void setEndpointConfig(EndpointConfig endpointConfig) {
+        this.endpointConfig = endpointConfig;
+    }
+
+    public ConnectContainer withEndpointConfig(EndpointConfig endpointConfig) {
+        this.endpointConfig = endpointConfig;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ConnectContainer)) return false;
+        ConnectContainer that = (ConnectContainer)o;
+        return Objects.equals(container, that.container) &&
+               Objects.equals(endpointConfig, that.endpointConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(container, endpointConfig);
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectContainer{" +
+               "container='" + container + '\'' +
+               ", endpointConfig=" + endpointConfig +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ConnectContainer.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ConnectContainer.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 /**
  * Represents configuration that should be passed to docker API to connect container to network.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class ConnectContainer {
     private String         container;
@@ -48,17 +48,24 @@ public class ConnectContainer {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ConnectContainer)) return false;
-        ConnectContainer that = (ConnectContainer)o;
-        return Objects.equals(container, that.container) &&
-               Objects.equals(endpointConfig, that.endpointConfig);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ConnectContainer)) {
+            return false;
+        }
+        final ConnectContainer that = (ConnectContainer)obj;
+        return Objects.equals(container, that.container)
+               && Objects.equals(endpointConfig, that.endpointConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(container, endpointConfig);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(container);
+        hash = 31 * hash + Objects.hashCode(endpointConfig);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ContainerInNetwork.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ContainerInNetwork.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 /**
  * Represents description of container inside {@link Network}.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class ContainerInNetwork {
     private String name;
@@ -90,20 +90,30 @@ public class ContainerInNetwork {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ContainerInNetwork)) return false;
-        ContainerInNetwork that = (ContainerInNetwork)o;
-        return Objects.equals(name, that.name) &&
-               Objects.equals(endpointID, that.endpointID) &&
-               Objects.equals(macAddress, that.macAddress) &&
-               Objects.equals(iPv4Address, that.iPv4Address) &&
-               Objects.equals(iPv6Address, that.iPv6Address);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ContainerInNetwork)) {
+            return false;
+        }
+        final ContainerInNetwork that = (ContainerInNetwork)obj;
+        return Objects.equals(name, that.name)
+               && Objects.equals(endpointID, that.endpointID)
+               && Objects.equals(macAddress, that.macAddress)
+               && Objects.equals(iPv4Address, that.iPv4Address)
+               && Objects.equals(iPv6Address, that.iPv6Address);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, endpointID, macAddress, iPv4Address, iPv6Address);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(name);
+        hash = 31 * hash + Objects.hashCode(endpointID);
+        hash = 31 * hash + Objects.hashCode(macAddress);
+        hash = 31 * hash + Objects.hashCode(iPv4Address);
+        hash = 31 * hash + Objects.hashCode(iPv6Address);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ContainerInNetwork.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/ContainerInNetwork.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Objects;
+
+/**
+ * Represents description of container inside {@link Network}.
+ *
+ * author Alexander Garagatyi
+ */
+public class ContainerInNetwork {
+    private String name;
+    private String endpointID;
+    private String macAddress;
+    private String iPv4Address;
+    private String iPv6Address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ContainerInNetwork withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getEndpointID() {
+        return endpointID;
+    }
+
+    public void setEndpointID(String endpointID) {
+        this.endpointID = endpointID;
+    }
+
+    public ContainerInNetwork withEndpointID(String endpointID) {
+        this.endpointID = endpointID;
+        return this;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    public ContainerInNetwork withMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+        return this;
+    }
+
+    public String getIPv4Address() {
+        return iPv4Address;
+    }
+
+    public void setIPv4Address(String iPv4Address) {
+        this.iPv4Address = iPv4Address;
+    }
+
+    public ContainerInNetwork withIPv4Address(String iPv4Address) {
+        this.iPv4Address = iPv4Address;
+        return this;
+    }
+
+    public String getIPv6Address() {
+        return iPv6Address;
+    }
+
+    public void setiPv6Address(String iPv6Address) {
+        this.iPv6Address = iPv6Address;
+    }
+
+    public ContainerInNetwork withIPv6Address(String iPv6Address) {
+        this.iPv6Address = iPv6Address;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ContainerInNetwork)) return false;
+        ContainerInNetwork that = (ContainerInNetwork)o;
+        return Objects.equals(name, that.name) &&
+               Objects.equals(endpointID, that.endpointID) &&
+               Objects.equals(macAddress, that.macAddress) &&
+               Objects.equals(iPv4Address, that.iPv4Address) &&
+               Objects.equals(iPv6Address, that.iPv6Address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, endpointID, macAddress, iPv4Address, iPv6Address);
+    }
+
+    @Override
+    public String toString() {
+        return "ContainerInNetwork{" +
+               "name='" + name + '\'' +
+               ", endpointID='" + endpointID + '\'' +
+               ", macAddress='" + macAddress + '\'' +
+               ", iPv4Address='" + iPv4Address + '\'' +
+               ", iPv6Address='" + iPv6Address + '\'' +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/DisconnectContainer.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/DisconnectContainer.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Objects;
+
+/**
+ * Represents configuration that should be passed to docker API to disconnect container from network.
+ *
+ * author Alexander Garagatyi
+ */
+public class DisconnectContainer {
+    private String  container;
+    private boolean force;
+
+    public String getContainer() {
+        return container;
+    }
+
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    public DisconnectContainer withContainer(String container) {
+        this.container = container;
+        return this;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
+    public DisconnectContainer withForce(boolean force) {
+        this.force = force;
+        return  this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DisconnectContainer)) return false;
+        DisconnectContainer that = (DisconnectContainer)o;
+        return force == that.force &&
+               Objects.equals(container, that.container);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(container, force);
+    }
+
+    @Override
+    public String toString() {
+        return "DisconnectContainer{" +
+               "container='" + container + '\'' +
+               ", force=" + force +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/DisconnectContainer.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/DisconnectContainer.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 /**
  * Represents configuration that should be passed to docker API to disconnect container from network.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class DisconnectContainer {
     private String  container;
@@ -44,21 +44,28 @@ public class DisconnectContainer {
 
     public DisconnectContainer withForce(boolean force) {
         this.force = force;
-        return  this;
+        return this;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DisconnectContainer)) return false;
-        DisconnectContainer that = (DisconnectContainer)o;
-        return force == that.force &&
-               Objects.equals(container, that.container);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DisconnectContainer)) {
+            return false;
+        }
+        final DisconnectContainer that = (DisconnectContainer)obj;
+        return force == that.force
+               && Objects.equals(container, that.container);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(container, force);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(container);
+        hash = 31 * hash + Boolean.hashCode(force);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/EndpointConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/EndpointConfig.java
@@ -10,18 +10,18 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.client.json.network;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
  * Represents description of network needed to connect container into.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class EndpointConfig {
     private NewIpamConfig iPAMConfig;
-    private List<String>  links;
-    private List<String>  aliases;
+    private String[]      links;
+    private String[]      aliases;
 
     public NewIpamConfig getIPAMConfig() {
         return iPAMConfig;
@@ -36,53 +36,61 @@ public class EndpointConfig {
         return this;
     }
 
-    public List<String> getLinks() {
+    public String[] getLinks() {
         return links;
     }
 
-    public void setLinks(List<String> links) {
+    public void setLinks(String[] links) {
         this.links = links;
     }
 
-    public EndpointConfig withLinks(List<String> links) {
+    public EndpointConfig withLinks(String[] links) {
         this.links = links;
         return this;
     }
 
-    public List<String> getAliases() {
+    public String[] getAliases() {
         return aliases;
     }
 
-    public void setAliases(List<String> aliases) {
+    public void setAliases(String[] aliases) {
         this.aliases = aliases;
     }
 
-    public EndpointConfig withAliases(List<String> aliases) {
+    public EndpointConfig withAliases(String[] aliases) {
         this.aliases = aliases;
         return this;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof EndpointConfig)) return false;
-        EndpointConfig that = (EndpointConfig)o;
-        return Objects.equals(iPAMConfig, that.iPAMConfig) &&
-               Objects.equals(links, that.links) &&
-               Objects.equals(aliases, that.aliases);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof EndpointConfig)) {
+            return false;
+        }
+        final EndpointConfig that = (EndpointConfig)obj;
+        return Objects.equals(iPAMConfig, that.iPAMConfig)
+               && Arrays.equals(links, that.links)
+               && Arrays.equals(aliases, that.aliases);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(iPAMConfig, links, aliases);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(iPAMConfig);
+        hash = 31 * hash + Arrays.hashCode(links);
+        hash = 31 * hash + Arrays.hashCode(aliases);
+        return hash;
     }
 
     @Override
     public String toString() {
         return "EndpointConfig{" +
                "iPAMConfig=" + iPAMConfig +
-               ", links=" + links +
-               ", aliases=" + aliases +
+               ", links=" + Arrays.toString(links) +
+               ", aliases=" + Arrays.toString(aliases) +
                '}';
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/EndpointConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/EndpointConfig.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents description of network needed to connect container into.
+ *
+ * author Alexander Garagatyi
+ */
+public class EndpointConfig {
+    private NewIpamConfig iPAMConfig;
+    private List<String>  links;
+    private List<String>  aliases;
+
+    public NewIpamConfig getIPAMConfig() {
+        return iPAMConfig;
+    }
+
+    public void setIPAMConfig(NewIpamConfig iPAMConfig) {
+        this.iPAMConfig = iPAMConfig;
+    }
+
+    public EndpointConfig withIPAMConfig(NewIpamConfig iPAMConfig) {
+        this.iPAMConfig = iPAMConfig;
+        return this;
+    }
+
+    public List<String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<String> links) {
+        this.links = links;
+    }
+
+    public EndpointConfig withLinks(List<String> links) {
+        this.links = links;
+        return this;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
+
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
+    }
+
+    public EndpointConfig withAliases(List<String> aliases) {
+        this.aliases = aliases;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EndpointConfig)) return false;
+        EndpointConfig that = (EndpointConfig)o;
+        return Objects.equals(iPAMConfig, that.iPAMConfig) &&
+               Objects.equals(links, that.links) &&
+               Objects.equals(aliases, that.aliases);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(iPAMConfig, links, aliases);
+    }
+
+    @Override
+    public String toString() {
+        return "EndpointConfig{" +
+               "iPAMConfig=" + iPAMConfig +
+               ", links=" + links +
+               ", aliases=" + aliases +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Ipam.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Ipam.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class Ipam {
     private String              driver;
@@ -62,18 +62,26 @@ public class Ipam {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Ipam)) return false;
-        Ipam ipam = (Ipam)o;
-        return Objects.equals(driver, ipam.driver) &&
-               Objects.equals(config, ipam.config) &&
-               Objects.equals(options, ipam.options);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Ipam)) {
+            return false;
+        }
+        final Ipam that = (Ipam)obj;
+        return Objects.equals(driver, that.driver)
+               && getConfig().equals(that.getConfig())
+               && getOptions().equals(that.getOptions());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(driver, config, options);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(driver);
+        hash = 31 * hash + getConfig().hashCode();
+        hash = 31 * hash + getOptions().hashCode();
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Ipam.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Ipam.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * author Alexander Garagatyi
+ */
+public class Ipam {
+    private String              driver;
+    private List<IpamConfig>    config;
+    private Map<String, String> options;
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    public Ipam withDriver(String driver) {
+        this.driver = driver;
+        return this;
+    }
+
+    public List<IpamConfig> getConfig() {
+        return config;
+    }
+
+    public void setConfig(List<IpamConfig> config) {
+        this.config = config;
+    }
+
+    public Ipam withConfig(List<IpamConfig> config) {
+        this.config = config;
+        return this;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    public Ipam withOptions(Map<String, String> options) {
+        this.options = options;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Ipam)) return false;
+        Ipam ipam = (Ipam)o;
+        return Objects.equals(driver, ipam.driver) &&
+               Objects.equals(config, ipam.config) &&
+               Objects.equals(options, ipam.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(driver, config, options);
+    }
+
+    @Override
+    public String toString() {
+        return "Ipam{" +
+               "driver='" + driver + '\'' +
+               ", config=" + config +
+               ", options=" + options +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/IpamConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/IpamConfig.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Objects;
+
+/**
+ * author Alexander Garagatyi
+ */
+public class IpamConfig {
+    private String subnet;
+    private String gateway;
+    private String iPRange;
+
+    public String getSubnet() {
+        return subnet;
+    }
+
+    public void setSubnet(String subnet) {
+        this.subnet = subnet;
+    }
+
+    public IpamConfig withSubnet(String subnet) {
+        this.subnet = subnet;
+        return this;
+    }
+
+    public String getGateway() {
+        return gateway;
+    }
+
+    public void setGateway(String gateway) {
+        this.gateway = gateway;
+    }
+
+    public IpamConfig withGateway(String gateway) {
+        this.gateway = gateway;
+        return this;
+    }
+
+    public String getIPRange() {
+        return iPRange;
+    }
+
+    public void setIPRange(String iPRange) {
+        this.iPRange = iPRange;
+    }
+
+    public IpamConfig withIPRange(String iPRange) {
+        this.iPRange = iPRange;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IpamConfig)) return false;
+        IpamConfig that = (IpamConfig)o;
+        return Objects.equals(subnet, that.subnet) &&
+               Objects.equals(gateway, that.gateway) &&
+               Objects.equals(iPRange, that.iPRange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subnet, gateway, iPRange);
+    }
+
+    @Override
+    public String toString() {
+        return "IpamConfig{" +
+               "subnet='" + subnet + '\'' +
+               ", gateway='" + gateway + '\'' +
+               ", iPRange='" + iPRange + '\'' +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/IpamConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/IpamConfig.java
@@ -13,7 +13,7 @@ package org.eclipse.che.plugin.docker.client.json.network;
 import java.util.Objects;
 
 /**
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class IpamConfig {
     private String subnet;
@@ -60,18 +60,26 @@ public class IpamConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof IpamConfig)) return false;
-        IpamConfig that = (IpamConfig)o;
-        return Objects.equals(subnet, that.subnet) &&
-               Objects.equals(gateway, that.gateway) &&
-               Objects.equals(iPRange, that.iPRange);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof IpamConfig)) {
+            return false;
+        }
+        final IpamConfig that = (IpamConfig)obj;
+        return Objects.equals(subnet, that.subnet)
+               && Objects.equals(gateway, that.gateway)
+               && Objects.equals(iPRange, that.iPRange);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subnet, gateway, iPRange);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(subnet);
+        hash = 31 * hash + Objects.hashCode(gateway);
+        hash = 31 * hash + Objects.hashCode(iPRange);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Network.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Network.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents docker network description.
+ *
+ * author Alexander Garagatyi
+ */
+public class Network {
+    private String                          name;
+    private String                          id;
+    private String                          scope;
+    private String                          driver;
+    private boolean                         enableIPv6;
+    private boolean                         internal;
+    private Ipam                            iPAM;
+    private Map<String, ContainerInNetwork> containers;
+    private Map<String, String>             options;
+    private Map<String, String>             labels;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Network withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Network withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public Network withScope(String scope) {
+        this.scope = scope;
+        return this;
+    }
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    public Network withDriver(String driver) {
+        this.driver = driver;
+        return this;
+    }
+
+    public boolean isEnableIPv6() {
+        return enableIPv6;
+    }
+
+    public void setEnableIPv6(boolean enableIPv6) {
+        this.enableIPv6 = enableIPv6;
+    }
+
+    public Network withEnableIPv6(boolean enableIPv6) {
+        this.enableIPv6 = enableIPv6;
+        return this;
+    }
+
+    public boolean isInternal() {
+        return internal;
+    }
+
+    public void setInternal(boolean internal) {
+        this.internal = internal;
+    }
+
+    public Network withInternal(boolean internal) {
+        this.internal = internal;
+        return this;
+    }
+
+    public Ipam getIPAM() {
+        return iPAM;
+    }
+
+    public void setIPAM(Ipam iPAM) {
+        this.iPAM = iPAM;
+    }
+
+    public Network withIPAM(Ipam iPAM) {
+        this.iPAM = iPAM;
+        return this;
+    }
+
+    public Map<String, ContainerInNetwork> getContainers() {
+        return containers;
+    }
+
+    public void setContainers(Map<String, ContainerInNetwork> containers) {
+        this.containers = containers;
+    }
+
+    public Network withContainers(Map<String, ContainerInNetwork> containers) {
+        this.containers = containers;
+        return this;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    public Network withOptions(Map<String, String> options) {
+        this.options = options;
+        return this;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public Network withLabels(Map<String, String> labels) {
+        this.labels = labels;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Network)) return false;
+        Network network = (Network)o;
+        return enableIPv6 == network.enableIPv6 &&
+               internal == network.internal &&
+               Objects.equals(name, network.name) &&
+               Objects.equals(id, network.id) &&
+               Objects.equals(scope, network.scope) &&
+               Objects.equals(driver, network.driver) &&
+               Objects.equals(iPAM, network.iPAM) &&
+               Objects.equals(containers, network.containers) &&
+               Objects.equals(options, network.options) &&
+               Objects.equals(labels, network.labels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id, scope, driver, enableIPv6, internal, iPAM, containers, options, labels);
+    }
+
+    @Override
+    public String toString() {
+        return "Network{" +
+               "name='" + name + '\'' +
+               ", id='" + id + '\'' +
+               ", scope='" + scope + '\'' +
+               ", driver='" + driver + '\'' +
+               ", enableIPv6=" + enableIPv6 +
+               ", internal=" + internal +
+               ", iPAM=" + iPAM +
+               ", containers=" + containers +
+               ", options=" + options +
+               ", labels=" + labels +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Network.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/Network.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 /**
  * Represents docker network description.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class Network {
     private String                          name;
@@ -161,25 +161,40 @@ public class Network {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Network)) return false;
-        Network network = (Network)o;
-        return enableIPv6 == network.enableIPv6 &&
-               internal == network.internal &&
-               Objects.equals(name, network.name) &&
-               Objects.equals(id, network.id) &&
-               Objects.equals(scope, network.scope) &&
-               Objects.equals(driver, network.driver) &&
-               Objects.equals(iPAM, network.iPAM) &&
-               Objects.equals(containers, network.containers) &&
-               Objects.equals(options, network.options) &&
-               Objects.equals(labels, network.labels);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Network)) {
+            return false;
+        }
+        final Network that = (Network)obj;
+        return enableIPv6 == that.enableIPv6
+               && internal == that.internal
+               && Objects.equals(name, that.name)
+               && Objects.equals(id, that.id)
+               && Objects.equals(scope, that.scope)
+               && Objects.equals(driver, that.driver)
+               && Objects.equals(iPAM, that.iPAM)
+               && getContainers().equals(that.getContainers())
+               && getOptions().equals(that.getOptions())
+               && getLabels().equals(that.getLabels());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, id, scope, driver, enableIPv6, internal, iPAM, containers, options, labels);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(name);
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(scope);
+        hash = 31 * hash + Objects.hashCode(driver);
+        hash = 31 * hash + Boolean.hashCode(enableIPv6);
+        hash = 31 * hash + Boolean.hashCode(internal);
+        hash = 31 * hash + Objects.hashCode(iPAM);
+        hash = 31 * hash + getContainers().hashCode();
+        hash = 31 * hash + getOptions().hashCode();
+        hash = 31 * hash + getLabels().hashCode();
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewIpamConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewIpamConfig.java
@@ -13,7 +13,7 @@ package org.eclipse.che.plugin.docker.client.json.network;
 import java.util.Objects;
 
 /**
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class NewIpamConfig {
     private String iPv4Address;
@@ -46,17 +46,24 @@ public class NewIpamConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof NewIpamConfig)) return false;
-        NewIpamConfig that = (NewIpamConfig)o;
-        return Objects.equals(iPv4Address, that.iPv4Address) &&
-               Objects.equals(iPv6Address, that.iPv6Address);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NewIpamConfig)) {
+            return false;
+        }
+        final NewIpamConfig that = (NewIpamConfig)obj;
+        return Objects.equals(iPv4Address, that.iPv4Address)
+               && Objects.equals(iPv6Address, that.iPv6Address);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(iPv4Address, iPv6Address);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(iPv4Address);
+        hash = 31 * hash + Objects.hashCode(iPv6Address);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewIpamConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewIpamConfig.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Objects;
+
+/**
+ * author Alexander Garagatyi
+ */
+public class NewIpamConfig {
+    private String iPv4Address;
+    private String iPv6Address;
+
+    public String getIPv4Address() {
+        return iPv4Address;
+    }
+
+    public void setIPv4Address(String iPv4Address) {
+        this.iPv4Address = iPv4Address;
+    }
+
+    public NewIpamConfig withIPv4Address(String iPv4Address) {
+        this.iPv4Address = iPv4Address;
+        return this;
+    }
+
+    public String getIPv6Address() {
+        return iPv6Address;
+    }
+
+    public void setIPv6Address(String iPv6Address) {
+        this.iPv6Address = iPv6Address;
+    }
+
+    public NewIpamConfig withIPv6Address(String iPv6Address) {
+        this.iPv6Address = iPv6Address;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NewIpamConfig)) return false;
+        NewIpamConfig that = (NewIpamConfig)o;
+        return Objects.equals(iPv4Address, that.iPv4Address) &&
+               Objects.equals(iPv6Address, that.iPv6Address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(iPv4Address, iPv6Address);
+    }
+
+    @Override
+    public String toString() {
+        return "NewIpamConfig{" +
+               "iPv4Address='" + iPv4Address + '\'' +
+               ", iPv6Address='" + iPv6Address + '\'' +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewNetwork.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewNetwork.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 /**
  * Represents configuration that should be passed to docker API to create new network.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class NewNetwork {
     private String              name;
@@ -133,23 +133,36 @@ public class NewNetwork {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof NewNetwork)) return false;
-        NewNetwork that = (NewNetwork)o;
-        return checkDuplicate == that.checkDuplicate &&
-               internal == that.internal &&
-               enableIPv6 == that.enableIPv6 &&
-               Objects.equals(name, that.name) &&
-               Objects.equals(driver, that.driver) &&
-               Objects.equals(iPAM, that.iPAM) &&
-               Objects.equals(options, that.options) &&
-               Objects.equals(labels, that.labels);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NewNetwork)) {
+            return false;
+        }
+        final NewNetwork that = (NewNetwork)obj;
+        return checkDuplicate == that.checkDuplicate
+               && internal == that.internal
+               && enableIPv6 == that.enableIPv6
+               && Objects.equals(name, that.name)
+               && Objects.equals(driver, that.driver)
+               && Objects.equals(iPAM, that.iPAM)
+               && getOptions().equals(that.getOptions())
+               && getLabels().equals(that.getLabels());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, checkDuplicate, driver, internal, iPAM, enableIPv6, options, labels);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(name);
+        hash = 31 * hash + Boolean.hashCode(checkDuplicate);
+        hash = 31 * hash + Objects.hashCode(driver);
+        hash = 31 * hash + Boolean.hashCode(internal);
+        hash = 31 * hash + Objects.hashCode(iPAM);
+        hash = 31 * hash + Boolean.hashCode(enableIPv6);
+        hash = 31 * hash + getOptions().hashCode();
+        hash = 31 * hash + getLabels().hashCode();
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewNetwork.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/network/NewNetwork.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.json.network;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents configuration that should be passed to docker API to create new network.
+ *
+ * author Alexander Garagatyi
+ */
+public class NewNetwork {
+    private String              name;
+    private boolean             checkDuplicate;
+    private String              driver;
+    private boolean             internal;
+    private Ipam                iPAM;
+    private boolean             enableIPv6;
+    private Map<String, String> options;
+    private Map<String, String> labels;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public NewNetwork withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public boolean isCheckDuplicate() {
+        return checkDuplicate;
+    }
+
+    public void setCheckDuplicate(boolean checkDuplicate) {
+        this.checkDuplicate = checkDuplicate;
+    }
+
+    public NewNetwork withCheckDuplicate(boolean checkDuplicate) {
+        this.checkDuplicate = checkDuplicate;
+        return this;
+    }
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    public NewNetwork withDriver(String driver) {
+        this.driver = driver;
+        return this;
+    }
+
+    public boolean isInternal() {
+        return internal;
+    }
+
+    public void setInternal(boolean internal) {
+        this.internal = internal;
+    }
+
+    public NewNetwork withInternal(boolean internal) {
+        this.internal = internal;
+        return this;
+    }
+
+    public Ipam getIPAM() {
+        return iPAM;
+    }
+
+    public void setIPAM(Ipam iPAM) {
+        this.iPAM = iPAM;
+    }
+
+    public NewNetwork withIPAM(Ipam iPAM) {
+        this.iPAM = iPAM;
+        return this;
+    }
+
+    public boolean isEnableIPv6() {
+        return enableIPv6;
+    }
+
+    public void setEnableIPv6(boolean enableIPv6) {
+        this.enableIPv6 = enableIPv6;
+    }
+
+    public NewNetwork withEnableIPv6(boolean enableIPv6) {
+        this.enableIPv6 = enableIPv6;
+        return this;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    public NewNetwork withOptions(Map<String, String> options) {
+        this.options = options;
+        return this;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public NewNetwork withLabels(Map<String, String> labels) {
+        this.labels = labels;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NewNetwork)) return false;
+        NewNetwork that = (NewNetwork)o;
+        return checkDuplicate == that.checkDuplicate &&
+               internal == that.internal &&
+               enableIPv6 == that.enableIPv6 &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(driver, that.driver) &&
+               Objects.equals(iPAM, that.iPAM) &&
+               Objects.equals(options, that.options) &&
+               Objects.equals(labels, that.labels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, checkDuplicate, driver, internal, iPAM, enableIPv6, options, labels);
+    }
+
+    @Override
+    public String toString() {
+        return "NewNetwork{" +
+               "name='" + name + '\'' +
+               ", checkDuplicate=" + checkDuplicate +
+               ", driver='" + driver + '\'' +
+               ", internal=" + internal +
+               ", iPAM=" + iPAM +
+               ", enableIPv6=" + enableIPv6 +
+               ", options=" + options +
+               ", labels=" + labels +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
@@ -162,11 +162,11 @@ public class BuildImageParams {
      *         if other parameter incompatible with files is set
      */
     public BuildImageParams withFiles(@NotNull File... files) {
-        requireNonNull(files);
-        requireNonEmptyArray(files);
         if (remote != null) {
             throw new IllegalStateException("Remote parameter is already set. Remote and files parameters are mutually exclusive.");
         }
+        requireNonNull(files);
+        requireNonEmptyArray(files);
         this.files = new ArrayList<>(files.length + 1);
         return addFiles(files);
     }
@@ -262,24 +262,38 @@ public class BuildImageParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BuildImageParams)) return false;
-        BuildImageParams that = (BuildImageParams)o;
-        return Objects.equals(repository, that.repository) &&
-               Objects.equals(tag, that.tag) &&
-               Objects.equals(authConfigs, that.authConfigs) &&
-               Objects.equals(doForcePull, that.doForcePull) &&
-               Objects.equals(memoryLimit, that.memoryLimit) &&
-               Objects.equals(memorySwapLimit, that.memorySwapLimit) &&
-               Objects.equals(files, that.files) &&
-               Objects.equals(dockerfile, that.dockerfile) &&
-               Objects.equals(remote, that.remote);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof BuildImageParams)) {
+            return false;
+        }
+        final BuildImageParams that = (BuildImageParams)obj;
+        return Objects.equals(repository, that.repository)
+               && Objects.equals(tag, that.tag)
+               && Objects.equals(authConfigs, that.authConfigs)
+               && Objects.equals(doForcePull, that.doForcePull)
+               && Objects.equals(memoryLimit, that.memoryLimit)
+               && Objects.equals(memorySwapLimit, that.memorySwapLimit)
+               && getFiles().equals(that.getFiles())
+               && Objects.equals(dockerfile, that.dockerfile)
+               && Objects.equals(remote, that.remote);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(repository, tag, authConfigs, doForcePull, memoryLimit, memorySwapLimit, files, dockerfile, remote);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(repository);
+        hash = 31 * hash + Objects.hashCode(tag);
+        hash = 31 * hash + Objects.hashCode(authConfigs);
+        hash = 31 * hash + Objects.hashCode(doForcePull);
+        hash = 31 * hash + Objects.hashCode(memoryLimit);
+        hash = 31 * hash + Objects.hashCode(memorySwapLimit);
+        hash = 31 * hash + getFiles().hashCode();
+        hash = 31 * hash + Objects.hashCode(dockerfile);
+        hash = 31 * hash + Objects.hashCode(remote);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/CreateExecParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/CreateExecParams.java
@@ -122,4 +122,13 @@ public class CreateExecParams {
         return Objects.hash(container, detach, Arrays.hashCode(cmd));
     }
 
+
+    @Override
+    public String toString() {
+        return "CreateExecParams{" +
+               "container='" + container + '\'' +
+               ", detach=" + detach +
+               ", cmd=" + Arrays.toString(cmd) +
+               '}';
+    }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/CreateExecParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/CreateExecParams.java
@@ -108,20 +108,27 @@ public class CreateExecParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CreateExecParams that = (CreateExecParams)o;
-        return Objects.equals(container, that.container) &&
-               Objects.equals(detach, that.detach) &&
-               Arrays.equals(cmd, that.cmd);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CreateExecParams)) {
+            return false;
+        }
+        final CreateExecParams that = (CreateExecParams)obj;
+        return Objects.equals(container, that.container)
+               && Objects.equals(detach, that.detach)
+               && Arrays.equals(cmd, that.cmd);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(container, detach, Arrays.hashCode(cmd));
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(container);
+        hash = 31 * hash + Objects.hashCode(detach);
+        hash = 31 * hash + Arrays.hashCode(cmd);
+        return hash;
     }
-
 
     @Override
     public String toString() {

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/ParamsUtils.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/ParamsUtils.java
@@ -12,6 +12,9 @@ package org.eclipse.che.plugin.docker.client.params;
 
 /**
  * Contains util methods for {@code *Params} classes.
+ *
+ * @author Mykola Morhun
+ * @author Alexander Garagatyi
  */
 public class ParamsUtils {
 
@@ -26,6 +29,23 @@ public class ParamsUtils {
      */
     public static void requireNonEmptyArray(Object[] array) {
         if (array.length == 0) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Checks whether provided string is NULL or empty.
+     *
+     * @throws NullPointerException
+     *         if provided argument is null
+     * @throws IllegalArgumentException
+     *         if provided argument is empty
+     */
+    public static void requireNonNullNorEmpty(String s) {
+        if (s == null) {
+            throw new NullPointerException();
+        }
+        if (s.isEmpty()) {
             throw new IllegalArgumentException();
         }
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/ParamsUtils.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/ParamsUtils.java
@@ -50,4 +50,5 @@ public class ParamsUtils {
         }
     }
 
+    private ParamsUtils() {}
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/PutResourceParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/PutResourceParams.java
@@ -39,9 +39,18 @@ public class PutResourceParams {
      * @throws NullPointerException
      *         if {@code container} or {@code targetPath} is null
      */
+    @Deprecated
     public static PutResourceParams create(@NotNull String container, @NotNull String targetPath) {
         return new PutResourceParams().withContainer(container)
                                       .withTargetPath(targetPath);
+    }
+
+    public static PutResourceParams create(@NotNull String container,
+                                           @NotNull String targetPath,
+                                           @NotNull InputStream sourceStream) {
+        return new PutResourceParams().withContainer(container)
+                                      .withTargetPath(targetPath)
+                                      .withSourceStream(sourceStream);
     }
 
     private PutResourceParams() {}
@@ -84,8 +93,11 @@ public class PutResourceParams {
      *         stream of files from source container, must be obtained from another container
      *          using {@link org.eclipse.che.plugin.docker.client.DockerConnector#getResource(GetResourceParams)}
      * @return this params instance
+     * @throws NullPointerException
+     *         if {@code sourceStream} is null
      */
-    public PutResourceParams withSourceStream(InputStream sourceStream) {
+    public PutResourceParams withSourceStream(@NotNull InputStream sourceStream) {
+        requireNonNull(sourceStream);
         this.sourceStream = sourceStream;
         return this;
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/PutResourceParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/PutResourceParams.java
@@ -132,19 +132,37 @@ public class PutResourceParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PutResourceParams that = (PutResourceParams)o;
-        return Objects.equals(container, that.container) &&
-               Objects.equals(targetPath, that.targetPath) &&
-               Objects.equals(sourceStream, that.sourceStream) &&
-               Objects.equals(noOverwriteDirNonDir, that.noOverwriteDirNonDir);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PutResourceParams)) {
+            return false;
+        }
+        final PutResourceParams that = (PutResourceParams)obj;
+        return Objects.equals(container, that.container)
+               && Objects.equals(targetPath, that.targetPath)
+               && Objects.equals(sourceStream, that.sourceStream)
+               && Objects.equals(noOverwriteDirNonDir, that.noOverwriteDirNonDir);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(container, targetPath, sourceStream, noOverwriteDirNonDir);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(container);
+        hash = 31 * hash + Objects.hashCode(targetPath);
+        hash = 31 * hash + Objects.hashCode(sourceStream);
+        hash = 31 * hash + Objects.hashCode(noOverwriteDirNonDir);
+        return hash;
     }
 
+    @Override
+    public String toString() {
+        return "PutResourceParams{" +
+               "container='" + container + '\'' +
+               ", targetPath='" + targetPath + '\'' +
+               ", sourceStream=" + sourceStream +
+               ", noOverwriteDirNonDir=" + noOverwriteDirNonDir +
+               '}';
+    }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveImageParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveImageParams.java
@@ -48,7 +48,7 @@ public class RemoveImageParams {
      *         image identifier, either id or name
      * @return this params instance
      * @throws NullPointerException
-     *         if {@code container} is null
+     *         if {@code image} is null
      */
     public RemoveImageParams withImage(@NotNull String image) {
         requireNonNull(image);

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveImageParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveImageParams.java
@@ -77,17 +77,31 @@ public class RemoveImageParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RemoveImageParams that = (RemoveImageParams)o;
-        return Objects.equals(image, that.image) &&
-               Objects.equals(force, that.force);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RemoveImageParams)) {
+            return false;
+        }
+        final RemoveImageParams that = (RemoveImageParams)obj;
+        return Objects.equals(image, that.image)
+               && Objects.equals(force, that.force);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(image, force);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(image);
+        hash = 31 * hash + Objects.hashCode(force);
+        return hash;
     }
 
+    @Override
+    public String toString() {
+        return "RemoveImageParams{" +
+               "image='" + image + '\'' +
+               ", force=" + force +
+               '}';
+    }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveNetworkParams.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.params;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#removeNetwork(RemoveNetworkParams)}.
+ *
+ * author Alexander Garagatyi
+ */
+public class RemoveNetworkParams {
+    private String netId;
+
+    private RemoveNetworkParams() {}
+
+    /**
+     * Creates arguments holder with required parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @return arguments holder with required parameters
+     * @throws NullPointerException
+     *         if {@code netId} is null
+     */
+    public static RemoveNetworkParams create(@NotNull String netId) {
+        return new RemoveNetworkParams().withNetworkId(netId);
+    }
+
+    /**
+     * Adds network identifier to this parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code netId} is null
+     */
+    public RemoveNetworkParams withNetworkId(@NotNull String netId) {
+        requireNonNull(netId);
+        this.netId = netId;
+        return this;
+    }
+
+    public String getNetworkId() {
+        return netId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RemoveNetworkParams)) return false;
+        RemoveNetworkParams that = (RemoveNetworkParams)o;
+        return Objects.equals(netId, that.netId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(netId);
+    }
+
+    @Override
+    public String toString() {
+        return "RemoveNetworkParams{" +
+               "netId='" + netId + '\'' +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/RemoveNetworkParams.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#removeNetwork(RemoveNetworkParams)}.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class RemoveNetworkParams {
     private String netId;
@@ -59,22 +59,21 @@ public class RemoveNetworkParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof RemoveNetworkParams)) return false;
-        RemoveNetworkParams that = (RemoveNetworkParams)o;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RemoveNetworkParams)) {
+            return false;
+        }
+        final RemoveNetworkParams that = (RemoveNetworkParams)obj;
         return Objects.equals(netId, that.netId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(netId);
-    }
-
-    @Override
-    public String toString() {
-        return "RemoveNetworkParams{" +
-               "netId='" + netId + '\'' +
-               '}';
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(netId);
+        return hash;
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/StartExecParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/StartExecParams.java
@@ -97,18 +97,26 @@ public class StartExecParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        StartExecParams that = (StartExecParams)o;
-        return Objects.equals(execId, that.execId) &&
-               Objects.equals(detach, that.detach) &&
-               Objects.equals(tty, that.tty);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StartExecParams)) {
+            return false;
+        }
+        final StartExecParams that = (StartExecParams)obj;
+        return Objects.equals(execId, that.execId)
+               && Objects.equals(detach, that.detach)
+               && Objects.equals(tty, that.tty);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(execId, detach, tty);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(execId);
+        hash = 31 * hash + Objects.hashCode(detach);
+        hash = 31 * hash + Objects.hashCode(tty);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/StartExecParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/StartExecParams.java
@@ -111,4 +111,12 @@ public class StartExecParams {
         return Objects.hash(execId, detach, tty);
     }
 
+    @Override
+    public String toString() {
+        return "StartExecParams{" +
+               "execId='" + execId + '\'' +
+               ", detach=" + detach +
+               ", tty=" + tty +
+               '}';
+    }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/ConnectContainerToNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/ConnectContainerToNetworkParams.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.params.network;
+
+import org.eclipse.che.plugin.docker.client.json.network.ConnectContainer;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#connectContainerToNetwork(ConnectContainerToNetworkParams)}.
+ *
+ * author Alexander Garagatyi
+ */
+public class ConnectContainerToNetworkParams {
+    private String           netId;
+    private ConnectContainer connectContainer;
+
+    private ConnectContainerToNetworkParams() {}
+
+    /**
+     * Creates arguments holder with required parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @param connectContainer
+     *         container connection configuration
+     * @return arguments holder with required parameters
+     * @throws NullPointerException
+     *         if {@code netId} or {@code container} is null
+     */
+    public static ConnectContainerToNetworkParams create(@NotNull String netId, @NotNull ConnectContainer connectContainer) {
+        return new ConnectContainerToNetworkParams().withNetworkId(netId)
+                                                    .withConnectContainer(connectContainer);
+    }
+
+    /**
+     * Adds network identifier to this parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code netId} is null
+     */
+    public ConnectContainerToNetworkParams withNetworkId(@NotNull String netId) {
+        requireNonNull(netId);
+        this.netId = netId;
+        return this;
+    }
+
+    public String getNetworkId() {
+        return netId;
+    }
+
+    /**
+     * Adds container identifier to this parameters.
+     *
+     * @param connectContainer
+     *         container connection configuration
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code connectContainer} is null
+     */
+    public ConnectContainerToNetworkParams withConnectContainer(@NotNull ConnectContainer connectContainer) {
+        requireNonNull(connectContainer);
+        this.connectContainer = connectContainer;
+        return this;
+    }
+
+    public ConnectContainer getConnectContainer() {
+        return connectContainer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ConnectContainerToNetworkParams)) return false;
+        ConnectContainerToNetworkParams that = (ConnectContainerToNetworkParams)o;
+        return Objects.equals(netId, that.netId) &&
+               Objects.equals(connectContainer, that.connectContainer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(netId, connectContainer);
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectContainerToNetworkParams{" +
+               "netId='" + netId + '\'' +
+               ", connectContainer=" + connectContainer +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/ConnectContainerToNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/ConnectContainerToNetworkParams.java
@@ -13,6 +13,7 @@ package org.eclipse.che.plugin.docker.client.params.network;
 import org.eclipse.che.plugin.docker.client.json.network.ConnectContainer;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -20,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#connectContainerToNetwork(ConnectContainerToNetworkParams)}.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class ConnectContainerToNetworkParams {
     private String           netId;
@@ -59,10 +60,6 @@ public class ConnectContainerToNetworkParams {
         return this;
     }
 
-    public String getNetworkId() {
-        return netId;
-    }
-
     /**
      * Adds container identifier to this parameters.
      *
@@ -78,22 +75,33 @@ public class ConnectContainerToNetworkParams {
         return this;
     }
 
+    public String getNetworkId() {
+        return netId;
+    }
+
     public ConnectContainer getConnectContainer() {
         return connectContainer;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ConnectContainerToNetworkParams)) return false;
-        ConnectContainerToNetworkParams that = (ConnectContainerToNetworkParams)o;
-        return Objects.equals(netId, that.netId) &&
-               Objects.equals(connectContainer, that.connectContainer);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ConnectContainerToNetworkParams)) {
+            return false;
+        }
+        final ConnectContainerToNetworkParams that = (ConnectContainerToNetworkParams)obj;
+        return Objects.equals(netId, that.netId)
+               && Objects.equals(connectContainer, that.connectContainer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(netId, connectContainer);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(netId);
+        hash = 31 * hash + Objects.hashCode(connectContainer);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/CreateNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/CreateNetworkParams.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.params.network;
+
+import org.eclipse.che.plugin.docker.client.json.network.NewNetwork;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#createNetwork(CreateNetworkParams)}.
+ *
+ * author Alexander Garagatyi
+ */
+public class CreateNetworkParams {
+    // todo consider validation that network config has all required fields
+    private NewNetwork network;
+
+    private CreateNetworkParams() {}
+
+    /**
+     * Creates arguments holder with required parameters.
+     *
+     * @param newNetwork
+     *         network configuration
+     * @return arguments holder with required parameters
+     * @throws NullPointerException
+     *         if {@code newNetwork} is null
+     */
+    public static CreateNetworkParams create(@NotNull NewNetwork newNetwork) {
+        return new CreateNetworkParams().withNetwork(newNetwork);
+    }
+
+    /**
+     * Adds network name to this parameters.
+     *
+     * @param newNetwork
+     *         network configuration
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code newNetwork} is null
+     */
+    public CreateNetworkParams withNetwork(@NotNull NewNetwork newNetwork) {
+        requireNonNull(newNetwork);
+        this.network = newNetwork;
+        return this;
+    }
+
+    public NewNetwork getNetwork() {
+        return network;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CreateNetworkParams)) return false;
+        CreateNetworkParams that = (CreateNetworkParams)o;
+        return Objects.equals(network, that.network);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(network);
+    }
+
+    @Override
+    public String toString() {
+        return "CreateNetworkParams{" +
+               "network=" + network +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/CreateNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/CreateNetworkParams.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#createNetwork(CreateNetworkParams)}.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class CreateNetworkParams {
     // todo consider validation that network config has all required fields
@@ -62,16 +62,22 @@ public class CreateNetworkParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof CreateNetworkParams)) return false;
-        CreateNetworkParams that = (CreateNetworkParams)o;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CreateNetworkParams)) {
+            return false;
+        }
+        final CreateNetworkParams that = (CreateNetworkParams)obj;
         return Objects.equals(network, that.network);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(network);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(network);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/DisconnectContainerFromNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/DisconnectContainerFromNetworkParams.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.params.network;
+
+import org.eclipse.che.plugin.docker.client.json.network.DisconnectContainer;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#disconnectContainerFromNetwork(DisconnectContainerFromNetworkParams)}.
+ *
+ * author Alexander Garagatyi
+ */
+public class DisconnectContainerFromNetworkParams {
+    private String              netId;
+    private DisconnectContainer disconnectContainer;
+
+    private DisconnectContainerFromNetworkParams() {}
+
+    /**
+     * Creates arguments holder with required parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @param disconnectContainer
+     *         container disconnection configuration
+     * @return arguments holder with required parameters
+     * @throws NullPointerException
+     *         if {@code netId} or {@code disconnectContainer} is null
+     */
+    public static DisconnectContainerFromNetworkParams create(@NotNull String netId, @NotNull DisconnectContainer disconnectContainer) {
+        return new DisconnectContainerFromNetworkParams().withNetworkId(netId)
+                                                         .withDisconnectContainer(disconnectContainer);
+    }
+
+    /**
+     * Adds network identifier to this parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code netId} is null
+     */
+    public DisconnectContainerFromNetworkParams withNetworkId(@NotNull String netId) {
+        requireNonNull(netId);
+        this.netId = netId;
+        return this;
+    }
+
+    public String getNetworkId() {
+        return netId;
+    }
+
+    /**
+     * Adds container identifier to this parameters.
+     *
+     * @param disconnectContainer
+     *         container disconnection configuration
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code disconnectContainer} is null
+     */
+    public DisconnectContainerFromNetworkParams withDisconnectContainer(@NotNull DisconnectContainer disconnectContainer) {
+        requireNonNull(disconnectContainer);
+        this.disconnectContainer = disconnectContainer;
+        return this;
+    }
+
+    public DisconnectContainer getDisconnectContainer() {
+        return disconnectContainer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DisconnectContainerFromNetworkParams)) return false;
+        DisconnectContainerFromNetworkParams that = (DisconnectContainerFromNetworkParams)o;
+        return Objects.equals(netId, that.netId) &&
+               Objects.equals(disconnectContainer, that.disconnectContainer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(netId, disconnectContainer);
+    }
+
+    @Override
+    public String toString() {
+        return "DisconnectContainerFromNetworkParams{" +
+               "netId='" + netId + '\'' +
+               ", disconnectContainer=" + disconnectContainer +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/DisconnectContainerFromNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/DisconnectContainerFromNetworkParams.java
@@ -13,6 +13,7 @@ package org.eclipse.che.plugin.docker.client.params.network;
 import org.eclipse.che.plugin.docker.client.json.network.DisconnectContainer;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -20,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#disconnectContainerFromNetwork(DisconnectContainerFromNetworkParams)}.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class DisconnectContainerFromNetworkParams {
     private String              netId;
@@ -59,10 +60,6 @@ public class DisconnectContainerFromNetworkParams {
         return this;
     }
 
-    public String getNetworkId() {
-        return netId;
-    }
-
     /**
      * Adds container identifier to this parameters.
      *
@@ -78,22 +75,33 @@ public class DisconnectContainerFromNetworkParams {
         return this;
     }
 
+    public String getNetworkId() {
+        return netId;
+    }
+
     public DisconnectContainer getDisconnectContainer() {
         return disconnectContainer;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DisconnectContainerFromNetworkParams)) return false;
-        DisconnectContainerFromNetworkParams that = (DisconnectContainerFromNetworkParams)o;
-        return Objects.equals(netId, that.netId) &&
-               Objects.equals(disconnectContainer, that.disconnectContainer);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DisconnectContainerFromNetworkParams)) {
+            return false;
+        }
+        final DisconnectContainerFromNetworkParams that = (DisconnectContainerFromNetworkParams)obj;
+        return Objects.equals(netId, that.netId)
+               && Objects.equals(disconnectContainer, that.disconnectContainer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(netId, disconnectContainer);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(netId);
+        hash = 31 * hash + Objects.hashCode(disconnectContainer);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/GetNetworksParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/GetNetworksParams.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.params.network;
+
+import org.eclipse.che.plugin.docker.client.json.Filters;
+
+import java.util.Objects;
+
+/**
+ * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#getNetworks(GetNetworksParams)}.
+ *
+ * @author Alexander Garagatyi
+ */
+public class GetNetworksParams {
+
+    private Filters filters;
+
+    /**
+     * Creates arguments holder.
+     */
+    public static GetNetworksParams create() {
+        return new GetNetworksParams();
+    }
+
+    private GetNetworksParams() {}
+
+    /**
+     * Adds filters to this parameters.
+     *
+     * @param filters
+     *         filter of needed networks. Available filters: {@code name=<string>},
+     *         {@code id=<string>}, {@code type=<string>}
+     * @return this params instance
+     */
+    public GetNetworksParams withFilters(Filters filters) {
+        this.filters = filters;
+        return this;
+    }
+
+    public Filters getFilters() {
+        return filters;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GetNetworksParams)) return false;
+        GetNetworksParams that = (GetNetworksParams)o;
+        return Objects.equals(filters, that.filters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filters);
+    }
+
+    @Override
+    public String toString() {
+        return "GetNetworksParams{" +
+               "filters=" + filters +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/GetNetworksParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/GetNetworksParams.java
@@ -50,16 +50,22 @@ public class GetNetworksParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GetNetworksParams)) return false;
-        GetNetworksParams that = (GetNetworksParams)o;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof GetNetworksParams)) {
+            return false;
+        }
+        final GetNetworksParams that = (GetNetworksParams)obj;
         return Objects.equals(filters, that.filters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filters);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(filters);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/InspectNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/InspectNetworkParams.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.params.network;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#inspectNetwork(InspectNetworkParams)}.
+ *
+ * author Alexander Garagatyi
+ */
+public class InspectNetworkParams {
+    private String netId;
+
+    private InspectNetworkParams() {}
+
+    /**
+     * Creates arguments holder with required parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @return arguments holder with required parameters
+     * @throws NullPointerException
+     *         if {@code netId} is null
+     */
+    public static InspectNetworkParams create(@NotNull String netId) {
+        return new InspectNetworkParams().withNetworkId(netId);
+    }
+
+    /**
+     * Adds network identifier to this parameters.
+     *
+     * @param netId
+     *         network identifier
+     * @return this params instance
+     * @throws NullPointerException
+     *         if {@code netId} is null
+     */
+    public InspectNetworkParams withNetworkId(@NotNull String netId) {
+        requireNonNull(netId);
+        this.netId = netId;
+        return this;
+    }
+
+    public String getNetworkId() {
+        return netId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof InspectNetworkParams)) return false;
+        InspectNetworkParams that = (InspectNetworkParams)o;
+        return Objects.equals(netId, that.netId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(netId);
+    }
+
+    @Override
+    public String toString() {
+        return "InspectNetworkParams{" +
+               "netId='" + netId + '\'' +
+               '}';
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/InspectNetworkParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/network/InspectNetworkParams.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Arguments holder for {@link org.eclipse.che.plugin.docker.client.DockerConnector#inspectNetwork(InspectNetworkParams)}.
  *
- * author Alexander Garagatyi
+ * @author Alexander Garagatyi
  */
 public class InspectNetworkParams {
     private String netId;
@@ -59,16 +59,22 @@ public class InspectNetworkParams {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InspectNetworkParams)) return false;
-        InspectNetworkParams that = (InspectNetworkParams)o;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof InspectNetworkParams)) {
+            return false;
+        }
+        final InspectNetworkParams that = (InspectNetworkParams)obj;
         return Objects.equals(netId, that.netId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(netId);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(netId);
+        return hash;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -269,7 +269,7 @@ public class DockerConnectorTest {
     public void shouldBeAbleToGetListImages() throws IOException, JsonParseException {
         List<Image> images = new ArrayList<>();
 
-        doReturn(images).when(dockerConnector).parseResponseStreamAsListAndClose(eq(inputStream), any());
+        doReturn(images).when(dockerConnector).parseResponseStreamAndClose(eq(inputStream), any(TypeToken.class));
 
         List<Image> returnedImages =
                 dockerConnector.listImages();
@@ -300,7 +300,7 @@ public class DockerConnectorTest {
         ContainerListEntry containerListEntry = mock(ContainerListEntry.class);
         List<ContainerListEntry> expectedListContainers = singletonList(containerListEntry);
 
-        doReturn(expectedListContainers).when(dockerConnector).parseResponseStreamAsListAndClose(eq(inputStream), any());
+        doReturn(expectedListContainers).when(dockerConnector).parseResponseStreamAndClose(eq(inputStream), any(TypeToken.class));
 
         List<ContainerListEntry> containers = dockerConnector.listContainers(listContainersParams);
 
@@ -312,7 +312,7 @@ public class DockerConnectorTest {
         verify(dockerConnection).request();
         verify(dockerResponse).getStatus();
         verify(dockerResponse).getInputStream();
-        verify(dockerConnector).parseResponseStreamAsListAndClose(eq(inputStream), any());
+        verify(dockerConnector).parseResponseStreamAndClose(eq(inputStream), any(TypeToken.class));
 
         assertEquals(containers, expectedListContainers);
     }
@@ -324,7 +324,7 @@ public class DockerConnectorTest {
         ContainerListEntry containerListEntry = mock(ContainerListEntry.class);
         List<ContainerListEntry> expectedListContainers = singletonList(containerListEntry);
 
-        doReturn(expectedListContainers).when(dockerConnector).parseResponseStreamAsListAndClose(eq(inputStream), any());
+        doReturn(expectedListContainers).when(dockerConnector).parseResponseStreamAndClose(eq(inputStream), any(TypeToken.class));
 
         List<ContainerListEntry> containers = dockerConnector.listContainers(listContainersParams);
 
@@ -1356,8 +1356,8 @@ public class DockerConnectorTest {
                           "  }\n" +
                           "]\n";
 
-        List<Image> images = dockerConnector.parseResponseStreamAsListAndClose(new ByteArrayInputStream(response.getBytes()),
-                                                                               new TypeToken<List<Image>>() {}.getType());
+        List<Image> images = dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream(response.getBytes()),
+                                                                         new TypeToken<List<Image>>() {});
         assertEquals(images.size(), 2);
         Image actualImage1 = images.get(0);
         Image actualImage2 = images.get(1);
@@ -1392,9 +1392,8 @@ public class DockerConnectorTest {
                           "         }" +
                           "]\n";
 
-        List<ContainerListEntry> containers = dockerConnector.parseResponseStreamAsListAndClose(new ByteArrayInputStream(response.getBytes()),
-                                                                                            new TypeToken<List<ContainerListEntry>>() {}
-                                                                                                    .getType());
+        List<ContainerListEntry> containers = dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream(response.getBytes()),
+                                                                                          new TypeToken<List<ContainerListEntry>>() {});
         assertEquals(containers.size(), 1);
         ContainerListEntry actualContainer1 = containers.get(0);
 
@@ -1411,9 +1410,8 @@ public class DockerConnectorTest {
     public void shouldBeAbleToParseResponseStreamAsEmptyListOfContainersAndClose() throws IOException, JsonParseException {
         String response = "[]";
 
-        List<ContainerListEntry> containers = dockerConnector.parseResponseStreamAsListAndClose(new ByteArrayInputStream(response.getBytes()),
-                                                                                                new TypeToken<List<ContainerListEntry>>() {}
-                                                                                                        .getType());
+        List<ContainerListEntry> containers = dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream(response.getBytes()),
+                                                                                          new TypeToken<List<ContainerListEntry>>() {});
         assertEquals(containers.size(), 0);
     }
 
@@ -1734,8 +1732,8 @@ public class DockerConnectorTest {
     private ConnectContainer createConnectContainer() {
         return new ConnectContainer().withContainer("container_id")
                                      .withEndpointConfig(
-                                             new EndpointConfig().withLinks(singletonList("link_1"))
-                                                                 .withAliases(singletonList("alias_1"))
+                                             new EndpointConfig().withLinks(new String[] {"link_1"})
+                                                                 .withAliases(new String[] {"alias_1"})
                                                                  .withIPAMConfig(new NewIpamConfig().withIPv4Address("ipv4_address")
                                                                                                     .withIPv6Address("ipv6_address")));
     }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -32,8 +32,13 @@ import org.eclipse.che.plugin.docker.client.LogMessage;
 import org.eclipse.che.plugin.docker.client.ProgressLineFormatterImpl;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.params.CommitParams;
+import org.eclipse.che.plugin.docker.client.params.CreateExecParams;
+import org.eclipse.che.plugin.docker.client.params.GetResourceParams;
 import org.eclipse.che.plugin.docker.client.params.PushParams;
+import org.eclipse.che.plugin.docker.client.params.PutResourceParams;
+import org.eclipse.che.plugin.docker.client.params.RemoveContainerParams;
 import org.eclipse.che.plugin.docker.client.params.RemoveImageParams;
+import org.eclipse.che.plugin.docker.client.params.StartExecParams;
 import org.eclipse.che.plugin.docker.machine.node.DockerNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,8 +173,12 @@ public class DockerInstance extends AbstractInstance {
     public List<InstanceProcess> getProcesses() throws MachineException {
         List<InstanceProcess> processes = new LinkedList<>();
         try {
-            final Exec exec = docker.createExec(container, false, "/bin/bash", "-c", GET_ALIVE_PROCESSES_COMMAND);
-            docker.startExec(exec.getId(), logMessage -> {
+            final Exec exec = docker.createExec(CreateExecParams.create(container,
+                                                                        new String[] {"/bin/bash",
+                                                                                      "-c",
+                                                                                      GET_ALIVE_PROCESSES_COMMAND})
+                                                                .withDetach(false));
+            docker.startExec(StartExecParams.create(exec.getId()), logMessage -> {
                 final String pidFilePath = logMessage.getContent().trim();
                 final Matcher matcher = PID_FILE_PATH_PATTERN.matcher(pidFilePath);
                 if (matcher.matches()) {
@@ -243,7 +252,8 @@ public class DockerInstance extends AbstractInstance {
         // !! We SHOULD NOT pause container before commit because all execs will fail
         // to push image to private registry it should be tagged with registry in repo name
         // https://docs.docker.com/reference/api/docker_remote_api_v1.16/#push-an-image-on-the-registry
-        docker.commit(CommitParams.create(container, repository)
+        docker.commit(CommitParams.create(container)
+                                  .withRepository(repository)
                                   .withTag(tag)
                                   .withComment(comment));
     }
@@ -272,13 +282,15 @@ public class DockerInstance extends AbstractInstance {
 
             docker.killContainer(container);
 
-            docker.removeContainer(container, true, true);
+            docker.removeContainer(RemoveContainerParams.create(container)
+                                                        .withRemoveVolumes(true)
+                                                        .withForce(true));
         } catch (IOException e) {
             throw new MachineException(e.getLocalizedMessage());
         }
 
         try {
-            docker.removeImage(image, false);
+            docker.removeImage(RemoveImageParams.create(image).withForce(false));
         } catch (IOException ignore) {
         }
     }
@@ -322,8 +334,8 @@ public class DockerInstance extends AbstractInstance {
 
         ListLineConsumer lines = new ListLineConsumer();
         try {
-            Exec exec = docker.createExec(container, false, command);
-            docker.startExec(exec.getId(), new LogMessagePrinter(lines, LogMessage::getContent));
+            Exec exec = docker.createExec(CreateExecParams.create(container, command).withDetach(false));
+            docker.startExec(StartExecParams.create(exec.getId()), new LogMessagePrinter(lines, LogMessage::getContent));
         } catch (IOException e) {
             throw new MachineException(format("Error occurs while initializing command %s in docker container %s: %s",
                                               Arrays.toString(command), container, e.getLocalizedMessage()), e);
@@ -343,10 +355,11 @@ public class DockerInstance extends AbstractInstance {
             throw new MachineException("Unsupported copying between not docker machines");
         }
         try {
-            docker.putResource(container,
-                               targetPath,
-                               docker.getResource(((DockerInstance)sourceMachine).container, sourcePath),
-                               overwriteDirNonDir);
+            docker.putResource(PutResourceParams.create(container,
+                                                        targetPath,
+                                                        docker.getResource(GetResourceParams.create(
+                                                                ((DockerInstance)sourceMachine).container, sourcePath)))
+                                                .withNoOverwriteDirNonDir(overwriteDirNonDir));
         } catch (IOException e) {
             throw new MachineException(e.getLocalizedMessage());
         }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -52,6 +52,8 @@ import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.json.HostConfig;
 import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.eclipse.che.plugin.docker.client.params.GetContainerLogsParams;
+import org.eclipse.che.plugin.docker.client.params.BuildImageParams;
+import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.eclipse.che.plugin.docker.client.params.PullParams;
 import org.eclipse.che.plugin.docker.client.params.RemoveImageParams;
 import org.eclipse.che.plugin.docker.client.params.StartContainerParams;
@@ -360,7 +362,7 @@ public class DockerInstanceProvider implements InstanceProvider {
         }
         try {
             // remove unneeded tag
-            docker.removeImage(fullNameOfPulledImage, false);
+            docker.removeImage(RemoveImageParams.create(fullNameOfPulledImage).withForce(false));
         } catch (IOException e) {
             LOG.error(e.getLocalizedMessage(), e);
         }
@@ -421,13 +423,13 @@ public class DockerInstanceProvider implements InstanceProvider {
                     LOG.error(e.getLocalizedMessage(), e);
                 }
             };
-            docker.buildImage(imageName,
-                              progressMonitor,
-                              dockerCredentials.getCredentials(),
-                              doForcePullOnBuild,
-                              memoryLimit,
-                              memorySwapLimit,
-                              files.toArray(new File[files.size()]));
+            docker.buildImage(BuildImageParams.create(files.toArray(new File[files.size()]))
+                                              .withRepository(imageName)
+                                              .withAuthConfigs(dockerCredentials.getCredentials())
+                                              .withDoForcePull(doForcePullOnBuild)
+                                              .withMemoryLimit(memoryLimit)
+                                              .withMemorySwapLimit(memorySwapLimit),
+                              progressMonitor);
         } catch (IOException | InterruptedException e) {
             throw new MachineException(e.getMessage(), e);
         } finally {

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -129,7 +129,7 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
             md.put("config.cmd", Arrays.toString(config.getCmd()));
             md.put("config.volumes", String.valueOf(config.getVolumes()));
             md.put("config.cpuset", config.getCpuset());
-            md.put("config.entrypoint", config.getEntrypoint());
+            md.put("config.entrypoint", Arrays.toString(config.getEntrypoint()));
             md.put("config.exposedPorts", String.valueOf(config.getExposedPorts()));
             md.put("config.macAddress", config.getMacAddress());
             md.put("config.securityOpts", Arrays.toString(config.getSecurityOpts()));

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceStopDetector.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceStopDetector.java
@@ -107,7 +107,6 @@ public class DockerInstanceStopDetector {
                 try {
                     dockerConnector.getEvents(GetEventsParams.create()
                                                              .withSinceSecond(lastProcessedEventDate)
-                                                             .withUntilSecond(0)
                                                              .withFilters(new Filters().withFilter("event", "die", "oom")),
                                               new EventsProcessor());
                 } catch (IOException e) {

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineImplTerminalLauncher.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineImplTerminalLauncher.java
@@ -16,6 +16,8 @@ import org.eclipse.che.api.machine.server.terminal.MachineImplSpecificTerminalLa
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.Exec;
 import org.eclipse.che.plugin.docker.client.LogMessage;
+import org.eclipse.che.plugin.docker.client.params.CreateExecParams;
+import org.eclipse.che.plugin.docker.client.params.StartExecParams;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -52,9 +54,13 @@ public class DockerMachineImplTerminalLauncher implements MachineImplSpecificTer
         try {
             final String container = ((DockerInstance)machine).getContainer();
 
-            final Exec exec = docker.createExec(container, true, "/bin/bash", "-c", terminalStartCommand);
+            final Exec exec = docker.createExec(CreateExecParams.create(container,
+                                                                        new String[] {"/bin/bash",
+                                                                                      "-c",
+                                                                                      terminalStartCommand})
+                                                                .withDetach(true));
 
-            docker.startExec(exec.getId(), logMessage -> {
+            docker.startExec(StartExecParams.create(exec.getId()), logMessage -> {
                 if (logMessage.getType() == LogMessage.Type.STDERR) {
                     try {
                         machine.getLogger().writeLine("Terminal error. %s" + logMessage.getContent());

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
@@ -31,16 +31,16 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
-import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredentialsProvider;
 import org.eclipse.che.plugin.docker.client.ProgressMonitor;
-import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
-import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
+import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredentialsProvider;
 import org.eclipse.che.plugin.docker.client.json.ContainerCreated;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.ContainerState;
 import org.eclipse.che.plugin.docker.client.json.HostConfig;
 import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.eclipse.che.plugin.docker.client.params.InspectContainerParams;
+import org.eclipse.che.plugin.docker.client.params.BuildImageParams;
+import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.eclipse.che.plugin.docker.client.params.PullParams;
 import org.eclipse.che.plugin.docker.client.params.RemoveImageParams;
 import org.eclipse.che.plugin.docker.client.params.StartContainerParams;
@@ -48,7 +48,6 @@ import org.eclipse.che.plugin.docker.client.params.TagParams;
 import org.eclipse.che.plugin.docker.machine.node.DockerNode;
 import org.eclipse.che.plugin.docker.machine.node.WorkspaceFolderPathProvider;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
@@ -71,9 +70,7 @@ import static java.util.Arrays.asList;
 import static org.eclipse.che.plugin.docker.machine.DockerInstanceProvider.DOCKER_FILE_TYPE;
 import static org.eclipse.che.plugin.docker.machine.DockerInstanceProvider.DOCKER_IMAGE_TYPE;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -127,9 +124,6 @@ public class DockerInstanceProviderTest {
 
     @Mock
     private ContainerState containerState;
-
-    @Captor
-    private ArgumentCaptor<CreateContainerParams> createContainerParamsArgumentCaptor;
 
     @Mock
     private RecipeRetriever recipeRetriever;
@@ -206,13 +200,13 @@ public class DockerInstanceProviderTest {
         createInstanceFromRecipe();
 
 
-        verify(dockerConnector).buildImage(eq("eclipse-che/" + generatedContainerId),
-                                           any(ProgressMonitor.class),
-                                           any(AuthConfigs.class),
-                                           anyBoolean(),
-                                           eq((long)MEMORY_LIMIT_MB * 1024 * 1024),
-                                           eq((long)-1),
-                                           anyVararg());
+        ArgumentCaptor<BuildImageParams> argumentCaptor = ArgumentCaptor.forClass(BuildImageParams.class);
+        verify(dockerConnector).buildImage(argumentCaptor.capture(),
+                                           any(ProgressMonitor.class));
+        BuildImageParams buildImageParams = argumentCaptor.getValue();
+        assertEquals(buildImageParams.getRepository(), "eclipse-che/" + generatedContainerId);
+        assertEquals((long)buildImageParams.getMemoryLimit(), (long)MEMORY_LIMIT_MB * 1024 * 1024);
+        assertEquals((long)buildImageParams.getMemorySwapLimit(), (long)-1);
     }
 
     @Test
@@ -242,10 +236,7 @@ public class DockerInstanceProviderTest {
         dockerInstanceProvider.createInstance(machine,
                                               LineConsumer.DEV_NULL);
 
-        verify(dockerConnector, never()).pull(anyString(),
-                                              anyString(),
-                                              anyString(),
-                                              any(ProgressMonitor.class));
+        verify(dockerConnector, never()).pull(any(PullParams.class), any(ProgressMonitor.class));
     }
 
     @Test
@@ -275,7 +266,11 @@ public class DockerInstanceProviderTest {
         createInstanceFromSnapshot(repo, tag, registry);
 
         verify(dockerConnector).tag(eq(tagParams));
-        verify(dockerConnector).removeImage(eq(registry + "/" + repo + ":" + tag), eq(false));
+        ArgumentCaptor<RemoveImageParams> argumentCaptor = ArgumentCaptor.forClass(RemoveImageParams.class);
+        verify(dockerConnector).removeImage(argumentCaptor.capture());
+        RemoveImageParams imageParams = argumentCaptor.getValue();
+        assertEquals(imageParams.getImage(), registry + "/" + repo + ":" + tag);
+        assertFalse(imageParams.isForce());
     }
 
     @Test
@@ -299,7 +294,9 @@ public class DockerInstanceProviderTest {
     public void shouldStartContainerOnCreateInstanceFromRecipe() throws Exception {
         createInstanceFromRecipe();
 
-        verify(dockerConnector).startContainer(any(StartContainerParams.class));
+        ArgumentCaptor<StartContainerParams> argumentCaptor = ArgumentCaptor.forClass(StartContainerParams.class);
+        verify(dockerConnector).startContainer(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue().getContainer(), CONTAINER_ID);
     }
 
     @Test
@@ -342,15 +339,18 @@ public class DockerInstanceProviderTest {
 
         createInstanceFromRecipe();
 
-        verify(dockerConnector).createContainer(createContainerParamsArgumentCaptor.capture());
-        assertTrue(createContainerParamsArgumentCaptor.getValue().getContainerConfig().getHostConfig().isPrivileged());
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getContainerConfig().getHostConfig().isPrivileged());
     }
 
     @Test
     public void shouldStartContainerOnCreateInstanceFromSnapshot() throws Exception {
         createInstanceFromSnapshot();
 
-        verify(dockerConnector).startContainer(any(StartContainerParams.class));
+        ArgumentCaptor<StartContainerParams> argumentCaptor = ArgumentCaptor.forClass(StartContainerParams.class);
+        verify(dockerConnector).startContainer(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue().getContainer(), CONTAINER_ID);
     }
 
     @Test
@@ -480,11 +480,11 @@ public class DockerInstanceProviderTest {
         createInstanceFromRecipe(memorySizeMB);
 
 
-        ArgumentCaptor<CreateContainerParams> createContainerCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
-        verify(dockerConnector).createContainer(createContainerCaptor.capture());
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
         verify(dockerConnector).startContainer(any(StartContainerParams.class));
         // docker accepts memory size in bytes
-        assertEquals(createContainerCaptor.getValue().getContainerConfig().getHostConfig().getMemory(), memorySizeMB * 1024 * 1024);
+        assertEquals(argumentCaptor.getValue().getContainerConfig().getHostConfig().getMemory(), memorySizeMB * 1024 * 1024);
     }
 
     @Test
@@ -495,11 +495,11 @@ public class DockerInstanceProviderTest {
         createInstanceFromSnapshot(memorySizeMB);
 
 
-        ArgumentCaptor<CreateContainerParams> createContainerCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
-        verify(dockerConnector).createContainer(createContainerCaptor.capture());
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
         verify(dockerConnector).startContainer(any(StartContainerParams.class));
         // docker accepts memory size in bytes
-        assertEquals(createContainerCaptor.getValue().getContainerConfig().getHostConfig().getMemory(), memorySizeMB * 1024 * 1024);
+        assertEquals(argumentCaptor.getValue().getContainerConfig().getHostConfig().getMemory(), memorySizeMB * 1024 * 1024);
     }
 
     @Test(dataProvider = "swapTestProvider")
@@ -530,9 +530,9 @@ public class DockerInstanceProviderTest {
         createInstanceFromRecipe(memoryMB);
 
         // then
-        ArgumentCaptor<CreateContainerParams> createContainerCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
-        verify(dockerConnector).createContainer(createContainerCaptor.capture());
-        assertEquals(createContainerCaptor.getValue().getContainerConfig().getHostConfig().getMemorySwap(), expectedSwapSize);
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue().getContainerConfig().getHostConfig().getMemorySwap(), expectedSwapSize);
     }
 
     @DataProvider(name = "swapTestProvider")
@@ -600,8 +600,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -643,8 +646,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -692,8 +698,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -735,8 +744,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -782,8 +794,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -829,8 +844,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -876,8 +894,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -923,8 +944,11 @@ public class DockerInstanceProviderTest {
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
 
-        assertTrue(new ArrayList<>(argumentCaptor.getValue().getContainerConfig().getExposedPorts().keySet())
-                                  .containsAll(expectedExposedPorts));
+        assertTrue(new ArrayList<>(argumentCaptor.getValue()
+                                                 .getContainerConfig()
+                                                 .getExposedPorts()
+                                                 .keySet())
+                           .containsAll(expectedExposedPorts));
     }
 
     @Test
@@ -1725,10 +1749,14 @@ public class DockerInstanceProviderTest {
         // then
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
-        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
+        assertTrue(asList(argumentCaptor.getValue()
+                                        .getContainerConfig()
+                                        .getEnv())
                            .containsAll(envVarsFromConfig.entrySet()
                                                          .stream()
-                                                         .map(entry -> entry.getKey() + "=" + entry.getValue())
+                                                         .map(entry -> entry.getKey() +
+                                                                       "=" +
+                                                                       entry.getValue())
                                                          .collect(Collectors.toList())));
     }
 
@@ -1771,11 +1799,15 @@ public class DockerInstanceProviderTest {
         // then
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
-        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
-                         .containsAll(envVarsFromConfig.entrySet()
-                                                       .stream()
-                                                       .map(entry -> entry.getKey() + "=" + entry.getValue())
-                                                       .collect(Collectors.toList())));
+        assertTrue(asList(argumentCaptor.getValue()
+                                        .getContainerConfig()
+                                        .getEnv())
+                           .containsAll(envVarsFromConfig.entrySet()
+                                                         .stream()
+                                                         .map(entry -> entry.getKey() +
+                                                                       "=" +
+                                                                       entry.getValue())
+                                                         .collect(Collectors.toList())));
     }
 
     @Test
@@ -1817,11 +1849,15 @@ public class DockerInstanceProviderTest {
         // then
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
-        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv()).containsAll(
-                envVarsFromConfig.entrySet()
-                                 .stream()
-                                 .map(entry -> entry.getKey() + "=" + entry.getValue())
-                                 .collect(Collectors.toList())));
+        assertTrue(asList(argumentCaptor.getValue()
+                                        .getContainerConfig()
+                                        .getEnv())
+                           .containsAll(envVarsFromConfig.entrySet()
+                                                         .stream()
+                                                         .map(entry -> entry.getKey() +
+                                                                       "=" +
+                                                                       entry.getValue())
+                                                         .collect(Collectors.toList())));
     }
 
     @Test
@@ -1863,11 +1899,15 @@ public class DockerInstanceProviderTest {
         // then
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
-        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
-                         .containsAll(envVarsFromConfig.entrySet()
-                                                       .stream()
-                                                       .map(entry -> entry.getKey() + "=" + entry.getValue())
-                                                       .collect(Collectors.toList())));
+        assertTrue(asList(argumentCaptor.getValue()
+                                        .getContainerConfig()
+                                        .getEnv())
+                           .containsAll(envVarsFromConfig.entrySet()
+                                                         .stream()
+                                                         .map(entry -> entry.getKey() +
+                                                                       "=" +
+                                                                       entry.getValue())
+                                                         .collect(Collectors.toList())));
     }
 
     private void createInstanceFromRecipe() throws Exception {

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
@@ -36,11 +36,9 @@ import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredential
 import org.eclipse.che.plugin.docker.client.json.ContainerCreated;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.ContainerState;
-import org.eclipse.che.plugin.docker.client.json.HostConfig;
 import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.eclipse.che.plugin.docker.client.params.InspectContainerParams;
 import org.eclipse.che.plugin.docker.client.params.BuildImageParams;
-import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.eclipse.che.plugin.docker.client.params.PullParams;
 import org.eclipse.che.plugin.docker.client.params.RemoveImageParams;
 import org.eclipse.che.plugin.docker.client.params.StartContainerParams;

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/integration/DockerProcessTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/integration/DockerProcessTest.java
@@ -22,6 +22,10 @@ import org.eclipse.che.plugin.docker.client.connection.DockerConnectionFactory;
 import org.eclipse.che.plugin.docker.client.helper.DefaultNetworkFinder;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.json.ContainerCreated;
+import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
+import org.eclipse.che.plugin.docker.client.params.RemoveContainerParams;
+import org.eclipse.che.plugin.docker.client.params.StartContainerParams;
+import org.eclipse.che.plugin.docker.client.params.StopContainerParams;
 import org.eclipse.che.plugin.docker.machine.DockerProcess;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -51,18 +55,21 @@ public class DockerProcessTest {
                                      new DockerConnectionFactory(dockerConnectorConfiguration),
                                      new DockerRegistryAuthResolver(null));
 
-        final ContainerCreated containerCreated = docker.createContainer(new ContainerConfig().withImage("ubuntu")
-                                                                                              .withCmd("tail", "-f", "/dev/null"),
-                                                                         null);
+        final ContainerCreated containerCreated = docker.createContainer(
+                CreateContainerParams.create(new ContainerConfig().withImage("ubuntu")
+                                                                  .withCmd("tail", "-f", "/dev/null")));
         container = containerCreated.getId();
-        docker.startContainer(containerCreated.getId(), null);
+        docker.startContainer(StartContainerParams.create(containerCreated.getId()));
     }
 
     @AfterMethod
     public void tearDown() throws Exception {
         if (container != null) {
-            docker.stopContainer(container, 2, TimeUnit.SECONDS);
-            docker.removeContainer(container, true, true);
+            docker.stopContainer(StopContainerParams.create(container)
+                                                    .withTimeout(2, TimeUnit.SECONDS));
+            docker.removeContainer(RemoveContainerParams.create(container)
+                                                        .withForce(true)
+                                                        .withRemoveVolumes(true));
         }
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/local/interceptor/EnableOfflineDockerMachineBuildInterceptorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/local/interceptor/EnableOfflineDockerMachineBuildInterceptorTest.java
@@ -14,9 +14,9 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.DockerImage;
-import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredentialsProvider;
 import org.eclipse.che.plugin.docker.client.Dockerfile;
 import org.eclipse.che.plugin.docker.client.ProgressMonitor;
+import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredentialsProvider;
 import org.eclipse.che.plugin.docker.client.params.PullParams;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.Collections;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -108,7 +107,7 @@ public class EnableOfflineDockerMachineBuildInterceptorTest {
         final String tag = "latest";
         final String repo = "my_repo/my_image";
         when(dockerImage.getFrom()).thenReturn(repo + ":" + tag);
-        doThrow(throwable).when(dockerConnector).pull(anyString(), anyString(), anyString(), any(ProgressMonitor.class));
+        doThrow(throwable).when(dockerConnector).pull(any(PullParams.class), any(ProgressMonitor.class));
 
 
         interceptor.invoke(methodInvocation);

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjector.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjector.java
@@ -22,6 +22,8 @@ import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.Exec;
 import org.eclipse.che.plugin.docker.client.LogMessage;
+import org.eclipse.che.plugin.docker.client.params.CreateExecParams;
+import org.eclipse.che.plugin.docker.client.params.StartExecParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +85,12 @@ public class KeysInjector {
                                    .append("' >> ~/.ssh/authorized_keys");
                         }
 
-                        final Exec exec = docker.createExec(containerId, true, "/bin/bash", "-c", command.toString());
-                        docker.startExec(exec.getId(), logMessage -> {
+                        final Exec exec = docker.createExec(CreateExecParams.create(containerId,
+                                                                                    new String[] {"/bin/bash",
+                                                                                                  "-c",
+                                                                                                  command.toString()})
+                                                                            .withDetach(true));
+                        docker.startExec(StartExecParams.create(exec.getId()), logMessage -> {
                             if (logMessage.getType() == LogMessage.Type.STDERR) {
                                 try {
                                     machine.getLogger().writeLine("Error of injection public ssh keys. " + logMessage.getContent());


### PR DESCRIPTION
**_1 Upvote**_ Add networking API to docker client.
Change JSON serialization/deserialization in docker client to fix incorrect naming policy work of JsonHelper.
Fix entrypoint field in ContainerConfig since it is array of
strings, not single string.
Remove deprecated methods from docker client.
Add possibility to provide remote docker build context.
