### PR TITLE
fix dropdown-menu freezing

### DIFF
--- a/dashboard/src/app/navbar/navbar-dropdown-menu/navbar-dropdown-menu.directive.js
+++ b/dashboard/src/app/navbar/navbar-dropdown-menu/navbar-dropdown-menu.directive.js
@@ -96,7 +96,7 @@ export class NavbarDropdownMenu {
       // iterate elements under cursor
       let limit = 50,
         nextTargetEl;
-      while (elementMouseIsOver.tagName !== 'MD-MENU' && limit > 0){
+      while (elementMouseIsOver && elementMouseIsOver.tagName !== 'BODY' && elementMouseIsOver.tagName !== 'MD-MENU' && limit > 0){
         elementMouseIsOver = self.$document[0].elementFromPoint(x, y);
 
         // break when top of tree is reached
@@ -120,7 +120,7 @@ export class NavbarDropdownMenu {
       // click on menu's backdrop to hide menu
       backdropEl.triggerHandler('click');
 
-      if (elementMouseIsOver.tagName === 'MD-MENU') {
+      if (elementMouseIsOver && elementMouseIsOver.tagName === 'MD-MENU') {
         // if menu is found then
         // check if click is caught over the same menu
         if(elementMouseIsOver === this.$rootScope.navbarDropdownActiveMenu) {


### PR DESCRIPTION
### What does this PR do?

Fix Dashboard freezing in Firefox.
### What issues does this PR fix or reference?

[https://github.com/eclipse/che/issues/1928](https://github.com/eclipse/che/issues/1928)
### Previous Behavior

Click outside any dropdown menu freezes Dashboard.
### New Behavior

Click outside dropdown menu closes it, normal work of Dashboard continues.

Signed-off-by: Oleksii Kurinnyi okurinnyi@codenvy.com
