### PR TITLE
Revert "CODENVY-413: Make it possible to mark MachineNode as 'sheduled for maintenace'"

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -26,6 +26,7 @@ import org.eclipse.che.plugin.docker.client.connection.CloseConnectionInputStrea
 import org.eclipse.che.plugin.docker.client.connection.DockerConnection;
 import org.eclipse.che.plugin.docker.client.connection.DockerConnectionFactory;
 import org.eclipse.che.plugin.docker.client.connection.DockerResponse;
+import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
 import org.eclipse.che.plugin.docker.client.exception.ContainerNotFoundException;
 import org.eclipse.che.plugin.docker.client.exception.DockerException;
 import org.eclipse.che.plugin.docker.client.exception.ImageNotFoundException;
@@ -757,28 +758,25 @@ public class DockerConnector {
     private String buildImage(final DockerConnection dockerConnection,
                               final BuildImageParams params,
                               final ProgressMonitor progressMonitor) throws IOException {
+        final AuthConfigs authConfigs = params.getAuthConfigs();
         final String repository = params.getRepository();
+        final String tag = params.getTag();
 
         try (DockerConnection connection = dockerConnection.method("POST")
                                                            .path(apiVersionPathPrefix + "/build")
+                                                           .query("rm", 1)
+                                                           .query("forcerm", 1)
                                                            .header("X-Registry-Config",
-                                                                   authResolver.getXRegistryConfigHeaderValue(params.getAuthConfigs()))) {
-            addQueryParamIfNotNull(connection, "rm", params.isRemoveIntermediateContainer());
-            addQueryParamIfNotNull(connection, "forcerm", params.isForceRemoveIntermediateContainers());
+                                                                   authResolver.getXRegistryConfigHeaderValue(authConfigs))) {
+            if (tag == null) {
+                addQueryParamIfNotNull(connection, "t", repository);
+            } else {
+                addQueryParamIfNotNull(connection, "t", repository == null ? null : repository + ':' + tag);
+            }
             addQueryParamIfNotNull(connection, "memory", params.getMemoryLimit());
             addQueryParamIfNotNull(connection, "memswap", params.getMemorySwapLimit());
             addQueryParamIfNotNull(connection, "pull", params.isDoForcePull());
             addQueryParamIfNotNull(connection, "dockerfile", params.getDockerfile());
-            addQueryParamIfNotNull(connection, "nocache", params.isNoCache());
-            addQueryParamIfNotNull(connection, "q", params.isQuiet());
-            if (params.getTag() == null) {
-                addQueryParamIfNotNull(connection, "t", repository);
-            } else {
-                addQueryParamIfNotNull(connection, "t", repository == null ? null : repository + ':' + params.getTag());
-            }
-            if (params.getBuildArgs() != null) {
-                addQueryParamIfNotNull(connection, "buildargs", URLEncoder.encode(GSON.toJson(params.getBuildArgs()), "UTF-8"));
-            }
 
             final DockerResponse response = connection.request();
             if (OK.getStatusCode() != response.getStatus()) {

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
@@ -16,9 +16,7 @@ import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
 import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -32,20 +30,16 @@ import static org.eclipse.che.plugin.docker.client.params.ParamsUtils.requireNon
  * @author Alexander Garagatyi
  */
 public class BuildImageParams {
-    private String              repository;
-    private String              tag;
-    private AuthConfigs         authConfigs;
-    private Boolean             doForcePull;
-    private Long                memoryLimit;
-    private Long                memorySwapLimit;
-    private List<File>          files;
-    private String              dockerfile;
-    private String              remote;
-    private Boolean             quiet;
-    private Boolean             noCache;
-    private Boolean             removeIntermediateContainer;
-    private Boolean             forceRemoveIntermediateContainers;
-    private Map<String, String> buildArgs;
+    // todo add next parameters q, nocache, rm, forcerm
+    private String      repository;
+    private String      tag;
+    private AuthConfigs authConfigs;
+    private Boolean     doForcePull;
+    private Long        memoryLimit;
+    private Long        memorySwapLimit;
+    private List<File>  files;
+    private String      dockerfile;
+    private String      remote;
 
     /**
      * Creates arguments holder with required parameters.
@@ -188,9 +182,6 @@ public class BuildImageParams {
      *         if {@code files} is null
      */
     public BuildImageParams addFiles(@NotNull File... files) {
-        if (remote != null) {
-            throw new IllegalStateException("Remote parameter is already set. Remote and files parameters are mutually exclusive.");
-        }
         requireNonNull(files);
         for (File file : files) {
             requireNonNull(file);
@@ -219,87 +210,6 @@ public class BuildImageParams {
         }
 
         this.remote = remote;
-        return this;
-    }
-
-    /**
-     * Suppress verbose build output.
-     *
-     * @param quiet
-     *         quiet flag
-     * @return this params instance
-     */
-    public BuildImageParams withQuiet(boolean quiet) {
-        this.quiet = quiet;
-        return this;
-    }
-
-    /**
-     * Do not use the cache when building the image.
-     *
-     * @param noCache
-     *         no cache flag
-     * @return this params instance
-     */
-    public BuildImageParams withNoCache(boolean noCache) {
-        this.noCache = noCache;
-        return this;
-    }
-
-    /**
-     * Remove intermediate containers after a successful build.
-     *
-     * @param removeIntermediateContainer
-     *         remove intermediate container flag
-     * @return this params instance
-     */
-    public BuildImageParams withRemoveIntermediateContainers(boolean removeIntermediateContainer) {
-        this.removeIntermediateContainer = removeIntermediateContainer;
-        return this;
-    }
-
-    /**
-     * Always remove intermediate containers (includes removeIntermediateContainer).
-     *
-     * @param forceRemoveIntermediateContainers
-     *         remove intermediate containers with force flag
-     * @return this params instance
-     */
-    public BuildImageParams withForceRemoveIntermediateContainers(boolean forceRemoveIntermediateContainers) {
-        this.forceRemoveIntermediateContainers = forceRemoveIntermediateContainers;
-        return this;
-    }
-
-    /**
-     * Map of string pairs for build-time variables.
-     * Users pass these values at build-time.
-     * Docker uses the buildargs as the environment context for command(s) run via the Dockerfile’s RUN instruction
-     * or for variable expansion in other Dockerfile instructions.
-     *
-     * @param buildArgs
-     *         map of build arguments
-     * @return this params instance
-     */
-    public BuildImageParams withBuildArgs(Map<String, String> buildArgs) {
-        this.buildArgs = buildArgs;
-        return this;
-    }
-
-    /**
-     * Adds build variable to build args.
-     * See {@link #withBuildArgs(Map)}
-     *
-     * @param key
-     *         variable name
-     * @param value
-     *         variable value
-     * @return this params instance
-     */
-    public BuildImageParams addBuildArg(String key, String value) {
-        if (buildArgs == null) {
-            buildArgs = new HashMap<>();
-        }
-        buildArgs.put(key, value);
         return this;
     }
 
@@ -351,63 +261,39 @@ public class BuildImageParams {
         return remote;
     }
 
-    public Boolean isQuiet() {
-        return quiet;
-    }
-
-    public Boolean isNoCache() {
-        return noCache;
-    }
-
-    public Boolean isRemoveIntermediateContainer() {
-        return removeIntermediateContainer;
-    }
-
-    public Boolean isForceRemoveIntermediateContainers() {
-        return forceRemoveIntermediateContainers;
-    }
-
-    public Map<String, String> getBuildArgs() {
-        return buildArgs;
-    }
-
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BuildImageParams that = (BuildImageParams)o;
-        return Objects.equals(repository, that.repository) &&
-               Objects.equals(tag, that.tag) &&
-               Objects.equals(authConfigs, that.authConfigs) &&
-               Objects.equals(doForcePull, that.doForcePull) &&
-               Objects.equals(memoryLimit, that.memoryLimit) &&
-               Objects.equals(memorySwapLimit, that.memorySwapLimit) &&
-               Objects.equals(files, that.files) &&
-               Objects.equals(dockerfile, that.dockerfile) &&
-               Objects.equals(remote, that.remote) &&
-               Objects.equals(quiet, that.quiet) &&
-               Objects.equals(noCache, that.noCache) &&
-               Objects.equals(removeIntermediateContainer, that.removeIntermediateContainer) &&
-               Objects.equals(forceRemoveIntermediateContainers, that.forceRemoveIntermediateContainers) &&
-               Objects.equals(buildArgs, that.buildArgs);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof BuildImageParams)) {
+            return false;
+        }
+        final BuildImageParams that = (BuildImageParams)obj;
+        return Objects.equals(repository, that.repository)
+               && Objects.equals(tag, that.tag)
+               && Objects.equals(authConfigs, that.authConfigs)
+               && Objects.equals(doForcePull, that.doForcePull)
+               && Objects.equals(memoryLimit, that.memoryLimit)
+               && Objects.equals(memorySwapLimit, that.memorySwapLimit)
+               && getFiles().equals(that.getFiles())
+               && Objects.equals(dockerfile, that.dockerfile)
+               && Objects.equals(remote, that.remote);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(repository,
-                            tag,
-                            authConfigs,
-                            doForcePull,
-                            memoryLimit,
-                            memorySwapLimit,
-                            files,
-                            dockerfile,
-                            remote,
-                            quiet,
-                            noCache,
-                            removeIntermediateContainer,
-                            forceRemoveIntermediateContainers,
-                            buildArgs);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(repository);
+        hash = 31 * hash + Objects.hashCode(tag);
+        hash = 31 * hash + Objects.hashCode(authConfigs);
+        hash = 31 * hash + Objects.hashCode(doForcePull);
+        hash = 31 * hash + Objects.hashCode(memoryLimit);
+        hash = 31 * hash + Objects.hashCode(memorySwapLimit);
+        hash = 31 * hash + getFiles().hashCode();
+        hash = 31 * hash + Objects.hashCode(dockerfile);
+        hash = 31 * hash + Objects.hashCode(remote);
+        return hash;
     }
 
     @Override
@@ -422,12 +308,6 @@ public class BuildImageParams {
                ", files=" + files +
                ", dockerfile='" + dockerfile + '\'' +
                ", remote='" + remote + '\'' +
-               ", quiet=" + quiet +
-               ", noCache=" + noCache +
-               ", removeIntermediateContainer=" + removeIntermediateContainer +
-               ", forceRemoveIntermediateContainers=" + forceRemoveIntermediateContainers +
-               ", buildArgs=" + buildArgs +
                '}';
     }
-
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -974,6 +974,8 @@ public class DockerConnectorTest {
         verify(dockerConnectionFactory).openConnection(any(URI.class));
         verify(dockerConnection).method(REQUEST_METHOD_POST);
         verify(dockerConnection).path("/build");
+        verify(dockerConnection).query("rm", 1);
+        verify(dockerConnection).query("forcerm", 1);
         verify(dockerConnection).header("Content-Type", "application/x-compressed-tar");
         verify(dockerConnection).header(eq("Content-Length"), anyInt());
         verify(dockerConnection).header(eq("X-Registry-Config"), any(byte[].class));

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/params/BuildImageParamsTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/params/BuildImageParamsTest.java
@@ -17,13 +17,10 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 /**
@@ -31,21 +28,14 @@ import static org.testng.Assert.assertNull;
  */
 public class BuildImageParamsTest {
 
-    private static final String             REPOSITORY                           = "repository";
-    private static final String             TAG                                  = "tag";
-    private static final AuthConfigs        AUTH_CONFIGS                         = mock(AuthConfigs.class);
-    private static final Boolean            DO_FORCE_PULL                        = true;
-    private static final Long               MEMORY_LIMIT                         = 12345L;
-    private static final Long               MEMORY_SWAP_LIMIT                    = 67890L;
-    private static final File               FILE                                 = new File(".");
-    private static final List<File>         FILES;
-    private static final String             DOCKERFILE                           = "/tmp/Dockerfile";
-    private static final String             REMOTE                               = "https://github.com/someuser/remote.git";
-    private static final Boolean            QUIET                                = false;
-    private static final Boolean            NO_CACHE                             = false;
-    private static final Boolean            REMOVE_INTERMEDIATE_CONTAINER        = true;
-    private static final Boolean            FORCE_REMOVE_INTERMEDIATE_CONTAINERS = true;
-    private static final Map<String,String> BUILD_ARGS                           = new HashMap<>();
+    private static final String      REPOSITORY        = "repository";
+    private static final String      TAG               = "tag";
+    private static final AuthConfigs AUTH_CONFIGS      = mock(AuthConfigs.class);
+    private static final Boolean     DO_FORCE_PULL     = true;
+    private static final Long        MEMORY_LIMIT      = 12345L;
+    private static final Long        MEMORY_SWAP_LIMIT = 67890L;
+    private static final File        FILE              = new File(".");
+    private static final List<File>  FILES;
 
     static {
         FILES = new ArrayList<>();
@@ -60,7 +50,7 @@ public class BuildImageParamsTest {
     }
 
     @Test
-    public void shouldCreateParamsObjectWithRequiredParametersFromFiles() {
+    public void shouldCreateParamsObjectWithRequiredParameters() {
         buildImageParams = BuildImageParams.create(FILE);
 
         assertEquals(buildImageParams.getFiles(), FILES);
@@ -71,54 +61,17 @@ public class BuildImageParamsTest {
         assertNull(buildImageParams.isDoForcePull());
         assertNull(buildImageParams.getMemoryLimit());
         assertNull(buildImageParams.getMemorySwapLimit());
-        assertNull(buildImageParams.getDockerfile());
-        assertNull(buildImageParams.getRemote());
-        assertNull(buildImageParams.isQuiet());
-        assertNull(buildImageParams.isNoCache());
-        assertNull(buildImageParams.isRemoveIntermediateContainer());
-        assertNull(buildImageParams.isForceRemoveIntermediateContainers());
-        assertNull(buildImageParams.getBuildArgs());
     }
 
     @Test
-    public void shouldCreateParamsObjectWithRequiredParametersFromRemote() {
-        buildImageParams = BuildImageParams.create(REMOTE);
-
-        assertEquals(buildImageParams.getRemote(), REMOTE);
-
-        assertNull(buildImageParams.getRepository());
-        assertNull(buildImageParams.getTag());
-        assertNull(buildImageParams.getAuthConfigs());
-        assertNull(buildImageParams.isDoForcePull());
-        assertNull(buildImageParams.getMemoryLimit());
-        assertNull(buildImageParams.getMemorySwapLimit());
-        assertNull(buildImageParams.getFiles());
-        assertNull(buildImageParams.getDockerfile());
-        assertNull(buildImageParams.isQuiet());
-        assertNull(buildImageParams.isNoCache());
-        assertNull(buildImageParams.isRemoveIntermediateContainer());
-        assertNull(buildImageParams.isForceRemoveIntermediateContainers());
-        assertNull(buildImageParams.getBuildArgs());
-    }
-
-
-    @Test
-    public void shouldCreateParamsObjectWithAllPossibleParametersFromFiles() {
+    public void shouldCreateParamsObjectWithAllPossibleParameters() {
         buildImageParams = BuildImageParams.create(FILE)
                                            .withRepository(REPOSITORY)
                                            .withTag(TAG)
                                            .withAuthConfigs(AUTH_CONFIGS)
                                            .withDoForcePull(DO_FORCE_PULL)
                                            .withMemoryLimit(MEMORY_LIMIT)
-                                           .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                                           .withDockerfile(DOCKERFILE)
-                                           .withQuiet(QUIET)
-                                           .withNoCache(NO_CACHE)
-                                           .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                                           .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                                           .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.getRemote());
+                                           .withMemorySwapLimit(MEMORY_SWAP_LIMIT);
 
         assertEquals(buildImageParams.getFiles(), FILES);
         assertEquals(buildImageParams.getTag(), TAG);
@@ -127,45 +80,6 @@ public class BuildImageParamsTest {
         assertEquals(buildImageParams.isDoForcePull(), DO_FORCE_PULL);
         assertEquals(buildImageParams.getMemoryLimit(), MEMORY_LIMIT);
         assertEquals(buildImageParams.getMemorySwapLimit(), MEMORY_SWAP_LIMIT);
-        assertEquals(buildImageParams.getDockerfile(), DOCKERFILE);
-        assertEquals(buildImageParams.isQuiet(), QUIET);
-        assertEquals(buildImageParams.isNoCache(), NO_CACHE);
-        assertEquals(buildImageParams.isRemoveIntermediateContainer(), REMOVE_INTERMEDIATE_CONTAINER);
-        assertEquals(buildImageParams.isForceRemoveIntermediateContainers(), FORCE_REMOVE_INTERMEDIATE_CONTAINERS);
-        assertEquals(buildImageParams.getBuildArgs(), BUILD_ARGS);
-    }
-
-    @Test
-    public void shouldCreateParamsObjectWithAllPossibleParametersFromRemote() {
-        buildImageParams = BuildImageParams.create(REMOTE)
-                                           .withRepository(REPOSITORY)
-                                           .withTag(TAG)
-                                           .withAuthConfigs(AUTH_CONFIGS)
-                                           .withDoForcePull(DO_FORCE_PULL)
-                                           .withMemoryLimit(MEMORY_LIMIT)
-                                           .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                                           .withDockerfile(DOCKERFILE)
-                                           .withQuiet(QUIET)
-                                           .withNoCache(NO_CACHE)
-                                           .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                                           .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                                           .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.getFiles());
-
-        assertEquals(buildImageParams.getRemote(), REMOTE);
-        assertEquals(buildImageParams.getTag(), TAG);
-        assertEquals(buildImageParams.getRepository(), REPOSITORY);
-        assertEquals(buildImageParams.getAuthConfigs(), AUTH_CONFIGS);
-        assertEquals(buildImageParams.isDoForcePull(), DO_FORCE_PULL);
-        assertEquals(buildImageParams.getMemoryLimit(), MEMORY_LIMIT);
-        assertEquals(buildImageParams.getMemorySwapLimit(), MEMORY_SWAP_LIMIT);
-        assertEquals(buildImageParams.getDockerfile(), DOCKERFILE);
-        assertEquals(buildImageParams.isQuiet(), QUIET);
-        assertEquals(buildImageParams.isNoCache(), NO_CACHE);
-        assertEquals(buildImageParams.isRemoveIntermediateContainer(), REMOVE_INTERMEDIATE_CONTAINER);
-        assertEquals(buildImageParams.isForceRemoveIntermediateContainers(), FORCE_REMOVE_INTERMEDIATE_CONTAINERS);
-        assertEquals(buildImageParams.getBuildArgs(), BUILD_ARGS);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -191,37 +105,13 @@ public class BuildImageParamsTest {
         buildImageParams.withFiles(FILE, null, FILE);
     }
 
-    @Test (expectedExceptions = IllegalStateException.class)
-    public void shouldThrowIllegalStateExceptionIfSetRemoteAfterSetFiles() {
-        buildImageParams = BuildImageParams.create(FILE)
-                                           .withRemote(REMOTE);
-    }
-
-    @Test (expectedExceptions = IllegalStateException.class)
-    public void shouldThrowIllegalStateExceptionIfSetFileAfterSetRemote() {
-        buildImageParams = BuildImageParams.create(REMOTE)
-                                           .withFiles(FILE);
-    }
-
-    @Test (expectedExceptions = IllegalStateException.class)
-    public void shouldThrowIllegalStateExceptionIfAddFileAfterSetRemote() {
-        buildImageParams = BuildImageParams.create(REMOTE)
-                                           .addFiles(FILE);
-    }
-
     @Test
     public void repositoryParameterShouldEqualsNullIfItNotSet() {
         buildImageParams.withTag(TAG)
                         .withAuthConfigs(AUTH_CONFIGS)
                         .withDoForcePull(DO_FORCE_PULL)
                         .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT);
 
         assertNull(buildImageParams.getRepository());
     }
@@ -232,13 +122,7 @@ public class BuildImageParamsTest {
                         .withAuthConfigs(AUTH_CONFIGS)
                         .withDoForcePull(DO_FORCE_PULL)
                         .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT);
 
         assertNull(buildImageParams.getTag());
     }
@@ -249,13 +133,7 @@ public class BuildImageParamsTest {
                         .withTag(TAG)
                         .withDoForcePull(DO_FORCE_PULL)
                         .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT);
 
         assertNull(buildImageParams.getAuthConfigs());
     }
@@ -266,13 +144,7 @@ public class BuildImageParamsTest {
                         .withTag(TAG)
                         .withAuthConfigs(AUTH_CONFIGS)
                         .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT);
 
         assertNull(buildImageParams.isDoForcePull());
     }
@@ -283,13 +155,7 @@ public class BuildImageParamsTest {
                         .withTag(TAG)
                         .withAuthConfigs(AUTH_CONFIGS)
                         .withDoForcePull(DO_FORCE_PULL)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT);
 
         assertNull(buildImageParams.getMemoryLimit());
     }
@@ -300,117 +166,9 @@ public class BuildImageParamsTest {
                         .withTag(TAG)
                         .withAuthConfigs(AUTH_CONFIGS)
                         .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+                        .withMemoryLimit(MEMORY_LIMIT);
 
         assertNull(buildImageParams.getMemorySwapLimit());
-    }
-
-    @Test
-    public void dockerfileParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.getDockerfile());
-    }
-
-    @Test
-    public void quietParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.isQuiet());
-    }
-
-    @Test
-    public void noCacheParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.isNoCache());
-    }
-
-    @Test
-    public void removeIntermediateContainerParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.isRemoveIntermediateContainer());
-    }
-
-    @Test
-    public void forceRemoveIntermediateContainersParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withBuildArgs(BUILD_ARGS);
-
-        assertNull(buildImageParams.isForceRemoveIntermediateContainers());
-    }
-
-    @Test
-    public void buildArgsParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS);
-
-        assertNull(buildImageParams.getBuildArgs());
     }
 
     @Test (expectedExceptions = NullPointerException.class)
