### PR TITLE
CHE-1785: restore commands when WS is started

### DIFF
--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineProcessDto.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineProcessDto.java
@@ -53,5 +53,7 @@ public interface MachineProcessDto extends MachineProcess, Hyperlinks {
     @Override
     MachineProcessDto withLinks(List<Link> links);
 
+    void setAttributes(Map<String, String> attributes);
+
     MachineProcessDto withAttributes(Map<String, String> attributes);
 }


### PR DESCRIPTION
### What does this PR do?

Restores all commands when ws-agent is started
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1785
### Tests written?

Yes

Please review @vparfonov 
