### PR TITLE
Add support for Git Log API.

### DIFF
--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/DiffCommitFile.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/DiffCommitFile.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.git.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Describes the changes of the committed file.
+ *
+ * @author Shimon Ben Yair.
+ */
+@DTO
+public interface DiffCommitFile {
+
+    /** Returns the file change type. */
+    String getChangeType();
+
+    /** Set the file change type. */
+    void setChangeType(String type);
+
+    /**
+     * Create a {@link DiffCommitFile} object based on a given file change type.
+     *
+     * @param type
+     *         file change type
+     * @return a {@link DiffCommitFile} object that contains information about changes of the committed file
+     */
+    DiffCommitFile withChangeType(String type);
+
+    /** Returns the file previous location. */
+    String getOldPath();
+
+    /** Set the file previous location. */
+    void setOldPath(String oldPath);
+
+    /**
+     * Create a {@link DiffCommitFile} object based on a given file previous location.
+     *
+     * @param oldPath
+     *         file previous location
+     * @return a {@link DiffCommitFile} object that contains information about changes of the committed file
+     */
+    DiffCommitFile withOldPath(String oldPath);
+
+    /** Returns the file new location. */
+    String getNewPath();
+
+    /** Set the file new location. */
+    void setNewPath(String newPath);
+
+    /**
+     * Create a {@link DiffCommitFile} object based on a given file new location.
+     *
+     * @param newPath
+     *         file new location
+     * @return a {@link DiffCommitFile} object that contains information about changes of the committed file
+     */
+    DiffCommitFile withNewPath(String newPath);
+}

--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/LogRequest.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/LogRequest.java
@@ -21,21 +21,90 @@ import org.eclipse.che.dto.shared.DTO;
  */
 @DTO
 public interface LogRequest extends GitRequest {
-    /** Filter revisions list by range of files. */
+
+    /** Returns the revision range since. */
+    String getRevisionRangeSince();
+
+    /** Set revision range since. */
+    void setRevisionRangeSince(String revisionRangeSince);
+
+    /**
+     * Create a {@link LogRequest} object based on a given revision range since.
+     *
+     * @param revisionRangeSince
+     *         revision range since
+     */
+    LogRequest withRevisionRangeSince(String revisionRangeSince);
+
+    /** Returns the revision range until. */
+    String getRevisionRangeUntil();
+
+    /** Set revision range until. */
+    void setRevisionRangeUntil(String revisionRangeUntil);
+
+    /**
+     * Create a {@link LogRequest} object based on a given revision range until.
+     *
+     * @param revisionRangeUntil
+     *         revision range until
+     */
+    LogRequest withRevisionRangeUntil(String revisionRangeUntil);
+
+    /** Returns the integer value of the number of commits that will be skipped when calling log command. */
+    Integer getSkip();
+
+    /**  Set the integer value of the number of commits that will be skipped when calling log command. */
+    void setSkip(Integer skip);
+
+    /**
+     * Create a {@link LogRequest} object based on a given integer value of the number of commits that
+     * will be skipped when calling log command
+     *
+     * @param skip
+     *         integer value of the number of commits that will be skipped when calling log command
+     */
+    LogRequest withSkip(Integer skip);
+
+    /** Returns the integer value of the number of commits that will be returned when calling log command. */
+    Integer getMaxCount();
+
+    /**  Set the integer value of the number of commits that will be returned when calling log command. */
+    void setMaxCount(Integer maxCount);
+
+    /**
+     * Create a {@link LogRequest} object based on a given integer value of the number of commits that
+     * will be returned when calling log command
+     *
+     * @param maxCount
+     *         integer value of the number of commits that will be returned when calling log command
+     */
+    LogRequest withMaxCount(Integer maxCount);
+
+    /** Returns the file/folder path used when calling the log command. */
+    String getFilePath();
+
+    /** Set the file/folder path used when calling the log command. */
+    void setFilePath(String filePath);
+
+    /**
+     * Create a {@link LogRequest} object based on a given file/folder path used when calling the log command
+     *
+     * @param filePath
+     *         file/folder path used when calling the log command
+     */
+    LogRequest withFilePath(String filePath);
+
+    /** Returns the Filter revisions list by range of files. */
     List<String> getFileFilter();
 
+    /** Set range of files. */
     void setFileFilter(List<String> fileFilter);
 
+    /**
+     * Create a {@link LogRequest} object based on a given range of files
+     *
+     * @param fileFilter
+     *         range of files
+     */
     LogRequest withFileFilter(List<String> fileFilter);
-    
-    /** @return revision range since */
-    String getRevisionRangeSince();
-    /** @return revision range since */
-    String getRevisionRangeUntil();
-    
-    void setRevisionRangeSince(String revisionRangeSince);
-    void setRevisionRangeUntil(String revisionRangeUntil);	
-    // private List<String> fileFilter;
-    // private boolean noRenames = true;
-    // private int renameLimit;
 }

