### PR TITLE
#1899: Add ability to copy and paste text in terminal view

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CopyResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CopyResourceAction.java
@@ -24,6 +24,7 @@ import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.resources.modification.ClipboardManager;
+import org.eclipse.che.ide.api.selection.Selection;
 
 import javax.validation.constraints.NotNull;
 
@@ -74,7 +75,8 @@ public class CopyResourceAction extends AbstractPerspectiveAction {
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
         event.getPresentation().setEnabled(clipboardManager.getCopyProvider().isCopyEnable(appContext)
-                                           && !(partPresenter instanceof TextEditor));
+                                           && !(partPresenter instanceof TextEditor)
+                                           && !(partPresenter.getSelection() instanceof Selection.NoSelectionProvided));
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CutResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CutResourceAction.java
@@ -24,6 +24,7 @@ import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.resources.modification.ClipboardManager;
+import org.eclipse.che.ide.api.selection.Selection;
 
 import javax.validation.constraints.NotNull;
 
@@ -74,7 +75,8 @@ public class CutResourceAction extends AbstractPerspectiveAction {
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
         event.getPresentation().setEnabled(clipboardManager.getCutProvider().isCutEnable(appContext)
-                                           && !(partPresenter instanceof TextEditor));
+                                           && !(partPresenter instanceof TextEditor)
+                                           && !(partPresenter.getSelection() instanceof Selection.NoSelectionProvided));
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/PasteResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/PasteResourceAction.java
@@ -24,6 +24,7 @@ import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.resources.modification.ClipboardManager;
+import org.eclipse.che.ide.api.selection.Selection;
 
 import javax.validation.constraints.NotNull;
 
@@ -74,7 +75,8 @@ public class PasteResourceAction extends AbstractPerspectiveAction {
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
         event.getPresentation().setEnabled(clipboardManager.getPasteProvider().isPastePossible(appContext)
-                                           && !(partPresenter instanceof TextEditor));
+                                           && !(partPresenter instanceof TextEditor)
+                                           && !(partPresenter.getSelection() instanceof Selection.NoSelectionProvided));
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This PR adds ability copy and paste selected text in and from the terminal view.

Related issue: https://github.com/eclipse/che/issues/1899

@vparfonov review it, plz.
