### PR TITLE
CODENVY-733: add possibility to set JAVA_OPTS for dev machines

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -163,3 +163,6 @@ workspace.runtime.auto_restore=true
 
 # Reserved user names
 user.reserved_names=
+
+# java opts for dev machine
+che.machine.java_opts=-Xms256m -Xmx2048m -Djava.security.egd=file:/dev/./urandom

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -42,12 +42,18 @@ import static java.util.stream.Collectors.toMap;
  *
  * @author andrew00x
  * @author Alexander Garagatyi
+ * @author Roman Iuvshyn
  */
 public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
     /**
      * Env variable that points to root folder of projects in dev machine
      */
     public static final String PROJECTS_ROOT_VARIABLE = "CHE_PROJECTS_ROOT";
+
+    /**
+     * Env variable for jvm settings
+     */
+    public static final String JAVA_OPTS_VARIABLE = "JAVA_OPTS";
 
     /**
      * Env variable for dev machine that contains url of Che API

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/DockerExtServerModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/DockerExtServerModule.java
@@ -23,6 +23,7 @@ import org.eclipse.che.plugin.docker.machine.ext.provider.WsAgentServerConfProvi
  *
  * @author Alexander Garagatyi
  * @author Sergii Leschenko
+ * @author Roman Iuvshyn
  */
 // Not a DynaModule, install manually
 public class DockerExtServerModule extends AbstractModule {
@@ -45,6 +46,7 @@ public class DockerExtServerModule extends AbstractModule {
                                                            .permitDuplicates();
         devMachineEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ext.provider.ApiEndpointEnvVariableProvider.class);
         devMachineEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ext.provider.ProjectsRootEnvVariableProvider.class);
+        devMachineEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ext.provider.JavaOptsEnvVariableProvider.class);
         devMachineEnvVars.addBinding()
                          .toInstance(CheBootstrap.CHE_LOCAL_CONF_DIR
                                      + '='

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/JavaOptsEnvVariableProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/JavaOptsEnvVariableProvider.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.machine.ext.provider;
+
+import org.eclipse.che.plugin.docker.machine.DockerInstanceRuntimeInfo;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * Add env variable to docker dev-machine with java opts
+ *
+ * @author Roman Iuvshyn
+ */
+@Singleton
+public class JavaOptsEnvVariableProvider implements Provider<String> {
+    @Inject
+    @Named("che.machine.java_opts")
+    private String javaOpts;
+
+    @Override
+    public String get() {
+        return DockerInstanceRuntimeInfo.JAVA_OPTS_VARIABLE + '=' + javaOpts;
+    }
+}


### PR DESCRIPTION
@garagatyi @skabashnyuk @vparfonov please take a look on that.

We have that `JAVA_OPTS` set up in setenv https://github.com/eclipse/che-lib/blob/master/che-tomcat8-slf4j-logback/src/assembly/bin/setenv.sh#L18
Same time we have `JAVA_OPTS` defined in `.bashrc` in our docker base image. According to logic in setenv.sh predefined `JAVA_OPTS` will never be used, that is why ws agent start so long `-Djava.security.egd=file:/dev/./urandom` just ignored.
But main goal of that PR is provide a way to configure http / s proxy configuration for WS agent.
