### PR TITLE
Add cascade removal for known entities

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-machine</artifactId>
         </dependency>
         <dependency>
@@ -73,6 +77,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -119,6 +127,10 @@
             <artifactId>che-plugin-ssh-machine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-core</artifactId>
         </dependency>
@@ -139,6 +151,31 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-factory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-jdbc-vendor-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/assembly/assembly-wsmaster-war/src/test/java/org/eclipse/che/api/jdbc/jpa/JpaEntitiesCascadeRemovalTest.java
+++ b/assembly/assembly-wsmaster-war/src/test/java/org/eclipse/che/api/jdbc/jpa/JpaEntitiesCascadeRemovalTest.java
@@ -1,0 +1,325 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.jdbc.jpa;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Stage;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.name.Named;
+import com.google.inject.persist.jpa.JpaPersistModule;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
+import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.factory.server.jpa.FactoryJpaModule;
+import org.eclipse.che.api.factory.server.jpa.JpaFactoryDao;
+import org.eclipse.che.api.factory.server.jpa.JpaFactoryDao.RemoveFactoriesBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.factory.server.model.impl.AuthorImpl;
+import org.eclipse.che.api.factory.server.model.impl.FactoryImpl;
+import org.eclipse.che.api.factory.server.spi.FactoryDao;
+import org.eclipse.che.api.machine.server.jpa.MachineJpaModule;
+import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
+import org.eclipse.che.api.machine.server.spi.SnapshotDao;
+import org.eclipse.che.api.ssh.server.jpa.JpaSshDao;
+import org.eclipse.che.api.ssh.server.jpa.JpaSshDao.RemoveSshKeysBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.ssh.server.jpa.SshJpaModule;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.server.spi.SshDao;
+import org.eclipse.che.api.user.server.jpa.JpaPreferenceDao.RemovePreferencesBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.user.server.jpa.JpaProfileDao.RemoveProfileBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.user.server.jpa.UserJpaModule;
+import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.user.server.spi.PreferenceDao;
+import org.eclipse.che.api.user.server.spi.ProfileDao;
+import org.eclipse.che.api.user.server.spi.UserDao;
+import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao;
+import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao.RemoveSnapshotsBeforeWorkspaceRemovedEventSubscriber;
+import org.eclipse.che.api.workspace.server.jpa.WorkspaceJpaModule;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.inject.lifecycle.InitModule;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+import javax.persistence.EntityManagerFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests top-level entities cascade removals.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class JpaEntitiesCascadeRemovalTest {
+
+    private Injector      injector;
+    private EventService eventService;
+    private PreferenceDao preferenceDao;
+    private UserDao       userDao;
+    private ProfileDao    profileDao;
+    private WorkspaceDao  workspaceDao;
+    private SnapshotDao   snapshotDao;
+    private SshDao        sshDao;
+    private FactoryDao    factoryDao;
+
+    /** User is a root of dependency tree. */
+    private UserImpl user;
+
+    /** Profile depends on user. */
+    private ProfileImpl profile;
+
+    /** Preferences depend on user. */
+    private Map<String, String> preferences;
+
+    /** Workspaces depend on user. */
+    private WorkspaceImpl workspace1;
+    private WorkspaceImpl workspace2;
+
+    /** SshPairs depend on user. */
+    private SshPairImpl sshPair1;
+    private SshPairImpl sshPair2;
+
+    /** Factories depend on user. */
+    private FactoryImpl factory1;
+    private FactoryImpl factory2;
+
+    /** Snapshots depend on workspace. */
+    private SnapshotImpl snapshot1;
+    private SnapshotImpl snapshot2;
+    private SnapshotImpl snapshot3;
+    private SnapshotImpl snapshot4;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        injector = Guice.createInjector(Stage.PRODUCTION, new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(EventService.class).in(Singleton.class);
+
+                bind(JpaInitializer.class).asEagerSingleton();
+                bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
+                install(new InitModule(PostConstruct.class));
+                install(new JpaPersistModule("test"));
+                install(new UserJpaModule());
+                install(new SshJpaModule());
+                install(new WorkspaceJpaModule());
+                install(new MachineJpaModule());
+                install(new FactoryJpaModule());
+            }
+        });
+
+        eventService = injector.getInstance(EventService.class);
+        userDao = injector.getInstance(UserDao.class);
+        preferenceDao = injector.getInstance(PreferenceDao.class);
+        profileDao = injector.getInstance(ProfileDao.class);
+        sshDao = injector.getInstance(SshDao.class);
+        snapshotDao = injector.getInstance(SnapshotDao.class);
+        workspaceDao = injector.getInstance(WorkspaceDao.class);
+        factoryDao = injector.getInstance(FactoryDao.class);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        injector.getInstance(EntityManagerFactory.class).close();
+    }
+
+    @Test
+    public void shouldDeleteAllTheEntitiesWhenUserIsDeleted() throws Exception {
+        createTestData();
+
+        // Remove the user, all entries must be removed along with the user
+        userDao.remove(user.getId());
+
+        // Check all the entities are removed
+        assertNull(notFoundToNull(() -> userDao.getById(user.getId())));
+        assertNull(notFoundToNull(() -> profileDao.getById(user.getId())));
+        assertTrue(preferenceDao.getPreferences(user.getId()).isEmpty());
+        assertTrue(sshDao.get(user.getId()).isEmpty());
+        assertTrue(workspaceDao.getByNamespace(user.getId()).isEmpty());
+        assertTrue(factoryDao.getByAttribute(0, 0, singletonList(Pair.of("creator.userId", user.getId()))).isEmpty());
+        assertTrue(snapshotDao.findSnapshots(workspace1.getId()).isEmpty());
+        assertTrue(snapshotDao.findSnapshots(workspace2.getId()).isEmpty());
+    }
+
+    @Test(dataProvider = "beforeRemoveRollbackActions")
+    public void shouldRollbackTransactionWhenFailedToRemoveAnyOfEntries(Class<EventSubscriber> eventSubscriber) throws Exception {
+        createTestData();
+        eventService.unsubscribe(injector.getInstance(eventSubscriber));
+
+        // Remove the user, all entries must be rolled back after fail
+        try {
+            userDao.remove(user.getId());
+            fail("UserDao#remove had to throw exception");
+        } catch (Exception ignored) {
+        }
+
+        // Check all the data rolled back
+        assertNotNull(userDao.getById(user.getId()));
+        assertNotNull(profileDao.getById(user.getId()));
+        assertFalse(preferenceDao.getPreferences(user.getId()).isEmpty());
+        assertFalse(sshDao.get(user.getId()).isEmpty());
+        assertFalse(workspaceDao.getByNamespace(user.getId()).isEmpty());
+        assertFalse(factoryDao.getByAttribute(0, 0, singletonList(Pair.of("creator.userId", user.getId()))).isEmpty());
+        assertFalse(snapshotDao.findSnapshots(workspace1.getId()).isEmpty());
+        assertFalse(snapshotDao.findSnapshots(workspace2.getId()).isEmpty());
+        wipeTestData();
+    }
+
+    @DataProvider(name = "beforeRemoveRollbackActions")
+    public Object[][] beforeRemoveActions() {
+        // TODO add workspace after https://github.com/eclipse/che/issues/1950 is done
+        return new Class[][] {
+                {RemovePreferencesBeforeUserRemovedEventSubscriber.class},
+                {RemoveProfileBeforeUserRemovedEventSubscriber.class},
+                {RemoveSnapshotsBeforeWorkspaceRemovedEventSubscriber.class},
+                {RemoveSshKeysBeforeUserRemovedEventSubscriber.class},
+                {RemoveFactoriesBeforeUserRemovedEventSubscriber.class}
+        };
+    }
+
+    private void createTestData() throws ConflictException, ServerException {
+        userDao.create(user = createUser("bobby"));
+
+        profileDao.create(profile = createProfile(user.getId()));
+
+        preferenceDao.setPreferences(user.getId(), preferences = createPreferences());
+
+        workspaceDao.create(workspace1 = createWorkspace("workspace1", user.getId()));
+        workspaceDao.create(workspace2 = createWorkspace("workspace2", user.getId()));
+
+        sshDao.create(sshPair1 = createSshPair(user.getId(), "service", "name1"));
+        sshDao.create(sshPair2 = createSshPair(user.getId(), "service", "name2"));
+
+        factoryDao.create(factory1 = createFactory("factory1", user.getId()));
+        factoryDao.create(factory2 = createFactory("factory2", user.getId()));
+
+        snapshotDao.saveSnapshot(snapshot1 = createSnapshot("snapshot1", workspace1.getId()));
+        snapshotDao.saveSnapshot(snapshot2 = createSnapshot("snapshot2", workspace1.getId()));
+        snapshotDao.saveSnapshot(snapshot3 = createSnapshot("snapshot3", workspace2.getId()));
+        snapshotDao.saveSnapshot(snapshot4 = createSnapshot("snapshot4", workspace2.getId()));
+    }
+
+    private void wipeTestData() throws ConflictException, ServerException, NotFoundException {
+        snapshotDao.removeSnapshot(snapshot1.getId());
+        snapshotDao.removeSnapshot(snapshot2.getId());
+        snapshotDao.removeSnapshot(snapshot3.getId());
+        snapshotDao.removeSnapshot(snapshot4.getId());
+
+        factoryDao.remove(factory1.getId());
+        factoryDao.remove(factory2.getId());
+
+        sshDao.remove(sshPair1.getOwner(), sshPair1.getService(), sshPair1.getName());
+        sshDao.remove(sshPair2.getOwner(), sshPair2.getService(), sshPair2.getName());
+
+        workspaceDao.remove(workspace1.getId());
+        workspaceDao.remove(workspace2.getId());
+
+        preferenceDao.remove(user.getId());
+
+        profileDao.remove(user.getId());
+
+        userDao.remove(user.getId());
+    }
+
+    public static UserImpl createUser(String id) {
+        return new UserImpl(id,
+                            id + "@eclipse.org",
+                            id + "_name",
+                            "password",
+                            asList(id + "_alias1", id + "_alias2"));
+    }
+
+    public static ProfileImpl createProfile(String userId) {
+        return new ProfileImpl(userId, new HashMap<>(ImmutableMap.of("attribute1", "value1",
+                                                                     "attribute2", "value2",
+                                                                     "attribute3", "value3")));
+    }
+
+    public static Map<String, String> createPreferences() {
+        return new HashMap<>(ImmutableMap.of("preference1", "value1",
+                                             "preference2", "value2",
+                                             "preference3", "value3"));
+    }
+
+    public static WorkspaceImpl createWorkspace(String id, String namespace) {
+        return new WorkspaceImpl(id,
+                                 namespace,
+                                 new WorkspaceConfigImpl(id + "_name",
+                                                         id + "description",
+                                                         "default-env",
+                                                         null,
+                                                         null,
+                                                         null));
+    }
+
+    public static SshPairImpl createSshPair(String owner, String service, String name) {
+        return new SshPairImpl(owner, service, name, "public-key", "private-key");
+    }
+
+    public static FactoryImpl createFactory(String id, String creator) {
+        return new FactoryImpl(id,
+                               id + "-name",
+                               "4.0",
+                               createWorkspace(id, creator).getConfig(),
+                               new AuthorImpl(creator, System.currentTimeMillis()),
+                               null,
+                               null,
+                               null,
+                               null);
+    }
+
+    public static SnapshotImpl createSnapshot(String snapshotId, String workspaceId) {
+        return new SnapshotImpl(snapshotId,
+                                "type",
+                                null,
+                                System.currentTimeMillis(),
+                                workspaceId,
+                                snapshotId + "_description",
+                                true,
+                                "dev-machine",
+                                snapshotId + "env-name");
+    }
+
+    private static <T> T notFoundToNull(Callable<T> action) throws Exception {
+        try {
+            return action.call();
+        } catch (NotFoundException x) {
+            return null;
+        }
+    }
+}