--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Revision.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Revision.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.git.shared;
 
+import java.util.List;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -20,34 +21,144 @@ import org.eclipse.che.dto.shared.DTO;
 @DTO
 public interface Revision {
 
-    /** @return branch name */
+    /**  Parameter which shows that this revision is a fake revision (i.e. TO for Exception). */
+    boolean isFake();
+
+    /** Represents whether this revision is a fake revision. */
+    void setFake(boolean fake);
+
+    /** Returns the branch name from witch this commit was performed. */
     String getBranch();
-    
+
+    /** Set branch name from witch this commit was performed */
     void setBranch(String branch);
-    
+
+    /**
+     * Create a {@link Revision} object based on a given branch name.
+     *
+     * @param branch
+     *         branch name
+     * @return a {@link Revision} object that contains information about revision
+     */
     Revision withBranch(String branch);
 
-    /** @return commit id */
+    /** Returns the commit id. */
     String getId();
-    
+
+    /** Set commit id. */
     void setId(String id);
-    
+
+    /**
+     * Create a {@link Revision} object based on a given commit id.
+     *
+     * @param id
+     *         commit id
+     * @return a {@link Revision} object that contains information about revision
+     */
     Revision withId(String id);
 
-    /** @return commit message */
+    /** Returns the commit message. */
     String getMessage();
-    
+
+    /** Set commit message. */
     void setMessage(String message);
-    
+
+    /**
+     * Create a {@link Revision} object based on a given commit message.
+     *
+     * @param message
+     *         commit message
+     * @return a {@link Revision} object that contains information about revision
+     */
     Revision withMessage(String message);
 
-    /** @return time of commit */
+    /** Returns the commit time. */
     long getCommitTime();
-    
+
+    /** Set commit time. */
+    void setCommitTime(long time);
+
+    /**
+     * Create a {@link Revision} object based on a given commit time.
+     *
+     * @param time
+     *         commit time
+     * @return a {@link Revision} object that contains information about revision
+     */
     Revision withCommitTime(long time);
 
-    /** @return committer */
+    /** Returns the GitUser object which represents the committer. */
     GitUser getCommitter();
-    
-    Revision withCommitter(GitUser user);
+
+    /** Set GitUser object which represents the committer. */
+    void setCommitter(GitUser committer);
+
+    /**
+     * Create a {@link Revision} object based on a given GitUser object which represents the committer
+     *
+     * @param committer
+     *         GitUser object which represents the committer
+     * @return a {@link Revision} object that contains information about revision
+     */
+    Revision withCommitter(GitUser committer);
+
+    /** Returns the commit author. */
+    GitUser getAuthor();
+
+    /** Set GitUser object which represents the commit author. */
+    void setAuthor(GitUser author);
+
+    /**
+     * Create a {@link Revision} object based on a given GitUser object which represents the commit author
+     *
+     * @param author
+     *         GitUser object which represents the commit author
+     * @return a {@link Revision} object that contains information about revision
+     */
+    Revision withAuthor(GitUser author);
+
+    /** Returns the branches where this commit is present.  */
+    List<Branch> getBranches();
+
+    /** Set branches where this commit is present. */
+    void setBranches(List<Branch> branches);
+
+    /**
+     * Create a {@link Revision} object based on a given list of branches where this commit is present
+     *
+     * @param branches
+     *         a list of branches where this commit is present
+     * @return a {@link Revision} object that contains information about revision
+     */
+    Revision withBranches(List<Branch> branches);
+
+    /** Returns a list of DiffCommitFile objects, which describes the changes in the commit files. */
+    List<DiffCommitFile> getDiffCommitFile();
+
+    /** Set a list of DiffCommitFile objects, which describes the changes in the commit files. */
+    void setDiffCommitFile(List<DiffCommitFile> diffCommitFiles);
+
+    /**
+     * Create a {@link Revision} object based on a given list of DiffCommitFile objects, which describes the changes in the commit files
+     *
+     * @param diffCommitFiles
+     *         a list of DiffCommitFile objects, which describes the changes in the commit files
+     * @return a {@link Revision} object that contains information about revision
+     */
+    Revision withDiffCommitFile(List<DiffCommitFile> diffCommitFiles);
+
+    /** Returns the commit parents. */
+    List<String> getCommitParent();
+
+    /** Set the commit parents. */
+    void setCommitParent(List<String> commitParents);
+
+    /**
+     * Create a {@link Revision} object based on a given list of commit parents
+     *
+     * @param commitParents
+     *         a list of commit parents
+     * @return a {@link Revision} object that contains information about revision
+     */
+    Revision withCommitParent(List<String> commitParents);
 }

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -47,6 +47,7 @@ import org.eclipse.che.api.git.shared.BranchListRequest;
 import org.eclipse.che.api.git.shared.CheckoutRequest;
 import org.eclipse.che.api.git.shared.CloneRequest;
 import org.eclipse.che.api.git.shared.CommitRequest;
