### PR TITLE
Launcher: fixed Path problems, splitted in 3 files and added tests

### DIFF
--- a/dockerfiles/che-launcher/Dockerfile
+++ b/dockerfiles/che-launcher/Dockerfile
@@ -11,10 +11,10 @@
 #  `docker build -t codenvy/che-launcher .`
 #
 # To use it:
-#  `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che start`
-#  `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che stop`
-#  `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che restart`
-#  `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che update`
+#  `docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che start`
+#  `docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che stop`
+#  `docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che restart`
+#  `docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che update`
 #
 
 FROM alpine:3.4
@@ -31,6 +31,8 @@ RUN set -x \
   && curl -sL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION" \
   > /usr/bin/docker; chmod +x /usr/bin/docker
 
+COPY /launcher_cmds.sh /bin/launcher_cmds.sh
+COPY /launcher_funcs.sh /bin/launcher_funcs.sh
 COPY /launcher.sh /bin/launcher.sh
 
 ENTRYPOINT ["bin/launcher.sh"]

--- a/dockerfiles/che-launcher/launcher_cmds.sh
+++ b/dockerfiles/che-launcher/launcher_cmds.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# Copyright (c) 2012-2016 Codenvy, S.A., Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Mario Loriedo - Initial implementation
+#
+
+start_che_server() {
+  if che_container_exist; then
+    error_exit "A container named \"${CHE_SERVER_CONTAINER_NAME}\" already exists. Please remove it manually (docker rm -f ${CHE_SERVER_CONTAINER_NAME}) and try again."
+  fi
+
+  CURRENT_IMAGE=$(docker images -q "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}")
+
+  if [ "${CURRENT_IMAGE}" != "" ]; then
+    info "ECLIPSE CHE: ALREADY HAVE IMAGE ${CHE_SERVER_IMAGE_NAME}:${CHE_VERSION}"
+  else
+    update_che_server
+  fi
+
+  info "ECLIPSE CHE: CONTAINER STARTING"
+  docker run -d --name "${CHE_SERVER_CONTAINER_NAME}" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /home/user/che/lib:/home/user/che/lib-copy \
+    ${CHE_LOCAL_BINARY_ARGS} \
+    -p "${CHE_PORT}":8080 \
+    --restart="${CHE_RESTART_POLICY}" \
+    --user="${CHE_USER}" \
+    ${CHE_CONF_ARGS} \
+    ${CHE_STORAGE_ARGS} \
+    "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" \
+                --remote:"${CHE_HOST_IP}" \
+                -s:uid \
+                -s:client \
+                ${CHE_DEBUG_OPTION} \
+                run > /dev/null
+
+  wait_until_container_is_running 10
+  if ! che_container_is_running; then
+    error_exit "ECLIPSE CHE: Timeout waiting Che container to start."
+  fi
+
+  info "ECLIPSE CHE: SERVER LOGS AT \"docker logs -f ${CHE_SERVER_CONTAINER_NAME}\""
+  info "ECLIPSE CHE: SERVER BOOTING..."
+  wait_until_server_is_booted 20
+
+  if server_is_booted; then
+    info "ECLIPSE CHE: BOOTED AND REACHABLE"
+    info "ECLIPSE CHE: http://${CHE_HOSTNAME}:${CHE_PORT}"
+  else
+    error_exit "ECLIPSE CHE: Timeout waiting Che server to boot. Run \"docker logs ${CHE_SERVER_CONTAINER_NAME}\" to see the logs."
+  fi
+}
+
+stop_che_server() {
+  if ! che_container_is_running; then
+    info "-------------------------------------------------------"
+    info "ECLIPSE CHE: CONTAINER IS NOT RUNNING. NOTHING TO DO."
+    info "-------------------------------------------------------"
+  else
+    info "ECLIPSE CHE: STOPPING SERVER..."
+    docker exec ${CHE_SERVER_CONTAINER_NAME} /home/user/che/bin/che.sh -c stop > /dev/null 2>&1
+    sleep 5
+    info "ECLIPSE CHE: REMOVING CONTAINER"
+    docker rm -f ${CHE_SERVER_CONTAINER_NAME} > /dev/null 2>&1
+    info "ECLIPSE CHE: STOPPED"
+  fi
+}
+
+restart_che_server() {
+  if che_container_is_running; then
+    stop_che_server
+  fi
+  start_che_server
+}
+
+update_che_server() {
+  if [ -z "${CHE_VERSION}" ]; then
+    CHE_VERSION=${DEFAULT_CHE_VERSION}
+  fi
+
+  info "ECLIPSE CHE: PULLING IMAGE ${CHE_SERVER_IMAGE_NAME}:${CHE_VERSION}"
+  execute_command_with_progress extended docker pull ${CHE_SERVER_IMAGE_NAME}:${CHE_VERSION}
+  info "ECLIPSE CHE: IMAGE ${CHE_SERVER_IMAGE_NAME}:${CHE_VERSION} INSTALLED"
+}
+
+print_debug_info() {
+  debug "---------------------------------------"
+  debug "---------  CHE DEBUG INFO   -----------"
+  debug "---------------------------------------"
+  debug ""
+  debug "DOCKER_INSTALL_TYPE       = ${DOCKER_INSTALL_TYPE}"
+  debug ""
+  debug "CHE_SERVER_CONTAINER_NAME = ${CHE_SERVER_CONTAINER_NAME}"
+  debug "CHE_SERVER_IMAGE_NAME     = ${CHE_SERVER_IMAGE_NAME}"
+  debug ""
+  VAL=$(if che_container_exist;then echo "YES"; else echo "NO"; fi)
+  debug "CHE CONTAINER EXISTS?     ${VAL}"
+  VAL=$(if che_container_is_running;then echo "YES"; else echo "NO"; fi)
+  debug "CHE CONTAINER IS RUNNING? ${VAL}"
+  VAL=$(if che_container_is_stopped;then echo "YES"; else echo "NO"; fi)
+  debug "CHE CONTAINER IS STOPPED? ${VAL}"
+  VAL=$(if server_is_booted;then echo "YES"; else echo "NO"; fi)
+  debug "CHE SERVER IS BOOTED?     ${VAL}"
+  debug ""
+  debug "CHE_PORT                  = ${CHE_PORT}"
+  debug "CHE_VERSION               = ${CHE_VERSION}"
+  debug "CHE_RESTART_POLICY        = ${CHE_RESTART_POLICY}"
+  debug "CHE_USER                  = ${CHE_USER}"
+  debug "CHE_HOST_IP               = ${CHE_HOST_IP}"
+  debug "CHE_LOG_LEVEL             = ${CHE_LOG_LEVEL}"
+  debug "CHE_HOSTNAME              = ${CHE_HOSTNAME}"
+  debug "CHE_DATA_FOLDER           = ${CHE_DATA_FOLDER}"
+  debug "CHE_CONF_FOLDER           = ${CHE_CONF_FOLDER:-not set}"
+  debug "CHE_LOCAL_BINARY          = ${CHE_LOCAL_BINARY:-not set}"
+  debug ""
+  debug "---------------------------------------"
+  debug "---------------------------------------"
+  debug "---------------------------------------"
+}