--- a/assembly/assembly-wsmaster-war/src/test/resources/META-INF/persistence.xml
+++ b/assembly/assembly-wsmaster-war/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,62 @@
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" version="1.0">
+    <persistence-unit name="test" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.che.api.user.server.model.impl.UserImpl</class>
+        <class>org.eclipse.che.api.user.server.model.impl.ProfileImpl</class>
+        <class>org.eclipse.che.api.user.server.jpa.PreferenceEntity</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl</class>
+        <class>org.eclipse.che.api.machine.server.model.impl.SnapshotImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl</class>
+        <class>org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl</class>
+        <class>org.eclipse.che.api.machine.server.model.impl.CommandImpl</class>
+        <class>org.eclipse.che.api.machine.server.model.impl.AclEntryImpl</class>
+        <class>org.eclipse.che.api.machine.server.model.impl.SnapshotImpl</class>
+        <class>org.eclipse.che.api.user.server.model.impl.UserImpl</class>
+        <class>org.eclipse.che.api.ssh.server.model.impl.SshPairImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.ActionImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.AuthorImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.ButtonAttributesImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.ButtonImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.FactoryImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.IdeImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.OnAppClosedImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.OnProjectsLoadedImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.OnAppLoadedImpl</class>
+        <class>org.eclipse.che.api.factory.server.model.impl.PoliciesImpl</class>
+        <class>org.eclipse.che.api.factory.server.FactoryImage</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:;DB_CLOSE_DELAY=0;MVCC=true;TRACE_LEVEL_FILE=4"/>
+            <property name="javax.persistence.jdbc.user" value=""/>
+            <property name="javax.persistence.jdbc.password" value=""/>
+
+            <property name="eclipselink.exception-handler" value="org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler"/>
+            <property name="eclipselink.target-server" value="None"/>
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+            <property name="eclipselink.ddl-generation.output-mode" value="database"/>
+            <property name="eclipselink.logging.logger" value="DefaultLogger"/>
+            <property name="eclipselink.logging.level" value="OFF"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/core/che-core-api-jdbc/pom.xml
+++ b/core/che-core-api-jdbc/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
         </dependency>
     </dependencies>