+import org.eclipse.che.api.git.shared.DiffCommitFile;
 import org.eclipse.che.api.git.shared.DiffRequest;
 import org.eclipse.che.api.git.shared.FetchRequest;
 import org.eclipse.che.api.git.shared.GitUser;
@@ -84,6 +85,7 @@ import org.eclipse.che.api.git.shared.TagListRequest;
 import org.eclipse.che.api.git.shared.GitRequest;
 import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
 import org.eclipse.che.commons.proxy.ProxyAuthenticator;
+import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CheckoutCommand;
 import org.eclipse.jgit.api.CloneCommand;
@@ -111,6 +113,8 @@ import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.api.errors.DetachedHeadException;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.dircache.DirCache;
 import org.eclipse.jgit.lib.BatchingProgressMonitor;
 import org.eclipse.jgit.lib.ConfigConstants;
@@ -143,10 +147,16 @@ import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.TrackingRefUpdate;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.EmptyTreeIterator;
 import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
+import org.eclipse.jgit.treewalk.filter.PathFilterGroup;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
 import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.FileUtils;
+import org.eclipse.jgit.util.io.NullOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +182,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
@@ -591,9 +602,8 @@ class JGitConnection implements GitConnection {
                                                   .setAmend(request.isAmend());
 
             // Check if repository is configured with Gerrit Support
-            String gerritSupportConfigValue = repository.getConfig().getString(
-                    ConfigConstants.CONFIG_GERRIT_SECTION, null,
-                    ConfigConstants.CONFIG_KEY_CREATECHANGEID);
+            String gerritSupportConfigValue = repository.getConfig().getString(ConfigConstants.CONFIG_GERRIT_SECTION, null,
+                                                                               ConfigConstants.CONFIG_KEY_CREATECHANGEID);
             boolean isGerritSupportConfigured = gerritSupportConfigValue != null ? Boolean.valueOf(gerritSupportConfigValue) : false;
             commitCommand.setInsertChangeId(isGerritSupportConfigured);
             RevCommit result = commitCommand.call();
@@ -731,28 +741,26 @@ class JGitConnection implements GitConnection {
         }
     }
 
+    /** @see org.eclipse.che.api.git.GitConnection#log(org.eclipse.che.api.git.shared.LogRequest) */
     @Override
