### PR TITLE
CHE-1408:Add check for amend before throwing error

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -533,9 +533,10 @@ class JGitConnection implements GitConnection {
 
             //Check that there are staged changes present for commit, or any changes if is 'isAll' enabled, otherwise throw exception
             Status status = status(StatusFormat.SHORT);
-            if (!request.isAll() && status.getAdded().isEmpty() && status.getChanged().isEmpty() && status.getRemoved().isEmpty()) {
+            if (!request.isAmend() && !request.isAll()
+                && status.getAdded().isEmpty() && status.getChanged().isEmpty() && status.getRemoved().isEmpty()) {
                 throw new GitException("No changes added to commit");
-            } else if (request.isAll() && status.isClean()) {
+            } else if (!request.isAmend() && request.isAll() && status.isClean()) {
                 throw new GitException("Nothing to commit, working directory clean");
             }
 


### PR DESCRIPTION
When we perform commit without staged changes we will get an error.
If it is needed to change the message of last commit we should allow
to do it, even if there are no staged changes. @skabashnyuk please review
