### PR TITLE
Add docker image to grab the ip used by docker

### DIFF
--- a/dockerfiles/che-ip/Dockerfile
+++ b/dockerfiles/che-ip/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# To build, in this directory:
+#  `docker build -t codenvy/che-ip .`
+#
+# To use it:
+#  `docker run --rm --net=host codenvy/che-ip`
+
+FROM alpine:3.4
+
+ADD getip.sh /bin/getip.sh
+
+CMD /bin/getip.sh

--- a/dockerfiles/che-ip/getip.sh
+++ b/dockerfiles/che-ip/getip.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright (c) 2012-2016 Codenvy, S.A., Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+
+# return true if system is using boot2docker
+is_boot2docker() {
+  if uname -r | grep -q 'boot2docker'; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# network interface to use to grab local ip
+NETWORK_IF="eth0"
+if is_boot2docker; then
+  NETWORK_IF="eth1"
+fi
+
+# grab ip from the following command
+ip a show "${NETWORK_IF}" | \
+            grep 'inet ' | \
+            cut -d/ -f1 | \
+            awk '{print $2}'
+


### PR DESCRIPTION
### What does this PR do?

Introduce docker image to get ip used by docker
### What issues does this PR fix or reference?
### Previous Behavior

hardcoded in the launcher script but it could be done within a docker image as well to share it with other docker images
### New Behavior

New 'codenvy/che-ip' docker image
### Tests written?

No

Change-Id: Id781e34c99f14c87909197b99969d645268e62d3
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