--- a/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/eclipselink/EntityListenerInjectionManagerInitializer.java
+++ b/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/eclipselink/EntityListenerInjectionManagerInitializer.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jdbc.jpa.eclipselink;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.persistence.sessions.server.ServerSession;
+
+import javax.persistence.EntityManagerFactory;
+
+/**
+ * Sets up {@link GuiceEntityListenerInjectionManager}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class EntityListenerInjectionManagerInitializer {
+
+    @Inject
+    public EntityListenerInjectionManagerInitializer(GuiceEntityListenerInjectionManager injManager, EntityManagerFactory emFactory) {
+        final ServerSession session = emFactory.unwrap(ServerSession.class);
+        session.setEntityListenerInjectionManager(injManager);
+    }
+}

--- a/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/eclipselink/GuiceEntityListenerInjectionManager.java
+++ b/core/che-core-api-jdbc/src/main/java/org/eclipse/che/api/core/jdbc/jpa/eclipselink/GuiceEntityListenerInjectionManager.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jdbc.jpa.eclipselink;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.cdi.EntityListenerInjectionManager;
+
+import javax.naming.NamingException;
+
+/**
+ * Allows to use dependency injection in entity listeners.
+ *
+ * <p>Example:
+ * <pre>
+ * class WorkspaceEntityListener {
+ *
+ *      &#064;Inject EventBus bus; <- EventBus will be injected by Guice
+ *
+ *      &#064;PreRemove
+ *      public void preRemove(Workspace workspace) {
+ *          bus.post(new BeforeWorkspaceRemovedEvent(workspace));
+ *      }
+ * }
+ *
+ * &#064;Entity
+ * &#064;EntityListeners(WorkspaceEntityListener.class)
+ * class Workspace {
+ *      // ...
+ * }
+ * </pre>
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class GuiceEntityListenerInjectionManager implements EntityListenerInjectionManager {
+
+    @Inject
+    private Injector injector;
+
+    @Override
+    public Object createEntityListenerAndInjectDependancies(Class entityListenerClass) throws NamingException {
+        try {
+            return injector.getInstance(entityListenerClass);
+        } catch (RuntimeException x) {
+            throw new NamingException(x.getLocalizedMessage());
+        }
+    }
+
+    @Override
+    public void cleanUp(AbstractSession session) {
+        // EntityListener objects are managed by Guice, nothing to cleanup
+    }
+}

--- a/wsmaster/che-core-api-factory/pom.xml
+++ b/wsmaster/che-core-api-factory/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/FactoryJpaModule.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/FactoryJpaModule.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.factory.server.jpa;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.api.factory.server.jpa.JpaFactoryDao.RemoveFactoriesBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.factory.server.spi.FactoryDao;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class FactoryJpaModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(FactoryDao.class).to(JpaFactoryDao.class);
+        bind(RemoveFactoriesBeforeUserRemovedEventSubscriber.class).asEagerSingleton();
+    }
+}

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/AuthorImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/AuthorImpl.java
@@ -15,8 +15,6 @@ import org.eclipse.che.api.user.server.model.impl.UserImpl;
 
 import javax.persistence.Basic;
 import javax.persistence.Embeddable;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
 import java.util.Objects;
 
 /**
@@ -32,10 +30,6 @@ public class AuthorImpl implements Author {
 
     @Basic
     private String userId;
-
-    @OneToOne
-    @JoinColumn(insertable = false, updatable = false, name = "userId", referencedColumnName = "id")
-    private UserImpl userEntity;
 
     public AuthorImpl() {}
 

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/FactoryImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/FactoryImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.core.model.factory.Button;
 import org.eclipse.che.api.core.model.factory.Factory;
 import org.eclipse.che.api.core.model.factory.Ide;
 import org.eclipse.che.api.core.model.factory.Policies;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.commons.lang.NameGenerator;
 
@@ -26,6 +27,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -60,6 +62,10 @@ public class FactoryImpl implements Factory {
 
     @Embedded
     private AuthorImpl creator;
+
+    @OneToOne
+    @JoinColumn(insertable = false, updatable = false, name = "userId")
+    private UserImpl userEntity;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private ButtonImpl button;

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/jpa/JpaSnapshotDao.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/jpa/JpaSnapshotDao.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.machine.server.jpa;
 import com.google.inject.persist.Transactional;
 
 import org.eclipse.che.api.core.NotFoundException;
-import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.jdbc.jpa.DuplicateKeyException;
 import org.eclipse.che.api.machine.server.exception.SnapshotException;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/jpa/MachineJpaModule.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/jpa/MachineJpaModule.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server.jpa;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.api.machine.server.spi.RecipeDao;
+import org.eclipse.che.api.machine.server.spi.SnapshotDao;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class MachineJpaModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(RecipeDao.class).to(JpaRecipeDao.class);
+        bind(SnapshotDao.class).to(JpaSnapshotDao.class);
+    }
+}

--- a/wsmaster/che-core-api-ssh/pom.xml
+++ b/wsmaster/che-core-api-ssh/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -97,6 +101,10 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/jpa/SshJpaModule.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/jpa/SshJpaModule.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.ssh.server.jpa;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.api.ssh.server.jpa.JpaSshDao.RemoveSshKeysBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.ssh.server.spi.SshDao;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class SshJpaModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(SshDao.class).to(JpaSshDao.class);
+        bind(RemoveSshKeysBeforeUserRemovedEventSubscriber.class).asEagerSingleton();
+    }
+}

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/model/impl/SshPairImpl.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/model/impl/SshPairImpl.java
@@ -21,12 +21,27 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import java.util.Objects;
 
 /**
  * @author Sergii Leschenko
  */
 @Entity(name = "SshKeyPair")
