### PR TITLE
Add support for Git Log API.

### DIFF
--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/DiffCommitFile.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/DiffCommitFile.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.api.git.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Created by I048384 on 24/05/2016.
+ */
+
+@DTO
+public interface DiffCommitFile {
+
+    /** @return the file change type*/
+    String getChangeType();
+
+    /** set the file change type*/
+    void setChangeType(String type);
+
+    /**
+     * Create a DiffCommitFile object based on a given file change type.
+     *
+     * @param type
+     *         file change type
+     * @return a DiffCommitFile object
+     */
+    DiffCommitFile withChangeType(String type);
+
+    /** @return the file previous location*/
+    String getOldPath();
+
+    /** set the file previous location*/
+    void setOldPath(String oldPath);
+
+    /**
+     * Create a DiffCommitFile object based on a given file previous location.
+     *
+     * @param oldPath
+     *         file previous location
+     * @return a DiffCommitFile object
+     */
+    DiffCommitFile withOldPath(String oldPath);
+
+    /** @return the file new location*/
+    String getNewPath();
+
+    /** set the file new location*/
+    void setNewPath(String newPath);
+
+    /**
+     * Create a DiffCommitFile object based on a given file new location.
+     *
+     * @param newPath
+     *         file new location
+     * @return a DiffCommitFile object
+     */
+    DiffCommitFile withNewPath(String newPath);
+}

--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/LogRequest.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/LogRequest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.git.shared;
 
 import java.util.List;
-
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -21,21 +20,96 @@ import org.eclipse.che.dto.shared.DTO;
  */
 @DTO
 public interface LogRequest extends GitRequest {
-    /** Filter revisions list by range of files. */
-    List<String> getFileFilter();
 
-    void setFileFilter(List<String> fileFilter);
-
-    LogRequest withFileFilter(List<String> fileFilter);
-    
     /** @return revision range since */
     String getRevisionRangeSince();
-    /** @return revision range since */
-    String getRevisionRangeUntil();
-    
+
+    /** @set revision range since */
     void setRevisionRangeSince(String revisionRangeSince);
-    void setRevisionRangeUntil(String revisionRangeUntil);	
-    // private List<String> fileFilter;
-    // private boolean noRenames = true;
-    // private int renameLimit;
+
+    /**
+     * Create a LogRequest object based on a given revision range since.
+     *
+     * @param revisionRangeSince
+     *         revision range since
+     * @return a LogRequest object
+     */
+    LogRequest withRevisionRangeSince(String revisionRangeSince);
+
+    /** @return revision range until */
+    String getRevisionRangeUntil();
+
+    /** @set revision range until */
+    void setRevisionRangeUntil(String revisionRangeUntil);
+
+    /**
+     * Create a LogRequest object based on a given revision range until.
+     *
+     * @param revisionRangeUntil
+     *         revision range until
+     * @return a LogRequest object
+     */
+    LogRequest withRevisionRangeUntil(String revisionRangeUntil);
+
+    /** @return the integer value of the number of commits that will be skipped when calling log API */
+    int getSkip();
+
+    /**  set the integer value of the number of commits that will be skipped when calling log API */
+    void setSkip(int skip);
+
+    /**
+     * Create a LogRequest object based on a given integer value of the number of commits that
+     * will be skipped when calling log API
+     *
+     * @param skip
+     *         integer value of the number of commits that will be skipped when calling log API
+     * @return a LogRequest object
+     */
+    LogRequest withSkip(int skip);
+
+    /** @return the integer value of the number of commits that will be returned when calling log API */
+    int getMaxCount();
+
+    /**  set the integer value of the number of commits that will be returned when calling log API */
+    void setMaxCount(int maxCount);
+
+    /**
+     * Create a LogRequest object based on a given integer value of the number of commits that
+     * will be returned when calling log API
+     *
+     * @param maxCount
+     *         integer value of the number of commits that will be returned when calling log API
+     * @return a LogRequest object
+     */
+    LogRequest withMaxCount(int maxCount);
+
+    /** @return the file/folder path used when calling the log API */
+    String getFilePath();
+
+    /** set the file/folder path used when calling the log API */
+    void setFilePath(String filePath);
+
+    /**
+     * Create a LogRequest object based on a given file/folder path used when calling the log API
+     *
+     * @param filePath
+     *         file/folder path used when calling the log API
+     * @return a LogRequest object
+     */
+    LogRequest withFilePath(String filePath);
+
+    /** @return Filter revisions list by range of files. */
+    List<String> getFileFilter();
+
+    /** @set range of files */
+    void setFileFilter(List<String> fileFilter);
+
+    /**
+     * Create a LogRequest object based on a given range of files
+     *
+     * @param fileFilter
+     *         range of files
+     * @return a LogRequest object
+     */
+    LogRequest withFileFilter(List<String> fileFilter);
 }