-    public LogPage log(LogRequest request) throws GitException {
+    public LogPage log(LogRequest logRequest) throws GitException {
         LogCommand logCommand = getGit().log();
+        String filePath = null;
         try {
-            setRevisionRange(logCommand, request);
-
-            request.getFileFilter().forEach(logCommand::addPath);
-
+            setRevisionRange(logCommand, logRequest);
+            setPaging(logCommand, logRequest);
+            if (logRequest != null) {
+                logRequest.getFileFilter().forEach(logCommand::addPath);
+                filePath = logRequest.getFilePath();
+                if (!isNullOrEmpty(filePath)) {
+                    logCommand.addPath(filePath);
+                }
+            }
             Iterator<RevCommit> revIterator = logCommand.call().iterator();
             List<Revision> commits = new ArrayList<>();
-
             while (revIterator.hasNext()) {
                 RevCommit commit = revIterator.next();
-                PersonIdent committerIdentity = commit.getCommitterIdent();
-
-                GitUser gitUser = newDto(GitUser.class).withName(committerIdentity.getName())
-                                                       .withEmail(committerIdentity.getEmailAddress());
-
-                Revision revision = newDto(Revision.class).withId(commit.getId().getName())
-                                                          .withMessage(commit.getFullMessage())
-                                                          .withCommitTime(MILLISECONDS.convert(commit.getCommitTime(), SECONDS))
-                                                          .withCommitter(gitUser);
+                Revision revision = getRevision(commit, filePath);
                 commits.add(revision);
             }
             return new LogPage(commits);
@@ -760,19 +768,124 @@ class JGitConnection implements GitConnection {
             String errorMessage = exception.getMessage();
             if (ERROR_LOG_NO_HEAD_EXISTS.equals(errorMessage)) {
                 throw new GitException(errorMessage, ErrorCodes.INIT_COMMIT_WAS_NOT_PERFORMED);
+            } else {
+                LOG.error("Failed to retrieve log. ", exception);
+                throw new GitException(exception);
             }
-            throw new GitException(errorMessage, exception);
         }
     }
 
-    private void setRevisionRange(LogCommand logCommand, LogRequest request) throws IOException {
-        if (request != null) {
-            String revisionRangeSince = request.getRevisionRangeSince();
-            String revisionRangeUntil = request.getRevisionRangeUntil();
+    private Revision getRevision(RevCommit commit, String filePath) throws GitAPIException, IOException {
+        List<String> commitParentsList = Stream.of(commit.getParents())
+                                               .map(RevCommit::getName)
+                                               .collect(Collectors.toList());
+
+        return newDto(Revision.class).withId(commit.getId().getName())
+                                     .withMessage(commit.getFullMessage())
+                                     .withCommitTime((long) commit.getCommitTime() * 1000)
+                                     .withCommitter(getCommitCommitter(commit))
+                                     .withAuthor(getCommitAuthor(commit))
+                                     .withBranches(getBranchesOfCommit(commit, ListMode.ALL))
+                                     .withCommitParent(commitParentsList)
+                                     .withDiffCommitFile(getCommitDiffFiles(commit, filePath));
+    }
+
+    private GitUser getCommitCommitter(RevCommit commit) {
+        PersonIdent committerIdentity = commit.getCommitterIdent();
+        return newDto(GitUser.class).withName(committerIdentity.getName())
+                                    .withEmail(committerIdentity.getEmailAddress());
+    }
+
+    private GitUser getCommitAuthor(RevCommit commit) {
+        PersonIdent authorIdentity = commit.getAuthorIdent();
+        return newDto(GitUser.class).withName(authorIdentity.getName())
+                                    .withEmail(authorIdentity.getEmailAddress());
+    }
+
+    private List<Branch>  getBranchesOfCommit(RevCommit commit, ListMode mode) throws GitAPIException {
+        List<Ref> branches = getGit().branchList()
+                                     .setListMode(mode)
+                                     .setContains(commit.getName())
+                                     .call();
+        return branches.stream()
+                       .map(branch -> newDto(Branch.class).withName(branch.getName()))
+                       .collect(Collectors.toList());
+    }
+
+    private List<DiffCommitFile> getCommitDiffFiles(RevCommit revCommit, String pattern) throws IOException {
+        List<DiffEntry> diffs;
+        TreeFilter filter = null;
+        if (!isNullOrEmpty(pattern)) {
+            filter = AndTreeFilter.create(PathFilterGroup.createFromStrings(Collections.singleton(pattern)), TreeFilter.ANY_DIFF);
+        }
+        List<DiffCommitFile> commitFilesList = new ArrayList<>();
+        try (TreeWalk tw = new TreeWalk(repository)){
+            tw.setRecursive(true);
+            // get the current commit parent in order to compare it with the current commit
+            // and to get the list of DiffEntry.
+            if (revCommit.getParentCount() > 0) {
+                RevCommit parent = parseCommit(revCommit.getParent(0));
+                tw.reset(parent.getTree(), revCommit.getTree());
+                if (filter != null) {
+                    tw.setFilter(filter);
+                } else {
+                    tw.setFilter(TreeFilter.ANY_DIFF);
+                }
+                diffs = DiffEntry.scan(tw);
+            } else {
+                // If the current commit has no parents (which means it is the initial commit),
+                // then create an empty tree and compare it to the current commit to get the
+                // list of DiffEntry.
+                try (RevWalk rw = new RevWalk(repository);
+                     DiffFormatter diffFormat = new DiffFormatter(NullOutputStream.INSTANCE)) {
+                    diffFormat.setRepository(repository);
+                    if (filter != null) {
+                        diffFormat.setPathFilter(filter);
+                    }
+                    diffs = diffFormat.scan(new EmptyTreeIterator(), new CanonicalTreeParser(null, rw.getObjectReader(), revCommit.getTree()));
+                }
+            }
+        }
+        if (diffs != null) {
+            commitFilesList.addAll(diffs.stream().map(diff -> newDto(DiffCommitFile.class).withOldPath(diff.getOldPath())
+                                                                                          .withNewPath(diff.getNewPath())
+                                                                                          .withChangeType(diff.getChangeType().name()))
+                                                 .collect(Collectors.toList()));
+        }
+        return commitFilesList;
+    }
+
+    private RevCommit parseCommit(RevCommit revCommit) {
+        try (RevWalk rw = new RevWalk(repository)) {
+            return rw.parseCommit(revCommit);
+        } catch (IOException exception) {
+            LOG.error("Failed to parse commit. ", exception);
+            return revCommit;
+        }
+    }
+
+
+    private void setRevisionRange(LogCommand logCommand, LogRequest logRequest) throws IOException {
+        if (logRequest != null && logCommand != null) {
+            String revisionRangeSince = logRequest.getRevisionRangeSince();
+            String revisionRangeUntil = logRequest.getRevisionRangeUntil();
             if (revisionRangeSince != null && revisionRangeUntil != null) {
                 ObjectId since = repository.resolve(revisionRangeSince);
                 ObjectId until = repository.resolve(revisionRangeUntil);
                 logCommand.addRange(since, until);
+            }
+        }
+    }
+
+    private void setPaging(LogCommand logCommand, LogRequest logRequest) {
+        if (logCommand != null && logRequest != null) {
+            Integer skip = logRequest.getSkip();
+            if (skip != null && skip.intValue() >= 0) {
+                logCommand.setSkip(skip.intValue());
+            }
+            Integer maxCount = logRequest.getMaxCount();
+            if (maxCount != null && maxCount.intValue() >= 0) {
+                logCommand.setMaxCount(maxCount.intValue());
             }
         }
     }
@@ -793,7 +906,6 @@ class JGitConnection implements GitConnection {
         } catch (GitAPIException exception) {
             throw new GitException(exception.getMessage(), exception);
         }
-
         return gitUsers;
     }
 


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

This content may also be included in the release notes.
### Tests written?

Yes/No
### Docs requirements?

Include the content for all the docs changes required. 
1.  API changes  
2.  User docs changes  

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Add support for skip and maxCount when calling the LOG API.
Add support to get the log for a specific folder or file in the repository.
For every commit that is returned when calling the LOG API, the following data was added:
The author of the commit
A list of branch names that the commit is related to.
A list of file names that were changed/deleted/added in the commit.
A list of commit parents (to enable for example clients to paint a graph)

Signed-off-by: Shimon Ben.Yair shimon.ben.yair@sap.com
