### PR TITLE
CHE-1933 Do not show recipe content if type is not Dockerfile

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/Machine.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/Machine.java
@@ -75,16 +75,22 @@ public class Machine {
         return descriptor.getConfig().getType();
     }
 
-    /** @return script of machine recipe */
+    /** @return location of machine recipe */
     public String getRecipeLocation() {
         MachineSourceDto machineSource = descriptor.getConfig().getSource();
         return machineSource.getLocation();
     }
 
-    /** @return script of machine recipe */
+    /** @return content of machine recipe */
     public String getRecipeContent() {
         MachineSourceDto machineSource = descriptor.getConfig().getSource();
         return machineSource.getContent();
+    }
+
+    /** @return type of machine recipe */
+    public String getRecipeType() {
+        MachineSourceDto machineSource = descriptor.getConfig().getSource();
+        return machineSource.getType();
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

Fixes an error during restoring workspace from snapshot.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1933
### Previous Behavior

Tried to fetch recipe which would fail if location is not a valid URL (which is valid, if only type is 'dockerfile' ).
### New Behavior

Do not fetch recipe if type is not 'dockerfile'.
### Tests written?

Yes
### Docs requirements?

No
