### PR TITLE
CHE-2055 Validate received Stacks

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackService.java
@@ -51,7 +51,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -75,11 +74,13 @@ import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_UPLOAD_ICO
 @Path("/stack")
 public class StackService extends Service {
 
-    private final StackDao stackDao;
+    private final StackDao       stackDao;
+    private final StackValidator stackValidator;
 
     @Inject
-    public StackService(StackDao stackDao) {
+    public StackService(StackDao stackDao, StackValidator stackValidator) {
         this.stackDao = stackDao;
+        this.stackValidator = stackValidator;
     }
 
     @POST
@@ -96,12 +97,8 @@ public class StackService extends Service {
                                                       "(e.g. The stack with such name already exists)"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response createStack(@ApiParam("The new stack") final StackDto stackDto) throws ApiException {
-        requireNonNull(stackDto, "Stack required");
-        requireNonNullAndNonEmpty(stackDto.getName(), "Stack name required");
-        if (stackDto.getSource() == null && stackDto.getWorkspaceConfig() == null) {
-            throw new BadRequestException("Stack source required. You must specify stack source: 'workspaceConfig' or 'stackSource'");
-        }
 
+        stackValidator.check(stackDto);
         String userId = EnvironmentContext.getCurrent().getSubject().getUserId();
 
         StackImpl newStack = StackImpl.builder()
@@ -154,11 +151,7 @@ public class StackService extends Service {
                                 @ApiParam(value = "The stack id", required = true)
                                 @PathParam("id")
                                 final String id) throws ApiException {
-        requireNonNull(updateDto, "Stack required");
-        if (updateDto.getSource() == null && updateDto.getWorkspaceConfig() == null) {
-            throw new BadRequestException("Stack source required. You must specify stack source: 'workspaceConfig' or 'stackSource'");
-        }
-
+        stackValidator.check(updateDto);
         final StackImpl stack = stackDao.getById(id);
 
         StackImpl stackForUpdate = StackImpl.builder()
@@ -332,17 +325,5 @@ public class StackService extends Service {
             links.add(getIconLink);
         }
         return asDto(stack).withLinks(links);
-    }
-
-    private void requireNonNull(Object object, String message) throws BadRequestException {
-        if (object == null) {
-            throw new BadRequestException(message);
-        }
-    }
-
-    private void requireNonNullAndNonEmpty(String parameter, String message) throws BadRequestException {
-        if (isNullOrEmpty(parameter)) {
-            throw new BadRequestException(message);
-        }
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackValidator.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.stack;
+
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.workspace.shared.stack.Stack;
+
+import javax.inject.Singleton;
+
+
+/**
+ * Validator for {@link Stack} objects
+ *
+ * @author Mihail Kuznyetsov
+ */
+@Singleton
+public class StackValidator {
+
+    /**
+     * Validate stack object
+     *
+     * @param stack
+     *          stack to validate
+     * @throws BadRequestException if stack is not valid
+     */
+    public void check(Stack stack) throws BadRequestException {
+        if (stack == null) {
+            throw new BadRequestException("Required non-null stack");
+        }
+        if (stack.getCreator() == null) {
+            throw new BadRequestException("Required non-null stack creator");
+        }
+        if (stack.getName() == null || stack.getName().isEmpty()) {
+            throw new BadRequestException("Required non-null and non-empty stack name");
+        }
+        if (stack.getScope() == null || !stack.getScope().equals("general") && !stack.getScope().equals("advanced")) {
+            throw new BadRequestException("Required non-null scope value: 'general' or 'advanced'");
+        }
+        if (stack.getSource() == null && stack.getWorkspaceConfig() == null) {
+            throw new BadRequestException("Stack source required. You must specify either 'workspaceConfig' or 'stackSource'");
+        }
+        if (stack.getTags() == null || stack.getTags().isEmpty()) {
+            throw new BadRequestException("Required non-null and non-empty tag list");
+        }
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackValidatorTest.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.stack;
+
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
+import org.eclipse.che.api.workspace.shared.dto.stack.StackComponentDto;
+import org.eclipse.che.api.workspace.shared.dto.stack.StackDto;
+import org.eclipse.che.api.workspace.shared.dto.stack.StackSourceDto;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
+/**
+ * Test for {@link StackValidator}
+ *
+ * @author Mihail Kuznyetsov
+ */
+public class StackValidatorTest {
+
+    StackValidator validator;
+
+    @BeforeMethod
+    public void setUp() {
+        validator = new StackValidator();
+    }
+
+    @Test
+    public void shouldcheck() throws Exception {
+        validator.check(createStack());
+    }
+
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null stack")
+    public void shouldNotValidateIfStackIsNull() throws Exception {
+        validator.check(null);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null stack creator")
+    public void shouldNotValidateIfStackCreatorIsNull() throws Exception {
+        validator.check(createStack().withCreator(null));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null and non-empty stack name")
+    public void shouldNotValidateIfStackNameIsNull() throws Exception {
+        validator.check(createStack().withName(null));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null and non-empty stack name")
+    public void shouldNotValidateIfStackNameIsEmpty() throws Exception {
+        validator.check(createStack().withName(""));
+    }
+
+    @Test
+    public void shouldValidateIfStackScopeIsGeneral() throws Exception {
+        validator.check(createStack().withScope("general"));
+    }
+
+    @Test
+    public void shouldValidateIfStackScopeIsAdvanced() throws Exception {
+        validator.check(createStack().withScope("advanced"));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null scope value: 'general' or 'advanced'")
+    public void shouldNotValidateIfStackScopeIsNull() throws Exception {
+        validator.check(createStack().withScope(null));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null scope value: 'general' or 'advanced'")
+    public void shouldNotValidateIfStackScopeIsNotGeneralOrAdvanced() throws Exception {
+        validator.check(createStack().withScope("not-valid"));
+    }
+
+    @Test
+    public void shouldValidateIfSourceIsWorkspaceConfigAndStackSourceIsNull() throws Exception {
+        validator.check(createStack().withSource(null));
+    }
+
+    @Test
+    public void shouldValidateIfSourceIsStackSourceAndWorkspaceConfigIsNull() throws Exception {
+        validator.check(createStack().withWorkspaceConfig(null));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Stack source required. You must specify either 'workspaceConfig' or 'stackSource'")
+    public void shouldNotValidateIfWorkspaceConfigAndSourceAreNull() throws Exception {
+        validator.check(createStack().withSource(null).withWorkspaceConfig(null));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null and non-empty tag list")
+    public void shouldNotValidateIfStackTagsListIsNull() throws Exception {
+        validator.check(createStack().withTags(null));
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null and non-empty tag list")
+    public void shouldNotValidateIfStackTagsListIsEmpty() throws Exception {
+        validator.check(createStack().withTags(Collections.emptyList()));
+    }
+
+    @Test
+    public void shouldNotcheck() throws Exception {
+        validator.check(createStack());
+    }
+
+    private static StackDto createStack() {
+        return newDto(StackDto.class)
+                .withId("stack123")
+                .withName("Name")
+                .withDescription("Description")
+                .withScope("general")
+                .withCreator("user123")
+                .withTags(new ArrayList<>(Collections.singletonList("latest")))
+                .withWorkspaceConfig(newDto(WorkspaceConfigDto.class))
+                .withSource(newDto(StackSourceDto.class).withType("recipe").withOrigin("FROM codenvy/ubuntu_jdk8"))
+                .withComponents(new ArrayList<>(
+                        Collections.singletonList(newDto(StackComponentDto.class).withName("maven").withVersion("3.3.1"))));
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Add Stack validation similarly to User/Workspace validations. 
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2055
### Previous Behavior

Validation of stack has been done partially in StackService and partially in StackImpl.
### New Behavior

Now validation is done in StackValidator which is reused in StackService.
### Tests written?

Yes
### Docs requirements?

No
