### PR TITLE
CHE-1849: Modify start workspace by ID API method

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
@@ -26,6 +26,7 @@ import java.util.List;
  * GWT Client for Workspace Service.
  *
  * @author Yevhenii Voevodin
+ * @author Igor Vinokur
  */
 public interface WorkspaceServiceClient {
 
@@ -116,10 +117,14 @@ public interface WorkspaceServiceClient {
      *         workspace ID
      * @param envName
      *         the name of the workspace environment that should be used for start
+     * @param restore
+     *         if <code>true</code> workspace will be restored from snapshot if snapshot exists,
+     *         if <code>false</code> workspace will not be restored from snapshot
+     *         even if auto-restore is enabled and snapshot exists
      * @return a promise that resolves to the {@link WorkspaceDto}, or rejects with an error
      * @see WorkspaceService#startById(String, String, Boolean, String)
      */
-    Promise<WorkspaceDto> startById(String id, String envName);
+    Promise<WorkspaceDto> startById(String id, String envName, boolean restore);
 
     /**
      * Stops running workspace.
@@ -276,17 +281,4 @@ public interface WorkspaceServiceClient {
      */
     Promise<Void> createSnapshot(String workspaceId);
 
-    /**
-     * Recovers workspace from snapshot.
-     *
-     * @param workspaceId
-     *         workspace ID
-     * @param envName
-     *         the name of the workspace environment to recover from
-     * @param accountId
-     *         the account id related to this operation
-     * @return a promise that resolves to the {@link WorkspaceDto}, or rejects with an error
-     * @see WorkspaceService#recoverWorkspace(String, String, String)
-     */
-    Promise<WorkspaceDto> recoverWorkspace(String workspaceId, String envName, String accountId);
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClientImpl.java
@@ -51,6 +51,7 @@ import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
  * @author Dmitry Shnurenko
  * @author Alexander Garagatyi
  * @author Yevhenii Voevodin
+ * @author Igor Vinokur
  */
 public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
 
@@ -189,21 +190,22 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
     }
 
     @Override
-    public Promise<WorkspaceDto> startById(@NotNull final String id, final String envName) {
+    public Promise<WorkspaceDto> startById(@NotNull final String id, final String envName, final boolean restore) {
         return newPromise(new RequestCall<WorkspaceDto>() {
             @Override
             public void makeCall(AsyncCallback<WorkspaceDto> callback) {
-                startById(id, envName, callback);
+                startById(id, envName, restore, callback);
             }
         });
     }
 
     private void startById(@NotNull String workspaceId,
                            @Nullable String envName,
+                           boolean restore,
                            @NotNull AsyncCallback<WorkspaceDto> callback) {
-        String url = baseHttpUrl + "/" + workspaceId + "/runtime";
+        String url = baseHttpUrl + "/" + workspaceId + "/runtime?restore=" + restore;
         if (envName != null) {
-            url += "?environment=" + envName;
+            url += "&environment=" + envName;
         }
         asyncRequestFactory.createPostRequest(url, null)
                            .header(ACCEPT, APPLICATION_JSON)
@@ -378,20 +380,6 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
                                    .header(ACCEPT, APPLICATION_JSON)
                                    .loader(loaderFactory.newLoader("Creating workspace's snapshot"))
                                    .send(newCallback(callback));
-            }
-        });
-    }
-
-    @Override
-    public Promise<WorkspaceDto> recoverWorkspace(final String workspaceId, final String envName, final String accountId) {
-        return newPromise(new RequestCall<WorkspaceDto>() {
-            @Override
-            public void makeCall(AsyncCallback<WorkspaceDto> callback) {
-                final String url = baseHttpUrl + '/' + workspaceId + "/runtime/snapshot?environment=" + envName;
-                asyncRequestFactory.createPostRequest(url, null)
-                                   .header(ACCEPT, APPLICATION_JSON)
-                                   .loader(loaderFactory.newLoader("Recovering workspace from snapshot"))
-                                   .send(newCallback(callback, dtoUnmarshallerFactory.newUnmarshaller(WorkspaceDto.class)));
             }
         });
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -257,8 +257,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
             @Override
             public void apply(List<SnapshotDto> snapshots) throws OperationException {
                 if (snapshots.isEmpty()) {
-                    handleWsStart(workspaceServiceClient.startById(workspace.getId(),
-                            workspace.getConfig().getDefaultEnv()));
+                    handleWsStart(workspaceServiceClient.startById(workspace.getId(), workspace.getConfig().getDefaultEnv(), false));
                 } else {
                     showRecoverWorkspaceConfirmDialog(workspace);
                 }
@@ -275,32 +274,30 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
 
     /**
      * Shows workspace recovering confirm dialog.
-     *
-     * <p> When "Ok" button is pressed - {@link WorkspaceServiceClient#recoverWorkspace(String, String, String) recovers workspace}
-     * <br>When "Cancel" button is pressed - {@link WorkspaceServiceClient#startById(String, String) starts workspace}
      */
     private void showRecoverWorkspaceConfirmDialog(final WorkspaceDto workspace) {
         dialogFactory.createConfirmDialog("Workspace recovering",
-                "Do you want to recover the workspace from snapshot?",
-                "Yes",
-                "No",
-                new ConfirmCallback() {
-                    @Override
-                    public void accepted() {
-                        handleWsStart(workspaceServiceClient.recoverWorkspace(workspace.getId(),
-                                workspace.getConfig()
-                                        .getDefaultEnv(),
-                                null));
-                    }
-                },
-                new CancelCallback() {
-                    @Override
-                    public void cancelled() {
-                        handleWsStart(workspaceServiceClient.startById(workspace.getId(),
-                                workspace.getConfig()
-                                        .getDefaultEnv()));
-                    }
-                })
+                                          "Do you want to recover the workspace from snapshot?",
+                                          "Yes",
+                                          "No",
+                                          new ConfirmCallback() {
+                                              @Override
+                                              public void accepted() {
+                                                  handleWsStart(workspaceServiceClient.startById(workspace.getId(),
+                                                                                                        workspace.getConfig()
+                                                                                                                 .getDefaultEnv(),
+                                                                                                        true));
+                                              }
+                                          },
+                                          new CancelCallback() {
+                                              @Override
+                                              public void cancelled() {
+                                                  handleWsStart(workspaceServiceClient.startById(workspace.getId(),
+                                                                                                 workspace.getConfig()
+                                                                                                          .getDefaultEnv(),
+                                                                                                 false));
+                                              }
+                                          })
                      .show();
 
         notifyShowIDE();

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -73,6 +73,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_GET_WORKSP
  * Defines Workspace REST API.
  *
  * @author Yevhenii Voevodin
+ * @author Igor Vinokur
  */
 @Api(value = "/workspace", description = "Workspace REST API")
 @Path("/workspace")
@@ -140,7 +141,7 @@ public class WorkspaceService extends Service {
                                                                          attributes,
                                                                          accountId);
         if (startAfterCreate) {
-            workspaceManager.startWorkspace(workspace.getId(), null, accountId);
+            workspaceManager.startWorkspace(workspace.getId(), null, accountId, false);
         }
         return Response.status(201)
                        .entity(linksInjector.injectLinks(asDto(workspace), getServiceContext()))
@@ -264,16 +265,17 @@ public class WorkspaceService extends Service {
                                   String envName,
                                   @ApiParam("The account id related to this operation")
                                   @QueryParam("accountId")
-                                  String accountId) throws ServerException,
-                                                           BadRequestException,
-                                                           NotFoundException,
-                                                           ForbiddenException,
-                                                           ConflictException {
-        final Map<String, String> params = Maps.newHashMapWithExpectedSize(2);
-        params.put("accountId", accountId);
-        params.put("workspaceId", workspaceId);
+                                  String accountId,
+                                  @ApiParam("Restore workspace from snapshot")
+                                  @QueryParam("restore")
+                                  Boolean restore) throws ServerException,
+                                                          BadRequestException,
+                                                          NotFoundException,
+                                                          ForbiddenException,
+                                                          ConflictException {
 
-        return linksInjector.injectLinks(asDto(workspaceManager.startWorkspace(workspaceId, envName, accountId)), getServiceContext());
+        return linksInjector.injectLinks(asDto(workspaceManager.startWorkspace(workspaceId, envName, accountId, restore)),
+                                         getServiceContext());
     }
 
     @POST
@@ -309,39 +311,6 @@ public class WorkspaceService extends Service {
                                                                                EnvironmentContext.getCurrent().getSubject().getUserName(),
                                                                                firstNonNull(isTemporary, false),
                                                                                accountId)), getServiceContext());
