### PR TITLE
Add support of BasicAuthentication Authentication to Git

### DIFF
--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/ProviderInfo.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/ProviderInfo.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.git.shared;
 
+import org.eclipse.che.commons.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,19 +29,26 @@ public class ProviderInfo {
 
     private Map<String, String> info = new HashMap<>();
 
+    public ProviderInfo(@NotNull String providerName) {
+        info.put(PROVIDER_NAME, providerName);
+    }
+
     public ProviderInfo(@NotNull String providerName,
                         @NotNull String authenticateUrl) {
         info.put(PROVIDER_NAME, providerName);
         info.put(AUTHENTICATE_URL, authenticateUrl);
     }
 
+
     public String getProviderName() {
         return info.get(PROVIDER_NAME);
     }
 
-    public String getAuthenticateUrl() {
-        return info.get(AUTHENTICATE_URL);
-    }
+    /**
+     * @return authenticate URL. It retrun String or null value.
+     */
+    @Nullable
+    public String getAuthenticateUrl() { return info.get(AUTHENTICATE_URL); }
 
     public void put(String key, String value) {
         info.put(key, value);

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitBasicAuthenticationCredentialsProvider.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitBasicAuthenticationCredentialsProvider.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.git;
+
+import com.google.inject.Singleton;
+import org.eclipse.che.api.git.shared.ProviderInfo;
+
+/**
+ * Credentials provider for Git basic authentication
+ *
+ * @author Yossi Balan
+ */
+@Singleton
+public class GitBasicAuthenticationCredentialsProvider implements CredentialsProvider {
+
+    private static ThreadLocal<UserCredential> currRequestCredentials = new ThreadLocal<>();
+    private static final String BASIC_PROVIDER_NAME = "basic";
+
+    @Override
+    public UserCredential getUserCredential() {
+        return currRequestCredentials.get();
+    }
+
+    @Override
+    public String getId() {
+        return BASIC_PROVIDER_NAME;
+    }
+
+    @Override
+    public boolean canProvideCredentials(String url) {
+        return getUserCredential() != null;
+    }
+
+    @Override
+    public ProviderInfo getProviderInfo() {
+        return new ProviderInfo(BASIC_PROVIDER_NAME);
+    }
+
+    public static void setCurrentCredentials(String user, String password) {
+        UserCredential creds = new UserCredential(user, password, BASIC_PROVIDER_NAME);
+        currRequestCredentials.set(creds);
+    }
+
+    public static void clearCredentials() {
+        currRequestCredentials.set(null);
+    }
+
+}

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
@@ -48,6 +48,8 @@ import java.util.Optional;
 import static org.eclipse.che.api.core.ErrorCodes.FAILED_CHECKOUT;
 import static org.eclipse.che.api.core.ErrorCodes.FAILED_CHECKOUT_WITH_START_POINT;
 import static org.eclipse.che.api.git.shared.BranchListRequest.LIST_ALL;
+import static org.eclipse.che.api.git.GitBasicAuthenticationCredentialsProvider.clearCredentials;
+import static org.eclipse.che.api.git.GitBasicAuthenticationCredentialsProvider.setCurrentCredentials;
 
 /**
  * @author Vladyslav Zhukovskii
@@ -105,6 +107,7 @@ public class GitProjectImporter implements ProjectImporter {
                                                                           IOException,
                                                                           ServerException {
         GitConnection git = null;
+        boolean credentialsHaveBeenSet = false;
         try {
             // For factory: checkout particular commit after clone
             String commitId = null;
@@ -137,6 +140,12 @@ public class GitProjectImporter implements ProjectImporter {
                     recursiveEnabled = true;
                 }
                 branchMerge = parameters.get("branchMerge");
+                final String user = parameters.get("userName");
+                final String pass = parameters.get("password");
+                if (user != null && pass != null) {
+                    credentialsHaveBeenSet = true;
+                    setCurrentCredentials(user, pass);
+                }
             }
             // Get path to local file. Git works with local filesystem only.
             final String localPath = baseFolder.getVirtualFile().toIoFile().getAbsolutePath();
@@ -196,6 +205,9 @@ public class GitProjectImporter implements ProjectImporter {
         } finally {
             if (git != null) {
                 git.close();
+            }
+            if (credentialsHaveBeenSet) {
+                clearCredentials();
             }
         }
     }

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.git.impl.jgit;
 
 import org.eclipse.che.api.git.CredentialsLoader;
 import org.eclipse.che.api.git.GitUserResolver;
+import org.eclipse.che.api.git.shared.GitRequest;
 import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.lib.Repository;
@@ -50,7 +51,8 @@ public class JGitConnectionTest {
     private GitUserResolver gitUserResolver;
     @Mock
     private TransportCommand transportCommand;
-
+    @Mock
+    private GitRequest request;
     @InjectMocks
     private JGitConnection jGitConnection;
 
@@ -80,7 +82,7 @@ public class JGitConnectionTest {
         passwordField.setAccessible(true);
 
         //when
-        jGitConnection.executeRemoteCommand(url, transportCommand);
+        jGitConnection.executeRemoteCommand(url, transportCommand, request);
 
         //then
         verify(transportCommand).setCredentialsProvider(captor.capture());
@@ -94,7 +96,7 @@ public class JGitConnectionTest {
     @Test(dataProvider = "gitUrlsWithoutOrWrongCredentials")
     public void shouldNotSetCredentialsProviderIfUrlDoesNotContainCredentials(String url) throws Exception{
         //when
-        jGitConnection.executeRemoteCommand(url, transportCommand);
+        jGitConnection.executeRemoteCommand(url, transportCommand, request);
 
         //then
         verify(transportCommand, never()).setCredentialsProvider(any());


### PR DESCRIPTION
### What does this PR do?

Add support of Basic Authenticationt git.
It will support in operation of import,clone,fetch,rebase,push,pull.
The user will provide the user and password for the request and it will create credentials provider
### What issues does this PR fix or reference?

Add support to clone and work with repository that support  basic authentication
### Previous Behavior

Remove this section if not relevant
It was not possible to work with repository that need basic Authentication
### New Behavior

This content may also be included in the release notes.
### Tests written?

Yes/No
It exist for our scenario 
### Docs requirements?

Include the content for all the docs changes required. 
1.  API changes  
2.  User docs changes  

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Signed-off-by: i053322 yossi.balan@sap.com
