### PR TITLE
Fix get_che_launcher_version function when version is not specified

### DIFF
--- a/dockerfiles/che-launcher/launcher_funcs.sh
+++ b/dockerfiles/che-launcher/launcher_funcs.sh
@@ -55,7 +55,13 @@ get_che_launcher_container_id() {
 get_che_launcher_version() {
   LAUNCHER_CONTAINER_ID=$(get_che_launcher_container_id)
   LAUNCHER_IMAGE_NAME=$(docker inspect --format='{{.Config.Image}}' "${LAUNCHER_CONTAINER_ID}")
-  echo "${LAUNCHER_IMAGE_NAME}" | cut -d : -f2
+  LAUNCHER_IMAGE_VERSION=$(echo "${LAUNCHER_IMAGE_NAME}" | cut -d : -f2 -s)
+
+  if [ -n "${LAUNCHER_IMAGE_VERSION}" ]; then
+    echo "${LAUNCHER_IMAGE_VERSION}"
+  else
+    echo "latest"
+  fi
 }
 
 is_boot2docker() {

--- a/dockerfiles/che-launcher/launcher_test.bats
+++ b/dockerfiles/che-launcher/launcher_test.bats
@@ -131,9 +131,6 @@ source ./launcher_funcs.sh
 }
 
 @test "get docker daemon version" {
-  # Given
-  export CHE_SERVER_CONTAINER_NAME="che-test-get-docker-version"
-
   # When
   result="$(get_docker_daemon_version)"
 
@@ -142,12 +139,46 @@ source ./launcher_funcs.sh
 }
 
 @test "get docker host os" {
-  # Given
-  export CHE_SERVER_CONTAINER_NAME="che-test-get-docker-host-os"
-
   # When
   result="$(get_docker_host_os)"
 
   # Then
   [ "$result" ]
+}
+
+@test "get che get che launcher version with nightly" {
+  # Given
+  export CHE_SERVER_CONTAINER_NAME="che-test-get-che-launcher-version"
+  long_id=$(docker run -d --name ${CHE_SERVER_CONTAINER_NAME} --entrypoint=true codenvy/che-launcher:nightly)
+
+  get_che_launcher_container_id() {
+    echo ${long_id:0:12}
+  }
+
+  # When
+  result="$(get_che_launcher_version)"
+  docker rm $CHE_SERVER_CONTAINER_NAME
+
+  # Then
+  [ "$result" = "nightly" ]
+}
+
+@test "get che get che launcher version with no specific version" {
+  # Given
+  export CHE_SERVER_CONTAINER_NAME="che-test-get-che-launcher-version"
+  long_id=$(docker run -d --name ${CHE_SERVER_CONTAINER_NAME} --entrypoint=true codenvy/che-launcher)
+
+  get_che_launcher_container_id() {
+    echo ${long_id:0:12}
+  }
+
+  # When
+  result="$(get_che_launcher_version)"
+  docker rm $CHE_SERVER_CONTAINER_NAME
+
+  echo "expected: latest"
+  echo "actual: $result"
+
+  # Then
+  [ "$result" = "latest" ]
 }


### PR DESCRIPTION
### What does this PR do?

The launcher try to infer che version from its own version. When a user run the launcher without specifying a version the launcher return a non valid version. 
### What issues does this PR fix or reference?

This issue has been spotted on #1976 
### Previous Behavior

If launcher was used without an explicit version (e.g. `docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-launcher info`) function get_che_launcher_version returned `codenvy/che-launcher`.
### New Behavior

If launcher is used without and explicit version function get_che_launcher_version returns `latest`. That's the default behavior of the Docker client.
### Tests written?

Yes
### Docs requirements?

No

Signed-off-by: Mario Loriedo mloriedo@redhat.com
