### PR TITLE
#1850: Remove closed file from the editor's popup list

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
@@ -211,8 +211,6 @@ public class EditorPartStackPresenter extends PartStackPresenter implements Edit
         ListItem listItem = getListItemByTab(tab);
         listButton.removeListItem(listItem);
         items.remove(listItem);
-
-        eventBus.fireEvent(new FileEvent(((EditorTab) tab).getFile(), CLOSE));
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
@@ -31,6 +31,7 @@ import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.event.FileEventHandler;
 import org.eclipse.che.ide.api.filetypes.FileType;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.parts.PartPresenter;
@@ -48,6 +49,7 @@ import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.validation.constraints.NotNull;
 
+import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.CLOSE;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.ADDED;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.MOVED_FROM;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.MOVED_TO;
@@ -62,7 +64,7 @@ import static org.eclipse.che.ide.api.resources.ResourceDelta.UPDATED;
  * @author Vitaliy Guliy
  * @author Vlad Zhukovskyi
  */
-public class EditorTabWidget extends Composite implements EditorTab, ContextMenuHandler, ResourceChangedHandler {
+public class EditorTabWidget extends Composite implements EditorTab, ContextMenuHandler, ResourceChangedHandler, FileEventHandler {
 
     interface EditorTabWidgetUiBinder extends UiBinder<Widget, EditorTabWidget> {
     }
@@ -96,7 +98,7 @@ public class EditorTabWidget extends Composite implements EditorTab, ContextMenu
                            @Assisted String title,
                            PartStackUIResources resources,
                            EditorTabContextMenuFactory editorTabContextMenu,
-                           EventBus eventBus,
+                           final EventBus eventBus,
                            FileTypeRegistry fileTypeRegistry) {
         this.resources = resources;
         this.eventBus = eventBus;
@@ -116,11 +118,12 @@ public class EditorTabWidget extends Composite implements EditorTab, ContextMenu
         addDomHandler(this, ContextMenuEvent.getType());
 
         eventBus.addHandler(ResourceChangedEvent.getType(), this);
+        eventBus.addHandler(FileEvent.TYPE, this);
 
         closeButton.addDomHandler(new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                delegate.onTabClose(EditorTabWidget.this);
+                eventBus.fireEvent(new FileEvent(EditorTabWidget.this.file, CLOSE));
             }
         }, ClickEvent.getType());
     }
@@ -205,7 +208,6 @@ public class EditorTabWidget extends Composite implements EditorTab, ContextMenu
             delegate.onTabClicked(this);
         } else if (NativeEvent.BUTTON_MIDDLE == event.getNativeButton()) {
             eventBus.fireEvent(new FileEvent(file, FileEvent.FileOperation.CLOSE));
-            delegate.onTabClose(this);
         }
     }
 
@@ -301,6 +303,13 @@ public class EditorTabWidget extends Composite implements EditorTab, ContextMenu
 
                 title.setText(file.getDisplayName());
             }
+        }
+    }
+
+    @Override
+    public void onFileOperation(FileEvent event) {
+        if (event.getOperationType() == CLOSE && event.getFile().equals(file)) {
+            delegate.onTabClose(this);
         }
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/listtab/ListButtonWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/listtab/ListButtonWidget.java
@@ -22,8 +22,11 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.part.widgets.editortab.EditorTabWidget;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -50,14 +53,17 @@ public class ListButtonWidget extends Composite implements ListButton {
 
     @UiField(provided = true)
     final Resources resources;
+    private EventBus eventBus;
 
     private ActionDelegate delegate;
 
     private long closeTime;
 
     @Inject
-    public ListButtonWidget(Resources resources) {
+    public ListButtonWidget(Resources resources,
+                            EventBus eventBus) {
         this.resources = resources;
+        this.eventBus = eventBus;
         initWidget(UI_BINDER.createAndBindUi(this));
 
         closeTime = System.currentTimeMillis();
@@ -112,8 +118,8 @@ public class ListButtonWidget extends Composite implements ListButton {
         @Override
         public void onCloseButtonClicked(@NotNull ListItem listItem) {
             popupPanel.hide();
-            if (delegate != null) {
-                delegate.onTabClose(listItem.getTabItem());
+            if (delegate != null && listItem.getTabItem() instanceof EditorTabWidget) {
+                eventBus.fireEvent(new FileEvent(((EditorTabWidget)listItem.getTabItem()).getFile(), FileEvent.FileOperation.CLOSE));
             }
         }
     };


### PR DESCRIPTION
Event calling was reorganized in editor tabs and list item, so after closing file, the last ones also removes from the editor's popup list.

Related issue: https://github.com/eclipse/che/issues/1850

@vparfonov, @RomanNikitenko review it, plz.