--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Revision.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Revision.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.git.shared;
 
+import java.util.List;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -20,34 +21,148 @@ import org.eclipse.che.dto.shared.DTO;
 @DTO
 public interface Revision {
 
+    /**
+     * Parameter which shows that this revision is a fake revision (i.e. TO for Exception)
+     *
+     * @return boolean
+     */
+    boolean isFake();
+
+    /** @set boolean value which represents whether this revision is a fake revision*/
+    void setFake(boolean fake);
+
     /** @return branch name */
     String getBranch();
-    
+
+    /** @set branch name*/
     void setBranch(String branch);
-    
+
+    /**
+     * Create a Revision object based on a given branch name.
+     *
+     * @param branch
+     *         rbranch name
+     * @return a Revision object
+     */
     Revision withBranch(String branch);
 
     /** @return commit id */
     String getId();
-    
+
+    /** @set commit id*/
     void setId(String id);
-    
+
+    /**
+     * Create a Revision object based on a given commit id.
+     *
+     * @param id
+     *         commit id
+     * @return a Revision object
+     */
     Revision withId(String id);
 
     /** @return commit message */
     String getMessage();
-    
+
+    /** @set commit message*/
     void setMessage(String message);
-    
+
+    /**
+     * Create a Revision object based on a given commit message.
+     *
+     * @param message
+     *         commit message
+     * @return a Revision object
+     */
     Revision withMessage(String message);
 
     /** @return time of commit */
     long getCommitTime();
-    
+
+    /** @set commit time*/
+    void setCommitTime(long time);
+
+    /**
+     * Create a Revision object based on a given commit time.
+     *
+     * @param time
+     *         commit time
+     * @return a Revision object
+     */
     Revision withCommitTime(long time);
 
-    /** @return committer */
+    /** @return GitUser object which represents the commit committer */
     GitUser getCommitter();
-    
-    Revision withCommitter(GitUser user);
+
+    /** @set GitUser object which represents the commit committer*/
+    void setCommitter(GitUser committer);
+
+    /**
+     * Create a Revision object based on a given GitUser object which represents the commit committer
+     *
+     * @param committer
+     *         GitUser object which represents the commit committer
+     * @return a Revision object
+     */
+    Revision withCommitter(GitUser committer);
+
+    /** @return commit author */
+    GitUser getAuthor();
+
+    /** @set GitUser object which represents the commit author*/
+    void setAuthor(GitUser author);
+
+    /**
+     * Create a Revision object based on a given GitUser object which represents the commit author
+     *
+     * @param author
+     *         GitUser object which represents the commit author
+     * @return a Revision object
+     */
+    Revision withAuthor(GitUser author);
+
+    /** @return commit branches */
+    List<Branch> getBranches();
+
+    /** @set commit branches */
+    void setBranches(List<Branch> branches);
+
+    /**
+     * Create a Revision object based on a given list of commit branches
+     *
+     * @param branches
+     *         a list of commit branches
+     * @return a Revision object
+     */
+    Revision withBranches(List<Branch> branches);
+
+    /** @return diff commit files */
+    List<DiffCommitFile> getDiffCommitFile();
+
+    /** @set diff commit files */
+    void setDiffCommitFile(List<DiffCommitFile> v);
+
+    /**
+     * Create a Revision object based on a given list of diff commit files
+     *
+     * @param diffCommitFiles
+     *         a list of diff commit files
+     * @return a Revision object
+     */
+    Revision withDiffCommitFile(List<DiffCommitFile> diffCommitFiles);
+
+    /** @return commit parents */
+    List<String> getCommitParent();
+
+    /** @set commit parents */
+    void setCommitParent(List<String> commitParents);
+
+    /**
+     * Create a Revision object based on a given list of commit parents
+     *
+     * @param commitParents
+     *         a list of commit parents
+     * @return a Revision object
+     */
+    Revision withCommitParent(List<String> commitParents);
 }


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

This content may also be included in the release notes.
### Tests written?

Yes/No
### Docs requirements?

Include the content for all the docs changes required. 
1.  API changes  
2.  User docs changes  

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Add support for skip and maxCount when calling the LOG API.
Add support to get the log for a specific folder or file in the repository.
For every commit that is returned when calling the LOG API, the following data was added:
The author of the commit
A list of branch names that the commit is related to.
A list of file names that were changed/deleted/added in the commit.
A list of commit parents (to enable for example clients to paint a graph)

Change-Id: I8500f5ae9e0e6189882c4ed1083a3c96861b3194
Signed-off-by: Shimon Ben.Yair shimon.ben.yair@sap.com
