### PR TITLE
CHE-1935; add custom User-Agent header value for JGit;

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -135,7 +135,6 @@ import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.TrackingRefUpdate;
 import org.eclipse.jgit.transport.Transport;
 import org.eclipse.jgit.transport.URIish;
-import org.eclipse.jgit.transport.UserAgent;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
@@ -231,8 +230,6 @@ class JGitConnection implements GitConnection {
     private static final String MESSAGE_COMMIT_NOT_POSSIBLE       = "Commit is not possible because repository state is '%s'";
     private static final String MESSAGE_COMMIT_AMEND_NOT_POSSIBLE = "Amend is not possible because repository state is '%s'";
 
-    private static final String USER_AGENT = "git/2.1.0";
-
     private static final Logger LOG = LoggerFactory.getLogger(JGitConnection.class);
 
     private Git                 git;
@@ -251,7 +248,6 @@ class JGitConnection implements GitConnection {
         this.credentialsLoader = credentialsLoader;
         this.sshKeyProvider = sshKeyProvider;
         this.userResolver = userResolver;
-        UserAgent.set(USER_AGENT);
     }
 
     @Override

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -135,6 +135,7 @@ import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.TrackingRefUpdate;
 import org.eclipse.jgit.transport.Transport;
 import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UserAgent;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
@@ -229,6 +230,8 @@ class JGitConnection implements GitConnection {
 
     private static final String MESSAGE_COMMIT_NOT_POSSIBLE       = "Commit is not possible because repository state is '%s'";
     private static final String MESSAGE_COMMIT_AMEND_NOT_POSSIBLE = "Amend is not possible because repository state is '%s'";
+
+    private static final String USER_AGENT = "git/2.1.0";
 
     private static final Logger LOG = LoggerFactory.getLogger(JGitConnection.class);
 
@@ -1605,7 +1608,7 @@ class JGitConnection implements GitConnection {
             }
 
             ProxyAuthenticator.initAuthenticator(remoteUrl);
-
+            UserAgent.set(USER_AGENT);
             return command.call();
         } catch (GitException | TransportException exception) {
             if ("Unable get private ssh key".equals(exception.getMessage())) {

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -251,6 +251,7 @@ class JGitConnection implements GitConnection {
         this.credentialsLoader = credentialsLoader;
         this.sshKeyProvider = sshKeyProvider;
         this.userResolver = userResolver;
+        UserAgent.set(USER_AGENT);
     }
 
     @Override
@@ -1608,7 +1609,6 @@ class JGitConnection implements GitConnection {
             }
 
             ProxyAuthenticator.initAuthenticator(remoteUrl);
-            UserAgent.set(USER_AGENT);
             return command.call();
         } catch (GitException | TransportException exception) {
             if ("Unable get private ssh key".equals(exception.getMessage())) {

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnectionFactory.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnectionFactory.java
@@ -51,6 +51,7 @@ public class JGitConnectionFactory extends GitConnectionFactory {
         this.sshKeyProvider = sshKeyProvider;
         this.userResolver = userResolver;
 
+        UserAgent.set(USER_AGENT);
         // Install the all-trusting trust manager
         try {
             SSLContext sslContext = SSLContext.getInstance("SSL");
@@ -70,7 +71,6 @@ public class JGitConnectionFactory extends GitConnectionFactory {
             };
             sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
             HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
-            UserAgent.set(USER_AGENT);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             throw new GitException(e);
         }

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnectionFactory.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnectionFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.UserAgent;
 
 import javax.inject.Inject;
 import javax.net.ssl.HttpsURLConnection;
@@ -37,6 +38,8 @@ import java.security.NoSuchAlgorithmException;
  * @author Tareq Sharafy (tareq.sha@gmail.com)
  */
 public class JGitConnectionFactory extends GitConnectionFactory {
+
+    private static final String USER_AGENT = "git/2.1.0";
 
     private final CredentialsLoader credentialsLoader;
     private final SshKeyProvider    sshKeyProvider;
@@ -67,6 +70,7 @@ public class JGitConnectionFactory extends GitConnectionFactory {
             };
             sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
             HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+            UserAgent.set(USER_AGENT);
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             throw new GitException(e);
         }


### PR DESCRIPTION
### What does this PR do?

 Sets custom header instead of "JGit-4.3.0" for git providers have filtration by User-Agent header.
### What issues does this PR fix or reference?
#1935  codenvy/codenvy#430
### Tests written?

No
### Docs requirements?

None
