### PR TITLE
CODENVY-572: Fix NullPointerException

### DIFF
--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/wsagent/WsAgentLauncherImplTest.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/wsagent/WsAgentLauncherImplTest.java
@@ -219,4 +219,12 @@ public class WsAgentLauncherImplTest {
 
         wsAgentLauncher.startWsAgent(WS_ID);
     }
+
+    @Test(expectedExceptions = MachineException.class,
+          expectedExceptionsMessageRegExp = "Workspace agent server not found in dev machine.")
+    public void shouldThrowMachineExceptionIfwsAgentNotFound() throws Exception {
+        doReturn(Collections.emptyMap()).when(machineRuntime).getServers();
+
+        wsAgentLauncher.startWsAgent(WS_ID);
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Checks for workspace agent server existence. If the map of servers from dev machine does not contain workspace agent server, exception is thrown.
### What issues does this PR fix or reference?

Sometimes `NullPointerException` appears on start workspace
### Tests written?

Yes
### Docs requirements?

No

@garagatyi @skabashnyuk @mmorhun please review