-    }
-
-    @POST
-    @Path("/{id}/runtime/snapshot")
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Recover the workspace by the id from the snapshot",
-                  notes = "This operation can be performed only by the workspace owner." +
-                          "The workspace recovers asynchronously")
-    @ApiResponses({@ApiResponse(code = 200, message = "The workspace is starting"),
-                   @ApiResponse(code = 404, message = "The workspace with specified id doesn't exist." +
-                                                      "The snapshot from this workspace doesn't exist"),
-                   @ApiResponse(code = 403, message = "The user is not workspace owner. " +
-                                                      "The operation is not allowed for the user"),
-                   @ApiResponse(code = 409, message = "Any conflict occurs during the workspace start"),
-                   @ApiResponse(code = 500, message = "Internal server error occurred")})
-    public WorkspaceDto recoverWorkspace(@ApiParam("The workspace id")
-                                         @PathParam("id")
-                                         String workspaceId,
-                                         @ApiParam("The name of the workspace environment to recover from")
-                                         @QueryParam("environment")
-                                         String envName,
-                                         @ApiParam("The account id related to this operation")
-                                         @QueryParam("accountId")
-                                         String accountId) throws BadRequestException,
-                                                                  ForbiddenException,
-                                                                  NotFoundException,
-                                                                  ServerException,
-                                                                  ConflictException {
-        final Map<String, String> params = Maps.newHashMapWithExpectedSize(2);
-        params.put("accountId", accountId);
-        params.put("workspaceId", workspaceId);
-
-        return linksInjector.injectLinks(asDto(workspaceManager.recoverWorkspace(workspaceId, envName, accountId)), getServiceContext());
     }
 
     @DELETE


### PR DESCRIPTION
### What does this PR do?

Adds query parameter to `startById()` method in `WorkspaceService`
to know if workspace needs to be recovered from snapshot or just to start.
Removes `recoverWorkspace()` API method from `WorkspaceService`.
### What issues does this PR fix or reference?

When user starts workspace that has snapshot the 'recover from snapshots?' dialog will be shown.
If user will select not to recover and auto-restore will be enabled workspace will be recovered from snapshot anywhere.
https://github.com/eclipse/che/issues/1849
### Tests written?

Yes
### Docs requirements?

API changes 
