### PR TITLE
CHE-1448: Fix cyclic request sending and possible NPE

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/newresource/NewFolderAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/newresource/NewFolderAction.java
@@ -17,6 +17,7 @@ import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.Resources;
@@ -90,6 +91,11 @@ public class NewFolderAction extends AbstractNewResourceAction {
             @Override
             public void apply(Folder folder) throws OperationException {
                 eventBus.fireEvent(new RevealResourceEvent(folder));
+            }
+        }).catchError(new Operation<PromiseError>() {
+            @Override
+            public void apply(PromiseError error) throws OperationException {
+                dialogFactory.createMessageDialog("Error", error.getMessage(), null).show();
             }
         });
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.ide.part.explorer.project;
 
 import com.google.common.base.MoreObjects;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -275,20 +276,36 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
         final Tree tree = view.getTree();
         final Resource resource = delta.getResource();
 
-        if (resource.getLocation().segmentCount() == 1) {
-            final Node projectNode = getNode(resource.getLocation());
+        final Node node = getNode(resource.getLocation());
 
-            if (projectNode != null) {
-                tree.getNodeStorage().remove(projectNode);
-            }
-
+        if (node == null) {
             return;
         }
 
-        final Node node = getParentNode(delta.getResource().getLocation());
+        if (resource.getLocation().segmentCount() == 1) {
+                tree.getNodeStorage().remove(node);
+            return;
+        }
 
-        if (node != null && tree.isExpanded(node)) {
-            tree.getNodeLoader().loadChildren(node, true);
+        final Node parentNode = getParentNode(resource.getLocation());
+
+        if (parentNode == null) {
+            return;
+        }
+
+        final Path parentLocation = ((ResourceNode)parentNode).getData().getLocation();
+
+        if (resource.getLocation().parent().equals(parentLocation)) {
+            tree.getNodeStorage().remove(node);
+        } else {
+            tree.getNodeStorage().remove(node);
+
+            Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+                @Override
+                public void execute() {
+                    tree.getNodeLoader().loadChildren(parentNode, true);
+                }
+            });
         }
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/RevealNodesPersistenceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/RevealNodesPersistenceComponent.java
@@ -93,6 +93,7 @@ public class RevealNodesPersistenceComponent implements PersistenceComponent {
            Then check if child is resource, then we store the path in user preference.
          */
 
+        outer:
         for (Node node : projectExplorer.getTree().getNodeStorage().getAll()) {
             if (projectExplorer.getTree().isExpanded(node) && node instanceof ResourceNode) {
 
@@ -101,6 +102,7 @@ public class RevealNodesPersistenceComponent implements PersistenceComponent {
                 for (Node children : childrenToStore) {
                     if (children instanceof ResourceNode) {
                         paths.add(((ResourceNode)children).getData().getLocation());
+                        continue outer;
                     }
                 }
             }
@@ -145,14 +147,14 @@ public class RevealNodesPersistenceComponent implements PersistenceComponent {
 
             for (final String path : paths) {
                 if (revealPromise == null) {
-                    revealPromise = revealer.reveal(Path.valueOf(path)).thenPromise(new Function<Node, Promise<Node>>() {
+                    revealPromise = revealer.reveal(Path.valueOf(path), false).thenPromise(new Function<Node, Promise<Node>>() {
                         @Override
                         public Promise<Node> apply(Node node) throws FunctionException {
                             if (node != null) {
                                 projectExplorer.getTree().setExpanded(node, true, false);
                             }
 
-                            return revealer.reveal(Path.valueOf(path));
+                            return revealer.reveal(Path.valueOf(path), false);
                         }
                     });
                     continue;
@@ -165,7 +167,7 @@ public class RevealNodesPersistenceComponent implements PersistenceComponent {
                             projectExplorer.getTree().setExpanded(node, true, false);
                         }
 
-                        return revealer.reveal(Path.valueOf(path));
+                        return revealer.reveal(Path.valueOf(path), false);
                     }
                 }).catchError(new Function<PromiseError, Node>() {
                     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
@@ -287,6 +287,7 @@ public class EditorTabWidget extends Composite implements EditorTab, ContextMenu
 
             if (file.getLocation().equals(movedFrom)) {
                 file = (VirtualFile)resource;
+                title.setText(file.getDisplayName());
             }
         } else if (delta.getKind() == UPDATED) {
             if (!delta.getResource().isFile()) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/InMemoryResourceStore.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/InMemoryResourceStore.java
@@ -203,7 +203,7 @@ class InMemoryResourceStore implements ResourceStore {
 
             final Path comparedPath = setEntry.getKey();
 
-            if (parent.segmentCount() > comparedPath.segmentCount() && !parent.isPrefixOf(comparedPath)) {
+            if (!parent.isPrefixOf(comparedPath)) {
                 continue;
             }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
@@ -294,7 +294,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
         }
 
         childRequested.put(parent, reloadExpandedChild);
-        return _load(parent);
+        return doLoad(parent);
     }
 
     /**
@@ -335,7 +335,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
      *         parent node
      * @return true if load was requested, otherwise false
      */
-    private boolean _load(@NotNull final Node parent) {
+    private boolean doLoad(@NotNull final Node parent) {
         if (fireEvent(new BeforeLoadEvent(parent))) {
             lastRequest = parent;
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/NewPackageAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/NewPackageAction.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ext.java.client.action;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
@@ -25,11 +26,11 @@ import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.Container;
 import org.eclipse.che.ide.api.resources.Folder;
+import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
 import org.eclipse.che.ide.ext.java.client.JavaUtils;
-import org.eclipse.che.ide.ext.java.client.resource.SourceFolderMarker;
 import org.eclipse.che.ide.newresource.AbstractNewResourceAction;
 import org.eclipse.che.ide.api.dialogs.InputCallback;
 import org.eclipse.che.ide.api.dialogs.InputDialog;
@@ -39,6 +40,7 @@ import org.eclipse.che.ide.resources.reveal.RevealResourceEvent;
 import javax.validation.constraints.NotNull;
 
 import static com.google.common.base.Preconditions.checkState;
+import static org.eclipse.che.ide.ext.java.client.resource.SourceFolderMarker.ID;
 import static org.eclipse.che.ide.ext.java.client.util.JavaUtil.isJavaProject;
 
 /**
@@ -67,10 +69,19 @@ public class NewPackageAction extends AbstractNewResourceAction {
 
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
-        final Resource[] resources = appContext.getResources();
-        final boolean inJavaProject = resources != null && resources.length == 1 && isJavaProject(resources[0].getRelatedProject().get());
+        final Resource resource = appContext.getResource();
+        if (resource == null) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
 
-        e.getPresentation().setEnabledAndVisible(inJavaProject && resources[0].getParentWithMarker(SourceFolderMarker.ID).isPresent());
+        final Optional<Project> project = resource.getRelatedProject();
+        if (!project.isPresent()) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        e.getPresentation().setEnabledAndVisible(isJavaProject(project.get()) && resource.getParentWithMarker(ID).isPresent());
     }
 
     @Override

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/ProjectClasspathAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/ProjectClasspathAction.java
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ext.java.client.action;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
 import org.eclipse.che.ide.ext.java.client.project.classpath.ProjectClasspathPresenter;
@@ -23,6 +25,7 @@ import org.eclipse.che.ide.ext.java.client.project.classpath.ProjectClasspathPre
 import javax.validation.constraints.NotNull;
 import java.util.Collections;
 
+import static org.eclipse.che.ide.ext.java.client.resource.SourceFolderMarker.ID;
 import static org.eclipse.che.ide.ext.java.client.util.JavaUtil.isJavaProject;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
@@ -57,8 +60,18 @@ public class ProjectClasspathAction extends AbstractPerspectiveAction {
 
     @Override
     public void updateInPerspective(@NotNull ActionEvent event) {
-        final Resource[] resources = appContext.getResources();
+        final Resource resource = appContext.getResource();
+        if (resource == null) {
+            event.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
 
-        event.getPresentation().setEnabledAndVisible(resources != null && resources.length == 1 && isJavaProject(resources[0].getRelatedProject().get()));
+        final Optional<Project> project = resource.getRelatedProject();
+        if (!project.isPresent()) {
+            event.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        event.getPresentation().setEnabledAndVisible(isJavaProject(project.get()) && resource.getParentWithMarker(ID).isPresent());
     }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/MoveAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/MoveAction.java
@@ -72,6 +72,12 @@ public class MoveAction extends Action {
         final Resource resource = resources[0];
 
         final Optional<Project> project = resource.getRelatedProject();
+
+        if (!project.isPresent()) {
+            event.getPresentation().setEnabled(false);
+            return;
+        }
+
         final Optional<Resource> srcFolder = resource.getParentWithMarker(SourceFolderMarker.ID);
 
         if (resource.getResourceType() == FILE) {

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/RenameRefactoringAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/RenameRefactoringAction.java
@@ -140,6 +140,11 @@ public class RenameRefactoringAction extends Action implements ActivePartChanged
             if (file instanceof File) {
                 final Optional<Project> project = ((File)file).getRelatedProject();
 
+                if (!project.isPresent()) {
+                    event.getPresentation().setEnabled(false);
+                    return;
+                }
+
                 event.getPresentation().setEnabled(JavaUtil.isJavaProject(project.get()) && isJavaFile(file));
             } else {
                 event.getPresentation().setEnabled(isJavaFile(file));
@@ -156,6 +161,12 @@ public class RenameRefactoringAction extends Action implements ActivePartChanged
             final Resource resource = resources[0];
 
             final Optional<Project> project = resource.getRelatedProject();
+
+            if (!project.isPresent()) {
+                event.getPresentation().setEnabled(false);
+                return;
+            }
+
             final Optional<Resource> srcFolder = resource.getParentWithMarker(SourceFolderMarker.ID);
 
             if (resource.getResourceType() == FILE) {

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/actions/GetEffectivePomAction.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/actions/GetEffectivePomAction.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.maven.client.actions;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -71,11 +72,20 @@ public class GetEffectivePomAction extends AbstractPerspectiveAction {
 
     @Override
     public void updateInPerspective(@NotNull ActionEvent event) {
-        final Resource[] resources = appContext.getResources();
 
-        event.getPresentation().setEnabledAndVisible(resources != null
-                                                     && resources.length == 1
-                                                     && MAVEN_ID.equals(resources[0].getRelatedProject().get().getType()));
+        final Resource resource = appContext.getResource();
+        if (resource == null) {
+            event.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        final Optional<Project> project = resource.getRelatedProject();
+        if (!project.isPresent()) {
+            event.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        event.getPresentation().setEnabledAndVisible(project.get().isTypeOf(MAVEN_ID));
     }
 
     @Override


### PR DESCRIPTION
`NewFolderAction` - added dialog showing if any error occurred.
`ProjectExplorerPresenter` - fix disappearing maven module after project reconfiguring.
`RevealNodesPersistenceComponent` - reduce count of files which stores into user preference.
`TreeResourceRevealer` - add ability to select node after reveal operation.
`InMemoryResourceStore` - checking resource only by ones prefix path.
`NodeLoader` - revert last changes, because they are redundant.
`NewPackageAction` - prevent potential NPE.
`ProjectClasspathAction` - prevent potential NPE.
`MoveAction` - prevent potential NPE.
`RenameRefactoringAction` - prevent potential NPE.
`GetEffectivePomAction` - prevent potential NPE.

Related issue: CHE-1448

@vparfonov review it, plz.
