### PR TITLE
Fix possible NPE if GitHub repo don't have description

### DIFF
--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPageViewImpl.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPageViewImpl.java
@@ -162,7 +162,7 @@ public class GithubImporterPageViewImpl extends Composite implements GithubImpor
             public SafeHtml getValue(final ProjectData item) {
                 return new SafeHtmlBuilder()
                         .appendHtmlConstant("<span>")
-                        .appendEscaped(item.getDescription())
+                        .appendEscaped(item.getDescription() == null ? "" : item.getDescription())
                         .appendHtmlConstant("</span>")
                         .toSafeHtml();
             }


### PR DESCRIPTION
### What does this PR do?

Fix possible NPE if GitHub repo don't have description
### Previous Behavior

GitHub import project page broken if repository don't have description
### New Behavior

Set empty string in description
### Tests written?

No
