### PR TITLE
Fixed che-launcher container name typo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -167,7 +167,7 @@ Vagrant.configure(2) do |config|
     echo "--------------------------------------------------"
     echo "ECLIPSE CHE: DOWNLOADING ECLIPSE CHE DOCKER IMAGES"
     echo "--------------------------------------------------"
-    perform $PROVISION_PROGRESS docker pull codenvy/che-launcer:${CHE_VERSION}
+    perform $PROVISION_PROGRESS docker pull codenvy/che-launcher:${CHE_VERSION}
     perform $PROVISION_PROGRESS docker pull codenvy/che-server:${CHE_VERSION}
 
     echo "--------------------------------"


### PR DESCRIPTION
### What does this PR do?

It fixes a typo in the che-launcher container name in the Vagrantfile
### Previous Behavior

The che-launcher container was not pulled during the "DOWNLOADING ECLIPSE CHE DOCKER IMAGES" vagrant provisioning phase and an error was shown. Provisioning would still continue successfully and the image would ultimately be pulled during execution of the che.sh script.

Signed-off-by: Carsten Reckord reckord@yatta.de
