### PR TITLE
#1903: fix export a workspace from the Dashboard

### DIFF
--- a/dashboard/bower.json
+++ b/dashboard/bower.json
@@ -33,7 +33,7 @@
     "zeroclipboard": "2.2.0",
     "angular-uuid4": "0.3.0",
     "angular-file-upload": "2.0.0",
-    "jquery": "1.8.1"
+    "jquery": "2.1.3"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
### What does this PR do?

Updates jQuery version to 2.1.3 in order to fix export a workspace from the Dashboard.
### What issues does this PR fix or reference?

[https://github.com/eclipse/che/issues/1903](https://github.com/eclipse/che/issues/1903)

Signed-off-by: Oleksii Kurinnyi okurinnyi@codenvy.com
