### PR TITLE
Introduce codenvy/che-test and codenvy/che-file docker images

### DIFF
--- a/dockerfiles/che-file/Dockerfile
+++ b/dockerfiles/che-file/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Prerequisite : typescript library compiled
+# see ../lib/typescript/README.md folder
+#
+# To build, see README.md
+#
+# To use:
+#  `docker run -v /var/run/docker.sock:/var/run/docker.sock \
+#              -v "$PWD":"$PWD" --rm codenvy/che-file \
+#              /bin/che $PWD <init|up>`
+# 
+#  where [COMMAND]:
+#    init -- Initialize configuration files for this directory
+#    up   -- Launch workspace, starting Che server, if necessary 
+#
+FROM mhart/alpine-node
+
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 1.6.0
+
+RUN set -x \
+    && apk add --no-cache \
+    ca-certificates \
+    curl \
+    openssl \
+    && curl -sL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION" \
+    > /usr/bin/docker; chmod +x /usr/bin/docker
+
+COPY lib/typescript/lib /lib
+COPY lib/typescript/dependencies/runtime/node_modules /lib/node_modules
+COPY lib/typescript/bin /bin
+ADD  che-file/src/che.properties /lib/che.properties
+
+ENTRYPOINT ["/bin/che", "che-file"]

