### PR TITLE
Downgrade docker installed in Che image

### DIFF
--- a/dockerfiles/che-server/Dockerfile
+++ b/dockerfiles/che-server/Dockerfile
@@ -16,13 +16,18 @@ FROM alpine:3.4
 ENV LANG=C.UTF-8 \
     JAVA_HOME=/usr/lib/jvm/default-jvm/jre \
     PATH=${PATH}:${JAVA_HOME}/bin \
-    CHE_HOME=/home/user/che
+    CHE_HOME=/home/user/che \
+    DOCKER_VERSION=1.6.0 \
+    DOCKER_BUCKET=get.docker.com
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     apk upgrade --update && \
-    apk add --update docker openjdk8 sudo bash && \
+    apk add --update ca-certificates curl openssl openjdk8 sudo bash && \
+    curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
+    chmod +x /usr/bin/docker && \
     addgroup -S user -g 1000 && \
     adduser -S user -h /home/user -s /bin/bash -G root -u 1000 -D && \
+    addgroup -S docker -g 101 && \
     adduser user docker && \
     adduser user user && \
     addgroup -g 50 -S docker4mac && \


### PR DESCRIPTION
### What does this PR do?

Use Docker version 1.6 in Che image
### What issues does this PR fix or reference?

On a machine with Docker 1.10 or lower Che failed to start in a container.
![image](https://cloud.githubusercontent.com/assets/606959/16916337/a065d336-4cfc-11e6-8be5-13173257709d.png)
### Previous Behavior

![image](https://cloud.githubusercontent.com/assets/606959/16916254/391f8e88-4cfc-11e6-8485-eed07dd3b519.png)
### New Behavior

![image](https://cloud.githubusercontent.com/assets/606959/16916287/5bd71d56-4cfc-11e6-9906-ec0e89d5ba8a.png)
### Tests written?

No
### Docs requirements?

No 

Signed-off-by: Mario Loriedo mloriedo@redhat.com