--- a/dockerfiles/che-launcher/launcher_funcs.sh
+++ b/dockerfiles/che-launcher/launcher_funcs.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# Copyright (c) 2012-2016 Codenvy, S.A., Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Mario Loriedo - Initial implementation
+#
+
+usage () {
+  printf "%s" "${USAGE}"
+}
+
+info() {
+  printf  "${GREEN}INFO:${NC} %s\n" "${1}"
+}
+
+debug() {
+  printf  "${BLUE}DEBUG:${NC} %s\n" "${1}"
+}
+
+error() {
+  printf  "${RED}ERROR:${NC} %s\n" "${1}"
+}
+
+error_exit() {
+  echo  "---------------------------------------"
+  error "!!!"
+  error "!!! ${1}"
+  error "!!!"
+  echo  "---------------------------------------"
+  container_self_destruction
+  exit 1
+}
+
+get_clean_path() {
+  INPUT_PATH=$1
+  # \some\path => /some/path
+  OUTPUT_PATH=$(echo ${INPUT_PATH} | tr '\\' '/')
+  # /somepath/ => /somepath
+  OUTPUT_PATH=${OUTPUT_PATH%/}
+  # /some//path => /some/path
+  OUTPUT_PATH=$(echo ${OUTPUT_PATH} | tr -s '/')
+  # "/some/path" => /some/path
+  OUTPUT_PATH=${OUTPUT_PATH//\"}
+  echo ${OUTPUT_PATH}
+}
+
+get_che_launcher_container_id() {
+  hostname
+}
+
+get_che_launcher_version() {
+  LAUNCHER_CONTAINER_ID=$(get_che_launcher_container_id)
+  LAUNCHER_IMAGE_NAME=$(docker inspect --format='{{.Config.Image}}' "${LAUNCHER_CONTAINER_ID}")
+  echo "${LAUNCHER_IMAGE_NAME}" | cut -d : -f2
+}
+
+is_boot2docker() {
+  if uname -r | grep -q 'boot2docker'; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+has_docker_for_windows_ip() {
+  DOCKER_HOST_IP=$(get_docker_host_ip)
+  if [ "${DOCKER_HOST_IP}" = "10.0.75.2" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_docker_for_mac() {
+  if uname -r | grep -q 'moby' && ! has_docker_for_windows_ip; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_docker_for_windows() {
+  if uname -r | grep -q 'moby' && has_docker_for_windows_ip; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+get_docker_install_type() {
+  if is_boot2docker; then
+    echo "boot2docker"
+  elif is_docker_for_windows; then
+    echo "docker4windows"
+  elif is_docker_for_mac; then
+    echo "docker4mac"
+  else
+    echo "native"
+  fi
+}
+
+get_docker_host_ip() {
+  NETWORK_IF="eth0"
+  if is_boot2docker; then
+    NETWORK_IF="eth1"
+  fi
+
+  docker run --rm --net host \
+            alpine sh -c \
+            "ip a show ${NETWORK_IF}" | \
+            grep 'inet ' | \
+            cut -d/ -f1 | \
+            awk '{ print $2}'
+}
+
+get_che_hostname() {
+  INSTALL_TYPE=$(get_docker_install_type)
+  if [ "${INSTALL_TYPE}" = "boot2docker" ] ||
+     [ "${INSTALL_TYPE}" = "docker4windows" ]; then
+    get_docker_host_ip
+  else
+    echo "localhost"
+  fi
+}
+
+check_docker() {
+  if [ ! -S /var/run/docker.sock ]; then
+    error_exit "Docker socket (/var/run/docker.sock) hasn't be mounted \
+inside the container. Verify the syntax of the \"docker run\" command."
+  fi
+
+  if ! docker ps > /dev/null 2>&1; then
+    output=$(docker ps)
+    error_exit "Error when running \"docker ps\": ${output}"
+  fi
+}
+
+che_container_exist() {
+  if [ "$(docker ps -aq  -f "name=${CHE_SERVER_CONTAINER_NAME}" | wc -l)" = "0" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+che_container_is_running() {
+  if [ "$(docker ps -qa -f "status=running" -f "name=${CHE_SERVER_CONTAINER_NAME}" | wc -l)" = "0" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+che_container_is_stopped() {
+  if [ "$(docker ps -qa -f "status=exited" -f "name=${CHE_SERVER_CONTAINER_NAME}" | wc -l)" = "0" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+wait_until_container_is_running() {
+  CONTAINER_START_TIMEOUT=${1}
+
+  ELAPSED=0
+  until che_container_is_running || [ ${ELAPSED} -eq "${CONTAINER_START_TIMEOUT}" ]; do
+    sleep 1
+    ELAPSED=$((ELAPSED+1))
+  done
+}
+
+server_is_booted() {
+  HTTP_STATUS_CODE=$(curl -I http://"${CHE_HOST_IP}":"${CHE_PORT}"/api/  \
+                     -s -o /dev/null --write-out "%{http_code}")
+  if [ "${HTTP_STATUS_CODE}" = "200" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+wait_until_server_is_booted () {
+  SERVER_BOOT_TIMEOUT=${1}
+
+  ELAPSED=0
+  until server_is_booted || [ ${ELAPSED} -eq "${SERVER_BOOT_TIMEOUT}" ]; do
+    sleep 1
+    ELAPSED=$((ELAPSED+1))
+  done
+}
+
+execute_command_with_progress() {
+  progress=$1
+  command=$2
+  shift 2
+
+  pid=""
+  printf "\n"
+
+  case "$progress" in
+    extended)
+      $command "$@"
+      ;;
+    basic|*)
+      $command "$@" &>/dev/null &
+      pid=$!
+      while kill -0 "$pid" >/dev/null 2>&1; do
+        printf "#"
+        sleep 10
+      done
+      wait $pid # return pid's exit code
+      printf "\n"
+    ;;
+  esac
+  printf "\n"
+}
+
+container_self_destruction() {
+  docker rm -f "$(get_che_launcher_container_id)" > /dev/null 2>&1
+}

--- a/dockerfiles/che-launcher/launcher_test.bats
+++ b/dockerfiles/che-launcher/launcher_test.bats
@@ -8,6 +8,9 @@
 # Contributors:
 #   Mario Loriedo - Initial implementation
 #
+# To run the tests:
+#   docker run -w /tests/ -v $PWD:/tests dduportal/bats:0.4.0 /tests/launcher_test.bats
+#
 
 source ./launcher_funcs.sh
 

--- a/dockerfiles/che-launcher/launcher_test.bats
+++ b/dockerfiles/che-launcher/launcher_test.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Copyright (c) 2012-2016 Codenvy, S.A., Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Mario Loriedo - Initial implementation
+#
+
+source ./launcher_funcs.sh
+
+@test "clean folder path that is already clean" {
+  result="$(get_clean_path /somefolder)"
+  [ "$result" = "/somefolder" ]
+}
+
+@test "clean folder path with extra slash" {
+  result="$(get_clean_path /somefolder/)"
+  [ "$result" = "/somefolder" ]
+}
+
+@test "clean folder path with two consecutive slashes" {
+  result="$(get_clean_path /some//path)"
+  [ "$result" = "/some/path" ]
+}
+
+@test "clean folder path with backslashes" {
+  result="$(get_clean_path \\some\\path)"
+  [ "$result" = "/some/path" ]
+}
+
+@test "clean folder path with quotes" {
+  result="$(get_clean_path \"/some\"/path\")"
+  [ "$result" = "/some/path" ]
+}


### PR DESCRIPTION
### What does this PR do?

Add a new function to cleanup paths strings provided by users, splitted the big shell script launcher.sh in 3 different scripts, added some unit tests.
### What issues does this PR fix or reference?

Problems with paths provided by users
### Previous Behavior

Che failed to store workspace when providing a path with a trailing slash: `-e CHE_STORAGE_FOLDER=/somefolder/`
### New Behavior

CHE_STORAGE_FOLDER and CHE_CONF_FOLDER variables are cleaned up (trailing slashes are removed)
### Tests written?

Yes
### Docs requirements?

No

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Signed-off-by: Mario Loriedo mloriedo@redhat.com
