### PR TITLE
CHE-1843: change value of "java.output.folder" attribute

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/OutputDirProvider.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/OutputDirProvider.java
@@ -19,9 +19,9 @@ import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
-import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
 import org.eclipse.che.ide.extension.machine.client.command.valueproviders.CommandPropertyValueProvider;
 
+import static org.eclipse.che.ide.ext.java.client.util.JavaUtil.isJavaProject;
 import static org.eclipse.che.ide.ext.java.shared.Constants.OUTPUT_FOLDER;
 
 /**
@@ -56,10 +56,22 @@ public class OutputDirProvider implements CommandPropertyValueProvider {
             final Resource resource = resources[0];
             final Optional<Project> project = resource.getRelatedProject();
 
-            if (JavaUtil.isJavaProject(project.get()) && project.get().getAttributes().containsKey(OUTPUT_FOLDER)) {
-                return promises.resolve(appContext.getProjectsRoot().append(project.get().getAttributes().get(OUTPUT_FOLDER).get(0)).toString());
+            if (!project.isPresent()) {
+                return promises.resolve("");
+            }
+
+            Project relatedProject = project.get();
+
+            if (!isJavaProject(relatedProject)) {
+                return promises.resolve("");
+            }
+
+            if (relatedProject.getAttributes().containsKey(OUTPUT_FOLDER)) {
+                return promises.resolve(appContext.getProjectsRoot()
+                                                  .append(relatedProject.getLocation())
+                                                  .append(relatedProject.getAttributes().get(OUTPUT_FOLDER).get(0)).toString());
             } else {
-                return promises.resolve(appContext.getProjectsRoot().append(project.get().getLocation()).toString());
+                return promises.resolve(appContext.getProjectsRoot().append(relatedProject.getLocation()).toString());
             }
         }
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/OutputDirProviderTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/OutputDirProviderTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.client.command.valueproviders;
+
+import com.google.common.base.Optional;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.resource.Path;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.ext.java.shared.Constants.LANGUAGE;
+import static org.eclipse.che.ide.ext.java.shared.Constants.OUTPUT_FOLDER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Valeriy Svydenko
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class OutputDirProviderTest {
+    @InjectMocks
+    private OutputDirProvider provider;
+
+    @Mock
+    private AppContext      appContext;
+    @Mock
+    private PromiseProvider promises;
+
+    @Mock
+    private Resource          resource1;
+    @Mock
+    private Resource          resource2;
+    @Mock
+    private Optional<Project> projectOptional;
+    @Mock
+    private Project           relatedProject;
+
+    @Captor
+    private ArgumentCaptor<Promise<String>> valuePromiseCaptor;
+
+    private Resource[] resources;
+    private Map<String, List<String>> attributes = new HashMap<>();
+
+    @Before
+    public void setUp() throws Exception {
+        resources = new Resource[]{resource1};
+        attributes.put(LANGUAGE, singletonList("java"));
+
+        when(appContext.getResources()).thenReturn(resources);
+        when(resource1.getRelatedProject()).thenReturn(projectOptional);
+        when(projectOptional.isPresent()).thenReturn(true);
+        when(projectOptional.get()).thenReturn(relatedProject);
+        when(appContext.getProjectsRoot()).thenReturn(new Path("/projects"));
+        when(relatedProject.getLocation()).thenReturn(new Path("projectParent/project"));
+        when(relatedProject.getAttributes()).thenReturn(attributes);
+    }
+
+    @Test
+    public void keyShouldBeReturned() throws Exception {
+        assertEquals("${project.java.output.dir}", provider.getKey());
+    }
+
+    @Test
+    public void valueShouldBeEmptyIfSelectedResourcesIsNull() throws Exception {
+        resources = null;
+        when(appContext.getResources()).thenReturn(resources);
+
+        provider.getValue();
+
+        verify(promises).resolve(eq(""));
+    }
+
+    @Test
+    public void valueShouldBeEmptyIfSelectedManyResources() throws Exception {
+        resources = new Resource[]{resource1, resource2};
+        when(appContext.getResources()).thenReturn(resources);
+
+        provider.getValue();
+
+        verify(promises).resolve(eq(""));
+    }
+
+    @Test
+    public void valueShouldBeEmptyIfRelatedProjectOfSelectedResourceIsNull() throws Exception {
+        when(projectOptional.isPresent()).thenReturn(false);
+
+        provider.getValue();
+
+        verify(promises).resolve(eq(""));
+    }
+
+    @Test
+    public void valueShouldBeEmptyIfRelatedProjectIsNotJavaProject() throws Exception {
+        attributes.put(LANGUAGE, singletonList("cpp"));
+        when(relatedProject.getAttributes()).thenReturn(attributes);
+
+        provider.getValue();
+
+        verify(promises).resolve(eq(""));
+    }
+
+    @Test
+    public void outputFolderShouldBeRootOfProjectIfAttributeDoesNotExist() throws Exception {
+        provider.getValue();
+
+        verify(promises).resolve(eq("/projects/projectParent/project"));
+    }
+
+    @Test
+    public void outputFolderShouldBeSetAsValueOfAttribute() throws Exception {
+        attributes.put(OUTPUT_FOLDER, singletonList("bin"));
+
+        provider.getValue();
+
+        verify(promises).resolve(eq("/projects/projectParent/project/bin"));
+    }
+}

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/wizard/PlainJavaPagePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/wizard/PlainJavaPagePresenter.java
@@ -18,6 +18,7 @@ import org.eclipse.che.ide.api.data.tree.Node;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardMode;
 import org.eclipse.che.ide.api.wizard.AbstractWizardPage;
+import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.resources.tree.ResourceNode;
 import org.eclipse.che.plugin.java.plain.client.wizard.selector.SelectNodePresenter;
 import org.eclipse.che.plugin.java.plain.client.wizard.selector.SelectionDelegate;
@@ -31,6 +32,7 @@ import java.util.Map;
 import static org.eclipse.che.ide.api.project.type.wizard.ProjectWizardMode.CREATE;
 import static org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar.WIZARD_MODE_KEY;
 import static org.eclipse.che.ide.ext.java.shared.Constants.SOURCE_FOLDER;
+import static org.eclipse.che.ide.resource.Path.valueOf;
 import static org.eclipse.che.plugin.java.plain.shared.PlainJavaProjectConstants.DEFAULT_SOURCE_FOLDER_VALUE;
 import static org.eclipse.che.plugin.java.plain.shared.PlainJavaProjectConstants.LIBRARY_FOLDER;
 
@@ -111,12 +113,13 @@ class PlainJavaPagePresenter extends AbstractWizardPage<MutableProjectConfig> im
 
     @Override
     public void onNodeSelected(List<Node> nodes) {
-        int projectNameLength = dataObject.getName().length();
+        String projectName = dataObject.getName();
 
         List<String> nodeRelativePath = new LinkedList<>();
 
         for (Node node : nodes) {
-            nodeRelativePath.add(((ResourceNode)node).getData().getLocation().toString().substring(projectNameLength + 1));
+            Path nodeLocation = ((ResourceNode)node).getData().getLocation();
+            nodeRelativePath.add(nodeLocation.makeRelativeTo(valueOf(projectName)).toString());
         }
 
         if (isSourceSelected) {

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/test/org/eclipse/che/plugin/java/plain/client/wizard/PlainJavaPagePresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/test/org/eclipse/che/plugin/java/plain/client/wizard/PlainJavaPagePresenterTest.java
@@ -13,9 +13,13 @@ package org.eclipse.che.plugin.java.plain.client.wizard;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
+import org.eclipse.che.ide.api.data.tree.Node;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar;
+import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.wizard.Wizard;
+import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
 import org.eclipse.che.plugin.java.plain.client.wizard.selector.SelectNodePresenter;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +40,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -155,5 +162,33 @@ public class PlainJavaPagePresenterTest {
         page.onBrowseSourceButtonClicked();
 
         verify(selectNodePresenter).show(page, "name");
+    }
+
+    @Test
+    public void selectedNodeShouldBeWithRelativePath() throws Exception {
+        when(view.getLibraryFolder()).thenReturn("lib1,   lib2");
+        when(view.getSourceFolder()).thenReturn("src1,   src2");
+        List<Node> selectedNodes = new ArrayList<>();
+        ResourceNode selectedNode1 = mock(ResourceNode.class);
+        ResourceNode selectedNode2 = mock(ResourceNode.class);
+        Resource resource1 = mock(Resource.class);
+        Resource resource2 = mock(Resource.class);
+
+        selectedNodes.add(selectedNode1);
+        selectedNodes.add(selectedNode2);
+
+        when(selectedNode1.getData()).thenReturn(resource1);
+        when(resource1.getLocation()).thenReturn(Path.valueOf("projectName/folder1/folder2"));
+
+        when(selectedNode2.getData()).thenReturn(resource2);
+        when(resource2.getLocation()).thenReturn(Path.valueOf("projectName/folder"));
+
+        when(dataObject.getName()).thenReturn("projectName");
+
+        page.setUpdateDelegate(updateDelegate);
+        page.init(dataObject);
+        page.onNodeSelected(selectedNodes);
+
+        verify(view).setLibraryFolder(eq("folder1/folder2,   folder"));
     }
 }

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/projecttype/PlainJavaValueProviderFactory.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/projecttype/PlainJavaValueProviderFactory.java
@@ -27,7 +27,6 @@ import org.eclipse.jdt.internal.core.JavaModel;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -90,7 +89,9 @@ public class PlainJavaValueProviderFactory implements ValueProviderFactory {
             IJavaProject project = model.getJavaProject(projectPath);
 
             try {
-                return Collections.singletonList(project.getOutputLocation().toOSString());
+                String outputDirPath = project.getOutputLocation().toOSString();
+                return outputDirPath.startsWith(projectPath) ? singletonList(outputDirPath.substring(projectPath.length() + 1))
+                                                             : singletonList(outputDirPath);
             } catch (JavaModelException e) {
                 throw new ValueStorageException("Can't get output location: " + e.getMessage());
             }
@@ -111,7 +112,7 @@ public class PlainJavaValueProviderFactory implements ValueProviderFactory {
                     String entryPath = entry.getPath().toOSString();
                     if (CPE_SOURCE == entry.getEntryKind() && !entryPath.equals(projectPath)) {
                         if (entryPath.startsWith(projectPath)) {
-                            sourceFolders.add(entryPath.substring(projectPath.length()));
+                            sourceFolders.add(entryPath.substring(projectPath.length() + 1));
                         } else {
                             sourceFolders.add(entryPath);
                         }

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/test/java/org/eclipse/che/plugin/java/plain/server/projecttype/PlainJavaValueProviderFactoryTest.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/test/java/org/eclipse/che/plugin/java/plain/server/projecttype/PlainJavaValueProviderFactoryTest.java
@@ -103,8 +103,8 @@ public class PlainJavaValueProviderFactoryTest extends BaseTest {
 
     @Test
     public void outputFolderShouldBeReturned() throws Exception {
-        when(rootProjectFolder.getPath()).thenReturn(Path.of("project"));
+        when(rootProjectFolder.getPath()).thenReturn(Path.of("/project"));
 
-        assertThat(plainJavaValueProviderFactory.newInstance(rootProjectFolder).getValues(OUTPUT_FOLDER)).contains("/project/bin");
+        assertThat(plainJavaValueProviderFactory.newInstance(rootProjectFolder).getValues(OUTPUT_FOLDER)).contains("bin");
     }
 }


### PR DESCRIPTION
### What does this PR do?

Change value of "java.output.folder" attribute for projects with javac project type
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1843
### Previous Behavior

It was the path with reference to root directory
### New Behavior

Now it is the path with reference to current project directory
### Tests written?

Yes

@vparfonov please review
