### PR TITLE
Allow to configure classpath for the plain java projects

### DIFF
--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/wizard/selector/SelectNodePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/wizard/selector/SelectNodePresenter.java
@@ -10,13 +10,16 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.java.plain.client.wizard.selector;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.data.tree.Node;
 import org.eclipse.che.ide.api.data.tree.settings.SettingsProvider;
-import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Container;
 import org.eclipse.che.ide.resources.tree.ResourceNode;
 
 import java.util.Collections;
@@ -56,15 +59,16 @@ public class SelectNodePresenter implements SelectNodeView.ActionDelegate {
     public void show(SelectionDelegate selectionDelegate, String projectName) {
         this.selectionDelegate = selectionDelegate;
 
-        final Project project = appContext.getRootProject();
+        appContext.getWorkspaceRoot().getContainer(projectName).then(new Operation<Optional<Container>>() {
+            @Override
+            public void apply(Optional<Container> container) throws OperationException {
+                if (container.isPresent()) {
+                    view.setStructure(Collections.<Node>singletonList(nodeFactory.newContainerNode(container.get(), settingsProvider.getSettings())));
 
-        if (project == null) {
-            return;
-        }
-
-        view.setStructure(Collections.<Node>singletonList(nodeFactory.newContainerNode(project, settingsProvider.getSettings())));
-
-        view.show();
+                    view.show();
+                }
+            }
+        });
     }
 
     /** {@inheritDoc} */

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/wizard/selector/SelectNodeViewImpl.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/wizard/selector/SelectNodeViewImpl.java
@@ -24,6 +24,7 @@ import com.google.inject.Singleton;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.data.tree.Node;
 import org.eclipse.che.ide.api.data.tree.NodeInterceptor;
+import org.eclipse.che.ide.resources.tree.SkipHiddenNodesInterceptor;
 import org.eclipse.che.ide.search.selectpath.FolderNodeInterceptor;
 import org.eclipse.che.ide.ui.smartTree.KeyboardNavigationHandler;
 import org.eclipse.che.ide.ui.smartTree.NodeLoader;
@@ -45,6 +46,7 @@ import static org.eclipse.che.ide.ui.smartTree.SelectionModel.Mode.MULTI;
 @Singleton
 public class SelectNodeViewImpl extends Window implements SelectNodeView {
     private final FolderNodeInterceptor folderNodeInterceptor;
+    private SkipHiddenNodesInterceptor skipHiddenNodesInterceptor;
 
     private Tree           tree;
     private ActionDelegate delegate;
@@ -61,8 +63,10 @@ public class SelectNodeViewImpl extends Window implements SelectNodeView {
     @Inject
     public SelectNodeViewImpl(CoreLocalizationConstant locale,
                               FolderNodeInterceptor folderNodeInterceptor,
-                              SelectPathViewImplUiBinder uiBinder) {
+                              SelectPathViewImplUiBinder uiBinder,
+                              SkipHiddenNodesInterceptor skipHiddenNodesInterceptor) {
         this.folderNodeInterceptor = folderNodeInterceptor;
+        this.skipHiddenNodesInterceptor = skipHiddenNodesInterceptor;
         setTitle(locale.selectPathWindowTitle());
 
         Widget widget = uiBinder.createAndBindUi(this);
@@ -136,6 +140,7 @@ public class SelectNodeViewImpl extends Window implements SelectNodeView {
         tree.getNodeStorage().clear();
         tree.getNodeLoader().getNodeInterceptors().clear();
         tree.getNodeLoader().getNodeInterceptors().add(folderNodeInterceptor);
+        tree.getNodeLoader().getNodeInterceptors().add(skipHiddenNodesInterceptor);
         for (Node node : nodes) {
             tree.getNodeStorage().add(node);
         }


### PR DESCRIPTION
After project import project was not appeared in application context and project configuration wizard didn't know everything about imported project, so that's why select source folder wizard wasn't able to be shown. This PR fix this situation, so that wizard is available in anytime.

Related issue: CHE-1446

@vparfonov review it, plz.
