### PR TITLE
che-launcher infer Che version and self destruct itself

### DIFF
--- a/dockerfiles/che-launcher/launcher.sh
+++ b/dockerfiles/che-launcher/launcher.sh
@@ -30,7 +30,7 @@ init_global_variables() {
   DEFAULT_DOCKER_HOST_IP=$(get_docker_host_ip)
   DEFAULT_CHE_HOSTNAME=$(get_che_hostname)
   DEFAULT_CHE_PORT="8080"
-  DEFAULT_CHE_VERSION="latest"
+  DEFAULT_CHE_VERSION=$(get_che_launcher_version)
   DEFAULT_CHE_RESTART_POLICY="no"
   DEFAULT_CHE_USER="root"
   DEFAULT_CHE_LOG_LEVEL="info"
@@ -137,6 +137,16 @@ print_debug_info() {
   debug "---------------------------------------"
   debug "---------------------------------------"
   debug "---------------------------------------"
+}
+
+get_che_launcher_container_id() {
+  hostname
+}
+
+get_che_launcher_version() {
+  LAUNCHER_CONTAINER_ID=$(get_che_launcher_container_id)
+  LAUNCHER_IMAGE_NAME=$(docker inspect --format='{{.Config.Image}}' "${LAUNCHER_CONTAINER_ID}")
+  echo "${LAUNCHER_IMAGE_NAME}" | cut -d : -f2
 }
 
 is_boot2docker() {
@@ -428,3 +438,6 @@ case ${CHE_SERVER_ACTION} in
     print_debug_info
   ;;
 esac
+
+# This container will self destruct after execution
+docker rm -f "$(get_che_launcher_container_id)" > /dev/null 2>&1


### PR DESCRIPTION
### What does this PR do?

The launcher container automatically retrieve its version and destruct itself at the end of execution
### What issues does this PR fix or reference?

Avoid to specify the version of the che-server image with the variable CHE_VERSION
### Previous Behavior

To run the nightly build of che:
`docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e "CHE_VERSION=nightly" codenvy/che-launcher:nightly start`
### New Behavior

To run the nightly build of che:
`docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-launcher:nightly start`
### Tests written?

No
### Docs requirements?

No

Signed-off-by: Mario Loriedo mloriedo@redhat.com
