### PR TITLE
CHE-1403: Fix clone with http url in JGit implementation

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/GitLocalizationConstant.properties
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/GitLocalizationConstant.properties
@@ -32,7 +32,7 @@ button.pull=Pull
 
 ############MESSAGES################
 messages.unableGetSshKey = Failed to get private ssh key. \
-  You can create a new SSH key pair in Profile->Preferences->SSH->Git.
+  You can create a new SSH key pair in Profile->Preferences->SSH->VCS.
 messages.warningTitle = Warning
 messages.index_empty=Index is empty
 messages.add_success=Git index updated

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/resources/org/eclipse/che/plugin/github/ide/GitHubLocalizationConstant.properties
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/resources/org/eclipse/che/plugin/github/ide/GitHubLocalizationConstant.properties
@@ -16,7 +16,7 @@ authorization.dialog.title = Authorization
 authorization.dialog.text = {0} requests authorization through OAuth2 protocol
 authorization.generateKeyLabel = generate ssh key and upload it on GitHub
 authorization.message.unableCreateSshKey = Unable create private ssh key. \
-  You can create a new SSH key pair in Profile->Preferences->SSH->Git.
+  You can create a new SSH key pair in Profile->Preferences->SSH->VCS.
 authorization.message.keyUploadSuccess = Ssh key uploaded
 ############### SamplesListGrid ###############
 samplesListGrid.column.name=Project


### PR DESCRIPTION
JGit does not support HTTP 301 redirects yet, it throws exception when
performing commands with remote using http url instead https. Native git can do it.
The solution is to replace http to https in the given url when performing clone.
Also I have added error code to "ssh key" exception and fixed related client message
@skabashnyuk please review
