### PR TITLE
CHE-1819: fix NPE when unresolved project is deleted

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -414,10 +414,14 @@ public class AppContextImpl implements AppContext,
             }
         }
 
+        if (currentResource == null) {
+            return null;
+        }
+
         Project root = null;
 
         for (Project project : projects) {
-            if (project.getLocation().isPrefixOf(currentResources[0].getLocation())) {
+            if (project.getLocation().isPrefixOf(currentResource.getLocation())) {
                 root = project;
             }
         }

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenProjectResolveTask.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenProjectResolveTask.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.plugin.maven.server.core;
 
 import org.eclipse.che.plugin.maven.server.core.project.MavenProject;
+import org.eclipse.core.resources.IProject;
 
 /**
  * @author Evgen Vidolob
@@ -29,7 +30,11 @@ public class MavenProjectResolveTask implements MavenProjectTask {
 
     @Override
     public void perform() {
-        projectManager.resolveMavenProject(mavenProject.getProject(), mavenProject);
+        IProject project = mavenProject.getProject();
+        if (!project.exists()) {
+            return;
+        }
+        projectManager.resolveMavenProject(project, mavenProject);
         if (afterTask != null) {
             afterTask.run();
         }

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenWorkspace.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenWorkspace.java
@@ -33,9 +33,11 @@ import org.eclipse.che.plugin.maven.shared.MavenAttributes;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.JavaModelStatus;
 import org.jdom.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -193,6 +195,11 @@ public class MavenWorkspace {
 
             IPath projectPath = project.getProject().getFullPath();
             RegisteredProject registeredProject = projectRegistryProvider.get().getProject(projectPath.toOSString());
+
+            if (registeredProject == null) {
+                throw new JavaModelException(new JavaModelStatus(IJavaModelStatusConstants.CORE_EXCEPTION,
+                                                                 "Project " + projectPath.toOSString() + " doesn't exist"));
+            }
 
             List<String> sourceFolders = registeredProject.getAttributes().get(Constants.SOURCE_FOLDER);
             List<String> testSourceFolders = registeredProject.getAttributes().get(MavenAttributes.TEST_SOURCE_FOLDER);


### PR DESCRIPTION
### What does this PR do?

Fix NPE after deleting unresolved multi-module project. 
Show notification with the number of modules which were deleted.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1819
### Previous Behavior

After deleting multi-module project the process of resolving dependencies is continued and threw many NPEs
### New Behavior

This content may also be included in the release notes.
After deleting multi-module project: project is deleted without exceptions and the process of resolving dependencies is ended 
### Tests written?

No

Please review @vparfonov 
