### PR TITLE
CHE-476: Add new methods to GitUrlUtils

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.che.git.impl.jgit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.jcraft.jsch.JSch;
@@ -229,6 +230,8 @@ class JGitConnection implements GitConnection {
 
     private static final String MESSAGE_COMMIT_NOT_POSSIBLE       = "Commit is not possible because repository state is '%s'";
     private static final String MESSAGE_COMMIT_AMEND_NOT_POSSIBLE = "Amend is not possible because repository state is '%s'";
+
+    private static final Pattern GIT_URL_WITH_CREDENTIALS_PATTERN = Pattern.compile("https?://[^:]+:.+@.*");
 
     private static final Logger LOG = LoggerFactory.getLogger(JGitConnection.class);
 
@@ -1566,7 +1569,8 @@ class JGitConnection implements GitConnection {
      * @throws GitAPIException
      * @throws UnauthorizedException
      */
-    private Object executeRemoteCommand(String remoteUrl, TransportCommand command)
+    @VisibleForTesting
+    Object executeRemoteCommand(String remoteUrl, TransportCommand command)
             throws GitException, GitAPIException, UnauthorizedException {
         File keyDirectory = null;
         UserCredential credentials = null;
@@ -1589,18 +1593,19 @@ class JGitConnection implements GitConnection {
                         return jsch;
                     }
                 };
-                command.setTransportConfigCallback(new TransportConfigCallback() {
-                    @Override
-                    public void configure(Transport transport) {
-                        SshTransport sshTransport = (SshTransport)transport;
-                        sshTransport.setSshSessionFactory(sshSessionFactory);
-                    }
+                command.setTransportConfigCallback(transport -> {
+                    SshTransport sshTransport = (SshTransport)transport;
+                    sshTransport.setSshSessionFactory(sshSessionFactory);
                 });
             } else {
                 credentials = credentialsLoader.getUserCredential(remoteUrl);
                 if (credentials != null) {
                     command.setCredentialsProvider(new UsernamePasswordCredentialsProvider(credentials.getUserName(),
                                                                                            credentials.getPassword()));
+                } else if (remoteUrl != null && GIT_URL_WITH_CREDENTIALS_PATTERN.matcher(remoteUrl).matches()) {
+                    String username = remoteUrl.substring(remoteUrl.indexOf("://") + 3, remoteUrl.lastIndexOf(":"));
+                    String password = remoteUrl.substring(remoteUrl.lastIndexOf(":") + 1, remoteUrl.indexOf("@"));
+                    command.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, password));
                 }
             }
 

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.git.impl.jgit;
+
+import org.eclipse.che.api.git.CredentialsLoader;
+import org.eclipse.che.api.git.GitUserResolver;
+import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
+import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Test class for {@link JGitConnection}
+ *
+ * @author Igor Vinokur
+ */
+@Listeners(value = {MockitoTestNGListener.class})
+public class JGitConnectionTest {
+
+    @Mock
+    Repository repository;
+    @Mock
+    CredentialsLoader credentialsLoader;
+    @Mock
+    SshKeyProvider sshKeyProvider;
+    @Mock
+    GitUserResolver gitUserResolver;
+
+    @InjectMocks
+    JGitConnection jGitConnection;
+
+    @DataProvider(name = "gitUrlsWithCredentialsProvider")
+    public static Object[][] gitUrlsWithCredentials() {
+        return new Object[][]{{"http://username:password@host.xz/path/to/repo.git"},
+                              {"https://username:password@host.xz/path/to/repo.git"}};
+    }
+
+    @Test(dataProvider = "gitUrlsWithCredentials")
+    public void shouldExecuteRemoteCommandByHttpOrHttpsUrlWithCredentials(String url) throws Exception {
+        //given
+        TransportCommand transportCommand = mock(TransportCommand.class);
+        ArgumentCaptor<UsernamePasswordCredentialsProvider> captor = ArgumentCaptor.forClass(UsernamePasswordCredentialsProvider.class);
+        Field usernameField = UsernamePasswordCredentialsProvider.class.getDeclaredField("username");
+        Field passwordField = UsernamePasswordCredentialsProvider.class.getDeclaredField("password");
+        usernameField.setAccessible(true);
+        passwordField.setAccessible(true);
+
+        //when
+        jGitConnection.executeRemoteCommand(url, transportCommand);
+
+        //then
+        verify(transportCommand).setCredentialsProvider(captor.capture());
+        UsernamePasswordCredentialsProvider credentialsProvider = captor.getValue();
+        String username = (String)usernameField.get(credentialsProvider);
+        char[] password = (char[])passwordField.get(credentialsProvider);
+        assertEquals("username", username);
+        assertEquals("password", String.valueOf(password));
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Add methods to get username and password from git url.
This is needed to paste these credentials to Jgit command when performing remote git operation 
with http url with credentials (http://username:password@host.xz/path/to/repo.git).
### What issues does this PR fix or reference?

https://github.com/codenvy/codenvy/issues/476
### Tests written?

Yes

@sleshchenko @skabashnyuk please review
