### PR TITLE
[WIP] Replace client side HTTP requests using the hostname that is in the address bar

### DIFF
--- a/dashboard/src/app/ide/ide.service.js
+++ b/dashboard/src/app/ide/ide.service.js
@@ -20,7 +20,7 @@ class IdeSvc {
    * Default constructor that is using resource
    * @ngInject for Dependency injection
    */
-  constructor(cheAPI, $rootScope, lodash, $mdDialog, userDashboardConfig, $timeout, $websocket, $sce, proxySettings, $location, routeHistory, $q, $log, cheWorkspace) {
+  constructor(cheAPI, $rootScope, lodash, $mdDialog, userDashboardConfig, $timeout, $websocket, $sce, proxySettings, $location, routeHistory, $q, $log, cheWorkspace, urlAdapter) {
     this.cheAPI = cheAPI;
     this.$rootScope = $rootScope;
     this.lodash = lodash;
@@ -35,6 +35,7 @@ class IdeSvc {
     this.$q = $q;
     this.$log = $log;
     this.cheWorkspace = cheWorkspace;
+    this.urlAdapter = urlAdapter;
 
     this.ideParams = new Map();
 
@@ -295,7 +296,7 @@ class IdeSvc {
     while (i < links.length) {
       let link = links[i];
       if (link.rel === name) {
-        return link.href;
+        return this.urlAdapter.fixHostName(link.href);
       }
       i++;
     }
@@ -311,6 +312,7 @@ class IdeSvc {
   updateRecentWorkspace(workspaceId) {
     this.$rootScope.$broadcast('recent-workspace:set', workspaceId);
   }
+
 }
 
 export default IdeSvc;

--- a/dashboard/src/components/api/che-project.js
+++ b/dashboard/src/components/api/che-project.js
@@ -21,7 +21,7 @@ export class CheProject {
   /**
    * Default constructor that is using resource
    */
-  constructor($resource, $q, cheWebsocket, wsagentPath) {
+  constructor($resource, $q, cheWebsocket, wsagentUrl, urlAdapter) {
 
     // keep resource
     this.$resource = $resource;
@@ -29,6 +29,8 @@ export class CheProject {
     this.cheWebsocket = cheWebsocket;
 
     this.$q = $q;
+
+    this.urlAdapter = urlAdapter;
 
     // project details map with key projectPath
     this.projectDetailsMap = new Map();
@@ -39,16 +41,18 @@ export class CheProject {
     // map of resolve per project  <project:projectType> --> Source Estimation
     this.resolveMap = new Map();
 
+    this.wsagentUrl = this.urlAdapter.fixHostName(wsagentUrl);
+
     // remote call
-    this.remoteProjectsAPI = this.$resource(wsagentPath + '/project', {}, {
-      import: {method: 'POST', url: wsagentPath + '/project/import/:path'},
-      create: {method: 'POST', url: wsagentPath + '/project?name=:path'},
-      details: {method: 'GET', url: wsagentPath + '/project/:path'},
-      estimate: {method: 'GET', url: wsagentPath + '/project/estimate/:path?type=:type'},
-      rename: {method: 'POST', url: wsagentPath + '/project/rename/:path?name=:name'},
-      remove: {method: 'DELETE', url: wsagentPath + '/project/:path'},
-      resolve: {method: 'GET', url: wsagentPath + '/project/resolve/:path', isArray: true},
-      update: {method: 'PUT', url: wsagentPath + '/project/:path'}
+    this.remoteProjectsAPI = this.$resource(this.wsagentUrl + '/project', {}, {
+      import: {method: 'POST', url: this.wsagentUrl + '/project/import/:path'},
+      create: {method: 'POST', url: this.wsagentUrl + '/project?name=:path'},
+      details: {method: 'GET', url: this.wsagentUrl + '/project/:path'},
+      estimate: {method: 'GET', url: this.wsagentUrl + '/project/estimate/:path?type=:type'},
+      rename: {method: 'POST', url: this.wsagentUrl + '/project/rename/:path?name=:name'},
+      remove: {method: 'DELETE', url: this.wsagentUrl + '/project/:path'},
+      resolve: {method: 'GET', url: this.wsagentUrl + '/project/resolve/:path', isArray: true},
+      update: {method: 'PUT', url: this.wsagentUrl + '/project/:path'}
     });
   }
 

--- a/dashboard/src/components/api/che-workspace-agent.js
+++ b/dashboard/src/components/api/che-workspace-agent.js
@@ -23,13 +23,14 @@ export class CheWorkspaceAgent {
   /**
    * Default constructor that is using resource
    */
-  constructor($resource, $q, cheWebsocket, workspaceAgentData) {
+  constructor($resource, $q, cheWebsocket, workspaceAgentData, urlAdapter) {
     this.$resource = $resource;
     this.workspaceAgentData = workspaceAgentData;
+    this.urlAdapter = urlAdapter;
 
-    this.project = new CheProject($resource, $q, cheWebsocket, this.workspaceAgentData.path);
-    this.git = new CheGit($resource, this.workspaceAgentData.path);
-    this.projectType = new CheProjectType($resource, $q, this.workspaceAgentData.path);
+    this.project = new CheProject($resource, $q, cheWebsocket, this.urlAdapter.fixHostName(this.workspaceAgentData.path), this.urlAdapter);
+    this.git = new CheGit($resource, this.urlAdapter.fixHostName(this.workspaceAgentData.path));
+    this.projectType = new CheProjectType($resource, $q, this.urlAdapter.fixHostName(this.workspaceAgentData.path));
   }
 
   getProject() {

--- a/dashboard/src/components/api/che-workspace.factory.js
+++ b/dashboard/src/components/api/che-workspace.factory.js
@@ -23,12 +23,13 @@ export class CheWorkspace {
    * Default constructor that is using resource
    * @ngInject for Dependency injection
    */
-  constructor ($resource, $q, cheWebsocket, lodash) {
+  constructor ($resource, $q, cheWebsocket, lodash, urlAdapter) {
     // keep resource
     this.$resource = $resource;
     this.$q = $q;
     this.lodash = lodash;
     this.cheWebsocket = cheWebsocket;
+    this.urlAdapter = urlAdapter;
 
     // current list of workspaces
     this.workspaces = [];
@@ -78,7 +79,7 @@ export class CheWorkspace {
       }
 
       let workspaceAgentData = {path : wsAgentLink.href};
-      let wsagent = new CheWorkspaceAgent(this.$resource, this.$q, this.cheWebsocket, workspaceAgentData);
+      let wsagent = new CheWorkspaceAgent(this.$resource, this.$q, this.cheWebsocket, workspaceAgentData, this.urlAdapter);
       this.workspaceAgents.set(workspaceId, wsagent);
       return wsagent;
     }
@@ -409,7 +410,7 @@ export class CheWorkspace {
       return '';
     }
     let websocketLink = this.lodash.find(workspace.runtime.devMachine.links, l => l.rel === "wsagent.websocket");
-    return websocketLink ? websocketLink.href : '';
+    return websocketLink ? this.urlAdapter.fixHostName(websocketLink.href) : '';
   }
 
   getIdeUrl(namespace, workspaceName) {

--- a/dashboard/src/components/components-config.js
+++ b/dashboard/src/components/components-config.js
@@ -22,6 +22,7 @@ import {CheNotificationConfig} from './notification/che-notification-config';
 import {RoutingConfig} from './routing/routing-config';
 import {ValidatorConfig} from './validator/validator-config';
 import {WidgetConfig} from './widget/widget-config';
+import {UrlAdapterConfig} from './url-adapter/url-adapter-config';
 
 import {CheStepsContainer} from './steps-container/steps-container.directive';
 
@@ -39,6 +40,7 @@ export class ComponentsConfig {
     new RoutingConfig(register);
     new ValidatorConfig(register);
     new WidgetConfig(register);
+    new UrlAdapterConfig(register);
 
     register.directive('cheStepsContainer', CheStepsContainer);
   }

--- a/dashboard/src/components/url-adapter/url-adapter-config.js
+++ b/dashboard/src/components/url-adapter/url-adapter-config.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015-2016 Codenvy, S.A., Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Mario Loriedo - initial implementation
+ */
+'use strict';
+
+import {UrlAdapter} from './url-adapter.service';
+
+export class UrlAdapterConfig {
+
+  constructor(register) {
+
+    register.service('urlAdapter', UrlAdapter);
+
+  }
+}

--- a/dashboard/src/components/url-adapter/url-adapter.service.js
+++ b/dashboard/src/components/url-adapter/url-adapter.service.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Mario Loriedo - initial implementation
+ */
+'use strict';
+
+/**
+ * Adapt an Url to the particular infrastructure:
+ *  - Replace the Url hostname with the value in browser address bar
+ *  - Use the hostname provided by the Che API
+ * @author Mario Loriedo
+ */
+export class UrlAdapter {
+
+  /**
+   * Default constructor that is using resource injection
+   * @ngInject for Dependency injection
+   */
+  constructor($location) {
+    this.$location = $location;
+  }
+
+  /**
+   * Replace the hostname in url with the hostname from the browser address bar
+   * @param url {String} URL to fix
+   * @returns {String}
+   */
+  fixHostName(oldurl) {
+    if ( !oldurl ) {
+      return '';
+    } else if (this.$location) {
+      let a = document.createElement('a');
+      a.href = oldurl;
+      a.hostname = this.$location.host();
+      return a.href;
+    } else {
+      return oldurl;
+    }
+  }
+}

--- a/dashboard/src/components/url-adapter/url-adapter.spec.js
+++ b/dashboard/src/components/url-adapter/url-adapter.spec.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015-2016 Codenvy, S.A., Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Mario Loriedo - initial implementation
+ */
+'use strict';
+
+/**
+ * Test the 
+ * @author Mario Loriedo
+ */
+
+describe('url-adapter', function () {
+  var $location;
+  var cheBackend;
+  var httpBackend;
+
+  beforeEach(angular.mock.module('userDashboard'));
+
+  beforeEach(inject(function (_$location_) {
+    $location = _$location_;
+    spyOn($location, 'host').and.returnValue('che.eclipse.org');
+  }));
+
+  beforeEach(inject(function (cheHttpBackend) {
+    cheBackend = cheHttpBackend;
+    httpBackend = cheHttpBackend.getHttpBackend();
+  }));
+
+  it('should update URL with IP address hostname', function () {
+    inject(function (urlAdapter) {
+      cheBackend.setup();
+      httpBackend.flush();
+
+      var validUrls = [
+        ['http://111.222.111.222:8080/path/', 'http://che.eclipse.org:8080/path/']
+      ];
+
+      validUrls.forEach(function (url) {
+        expect(urlAdapter.fixHostName(url[0])).toEqual(url[1]);
+        expect($location.host).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it('should update URLs with non IP address hostname', function () {
+    inject(function (urlAdapter) {
+      cheBackend.setup();
+      httpBackend.flush();
+
+      var validUrls = [
+        ['http://www.example.com:8080/path/', 'http://che.eclipse.org:8080/path/']
+      ];
+
+      validUrls.forEach(function (url) {
+        expect(urlAdapter.fixHostName(url[0])).toEqual(url[1]);
+        expect($location.host).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it('should update URLs using different protocols', function () {
+    inject(function (urlAdapter) {
+      cheBackend.setup();
+      httpBackend.flush();
+
+      var validUrls = [
+        ['https://111.222.111.222:8080/path/', 'https://che.eclipse.org:8080/path/'],
+        ['ws://111.222.111.222:8080/path/', 'ws://che.eclipse.org:8080/path/'],
+        ['wss://111.222.111.222:8080/path/', 'wss://che.eclipse.org:8080/path/'],
+        ['https://example.com:8080/path/', 'https://che.eclipse.org:8080/path/'],
+        ['ws://example:8080/path/', 'ws://che.eclipse.org:8080/path/'],
+        ['wss://www.example.com/path/', 'wss://che.eclipse.org/path/']
+      ];
+
+      validUrls.forEach(function (url) {
+        expect(urlAdapter.fixHostName(url[0])).toEqual(url[1]);
+        expect($location.host).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it('should update URLs without port', function () {
+    inject(function (urlAdapter) {
+      cheBackend.setup();
+      httpBackend.flush();
+
+      var validUrls = [
+        ['wss://www.example.com/path/', 'wss://che.eclipse.org/path/']
+      ];
+
+      validUrls.forEach(function (url) {
+        expect(urlAdapter.fixHostName(url[0])).toEqual(url[1]);
+        expect($location.host).toHaveBeenCalled();
+      });
+    });
+  });
+
+});
+

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachine.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachine.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.Server;
 import org.eclipse.che.api.machine.shared.Constants;
+import org.eclipse.che.ide.util.UrlUtils;
 import org.eclipse.che.ide.util.loging.Log;
 
 import javax.validation.constraints.NotNull;
@@ -68,7 +69,7 @@ public class DevMachine {
     public String getWsAgentWebSocketUrl() {
         for (Link link : devMachineLinks) {
             if (Constants.WSAGENT_WEBSOCKET_REFERENCE.equals(link.getRel())) {
-                return link.getHref();
+                return UrlUtils.fixHostName(link.getHref());
             }
         }
         //should not be
@@ -80,7 +81,7 @@ public class DevMachine {
     public String getTerminalUrl() {
         for (Link link : devMachineLinks) {
             if (Constants.TERMINAL_REFERENCE.equals(link.getRel())) {
-                return link.getHref();
+                return UrlUtils.fixHostName(link.getHref());
             }
         }
         //should not be
@@ -100,7 +101,7 @@ public class DevMachine {
             if (url.endsWith("/")) {
                 url = url.substring(0, url.length() - 1);
             }
-            return url;
+            return UrlUtils.fixHostName(url);
         } else {
             //should not be
             String message = "Reference " + Constants.WSAGENT_REFERENCE + " not found in DevMachine description";
@@ -139,7 +140,7 @@ public class DevMachine {
     /** Returns address (protocol://host:port) of the Workspace Agent. */
     public String getAddress() {
         final DevMachineServer server = getServer(Constants.WSAGENT_REFERENCE);
-        return server.getProtocol() + "://" + server.getAddress();
+        return UrlUtils.fixHostName(server.getProtocol() + "://" + server.getAddress());
     }
 
     /** Returns {@link Machine descriptor} of the Workspace Agent. */

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/UrlUtils.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/UrlUtils.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.util;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.regexp.shared.RegExp;
+import com.google.gwt.user.client.Window;
+
+public class UrlUtils {
+
+    public static String fixHostName(String internalUrl) {
+        if (GWT.isScript()) {
+            String hostnameInBrowser = Window.Location.getHostName();
+            return replaceHostNameInUrl(internalUrl, hostnameInBrowser);
+        } else {
+            return internalUrl;
+        }
+    }
+
+    protected static String replaceHostNameInUrl(String url, String newHostName) {
+        RegExp re = RegExp.compile("(\\://).+(?=[\\:])");
+        return re.replace(url, "$1" + newHostName);
+    }
+
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/UrlUtilsTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/UrlUtilsTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.util;
+
+import org.eclipse.che.ide.ui.loaders.initialization.LoaderPresenter;
+import org.eclipse.che.ide.ui.loaders.initialization.LoaderView;
+import org.eclipse.che.ide.ui.loaders.initialization.LoadingInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.eclipse.che.ide.ui.loaders.initialization.LoaderPresenter.State.WORKING;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UrlUtilsTest {
+
+    @Test
+    public void should_replaceHostName_when_hostname_is_an_IP_address() {
+        // Given
+        String hostnameInBrowser = "localhost";
+        String inputUrl = "http://192.58.16.2:8080/api/";
+
+        // When
+        String fixedUrl = UrlUtils.replaceHostNameInUrl(inputUrl, hostnameInBrowser);
+
+        // Then
+        Assert.assertEquals("http://localhost:8080/api/", fixedUrl);
+    }
+
+    @Test
+    public void should_replaceHostName_when_hostname_is_fqdn() {
+        // Given
+        String hostnameInBrowser = "localhost";
+        String inputUrl = "http://myhost.example.com:8080/api/";
+
+        // When
+        String fixedUrl = UrlUtils.replaceHostNameInUrl(inputUrl, hostnameInBrowser);
+
+        // Then
+        Assert.assertEquals("http://localhost:8080/api/", fixedUrl);
+    }
+
+}

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/Machine.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/Machine.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.machine.shared.dto.ServerDto;
 import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
 import org.eclipse.che.ide.extension.machine.client.inject.factories.EntityFactory;
 import org.eclipse.che.ide.extension.machine.client.perspective.widgets.machine.appliance.server.Server;
+import org.eclipse.che.ide.util.UrlUtils;
 import org.eclipse.che.ide.util.loging.Log;
 
 import java.util.ArrayList;
@@ -118,7 +119,7 @@ public class Machine {
     public String getTerminalUrl() {
         for (Link link : machineLinks) {
             if (Constants.TERMINAL_REFERENCE.equals(link.getRel())) {
-                return link.getHref();
+                return UrlUtils.fixHostName(link.getHref());
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

Che used the wsagent internal IP address to send HTTP requests from the browser to the wsagent itself. This can be a problem when the browser cannot ping this IP address. In this PR we have fixed the HTTP requests to the wsagent replacing this internal IP address with the hostname from the browser address bar.
### What issues does this PR fix or reference?

This PR fixes #1644 and #1925 
### Previous Behavior

HTTP requests from the browser to the wsagent used the wsagent internal IP address
### New Behavior

HTTP requests from the browser to the wsagent use the hostname in the address bar
### Tests written?

Yes
### Docs requirements?

Users don't need to set some options anymore:
- the env variable `CHE_HOST_IP` in the launcher is useless
- the option `--remote:` in `che.sh` is useless

Signed-off-by: Mario Loriedo mloriedo@redhat.com
