### PR TITLE
Allow to continue to start the script even if there is a chown failure

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -64,7 +64,7 @@ public class WsMasterModule extends AbstractModule {
 
         bindConstant().annotatedWith(Names.named(org.eclipse.che.api.machine.server.wsagent.WsAgentLauncherImpl.WS_AGENT_PROCESS_START_COMMAND))
                       .to("rm -rf ~/che && mkdir -p ~/che && unzip -qq /mnt/che/ws-agent.zip -d ~/che/ws-agent && " +
-                          "sudo chown -R $(id -u -n) /projects && " +
+                          "sudo sh -c \"chown -R $(id -u -n) /projects || true\" && " +
                           "export JPDA_ADDRESS=\"4403\" && ~/che/ws-agent/bin/catalina.sh jpda run");
         bindConstant().annotatedWith(Names.named(org.eclipse.che.plugin.docker.machine.DockerMachineImplTerminalLauncher.START_TERMINAL_COMMAND))
                       .to("mkdir -p ~/che " +


### PR DESCRIPTION
### What does this PR do?

Allow to continue to start the script even if there is a chown failure
### What issues does this PR fix or reference?

Keep docker image booting if chown issue
### Previous Behavior

When mounting a local folder with .git we have the following warnings
chown: changing permission on ....git.idx : permission denied
### New Behavior

we still see warning but we continue to start docker image
### Tests written?

No
