### PR TITLE
Remove environment before adding it

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -545,7 +545,7 @@ public class WorkspaceService extends Service {
         requiredNotNull(update, "Environment description");
         final WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
         final List<EnvironmentImpl> environments = workspace.getConfig().getEnvironments();
-        if (!environments.stream().anyMatch(env -> env.getName().equals(envName))) {
+        if (!environments.removeIf(env -> env.getName().equals(envName))) {
             throw new NotFoundException(format("Workspace '%s' doesn't contain environment '%s'", id, envName));
         }
         workspace.getConfig().getEnvironments().add(new EnvironmentImpl(update));
@@ -694,7 +694,7 @@ public class WorkspaceService extends Service {
         requiredNotNull(machineConfig.getSource().getType(), "Machine source type");
         // definition of source should come either with a content or with location
         requiredOnlyOneNotNull(machineConfig.getSource().getLocation(), machineConfig.getSource().getContent(),
-                        "Machine source should provide either location or content");
+                               "Machine source should provide either location or content");
 
         final WorkspaceImpl workspace = workspaceManager.getWorkspace(workspaceId);
         if (workspace.getRuntime() == null) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -501,6 +501,7 @@ public class WorkspaceServiceTest {
                                               + "/environment/" + envDto.getName());
 
         assertEquals(response.getStatusCode(), 200);
+        assertEquals(workspace.getConfig().getEnvironments().size(), 1);
         verify(validator).validateConfig(workspace.getConfig());
         verify(wsManager).updateWorkspace(any(), any());
     }


### PR DESCRIPTION
I think this is refactoring issue as previously environments were stored in map, so _contains + put_ actions were replaced with _contains + add_ for list, which is incorrect.

@garagatyi please review
