### PR TITLE
Update Vagrantfile to support new docker-launcher

### DIFF
--- a/dockerfiles/che-launcher/launcher_cmds.sh
+++ b/dockerfiles/che-launcher/launcher_cmds.sh
@@ -46,7 +46,7 @@ start_che_server() {
 
   info "ECLIPSE CHE: SERVER LOGS AT \"docker logs -f ${CHE_SERVER_CONTAINER_NAME}\""
   info "ECLIPSE CHE: SERVER BOOTING..."
-  wait_until_server_is_booted 20
+  wait_until_server_is_booted 60
 
   if server_is_booted; then
     info "ECLIPSE CHE: BOOTED AND REACHABLE"


### PR DESCRIPTION
### What does this PR do?

It updates the Vagrantfile in the root of the repository to use the che-launcher capability.  It also uses the che.sh CLI to automate the start and stop of the launcher.
### Previous Behavior

Previously, it would call codenvy/che-server directly and then run a loop to detect boot. This logic is now embedded within the launcher.
1. Added storage-overlay driver.
2. Use che-launcher instead of che-server image launche
3. Use the che.sh CLI to execute the start of the program.