--- a/dockerfiles/che-file/README.md
+++ b/dockerfiles/che-file/README.md
@@ -1,0 +1,31 @@
+### Creating an Eclipse Che instance from a local directory
+
+## Build Docker container
+```
+$ build-docker-image.sh
+```
+
+## Run container
+
+Check no docker Eclipse Che container is alive and kill it if any
+```
+$ docker ps -a
+```
+
+Clone a folder
+```
+$ git clone https://github.com/che-samples/web-java-spring-petclinic
+```
+
+Go into this checkout directory
+```
+$ cd web-java-spring-petclinic
+```
+
+Run script
+```
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+           -v "$PWD":"$PWD" --rm codenvy/che-file \
+           /bin/che $PWD <init|up>
+
+note: if Eclipse Che is already started, it does not handle yet this state

--- a/dockerfiles/che-file/src/che.properties
+++ b/dockerfiles/che-file/src/che.properties
@@ -1,0 +1,172 @@
+#
+# Copyright (c) 2012-2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
+# workspace proxy configuration
+http.proxy=
+https.proxy=
+no_proxy=
+
+### Storage and user configuration
+# The location where your workspaces (and their projects) are stored.
+# This property works for Docker for Windows, Mac, and Linux.
+# On virtualbox for windows, this property is ignored. Instead, they are stored at:
+# c:\%userprofile%\AppData\Local\Eclipse Che\
+che.workspace.storage=${che.home}/workspaces
+
+# Your projects are synchronized from the Che server into the machine running each
+# workspace. This is the directory in the machine where your projects are placed.
+che.machine.projects.internal.storage=/projects
+
+# Che stores various internal data objects as JSON on the file system.
+che.conf.storage=${che.home}/storage
+
+### Configuration of embedded templates and samples
+# Folder that contains JSON files with code templates and samples
+project.template_description.location_dir=${che.home}/templates
+
+### Configuration of embedded stacks
+#Path to predefined stacks json
+che.stacks.default=${che.home}/stacks/stacks.json
+#Path to folder with predefined stack icons
+che.stacks.images.storage=${che.home}/stacks/images
+
+### oAuth configuration. You can setup GitHub oAuth to automate authentication to remote
+### repositories. You need to first register this application with GitHub oAuth.
+# GitHub application client ID
+oauth.github.clientid=NULL
+oauth.github.clientsecret=NULL
+oauth.github.authuri= https://github.com/login/oauth/authorize
+oauth.github.tokenuri= https://github.com/login/oauth/access_token
+oauth.github.redirecturis= http://localhost:${SERVER_PORT}/wsmaster/api/oauth/callback
+auth.oauth.access_denied_error_page=/error-oauth
+
+# Activates user self-service at the API level.
+# Che has a single identity implementation, so this does not change the user experience.
+# If true, enables user creation at API level
+user.self.creation.allowed=false
+
+# Remove locations where internal message bus events should be propagated to.
+# For debugging - set to retrieve internal events from external clients.
+notification.server.propagate_events=
+
+# Che extensions can be scheduled executions on a time basis.
+# This configures the size of the thread pool allocated to extensions that are launched on
+# a recurring schedule.
+schedule.core_pool_size=10
+
+### Docker is the default machine implementation within Che. Workspaces are powered by machines
+### that are constructed when the workspace is started. The images used to generate containers
+### for the machines can come from DockerHub or a private Docker registry.
+machine.docker.registry=${CHE_REGISTRY_HOST}:5000
+machine.docker.snapshot.registry_namespace=NULL
+machine.docker.unused_containers_cleanup_period_min=60
+
+### Docker registry auth config example. Note that you can configure many registries with different names.
+#docker.registry.auth.your_registry_name.url=https://index.docker.io/v1/
+#docker.registry.auth.your_registry_name.username=user-name
+#docker.registry.auth.your_registry_name.password=user-password
+
+docker.api.version=1.20
+docker.connection.tcp.connection_timeout_ms=600000
+docker.connection.tcp.read_timeout_ms=600000
+
+### Machine configuration.  Machines power workspaces. This configures the Che behaviors that
+### occur within the machine.
+
+# This archive contains the server to run the workspace agent and any custom extensions.
+# Che injects this archive into machines when they are booted or started.
+machine.server.ext.archive=${che.home}/lib/ws-agent.zip
+
+# The machine's log files are stored here
+machine.logs.location=${che.logs.dir}/machine/logs
+
+# Size of the machine by default.  What is used if RAM parameter not provided by user or API.
+machine.default_mem_size_mb=1024
+
+# When the workspace master launches a new workspace, Che performs checks of the internal Web
+# services. When Che gets a valid response, we know that the workspace agent is ready for use.
+machine.ws_agent.max_start_time_ms=60000
+machine.ws_agent.ping_delay_ms=2000
+machine.ws_agent.ping_conn_timeout_ms=2000
+machine.ws_agent.ping_timed_out_error_msg=Timeout reached. The Che server has been unable to verify that your workspace's agent has successfully booted. Either the workspace is unreachable, the agent had an error during startup, or your workspace is starting slowly. You can configure machine.ws_agent.max_start_time_ms in Che properties to increase the timeout.
+
+# Hosts listed here will be added to /etc/hosts of each workspace machine.
+# Add an entry here if you write a ws-agent extension that needs to communicate outside the machine
+machine.docker.machine_extra_hosts=NULL
+
+# This is the API endpoint of the workspace master running within the core Che server.
+# This tells the workspace agent how to connect back to the Che server.
+# che-host is a fake DNS hostname that Che creates for itself.
+machine.docker.che_api.endpoint=http://che-host:${SERVER_PORT}/wsmaster/api
+
+# If this is true, then we always pull an image from a registry even if we have an image cached
+# locally. If false, Docker only pulls image if it does not exist locally.
+machine.docker.pull_image=true
+
+# If true, then all docker machines will start in privilege mode.
+machine.docker.privilege_mode=false
+
+# If the browser clients that are accessing Che are remote AND the configuration of Docker is an
+# internal IP address or using Unix sockets, then remote browser clients will not be able to connect
+# to the workspace. Set the Docker configuration so that Docker containers have an external IP
+# address and provide this host or IP address here.
+machine.docker.local_node_host=NULL
+
+# Allows to use registry for machine snapshots, you should set this property to {true},
+# otherwise workspace snapshots would be saved locally.
+machine.docker.snapshot_use_registry=false
+
+# Allows to adjust machine swap memory by multiplication current machnine memory on provided value.
+# default is -1 which means unlimited swap, if set multiplier value equal to 0.5 machine swap will be
+# configured with size that equal to half of current machine memory, to disable swap set it to 0.
+machine.docker.memory_swap_multiplier=-1
+
+# URL path to api service.
+# Browser clients use this to initiate REST communications with workspace master
+api.endpoint=http://localhost:${SERVER_PORT}/wsmaster/api
+
+#### Everrest is a Java Web Services toolkit that manages JAX-RS & web socket communications
+#### Users should rarely need to configure this.
+# Disable asynchronous mechanism that is embedded in everrest.
+org.everrest.asynchronous=false
+# Quantity of asynchronous requests which may be processed at the same time
+org.everrest.asynchronous.pool.size=20
+# Size of queue. If asynchronous request can't be processed after consuming it will be added in queue.
+org.everrest.asynchronous.queue.size=500
+# Timeout in minutes for request. If after timeout request is not done or client did not come yet to get result of request it may be discarded.
+org.everrest.asynchronous.job.timeout=10
+# Size of cache for waiting, running and ended request.
+org.everrest.asynchronous.cache.size=1024
+# Path to asynchronous service
+org.everrest.asynchronous.service.path=/async/
+
+machine.ssh.connection_timeout_ms=3000
+# The location of the Web Socket terminal used within the browser.
+# This is copied into the machine and run from within it.
+# Suffix helps differentiate archive for different architectures/OSes
+machine.server.terminal.path_to_archive.linux_amd64=${che.home}/lib/linux_amd64/terminal
+machine.server.terminal.path_to_archive.linux_arm7=${che.home}/lib/linux_arm7/terminal
+
+# During the stop of the workspace automatically creates a snapshot if the value is {true},
+# otherwise just stops the workspace.
+workspace.runtime.auto_snapshot=true
+# During the start of the workspace automatically restored it from a snapshot if the value is {true},
+# otherwise just creates the new workspace.
+workspace.runtime.auto_restore=true
+
+# Reserved user names
+user.reserved_names=
+
+# java opts for dev machine
+che.machine.java_opts=-Xms256m -Xmx2048m -Djava.security.egd=file:/dev/./urandom
+
+
+machine.server.extra.volume=

--- a/dockerfiles/che-test/Dockerfile
+++ b/dockerfiles/che-test/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright (c) 2012-2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - Initial implementation
+#
+# Prerequisite : typescript library compiled
+# see ../lib/typescript/README.md folder
+#
+# To build, see README.md
+#
+# To use it:
+#  `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-test <post-check> [URL of Che/Codenvy] [login] [password]`
+
+FROM mhart/alpine-node
+
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 1.6.0
+
+RUN set -x \
+    && apk add --no-cache \
+    ca-certificates \
+    curl \
+    openssl \
+    && curl -sL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION" \
+    > /usr/bin/docker; chmod +x /usr/bin/docker
+
+
+COPY lib/typescript/lib /lib
+COPY lib/typescript/dependencies/runtime/node_modules /lib/node_modules
+COPY lib/typescript/bin /bin
+
+ENTRYPOINT ["/bin/che", "che-test"]

--- a/dockerfiles/che-test/README.md
+++ b/dockerfiles/che-test/README.md
@@ -1,0 +1,11 @@
+### Testing local or remote Eclipse Che instance with a Docker container
+
+## Build container
+```
+$ build-docker-image.sh
+```
+
+## Run container
+```
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-test <post-check> [URL of Che/Codenvy] [login] [password]
+```

--- a/dockerfiles/lib/typescript/.gitignore
+++ b/dockerfiles/lib/typescript/.gitignore
@@ -1,0 +1,4 @@
+lib
+node_modules
+npm-debug.log
+src/typings

--- a/dockerfiles/lib/typescript/README.md
+++ b/dockerfiles/lib/typescript/README.md
@@ -1,0 +1,6 @@
+# Build the TypeScript library used in some docker images
+
+```
+$ compile.sh
+(or look at the content of this script)
+```

--- a/dockerfiles/lib/typescript/bin/che
+++ b/dockerfiles/lib/typescript/bin/che
@@ -1,17 +1,10 @@
+#!/bin/sh
 # Copyright (c) 2016 Codenvy, S.A.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
-# To build, in this directory:
-#  `docker build -t codenvy/che-ip .`
 #
-# To use it:
-#  `docker run --rm --net=host codenvy/che-ip`
-
-FROM alpine:3.4
-
-COPY getip.sh /bin/getip.sh
-
-CMD ["/bin/getip.sh"]
+cd /lib
+/usr/bin/env node index.js $*

--- a/dockerfiles/lib/typescript/compile.sh
+++ b/dockerfiles/lib/typescript/compile.sh
@@ -1,0 +1,8 @@
+docker run --rm -v $(pwd):/usr/src/app -w /usr/src/app node:6  /bin/bash -c "cd /usr/src/app/dependencies/compile && npm install && cd /usr/src/app/dependencies/runtime && npm install && npm install -g tsd && cd /usr/src/app/src && tsd install && cd /usr/src/app && /usr/src/app/dependencies/compile/node_modules/typescript/bin/tsc --outDir /usr/src/app/lib /usr/src/app/src/index.ts"
+
+if [ $? -eq 0 ]; then
+    echo 'Compilation of TypeScript is OK'
+else
+    echo 'Compilation has failed, please check TypeScript sources'
+    exit 1
+fi

--- a/dockerfiles/lib/typescript/dependencies/compile/package.json
+++ b/dockerfiles/lib/typescript/dependencies/compile/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "che-typescript",
+  "version": "1.0.0",
+  "description": "TypeScript library used in dockerfiles",
+  "main": "lib/index.js",
+  "author": "Florent Benoit",
+  "license": "EPL-1.0",
+  "devDependencies": {
+    "typescript": "1.8.10"
+  }
+}

--- a/dockerfiles/lib/typescript/dependencies/runtime/package.json
+++ b/dockerfiles/lib/typescript/dependencies/runtime/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "che-typescript",
+  "version": "1.0.0",
+  "description": "TypeScript library used in dockerfiles",
+  "main": "lib/index.js",
+  "author": "Florent Benoit",
+  "license": "EPL-1.0",
+  "devDependencies": {
+    "websocket": "1.0.23"
+  }
+}

--- a/dockerfiles/lib/typescript/incremental-compile.sh
+++ b/dockerfiles/lib/typescript/incremental-compile.sh
@@ -1,0 +1,8 @@
+docker run --rm -v $(pwd):/usr/src/app -w /usr/src/app node:6  /bin/bash -c "/usr/src/app/dependencies/compile/node_modules/typescript/bin/tsc --outDir /usr/src/app/lib /usr/src/app/src/index.ts"
+
+if [ $? -eq 0 ]; then
+    echo 'Compilation of TypeScript is OK'
+else
+    echo 'Compilation has failed, please check TypeScript sources'
+    exit 1
+fi

--- a/dockerfiles/lib/typescript/src/auth-data.ts
+++ b/dockerfiles/lib/typescript/src/auth-data.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {RemoteIp} from './remoteip';
+
+/**
+ * Defines a way to store the auth data in order to deal with remote REST or Websocket API
+ * @author Florent Benoit
+ */
+export class AuthData {
+
+
+    DEFAULT_TOKEN : string = '';
+    DEFAULT_HOSTNAME : string = new RemoteIp().getIp();
+    DEFAULT_PORT : number = 8080;
+
+
+    hostname : string;
+    port : number;
+    token : string;
+    secured : boolean;
+
+    constructor(hostname?: string, port? : number, token? : string) {
+        this.secured = false;
+        if (hostname) {
+            this.hostname = hostname;
+        } else {
+            this.hostname = this.DEFAULT_HOSTNAME;
+        }
+
+        if (port) {
+            this.port = port;
+        } else {
+            this.port = this.DEFAULT_PORT;
+        }
+
+
+        if (token) {
+            this.token = token;
+        } else {
+            this.token = this.DEFAULT_TOKEN;
+        }
+
+    }
+
+
+    getHostname() : string {
+        return this.hostname;
+    }
+
+    getPort() : number {
+        return this.port;
+    }
+
+    isSecured() : boolean {
+        return this.secured;
+    }
+
+    getToken(): string {
+        return this.token;
+    }
+
+
+    initToken(login: string, password: string) {
+        var http: any;
+        if (this.isSecured()) {
+            http = require('https');
+        } else {
+            http = require('http');
+        }
+
+        var options = {
+            hostname: this.hostname,
+            port: this.port,
+            path: '/api/auth/login',
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json, text/plain, */*',
+                'Content-Type': 'application/json;charset=UTF-8'
+            }
+        };
+
+        let p = new Promise<any>( (resolve, reject) => {
+            var req = http.request(options,  (res) => {
+                res.on('data', (body) => {
+                    if (res.statusCode == 200) {
+                        // token get, continue
+                        this.token = JSON.parse(body).value;
+                        resolve(true);
+                    } else {
+                        // error
+                        reject(body);
+                    }
+                });
+
+            });
+
+            req.on('error', (err) => {
+                reject('HTTP error: ' + err);
+            });
+
+            const auth = {
+                "username": login,
+                "password": password
+            };
+
+            req.write(JSON.stringify(auth));
+            req.end();
+
+        });
+        return p;
+
+
+    }
+
+
+    static parse(remoteUrl : string) : AuthData {
+        // extract hostname and port
+        const url = require('url');
+        var urlObject : any = url.parse(remoteUrl);
+        var port: number;
+        var isSecured: boolean = false;
+        // do we have a port ?
+        if (urlObject && !urlObject.port) {
+            if ('http:' === urlObject.protocol) {
+                port = 80;
+            } else if ('https:' === urlObject.protocol) {
+                isSecured = true;
+                port = 443;
+            }
+        }
+
+        let authData: AuthData = new AuthData(urlObject.hostname, port);
+        if (isSecured) {
+            authData.secured = true;
+        }
+        return authData;
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/che-file.ts
+++ b/dockerfiles/lib/typescript/src/che-file.ts
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+// imports
+import {RemoteIp} from './remoteip';
+import {RecipeBuilder} from './recipebuilder';
+import {Workspace} from './workspace';
+import {WorkspaceDto} from './dto/workspacedto';
+import {Websocket} from './websocket';
+
+
+export class CheFile {
+
+  // grab default hostname from the remote ip component
+  DEFAULT_HOSTNAME: string;
+
+  debug: boolean = false;
+  times: number = 10;
+
+  // gloabl var
+  waitDone = false;
+  che: { hostname: string, server: any };
+  dockerContent;
+
+  // requirements
+  path = require('path');
+  http = require('http');
+  fs = require('fs');
+  vm = require('vm');
+  readline = require('readline');
+  exec = require('child_process').exec;
+
+  // init folder/files variables
+  currentFolder: string = this.path.resolve('./');
+  folderName: any;
+  cheFile : any;
+  dotCheFolder : any;
+  confFolder : any;
+  workspacesFolder : any;
+  chePropertiesFile : any;
+
+  mode;
+  args : Array<string>;
+
+  constructor(args) {
+    this.args = args;
+
+    this.DEFAULT_HOSTNAME = new RemoteIp().getIp();
+    this.che =  {hostname: this.DEFAULT_HOSTNAME, server: 'tmp'};
+
+
+    this.currentFolder = this.path.resolve(args[0]);
+    this.folderName = this.path.basename(this.currentFolder);
+    this.cheFile = this.path.resolve(this.currentFolder, 'chefile');
+    this.dotCheFolder = this.path.resolve(this.currentFolder, '.che');
+    this.confFolder = this.path.resolve(this.dotCheFolder, 'conf');
+    this.workspacesFolder = this.path.resolve(this.dotCheFolder, 'workspaces');
+    this.chePropertiesFile = this.path.resolve(this.confFolder, 'che.properties');
+
+  }
+
+
+  startsWith(value:string, searchString: string) : boolean {
+    return value.substr(0, searchString.length) === searchString;
+  }
+
+
+
+
+
+  run() {
+    if (this.args.length == 0) {
+      console.log('only init and up commands are supported.');
+      return;
+    } else if ('init' === this.args[1]) {
+      this.init();
+    } else if ('up' === this.args[1]) {
+      this.init();
+      this.up();
+    } else {
+      console.log('Invalid arguments ' + this.args +': Only init and up commands are supported.');
+      return;
+    }
+
+  }
+
+  parse() {
+
+    try {
+      this.fs.statSync(this.cheFile);
+      // we have a file
+    } catch (e) {
+      console.log('No chefile defined, use default settings');
+      return;
+    }
+
+    // load the chefile script if defined
+    var script_code = this.fs.readFileSync(this.cheFile);
+
+    // setup the bindings for the script
+    this.che.server =  {};
+    this.che.server.ip = this.che.hostname;
+
+    // create sandboxed object
+    var sandbox = { "che": this.che, "console": console};
+
+    var script = this.vm.createScript(script_code);
+    script.runInNewContext(sandbox);
+
+    if (this.debug) {
+      console.log('Che file parsing object is ', this.che);
+    }
+  }
+
+
+  init() {
+    // needs to create folders
+    this.initCheFolders();
+    this.setupConfigFile();
+
+    console.log('Che configuration initialized in ' + this.dotCheFolder );
+  }
+
+  up() {
+    this.parse();
+
+    // test if conf is existing
+    try {
+      var statsPropertiesFile = this.fs.statSync(this.chePropertiesFile);
+    } catch (e) {
+      console.log('No che configured. che init has been done ?');
+      return;
+    }
+
+    console.log('Starting che');
+    // needs to invoke docker run
+    this.cheBoot();
+
+    this.dockerContent = new RecipeBuilder().getDockerContent();
+
+    // loop to check startup (during 30seconds)
+    this.waitCheBoot(this);
+  }
+
+
+
+// Create workspace based on the remote hostname and workspacename
+// if custom docker content is provided, use it
+  createWorkspace(remoteHostname, workspaceName, dockerContent) {
+    var options = {
+      hostname: remoteHostname,
+      port: 8080,
+      path: '/api/workspace?account=',
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json, text/plain, */*',
+        'Content-Type': 'application/json;charset=UTF-8'
+      }
+    };
+    var req = this.http.request(options, (res) => {
+      res.on('data', (body) => {
+
+        if (res.statusCode == 201) {
+          // workspace created, continue
+          this.displayUrlWorkspace(JSON.parse(body));
+        } else {
+          // error
+          console.log('Invalid response from the server side. Aborting');
+          console.log('response was ' + body);
+        }
+      });
+    });
+    req.on('error', (e) => {
+      console.log('problem with request: ' + e.message);
+    });
+
+    var workspace = {
+      "defaultEnv": "default",
+      "commands": [],
+      "projects": [],
+      "environments": [{
+        "machineConfigs": [{
+          "dev": true,
+          "servers": [],
+          "envVariables": {},
+          "limits": {"ram": 2500},
+          "source": {"type": "dockerfile", "content": dockerContent},
+          "name": "default",
+          "type": "docker",
+          "links": []
+        }], "name": "default"
+      }],
+      "name": workspaceName,
+      "links": [],
+      "description": null
+    };
+
+
+    req.write(JSON.stringify(workspace));
+    req.end();
+
+  }
+
+  displayUrlWorkspace(workspace) {
+
+    var found = false;
+    var i = 0;
+    var links = workspace.links;
+    while (i < links.length && !found) {
+      // display the ide url link
+      var link = links[i];
+      if (link.rel === 'ide url') {
+        found = true;
+        console.log('Open browser to ' + link.href);
+      }
+      i++;
+
+    }
+
+    if (!found) {
+      console.log('Workspace successfully started but unable to find workspace link');
+    }
+
+
+  }
+
+  initCheFolders() {
+
+    // create .che folder
+    try {
+      this.fs.mkdirSync(this.dotCheFolder, 0o744);
+    } catch (e) {
+      // already exist
+    }
+
+    // create .che/workspaces folder
+    try {
+      this.fs.mkdirSync(this.workspacesFolder, 0o744);
+    } catch (e) {
+      // already exist
+    }
+
+    // create .che/conf folder
+
+    try {
+      this.fs.mkdirSync(this.confFolder, 0o744);
+    } catch (e) {
+      // already exist
+    }
+
+
+    // copy configuration file
+
+    try {
+      var stats = this.fs.statSync(this.chePropertiesFile);
+    } catch (e) {
+      // file does not exist, copy it
+      this.fs.writeFileSync(this.chePropertiesFile, this.fs.readFileSync(this.path.resolve(__dirname, 'che.properties')));
+    }
+
+  }
+
+
+  setupConfigFile() {
+    // need to setup che.properties file with workspaces folder
+
+    // update che.user.workspaces.storage
+    this.updateConfFile('che.user.workspaces.storage', this.workspacesFolder);
+
+    // update extra volumes
+    this.updateConfFile('machine.server.extra.volume', this.currentFolder + ':/projects/' + this.folderName);
+
+  }
+
+  updateConfFile(propertyName, propertyValue) {
+
+    var content = '';
+    var foundLine = false;
+    this.fs.readFileSync(this.chePropertiesFile).toString().split('\n').forEach((line) => {
+
+      var updatedLine;
+
+
+
+      if (this.startsWith(line, propertyName)) {
+        foundLine = true;
+        updatedLine = propertyName + '=' + propertyValue + '\n';
+      } else {
+        updatedLine = line  + '\n';
+      }
+
+      content += updatedLine;
+    });
+
+    // add property if not present
+    if (!foundLine) {
+      content += propertyName + '=' + propertyValue + '\n';
+    }
+
+    this.fs.writeFileSync(this.chePropertiesFile, content);
+
+  }
+
+  cheBoot() {
+
+    var commandLine: string = 'docker run ' +
+        ' -v /var/run/docker.sock:/var/run/docker.sock' +
+        ' -e CHE_DATA_FOLDER=' + this.workspacesFolder +
+        ' -e CHE_CONF_FOLDER=' + this.confFolder +
+        ' codenvy/che-launcher:nightly start';
+
+    if (this.debug) {
+      console.log('Executing command line', commandLine);
+    }
+    var child = this.exec(commandLine , function callback(error, stdout, stderr) {
+          //console.log('error is ' + error, stdout, stderr);
+        }
+    );
+
+    //if (debug) {
+    child.stdout.on('data', (data) => {
+      console.log(data.toString());
+    });
+    //}
+
+  }
+
+
+// test if can connect on port 8080
+  waitCheBoot(self: CheFile) {
+
+    if(self.times < 1) {
+      return;
+    }
+    //console.log('wait che on boot', times);
+    var options = {
+      hostname: self.che.hostname,
+      port: 8080,
+      path: '/api/workspace',
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json, text/plain, */*',
+        'Content-Type': 'application/json;charset=UTF-8'
+      }
+    };
+    if (self.debug) {
+      console.log('using che ping options', options, 'and docker content', self.dockerContent);
+    }
+
+    var req = self.http.request(options, (res) => {
+      res.on('data', (body) => {
+
+        if (res.statusCode === 200 && !self.waitDone) {
+          self.waitDone = true;
+          if (self.debug) {
+            console.log('status code is 200, creating workspace');
+          }
+          self.createWorkspace(self.che.hostname, 'local', self.dockerContent);
+        }
+      });
+    });
+    req.on('error', (e) => {
+      if (self.debug) {
+        console.log('with request: ' + e.message);
+      }
+    });
+
+
+    req.end();
+
+
+    self.times--;
+    if (self.times > 0 && !self.waitDone) {
+      setTimeout(self.waitCheBoot, 5000, self);
+    }
+
+
+  }
+}

--- a/dockerfiles/lib/typescript/src/dto/workspacedto.ts
+++ b/dockerfiles/lib/typescript/src/dto/workspacedto.ts
@@ -1,0 +1,21 @@
+export class WorkspaceDto {
+
+    id: string;
+    content: any;
+
+
+    constructor(workspaceObject: any) {
+        this.content = workspaceObject;
+    }
+
+    getId() : string {
+        return this.content.id;
+    }
+
+    getName() : string {
+        return this.content.config.name;
+    }
+    getContent() : any {
+        return this.content;
+    }
+}

--- a/dockerfiles/lib/typescript/src/index.ts
+++ b/dockerfiles/lib/typescript/src/index.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+/// <reference path='./typings/tsd.d.ts' />
+import {PostCheck} from './post-check';
+import {CheFile} from "./che-file";
+
+/**
+ * Entry point of this library providing commands.
+ * @author Florent Benoit
+ */
+export class EntryPoint {
+
+    args: Array<string>;
+
+    constructor() {
+        this.args = process.argv.slice(2);
+    }
+
+    /**
+     * Run this entry point and analyze args to dispatch to the correct entry.
+     */
+    run() : void {
+        var promise : Promise<String>;
+        // get first arg if any
+        if (this.args.length > 0) {
+            let commandName = this.args[0];
+            if ('che-test' === commandName) {
+                // remove post-check arg for now as it's the only test
+                let postCheck: PostCheck = new PostCheck(this.args.slice(2));
+                promise = postCheck.run();
+            } else if ('che-file' === commandName) {
+                let cheFile: CheFile = new CheFile(this.args.slice(1));
+                cheFile.run();
+            } else {
+                this.printHelp();
+            }
+
+        }
+
+        // handle error of the promise
+        if (promise) {
+            promise.catch((error) => {
+                try {
+                    let errorMessage = JSON.parse(error);
+                    if (errorMessage.message) {
+                        console.log('Error: ', errorMessage.message);
+                    } else {
+                        console.log('Error: ', error.toString());
+                    }
+                } catch (e) {
+                    console.log('Error: ', error.toString());
+                }
+                process.exit(1);
+            });
+        }
+
+    }
+
+    /**
+     * Display the help.
+     */
+    printHelp() : void {
+        console.log('Help: ');
+        console.log('      valid options are : [che-test|che-file]');
+
+    }
+
+}
+
+
+// call run method
+new EntryPoint().run();

--- a/dockerfiles/lib/typescript/src/messagebuilder.ts
+++ b/dockerfiles/lib/typescript/src/messagebuilder.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+/**
+ * Generator of the messages to send with the {@link MessageBus} object.
+ * @author Florent Benoit
+ */
+export class MessageBuilder {
+
+    method: string;
+    path: string;
+    TYPE: string;
+    message : any;
+
+    constructor(method? : string, path? : string) {
+        this.TYPE = 'x-everrest-websocket-message-type';
+        if (method) {
+            this.method = method;
+        } else {
+            this.method = 'POST';
+        }
+        if (path) {
+            this.path = path;
+        } else {
+            this.path = null;
+        }
+
+
+        this.message = {};
+        // add uuid
+        this.message.uuid = this.buildUUID();
+
+        this.message.method = this.method;
+        this.message.path = this.path;
+        this.message.headers = [];
+        this.message.body;
+    }
+
+    subscribe(channel) {
+        var header = {name: this.TYPE, value: 'subscribe-channel'};
+        this.message.headers.push(header);
+        this.message.body = JSON.stringify({channel: channel});
+        return this;
+    }
+
+    unsubscribe(channel) {
+        var header = {name:this.TYPE, value: 'unsubscribe-channel'};
+        this.message.headers.push(header);
+        this.message.body = JSON.stringify({channel: channel});
+        return this;
+    }
+
+    /**
+     * Prepares ping frame for server.
+     *
+     * @returns {MessageBuilder}
+     */
+    ping() {
+        var header = {name:this.TYPE, value: 'ping'};
+        this.message.headers.push(header);
+        return this;
+    }
+
+    build() {
+        return this.message;
+    }
+
+    buildUUID() {
+        var time = new Date().getTime();
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (match) => {
+            var rem = (time + 16 * Math.random()) % 16 | 0;
+            time = Math.floor(time / 16);
+            return (match === 'x' ? rem : rem & 7 | 8).toString(16);
+        });
+    }
+
+
+}

--- a/dockerfiles/lib/typescript/src/messagebus-subscriber.ts
+++ b/dockerfiles/lib/typescript/src/messagebus-subscriber.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+/**
+ * Interface required to be implemented to subscribe to message bus messages.
+ * @author Florent Benoit
+ */
+export interface MessageBusSubscriber {
+
+    handleMessage(message: string);
+
+
+}

--- a/dockerfiles/lib/typescript/src/messagebus.ts
+++ b/dockerfiles/lib/typescript/src/messagebus.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {MessageBuilder} from './messagebuilder';
+import {MessageBusSubscriber} from './messagebus-subscriber';
+
+
+/**
+ * Allow to handle calls to the MessageBus running inside Eclipse Che by sending and receiving the messages.
+ * It handles the UUID messages and subscribers that can subscribe/unsubscribe
+ * @author Florent Benoit
+ */
+export class MessageBus {
+
+    websocketConnection : any;
+    heartbeatPeriod : number;
+    subscribersByChannel : Map<string, Array<MessageBusSubscriber>>;
+    keepAlive : any;
+    delaySend: Array<string>;
+    websocketClient : any;
+    closed : boolean;
+
+    constructor(websocketClient : any, url: string) {
+
+        this.websocketClient = websocketClient;
+
+        this.closed = false;
+        this.delaySend = [];
+
+        var client = websocketClient.on('connectFailed', function(error) {
+                console.log('Connect Error: ' + error.toString());
+            });
+
+
+        client.on('error', error => console.log('websocketclient error', error.toString()));
+
+        client.on('connect', (connection) => {
+            this.websocketConnection = connection;
+            // push all previous messages
+            this.delaySend.forEach((subscribeOrder) => this.send(subscribeOrder));
+
+            // remove them
+            this.delaySend.length = 0;
+
+            // init keep alive
+            this.setKeepAlive();
+
+            connection.on('error', (error) => {
+                if (!this.closed) {
+                    console.log("Connection Error: " + error.toString());
+                }
+            });
+            connection.on('close', () => {
+                if (!this.closed) {
+                    console.log('Websocket connection closed');
+                }
+            });
+            connection.on('message', (message) => {
+                if (message.type === 'utf8') {
+                    this.handleMessage(message.utf8Data);
+                }
+            });
+
+        });
+
+        // now connect
+        websocketClient.connect(url);
+
+
+
+        this.heartbeatPeriod = 3000;//1000 * 50; //ping each 50 seconds
+
+        this.subscribersByChannel = new Map<string, Array<MessageBusSubscriber>>();
+
+    }
+
+    close() {
+        this.closed = true;
+        this.websocketConnection.close();
+
+    }
+
+
+    /**
+     * Sets the keep alive interval, which sends
+     * ping frame to server to keep connection alive.
+     * */
+    setKeepAlive() {
+        this.keepAlive = setTimeout(this.ping, this.heartbeatPeriod, this);
+    }
+
+    /**
+     * Sends ping frame to server.
+     */
+    ping(instance) {
+        instance.send(new MessageBuilder().ping().build());
+    }
+
+    /**
+     * Restart ping timer (cancel previous and start again).
+     */
+    restartPing () {
+        if (this.keepAlive) {
+            clearTimeout(this.keepAlive);
+        }
+
+        this.setKeepAlive();
+    }
+
+    /**
+     * Subscribes a new callback which will listener for messages sent to the specified channel.
+     * Upon the first subscribe to a channel, a message is sent to the server to
+     * subscribe the client for that channel. Subsequent subscribes for a channel
+     * already previously subscribed to do not trigger a send of another message
+     * to the server because the client has already a subscription, and merely registers
+     * (client side) the additional handler to be fired for events received on the respective channel.
+     */
+    subscribe(channel, callback) {
+        // already subscribed ?
+        var existingSubscribers = this.subscribersByChannel.get(channel);
+        if (!existingSubscribers) {
+            // register callback
+
+            var subscribers = [];
+            subscribers.push(callback);
+            this.subscribersByChannel.set(channel, subscribers);
+
+            var subscribeOrder = new MessageBuilder().subscribe(channel).build();
+            // send subscribe order
+            if (!this.websocketConnection) {
+                this.delaySend.push(subscribeOrder);
+            } else {
+                this.send(subscribeOrder);
+            }
+
+        } else {
+            // existing there, add only callback
+            existingSubscribers.push(callback);
+        }
+    }
+
+
+
+    /**
+     * Unsubscribes a previously subscribed handler listening on the specified channel.
+     * If it's the last unsubscribe to a channel, a message is sent to the server to
+     * unsubscribe the client for that channel.
+     */
+    unsubscribe(channel) {
+        // already subscribed ?
+        var existingSubscribers = this.subscribersByChannel.get(channel);
+        // unable to cancel if not existing channel
+        if (!existingSubscribers) {
+            return;
+        }
+
+        if (existingSubscribers.length > 1) {
+            // only remove callback
+            for(let i = 0; i < existingSubscribers.length; i++) {
+                delete existingSubscribers[i];
+            }
+        } else {
+            // only one element, remove and send server message
+            this.subscribersByChannel.delete(channel);
+
+            // send unsubscribe order
+            this.send(new MessageBuilder().unsubscribe(channel).build());
+        }
+    }
+
+
+
+    send(message) {
+        var stringified = JSON.stringify(message);
+        this.websocketConnection.sendUTF(stringified);
+    }
+
+
+    handleMessage(message) {
+
+        // handling the receive of a message
+        // needs to parse it
+        var jsonMessage = JSON.parse(message);
+
+        // get headers
+        var headers = jsonMessage.headers;
+
+        var channelHeader;
+        // found channel headers
+        for(let i = 0; i < headers.length; i++) {
+            let header = headers[i];
+            if ('x-everrest-websocket-channel' === header.name) {
+                channelHeader = header;
+                continue;
+            }
+        }
+
+
+        if (channelHeader) {
+            // message for a channel, look at current subscribers
+            var subscribers : Array<MessageBusSubscriber> = this.subscribersByChannel.get(channelHeader.value);
+            if (subscribers) {
+                subscribers.forEach((subscriber : MessageBusSubscriber) => {
+                    subscriber.handleMessage(JSON.parse(jsonMessage.body));
+                });
+            }
+        }
+
+        // restart ping after received message
+        this.restartPing();
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/post-check.ts
+++ b/dockerfiles/lib/typescript/src/post-check.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+
+// imports
+import {Workspace} from './workspace';
+import {WorkspaceDto} from './dto/workspacedto';
+import {Websocket} from './websocket';
+import {MessageBus} from './messagebus';
+import {WorkspaceEventMessageBusSubscriber} from './workspace-event-subscriber';
+import {MessageBusSubscriber} from './messagebus-subscriber';
+import {WorkspaceDisplayOutputMessageBusSubscriber} from './workspace-log-output-subscriber';
+import {AuthData} from "./auth-data";
+
+
+/**
+ * This class is managing a post-check operation by creating a workspace, starting it and displaying the log data.
+ * @author Florent Benoit
+ */
+export class PostCheck {
+
+
+    websocket: Websocket;
+    authData: AuthData;
+    workspace: Workspace;
+    promiseAuth: Promise<any>;
+
+    constructor(args:Array<string>) {
+        this.websocket = new Websocket();
+
+        if (args.length > 0) {
+            this.authData = AuthData.parse(args[0]);
+        } else {
+            this.authData = new AuthData();
+        }
+
+        // if login and password, get a token
+        if (args.length >=3) {
+            // get token from login/password
+            this.promiseAuth = this.authData.initToken(args[1], args[2]);
+        }
+
+        this.workspace = new Workspace(this.authData);
+    }
+
+
+    run() : Promise<string> {
+        let p = new Promise<any>( (resolve, reject) => {
+
+            var securedOrNot:string;
+            if (this.authData.isSecured()) {
+                securedOrNot = ' using SSL.';
+            } else {
+                securedOrNot = '.';
+            }
+            console.log('PostCheck:: using hostname \"' + this.authData.getHostname() + '\" and port \"' + this.authData.getPort() + '\"' + securedOrNot);
+
+            // we have a promise for auth, wait it
+            if (this.promiseAuth) {
+                this.promiseAuth.then(()=> {
+                    resolve('Successfully authenticated.');
+                }, error => {
+                    reject('Error while authenticating: ' +  error.toString());
+                })
+            } else {
+                resolve('No authentication required');
+            }
+
+        }).then((val:string) => {
+            return this.createAndStart();
+        });
+
+
+        return p;
+
+    }
+
+
+    createAndStart(): Promise<any> {
+
+        // create the workspace
+        var promise:Promise<WorkspaceDto> = this.workspace.createWorkspace('your-first-workspace', 'FROM codenvy/ubuntu_jdk8')
+            .then(workspaceDto => {
+
+                // get id
+                let workspaceId:string = workspaceDto.getId();
+
+                var protocol: string;
+                if (this.authData.isSecured()) {
+                    protocol = 'wss';
+                } else {
+                    protocol = 'ws';
+                }
+
+                // get links for WS
+                var link: string;
+                workspaceDto.getContent().links.forEach(workspaceLink => {
+                    if ('get workspace events channel' === workspaceLink.rel) {
+                        link = workspaceLink.href;
+                    }
+                });
+
+                var messageBus:MessageBus = this.websocket.getMessageBus(link + '?token=' + this.authData.getToken() , workspaceId);
+
+                var callbackSubscriber:MessageBusSubscriber = new WorkspaceEventMessageBusSubscriber(messageBus, workspaceDto);
+                var displayOutputWorkspaceSubscriber:MessageBusSubscriber = new WorkspaceDisplayOutputMessageBusSubscriber();
+
+
+                messageBus.subscribe('workspace:' + workspaceId + ':ext-server:output', displayOutputWorkspaceSubscriber);
+                messageBus.subscribe(workspaceId + ':default:default', displayOutputWorkspaceSubscriber);
+                messageBus.subscribe('workspace:' + workspaceId, callbackSubscriber);
+
+                // wait to connect websocket
+                var waitTill = new Date(new Date().getTime() + 4 * 1000);
+                while(waitTill > new Date()){}
+
+                // start it
+                var startWorkspacePromise:Promise<WorkspaceDto> = this.workspace.startWorkspace(workspaceDto.getId());
+                startWorkspacePromise.then(workspaceDto => {
+                    return new Promise<WorkspaceDto>( (resolve, reject) => {
+                        console.log('Workspace is now starting...');
+                        resolve(workspaceDto);
+                    });
+                }, error => {
+                    return new Promise<WorkspaceDto>( (resolve, reject) => {
+                        reject(error);
+                    });
+                });
+
+                return startWorkspacePromise;
+
+            }, r => {
+                return new Promise<WorkspaceDto>( (resolve, reject) => {
+                    reject(r);
+                });
+            });
+
+        return promise;
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/recipebuilder.ts
+++ b/dockerfiles/lib/typescript/src/recipebuilder.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+
+/**
+ * Build a default recipe.
+ * @author Florent Benoit
+ */
+export class RecipeBuilder {
+
+    DEFAULT_DOCKERFILE_CONTENT: string = 'FROM codenvy/ubuntu_jdk8';
+    path: any;
+    fs: any;
+
+    constructor() {
+        this.path = require('path');
+        this.fs = require('fs');
+    }
+
+
+    getDockerContent() : string {
+
+        // build path to the Dockerfile in current directory
+        var dockerFilePath = this.path.resolve('./Dockerfile');
+
+        // use synchronous API
+        try {
+            var stats = this.fs.statSync(dockerFilePath);
+            console.log('Using a custom project Dockerfile \'' + dockerFilePath + '\' for the setup of the workspace.');
+            var content = this.fs.readFileSync(dockerFilePath, 'utf8');
+            return content;
+        } catch (e) {
+            // file does not exist, return default
+            return this.DEFAULT_DOCKERFILE_CONTENT;
+        }
+
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/remoteip.ts
+++ b/dockerfiles/lib/typescript/src/remoteip.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+/**
+ * Defines a way to grab remote ip
+ * @author Florent Benoit
+ */
+export class RemoteIp {
+
+    ip: string;
+
+    constructor() {
+        var execSync = require('child_process').execSync;
+        this.ip = execSync('docker run --net host --rm codenvy/che-ip').toString().replace(/[\n\r]/g, '');
+    }
+
+
+   getIp() : string {
+       return this.ip;
+   }
+
+}

--- a/dockerfiles/lib/typescript/src/tsd.json
+++ b/dockerfiles/lib/typescript/src/tsd.json
@@ -1,0 +1,18 @@
+{
+  "version": "v4",
+  "repo": "borisyankov/DefinitelyTyped",
+  "ref": "master",
+  "path": "typings",
+  "bundle": "typings/tsd.d.ts",
+  "installed": {
+    "node/node.d.ts": {
+      "commit": "de82425735f84a10b43921ae4b1d085b3752a626"
+    },
+    "es6-promise/es6-promise.d.ts": {
+      "commit": "c42b2ba16cc7f06869be1934ae829861296c2323"
+    },
+    "es6-collections/es6-collections.d.ts": {
+      "commit": "07378f4a20ef709de8aea9507144fcf48c38897d"
+    }
+  }
+}

--- a/dockerfiles/lib/typescript/src/websocket.ts
+++ b/dockerfiles/lib/typescript/src/websocket.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+
+import {MessageBus} from './messagebus';
+
+/**
+ * This class is handling the websocket handling by providing a {@link MessageBus} object
+ * @author Florent Benoit
+ */
+export class Websocket {
+
+    /**
+     * Websocket client object.
+     */
+    wsClient: any;
+
+    /**
+     * Map of bus per workspace ID.
+     */
+    websocketConnections: Map<string, MessageBus>;
+
+    /**
+     * Default constructor initializing websocket.
+     */
+    constructor() {
+        this.wsClient = require('websocket').client;
+        this.websocketConnections = new Map<string, MessageBus>();
+    }
+
+    /**
+     * Gets a MessageBus object for a remote workspace, by providing the remote URL to this websocket
+     * @param websocketURL the remote host base WS url
+     * @param workspaceId the workspaceID used as suffix for the URL
+     */
+    getMessageBus(websocketURL, workspaceId) : MessageBus {
+        var bus: MessageBus = this.websocketConnections.get(workspaceId);
+        if (!bus) {
+            var webSocketClient: any = new this.wsClient();
+            var remoteWebsocketUrl: string = websocketURL;
+            bus = new MessageBus(webSocketClient, remoteWebsocketUrl);
+            this.websocketConnections.set(workspaceId, bus);
+        }
+        return bus;
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/workspace-event-subscriber.ts
+++ b/dockerfiles/lib/typescript/src/workspace-event-subscriber.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {MessageBusSubscriber} from './messagebus-subscriber';
+import {MessageBus} from './messagebus';
+import {AuthData} from './auth-data';
+import {WorkspaceDto} from './dto/workspacedto';
+
+/**
+ * Logic on events received by the remote workspace. When workspace is going to running state, we close the websocket and display the IDE URL.
+ * @author Florent Benoit
+ */
+export class WorkspaceEventMessageBusSubscriber implements MessageBusSubscriber {
+
+    messageBus : MessageBus;
+    workspaceDto : WorkspaceDto;
+
+
+    constructor(messageBus : MessageBus, workspaceDto : WorkspaceDto) {
+        this.messageBus = messageBus;
+        this.workspaceDto = workspaceDto;
+    }
+
+    handleMessage(message: any) {
+        if ('RUNNING' === message.eventType) {
+
+            // search IDE url link
+            let ideUrl: string;
+            this.workspaceDto.getContent().links.forEach((link) => {
+                if ('ide url' === link.rel) {
+                    ideUrl = link.href;
+                }
+            });
+            console.log('Workspace is now running. Please connect to ' + ideUrl);
+            this.messageBus.close();
+        } else if ('ERROR' === message.eventType) {
+            console.log('Error when starting the workspace', message);
+            this.messageBus.close();
+            process.exit(1);
+        } else {
+            console.log('Event on workspace : ', message.eventType);
+        }
+
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/workspace-log-output-subscriber.ts
+++ b/dockerfiles/lib/typescript/src/workspace-log-output-subscriber.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {MessageBusSubscriber} from './messagebus-subscriber';
+
+/**
+ * Class that will display to console all workspace output messages.
+ * @author Florent Benoit
+ */
+export class WorkspaceDisplayOutputMessageBusSubscriber implements MessageBusSubscriber {
+
+    handleMessage(message: string) {
+        // maybe parse data to add colors
+        console.log(message);
+    }
+
+}

--- a/dockerfiles/lib/typescript/src/workspace.ts
+++ b/dockerfiles/lib/typescript/src/workspace.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {WorkspaceDto} from './dto/workspacedto';
+import {AuthData} from "./auth-data";
+
+/**
+ * Workspace class allowing to manage a workspace, like create/start/stop, etc operations
+ * @author Florent Benoit
+ */
+export class Workspace {
+
+    /**
+     * The HTTP library used to call REST API.
+     */
+    http: any;
+
+    /**
+     * Authentication data
+     */
+    authData : AuthData;
+
+
+    constructor(authData : AuthData) {
+        this.authData = authData;
+        if (authData.isSecured()) {
+            this.http = require('https');
+        } else {
+            this.http = require('http');
+        }
+    }
+
+
+    /**
+     * Create a workspace and return a promise with content of WorkspaceDto in case of success
+     */
+    createWorkspace(workspaceName: string, dockerContent: string) : Promise<WorkspaceDto> {
+
+        var options = {
+            hostname: this.authData.getHostname(),
+            port: this.authData.getPort(),
+            path: '/api/workspace?account=&token=' + this.authData.getToken(),
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json, text/plain, */*',
+                'Content-Type': 'application/json;charset=UTF-8'
+            }
+        };
+
+        let p = new Promise<WorkspaceDto>( (resolve, reject) => {
+            var req = this.http.request(options,  (res) => {
+                res.on('data', function (body) {
+
+                    if (res.statusCode == 201) {
+                        // workspace created, continue
+                        resolve(new WorkspaceDto(JSON.parse(body)));
+                    } else {
+                        // error
+                        reject(body);
+                    }
+                });
+
+            });
+
+            req.on('error', (err) => {
+                console.log('rejecting as we got error', err);
+                reject('HTTP error: ' + err);
+            });
+
+            var workspace = {
+                "defaultEnv": "default",
+                "commands": [],
+                "projects": [],
+                "environments": [{
+                    "machineConfigs": [{
+                        "dev": true,
+                        "servers": [],
+                        "envVariables": {},
+                        "limits": {"ram": 2500},
+                        "source": {"type": "dockerfile", "content": dockerContent},
+                        "name": "default",
+                        "type": "docker",
+                        "links": []
+                    }], "name": "default"
+                }],
+                "name": workspaceName,
+                "links": [],
+                "description": null
+            };
+
+
+            req.write(JSON.stringify(workspace));
+            req.end();
+
+        });
+        return p;
+    }
+
+
+    /**
+     * Start a workspace and provide a Promise with WorkspaceDto.
+     */
+    startWorkspace(workspaceId: string) : Promise<WorkspaceDto> {
+
+        var options = {
+            hostname: this.authData.getHostname(),
+            port: this.authData.getPort(),
+            path: '/api/workspace/' + workspaceId + '/runtime?environment=default&token=' + this.authData.getToken(),
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json, text/plain, */*',
+                'Content-Type': 'application/json;charset=UTF-8'
+            }
+        };
+
+        let p = new Promise<WorkspaceDto>( (resolve, reject) => {
+            var req = this.http.request(options,  (res) => {
+
+                res.on('error',  (body)=> {
+                    console.log('got the following error', body.toString());
+                    reject(body);
+                });
+
+                res.on('data', (body) => {
+                    if (res.statusCode == 200) {
+                        // workspace created, continue
+                        resolve(new WorkspaceDto(JSON.parse(body)));
+                    } else {
+                        // error
+                        reject(body);
+                    }
+                });
+
+            });
+
+            req.on('error', (err) => {
+                reject('HTTP error: ' + err);
+            });
+
+            req.write('{}');
+            req.end();
+
+        });
+        return p;
+    }
+
+
+}

--- a/dockerfiles/lib/typescript/tsconfig.json
+++ b/dockerfiles/lib/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "system",
+    "moduleResolution": "node"
+  },
+"exclude": [
+    "node_modules",
+    "jspm_packages"
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

It provides two docker images
**codenvy/che-test**
`docker run --rm -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-test <post-check> [URL of Che/Codenvy] [login] [password]
`
Which create a workspace, start it and display log

**codenvy/che-file**
still in wip with a run syntax close to
docker run -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD":"$PWD" --rm codenvy/che-file $PWD <init|up>
### Tests written?

No
