### PR TITLE
CODENVY-453: Add snippet of dynamic passwords support in docker registries

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolver.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolver.java
@@ -42,11 +42,14 @@ public class DockerRegistryAuthResolver {
 
     public static final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
 
-    private final InitialAuthConfig initialAuthConfig;
+    private final InitialAuthConfig                 initialAuthConfig;
+    private final DockerRegistryDynamicAuthResolver dynamicAuthResolver;
 
     @Inject
-    public DockerRegistryAuthResolver(InitialAuthConfig initialAuthConfig) {
+    public DockerRegistryAuthResolver(InitialAuthConfig initialAuthConfig,
+                                      DockerRegistryDynamicAuthResolver dynamicAuthResolver) {
         this.initialAuthConfig = initialAuthConfig;
+        this.dynamicAuthResolver = dynamicAuthResolver;
     }
 
     /**
@@ -69,6 +72,9 @@ public class DockerRegistryAuthResolver {
         }
         if (authConfig == null) {
             authConfig = normalizeDockerHubRegistryUrl(initialAuthConfig.getAuthConfigs().getConfigs()).get(normalizedRegistry);
+        }
+        if (authConfig == null) {
+            authConfig = dynamicAuthResolver.getXRegistryAuth(registry);
         }
 
         String authConfigJson;
@@ -97,8 +103,9 @@ public class DockerRegistryAuthResolver {
         if (paramAuthConfigs != null && paramAuthConfigs.getConfigs() != null) {
             authConfigs.putAll(paramAuthConfigs.getConfigs());
         }
+        authConfigs.putAll(dynamicAuthResolver.getXRegistryConfig());
 
-       authConfigs = normalizeDockerHubRegistryUrl(authConfigs);
+        authConfigs = normalizeDockerHubRegistryUrl(authConfigs);
 
         return Base64.getEncoder().encodeToString(JsonHelper.toJson(authConfigs).getBytes());
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryDynamicAuthResolver.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryDynamicAuthResolver.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client;
+
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.plugin.docker.client.dto.AuthConfig;
+
+import java.util.Map;
+
+/**
+ * Resolves dynamic auth config for docker registries.
+ *
+ * @author Mykola Morhun
+ */
+public interface DockerRegistryDynamicAuthResolver {
+    /**
+     * Retrieves actual auth data for given registry.
+     * If no credential found for given registry null will be returned.
+     *
+     * @param registry
+     *         registry to which
+     * @return dynamic auth data for specified registry or null if no credential found
+     */
+    @Nullable
+    AuthConfig getXRegistryAuth(@Nullable String registry);
+
+    /**
+     * Retrieves all actual auth configs for all configured registries with dynamic auth credentials.
+     * If no registries with dynamic auth credentials found, empty map will be returned.
+     *
+     * @return all dynamic auth configs or empty map if no credentials found
+     */
+    Map<String, AuthConfig> getXRegistryConfig();
+
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/NoOpDockerRegistryDynamicAuthResolverImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/NoOpDockerRegistryDynamicAuthResolverImpl.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client;
+
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.plugin.docker.client.dto.AuthConfig;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Mykola Morhun
+ */
+public class NoOpDockerRegistryDynamicAuthResolverImpl implements DockerRegistryDynamicAuthResolver {
+    @Override
+    @Nullable
+    public AuthConfig getXRegistryAuth(@Nullable String registry) {
+        return null;
+    }
+
+    @Override
+    public Map<String, AuthConfig> getXRegistryConfig() {
+        return Collections.emptyMap();
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
@@ -49,6 +49,8 @@ public class LocalDockerModule extends AbstractModule {
         bind(org.eclipse.che.plugin.docker.machine.node.WorkspaceFolderPathProvider.class)
                 .to(org.eclipse.che.plugin.docker.machine.local.node.provider.LocalWorkspaceFolderPathProvider.class);
 
+        bind(org.eclipse.che.plugin.docker.client.DockerRegistryDynamicAuthResolver.class)
+                .to(org.eclipse.che.plugin.docker.client.NoOpDockerRegistryDynamicAuthResolverImpl.class);
         bind(org.eclipse.che.plugin.docker.client.DockerRegistryChecker.class).asEagerSingleton();
 
         Multibinder<String> devMachineEnvVars = Multibinder.newSetBinder(binder(),

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/integration/DockerProcessTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/integration/DockerProcessTest.java
@@ -54,7 +54,7 @@ public class DockerProcessTest {
                                                                         new DefaultNetworkFinder());
         docker = new DockerConnector(dockerConnectorConfiguration,
                                      new DockerConnectionFactory(dockerConnectorConfiguration),
-                                     new DockerRegistryAuthResolver(null),
+                                     new DockerRegistryAuthResolver(null, null),
                                      new DockerApiVersionPathPrefixProvider("1.18"));
 
         final ContainerCreated containerCreated = docker.createContainer(
@@ -93,7 +93,7 @@ public class DockerProcessTest {
                                                                             new DefaultNetworkFinder());
             docker = new DockerConnector(dockerConnectorConfiguration,
                                          new DockerConnectionFactory(dockerConnectorConfiguration),
-                                         new DockerRegistryAuthResolver(null),
+                                         new DockerRegistryAuthResolver(null, null),
                                          new DockerApiVersionPathPrefixProvider(""));
         }
         Command command = new CommandImpl("tailf", "tail -f /dev/null", "mvn");


### PR DESCRIPTION
### What does this PR do?

This PR adds ability to support docker registries with dynamic passwords.
Registry with dynamic password means, that registry changes its password every x hours. So, in this case, we need to retrieve current password using special auth token or etc. 
This PR doesn't add any specific registry with dynamic password. It adds code snippet with NoOp implementation, which returns to Auth Resolver no auth config for any registry. Support for a registry with dynamic password can be added by implementing `DockerRegistryDynamicAuthResolver` interface.
### Tests written?

Yes
