### PR TITLE
Fix docker_host_ip lookup

### DIFF
--- a/che.sh
+++ b/che.sh
@@ -146,10 +146,17 @@ is_boot2docker() {
 }
 
 get_docker_host_ip() {
-  NETWORK_IF="eth0"
-  if is_boot2docker; then
-    NETWORK_IF="eth1"
-  fi
+  case $(get_docker_install_type) in
+   boot2docker)
+     NETWORK_IF="eth1"
+   ;;
+   native)
+     NETWORK_IF="docker0"
+   ;;
+   *)
+     NETWORK_IF="eth0"
+   ;;
+  esac
 
   docker run --rm --net host \
             alpine sh -c \
@@ -169,7 +176,9 @@ has_docker_for_windows_ip() {
 }
 
 is_moby_vm() {
-  if [ $(docker info | grep "Name:" | cut -d" " -f2) = "moby" ]; then
+  NAME_MAP=$(docker info | grep "Name:" | cut -d" " -f2)
+
+  if [ "${NAME_MAP}" = "*moby*" ]; then
     return 0
   else
     return 1

--- a/dockerfiles/che-launcher/launcher_funcs.sh
+++ b/dockerfiles/che-launcher/launcher_funcs.sh
@@ -110,10 +110,17 @@ get_docker_install_type() {
 }
 
 get_docker_host_ip() {
-  NETWORK_IF="eth0"
-  if is_boot2docker; then
-    NETWORK_IF="eth1"
-  fi
+  case $(get_docker_install_type) in
+   boot2docker)
+     NETWORK_IF="eth1"
+   ;;
+   native)
+     NETWORK_IF="docker0"
+   ;;
+   *)
+     NETWORK_IF="eth0"
+   ;;
+  esac
 
   docker run --rm --net host \
             alpine sh -c \


### PR DESCRIPTION
### What does this PR do?
1. Replaces windows line endings with linux line endings.
2. Updates get_docker_host_ip() function to return docker0 if on native systems.
### What issues does this PR fix or reference?
#2039
### Previous Behavior

On Fedora 24, the lookup method would return an error that eth0 is not discoverable.
