### PR TITLE
CODENVY-556 Do not allow HTTP recipes if working over HTTPS

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidator.java
@@ -130,7 +130,7 @@ public class DefaultWorkspaceValidator implements WorkspaceValidator {
         checkNotNull(machineCfg.getSource(), "Environment " + envName + " contains machine without source");
 
         if (apiEndpoint.startsWith("https://")
-            && machineCfg.getSource().getType() == "recipe"
+            && machineCfg.getSource().getType() == "dockerfile"
             && machineCfg.getSource().getLocation() != null) {
             checkArgument(machineCfg.getSource().getLocation().startsWith("https://"),
                           "Environment '%s' contains source recipe with http location, which is not allowed", envName);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidator.java
@@ -16,6 +16,7 @@ import com.google.inject.name.Named;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.model.machine.Command;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.MachineSource;
 import org.eclipse.che.api.core.model.machine.ServerConf;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.Workspace;
@@ -127,10 +128,14 @@ public class DefaultWorkspaceValidator implements WorkspaceValidator {
     private void validateMachine(MachineConfig machineCfg, String envName) throws BadRequestException {
         checkArgument(!isNullOrEmpty(machineCfg.getName()), "Environment %s contains machine with null or empty name", envName);
         checkNotNull(machineCfg.getSource(), "Environment " + envName + " contains machine without source");
-        if (apiEndpoint.startsWith("https://") && machineCfg.getSource().getLocation() != null) {
-            checkArgument(!machineCfg.getSource().getLocation().startsWith("http://"),
-                          "Environment '%s' contains source with http location, which is not allowed", envName);
+
+        if (apiEndpoint.startsWith("https://")
+            && machineCfg.getSource().getType() == "recipe"
+            && machineCfg.getSource().getLocation() != null) {
+            checkArgument(machineCfg.getSource().getLocation().startsWith("https://"),
+                          "Environment '%s' contains source recipe with http location, which is not allowed", envName);
         }
+
         checkArgument(!(machineCfg.getSource().getContent() == null && machineCfg.getSource().getLocation() == null),
                       "Environment " + envName + " contains machine with source but this source doesn't define a location or content");
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidator.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.workspace.server;
 
 import com.google.common.base.Joiner;
+import com.google.inject.name.Named;
 
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.model.machine.Command;
@@ -42,10 +43,13 @@ public class DefaultWorkspaceValidator implements WorkspaceValidator {
     private static final Pattern SERVER_PROTOCOL = Pattern.compile("[a-z][a-z0-9-+.]*");
     
     private final MachineInstanceProviders machineInstanceProviders;
+    private final String apiEndpoint;
     
     @Inject
-    public DefaultWorkspaceValidator(MachineInstanceProviders machineInstanceProviders) {
+    public DefaultWorkspaceValidator(MachineInstanceProviders machineInstanceProviders,
+                                     @Named("api.endpoint") String apiEndpoint) {
     	this.machineInstanceProviders = machineInstanceProviders;
+        this.apiEndpoint = apiEndpoint;
     }
 
     @Override
@@ -123,6 +127,10 @@ public class DefaultWorkspaceValidator implements WorkspaceValidator {
     private void validateMachine(MachineConfig machineCfg, String envName) throws BadRequestException {
         checkArgument(!isNullOrEmpty(machineCfg.getName()), "Environment %s contains machine with null or empty name", envName);
         checkNotNull(machineCfg.getSource(), "Environment " + envName + " contains machine without source");
+        if (apiEndpoint.startsWith("https://") && machineCfg.getSource().getLocation() != null) {
+            checkArgument(!machineCfg.getSource().getLocation().startsWith("http://"),
+                          "Environment '%s' contains source with http location, which is not allowed", envName);
+        }
         checkArgument(!(machineCfg.getSource().getContent() == null && machineCfg.getSource().getLocation() == null),
                       "Environment " + envName + " contains machine with source but this source doesn't define a location or content");
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
@@ -516,10 +516,15 @@ public class DefaultWorkspaceValidatorTest {
     }
 
     @Test(expectedExceptions = BadRequestException.class,
-          expectedExceptionsMessageRegExp = "Environment 'dev-env' contains source with http location, which is not allowed")
+          expectedExceptionsMessageRegExp = "Environment 'dev-env' contains source recipe with http location, which is not allowed")
     public void shouldFailValidationIfUsingHttpRecipeOnHttps() throws Exception {
         wsValidator = new DefaultWorkspaceValidator(machineInstanceProviders, "https://localhost");
         final WorkspaceConfigDto configDto = createConfig();
+        configDto.getEnvironments()
+                 .get(0)
+                 .getMachineConfigs()
+                 .get(0)
+                 .getSource().setType("recipe");
 
         wsValidator.validateConfig(configDto);
     }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
@@ -520,11 +520,6 @@ public class DefaultWorkspaceValidatorTest {
     public void shouldFailValidationIfUsingHttpRecipeOnHttps() throws Exception {
         wsValidator = new DefaultWorkspaceValidator(machineInstanceProviders, "https://localhost");
         final WorkspaceConfigDto configDto = createConfig();
-        configDto.getEnvironments()
-                 .get(0)
-                 .getMachineConfigs()
-                 .get(0)
-                 .getSource().setType("recipe");
 
         wsValidator.validateConfig(configDto);
     }


### PR DESCRIPTION
We have problems with accessing HTTP recipes, if Che/Codenvy is working over HTTPS.
So it is proposed to not allow having workspaces with such recipes.
