### PR TITLE
CHE-1412: Fix bug when codenvy/ubuntu_jdk8 image is removed

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -55,6 +55,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
+import static org.eclipse.che.plugin.docker.machine.DockerInstanceProvider.MACHINE_SNAPSHOT_PREFIX;
 
 /**
  * Docker implementation of {@link Instance}
@@ -260,9 +261,9 @@ public class DockerInstance extends AbstractInstance {
 
     private String generateRepository() {
         if (registryNamespace != null) {
-            return registryNamespace + '/' + NameGenerator.generate(null, 16);
+            return registryNamespace + '/' + MACHINE_SNAPSHOT_PREFIX + NameGenerator.generate(null, 16);
         }
-        return NameGenerator.generate(null, 16);
+        return MACHINE_SNAPSHOT_PREFIX + NameGenerator.generate(null, 16);
     }
 
     @Override


### PR DESCRIPTION
When we are creating machine not from recipe, but from local image, the image will be removed after machine is created. So if user creates a machine from codenvy/ubuntu_jdk8 image, the image will be removed.
In the step of creating a snapshot from machine I have added a special prefix to image repository to mark  this image as snapshot.
In the step of creating machine (recovering from snapshot) I have added two checks: 
do not pull if image is a local snapshot;
remove source image only if the image is a snapshot from registry.
