### PR TITLE
Always set root as parent in create project wizard

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CreateProjectAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CreateProjectAction.java
@@ -10,16 +10,12 @@
  *******************************************************************************/
 package org.eclipse.che.ide.actions;
 
-import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.che.ide.Resources;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
-import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.resources.Container;
-import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.projecttype.wizard.presenter.ProjectWizardPresenter;
 import org.eclipse.che.ide.resource.Path;
 
@@ -37,42 +33,17 @@ import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspect
 public class CreateProjectAction extends AbstractPerspectiveAction {
 
     private final ProjectWizardPresenter wizard;
-    private final AppContext appContext;
 
     @Inject
     public CreateProjectAction(Resources resources,
-                               ProjectWizardPresenter wizard,
-                               AppContext appContext) {
+                               ProjectWizardPresenter wizard) {
         super(singletonList(PROJECT_PERSPECTIVE_ID), "Create Project...", "Create new project", null, resources.newProject());
         this.wizard = wizard;
-        this.appContext = appContext;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        final Resource[] resources = appContext.getResources();
-
-        if (resources != null && resources.length == 1) {
-            final Resource resource = resources[0];
-            final Path path;
-
-            if (resource.getResourceType() == Resource.FILE) {
-                final Optional<Container> parent = resource.getParent();
-
-                if (parent.isPresent()) {
-                    path = parent.get().getLocation();
-                } else {
-                    wizard.show();
-                    return;
-                }
-            } else {
-                path = resource.getLocation();
-            }
-
-            wizard.show(path);
-        } else {
-            wizard.show();
-        }
+        wizard.show(Path.ROOT);
     }
 
     @Override


### PR DESCRIPTION
Now when create project wizard appears, the parent is always set to root instead of selected item in application context.

Related issue: CHE-1455

@vparfonov review it, plz.
