### PR TITLE
CHE-1964: add libraries from containers for building classpath

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/ClasspathContainer.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/ClasspathContainer.java
@@ -31,6 +31,8 @@ import java.util.Map;
  */
 @Singleton
 public class ClasspathContainer implements ClasspathChangedEvent.ClasspathChangedHandler {
+    public static String JRE_CONTAINER = "org.eclipse.jdt.launching.JRE_CONTAINER";
+
     private final ClasspathServiceClient classpathServiceClient;
 
     private Map<String, Promise<List<ClasspathEntryDto>>> classpathes;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/ClasspathProvider.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/ClasspathProvider.java
@@ -30,6 +30,9 @@ import org.eclipse.che.ide.extension.machine.client.command.valueproviders.Comma
 import java.util.List;
 import java.util.Set;
 
+import static org.eclipse.che.ide.ext.java.client.command.ClasspathContainer.JRE_CONTAINER;
+import static org.eclipse.che.ide.ext.java.shared.ClasspathEntryKind.LIBRARY;
+
 /**
  * Provides project's classpath.
  *
@@ -88,6 +91,12 @@ public class ClasspathProvider implements CommandPropertyValueProvider {
                     classpath.append(lib).append(':');
                 }
 
+                for (ClasspathEntryDto container : classpathResolver.getContainers()) {
+                    if (!JRE_CONTAINER.equals(container.getPath())) {
+                        addLibsFromContainer(container, classpath);
+                    }
+                }
+
                 if (classpath.toString().isEmpty()) {
                     classpath.append(appContext.getProjectsRoot().toString()).append(projectPath).append(':');
                 }
@@ -95,6 +104,14 @@ public class ClasspathProvider implements CommandPropertyValueProvider {
                 return classpath.toString();
             }
         });
+    }
+
+    private void addLibsFromContainer(ClasspathEntryDto container, StringBuilder classpath) {
+        for (ClasspathEntryDto entry : container.getExpandedEntries()) {
+            if (LIBRARY == entry.getEntryKind()) {
+                classpath.append(entry.getPath()).append(':');
+            }
+        }
     }
 
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/preview/PreviewViewImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/preview/PreviewViewImpl.java
@@ -227,6 +227,8 @@ final class PreviewViewImpl extends Window implements PreviewView {
 
         root.setWidget(element);
 
+        element.getElement().getParentElement().getStyle().setMargin(1, PX);
+
         itemCheckBox.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
             @Override
             public void onValueChange(ValueChangeEvent<Boolean> event) {

--- a/plugins/plugin-ssh-key/che-plugin-ssh-key-ide/pom.xml
+++ b/plugins/plugin-ssh-key/che-plugin-ssh-key-ide/pom.xml
@@ -29,10 +29,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.gwt.inject</groupId>
             <artifactId>gin</artifactId>
         </dependency>


### PR DESCRIPTION
### What does this PR do?

Adds libraries from java containers to classpath
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1964
### Previous Behavior

Classpath contains only external jars
### New Behavior

Classpath contains only external jars, and jars from containers (for example from MAVEN_CLASSPATH_CONTAINER)
### Tests written?

Yes

Please review @dkuleshov
