### PR TITLE
CHE-1810 Create JPA based SshDao implementation

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/test/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjectorTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/test/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjectorTest.java
@@ -132,7 +132,7 @@ public class KeysInjectorTest {
     @Test
     public void shouldNotInjectSshKeysWhenThereAreNotAnyPairWithPublicKey() throws Exception {
         when(sshManager.getPairs(anyString(), anyString()))
-                .thenReturn(Collections.singletonList(new SshPairImpl("machine", "myPair", null, null)));
+                .thenReturn(Collections.singletonList(new SshPairImpl(OWNER_ID, "machine", "myPair", null, null)));
 
         subscriber.onEvent(newDto(MachineStatusEvent.class).withEventType(MachineStatusEvent.EventType.RUNNING)
                                                            .withMachineId(MACHINE_ID));
@@ -145,8 +145,8 @@ public class KeysInjectorTest {
     @Test
     public void shouldInjectSshKeysWhenThereAreAnyPairWithNotNullPublicKey() throws Exception {
         when(sshManager.getPairs(anyString(), anyString()))
-                .thenReturn(Arrays.asList(new SshPairImpl("machine", "myPair", "publicKey1", null),
-                                          new SshPairImpl("machine", "myPair", "publicKey2", null)));
+                .thenReturn(Arrays.asList(new SshPairImpl(OWNER_ID, "machine", "myPair", "publicKey1", null),
+                                          new SshPairImpl(OWNER_ID, "machine", "myPair", "publicKey2", null)));
 
         subscriber.onEvent(newDto(MachineStatusEvent.class).withEventType(MachineStatusEvent.EventType.RUNNING)
                                                            .withMachineId(MACHINE_ID));
@@ -166,7 +166,7 @@ public class KeysInjectorTest {
     @Test
     public void shouldSendMessageInMachineLoggerWhenSomeErrorOcursOnKeysInjection() throws Exception {
         when(sshManager.getPairs(anyString(), anyString()))
-                .thenReturn(Collections.singletonList(new SshPairImpl("machine", "myPair", "publicKey1", null)));
+                .thenReturn(Collections.singletonList(new SshPairImpl(OWNER_ID, "machine", "myPair", "publicKey1", null)));
         when(logMessage.getType()).thenReturn(LogMessage.Type.STDERR);
         when(logMessage.getContent()).thenReturn("FAILED");
 

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-ssh</artifactId>
+                <version>${che.version}</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-ssh-shared</artifactId>
                 <version>${che.version}</version>
             </dependency>

--- a/wsagent/che-core-git-impl-native/src/test/java/org/eclipse/che/api/ssh/server/SshManagerTest.java
+++ b/wsagent/che-core-git-impl-native/src/test/java/org/eclipse/che/api/ssh/server/SshManagerTest.java
@@ -52,7 +52,7 @@ public class SshManagerTest {
     public void shouldGenerateSshPair() throws Exception {
         SshPairImpl generatedPair = sshManager.generatePair(OWNER, "service", "name");
 
-        verify(sshDao).create(eq(OWNER), sshPairCaptor.capture());
+        verify(sshDao).create(sshPairCaptor.capture());
         SshPairImpl storedSshPair = sshPairCaptor.getValue();
         assertEquals(generatedPair, storedSshPair);
         assertEquals(generatedPair.getName(), "name");
@@ -65,9 +65,9 @@ public class SshManagerTest {
     @Test
     public void shouldCreateSshPair() throws Exception {
         SshPairImpl sshPair = createSshPair();
-        sshManager.createPair(OWNER, sshPair);
+        sshManager.createPair(sshPair);
 
-        verify(sshDao).create(eq(OWNER), eq(sshPair));
+        verify(sshDao).create(eq(sshPair));
     }
 
     @Test
@@ -101,7 +101,8 @@ public class SshManagerTest {
     }
 
     private SshPairImpl createSshPair() {
-        return new SshPairImpl("service",
+        return new SshPairImpl(OWNER,
+                               "service",
                                "name",
                                "publicKey",
                                "privateKey");

--- a/wsmaster/che-core-api-ssh/pom.xml
+++ b/wsmaster/che-core-api-ssh/pom.xml
@@ -35,6 +35,14 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-persist</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
         </dependency>
@@ -64,11 +72,31 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-user</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
@@ -78,6 +106,21 @@
         <dependency>
             <groupId>com.google.gwt.gwtmockito</groupId>
             <artifactId>gwtmockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc-vendor-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -195,6 +238,23 @@
                         <version>${project.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <!-- Create the test jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/spi/tck/*.*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/SshManager.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/SshManager.java
@@ -70,19 +70,18 @@ public class SshManager {
         ByteArrayOutputStream publicBuff = new ByteArrayOutputStream();
         keyPair.writePublicKey(publicBuff, null);
 
-        final SshPairImpl generatedSshPair = new SshPairImpl(service,
+        final SshPairImpl generatedSshPair = new SshPairImpl(owner,
+                                                             service,
                                                              name,
                                                              publicBuff.toString(),
                                                              privateBuff.toString());
-        sshDao.create(owner, generatedSshPair);
+        sshDao.create(generatedSshPair);
         return generatedSshPair;
     }
 
     /**
      * Creates new ssh pair for specified user.
      *
-     * @param owner
-     *         the id of the user who will be the owner of the ssh pair
      * @param sshPair
      *         ssh pair to create
      * @throws ConflictException
@@ -90,8 +89,8 @@ public class SshManager {
      * @throws ServerException
      *         when any other error occurs during ssh pair creating
      */
-    public void createPair(String owner, SshPairImpl sshPair) throws ServerException, ConflictException {
-        sshDao.create(owner, sshPair);
+    public void createPair(SshPairImpl sshPair) throws ServerException, ConflictException {
+        sshDao.create(sshPair);
     }
 
     /**

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/SshService.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/SshService.java
@@ -131,7 +131,7 @@ public class SshService extends Service {
             throw new BadRequestException("Key content was not provided.");
         }
 
-        sshManager.createPair(getCurrentUserId(), new SshPairImpl(service, name, publicKey, privateKey));
+        sshManager.createPair(new SshPairImpl(getCurrentUserId(), service, name, publicKey, privateKey));
 
         // We should send 200 response code and body with empty line
         // through specific of html form that doesn't invoke complete submit handler
@@ -158,7 +158,7 @@ public class SshService extends Service {
             throw new BadRequestException("Key content was not provided.");
         }
 
-        sshManager.createPair(getCurrentUserId(), new SshPairImpl(sshPair));
+        sshManager.createPair(new SshPairImpl(getCurrentUserId(), sshPair));
     }
 
     @GET

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/jpa/JpaSshDao.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/jpa/JpaSshDao.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.ssh.server.jpa;
+
+import com.google.inject.persist.Transactional;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jdbc.jpa.DuplicateKeyException;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.server.spi.SshDao;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * JPA based implementation of {@link SshDao}.
+ *
+ * @author Mihail Kuznyetsov
+ */
+@Singleton
+public class JpaSshDao implements SshDao {
+
+    @Inject
+    private Provider<EntityManager> managerProvider;
+
+    @Override
+    public void create(SshPairImpl sshPair) throws ServerException, ConflictException {
+        requireNonNull(sshPair);
+        try {
+            doCreate(sshPair);
+        } catch (DuplicateKeyException e) {
+            throw new ConflictException(String.format("Ssh pair with service '%s' and name '%s' already exists",
+                                                      sshPair.getService(),
+                                                      sshPair.getName()));
+        } catch (RuntimeException e) {
+            throw new ServerException(e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public List<SshPairImpl> get(String owner, String service) throws ServerException {
+        requireNonNull(owner);
+        requireNonNull(service);
+        try {
+            return managerProvider.get()
+                                  .createQuery("SELECT pair " +
+                                               "FROM SshKeyPair pair " +
+                                               "WHERE pair.owner = :owner " +
+                                               "  AND pair.service = :service", SshPairImpl.class)
+                                  .setParameter("owner", owner)
+                                  .setParameter("service", service)
+                                  .getResultList();
+        } catch (RuntimeException e) {
+            throw new ServerException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public SshPairImpl get(String owner, String service, String name) throws ServerException, NotFoundException {
+        requireNonNull(owner);
+        requireNonNull(service);
+        requireNonNull(name);
+        try {
+            SshPairImpl result = managerProvider.get().find(SshPairImpl.class, new SshPairPrimaryKey(owner, service, name));
+            if (result == null) {
+                throw new NotFoundException(String.format("Ssh pair with service '%s' and name '%s' was not found.", service, name));
+            }
+            return result;
+        } catch (RuntimeException e) {
+            throw new ServerException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    @Override
+    public void remove(String owner, String service, String name) throws ServerException, NotFoundException {
+        requireNonNull(owner);
+        requireNonNull(service);
+        requireNonNull(name);
+        try {
+            doRemove(owner, service, name);
+        } catch (RuntimeException e) {
+            throw new ServerException(e);
+        }
+    }
+
+    @Transactional
+    protected void doCreate(SshPairImpl entity) {
+        managerProvider.get().persist(entity);
+    }
+
+    @Transactional
+    protected void doRemove(String owner, String service, String name) throws NotFoundException {
+        EntityManager manager = managerProvider.get();
+        SshPairImpl entity = manager.find(SshPairImpl.class, new SshPairPrimaryKey(owner, service, name));
+        if (entity == null) {
+            throw new NotFoundException(String.format("Ssh pair with service '%s' and name '%s' was not found.", service, name));
+        }
+        manager.remove(entity);
+    }
+}

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/jpa/SshPairPrimaryKey.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/jpa/SshPairPrimaryKey.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.ssh.server.jpa;
+
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Primary key for {@link SshPairImpl} entity
+ *
+ * @author Mihail Kuznyetsov
+ */
+public class SshPairPrimaryKey implements Serializable {
+    private String owner;
+    private String service;
+    private String name;
+
+    public SshPairPrimaryKey() {
+    }
+
+    public SshPairPrimaryKey(String owner, String service, String name) {
+        this.owner = owner;
+        this.service = service;
+        this.name = name;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof SshPairPrimaryKey)) return false;
+        final SshPairPrimaryKey other = (SshPairPrimaryKey)obj;
+        return Objects.equals(owner, other.owner) &&
+               Objects.equals(service, other.service) &&
+               Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(owner);
+        hash = 31 * hash + Objects.hashCode(service);
+        hash = 31 * hash + Objects.hashCode(name);
+        return hash;
+    }
+}

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/model/impl/SshPairImpl.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/model/impl/SshPairImpl.java
@@ -10,32 +10,61 @@
  *******************************************************************************/
 package org.eclipse.che.api.ssh.server.model.impl;
 
+import org.eclipse.che.api.ssh.server.jpa.SshPairPrimaryKey;
 import org.eclipse.che.api.ssh.shared.model.SshPair;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.util.Objects;
 
 /**
  * @author Sergii Leschenko
  */
+@Entity(name = "SshKeyPair")
+@IdClass(SshPairPrimaryKey.class)
 public class SshPairImpl implements SshPair {
-    private final String service;
-    private final String name;
-    private final String publicKey;
-    private final String privateKey;
+    @Id
+    private String owner;
+    @Id
+    private String service;
+    @Id
+    private String name;
+    @Basic
+    private String publicKey;
+    @Basic
+    private String privateKey;
 
-    public SshPairImpl(String service, String name, String publicKey, String privateKey) {
+    @ManyToOne
+    @JoinColumn(name="owner", insertable = false, updatable = false)
+    private UserImpl user;
+
+    public SshPairImpl() {
+    }
+
+    public SshPairImpl(String owner, String service, String name, String publicKey, String privateKey) {
+        this.owner = owner;
         this.service = service;
         this.name = name;
         this.publicKey = publicKey;
         this.privateKey = privateKey;
     }
 
-    public SshPairImpl(SshPair sshPair) {
+    public SshPairImpl(String owner, SshPair sshPair) {
+        this.owner = owner;
         this.service = sshPair.getService();
         this.name = sshPair.getName();
         this.publicKey = sshPair.getPublicKey();
         this.privateKey = sshPair.getPrivateKey();
+    }
+
+    public String getOwner() {
+        return owner;
     }
 
     @Override
@@ -65,7 +94,8 @@ public class SshPairImpl implements SshPair {
         if (this == obj) return true;
         if (!(obj instanceof SshPairImpl)) return false;
         final SshPairImpl other = (SshPairImpl)obj;
-        return Objects.equals(service, other.service) &&
+        return Objects.equals(owner, other.owner) &&
+               Objects.equals(service, other.service) &&
                Objects.equals(name, other.name) &&
                Objects.equals(publicKey, other.publicKey) &&
                Objects.equals(privateKey, other.privateKey);
@@ -74,6 +104,7 @@ public class SshPairImpl implements SshPair {
     @Override
     public int hashCode() {
         int hash = 7;
+        hash = 31 * hash + Objects.hashCode(owner);
         hash = 31 * hash + Objects.hashCode(service);
         hash = 31 * hash + Objects.hashCode(name);
         hash = 31 * hash + Objects.hashCode(publicKey);
@@ -84,7 +115,8 @@ public class SshPairImpl implements SshPair {
     @Override
     public String toString() {
         return "SshPairImpl{" +
-               "service='" + service + '\'' +
+               "owner='" + owner + '\'' +
+               ", service='" + service + '\'' +
                ", name='" + name + '\'' +
                ", publicKey='" + publicKey + '\'' +
                ", privateKey='" + privateKey + '\'' +

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/spi/SshDao.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/spi/SshDao.java
@@ -28,16 +28,16 @@ public interface SshDao {
     /**
      * Creates new ssh pair for specified user.
      *
-     * @param owner
-     *         the id of the user who will be the owner of the ssh pair
      * @param sshPair
      *         ssh pair to create
      * @throws ConflictException
      *         when specified user already has ssh pair with given service and name
+     * @throws NullPointerException
+     *         when {@sshPair} is null
      * @throws ServerException
      *         when any other error occurs during ssh pair creating
      */
-    void create(String owner, SshPairImpl sshPair) throws ServerException, ConflictException;
+    void create(SshPairImpl sshPair) throws ServerException, ConflictException;
 
     /**
      * Returns ssh pairs by owner and service.
@@ -47,6 +47,8 @@ public interface SshDao {
      * @param service
      *         service name of ssh pair
      * @return list of ssh pair with given service and owned by given service.
+     * @throws NullPointerException
+     *         when {@code owner} or {@code service} is null
      * @throws ServerException
      *         when any other error occurs during ssh pair fetching
      */
@@ -62,6 +64,8 @@ public interface SshDao {
      * @param name
      *         name of ssh pair
      * @return ssh pair instance
+     * @throws NullPointerException
+     *         when {@code owner} or {@code service} or {@code name} is null
      * @throws NotFoundException
      *         when ssh pair is not found
      * @throws ServerException
@@ -78,6 +82,8 @@ public interface SshDao {
      *         service name of ssh pair
      * @param name
      *         of ssh pair
+     * @throws NullPointerException
+     *         when {@code owner} or {@code service} or {@code name} is null
      * @throws NotFoundException
      *         when ssh pair is not found
      * @throws ServerException

--- a/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/jpa/SshTckModule.java
+++ b/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/jpa/SshTckModule.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.ssh.server.jpa;
+
+import com.google.inject.TypeLiteral;
+import com.google.inject.persist.jpa.JpaPersistModule;
+
+import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.server.spi.SshDao;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+
+/**
+ * @author Mihail Kuznyetsov
+ */
+public class SshTckModule extends TckModule {
+
+    @Override
+    protected void configure() {
+        bind(SshDao.class).to(JpaSshDao.class);
+        bind(new TypeLiteral<TckRepository<SshPairImpl>>(){}).toInstance(new JpaTckRepository<>(SshPairImpl.class));
+        bind(new TypeLiteral<TckRepository<UserImpl>>(){}).toInstance(new JpaTckRepository<>(UserImpl.class));
+
+        install(new JpaPersistModule("main"));
+        bind(JpaInitializer.class).asEagerSingleton();
+        bind(org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler.class);
+    }
+}

--- a/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/spi/tck/SshDaoTest.java
+++ b/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/spi/tck/SshDaoTest.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.ssh.server.spi.tck;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.server.spi.SshDao;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * @author Mihail Kuznyetsov.
+ */
+@Guice(moduleFactory = TckModuleFactory.class)
+@Test(suiteName = SshDaoTest.SUITE_NAME)
+public class SshDaoTest {
+    public static final String SUITE_NAME   = "SshDaoTck";
+    private static final int COUNT_OF_PAIRS = 5;
+    private static final int COUNT_OF_USERS = 3;
+
+    SshPairImpl[] pairs;
+
+    @Inject
+    private SshDao sshDao;
+
+    @Inject
+    private TckRepository<SshPairImpl> sshRepository;
+
+    @Inject
+    private TckRepository<UserImpl> userRepository;
+
+    @BeforeMethod
+    public void setUp() throws TckRepositoryException {
+        UserImpl[] users = new UserImpl[COUNT_OF_USERS];
+        for (int i = 0; i < COUNT_OF_USERS; i++) {
+            users[i] = new UserImpl("owner" + i,
+                                    "owner" + i + "@eclipse.org",
+                                    "owner" + i,
+                                    "password",
+                                    emptyList());
+        }
+
+        pairs = new SshPairImpl[COUNT_OF_PAIRS];
+
+        for (int i = 0; i < COUNT_OF_PAIRS; i++) {
+            // 2 pairs share same owner and service
+            pairs[i] = new SshPairImpl("owner" + i/2,
+                                       "service" + i/2,
+                                       "name" + i,
+                                       NameGenerator.generate("publicKey-", 20),
+                                       NameGenerator.generate("privateKey-", 20));
+        }
+
+        userRepository.createAll(Arrays.asList(users));
+        sshRepository.createAll(Arrays.asList(pairs));
+    }
+
+    @AfterMethod
+    public void cleanUp() throws TckRepositoryException {
+        sshRepository.removeAll();
+        userRepository.removeAll();
+    }
+
+    @Test
+    public void shouldCreateSshKeyPair() throws Exception {
+        SshPairImpl pair = new SshPairImpl("owner1", "service", "name", "publicKey", "privateKey");
+        sshDao.create(pair);
+
+        assertEquals(sshDao.get("owner1", "service", "name"), pair);
+    }
+
+    @Test(expectedExceptions = ConflictException.class)
+    public void shouldThrowConflictExceptionWhenSshPairWithSuchOwnerAndServiceAndNameAlreadyExists() throws Exception {
+        sshDao.create(pairs[0]);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnCreateIfSshPairIsNull() throws Exception {
+        sshDao.create(null);
+    }
+    @Test
+    public void shouldGetSshPairByNameOwnerAndService() throws Exception{
+        SshPairImpl sshPair = pairs[0];
+
+        sshDao.get(sshPair.getOwner(), sshPair.getService(), sshPair.getName());
+    }
+
+    @Test(expectedExceptions = NotFoundException.class)
+    public void shouldThrowNotFoundExceptionIfPairWithSuchNameOwnerAndServiceDoesNotExist() throws Exception {
+        SshPairImpl sshPair = pairs[0];
+
+        sshDao.get(sshPair.getService(), sshPair.getService(), sshPair.getName());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnGetSshPairWhenOwnerIsNull() throws Exception{
+        sshDao.get(null, "service", "name");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnGetSshPairWhenServiceIsNull() throws Exception{
+        sshDao.get("owner", null, "name");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnGetSshPairWhenNameIsNull() throws Exception{
+        sshDao.get("owner", "service", null);
+    }
+
+    @Test
+    public void shouldGetSshPairListByNameAndService() throws Exception{
+        SshPairImpl sshPair1 = pairs[0];
+        SshPairImpl sshPair2 = pairs[1];
+        assertEquals(sshPair1.getOwner(), sshPair2.getOwner(), "Owner must be the same");
+        assertEquals(sshPair1.getService(), sshPair2.getService(), "Service must be the same");
+
+        final List<SshPairImpl> found = sshDao.get(sshPair1.getOwner(), sshPair1.getService());
+        assertEquals(new HashSet<>(found), new HashSet<>(asList(sshPair1, sshPair2)));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenThereAreNoPairsWithGivenOwnerAndService() throws Exception {
+        assertTrue(sshDao.get("non-existing-owner", "non-existing-service").isEmpty());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnGetSshPairsListWhenOwnerIsNull() throws Exception{
+        sshDao.get(null, "service");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnGetSshPairsListWhenServiceIsNull() throws Exception{
+        sshDao.get("owner", null);
+    }
+
+    @Test
+    public void shouldRemoveSshKeyPair() throws Exception {
+        sshDao.remove(pairs[4].getOwner(), pairs[4].getService(), pairs[4].getName());
+
+        try {
+            sshDao.get(pairs[4].getOwner(), pairs[4].getService(), pairs[4].getName());
+            fail("Object is still present in database");
+        } catch (NotFoundException e) {
+        }
+
+    }
+
+    @Test(expectedExceptions = NotFoundException.class)
+    public void shouldThrowNotFoundExceptionWhenRemovingNonExistingPair() throws Exception {
+        sshDao.remove(pairs[4].getService(), pairs[4].getService(), pairs[4].getService());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnRemoveWhenOwnerIsNull() throws Exception {
+        sshDao.remove(null, "service", "name");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnRemoveWhenServiceIsNull() throws Exception {
+        sshDao.remove("owner", null, "name");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNpeOnRemoveWhenNameIsNull() throws Exception {
+        sshDao.remove("owner", "service", null);
+    }
+}

--- a/wsmaster/che-core-api-ssh/src/test/resources/META-INF/persistence.xml
+++ b/wsmaster/che-core-api-ssh/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" version="1.0">
+    <persistence-unit name="main" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.che.api.ssh.server.model.impl.SshPairImpl</class>
+        <class>org.eclipse.che.api.user.server.model.impl.UserImpl</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:;DB_CLOSE_DELAY=0;MVCC=true;TRACE_LEVEL_FILE=4;TRACE_LEVEL_SYSTEM_OUT=4"/>
+            <property name="javax.persistence.jdbc.user" value=""/>
+            <property name="javax.persistence.jdbc.password" value=""/>
+
+            <property name="eclipselink.exception-handler" value="org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler"/>
+            <property name="eclipselink.target-server" value="None"/>
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="database"/>
+            <property name="eclipselink.logging.logger" value="DefaultLogger"/>
+            <property name="eclipselink.logging.level" value="INFO"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/wsmaster/che-core-api-ssh/src/test/resources/META-INF/services/org.eclipse.che.commons.test.tck.TckModule
+++ b/wsmaster/che-core-api-ssh/src/test/resources/META-INF/services/org.eclipse.che.commons.test.tck.TckModule
@@ -1,0 +1,1 @@
+org.eclipse.che.api.ssh.server.jpa.SshTckModule

--- a/wsmaster/wsmaster-local/pom.xml
+++ b/wsmaster/wsmaster-local/pom.xml
@@ -37,6 +37,14 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-persist</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
         </dependency>
@@ -74,6 +82,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-machine</artifactId>
         </dependency>
         <dependency>
@@ -87,6 +99,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -113,6 +129,10 @@
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-core</artifactId>
         </dependency>
@@ -137,6 +157,12 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-machine</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -202,7 +228,8 @@
                             <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                             <includeArtifactIds>che-core-api-user,
                                 che-core-api-machine,
-                                che-core-api-workspace</includeArtifactIds>
+                                che-core-api-workspace,
+                                che-core-api-ssh</includeArtifactIds>
                             <includeScope>test</includeScope>
                         </configuration>
                     </execution>

--- a/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalSshDaoImplTest.java
+++ b/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalSshDaoImplTest.java
@@ -56,16 +56,16 @@ public class LocalSshDaoImplTest {
     public void testSshPairsSerialization() throws Exception {
         SshPairImpl pair = createPair();
 
-        sshDao.create("owner", pair);
+        sshDao.create(pair);
         sshDao.saveSshPairs();
 
-        assertEquals(GSON.toJson(ImmutableMap.of("owner", singletonList(pair))), new String(readAllBytes(sshPath)));
+        assertEquals(GSON.toJson(singletonList(pair)), new String(readAllBytes(sshPath)));
     }
 
     @Test
     public void testSshPairsDeserialization() throws Exception {
         SshPairImpl pair = createPair();
-        Files.write(sshPath, GSON.toJson(ImmutableMap.of("owner", singletonList(pair))).getBytes());
+        Files.write(sshPath, GSON.toJson(singletonList(pair)).getBytes());
 
         sshDao.loadSshPairs();
 
@@ -75,6 +75,6 @@ public class LocalSshDaoImplTest {
     }
 
     private static SshPairImpl createPair() {
-        return new SshPairImpl("service", "name", "publicKey", "privateKey");
+        return new SshPairImpl("owner", "service", "name", "publicKey", "privateKey");
     }
 }

--- a/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalSshTckRepository.java
+++ b/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalSshTckRepository.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.local;
+
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
+
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Mihail Kuznyetsov
+ */
+public class LocalSshTckRepository implements TckRepository<SshPairImpl> {
+    @Inject
+    private LocalSshDaoImpl sshDao;
+
+    @Override
+    public void createAll(Collection<? extends SshPairImpl> entities) throws TckRepositoryException {
+        sshDao.pairs.addAll(entities);
+    }
+
+    @Override
+    public void removeAll() throws TckRepositoryException {
+        sshDao.pairs.clear();
+    }
+}

--- a/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalTckModule.java
+++ b/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalTckModule.java
@@ -21,6 +21,9 @@ import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;
 import org.eclipse.che.api.machine.server.spi.RecipeDao;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.server.spi.SshDao;
+import org.eclipse.che.api.user.server.jpa.PreferenceEntity;
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.PreferenceDao;
@@ -37,6 +40,7 @@ import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -79,6 +83,7 @@ public class LocalTckModule extends TckModule {
         bind(new TypeLiteral<TckRepository<Pair<String, Map<String, String>>>>() {}).to(LocalPreferenceTckRepository.class);
         bind(new TypeLiteral<TckRepository<StackImpl>>() {}).to(LocalStackTckRepository.class);
         bind(new TypeLiteral<TckRepository<SnapshotImpl>>() {}).to(SnapshotTckRepository.class);
+        bind(new TypeLiteral<TckRepository<SshPairImpl>>() {}).to(LocalSshTckRepository.class);
 
         bind(UserDao.class).to(LocalUserDaoImpl.class);
         bind(ProfileDao.class).to(LocalProfileDaoImpl.class);
@@ -87,6 +92,7 @@ public class LocalTckModule extends TckModule {
         bind(PreferenceDao.class).to(LocalPreferenceDaoImpl.class);
         bind(StackDao.class).to(LocalStackDaoImpl.class);
         bind(SnapshotDao.class).to(LocalSnapshotDaoImpl.class);
+        bind(SshDao.class).to(LocalSshDaoImpl.class);
     }
 
     @Singleton
@@ -143,6 +149,14 @@ public class LocalTckModule extends TckModule {
         @Inject
         public LocalPreferenceTckRepository(LocalPreferenceDaoImpl localDao) {
             super(localDao.preferences, (map, entity) -> map.put(entity.first, entity.second), Map::clear);
+        }
+    }
+
+    @Singleton
+    private static class LocalSshTckRepository extends LocalTckRepository<List<SshPairImpl>, SshPairImpl> {
+        @Inject
+        public LocalSshTckRepository(LocalSshDaoImpl sshDao) {
+            super(sshDao.pairs, List::add, List::clear);
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds JpaSshDao and TCK to test it, as well as local DAO implementation.
### What issues does this PR fix or reference?

CHE-1810
### Previous Behavior

LocalSshDao previously stored as map of pairs by owner.
### New Behavior

SshImpl now contains field owner. LocalSshDao now stores pairs in list.
### Tests written?

Yes
### Docs requirements?

No
