### PR TITLE
Fix new alpine based Dockerfile for Boot2Docker

### DIFF
--- a/dockerfiles/che-server/Dockerfile
+++ b/dockerfiles/che-server/Dockerfile
@@ -30,6 +30,7 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/reposit
     addgroup -S docker -g 101 && \
     adduser user docker && \
     adduser user user && \
+    adduser user users && \
     addgroup -g 50 -S docker4mac && \
     adduser user docker4mac && \
     echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \


### PR DESCRIPTION
### What does this PR do?

Add user `user` to the group `users` that happen to have gid 100 that correspond to docker group in a boot2docker VM.
### What issues does this PR fix or reference?

A permission issue when trying to access the docker socket `/var/run/docker.sock` when running Che in a container using boot2docker.
### Tests written?

No

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Signed-off-by: Mario Loriedo mloriedo@redhat.com
