### PR TITLE
CHE-1825: fix problem with the window selection

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/categoriespage/CategoriesPagePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/categoriespage/CategoriesPagePresenter.java
@@ -192,10 +192,13 @@ public class CategoriesPagePresenter extends AbstractWizardPage<MutableProjectCo
                 originParent = path;
                 dataObject.setPath(!isNullOrEmpty(dataObject.getName()) ? path.append(dataObject.getName()).toString() : path.toString());
                 view.setParentPath(path);
+
+                view.focusSelectPathButton();
             }
 
             @Override
             public void onSelectionCancelled() {
+                view.focusSelectPathButton();
             }
         });
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/categoriespage/CategoriesPageView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/categoriespage/CategoriesPageView.java
@@ -46,6 +46,9 @@ public interface CategoriesPageView extends View<CategoriesPageView.ActionDelega
 
     void showNameError();
 
+    /**Sets focus to the Select Path button.*/
+    void focusSelectPathButton();
+
     void focusName();
 
     void setProjectTypes(List<ProjectTypeDto> availableProjectTypes);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/categoriespage/CategoriesPageViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/categoriespage/CategoriesPageViewImpl.java
@@ -287,6 +287,16 @@ public class CategoriesPageViewImpl implements CategoriesPageView {
     }
 
     @Override
+    public void focusSelectPathButton() {
+        new Timer() {
+            @Override
+            public void run() {
+                selectPath.setFocus(true);
+            }
+        }.schedule(300);
+    }
+
+    @Override
     public void focusName() {
         new Timer() {
             @Override

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/classpath/ProjectClasspathViewImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/classpath/ProjectClasspathViewImpl.java
@@ -111,6 +111,9 @@ public class ProjectClasspathViewImpl extends Window implements ProjectClasspath
     @Override
     public void show() {
         super.show();
+        super.setHideOnEscapeEnabled(true);
+
+        doneButton.setFocus(true);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?

Activate last opened window
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1825
### Previous Behavior

Project Wizard window was active when trying to select the path to the parent folder.
### New Behavior

Select Path window is active when it is opened.
### Tests written?

No

@vparfonov please review
