### PR TITLE
CODENVY-556 Add service for fetching recipe script

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/RecipeScriptDownloadServiceClient.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/RecipeScriptDownloadServiceClient.java
@@ -8,19 +8,22 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.ext.machine.server;
+package org.eclipse.che.ide.extension.machine.client;
 
-import com.google.inject.AbstractModule;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.ide.extension.machine.client.machine.Machine;
 
-import org.eclipse.che.api.machine.server.MachineService;
-import org.eclipse.che.ide.ext.machine.server.ssh.KeysInjector;
-import org.eclipse.che.inject.DynaModule;
+/**
+ * @author Mihail Kuznyetsov.
+ */
+public interface RecipeScriptDownloadServiceClient {
 
-@DynaModule
-public class MachineModule extends AbstractModule {
-    protected void configure() {
-        bind(KeysInjector.class).asEagerSingleton();
-
-        bind(RecipeScriptDownloadService.class);
-    }
+    /**
+     * Fetch recipe script for machine source location
+     *
+     * @param machine
+     *         machine to fetch script for
+     * @return content of the recipe script
+     */
+    Promise<String> getRecipeScript(Machine machine);
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/RecipeScriptDownloadServiceClientImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/RecipeScriptDownloadServiceClientImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.extension.machine.client;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.ide.extension.machine.client.machine.Machine;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.RestContext;
+import org.eclipse.che.ide.rest.StringUnmarshaller;
+
+import javax.inject.Inject;
+
+/**
+ * @author Mihail Kuznyetsov.
+ */
+public class RecipeScriptDownloadServiceClientImpl implements RecipeScriptDownloadServiceClient {
+
+    private final String restContext;
+    private final AsyncRequestFactory asyncRequestFactory;
+
+    @Inject
+    public RecipeScriptDownloadServiceClientImpl(@RestContext String restContext, AsyncRequestFactory asyncRequestFactory) {
+        this.restContext = restContext;
+        this.asyncRequestFactory = asyncRequestFactory;
+    }
+
+    @Override
+    public Promise<String> getRecipeScript(Machine machine) {
+        return asyncRequestFactory
+                .createGetRequest(restContext + "/recipe/script/" + machine.getId())
+                .send(new StringUnmarshaller());
+    }
+}

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/inject/MachineGinModule.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/inject/MachineGinModule.java
@@ -22,6 +22,8 @@ import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 import org.eclipse.che.ide.api.machine.MachineManager;
 import org.eclipse.che.ide.api.outputconsole.OutputConsole;
 import org.eclipse.che.ide.api.parts.Perspective;
+import org.eclipse.che.ide.extension.machine.client.RecipeScriptDownloadServiceClient;
+import org.eclipse.che.ide.extension.machine.client.RecipeScriptDownloadServiceClientImpl;
 import org.eclipse.che.ide.extension.machine.client.command.CommandType;
 import org.eclipse.che.ide.extension.machine.client.command.custom.CustomCommandType;
 import org.eclipse.che.ide.extension.machine.client.command.edit.EditCommandsView;
@@ -128,6 +130,8 @@ public class MachineGinModule extends AbstractGinModule {
         bind(DevelopmentView.class).to(DevelopmentViewImpl.class);
 
         bind(Target.class).to(BaseTarget.class);
+
+        bind(RecipeScriptDownloadServiceClient.class).to(RecipeScriptDownloadServiceClientImpl.class).in(Singleton.class);
 
         final GinMultibinder<CategoryPage> categoryPageBinder = GinMultibinder.newSetBinder(binder(), CategoryPage.class);
         categoryPageBinder.addBinding().to(SshCategoryPresenter.class);

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/recipe/RecipeTabPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/recipe/RecipeTabPresenter.java
@@ -10,22 +10,19 @@
  *******************************************************************************/
 package org.eclipse.che.ide.extension.machine.client.perspective.widgets.machine.appliance.recipe;
 
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.RequestBuilder;
-import com.google.gwt.http.client.RequestCallback;
-import com.google.gwt.http.client.RequestException;
-import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.ide.extension.machine.client.RecipeScriptDownloadServiceClient;
 import org.eclipse.che.ide.extension.machine.client.machine.Machine;
 import org.eclipse.che.ide.extension.machine.client.perspective.widgets.tab.content.TabPresenter;
 import org.eclipse.che.ide.util.loging.Log;
 
 import javax.validation.constraints.NotNull;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * The class contains business logic which allows update a recipe for current machine. The class is a tab presenter and
@@ -35,11 +32,13 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  */
 public class RecipeTabPresenter implements TabPresenter {
 
-    private final RecipeView view;
+    private final RecipeView                        view;
+    private final RecipeScriptDownloadServiceClient recipeScriptClient;
 
     @Inject
-    public RecipeTabPresenter(RecipeView view) {
+    public RecipeTabPresenter(RecipeView view, RecipeScriptDownloadServiceClient recipeScriptClient) {
         this.view = view;
+        this.recipeScriptClient = recipeScriptClient;
     }
 
     /**
@@ -48,28 +47,19 @@ public class RecipeTabPresenter implements TabPresenter {
      * @param machine
      *         machine for which need update information
      */
-    public void updateInfo(@NotNull Machine machine) {
-        String scriptLocation = machine.getRecipeLocation();
-        if (!isNullOrEmpty(scriptLocation)) { //TODO : need to add test this block
-            RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, scriptLocation);
-            try {
-                requestBuilder.sendRequest(null, new RequestCallback() {
+    public void updateInfo(@NotNull final Machine machine) {
+        recipeScriptClient.getRecipeScript(machine).then(new Operation<String>() {
                     @Override
-                    public void onResponseReceived(Request request, Response response) {
-                        view.setScript(response.getText());
+                    public void apply(String recipe) throws OperationException {
+                        view.setScript(recipe);
                     }
-
-                    @Override
-                    public void onError(Request request, Throwable exception) {
-
-                    }
-                });
-            } catch (RequestException exception) {
-                Log.error(getClass(), exception);
+                }).catchError(new Operation<PromiseError>() {
+            @Override
+            public void apply(PromiseError error) throws OperationException {
+                Log.error(RecipeTabPresenter.class,
+                          "Failed to get recipe script for machine " + machine.getId() + ": " + error.getMessage());
             }
-        } else if (!isNullOrEmpty(machine.getRecipeContent())) {
-            view.setScript(machine.getRecipeContent());
-        }
+        });
     }
 
     /** {@inheritDoc} */

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/recipe/RecipeTabPresenterTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/recipe/RecipeTabPresenterTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.che.ide.extension.machine.client.perspective.widgets.machine.appliance.recipe;
 
 import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.ide.extension.machine.client.RecipeScriptDownloadServiceClient;
 import org.eclipse.che.ide.extension.machine.client.machine.Machine;
-import org.eclipse.che.ide.websocket.rest.RequestCallback;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -23,7 +23,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,12 +33,17 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RecipeTabPresenterTest {
     @Mock
-    private RecipeView view;
+    private RecipeView                        view;
     @Mock
-    private Machine    machine;
+    private Machine                           machine;
+    @Mock
+    private RecipeScriptDownloadServiceClient recipeScriptClient;
+
+    @Mock
+    private Promise<String> recipePromise;
 
     @Captor
-    private ArgumentCaptor<RequestCallback> argumentCaptor;
+    private ArgumentCaptor<Operation<String>> argumentCaptor;
 
     @InjectMocks
     private RecipeTabPresenter presenter;
@@ -64,8 +69,13 @@ public class RecipeTabPresenterTest {
 
     @Test
     public void tabGetScriptAsContent() throws Exception {
-        when(machine.getRecipeContent()).thenReturn("test content");
+        when(recipeScriptClient.getRecipeScript(any(Machine.class))).thenReturn(recipePromise);
+        when(recipePromise.then(any(Operation.class))).thenReturn(recipePromise);
+
         presenter.updateInfo(machine);
+
+        verify(recipePromise).then(argumentCaptor.capture());
+        argumentCaptor.getValue().apply("test content");
         verify(view).setScript("test content");
     }
 

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/RecipeScriptDownloadService.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/RecipeScriptDownloadService.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.machine.server;
+
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.rest.Service;
+import org.eclipse.che.api.machine.server.MachineManager;
+import org.eclipse.che.api.machine.server.util.RecipeRetriever;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Service for downloading recipe script for machine.
+ *
+ * @author Mihail Kuznyetsov.
+ */
+@Path("/recipe/script")
+public class RecipeScriptDownloadService extends Service {
+
+    private final MachineManager  machineManager;
+    private final RecipeRetriever recipeRetriever;
+
+    @Inject
+    public RecipeScriptDownloadService(MachineManager machineManager, RecipeRetriever recipeRetriever) {
+        this.machineManager = machineManager;
+        this.recipeRetriever = recipeRetriever;
+    }
+
+    @GET
+    @Path("/{machineId}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getRecipeScript(@PathParam("machineId") String machineId) throws ServerException, NotFoundException {
+        return recipeRetriever.getRecipe(machineManager.getMachine(machineId).getConfig()).getScript();
+    }
+}

--- a/plugins/plugin-ssh-machine/src/test/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstanceProviderTest.java
+++ b/plugins/plugin-ssh-machine/src/test/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstanceProviderTest.java
@@ -47,6 +47,8 @@ import static org.testng.Assert.assertEquals;
  */
 @Listeners(MockitoTestNGListener.class)
 public class SshMachineInstanceProviderTest {
+    private static final String RECIPE_SCRIPT = new Gson().toJson(new SshMachineRecipe("localhost", 22, "user", "password"));
+
     @Mock
     private RecipeDownloader recipeDownloader;
 
@@ -70,7 +72,7 @@ public class SshMachineInstanceProviderTest {
                                                                  "user",
                                                                  "password");
         recipe = new RecipeImpl().withType("ssh-config")
-                                 .withScript(new Gson().toJson(sshMachineRecipe));
+                                 .withScript(RECIPE_SCRIPT);
     }
 
     @Test

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/util/RecipeDownloader.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/util/RecipeDownloader.java
@@ -77,7 +77,7 @@ public class RecipeDownloader {
             return new RecipeImpl().withType(machineConfig.getSource().getType())
                                    .withScript(IoUtil.readAndCloseQuietly(new FileInputStream(file)));
         } catch (IOException | IllegalArgumentException e) {
-            throw new MachineException(format("Can't start machine %s because machine recipe downloading failed. Recipe url %s. Error: %s",
+            throw new MachineException(format("Failed to download recipe for machine %s. Recipe url %s. Error: %s",
                                               machineConfig.getName(),
                                               location,
                                               e.getLocalizedMessage()));

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
@@ -515,6 +515,32 @@ public class DefaultWorkspaceValidatorTest {
         wsValidator.validateConfig(config);
     }
 
+    @Test(expectedExceptions = BadRequestException.class,
+          expectedExceptionsMessageRegExp = "Environment dev-env contains machine with invalid source location: localhost")
+    public void shouldFailValidationIfLocationIsInvalidUrl() throws Exception {
+        final WorkspaceConfigDto config = createConfig();
+        config.getEnvironments()
+              .get(0)
+              .getMachineConfigs()
+              .get(0)
+              .withSource(newDto(MachineSourceDto.class).withType("dockerfile").withLocation("localhost"));
+
+        wsValidator.validateConfig(config);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class,
+          expectedExceptionsMessageRegExp = "Environment dev-env contains machine with invalid source location protocol: ftp://localhost")
+    public void shouldFailValidationIfLocationHasInvalidProtocol() throws Exception {
+        final WorkspaceConfigDto config = createConfig();
+        config.getEnvironments()
+              .get(0)
+              .getMachineConfigs()
+              .get(0)
+              .withSource(newDto(MachineSourceDto.class).withType("dockerfile").withLocation("ftp://localhost"));
+
+        wsValidator.validateConfig(config);
+    }
+
     private static WorkspaceConfigDto createConfig() {
         final WorkspaceConfigDto workspaceConfigDto = newDto(WorkspaceConfigDto.class).withName("ws-name")
                                                                                       .withDefaultEnv("dev-env");
@@ -530,7 +556,7 @@ public class DefaultWorkspaceValidatorTest {
         MachineConfigDto devMachine = newDto(MachineConfigDto.class).withDev(true)
                                                                     .withName("dev-machine")
                                                                     .withType("docker")
-                                                                    .withSource(newDto(MachineSourceDto.class).withLocation("location")
+                                                                    .withSource(newDto(MachineSourceDto.class).withLocation("http://location")
                                                                                                               .withType("dockerfile"))
                                                                     .withServers(serversConf)
                                                                     .withEnvVariables(new HashMap<>(singletonMap("key1", "value1")));


### PR DESCRIPTION
In order to fetch recipe script from external host, and not
end up with 'Mixed content' error, when trying to send
HTTP request on HTTPS installation, we will do it on server side instead.
from HTT