@@ -434,17 +192,6 @@ public class BuildImageParamsTest {
         buildImageParams.addFiles(file);
 
         assertEquals(buildImageParams.getFiles(), files);
-    }
-
-    @Test
-    public void shouldAddBuildArgToBuildArgs() {
-        String key = "ba_key";
-        String value = "ba_value";
-
-        buildImageParams.addBuildArg(key, value);
-
-        assertNotNull(buildImageParams.getBuildArgs());
-        assertEquals(buildImageParams.getBuildArgs().get(key), value);
     }
 
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -94,7 +94,6 @@ import static org.eclipse.che.plugin.docker.machine.DockerInstance.LATEST_TAG;
  * @author andrew00x
  * @author Alexander Garagatyi
  * @author Roman Iuvshyn
- * @author Mykola Morhun
  */
 @Singleton
 public class DockerInstanceProvider implements InstanceProvider {
@@ -122,7 +121,6 @@ public class DockerInstanceProvider implements InstanceProvider {
     private final ExecutorService                               executor;
     private final DockerInstanceStopDetector                    dockerInstanceStopDetector;
     private final DockerContainerNameGenerator                  containerNameGenerator;
-    private final RecipeRetriever                               recipeRetriever;
     private final WorkspaceFolderPathProvider                   workspaceFolderPathProvider;
     private final boolean                                       doForcePullOnBuild;
     private final boolean                                       privilegeMode;
@@ -137,6 +135,7 @@ public class DockerInstanceProvider implements InstanceProvider {
     private final String[]                                      allMachinesExtraHosts;
     private final String                                        projectFolderPath;
     private final boolean                                       snapshotUseRegistry;
+    private final RecipeRetriever                               recipeRetriever;
     private final double                                        memorySwapMultiplier;
 
     @Inject
@@ -398,7 +397,6 @@ public class DockerInstanceProvider implements InstanceProvider {
             dockerfile.writeDockerfile(dockerfileFile);
 
             docker.buildImage(BuildImageParams.create(dockerfileFile)
-                                              .withForceRemoveIntermediateContainers(true)
                                               .withRepository(machineImageName)
                                               .withAuthConfigs(dockerCredentials.getCredentials())
                                               .withDoForcePull(doForcePullOnBuild)


### PR DESCRIPTION
Reverts eclipse/che#1705 because of fix version 4.6
