### PR TITLE
CHE-2022; fixed validation behavior when field value matches default value for its type

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -245,8 +245,8 @@ public class FactoryService extends Service {
         if (factory == null) {
             throw new BadRequestException("Not null factory required");
         }
-        processDefaults(factory);
         factoryBuilder.checkValid(factory);
+        processDefaults(factory);
         createValidator.validateOnCreate(factory);
         final Factory storedFactory = factoryStore.getFactory(factoryStore.saveFactory(factory, null));
         return storedFactory.withLinks(createLinks(storedFactory, null, uriInfo));

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -246,6 +246,7 @@ public class FactoryService extends Service {
             throw new BadRequestException("Not null factory required");
         }
         processDefaults(factory);
+        factoryBuilder.checkValid(factory);
         createValidator.validateOnCreate(factory);
         final Factory storedFactory = factoryStore.getFactory(factoryStore.saveFactory(factory, null));
         return storedFactory.withLinks(createLinks(storedFactory, null, uriInfo));
@@ -345,6 +346,7 @@ public class FactoryService extends Service {
         newFactory.setId(existingFactory.getId());
 
         // validate the new content
+        factoryBuilder.checkValid(newFactory, true);
         createValidator.validateOnCreate(newFactory);
 
         // access granted, user can update the factory

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ValueHelper.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/ValueHelper.java
@@ -13,6 +13,8 @@ package org.eclipse.che.api.factory.server;
 import java.util.Collection;
 import java.util.Map;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 /**
  * @author Sergii Kabashniuk
  */
@@ -22,19 +24,13 @@ public class ValueHelper {
      *
      * @param value
      *         - value to check
-     * @return - true if value is useless for factory (0 for primitives or empty collection or map), false otherwise
+     * @return - true if value is useless for factory (empty string, collection or map), false otherwise
      */
     public static boolean isEmpty(Object value) {
         return (null == value) ||
-               (value.getClass().equals(Boolean.class) && !((Boolean)value)) ||
-               (value.getClass().equals(Integer.class) && (Integer)value == 0) ||
-               (value.getClass().equals(Long.class) && (Long)value == 0) ||
+               (value.getClass().equals(String.class) && isNullOrEmpty((String)value) ||
                (Collection.class.isAssignableFrom(value.getClass()) && ((Collection)value).isEmpty()) ||
-               (Map.class.isAssignableFrom(value.getClass()) && ((Map)value).isEmpty()) ||
-               (value.getClass().equals(Byte.class) && (Byte)value == 0) ||
-               (value.getClass().equals(Short.class) && (Short)value == 0) ||
-               (value.getClass().equals(Double.class) && (Double)value == 0) ||
-               (value.getClass().equals(Float.class) && (Float)value == 0);
+               (Map.class.isAssignableFrom(value.getClass()) && ((Map)value).isEmpty()));
     }
 
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
@@ -89,6 +89,7 @@ import static org.eclipse.che.api.factory.server.FactoryService.VALIDATE_QUERY_P
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anySetOf;
@@ -160,6 +161,7 @@ public class FactoryServiceTest {
         dto = DtoFactory.getInstance();
         factoryBuilder = spy(new FactoryBuilder(new SourceStorageParametersValidator()));
         doNothing().when(factoryBuilder).checkValid(any(Factory.class));
+        doNothing().when(factoryBuilder).checkValid(any(Factory.class), anyBoolean());
         when(factoryParametersResolverHolder.getFactoryParametersResolvers()).thenReturn(factoryParametersResolvers);
         when(userDao.getById(anyString())).thenReturn(new UserImpl(null,
                                                                    null,

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
@@ -102,6 +102,12 @@ public class FactoryBuilderTest {
         factoryBuilder.checkValid(factory);
     }
 
+    @Test(dataProvider = "setByServerParamsProvider")
+    public void shouldAllowUsingParamsThatCanBeSetOnlyByServerDuringUpdate(Factory factory)
+            throws InvocationTargetException, IllegalAccessException, ApiException, NoSuchMethodException {
+        factoryBuilder.checkValid(factory, true);
+    }
+
     @DataProvider(name = "setByServerParamsProvider")
     public static Object[][] setByServerParamsProvider() throws URISyntaxException, IOException, NoSuchMethodException {
         Factory factory = prepareFactory();

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
@@ -134,7 +134,7 @@ public class FactoryBuilderTest {
     public static Object[][] notValidParamsProvider() throws URISyntaxException, IOException, NoSuchMethodException {
         Factory factory = prepareFactory();
         EnvironmentDto environmentDto = factory.getWorkspace().getEnvironments().get(0);
-        environmentDto.getMachineConfigs().add(dto.createDto(MachineConfigDto.class).withName(null));
+        environmentDto.getMachineConfigs().add(dto.createDto(MachineConfigDto.class).withType(null));
         return new Object[][] {
                 {dto.clone(factory).withWorkspace(factory.getWorkspace().withDefaultEnv(null)) },
                 {dto.clone(factory).withWorkspace(factory.getWorkspace().withEnvironments(Collections.singletonList(environmentDto))) }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
@@ -14,6 +14,8 @@ import com.google.common.collect.ImmutableMap;
 
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.factory.FactoryParameter;
+import org.eclipse.che.api.core.model.machine.Limits;
+import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.factory.server.impl.SourceStorageParametersValidator;
 import org.eclipse.che.api.factory.shared.dto.Action;
 import org.eclipse.che.api.factory.shared.dto.Author;
@@ -26,6 +28,7 @@ import org.eclipse.che.api.factory.shared.dto.OnAppLoaded;
 import org.eclipse.che.api.factory.shared.dto.OnProjectsLoaded;
 import org.eclipse.che.api.factory.shared.dto.Policies;
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
+import org.eclipse.che.api.machine.shared.dto.LimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
 import org.eclipse.che.api.machine.shared.dto.ServerConfDto;
@@ -45,6 +48,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -128,7 +132,30 @@ public class FactoryBuilderTest {
 
     @DataProvider(name = "notValidParamsProvider")
     public static Object[][] notValidParamsProvider() throws URISyntaxException, IOException, NoSuchMethodException {
-        return new Object[][] {};
+        Factory factory = prepareFactory();
+        EnvironmentDto environmentDto = factory.getWorkspace().getEnvironments().get(0);
+        environmentDto.getMachineConfigs().add(dto.createDto(MachineConfigDto.class).withName(null));
+        return new Object[][] {
+                {dto.clone(factory).withWorkspace(factory.getWorkspace().withDefaultEnv(null)) },
+                {dto.clone(factory).withWorkspace(factory.getWorkspace().withEnvironments(Collections.singletonList(environmentDto))) }
+        };
+    }
+
+    @Test(dataProvider = "sameAsDefaultParamsProvider")
+    public void shouldAllowUsingParamsWIthValueLikeDefaultForType(Factory factory)
+            throws InvocationTargetException, IllegalAccessException, ApiException, NoSuchMethodException {
+        factoryBuilder.checkValid(factory);
+    }
+
+    @DataProvider(name = "sameAsDefaultParamsProvider")
+    public static Object[][] sameAsDefaultParamsProvider() throws URISyntaxException, IOException, NoSuchMethodException {
+        Factory factory = prepareFactory();
+        EnvironmentDto environmentDto = factory.getWorkspace().getEnvironments().get(0);
+        environmentDto.getMachineConfigs().get(0).withDev(false)
+                                                .withLimits(dto.newDto(LimitsDto.class).withRam(0));
+        return new Object[][] {
+                {dto.clone(factory).withWorkspace(factory.getWorkspace().withEnvironments(Collections.singletonList(environmentDto))) }
+        };
     }
 
 


### PR DESCRIPTION
### What does this PR do?

 Fixes validation behavior when field value matches default for its type.
This PR limits checking to just collections and strings, because for other types we have no way to distinguish whether the value wasn't set at all or it was set to value which is matches default.
### What issues does this PR fix or reference?
#2022
### Previous Behavior

Validator failed on fields like `"integer":0` or `"boolean": false`
### New Behavior

No fails on default values
### Tests written?

Yes
### Docs requirements?

None
