### PR TITLE
Fix the ENV about configuration folder to set when using docker image

### DIFF
--- a/dockerfiles/che-launcher/launcher.sh
+++ b/dockerfiles/che-launcher/launcher.sh
@@ -48,7 +48,7 @@ init_global_variables() {
   # CHE_CONF_ARGS are the Docker run options that need to be used if users set CHE_CONF_FOLDER:
   #   - empty if CHE_CONF_FOLDER is not set
   #   - -v ${CHE_CONF_FOLDER}:/conf -e "CHE_LOCAL_CONF_DIR=/conf" if CHE_CONF_FOLDER is set
-  CHE_CONF_ARGS=${CHE_CONF_FOLDER:+-v ${CHE_CONF_FOLDER}:/conf -e \"CHE_LOCAL_CONF_DIR=/conf\"}
+  CHE_CONF_ARGS=${CHE_CONF_FOLDER:+-v ${CHE_CONF_FOLDER}:/conf -e CHE_LOCAL_CONF_DIR=/conf}
   CHE_LOCAL_BINARY_ARGS=${CHE_LOCAL_BINARY:+-v ${CHE_LOCAL_BINARY}:/home/user/che}
 
   if is_docker_for_mac || is_docker_for_windows; then


### PR DESCRIPTION
### What does this PR do?

Fix the environment variable setup on configuration folder
### What issues does this PR fix or reference?
### Previous Behavior

Previously, when using the CHE_CONF_FOLDER to the launcher, there was an invalid argument given to the docker container with quotes
### New Behavior

Variable is given as expected
### Tests written?

No