+@NamedQueries(
+        {
+                @NamedQuery(name = "SshKeyPair.getByOwnerAndService",
+                            query = "SELECT pair " +
+                                    "FROM SshKeyPair pair " +
+                                    "WHERE pair.owner = :owner " +
+                                    "  AND pair.service = :service"),
+                @NamedQuery(name = "SshKeyPair.getByOwner",
+                            query = "SELECT pair " +
+                                    "FROM SshKeyPair pair " +
+                                    "WHERE pair.owner = :owner")
+        }
+)
 @IdClass(SshPairPrimaryKey.class)
 public class SshPairImpl implements SshPair {
     @Id
@@ -41,7 +56,7 @@ public class SshPairImpl implements SshPair {
     private String privateKey;
 
     @ManyToOne
-    @JoinColumn(name="owner", insertable = false, updatable = false)
+    @JoinColumn(name = "owner", insertable = false, updatable = false)
     private UserImpl user;
 
     public SshPairImpl() {
@@ -61,6 +76,10 @@ public class SshPairImpl implements SshPair {
         this.name = sshPair.getName();
         this.publicKey = sshPair.getPublicKey();
         this.privateKey = sshPair.getPrivateKey();
+    }
+
+    public SshPairImpl(SshPairImpl sshPair) {
+        this(sshPair.owner, sshPair.service, sshPair.name, sshPair.publicKey, sshPair.privateKey);
     }
 
     public String getOwner() {

--- a/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/spi/SshDao.java
+++ b/wsmaster/che-core-api-ssh/src/main/java/org/eclipse/che/api/ssh/server/spi/SshDao.java
@@ -90,4 +90,18 @@ public interface SshDao {
      *         when any other error occurs during ssh pair removing
      */
     void remove(String owner, String service, String name) throws ServerException, NotFoundException;
+
+    /**
+     * Gets ssh pairs by owner.
+     *
+     * @param owner
+     *         the owner of the ssh key
+     * @return the list of the ssh key  pairs owned by the {@code owner}, or empty list if
+     * there are no ssh key pairs by the given {@code owner}
+     * @throws NullPointerException
+     *         when {@code owner} is null
+     * @throws ServerException
+     *         when any error occurs(e.g. database connection error)
+     */
+    List<SshPairImpl> get(String owner) throws ServerException;
 }

--- a/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/jpa/SshTckModule.java
+++ b/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/jpa/SshTckModule.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.ssh.server.jpa;
 import com.google.inject.TypeLiteral;
 import com.google.inject.persist.jpa.JpaPersistModule;
 
+import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
 import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.api.ssh.server.spi.SshDao;
@@ -34,6 +35,7 @@ public class SshTckModule extends TckModule {
 
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
+        bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
         bind(org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler.class);
     }
 }

--- a/wsmaster/che-core-api-user/pom.xml
+++ b/wsmaster/che-core-api-user/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserManager.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserManager.java
@@ -207,7 +207,7 @@ public class UserManager {
     }
 
     /**
-     * Removes user and his dependencies by given {@code id}.
+     * Removes user by given {@code id}.
      *
      * @param id
      *         user identifier
@@ -220,8 +220,6 @@ public class UserManager {
      */
     public void remove(String id) throws ServerException, ConflictException {
         requireNonNull(id, "Required non-null id");
-        profileDao.remove(id);
-        preferencesDao.remove(id);
         userDao.remove(id);
     }
 }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/event/BeforeUserRemovedEvent.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/event/BeforeUserRemovedEvent.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.event;
+
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+
+/**
+ * Published before {@link UserImpl user} removed.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class BeforeUserRemovedEvent {
+
+    private final UserImpl user;
+
+    public BeforeUserRemovedEvent(UserImpl user) {
+        this.user = user;
+    }
+
+    /** Returns user which is going to be removed. */
+    public UserImpl getUser() {
+        return user;
+    }
+}

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/UserEntityListener.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/UserEntityListener.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.user.server.event.BeforeUserRemovedEvent;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.persistence.PreRemove;
+
+/**
+ * Callback for {@link UserImpl user} jpa related events.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class UserEntityListener {
+
+    @Inject
+    private EventService eventService;
+
+    @PreRemove
+    public void preRemove(UserImpl user) {
+        eventService.publish(new BeforeUserRemovedEvent(user));
+    }
+}

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/UserJpaModule.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/UserJpaModule.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.user.server.jpa;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.api.user.server.jpa.JpaPreferenceDao.RemovePreferencesBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.user.server.jpa.JpaProfileDao.RemoveProfileBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.user.server.spi.PreferenceDao;
+import org.eclipse.che.api.user.server.spi.ProfileDao;
+import org.eclipse.che.api.user.server.spi.UserDao;
+import org.eclipse.che.security.PBKDF2PasswordEncryptor;
+import org.eclipse.che.security.PasswordEncryptor;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class UserJpaModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(PasswordEncryptor.class).to(PBKDF2PasswordEncryptor.class);
+        bind(UserDao.class).to(JpaUserDao.class);
+        bind(ProfileDao.class).to(JpaProfileDao.class);
+        bind(PreferenceDao.class).to(JpaPreferenceDao.class);
+        bind(RemoveProfileBeforeUserRemovedEventSubscriber.class).asEagerSingleton();
+        bind(RemovePreferencesBeforeUserRemovedEventSubscriber.class).asEagerSingleton();
+    }
+}

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
@@ -11,12 +11,14 @@
 package org.eclipse.che.api.user.server.model.impl;
 
 import org.eclipse.che.api.core.model.user.User;
+import org.eclipse.che.api.user.server.jpa.UserEntityListener;
 
 import javax.persistence.Basic;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
@@ -48,6 +50,7 @@ import java.util.Objects;
                             query = "SELECT u FROM \"User\" u WHERE u.email = :email")
         }
 )
+@EntityListeners(UserEntityListener.class)
 public class UserImpl implements User {
 
     @Id

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserManagerTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserManagerTest.java
@@ -201,8 +201,6 @@ public class UserManagerTest {
         manager.remove("user123");
 
         verify(userDao).remove("user123");
-        verify(preferencesDao).remove("user123");
-        verify(profileDao).remove("user123");
     }
 
     @Test(expectedExceptions = ConflictException.class)

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/JpaTckModule.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/JpaTckModule.java
@@ -14,6 +14,7 @@ import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.persist.jpa.JpaPersistModule;
 
+import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
 import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
@@ -28,7 +29,6 @@ import org.eclipse.che.security.SHA512PasswordEncryptor;
 
 import java.util.Map;
 
-
 /**
  * @author Yevhenii Voevodin
  */
@@ -38,6 +38,7 @@ public class JpaTckModule extends TckModule {
     protected void configure() {
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
+        bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
 
         bind(new TypeLiteral<TckRepository<UserImpl>>() {}).to(UserJpaTckRepository.class);
         bind(new TypeLiteral<TckRepository<ProfileImpl>>() {}).to(ProfileJpaTckRepository.class);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/BeforeWorkspaceRemovedEvent.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/BeforeWorkspaceRemovedEvent.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.event;
+
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+
+/**
+ * Published before {@link WorkspaceImpl workspace} removed.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class BeforeWorkspaceRemovedEvent {
+
+    private final WorkspaceImpl workspace;
+
+    public BeforeWorkspaceRemovedEvent(WorkspaceImpl workspace) {
+        this.workspace = workspace;
+    }
+
+    public WorkspaceImpl getWorkspace() {
+        return workspace;
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceEntityListener.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceEntityListener.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.jpa;
+
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.event.BeforeWorkspaceRemovedEvent;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.persistence.PreRemove;
+
+/**
+ * Callback for {@link WorkspaceImpl workspace} jpa related events.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class WorkspaceEntityListener {
+
+    @Inject
+    private EventService eventService;
+
+    @PreRemove
+    private void preRemove(WorkspaceImpl workspace) {
+        eventService.publish(new BeforeWorkspaceRemovedEvent(workspace));
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceJpaModule.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceJpaModule.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.jpa;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao.RemoveSnapshotsBeforeWorkspaceRemovedEventSubscriber;
+import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao.RemoveWorkspaceBeforeUserRemovedEventSubscriber;
+import org.eclipse.che.api.workspace.server.spi.StackDao;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+public class WorkspaceJpaModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(StackDao.class).to(JpaStackDao.class);
+        bind(WorkspaceDao.class).to(JpaWorkspaceDao.class);
+        bind(RemoveWorkspaceBeforeUserRemovedEventSubscriber.class).asEagerSingleton();
+        bind(RemoveSnapshotsBeforeWorkspaceRemovedEventSubscriber.class).asEagerSingleton();
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceRuntime;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
+import org.eclipse.che.api.workspace.server.jpa.WorkspaceEntityListener;
 import org.eclipse.che.commons.lang.NameGenerator;
 
 import javax.persistence.Basic;
@@ -22,6 +23,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -57,6 +59,7 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
                             query = "SELECT w FROM Workspace w")
         }
 )
+@EntityListeners(WorkspaceEntityListener.class)
 public class WorkspaceImpl implements Workspace {
 
     public static WorkspaceImplBuilder builder() {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
@@ -14,6 +14,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.jpa.JpaPersistModule;
 
+import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
 import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
 import org.eclipse.che.api.machine.server.model.impl.AclEntryImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
@@ -40,6 +41,7 @@ public class WorkspaceTckModule extends TckModule {
     protected void configure() {
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
+        bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
         bind(org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler.class);
 
         bind(new TypeLiteral<TckRepository<WorkspaceImpl>>() {}).toInstance(new JpaTckRepository<>(WorkspaceImpl.class));

--- a/wsmaster/wsmaster-local/pom.xml
+++ b/wsmaster/wsmaster-local/pom.xml
@@ -130,6 +130,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalProfileDaoImpl.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalProfileDaoImpl.java
@@ -30,13 +30,16 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * In-memory implementation of {@link ProfileDao}.
+ *
+ * <p>The implementation is thread-safe guarded by this instance.
+ * Clients may use instance locking to perform extra, thread-safe operation.
+ *
  * @author Anton Korneta
  */
 @Singleton
@@ -45,18 +48,16 @@ public class LocalProfileDaoImpl implements ProfileDao {
     @VisibleForTesting
     final Map<String, ProfileImpl> profiles;
 
-    private final ReadWriteLock            lock;
-    private final LocalStorage             profileStorage;
+    private final LocalStorage profileStorage;
 
     @Inject
     public LocalProfileDaoImpl(LocalStorageFactory storageFactory) throws IOException {
         profiles = new LinkedHashMap<>();
-        lock = new ReentrantReadWriteLock();
         profileStorage = storageFactory.create("profiles.json");
     }
 
     @PostConstruct
-    private void start() {
+    private synchronized void start() {
         profiles.putAll(profileStorage.loadMap(new TypeToken<Map<String, ProfileImpl>>() {}));
         // Add default entry if file doesn't exist or invalid or empty.
         if (profiles.isEmpty()) {
@@ -70,63 +71,43 @@ public class LocalProfileDaoImpl implements ProfileDao {
     }
 
     @PreDestroy
-    private void stop() throws IOException {
+    private synchronized void stop() throws IOException {
         profileStorage.store(profiles);
     }
 
     @Override
-    public void create(ProfileImpl profile) throws ConflictException {
+    public synchronized void create(ProfileImpl profile) throws ConflictException {
         requireNonNull(profile, "Required non-null profile");
-        lock.writeLock().lock();
-        try {
-            if (profiles.containsKey(profile.getUserId())) {
-                throw new ConflictException(format("Profile for user '%s' already exists", profile.getUserId()));
-            }
-            profiles.put(profile.getUserId(), new ProfileImpl(profile));
-        } finally {
-            lock.writeLock().unlock();
+        if (profiles.containsKey(profile.getUserId())) {
+            throw new ConflictException(format("Profile for user '%s' already exists", profile.getUserId()));
         }
+        profiles.put(profile.getUserId(), new ProfileImpl(profile));
     }
 
     @Override
-    public void update(ProfileImpl profile) throws NotFoundException {
+    public synchronized void update(ProfileImpl profile) throws NotFoundException {
         requireNonNull(profile, "Required non-null profile");
-        lock.writeLock().lock();
-        try {
-            final Profile myProfile = profiles.get(profile.getUserId());
-            if (myProfile == null) {
-                throw new NotFoundException(format("Profile with id '%s' not found", profile.getUserId()));
-            }
-            myProfile.getAttributes().clear();
-            myProfile.getAttributes().putAll(profile.getAttributes());
-        } finally {
-            lock.writeLock().unlock();
+        final Profile myProfile = profiles.get(profile.getUserId());
+        if (myProfile == null) {
+            throw new NotFoundException(format("Profile with id '%s' not found", profile.getUserId()));
         }
+        myProfile.getAttributes().clear();
+        myProfile.getAttributes().putAll(profile.getAttributes());
     }
 
     @Override
-    public void remove(String id) {
+    public synchronized void remove(String id) {
         requireNonNull(id, "Required non-null id");
-        lock.writeLock().lock();
-        try {
-           profiles.remove(id);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        profiles.remove(id);
     }
 
     @Override
-    public ProfileImpl getById(String id) throws NotFoundException {
+    public synchronized ProfileImpl getById(String id) throws NotFoundException {
         requireNonNull(id, "Required non-null id");
-        lock.readLock().lock();
-        try {
-            final Profile profile = profiles.get(id);
-            if (profile == null) {
-                throw new NotFoundException(format("Profile with id '%s' not found", id));
-            }
-            return new ProfileImpl(profile);
-        } finally {
-            lock.readLock().unlock();
+        final Profile profile = profiles.get(id);
+        if (profile == null) {
+            throw new NotFoundException(format("Profile with id '%s' not found", id));
         }
+        return new ProfileImpl(profile);
     }
 }

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalRecipeDaoImpl.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalRecipeDaoImpl.java
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -38,7 +36,12 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @author Eugene Voevodin
+ * In-memory implementation of {@link RecipeDao}.
+ *
+ * <p>The implementation is thread-safe guarded by this instance.
+ * Clients may use instance locking to perform extra, thread-safe operation.
+ *
+ * @author Yevhenii Voevodin
  * @author Anton Korneta
  */
 @Singleton
@@ -47,116 +50,90 @@ public class LocalRecipeDaoImpl implements RecipeDao {
     @VisibleForTesting
     final Map<String, RecipeImpl> recipes;
 
-    private final ReadWriteLock lock;
-    private final LocalStorage  recipeStorage;
+    private final LocalStorage recipeStorage;
 
     @Inject
     public LocalRecipeDaoImpl(LocalStorageFactory storageFactory) throws IOException {
         this.recipeStorage = storageFactory.create("recipes.json");
         this.recipes = new HashMap<>();
-        this.lock = new ReentrantReadWriteLock();
     }
 
     @PostConstruct
-    public void loadRecipes() {
+    public synchronized void loadRecipes() {
         recipes.putAll(recipeStorage.loadMap(new TypeToken<Map<String, RecipeImpl>>() {}));
     }
 
     @PreDestroy
-    public void saveRecipes() throws IOException {
+    public synchronized void saveRecipes() throws IOException {
         recipeStorage.store(recipes);
     }
 
     @Override
-    public void create(RecipeImpl recipe) throws ConflictException {
-        lock.writeLock().lock();
-        try {
-            if (recipes.containsKey(recipe.getId())) {
-                throw new ConflictException(format("Recipe with id %s already exists", recipe.getId()));
-            }
-            recipes.put(recipe.getId(), recipe);
-        } finally {
-            lock.writeLock().unlock();
+    public synchronized void create(RecipeImpl recipe) throws ConflictException {
+        if (recipes.containsKey(recipe.getId())) {
+            throw new ConflictException(format("Recipe with id %s already exists", recipe.getId()));
         }
+        recipes.put(recipe.getId(), recipe);
     }
 
     @Override
-    public RecipeImpl update(RecipeImpl update) throws NotFoundException {
-        lock.writeLock().lock();
-        try {
-            final RecipeImpl target = recipes.get(update.getId());
-            if (target == null) {
-                throw new NotFoundException(format("Recipe with id '%s' was not found", update.getId()));
-            }
-            if (update.getType() != null) {
-                target.setType(update.getType());
-            }
-            if (update.getScript() != null) {
-                target.setScript(update.getScript());
-            }
-            if (update.getCreator() != null) {
-                target.setCreator(update.getCreator());
-            }
-            if (update.getDescription() != null) {
-                target.setDescription(update.getDescription());
-            }
-            if (update.getName() != null) {
-                target.setName(update.getName());
-            }
-            if (!update.getTags().isEmpty()) {
-                target.setTags(update.getTags());
-            }
-            if (update.getAcl() != null && !update.getAcl().isEmpty()) {
-                target.setAcl(update.getAcl());
-            }
-
-            return new RecipeImpl(target);
-        } finally {
-            lock.writeLock().unlock();
+    public synchronized RecipeImpl update(RecipeImpl update) throws NotFoundException {
+        final RecipeImpl target = recipes.get(update.getId());
+        if (target == null) {
+            throw new NotFoundException(format("Recipe with id '%s' was not found", update.getId()));
         }
+        if (update.getType() != null) {
+            target.setType(update.getType());
+        }
+        if (update.getScript() != null) {
+            target.setScript(update.getScript());
+        }
+        if (update.getCreator() != null) {
+            target.setCreator(update.getCreator());
+        }
+        if (update.getDescription() != null) {
+            target.setDescription(update.getDescription());
+        }
+        if (update.getName() != null) {
+            target.setName(update.getName());
+        }
+        if (!update.getTags().isEmpty()) {
+            target.setTags(update.getTags());
+        }
+        if (update.getAcl() != null && !update.getAcl().isEmpty()) {
+            target.setAcl(update.getAcl());
+        }
+
+        return new RecipeImpl(target);
     }
 
     @Override
-    public void remove(String id) {
+    public synchronized void remove(String id) {
         requireNonNull(id);
-        lock.writeLock().lock();
-        try {
-            recipes.remove(id);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        recipes.remove(id);
     }
 
     @Override
-    public RecipeImpl getById(String id) throws NotFoundException {
+    public synchronized RecipeImpl getById(String id) throws NotFoundException {
         requireNonNull(id);
-        lock.readLock().lock();
-        try {
-            final RecipeImpl recipe = recipes.get(id);
-            if (recipe == null) {
-                throw new NotFoundException(format("Recipe with id %s was not found", id));
-            }
-            return new RecipeImpl(recipe);
-        } finally {
-            lock.readLock().unlock();
+        final RecipeImpl recipe = recipes.get(id);
+        if (recipe == null) {
+            throw new NotFoundException(format("Recipe with id %s was not found", id));
         }
+        return new RecipeImpl(recipe);
     }
 
     @Override
-    public List<RecipeImpl> search(String user, List<String> tags, String type, int skipCount, int maxItems) throws ServerException {
-        lock.readLock().lock();
-        try {
-            Stream<RecipeImpl> recipesStream = recipes.values()
-                                                      .stream()
-                                                      .filter(recipe -> (tags == null || recipe.getTags().containsAll(tags))
-                                                                        && (type == null || type.equals(recipe.getType())))
-                                                      .skip(skipCount);
-            if (maxItems != 0) {
-                recipesStream = recipesStream.limit(maxItems);
-            }
-            return recipesStream.collect(Collectors.toList());
-        } finally {
-            lock.readLock().unlock();
+    public synchronized List<RecipeImpl> search(String user, List<String> tags, String type, int skipCount, int maxItems)
+            throws ServerException {
+        Stream<RecipeImpl> recipesStream = recipes.values()
+                                                  .stream()
+                                                  .filter(recipe -> (tags == null || recipe.getTags().containsAll(tags))
+                                                                    && (type == null || type.equals(recipe.getType())))
+                                                  .skip(skipCount);
+        if (maxItems != 0) {
+            recipesStream = recipesStream.limit(maxItems);
         }
+        return recipesStream.collect(Collectors.toList());
     }
 }

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalSnapshotDaoImpl.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalSnapshotDaoImpl.java
@@ -40,6 +40,9 @@ import static java.util.stream.Collectors.toList;
 /**
  * In-memory implementation of {@link SnapshotDao}.
  *
+ * <p>The implementation is thread-safe guarded by this instance.
+ * Clients may use instance locking to perform extra, thread-safe operation.
+ *
  * @author Yevhenii Voevodin
  */
 @Singleton

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalStackDaoImpl.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/LocalStackDaoImpl.java
@@ -40,7 +40,11 @@ import static java.util.stream.Collectors.toList;
 /**
  * Implementation local storage for {@link Stack}
  *
+ * <p>The implementation is thread-safe guarded by this instance.
+ * Clients may use instance locking to perform extra, thread-safe operation.
+ *
  * @author Alexander Andrienko
+ * @author Yevhenii Voevodin
  */
 @Singleton
 public class LocalStackDaoImpl implements StackDao {
@@ -49,110 +53,79 @@ public class LocalStackDaoImpl implements StackDao {
     final Map<String, StackImpl> stacks;
 
     private final StackLocalStorage stackStorage;
-    private final ReadWriteLock     lock;
 
     @Inject
     public LocalStackDaoImpl(StackLocalStorage stackLocalStorage) throws IOException {
         this.stackStorage = stackLocalStorage;
         this.stacks = new LinkedHashMap<>();
-        this.lock = new ReentrantReadWriteLock();
     }
 
     @PostConstruct
-    public void start() {
-        lock.readLock().lock();
+    public synchronized void start() {
         stacks.putAll(stackStorage.loadMap());
-        lock.readLock().unlock();
     }
 
     @PreDestroy
-    public void stop() throws IOException {
-        lock.writeLock().lock();
+    public synchronized void stop() throws IOException {
         stackStorage.store(stacks);
-        lock.writeLock().unlock();
     }
 
     @Override
-    public void create(StackImpl stack) throws ConflictException, ServerException {
+    public synchronized void create(StackImpl stack) throws ConflictException, ServerException {
         requireNonNull(stack, "Stack required");
-        lock.writeLock().lock();
-        try {
-            if (stacks.containsKey(stack.getId())) {
-                throw new ConflictException(format("Stack with id %s is already exist", stack.getId()));
-            }
-            if (stacks.values()
-                      .stream()
-                      .anyMatch(s -> s.getName().equals(stack.getName()))) {
-                throw new ConflictException(format("Stack with name '%s' already exists", stack.getName()));
-            }
-            stacks.put(stack.getId(), new StackImpl(stack));
-        } finally {
-            lock.writeLock().unlock();
+        if (stacks.containsKey(stack.getId())) {
+            throw new ConflictException(format("Stack with id %s is already exist", stack.getId()));
         }
+        if (stacks.values()
+                  .stream()
+                  .anyMatch(s -> s.getName().equals(stack.getName()))) {
+            throw new ConflictException(format("Stack with name '%s' already exists", stack.getName()));
+        }
+        stacks.put(stack.getId(), new StackImpl(stack));
     }
 
     @Override
-    public StackImpl getById(String id) throws NotFoundException {
+    public synchronized StackImpl getById(String id) throws NotFoundException {
         requireNonNull(id, "Stack id required");
-        lock.readLock().lock();
-        try {
-            final StackImpl stack = stacks.get(id);
-            if (stack == null) {
-                throw new NotFoundException(format("Stack with id %s was not found", id));
-            }
-            return new StackImpl(stack);
-        } finally {
-            lock.readLock().unlock();
+        final StackImpl stack = stacks.get(id);
+        if (stack == null) {
+            throw new NotFoundException(format("Stack with id %s was not found", id));
         }
+        return new StackImpl(stack);
     }
 
     @Override
-    public void remove(String id) throws ServerException {
+    public synchronized void remove(String id) throws ServerException {
         requireNonNull(id, "Stack id required");
-        lock.writeLock().lock();
-        try {
-            stacks.remove(id);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        stacks.remove(id);
     }
 
     @Override
-    public StackImpl update(StackImpl update) throws NotFoundException, ServerException, ConflictException {
+    public synchronized StackImpl update(StackImpl update) throws NotFoundException, ServerException, ConflictException {
         requireNonNull(update, "Stack required");
         requireNonNull(update.getId(), "Stack id required");
-        lock.writeLock().lock();
-        try {
-            String updateId = update.getId();
-            if (!stacks.containsKey(updateId)) {
-                throw new NotFoundException(format("Stack with id %s was not found", updateId));
-            }
-            if (stacks.values()
-                      .stream()
-                      .anyMatch(stack -> stack.getName().equals(update.getName()) && !stack.getId().equals(updateId))) {
-                throw new ConflictException(format("Stack with name '%s' already exists", updateId));
-            }
-            stacks.replace(updateId, new StackImpl(update));
-            return new StackImpl(update);
-        } finally {
-            lock.writeLock().unlock();
+        String updateId = update.getId();
+        if (!stacks.containsKey(updateId)) {
+            throw new NotFoundException(format("Stack with id %s was not found", updateId));
         }
+        if (stacks.values()
+                  .stream()
+                  .anyMatch(stack -> stack.getName().equals(update.getName()) && !stack.getId().equals(updateId))) {
+            throw new ConflictException(format("Stack with name '%s' already exists", updateId));
+        }
+        stacks.replace(updateId, new StackImpl(update));
+        return new StackImpl(update);
     }
 
     @Override
-    public List<StackImpl> searchStacks(String user, @Nullable List<String> tags, int skipCount, int maxItems) {
-        lock.readLock().lock();
-        try {
-            Stream<StackImpl> stream = stacks.values()
-                                             .stream()
-                                             .skip(skipCount)
-                                             .filter(s -> tags == null || s.getTags().containsAll(tags));
-            if (maxItems != 0) {
-                stream = stream.limit(maxItems);
-            }
-            return stream.map(StackImpl::new).collect(toList());
-        } finally {
-            lock.readLock().unlock();
+    public synchronized List<StackImpl> searchStacks(String user, @Nullable List<String> tags, int skipCount, int maxItems) {
+        Stream<StackImpl> stream = stacks.values()
+                                         .stream()
+                                         .skip(skipCount)
+                                         .filter(s -> tags == null || s.getTags().containsAll(tags));
+        if (maxItems != 0) {
+            stream = stream.limit(maxItems);
         }
+        return stream.map(StackImpl::new).collect(toList());
     }
 }

--- a/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalMapTckRepository.java
+++ b/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalMapTckRepository.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.local;
 
+import org.eclipse.che.commons.annotation.Nullable;
+
 import java.util.Map;
 import java.util.function.Function;
 
@@ -22,7 +24,7 @@ import java.util.function.Function;
  */
 public class LocalMapTckRepository<T> extends LocalTckRepository<Map<String, T>, T> {
 
-    public LocalMapTckRepository(Map<String, T> storage, Function<T, String> keyMapper) {
-        super(storage, (s, entity) -> storage.put(keyMapper.apply(entity), entity), Map::clear);
+    public LocalMapTckRepository(Map<String, T> storage, Function<T, String> keyMapper, @Nullable Object mutex) {
+        super(storage, (s, entity) -> storage.put(keyMapper.apply(entity), entity), Map::clear, mutex);
     }
 }

--- a/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalTckModule.java
+++ b/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalTckModule.java
@@ -23,7 +23,6 @@ import org.eclipse.che.api.machine.server.spi.RecipeDao;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.api.ssh.server.spi.SshDao;
-import org.eclipse.che.api.user.server.jpa.PreferenceEntity;
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.PreferenceDao;
@@ -43,8 +42,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import static java.util.Collections.emptySet;
 import static org.mockito.Matchers.any;
@@ -99,7 +96,7 @@ public class LocalTckModule extends TckModule {
     private static class SnapshotTckRepository extends LocalMapTckRepository<SnapshotImpl> {
         @Inject
         public SnapshotTckRepository(LocalSnapshotDaoImpl snapshotDao) {
-            super(snapshotDao.snapshots, SnapshotImpl::getId);
+            super(snapshotDao.snapshots, SnapshotImpl::getId, snapshotDao);
         }
     }
 
@@ -107,7 +104,7 @@ public class LocalTckModule extends TckModule {
     private static class LocalUserTckRepository extends LocalMapTckRepository<UserImpl> {
         @Inject
         public LocalUserTckRepository(LocalUserDaoImpl userDao) {
-            super(userDao.users, UserImpl::getId);
+            super(userDao.users, UserImpl::getId, userDao);
         }
     }
 
@@ -115,7 +112,7 @@ public class LocalTckModule extends TckModule {
     private static class LocalProfileTckRepository extends LocalMapTckRepository<ProfileImpl> {
         @Inject
         public LocalProfileTckRepository(LocalProfileDaoImpl profileDao) {
-            super(profileDao.profiles, ProfileImpl::getUserId);
+            super(profileDao.profiles, ProfileImpl::getUserId, profileDao);
         }
     }
 
@@ -123,7 +120,7 @@ public class LocalTckModule extends TckModule {
     private static class LocalRecipeTckRepository extends LocalMapTckRepository<RecipeImpl> {
         @Inject
         public LocalRecipeTckRepository(LocalRecipeDaoImpl recipeDao) {
-            super(recipeDao.recipes, RecipeImpl::getId);
+            super(recipeDao.recipes, RecipeImpl::getId, recipeDao);
         }
     }
 
@@ -131,7 +128,7 @@ public class LocalTckModule extends TckModule {
     private static class LocalWorkspaceTckRepository extends LocalMapTckRepository<WorkspaceImpl> {
         @Inject
         public LocalWorkspaceTckRepository(LocalWorkspaceDaoImpl workspaceDao) {
-            super(workspaceDao.workspaces, WorkspaceImpl::getId);
+            super(workspaceDao.workspaces, WorkspaceImpl::getId, workspaceDao);
         }
     }
 
@@ -139,7 +136,7 @@ public class LocalTckModule extends TckModule {
     private static class LocalStackTckRepository extends LocalMapTckRepository<StackImpl> {
         @Inject
         public LocalStackTckRepository(LocalStackDaoImpl stackDao) {
-            super(stackDao.stacks, StackImpl::getId);
+            super(stackDao.stacks, StackImpl::getId, stackDao);
         }
     }
 
@@ -147,8 +144,8 @@ public class LocalTckModule extends TckModule {
     private static class LocalPreferenceTckRepository
             extends LocalTckRepository<Map<String, Map<String, String>>, Pair<String, Map<String, String>>> {
         @Inject
-        public LocalPreferenceTckRepository(LocalPreferenceDaoImpl localDao) {
-            super(localDao.preferences, (map, entity) -> map.put(entity.first, entity.second), Map::clear);
+        public LocalPreferenceTckRepository(LocalPreferenceDaoImpl prefsDao) {
+            super(prefsDao.preferences, (map, entity) -> map.put(entity.first, entity.second), Map::clear, prefsDao);
         }
     }
 
@@ -156,7 +153,7 @@ public class LocalTckModule extends TckModule {
     private static class LocalSshTckRepository extends LocalTckRepository<List<SshPairImpl>, SshPairImpl> {
         @Inject
         public LocalSshTckRepository(LocalSshDaoImpl sshDao) {
-            super(sshDao.pairs, List::add, List::clear);
+            super(sshDao.pairs, List::add, List::clear, sshDao);
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Introduces cascade removal strategies, which are:
- Use `orphanRemoval` or `@CascadeOnDelete` those strategies require entries to declare
  either bidirectional mapping, or mapping present on owning side, for example `Profile` depends on `User`while `User` doesn't know anything about profile, so for removing profile along with a user we have to declare Profile mapping on User object side, and mark the dependency with `orphanRemoval`, this is not always possible as objects may be in separate modules and it will produce circular dependencies.
- Use `foreignKeyDefinition` for defining foreign keys e.g.:

```
@JoinColumn(foreignKey = 
            @ForeignKey(name = "USER_FK",
                        foreignKeyDefinition = "FOREIGN KEY(user_id) REFERENCES User(id) ON DELETE CASCADE"))
```

While this strategy doesn't require to define dependenies on owning side, it is RDBMS specific, 
another problem is that it won't affect Caches(L2 is a problem here) as all the removal stuff will be performed by the database.
- Use JPA events + `EventService` for removing entities. 
  As `EventService` is synchronous we can publish events and wait while all the notifiers proceed those events. On the other hand we don't use any native queries and always  remove entries using `EntityManager#remove` method, which means that JPA takes care of removal and publishes entity related events. In that case we can connect JPA events and `EventService` events to allow another modules/entities/components to react on the removal. All the database interaction methods are marked with the `@Transactional` annotation which may be nested.
  The example:

```
-> Transaction begins
-> before User#remove() 
       -> @PreRemove(User) event is published by JPA, 
       -> @PreRemove(User) event is handled and `BeforeUserRemoved` event is published to `EventService`
       -> BeforeUserRemoved event is catched by profile subscriber, 
       -> before ProfileDao#remove(profile)
             -> @PreRemove(Profile) event is published
            // ...
       -> ProfileDao#remove(profile) performed
      // ...
-> User#remove() performed
-> Transaction committed/rolled back
```

If any entry removal fails, then transaction will be rolled back and all the data will be in consistent state. 
Another nice thing in this strategy is that we can create application level components which may react on such kind of events and rollback transactions on the application level(which is useful for recipes and stacks their removal will be based on permissions).
It is still possible and preferable to use `orphanRemoval` for those entities which are not root model entities, for instance `Workspace` relies on the `WorkspaceConfig` with `orphanRemoval` attribute.

I implemented the last strategy as it is the most appropriate. Along with that i changed 
current Local dao implementations to  use self monitor for locking, as it allows to extend them with a new functionality which may also be thread-safe as client becomes allowed to use instance locks, this may be needed for migration tools.
### What issues does this PR fix or reference?
#1803
### Previous Behavior

No cascade removals 
### New Behavior

All the entries removed when any of entries which they depend on is removed.
### Tests written?

Yes

@skabashnyuk, @sleshchenko, @akorneta please review
