### PR TITLE
Duplex Json RPC protocol implementation based on web socket transport

### DIFF
--- a/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -12,6 +12,7 @@ package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
 
 import org.eclipse.che.ApiEndpointAccessibilityChecker;
@@ -20,18 +21,36 @@ import org.eclipse.che.EventBusURLProvider;
 import org.eclipse.che.UriApiEndpointProvider;
 import org.eclipse.che.UserTokenProvider;
 import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestReceiver;
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestTransmitter;
+import org.eclipse.che.api.core.jsonrpc.JsonRpcResponseReceiver;
+import org.eclipse.che.api.core.jsonrpc.JsonRpcResponseTransmitter;
+import org.eclipse.che.api.core.jsonrpc.impl.BasicJsonRpcObjectValidator;
+import org.eclipse.che.api.core.jsonrpc.impl.JsonRpcDispatcher;
+import org.eclipse.che.api.core.jsonrpc.impl.JsonRpcObjectValidator;
+import org.eclipse.che.api.core.jsonrpc.impl.WebSocketJsonRpcDispatcher;
+import org.eclipse.che.api.core.jsonrpc.impl.WebSocketJsonRpcRequestDispatcher;
+import org.eclipse.che.api.core.jsonrpc.impl.WebSocketJsonRpcRequestTransmitter;
+import org.eclipse.che.api.core.jsonrpc.impl.WebSocketJsonRpcResponseDispatcher;
+import org.eclipse.che.api.core.jsonrpc.impl.WebSocketJsonRpcResponseTransmitter;
 import org.eclipse.che.api.core.notification.WSocketEventBusClient;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.api.core.rest.CoreRestModule;
 import org.eclipse.che.api.core.util.FileCleaner.FileCleanerModule;
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.WebSocketMessageTransmitter;
+import org.eclipse.che.api.core.websocket.impl.BasicWebSocketTransmissionValidator;
+import org.eclipse.che.api.core.websocket.impl.GuiceInjectorEndpointConfigurator;
+import org.eclipse.che.api.core.websocket.impl.BasicWebSocketMessageTransmitter;
+import org.eclipse.che.api.core.websocket.impl.WebSocketTransmissionValidator;
 import org.eclipse.che.api.git.GitConnectionFactory;
 import org.eclipse.che.api.git.GitUserResolver;
+import org.eclipse.che.api.git.LocalGitUserResolver;
 import org.eclipse.che.api.project.server.ProjectApiModule;
 import org.eclipse.che.api.ssh.server.HttpSshServiceClient;
 import org.eclipse.che.api.ssh.server.SshServiceClient;
 import org.eclipse.che.api.user.server.spi.PreferenceDao;
 import org.eclipse.che.commons.lang.Pair;
-import org.eclipse.che.api.git.LocalGitUserResolver;
 import org.eclipse.che.git.impl.jgit.JGitConnectionFactory;
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.plugin.java.server.rest.WsAgentURLProvider;
@@ -78,6 +97,9 @@ public class WsAgentModule extends AbstractModule {
 
         bind(String.class).annotatedWith(Names.named("wsagent.endpoint"))
                           .toProvider(WsAgentURLProvider.class);
+
+        configureJsonRpc();
+        configureWebSocket();
     }
 
     //it's need for WSocketEventBusClient and in the future will be replaced with the property
@@ -85,7 +107,7 @@ public class WsAgentModule extends AbstractModule {
     @Provides
     @SuppressWarnings("unchecked")
     Pair<String, String>[] eventSubscriptionsProvider(@Named("event.bus.url") String eventBusURL) {
-        return new Pair[] {Pair.of(eventBusURL, "")};
+        return new Pair[]{Pair.of(eventBusURL, "")};
     }
 
     //it's need for EventOriginClientPropagationPolicy and in the future will be replaced with the property
@@ -93,6 +115,37 @@ public class WsAgentModule extends AbstractModule {
     @Provides
     @SuppressWarnings("unchecked")
     Pair<String, String>[] propagateEventsProvider(@Named("event.bus.url") String eventBusURL) {
-        return new Pair[] {Pair.of(eventBusURL, "")};
+        return new Pair[]{Pair.of(eventBusURL, "")};
+    }
+
+    private void configureWebSocket() {
+        requestStaticInjection(GuiceInjectorEndpointConfigurator.class);
+
+        bind(WebSocketTransmissionValidator.class).to(BasicWebSocketTransmissionValidator.class);
+
+        bind(WebSocketMessageTransmitter.class).to(BasicWebSocketMessageTransmitter.class);
+
+        MapBinder<String, WebSocketMessageReceiver> receivers =
+                MapBinder.newMapBinder(binder(), String.class, WebSocketMessageReceiver.class);
+
+        receivers.addBinding("jsonrpc-2.0").to(WebSocketJsonRpcDispatcher.class);
+    }
+
+    private void configureJsonRpc() {
+        bind(JsonRpcObjectValidator.class).to(BasicJsonRpcObjectValidator.class);
+
+        bind(JsonRpcResponseTransmitter.class).to(WebSocketJsonRpcResponseTransmitter.class);
+        bind(JsonRpcRequestTransmitter.class).to(WebSocketJsonRpcRequestTransmitter.class);
+
+        MapBinder<String, JsonRpcDispatcher> dispatchers =
+                MapBinder.newMapBinder(binder(), String.class, JsonRpcDispatcher.class);
+
+        dispatchers.addBinding("request").to(WebSocketJsonRpcRequestDispatcher.class);
+        dispatchers.addBinding("response").to(WebSocketJsonRpcResponseDispatcher.class);
+
+        MapBinder<String, JsonRpcRequestReceiver> requestReceivers =
+                MapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+        MapBinder<String, JsonRpcResponseReceiver> responseReceivers =
+                MapBinder.newMapBinder(binder(), String.class, JsonRpcResponseReceiver.class);
     }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcRequestReceiver.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcRequestReceiver.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+
+/**
+ * The implementation of this interface receives JSON RPC requests according to
+ * the mapping. The mapping is defined via MapBinder in one of Guice modules that
+ * are used in the application. Example is simple:
+ *
+ * <pre>
+ *     <code>
+ *         MapBinder<String, JsonRpcRequestReceiver> requestReceivers =
+ *         MapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+ *         requestReceivers.addBinding("method-name").to(CustomJsonRpcRequestReceiver.class)
+ *     </code>
+ * </pre>
+ *
+ * All JSON RPC requests that has their method names equal to "method-name" will be
+ * processed by instance of <code>CustomJsonRpcRequestReceiver</code>. Please note
+ * that you can use regular expressions for method names in order to be able to map
+ * single receiver implementation to a several kinds of requests.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcRequestReceiver {
+    /**
+     * Receives a JSON RPC request from an endpoint
+     *
+     * @param request
+     *         request instance
+     * @param endpoint
+     *         endpoint identifier
+     */
+    void receive(JsonRpcRequest request, Integer endpoint);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcRequestTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcRequestTransmitter.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+
+/**
+ * Transmits a JSON RPC request to an endpoint or broadcast it.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcRequestTransmitter {
+    /**
+     * Transmits a JSON RPC request to an endpoint
+     *
+     * @param request
+     *         JSON RPC request instance
+     * @param endpoint
+     *         endpoint identifier
+     */
+    void transmit(JsonRpcRequest request, Integer endpoint);
+
+    /**
+     * Broadcasts a JSON RPC request to all available endpoints
+     *
+     * @param request
+     *         JSON RPC request instance
+     */
+    void transmit(JsonRpcRequest request);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcResponseReceiver.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcResponseReceiver.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+
+/**
+ * The implementation of this interface receives JSON RPC responses according to
+ * the mapping. The mapping is defined via MapBinder in one of Guice modules that
+ * are used in the application. Example is simple:
+ *
+ * <pre>
+ *     <code>
+ *         MapBinder<String, JsonRpcRequestReceiver> responseReceivers =
+ *         MapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+ *         responseReceivers.addBinding("method-name").to(CustomJsonRpcResponseReceiver.class)
+ *     </code>
+ * </pre>
+ *
+ * In fact JSON RPC responses has no method defined in their body, though it is quite
+ * possible to bind requests and responses by their identifiers thus we can know which
+ * response correspond to which method. So responses that has their method names equal
+ * to "method-name" will be processed by instance of <code>CustomJsonRpcResponseReceiver</code>.
+ * Please note that you can use regular expressions for method names in order to be able
+ * to map single receiver implementation to a several kinds of requests.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcResponseReceiver {
+    /**
+     * Receive JSON RPC response from an endpoint
+     *
+     * @param response
+     *         response instance
+     * @param endpoint
+     *         endpoint identifier
+     */
+    void receive(JsonRpcResponse response, Integer endpoint);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcResponseTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcResponseTransmitter.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+
+/**
+ * Transmits a JSON RPC response to an endpoint or broadcast it.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcResponseTransmitter {
+
+    /**
+     * Transmits a JSON RPC response to an endpoint
+     *
+     * @param response
+     *         JSON RPC response instance
+     * @param endpoint
+     *         endpoint identifier
+     */
+    void transmit(JsonRpcResponse response, Integer endpoint);
+
+    /**
+     * Broadcasts a JSON RPC response to all endpoints
+     *
+     * @param response
+     *         JSON RPC response instance
+     */
+    void transmit(JsonRpcResponse response);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/BasicJsonRpcObjectValidator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/BasicJsonRpcObjectValidator.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Basic implementation of JSON RPC object validator. Validation rules are simple:
+ *
+ * <ul>
+ * <li><code>type</code> must not be <code>null</code></li>
+ * <li><code>type</code> must not be empty</li>
+ * <li><code>type</code> must be registered (mapped to a corresponding receiver implementation)</li>
+ * <li><code>message</code> must not be <code>null</code></li>
+ * <li><code>message</code> must not be empty</li>
+ * <li><code>message</code> must be a valid JSON</li>
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicJsonRpcObjectValidator implements JsonRpcObjectValidator {
+    private static final Logger LOG = LoggerFactory.getLogger(BasicJsonRpcObjectValidator.class);
+
+    private final Set<String> registeredTypes;
+
+    @Inject
+    public BasicJsonRpcObjectValidator(Map<String, JsonRpcDispatcher> dispatchers) {
+        this.registeredTypes = dispatchers.keySet();
+    }
+
+    @Override
+    public void validate(JsonRpcObject object) {
+        validateType(object.getType());
+        validateMessage(object.getMessage());
+    }
+
+    private void validateType(String type) {
+        if (registeredTypes.contains(type)) {
+            LOG.trace("Json rpc object type {} is among registered", type);
+        } else {
+            logError("Json rpc object is of not registered type");
+        }
+    }
+
+    private void validateMessage(String message) {
+        validateNull(message);
+        validateEmpty(message);
+        validateJson(message);
+    }
+
+    private void validateNull(String message) {
+        if (message == null) {
+            logError("Json rpc object message is null");
+        } else {
+            LOG.trace("Json rpc object message is not null");
+        }
+    }
+
+    private void validateEmpty(String message) {
+        if (message.isEmpty()) {
+            logError("Json rpc object message is empty");
+        } else {
+            LOG.trace("Json rpc object message is not empty");
+        }
+    }
+
+    private void validateJson(String message) {
+        boolean error = false;
+
+        try {
+            new JsonParser().parse(message);
+        } catch (JsonSyntaxException e) {
+            error = true;
+        }
+
+        if (error) {
+            logError("Json rpc object message is not a valid json");
+        } else {
+            LOG.trace("Json rpc object message is a valid json");
+        }
+    }
+
+    private void logError(String error) {
+        LOG.error(error);
+        throw new IllegalArgumentException(error);
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcDispatcher.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+
+/**
+ * There are two implementations of this interface:
+ *
+ * <ul>
+ * <li>{@link WebSocketJsonRpcRequestDispatcher}</li>
+ * <li>{@link WebSocketJsonRpcResponseDispatcher}</li>
+ * </ul>
+ *
+ * Each implementation is used to dispatch messages of {@link JsonRpcObject}
+ * of corresponding type: requests or response.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcDispatcher {
+    /**
+     * Dispatches a message from an endpoint
+     *
+     * @param message
+     *         message
+     * @param endpointId
+     *         endpoint identifier
+     */
+    void dispatch(String message, Integer endpointId);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcObjectValidator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcObjectValidator.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+
+/**
+ * It is used to make sure that {@link JsonRpcObject} is a valid entity.
+ * Implementation of this interface must be called before any other operation
+ * is performed to avoid any kind of inconsistency.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcObjectValidator {
+    void validate(JsonRpcObject object);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcRequestRegistry.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcRequestRegistry.java
@@ -15,8 +15,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Binds request identifiers with request methods. Registry is used by response receivers
@@ -34,7 +34,7 @@ public class JsonRpcRequestRegistry {
 
     @Inject
     public JsonRpcRequestRegistry() {
-        this.requests = new HashMap<>();
+        this.requests = new ConcurrentHashMap<>();
     }
 
     /**

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcRequestRegistry.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcRequestRegistry.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Binds request identifiers with request methods. Registry is used by response receivers
+ * to find out what method call is being answered. This is mostly needed because JSON RPC
+ * specification does not define method section in JSON RPC responses so there is no method
+ * name that can be directly mapped to a corresponding receiver.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class JsonRpcRequestRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(JsonRpcRequestRegistry.class);
+
+    private final Map<Integer, String> requests;
+
+    @Inject
+    public JsonRpcRequestRegistry() {
+        this.requests = new HashMap<>();
+    }
+
+    /**
+     * Add request identifier - request method binding to the registry.
+     *
+     * @param id
+     *         request identifier
+     * @param method
+     *         request method
+     */
+    public void add(Integer id, String method) {
+        LOG.debug("Binding ID: {} to method: {}", id, method);
+
+        requests.put(id, method);
+    }
+
+    /**
+     * Extracts request method name bound to request identifier
+     *
+     * @param id
+     *         request identifier
+     *
+     * @return request method name
+     */
+    public String extractFor(Integer id) {
+        LOG.debug("Extracting method with ID: {}", id);
+
+        return requests.remove(id);
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcDispatcher.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Receives instances of raw {@link JsonRpcObject} extracted from {@link WebSocketTransmission}.
+ * They are raw because they are presented as {@link String}. Those objects are dispatched among
+ * more specific dispatchers {@link JsonRpcDispatcher}) according to their type (e.g. JSON RPC
+ * request/response dispatchers).
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcDispatcher implements WebSocketMessageReceiver {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonRpcDispatcher.class);
+
+    private final Map<String, JsonRpcDispatcher> dispatchers;
+    private final JsonRpcObjectValidator         validator;
+
+    @Inject
+    public WebSocketJsonRpcDispatcher(Map<String, JsonRpcDispatcher> dispatchers, JsonRpcObjectValidator validator) {
+        this.dispatchers = dispatchers;
+        this.validator = validator;
+    }
+
+    @Override
+    public void receive(String rawJsonRpcObject, Integer endpointId) {
+        final JsonRpcObject jsonRpcObject = DtoFactory.getInstance().createDtoFromJson(rawJsonRpcObject, JsonRpcObject.class);
+        validator.validate(jsonRpcObject);
+
+        final String type = jsonRpcObject.getType();
+        final String message = jsonRpcObject.getMessage();
+
+        for (Entry<String, JsonRpcDispatcher> entry : dispatchers.entrySet()) {
+            final String typeCandidate = entry.getKey();
+            if (Objects.equals(typeCandidate, type)) {
+                final JsonRpcDispatcher dispatcher = entry.getValue();
+                LOG.debug("Matching json rpc message dispatcher: {}", dispatcher.getClass());
+                dispatcher.dispatch(message, endpointId);
+
+                return;
+            }
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestDispatcher.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestReceiver;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Dispatches JSON RPC requests among all registered implementations of {@link JsonRpcRequestReceiver}
+ * according to their method names.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcRequestDispatcher implements JsonRpcDispatcher {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonRpcRequestDispatcher.class);
+
+    private final Map<Pattern, JsonRpcRequestReceiver> receivers = new HashMap<>();
+
+    @Inject
+    public WebSocketJsonRpcRequestDispatcher(Map<String, JsonRpcRequestReceiver> receivers) {
+        receivers.forEach((k, v) -> this.receivers.put(Pattern.compile(k), v));
+    }
+
+    @Override
+    public void dispatch(String message, Integer endpointId) {
+        final JsonRpcRequest request = DtoFactory.getInstance().createDtoFromJson(message, JsonRpcRequest.class);
+        final String method = request.getMethod();
+
+        for (Entry<Pattern, JsonRpcRequestReceiver> entry : receivers.entrySet()) {
+            final Pattern pattern = entry.getKey();
+            final Matcher matcher = pattern.matcher(method);
+            if (matcher.matches()) {
+                final JsonRpcRequestReceiver receiver = entry.getValue();
+                LOG.debug("Matching json rpc request receiver: {}", receiver.getClass());
+                receiver.receive(request, endpointId);
+            }
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestTransmitter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestTransmitter;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Transmits JSON RPC requests through to {@link WebSocketJsonRpcTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcRequestTransmitter implements JsonRpcRequestTransmitter {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonRpcRequestTransmitter.class);
+
+    private final WebSocketJsonRpcTransmitter transmitter;
+    private final JsonRpcRequestRegistry      registry;
+
+    @Inject
+    public WebSocketJsonRpcRequestTransmitter(WebSocketJsonRpcTransmitter transmitter, JsonRpcRequestRegistry registry) {
+        this.transmitter = transmitter;
+        this.registry = registry;
+    }
+
+    @Override
+    public void transmit(JsonRpcRequest request, Integer endpoint) {
+        internalTransmit(request, endpoint);
+    }
+
+    @Override
+    public void transmit(JsonRpcRequest request) {
+        internalTransmit(request, null);
+    }
+
+    private void internalTransmit(JsonRpcRequest request, Integer endpointId) {
+        final Integer id = request.getId();
+        final String method = request.getMethod();
+
+        if (id != null) {
+            registry.add(id, method);
+        }
+
+        LOG.debug("Transmitting a request\n {}", request);
+
+        if (endpointId == null) {
+            transmitter.transmit("request", request.toString());
+        } else {
+            transmitter.transmit("request", request.toString(), endpointId);
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseDispatcher.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcResponseReceiver;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Dispatches JSON RPC responses among all registered implementations of {@link JsonRpcResponseReceiver}
+ * according to their method names.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcResponseDispatcher implements JsonRpcDispatcher {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonRpcResponseDispatcher.class);
+
+    private final JsonRpcRequestRegistry requestRegistry;
+
+    private final Map<Pattern, JsonRpcResponseReceiver> receivers = new HashMap<>();
+
+    @Inject
+    public WebSocketJsonRpcResponseDispatcher(JsonRpcRequestRegistry requestRegistry, Map<String, JsonRpcResponseReceiver> receivers) {
+        this.requestRegistry = requestRegistry;
+
+        receivers.forEach((k, v) -> this.receivers.put(Pattern.compile(k), v));
+    }
+
+    @Override
+    public void dispatch(String message, Integer endpointId) {
+        final JsonRpcResponse response = DtoFactory.getInstance().createDtoFromJson(message, JsonRpcResponse.class);
+        final String method = requestRegistry.extractFor(response.getId());
+
+        for (Entry<Pattern, JsonRpcResponseReceiver> entry : receivers.entrySet()) {
+            final Pattern pattern = entry.getKey();
+            final Matcher matcher = pattern.matcher(method);
+            if (matcher.matches()) {
+                final JsonRpcResponseReceiver receiver = entry.getValue();
+                LOG.debug("Matching json rpc response receiver: {}", receiver.getClass());
+                receiver.receive(response, endpointId);
+            }
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseTransmitter.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcResponseTransmitter;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Transmits JSON RPC responses to {@link WebSocketJsonRpcTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcResponseTransmitter implements JsonRpcResponseTransmitter {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonRpcResponseTransmitter.class);
+
+    private final WebSocketJsonRpcTransmitter transmitter;
+
+    @Inject
+    public WebSocketJsonRpcResponseTransmitter(WebSocketJsonRpcTransmitter transmitter) {
+        this.transmitter = transmitter;
+    }
+
+    @Override
+    public void transmit(JsonRpcResponse response, Integer endpoint) {
+        internalTransmit(response, endpoint);
+    }
+
+    @Override
+    public void transmit(JsonRpcResponse response) {
+        internalTransmit(response, null);
+    }
+
+    private void internalTransmit(JsonRpcResponse response, Integer endpointId) {
+        LOG.debug("Transmitting a response\n {}", response);
+
+        if (endpointId == null) {
+            transmitter.transmit("response", response.toString());
+        } else {
+            transmitter.transmit("response", response.toString(), endpointId);
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcTransmitter.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.api.core.websocket.WebSocketMessageTransmitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
+/**
+ * Transmits JSON RPC objects to {@link WebSocketMessageTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcTransmitter {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonRpcTransmitter.class);
+
+    private final WebSocketMessageTransmitter transmitter;
+    private final JsonRpcObjectValidator      validator;
+
+    @Inject
+    public WebSocketJsonRpcTransmitter(WebSocketMessageTransmitter transmitter, JsonRpcObjectValidator validator) {
+        this.transmitter = transmitter;
+        this.validator = validator;
+    }
+
+    public void transmit(String type, String message, Integer endpointId) {
+        internalTransmit(message, type, endpointId);
+    }
+
+    public void transmit(String type, String message) {
+        internalTransmit(message, type, null);
+    }
+
+    private void internalTransmit(String message, String type, Integer endpointId) {
+        LOG.debug("Transmitting a json rpc object. Message: {} of type: {}", message);
+        final JsonRpcObject jsonRpcObject = newDto(JsonRpcObject.class).withType(type).withMessage(message);
+        validator.validate(jsonRpcObject);
+
+        if (endpointId == null) {
+            transmitter.transmit("jsonrpc-2.0", jsonRpcObject.toString());
+        } else {
+            transmitter.transmit("jsonrpc-2.0", jsonRpcObject.toString(), endpointId);
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcError.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcError.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * When a rpc call encounters an error, the Response Object MUST contain the error member
+ * with a value that is a Object with the following members:
+ *
+ * <ul>
+ * <li>code</li>
+ * A Number that indicates the error type that occurred. This MUST be an integer.
+ * <li>message</li>
+ * A String providing a short description of the error. The message SHOULD be limited to a
+ * concise single sentence.
+ * <li>data</li>
+ * A Primitive or Structured value that contains additional information about the error.
+ * This may be omitted. The value of this member is defined by the Server (e.g. detailed
+ * error information, nested errors etc.).
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ * @see <a href="http://www.jsonrpc.org/specification#error_object">Error Object</a>
+ */
+@DTO
+public interface JsonRpcError {
+
+    Integer getCode();
+
+    String getMessage();
+
+    String getData();
+
+    JsonRpcError withCode(Integer code);
+
+    JsonRpcError withMessage(String message);
+
+    JsonRpcError withData(String data);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcObject.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcObject.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Stores JSON RPC request or JSON RPC response instances. Type of the instance
+ * is defined by <code>type</code> field, while request/response is stored as a
+ * {@link String} representation in a <code>message</code> field.
+ *
+ * @author Dmitry Kuleshov
+ */
+@DTO
+public interface JsonRpcObject {
+
+    String getType();
+
+    String getMessage();
+
+    JsonRpcObject withType(String type);
+
+    JsonRpcObject withMessage(String message);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcRequest.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcRequest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * A rpc call is represented by sending a Request object to a Server. The Request object
+ * has the following members:
+ *
+ * <ul>
+ * <li>jsonrpc</li>
+ * A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
+ * <li>method</li>
+ * A String containing the name of the method to be invoked. Method names that begin with
+ * the word rpc followed by a period character (U+002E or ASCII 46) are reserved for rpc-
+ * internal methods and extensions and MUST NOT be used for anything else.
+ * <li>params</li>
+ * A Structured value that holds the parameter values to be used during the invocation of
+ * the method. This member MAY be omitted.
+ * <li>id</li>
+ * An identifier established by the Client that MUST contain a String, Number, or NULL
+ * value if included. If it is not included it is assumed to be a notification. The value
+ * SHOULD normally not be <code>null</code> and Numbers SHOULD NOT contain fractional parts
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ * @see <a href="http://www.jsonrpc.org/specification#request_object">Request Object</a>
+ */
+@DTO
+public interface JsonRpcRequest {
+
+    Integer getId();
+
+    JsonRpcRequest withId(Integer id);
+
+    String getJsonrpc();
+
+    String getMethod();
+
+    String getParams();
+
+    JsonRpcRequest withJsonrpc(String jsonrpc);
+
+    JsonRpcRequest withMethod(String method);
+
+    JsonRpcRequest withParams(String params);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcResponse.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/shared/JsonRpcResponse.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * When a rpc call is made, the Server MUST reply with a Response, except for in the
+ * case of Notifications. The Response is expressed as a single JSON Object, with the
+ * following members:
+ *
+ * <ul>
+ * <li>jsonrpc</li>
+ * A {@link String} specifying the version of the JSON-RPC protocol. MUST be
+ * exactly "2.0".
+ * <li>result</li>
+ * This member is REQUIRED on success. This member MUST NOT exist if there was
+ * an error invoking the method. The value of this member is determined by the
+ * method invoked on the Server.
+ * <li>error</li>
+ * This member is REQUIRED on error. This member MUST NOT exist if there was no
+ * error triggered during invocation.
+ * <li>id</li>
+ * This member is REQUIRED. It MUST be the same as the value of the id member in
+ * the Request Object. If there was an error in detecting the id in the Request
+ * object (e.g. Parse error/Invalid Request), it MUST be <code>null</code>.
+ * </ul>
+ *
+ * Either the result member or error member MUST be included, but both members MUST NOT
+ * be included.
+ *
+ * @author Dmitry Kuleshov
+ * @see <a href="http://www.jsonrpc.org/specification#response_object">Response Object</a>
+ */
+@DTO
+public interface JsonRpcResponse {
+
+    String getJsonrpc();
+
+    String getResult();
+
+    JsonRpcError getError();
+
+    Integer getId();
+
+    JsonRpcResponse withJsonrpc(String jsonrpc);
+
+    JsonRpcResponse withResult(String result);
+
+    JsonRpcResponse withError(JsonRpcError error);
+
+    JsonRpcResponse withId(Integer id);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/WebSocketMessageReceiver.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/WebSocketMessageReceiver.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket;
+
+/**
+ * The implementation of this interface receives WEB SOCKET messages corresponding
+ * to the registered protocol according to the defined mapping. The protocol must
+ * be mapped via MapBinder in an ordinary Guice module, for example:
+ *
+ * <pre>
+ *     <code>
+ *         MapBinder<String, WebSocketMessageReceiver> receivers =
+ *         MapBinder.newMapBinder(binder(), String.class, WebSocketMessageReceiver.class);
+ *         receivers.addBinding("protocol-name").to(CustomWebSocketMessageReceiver.class);
+ *     </code>
+ * </pre>
+ *
+ * All WEB SOCKET transmissions with the protocol field equal to "protocol-name" will
+ * be processed with the <code>CustomWebSocketMessageReceiver</code> instance.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketMessageReceiver {
+    void receive(String message, Integer endpointId);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/WebSocketMessageTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/WebSocketMessageTransmitter.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket;
+
+/**
+ * Transmits WEB SOCKET messages to an endpoint or broadcasts them
+ * to all available endpoints.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketMessageTransmitter {
+    /**
+     * Transmits WEB SOCKET messages to an endpoint
+     *
+     * @param protocol
+     *         message protocol
+     * @param message
+     *         message body
+     * @param endpointId
+     *         endpoint identifier
+     */
+    void transmit(String protocol, String message, Integer endpointId);
+
+    /**
+     * Broadcasts WEB SOCKET messages to all endpoints
+     *
+     * @param protocol
+     *         message protocol
+     * @param message
+     *         message body
+     */
+    void transmit(String protocol, String message);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpoint.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpoint.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.websocket.CloseReason;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.PathParam;
+import javax.websocket.server.ServerEndpoint;
+
+/**
+ * Duplex WEB SOCKET endpoint, handles messages, errors, session open/close events.
+ *
+ * @author Dmitry Kuleshov
+ */
+@ServerEndpoint(value = "/websocket/{endpoint-id}", configurator = GuiceInjectorEndpointConfigurator.class)
+public class BasicWebSocketEndpoint {
+    private static final Logger LOG = LoggerFactory.getLogger(BasicWebSocketEndpoint.class);
+
+    private final WebSocketSessionRegistry        registry;
+    private final PendingMessagesReSender         reSender;
+    private final WebSocketTransmissionDispatcher dispatcher;
+
+    @Inject
+    public BasicWebSocketEndpoint(WebSocketSessionRegistry registry,
+                                  PendingMessagesReSender reSender,
+                                  WebSocketTransmissionDispatcher dispatcher) {
+
+        this.registry = registry;
+        this.reSender = reSender;
+        this.dispatcher = dispatcher;
+    }
+
+    @OnOpen
+    public void onOpen(Session session, @PathParam("endpoint-id") Integer endpointId) {
+        LOG.info("Web socket session opened");
+        LOG.info("Endpoint: {}", endpointId);
+
+        session.setMaxIdleTimeout(0);
+
+        registry.add(endpointId, session);
+        reSender.resend(endpointId);
+    }
+
+    @OnMessage
+    public void onMessage(String message, @PathParam("endpoint-id") Integer endpointId) {
+        LOG.debug("Receiving a web socket message.");
+        LOG.debug("Endpoint: {}", endpointId);
+        LOG.debug("Message: {}", message);
+
+        dispatcher.dispatch(message, endpointId);
+    }
+
+    @OnClose
+    public void onClose(CloseReason closeReason, @PathParam("endpoint-id") Integer endpointId) {
+        LOG.info("Web socket session closed");
+        LOG.debug("Endpoint: {}", endpointId);
+        LOG.debug("Close reason: {}:{}", closeReason.getReasonPhrase(), closeReason.getCloseCode());
+
+        registry.remove(endpointId);
+    }
+
+    @OnError
+    public void onError(Throwable t, @PathParam("endpoint-id") Integer endpointId) {
+        LOG.info("Web socket session error");
+        LOG.debug("Endpoint: {}", endpointId);
+        LOG.debug("Error: {}", t);
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketMessageTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketMessageTransmitter.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.WebSocketMessageTransmitter;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.websocket.Session;
+import java.util.Optional;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Transmits messages over WEB SOCKET to a specific endpoint or broadcasts them.
+ * If WEB SOCKET session is not opened adds messages to re-sender to try to send
+ * them when session will be opened again.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicWebSocketMessageTransmitter implements WebSocketMessageTransmitter {
+    private static final Logger LOG = getLogger(BasicWebSocketMessageTransmitter.class);
+
+    private final WebSocketSessionRegistry       registry;
+    private final PendingMessagesReSender        resender;
+    private final WebSocketTransmissionValidator validator;
+
+    @Inject
+    public BasicWebSocketMessageTransmitter(WebSocketSessionRegistry registry,
+                                            PendingMessagesReSender resender,
+                                            WebSocketTransmissionValidator validator) {
+        this.registry = registry;
+        this.resender = resender;
+        this.validator = validator;
+    }
+
+    @Override
+    public void transmit(String protocol, String message, Integer endpointId) {
+        final WebSocketTransmission transmission = newDto(WebSocketTransmission.class).withProtocol(protocol).withMessage(message);
+        validator.validate(transmission);
+
+        final Optional<Session> sessionOptional = registry.get(endpointId);
+
+        if (!sessionOptional.isPresent() || !sessionOptional.get().isOpen()) {
+            LOG.debug("Session is not registered or closed, adding message to pending");
+
+            resender.add(endpointId, transmission);
+        } else {
+            LOG.debug("Session registered and open, sending message");
+
+            sessionOptional.get().getAsyncRemote().sendText(transmission.toString());
+        }
+    }
+
+    @Override
+    public void transmit(String protocol, String message) {
+        final WebSocketTransmission transmission = newDto(WebSocketTransmission.class).withProtocol(protocol).withMessage(message);
+        validator.validate(transmission);
+
+        LOG.debug("Broadcasting a web socket transmission: ", transmission.toString());
+
+        registry.getSessions()
+                .stream()
+                .filter(Session::isOpen)
+                .map(Session::getAsyncRemote)
+                .forEach(it -> it.sendText(transmission.toString()));
+    }
+
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketTransmissionValidator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketTransmissionValidator.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Set;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Basic implementation of WEB SOCKET transmission validator, validation rules are the following:
+ *
+ * <ul>
+ * <li><code>protocol</code> must be not <code>null</code></li>
+ * <li><code>protocol</code> must be not empty</li>
+ * <li><code>protocol</code> must be registered (mapped to a corresponding receiver implementation</li>
+ * <li><code>message</code> must be not <code>null</code></li>
+ * <li><code>message</code> must be not empty</li>
+ * <li><code>message</code> must be a valid JSON</li>
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicWebSocketTransmissionValidator implements WebSocketTransmissionValidator {
+    private static final Logger LOG = getLogger(BasicWebSocketTransmissionValidator.class);
+
+    private final Set<String> protocols;
+
+    @Inject
+    public BasicWebSocketTransmissionValidator(Map<String, WebSocketMessageReceiver> receivers) {
+        this.protocols = receivers.keySet();
+    }
+
+
+    @Override
+    public void validate(WebSocketTransmission transmission) {
+        validateProtocol(transmission.getProtocol());
+        validateMessage(transmission.getMessage());
+    }
+
+    private void validateProtocol(String protocol) {
+        if (protocols.contains(protocol)) {
+            LOG.trace("Web socket transmission protocol {} is among registered", protocol);
+        } else {
+            logError("Web socket transmission of not registered protocol");
+        }
+    }
+
+    private void validateMessage(String message) {
+        validateNull(message);
+        validateEmpty(message);
+        validateJson(message);
+    }
+
+    private void validateNull(String message) {
+        if (message == null) {
+            logError("Web socket transmission message is null");
+        } else {
+            LOG.trace("Web socket transmission message is not null");
+        }
+    }
+
+    private void validateEmpty(String message) {
+        if (message.isEmpty()) {
+            logError("Web socket transmission message is empty");
+        } else {
+            LOG.trace("Web socket transmission message is not empty");
+        }
+    }
+
+    private void validateJson(String message) {
+        boolean error = false;
+
+        try {
+            new JsonParser().parse(message);
+        } catch (JsonSyntaxException e) {
+            error = true;
+        }
+
+        if (error) {
+            logError("Web socket transmission message is not a valid json");
+        } else {
+            LOG.trace("Web socket transmission message is a valid json");
+        }
+    }
+
+    private void logError(String error) {
+        LOG.error(error);
+        throw new IllegalArgumentException(error);
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/GuiceInjectorEndpointConfigurator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/GuiceInjectorEndpointConfigurator.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import com.google.inject.Injector;
+
+import javax.inject.Inject;
+import javax.websocket.server.ServerEndpointConfig;
+
+/**
+ * Allows inject Guice instances on WEB SOCKET endpoint creation.
+ *
+ * @author Dmitry Kuleshov
+ */
+public class GuiceInjectorEndpointConfigurator extends ServerEndpointConfig.Configurator {
+    @Inject
+    private static Injector injector;
+
+    public <T> T getEndpointInstance(Class<T> endpointClass) {
+        return injector.getInstance(endpointClass);
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/PendingMessagesReSender.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/PendingMessagesReSender.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.websocket.Session;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Instance is responsible for re-sending messages that were not sent during the period
+ * when WEB SOCKET session was closed. If session is closed during re-send process it
+ * stops and left messages will be re-sent as WEB SOCKET session becomes open again.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class PendingMessagesReSender {
+    private static final int MAX_MESSAGES = 100;
+
+    private final WebSocketSessionRegistry registry;
+
+    private final Map<Integer, List<WebSocketTransmission>> messagesMap = new HashMap<>();
+
+    @Inject
+    public PendingMessagesReSender(WebSocketSessionRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void add(Integer endpointId, WebSocketTransmission message) {
+        List<WebSocketTransmission> messages = messagesMap.get(endpointId);
+
+        if (messages == null) {
+            messages = new LinkedList<>();
+            messagesMap.put(endpointId, messages);
+        }
+
+        if (messages.size() <= MAX_MESSAGES) {
+            messages.add(message);
+        }
+    }
+
+    public void resend(Integer endpointId) {
+        final List<WebSocketTransmission> messages = messagesMap.remove(endpointId);
+
+        if (messages == null || messages.isEmpty()) {
+            return;
+        }
+
+        final Optional<Session> sessionOptional = registry.get(endpointId);
+
+        if (!sessionOptional.isPresent()) {
+            return;
+        }
+
+        final Session session = sessionOptional.get();
+
+        final List<WebSocketTransmission> backing = new ArrayList<>(messages);
+        messages.clear();
+
+        for (WebSocketTransmission message : backing) {
+
+            if (session.isOpen()) {
+                session.getAsyncRemote().sendText(message.toString());
+            } else {
+                messages.add(message);
+            }
+        }
+
+        messagesMap.put(endpointId, messages);
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistry.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistry.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.slf4j.Logger;
+
+import javax.inject.Singleton;
+import javax.websocket.Session;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Binds WEB SOCKET session to a specific endpoint form which it was opened.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketSessionRegistry {
+    private static final Logger LOG = getLogger(WebSocketSessionRegistry.class);
+
+    private final Map<Integer, Session> sessionsMap = new HashMap<>();
+
+    public void add(Integer endpointId, Session session) {
+        LOG.debug("Registering session with endpoint {}", session.getId(), endpointId);
+
+        sessionsMap.put(endpointId, session);
+    }
+
+    public void remove(Integer endpointId) {
+        LOG.debug("Cancelling registration for session with endpoint {}", endpointId);
+
+        sessionsMap.remove(endpointId);
+    }
+
+    public Optional<Session> get(Integer endpointId) {
+        return Optional.ofNullable(sessionsMap.get(endpointId));
+    }
+
+    public Set<Session> getSessions() {
+        return sessionsMap.values().stream().collect(toSet());
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistry.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistry.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.stream.Collectors.toSet;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -31,7 +32,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class WebSocketSessionRegistry {
     private static final Logger LOG = getLogger(WebSocketSessionRegistry.class);
 
-    private final Map<Integer, Session> sessionsMap = new HashMap<>();
+    private final Map<Integer, Session> sessionsMap = new ConcurrentHashMap<>();
 
     public void add(Integer endpointId, Session session) {
         LOG.debug("Registering session with endpoint {}", session.getId(), endpointId);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketTransmissionDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketTransmissionDispatcher.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Dispatches a {@link WebSocketTransmission} messages among registered receivers
+ * ({@link WebSocketMessageReceiver}) according to WEB SOCKET transmission protocol
+ * field value.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketTransmissionDispatcher {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketTransmissionDispatcher.class);
+
+    private final Map<String, WebSocketMessageReceiver> receivers;
+    private final WebSocketTransmissionValidator        validator;
+
+    @Inject
+    public WebSocketTransmissionDispatcher(Map<String, WebSocketMessageReceiver> receivers, WebSocketTransmissionValidator validator) {
+        this.receivers = receivers;
+        this.validator = validator;
+    }
+
+    public void dispatch(String rawTransmission, Integer endpointId) {
+        final WebSocketTransmission transmission = DtoFactory.getInstance().createDtoFromJson(rawTransmission, WebSocketTransmission.class);
+        validator.validate(transmission);
+
+        final String protocol = transmission.getProtocol();
+        final String message = transmission.getMessage();
+
+        LOG.debug("Receiving a web socket transmission. Protocol: " + protocol + " Message: " + message);
+
+        for (Entry<String, WebSocketMessageReceiver> entry : receivers.entrySet()) {
+            final String protocolCandidate = entry.getKey();
+            if (Objects.equals(protocolCandidate, protocol)) {
+                final WebSocketMessageReceiver receiver = entry.getValue();
+                LOG.debug("Matching web socket transmission receiver: {}", receiver.getClass());
+                receiver.receive(message, endpointId);
+
+                return;
+            }
+        }
+    }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketTransmissionValidator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketTransmissionValidator.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+
+/**
+ * It is used to make sure that {@link WebSocketTransmission} is a valid entity.
+ * Implementation of this interface must be called before any other operation
+ * is performed to avoid any kind of inconsistency.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketTransmissionValidator {
+    void validate(WebSocketTransmission transmission);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/shared/WebSocketTransmission.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/shared/WebSocketTransmission.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Stores a WEB SOCKET transmission. Transmission contains the protocol and
+ * the message. Transmission protocol is defined by <code>protocol</code> field,
+ * while transmission message body is stored within <code>message</code> field.
+ */
+@DTO
+public interface WebSocketTransmission {
+    String getProtocol();
+
+    WebSocketTransmission withProtocol(final String protocol);
+
+    String getMessage();
+
+    WebSocketTransmission withMessage(final String message);
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/BasicJsonRpcObjectValidatorTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/BasicJsonRpcObjectValidatorTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static java.util.Collections.singleton;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link BasicJsonRpcObjectValidator}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class BasicJsonRpcObjectValidatorTest {
+    private static final String REGISTERED_TYPE     = "registered-type";
+    private static final String NOT_REGISTERED_TYPE = "not-registered-type";
+    private static final String VALID_JSON          = "{ \"name\": \"value\" }";
+    private static final String NOT_VALID_JSON      = "not a json value";
+    @Mock
+    private Map<String, JsonRpcDispatcher> dispatchers;
+
+    private BasicJsonRpcObjectValidator validator;
+
+    @Mock
+    private JsonRpcObject jsonRpcObject;
+
+    @BeforeMethod
+    public void before() {
+        when(dispatchers.keySet()).thenReturn(singleton(REGISTERED_TYPE));
+
+        validator = new BasicJsonRpcObjectValidator(dispatchers);
+
+        when(jsonRpcObject.getType()).thenReturn(REGISTERED_TYPE);
+        when(jsonRpcObject.getMessage()).thenReturn(VALID_JSON);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTypeIsNull() {
+        when(jsonRpcObject.getType()).thenReturn(null);
+
+        validator.validate(jsonRpcObject);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTypeIsEmpty() {
+        when(jsonRpcObject.getType()).thenReturn("");
+
+        validator.validate(jsonRpcObject);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTypeIsNotRegistered() {
+        when(jsonRpcObject.getType()).thenReturn(NOT_REGISTERED_TYPE);
+
+        validator.validate(jsonRpcObject);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNull() {
+        when(jsonRpcObject.getMessage()).thenReturn(null);
+
+        validator.validate(jsonRpcObject);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsEmpty() {
+        when(jsonRpcObject.getMessage()).thenReturn("");
+
+        validator.validate(jsonRpcObject);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNotAJson() {
+        when(jsonRpcObject.getMessage()).thenReturn(NOT_VALID_JSON);
+
+        validator.validate(jsonRpcObject);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionIfObjectIsValid() {
+        validator.validate(jsonRpcObject);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcRequestRegistryTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcRequestRegistryTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Tests for {@link JsonRpcRequestRegistry}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class JsonRpcRequestRegistryTest {
+    private static final String METHOD_NAME = "method-name";
+    private static final int    REQUEST_ID  = 1;
+
+    private JsonRpcRequestRegistry registry;
+
+    @BeforeMethod
+    public void before() {
+        registry = new JsonRpcRequestRegistry();
+    }
+
+    @Test
+    public void shouldProperlyRegister() {
+        registry.add(REQUEST_ID, METHOD_NAME);
+
+        assertEquals(METHOD_NAME, registry.extractFor(1));
+    }
+
+    @Test
+    public void shouldProperlyExtract() {
+        registry.add(REQUEST_ID, METHOD_NAME);
+
+        assertEquals(METHOD_NAME, registry.extractFor(1));
+        assertNull(registry.extractFor(1));
+    }
+
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcDispatcherTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcDispatcherTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketJsonRpcDispatcherTest {
+    private static final String MESSAGE             = "message";
+    private static final String REGISTERED_TYPE     = "registered-type";
+    private static final String NOT_REGISTERED_TYPE = "not-registered-type";
+    private static final int    ENDPOINT_ID         = 0;
+
+    @Mock
+    private Map<String, JsonRpcDispatcher> dispatchers;
+    @Mock
+    private JsonRpcObjectValidator         validator;
+    @InjectMocks
+    private WebSocketJsonRpcDispatcher     dispatcher;
+
+    @Mock
+    private JsonRpcDispatcher jsonRpcDispatcher;
+
+    private JsonRpcObject object;
+
+    @BeforeMethod
+    public void before() {
+        when(dispatchers.entrySet()).thenReturn(singletonMap(REGISTERED_TYPE, jsonRpcDispatcher).entrySet());
+
+        object = newDto(JsonRpcObject.class).withType(REGISTERED_TYPE).withMessage(MESSAGE);
+    }
+
+    @Test
+    public void should() {
+        dispatcher.receive(object.toString(), ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldValidateOnReceive() {
+        dispatcher.receive(object.toString(), ENDPOINT_ID);
+
+        verify(validator).validate(eq(object));
+    }
+
+    @Test
+    public void shouldDispatchIfMatchFound() {
+        dispatcher.receive(object.toString(), ENDPOINT_ID);
+
+        verify(jsonRpcDispatcher).dispatch(MESSAGE, ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldNotDispatchIfMatchNotFound() {
+        object.withType(NOT_REGISTERED_TYPE);
+
+        dispatcher.receive(object.toString(), ENDPOINT_ID);
+
+        verify(jsonRpcDispatcher, never()).dispatch(MESSAGE, ENDPOINT_ID);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
@@ -13,24 +13,24 @@ package org.eclipse.che.api.core.jsonrpc.impl;
 import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestReceiver;
 import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
-import static org.mockito.Matchers.any;
+import static java.util.Collections.singletonMap;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for {@link WebSocketJsonRpcRequestDispatcher}
@@ -43,23 +43,21 @@ public class WebSocketJsonRpcRequestDispatcherTest {
     private static final int    ENDPOINT_ID = 0;
     private static final String PARAMS      = "params";
 
-    @Spy
-    private Map<String, JsonRpcRequestReceiver> receivers = new HashMap<>();
+    @Mock
+    private Map<String, JsonRpcRequestReceiver> receivers;
+    @InjectMocks
+    private WebSocketJsonRpcRequestDispatcher dispatcher;
+
     @Mock
     private JsonRpcRequestReceiver receiver;
 
-    private WebSocketJsonRpcRequestDispatcher dispatcher;
-
     @BeforeMethod
     public void before() {
-        receivers.clear();
+        when(receivers.entrySet()).thenReturn(singletonMap(METHOD_NAME, receiver).entrySet());
     }
 
     @Test
     public void shouldRunMatchingReceiver() {
-        receivers.put(METHOD_NAME, receiver);
-        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers);
-
         dispatcher.dispatch(getMessage(METHOD_NAME), ENDPOINT_ID);
 
         ArgumentCaptor<JsonRpcRequest> requestCaptor = ArgumentCaptor.forClass(JsonRpcRequest.class);
@@ -70,37 +68,6 @@ public class WebSocketJsonRpcRequestDispatcherTest {
 
         assertEquals(request.getMethod(), "test-method");
         assertEquals(request.getParams(), PARAMS);
-    }
-
-    @Test
-    public void shouldRunMatchingReceiverWithRegExpedName() {
-        receivers.put("test-met.*", receiver);
-        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers);
-
-        final List<String> methods = asList("test-meth", "test-metho", METHOD_NAME);
-
-        methods.forEach(m -> dispatcher.dispatch(getMessage(m), ENDPOINT_ID));
-
-        ArgumentCaptor<JsonRpcRequest> requestCaptor = ArgumentCaptor.forClass(JsonRpcRequest.class);
-
-        verify(receiver, times(methods.size())).receive(requestCaptor.capture(), eq(ENDPOINT_ID));
-
-        requestCaptor.getAllValues().forEach(request -> {
-            assertTrue(methods.contains(request.getMethod()));
-            assertEquals(request.getParams(), PARAMS);
-        });
-    }
-
-    @Test
-    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
-        receivers.put("test-met.*", receiver);
-        receivers.put("test-me.*", receiver);
-        receivers.put("test-m.*", receiver);
-        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers);
-
-        dispatcher.dispatch(getMessage("test-method"), ENDPOINT_ID);
-
-        verify(receiver, times(receivers.size())).receive(any(JsonRpcRequest.class), eq(ENDPOINT_ID));
     }
 
     private String getMessage(String method) {

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestReceiver;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for {@link WebSocketJsonRpcRequestDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketJsonRpcRequestDispatcherTest {
+    private static final String METHOD_NAME = "test-method";
+    private static final int    ENDPOINT_ID = 0;
+    private static final String PARAMS      = "params";
+
+    @Spy
+    private Map<String, JsonRpcRequestReceiver> receivers = new HashMap<>();
+    @Mock
+    private JsonRpcRequestReceiver receiver;
+
+    private WebSocketJsonRpcRequestDispatcher dispatcher;
+
+    @BeforeMethod
+    public void before() {
+        receivers.clear();
+    }
+
+    @Test
+    public void shouldRunMatchingReceiver() {
+        receivers.put(METHOD_NAME, receiver);
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers);
+
+        dispatcher.dispatch(getMessage(METHOD_NAME), ENDPOINT_ID);
+
+        ArgumentCaptor<JsonRpcRequest> requestCaptor = ArgumentCaptor.forClass(JsonRpcRequest.class);
+
+        verify(receiver).receive(requestCaptor.capture(), eq(ENDPOINT_ID));
+
+        final JsonRpcRequest request = requestCaptor.getValue();
+
+        assertEquals(request.getMethod(), "test-method");
+        assertEquals(request.getParams(), PARAMS);
+    }
+
+    @Test
+    public void shouldRunMatchingReceiverWithRegExpedName() {
+        receivers.put("test-met.*", receiver);
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers);
+
+        final List<String> methods = asList("test-meth", "test-metho", METHOD_NAME);
+
+        methods.forEach(m -> dispatcher.dispatch(getMessage(m), ENDPOINT_ID));
+
+        ArgumentCaptor<JsonRpcRequest> requestCaptor = ArgumentCaptor.forClass(JsonRpcRequest.class);
+
+        verify(receiver, times(methods.size())).receive(requestCaptor.capture(), eq(ENDPOINT_ID));
+
+        requestCaptor.getAllValues().forEach(request -> {
+            assertTrue(methods.contains(request.getMethod()));
+            assertEquals(request.getParams(), PARAMS);
+        });
+    }
+
+    @Test
+    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
+        receivers.put("test-met.*", receiver);
+        receivers.put("test-me.*", receiver);
+        receivers.put("test-m.*", receiver);
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers);
+
+        dispatcher.dispatch(getMessage("test-method"), ENDPOINT_ID);
+
+        verify(receiver, times(receivers.size())).receive(any(JsonRpcRequest.class), eq(ENDPOINT_ID));
+    }
+
+    private String getMessage(String method) {
+        return "{" +
+               "\"id\":\"" + "0" + "\"," +
+               "\"jsonrpc\":\"" + "2.0" + "\"," +
+               "\"method\":\"" + method + "\"," +
+               "\"params\":\"" + PARAMS + "\"" +
+               "}";
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestTransmitterTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcRequestTransmitterTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcRequestTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketJsonRpcRequestTransmitterTest {
+    private static final int    ENDPOINT_ID = 0;
+    private static final int    REQUEST_ID  = 1;
+    private static final String MESSAGE     = "message";
+    private static final String TYPE        = "request";
+    private static final String METHOD_NAME = "method-name";
+
+    @Mock
+    private WebSocketJsonRpcTransmitter        transmitter;
+    @Mock
+    private JsonRpcRequestRegistry             registry;
+    @InjectMocks
+    private WebSocketJsonRpcRequestTransmitter requestTransmitter;
+
+    @Mock
+    private JsonRpcRequest request;
+
+    @BeforeMethod
+    public void before() {
+        when(request.toString()).thenReturn(MESSAGE);
+        when(request.getMethod()).thenReturn(METHOD_NAME);
+        when(request.getId()).thenReturn(REQUEST_ID);
+    }
+
+    @Test
+    public void shouldRunWebSocketTransmitterWithEndpoint() {
+        requestTransmitter.transmit(request, ENDPOINT_ID);
+
+
+        verify(registry).add(eq(REQUEST_ID), eq(METHOD_NAME));
+        verify(transmitter).transmit(TYPE, MESSAGE, ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldRunWebSocketTransmitterWithoutEndpoint() {
+        requestTransmitter.transmit(request);
+
+
+        verify(registry).add(REQUEST_ID, METHOD_NAME);
+        verify(transmitter).transmit(TYPE, MESSAGE);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseDispatcherTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseDispatcherTest.java
@@ -15,23 +15,17 @@ import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
+import static java.util.Collections.singletonMap;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**
@@ -44,27 +38,26 @@ public class WebSocketJsonRpcResponseDispatcherTest {
     private static final Integer REQUEST_ID  = 0;
     private static final int     ENDPOINT_ID = 1;
     private static final String  RESULT      = "result";
+    private static final String  METHOD_NAME = "test-method";
 
     @Mock
-    private JsonRpcRequestRegistry requestRegistry;
-    @Spy
-    private Map<String, JsonRpcResponseReceiver> receivers = new HashMap<>();
+    private JsonRpcRequestRegistry               requestRegistry;
+    @Mock
+    private Map<String, JsonRpcResponseReceiver> receivers;
     @InjectMocks
-    private WebSocketJsonRpcResponseDispatcher dispatcher;
+    private WebSocketJsonRpcResponseDispatcher   dispatcher;
 
     @Mock
     private JsonRpcResponseReceiver receiver;
 
     @BeforeMethod
     public void before() {
-        receivers.clear();
+        when(receivers.entrySet()).thenReturn(singletonMap(METHOD_NAME, receiver).entrySet());
     }
 
     @Test
     public void shouldRunMatchingReceiver() {
-        receivers.put("test-method", receiver);
-        dispatcher = new WebSocketJsonRpcResponseDispatcher(requestRegistry, receivers);
-        when(requestRegistry.extractFor(eq(0))).thenReturn("test-method");
+        when(requestRegistry.extractFor(eq(0))).thenReturn(METHOD_NAME);
 
         dispatcher.dispatch(getMessage(0), ENDPOINT_ID);
 
@@ -76,44 +69,6 @@ public class WebSocketJsonRpcResponseDispatcherTest {
 
         assertEquals(response.getResult(), RESULT);
         assertEquals(response.getId(), REQUEST_ID);
-    }
-
-    @Test
-    public void shouldRunMatchingReceiverWithRegExpedName() {
-        receivers.put("test-met.*", receiver);
-        dispatcher = new WebSocketJsonRpcResponseDispatcher(requestRegistry, receivers);
-
-        when(requestRegistry.extractFor(eq(0))).thenReturn("test-method");
-        when(requestRegistry.extractFor(eq(1))).thenReturn("test-metho");
-        when(requestRegistry.extractFor(eq(2))).thenReturn("test-meth");
-
-        final List<Integer> ids = Arrays.asList(0, 1, 2);
-
-        for (int i : ids) {
-            dispatcher.dispatch(getMessage(i), ENDPOINT_ID);
-        }
-
-        ArgumentCaptor<JsonRpcResponse> responseCaptor = ArgumentCaptor.forClass(JsonRpcResponse.class);
-
-        verify(receiver, times(3)).receive(responseCaptor.capture(), eq(ENDPOINT_ID));
-
-        responseCaptor.getAllValues().forEach(response -> {
-            assertTrue(ids.contains(response.getId()));
-            assertEquals(response.getResult(), RESULT);
-        });
-    }
-
-    @Test
-    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
-        receivers.put("test-met.*", receiver);
-        receivers.put("test-me.*", receiver);
-        receivers.put("test-m.*", receiver);
-        dispatcher = new WebSocketJsonRpcResponseDispatcher(requestRegistry, receivers);
-        when(requestRegistry.extractFor(eq(0))).thenReturn("test-method");
-
-        dispatcher.dispatch(getMessage(0), ENDPOINT_ID);
-
-        verify(receiver, times(receivers.size())).receive(any(JsonRpcResponse.class), eq(ENDPOINT_ID));
     }
 
     private String getMessage(Integer id) {

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseDispatcherTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseDispatcherTest.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcResponseReceiver;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests for {@link WebSocketJsonRpcResponseDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketJsonRpcResponseDispatcherTest {
+    private static final Integer REQUEST_ID  = 0;
+    private static final int     ENDPOINT_ID = 1;
+    private static final String  RESULT      = "result";
+
+    @Mock
+    private JsonRpcRequestRegistry requestRegistry;
+    @Spy
+    private Map<String, JsonRpcResponseReceiver> receivers = new HashMap<>();
+    @InjectMocks
+    private WebSocketJsonRpcResponseDispatcher dispatcher;
+
+    @Mock
+    private JsonRpcResponseReceiver receiver;
+
+    @BeforeMethod
+    public void before() {
+        receivers.clear();
+    }
+
+    @Test
+    public void shouldRunMatchingReceiver() {
+        receivers.put("test-method", receiver);
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(requestRegistry, receivers);
+        when(requestRegistry.extractFor(eq(0))).thenReturn("test-method");
+
+        dispatcher.dispatch(getMessage(0), ENDPOINT_ID);
+
+        ArgumentCaptor<JsonRpcResponse> responseCaptor = ArgumentCaptor.forClass(JsonRpcResponse.class);
+
+        verify(receiver).receive(responseCaptor.capture(), eq(ENDPOINT_ID));
+
+        final JsonRpcResponse response = responseCaptor.getValue();
+
+        assertEquals(response.getResult(), RESULT);
+        assertEquals(response.getId(), REQUEST_ID);
+    }
+
+    @Test
+    public void shouldRunMatchingReceiverWithRegExpedName() {
+        receivers.put("test-met.*", receiver);
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(requestRegistry, receivers);
+
+        when(requestRegistry.extractFor(eq(0))).thenReturn("test-method");
+        when(requestRegistry.extractFor(eq(1))).thenReturn("test-metho");
+        when(requestRegistry.extractFor(eq(2))).thenReturn("test-meth");
+
+        final List<Integer> ids = Arrays.asList(0, 1, 2);
+
+        for (int i : ids) {
+            dispatcher.dispatch(getMessage(i), ENDPOINT_ID);
+        }
+
+        ArgumentCaptor<JsonRpcResponse> responseCaptor = ArgumentCaptor.forClass(JsonRpcResponse.class);
+
+        verify(receiver, times(3)).receive(responseCaptor.capture(), eq(ENDPOINT_ID));
+
+        responseCaptor.getAllValues().forEach(response -> {
+            assertTrue(ids.contains(response.getId()));
+            assertEquals(response.getResult(), RESULT);
+        });
+    }
+
+    @Test
+    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
+        receivers.put("test-met.*", receiver);
+        receivers.put("test-me.*", receiver);
+        receivers.put("test-m.*", receiver);
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(requestRegistry, receivers);
+        when(requestRegistry.extractFor(eq(0))).thenReturn("test-method");
+
+        dispatcher.dispatch(getMessage(0), ENDPOINT_ID);
+
+        verify(receiver, times(receivers.size())).receive(any(JsonRpcResponse.class), eq(ENDPOINT_ID));
+    }
+
+    private String getMessage(Integer id) {
+        return "{" +
+               "\"id\":\"" + id + "\"," +
+               "\"jsonrpc\":\"" + "2.0" + "\"," +
+               "\"result\":\"" + RESULT + "\"" +
+               "}";
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseTransmitterTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcResponseTransmitterTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcResponseTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketJsonRpcResponseTransmitterTest {
+    private static final int    ENDPOINT_ID = 0;
+    private static final String MESSAGE     = "message";
+    private static final String TYPE        = "response";
+
+    @Mock
+    private WebSocketJsonRpcTransmitter         transmitter;
+    @InjectMocks
+    private WebSocketJsonRpcResponseTransmitter responseTransmitter;
+
+    @Mock
+    private JsonRpcResponse response;
+
+    @BeforeMethod
+    public void before() {
+        when(response.toString()).thenReturn(MESSAGE);
+    }
+
+
+    @Test
+    public void shouldRunWebSocketTransmitterWithEndpoint() {
+        responseTransmitter.transmit(response, ENDPOINT_ID);
+
+        verify(transmitter).transmit(TYPE, MESSAGE, ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldRunWebSocketTransmitterWithoutEndpoint() {
+        responseTransmitter.transmit(response);
+
+        verify(transmitter).transmit(TYPE, MESSAGE);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcTransmitterTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/impl/WebSocketJsonRpcTransmitterTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.api.core.websocket.WebSocketMessageTransmitter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link WebSocketJsonRpcTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketJsonRpcTransmitterTest {
+    private static final String PROTOCOL    = "jsonrpc-2.0";
+    private static final String MESSAGE     = "message";
+    private static final String TYPE        = "registered-type";
+    private static final int    ENDPOINT_ID = 0;
+
+    @Mock
+    private WebSocketMessageTransmitter transmitter;
+    @Mock
+    private JsonRpcObjectValidator      validator;
+    @InjectMocks
+    private WebSocketJsonRpcTransmitter jsonRpcTransmitter;
+
+    private JsonRpcObject object;
+
+    @BeforeMethod
+    public void before() {
+        object = newDto(JsonRpcObject.class).withType(TYPE).withMessage(MESSAGE);
+    }
+
+    @Test
+    public void shouldValidateJsonRpcObjectWithoutEndpointSet() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE);
+
+        verify(validator).validate(object);
+    }
+
+    @Test
+    public void shouldTransmitJsonRpcObjectWithoutEndpointSet() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE);
+
+        verify(transmitter).transmit(PROTOCOL, object.toString());
+    }
+
+    @Test
+    public void shouldValidateJsonRpcObjectWithEndpoint() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE, ENDPOINT_ID);
+
+        verify(validator).validate(object);
+    }
+
+    @Test
+    public void shouldTransmitJsonRpcObjectWithEndpoint() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE, ENDPOINT_ID);
+
+        verify(transmitter).transmit(PROTOCOL, object.toString(), ENDPOINT_ID);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpointTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpointTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.websocket.CloseReason;
+import javax.websocket.Session;
+
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for {@link BasicWebSocketEndpoint}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class BasicWebSocketEndpointTest {
+    private static final int    ENDPOINT_ID      = 0;
+    private static final String MESSAGE          = "message";
+    private static final int    MAX_IDLE_TIMEOUT = 0;
+
+    @Mock
+    private WebSocketSessionRegistry        registry;
+    @Mock
+    private PendingMessagesReSender         reSender;
+    @Mock
+    private WebSocketTransmissionDispatcher dispatcher;
+    @Mock
+    private WebSocketTransmissionValidator  validator;
+    @InjectMocks
+    private BasicWebSocketEndpoint          endpoint;
+
+    @Mock
+    private Session     session;
+    @Mock
+    private CloseReason closeReason;
+    @Mock
+    private Throwable   throwable;
+
+    @Test
+    public void shouldSetSessionMaxIdleTimeoutOnOpen() {
+        endpoint.onOpen(session, ENDPOINT_ID);
+
+        verify(session).setMaxIdleTimeout(MAX_IDLE_TIMEOUT);
+    }
+
+    @Test
+    public void shouldRegisterSessionOnOpen() {
+        endpoint.onOpen(session, ENDPOINT_ID);
+
+        verify(registry).add(ENDPOINT_ID, session);
+    }
+
+    @Test
+    public void shouldSendPendingMessagesSessionOnOpen() {
+        endpoint.onOpen(session, ENDPOINT_ID);
+
+        verify(reSender).resend(ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldRemoveSessionFromRegistryOnClose() {
+        endpoint.onClose(closeReason, ENDPOINT_ID);
+
+        verify(registry).remove(ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldRunReceiverOnMessage() {
+        endpoint.onMessage(MESSAGE, ENDPOINT_ID);
+
+        verify(dispatcher).dispatch(MESSAGE, ENDPOINT_ID);
+    }
+
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketTransmissionTransmitterTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketTransmissionTransmitterTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.Session;
+import java.util.Optional;
+
+import static java.util.Collections.emptySet;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link BasicWebSocketMessageTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class BasicWebSocketTransmissionTransmitterTest {
+    private static final String PROTOCOL    = "protocol";
+    private static final String MESSAGE     = "message";
+    private static final int    ENDPOINT_ID = 0;
+
+    @Mock
+    private WebSocketSessionRegistry         registry;
+    @Mock
+    private PendingMessagesReSender          reSender;
+    @Mock
+    private WebSocketTransmissionValidator   validator;
+    @InjectMocks
+    private BasicWebSocketMessageTransmitter transmitter;
+
+    @Mock
+    private Session              session;
+    @Mock
+    private RemoteEndpoint.Async remote;
+
+    private WebSocketTransmission transmission;
+
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        when(session.getAsyncRemote()).thenReturn(remote);
+        when(session.isOpen()).thenReturn(true);
+
+        when(registry.get(eq(ENDPOINT_ID))).thenReturn(Optional.of(session));
+        when(registry.getSessions()).thenReturn(emptySet());
+
+        transmission = DtoFactory.newDto(WebSocketTransmission.class).withProtocol(PROTOCOL).withMessage(MESSAGE);
+    }
+
+    @Test
+    public void shouldValidateDirectMessage() {
+        transmitter.transmit(PROTOCOL, MESSAGE, ENDPOINT_ID);
+
+        verify(validator).validate(any(WebSocketTransmission.class));
+    }
+
+    @Test
+    public void shouldValidateBroadcastMessage() {
+        transmitter.transmit(PROTOCOL, MESSAGE, ENDPOINT_ID);
+
+        verify(validator).validate(any(WebSocketTransmission.class));
+    }
+
+    @Test
+    public void shouldSendDirectMessageIfSessionIsOpenAndEndpointIsSet() {
+        transmitter.transmit(PROTOCOL, MESSAGE, ENDPOINT_ID);
+
+        verify(session).getAsyncRemote();
+        verify(remote).sendText(transmission.toString());
+        verify(reSender, never()).add(eq(ENDPOINT_ID), any(WebSocketTransmission.class));
+    }
+
+    @Test
+    public void shouldSendBroadcastingMessageIfSessionIsOpen() {
+        transmitter.transmit(PROTOCOL, MESSAGE);
+
+        verify(session, never()).getAsyncRemote();
+        verify(remote, never()).sendText(transmission.toString());
+        verify(reSender, never()).add(any(), any(WebSocketTransmission.class));
+
+        verify(registry).getSessions();
+    }
+
+    @Test
+    public void shouldAddMessageToPendingIfSessionIsNotOpenedAndEndpointIsSet() {
+        when(session.isOpen()).thenReturn(false);
+
+        transmitter.transmit(PROTOCOL, MESSAGE, ENDPOINT_ID);
+
+        verify(session, never()).getAsyncRemote();
+        verify(remote, never()).sendText(transmission.toString());
+        verify(reSender).add(eq(ENDPOINT_ID), any(WebSocketTransmission.class));
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketTransmissionValidatorTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketTransmissionValidatorTest.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Tests for {@link BasicWebSocketTransmissionValidator}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class BasicWebSocketTransmissionValidatorTest {
+    private static final String REGISTERED_PROTOCOL     = "registered-protocol";
+    private static final String NOT_REGISTERED_PROTOCOL = "not-registered-protocol";
+    private static final String VALID_JSON              = "{ \"name\": \"value\" }";
+    private static final String NOT_VALID_JSON          = "not valid json";
+
+    @Mock
+    private Map<String, WebSocketMessageReceiver> receivers;
+
+    private BasicWebSocketTransmissionValidator   validator;
+
+    @Mock
+    private WebSocketTransmission transmission;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        when(transmission.getProtocol()).thenReturn(REGISTERED_PROTOCOL);
+        when(transmission.getMessage()).thenReturn(VALID_JSON);
+
+        when(receivers.keySet()).thenReturn(Collections.singletonMap(REGISTERED_PROTOCOL, mock(WebSocketMessageReceiver.class)).keySet());
+        validator = new BasicWebSocketTransmissionValidator(receivers);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void validateTransmissionShouldThrowExceptionIfProtocolIsNull() {
+        when(transmission.getProtocol()).thenReturn(null);
+
+        validator.validate(transmission);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfProtocolIsEmpty() {
+        when(transmission.getProtocol()).thenReturn("");
+
+        validator.validate(transmission);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNull() {
+        when(transmission.getMessage()).thenReturn(null);
+
+        validator.validate(transmission);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsEmpty() {
+        when(transmission.getMessage()).thenReturn("");
+
+        validator.validate(transmission);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfProtocolIsNotRegistered() {
+        when(transmission.getProtocol()).thenReturn(NOT_REGISTERED_PROTOCOL);
+
+        validator.validate(transmission);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNotValidJson() {
+        when(transmission.getMessage()).thenReturn(NOT_VALID_JSON);
+
+        validator.validate(transmission);
+    }
+
+    @Test
+    public void validateReceptionShouldPassForValidWebSocketTransmission() {
+        validator.validate(transmission);
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/PendingMessagesReSenderTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/PendingMessagesReSenderTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.Session;
+import java.util.Optional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link PendingMessagesReSender}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class PendingMessagesReSenderTest {
+    private static final String MESSAGE     = "message";
+    private static final int    ENDPOINT_ID = 0;
+
+    @Mock
+    private WebSocketSessionRegistry sessionRegistry;
+    @InjectMocks
+    private PendingMessagesReSender  resender;
+
+    @Mock
+    private Session               session;
+    @Mock
+    private RemoteEndpoint.Async  endpoint;
+    @Mock
+    private WebSocketTransmission transmission;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        when(sessionRegistry.get(any(Integer.class))).thenReturn(Optional.of(session));
+        when(session.getAsyncRemote()).thenReturn(endpoint);
+        when(session.isOpen()).thenReturn(true);
+        when(transmission.toString()).thenReturn(MESSAGE);
+    }
+
+    @BeforeMethod
+    public void before() {
+        resender = new PendingMessagesReSender(sessionRegistry);
+    }
+
+    @Test
+    public void shouldStopIfSessionIsNotRegistered() {
+        when(sessionRegistry.get(any(Integer.class))).thenReturn(Optional.empty());
+
+        resender.add(ENDPOINT_ID, transmission);
+
+        resender.resend(ENDPOINT_ID);
+
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(session, never()).getAsyncRemote();
+        verify(endpoint, never()).sendText(eq(MESSAGE));
+    }
+
+    @Test
+    public void shouldKeepMessagesIfSessionIsClosed() {
+        resender.add(ENDPOINT_ID, transmission);
+
+        when(session.isOpen()).thenReturn(false);
+        resender.resend(ENDPOINT_ID);
+
+        verify(session, never()).getAsyncRemote();
+        verify(endpoint, never()).sendText(eq(MESSAGE));
+
+        when(session.isOpen()).thenReturn(true);
+        resender.resend(ENDPOINT_ID);
+
+        verify(session).getAsyncRemote();
+        verify(endpoint).sendText(eq(MESSAGE));
+    }
+
+    @Test
+    public void shouldProperlyAddForSingleEndpoint() {
+        resender.add(ENDPOINT_ID, transmission);
+
+        resender.resend(ENDPOINT_ID);
+
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(session).getAsyncRemote();
+        verify(endpoint).sendText(eq(MESSAGE));
+    }
+
+    @Test
+    public void shouldProperlyAddForSeveralEndpoints() {
+        resender.add(ENDPOINT_ID, transmission);
+        resender.add(1, transmission);
+
+        resender.resend(ENDPOINT_ID);
+        resender.resend(1);
+
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(sessionRegistry).get(eq(1));
+        verify(session, times(2)).getAsyncRemote();
+        verify(endpoint, times(2)).sendText(eq(MESSAGE));
+    }
+
+    @Test
+    public void shouldClearOnExtractionForSingleEndpoint() {
+        resender.add(ENDPOINT_ID, transmission);
+
+        resender.resend(ENDPOINT_ID);
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(session).getAsyncRemote();
+        verify(endpoint).sendText(eq(MESSAGE));
+
+        resender.resend(ENDPOINT_ID);
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(session).getAsyncRemote();
+        verify(endpoint).sendText(eq(MESSAGE));
+    }
+
+    @Test
+    public void shouldClearOnExtractionForSeveralEndpoint() {
+        resender.add(ENDPOINT_ID, transmission);
+        resender.add(1, transmission);
+
+        resender.resend(ENDPOINT_ID);
+        resender.resend(1);
+
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(sessionRegistry).get(eq(1));
+        verify(session, times(2)).getAsyncRemote();
+        verify(endpoint, times(2)).sendText(eq(MESSAGE));
+
+        resender.resend(ENDPOINT_ID);
+        resender.resend(1);
+
+        verify(sessionRegistry).get(eq(ENDPOINT_ID));
+        verify(sessionRegistry).get(eq(1));
+        verify(session, times(2)).getAsyncRemote();
+        verify(endpoint, times(2)).sendText(eq(MESSAGE));
+    }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistryTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistryTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.websocket.Session;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for {@link WebSocketSessionRegistry}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketSessionRegistryTest {
+
+    private WebSocketSessionRegistry registry;
+
+    @Mock
+    private Session session;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        registry = new WebSocketSessionRegistry();
+    }
+
+    @Test
+    public void shouldAddSession() {
+        assertTrue(registry.getSessions().isEmpty());
+
+        registry.add(0, session);
+
+        assertFalse(registry.getSessions().isEmpty());
+    }
+
+    @Test
+    public void shouldAddCorrectSession() {
+        registry.add(0, this.session);
+
+        final Optional<Session> sessionOptional = registry.get(0);
+        assertTrue(sessionOptional.isPresent());
+
+        final Session session = sessionOptional.get();
+        assertEquals(this.session, session);
+    }
+
+
+    @Test
+    public void shouldRemoveSession() {
+        registry.add(0, session);
+
+        assertFalse(registry.getSessions().isEmpty());
+        assertEquals(1, registry.getSessions().size());
+
+        registry.remove(0);
+
+        assertTrue(registry.getSessions().isEmpty());
+    }
+
+    @Test
+    public void shouldGetAllSessions() {
+        registry.add(0, session);
+
+        assertFalse(registry.getSessions().isEmpty());
+        assertEquals(1, registry.getSessions().size());
+
+        registry.add(1, mock(Session.class));
+
+        assertFalse(registry.getSessions().isEmpty());
+        assertEquals(2, registry.getSessions().size());
+    }
+
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/WebSocketTransmissionDispatcherTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/websocket/impl/WebSocketTransmissionDispatcherTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.websocket.impl;
+
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketTransmissionDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WebSocketTransmissionDispatcherTest {
+    private static final int    ENDPOINT_ID             = 0;
+    private static final String REGISTERED_PROTOCOL     = "registered-protocol";
+    private static final String NOT_REGISTERED_PROTOCOL = "not-registered-protocol";
+    private static final String MESSAGE                 = "message";
+    @Mock
+    private Map<String, WebSocketMessageReceiver> receivers;
+    @Mock
+    private WebSocketTransmissionValidator        validator;
+    @InjectMocks
+    private WebSocketTransmissionDispatcher       dispatcher;
+
+    @Mock
+    private WebSocketMessageReceiver receiver;
+
+    private WebSocketTransmission transmission;
+
+    @BeforeMethod
+    public void before() {
+        when(receivers.entrySet()).thenReturn(Collections.singletonMap(REGISTERED_PROTOCOL, receiver).entrySet());
+
+        transmission = newDto(WebSocketTransmission.class).withProtocol(REGISTERED_PROTOCOL).withMessage(MESSAGE);
+    }
+
+    @Test
+    public void shouldValidateWebSocketTransmission() {
+        dispatcher.dispatch(transmission.toString(), ENDPOINT_ID);
+
+        verify(validator).validate(transmission);
+    }
+
+    @Test
+    public void shouldRunReceiverOnMatch() {
+        dispatcher.dispatch(transmission.toString(), ENDPOINT_ID);
+
+        verify(receiver).receive(MESSAGE, ENDPOINT_ID);
+    }
+
+    @Test
+    public void shouldNotRunReceiverOnNoMatch() {
+        transmission.withProtocol(NOT_REGISTERED_PROTOCOL);
+
+        dispatcher.dispatch(transmission.toString(), ENDPOINT_ID);
+
+        verify(receiver, never()).receive(MESSAGE, ENDPOINT_ID);
+    }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventService.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventService.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.event.ng;
+
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.api.project.shared.dto.event.FileClosedDto;
+import org.eclipse.che.api.project.shared.dto.event.FileOpenedDto;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.event.FileEventHandler;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestTransmitter;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class ClientServerEventService {
+    private final JsonRpcRequestTransmitter transmitter;
+    private final DtoFactory                dtoFactory;
+
+    @Inject
+    public ClientServerEventService(final JsonRpcRequestTransmitter transmitter,
+                                    final EventBus eventBus,
+                                    final DtoFactory dtoFactory) {
+        this.transmitter = transmitter;
+        this.dtoFactory = dtoFactory;
+
+        Log.info(getClass(), "Adding file event listener");
+        eventBus.addHandler(FileEvent.TYPE, new FileEventHandler() {
+            @Override
+            public void onFileOperation(FileEvent event) {
+                final String path = event.getFile().getLocation().toString();
+
+                switch (event.getOperationType()) {
+                    case OPEN: {
+                        transmitOpenFileNotification(path);
+
+                        break;
+                    }
+                    case CLOSE: {
+                        transmitCloseFileNotification(path);
+
+                        break;
+                    }
+                }
+            }
+        });
+
+
+    }
+
+    private void transmitCloseFileNotification(String path) {
+        Log.info(ClientServerEventService.class, "Sending file closed event: " + path);
+
+        final FileClosedDto dto = dtoFactory.createDto(FileClosedDto.class).withPath(path);
+
+        final JsonRpcRequest request = dtoFactory.createDto(JsonRpcRequest.class)
+                                                 .withJsonrpc("2.0")
+                                                 .withMethod("event:file-closed")
+                                                 .withParams(dto.toString());
+
+        transmitter.transmit(request);
+    }
+
+    private void transmitOpenFileNotification(String path) {
+        Log.info(ClientServerEventService.class, "Sending file opened event: " + path);
+
+        final FileOpenedDto dto = dtoFactory.createDto(FileOpenedDto.class).withPath(path);
+
+        final JsonRpcRequest notification = dtoFactory.createDto(JsonRpcRequest.class)
+                                                      .withJsonrpc("2.0")
+                                                      .withMethod("event:file-opened")
+                                                      .withParams(dto.toString());
+
+        transmitter.transmit(notification);
+    }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileUpdateEventRequestReceiver.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileUpdateEventRequestReceiver.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.event.ng;
+
+
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.api.project.shared.dto.event.FileUpdatedDto;
+import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestReceiver;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class FileUpdateEventRequestReceiver implements JsonRpcRequestReceiver {
+    private final DtoFactory dtoFactory;
+    private final EventBus   eventBus;
+
+    @Inject
+    public FileUpdateEventRequestReceiver(DtoFactory dtoFactory, EventBus eventBus) {
+        this.dtoFactory = dtoFactory;
+        this.eventBus = eventBus;
+    }
+
+    @Override
+    public void receive(JsonRpcRequest request) {
+        final String params = request.getParams();
+        final FileUpdatedDto dto = dtoFactory.createDtoFromJson(params, FileUpdatedDto.class);
+        eventBus.fireEvent(new FileContentUpdateEvent(dto.getPath()));
+    }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.event.ng;
+
+import com.google.gwt.user.client.Random;
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
+import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
+import org.eclipse.che.ide.jsonrpc.impl.JsonRpcInitializer;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Singleton;
+
+import static java.util.Collections.singletonMap;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class JsonRpcWebSocketAgentEventListener implements WsAgentStateHandler {
+    private static final int ENDPOINT_ID = Random.nextInt(Integer.MAX_VALUE);
+
+    private final JsonRpcInitializer initializer;
+    private final AppContext         appContext;
+
+    @Inject
+    public JsonRpcWebSocketAgentEventListener(JsonRpcInitializer initializer, AppContext appContext, EventBus eventBus) {
+        this.appContext = appContext;
+        this.initializer = initializer;
+
+        eventBus.addHandler(WsAgentStateEvent.TYPE, this);
+    }
+
+    @Override
+    public void onWsAgentStarted(WsAgentStateEvent event) {
+        Log.info(JsonRpcWebSocketAgentEventListener.class, "Web socket agent started event caught.");
+        try {
+            internalInitialize();
+        } catch (Exception e) {
+            Log.info(JsonRpcWebSocketAgentEventListener.class, "Failed, will try one more time.");
+            new Timer() {
+                @Override
+                public void run() {
+                    internalInitialize();
+                }
+            }.schedule(1_000);
+        }
+    }
+
+    private void internalInitialize() {
+        final DevMachine devMachine = appContext.getDevMachine();
+        final String wsAgentWebSocketUrl = devMachine.getWsAgentWebSocketUrl();
+        // Ugly temporary shi^wmeasure
+        final String url = wsAgentWebSocketUrl.split("wsagent")[0] + "wsagent/websocket/" + ENDPOINT_ID;
+
+        initializer.initialize(singletonMap("url", url));
+    }
+
+    @Override
+    public void onWsAgentStopped(WsAgentStateEvent event) {
+        Log.info(JsonRpcWebSocketAgentEventListener.class, "Web socket agent stopped event caught.");
+
+        initializer.terminate();
+    }
+}

--- a/ide/che-core-ide-api/src/main/resources/org/eclipse/che/api/core/Core.gwt.xml
+++ b/ide/che-core-ide-api/src/main/resources/org/eclipse/che/api/core/Core.gwt.xml
@@ -16,4 +16,6 @@
     <inherits name='com.google.gwt.user.User'/>
     <inherits name="com.google.gwt.json.JSON"/>
     <source path='rest/shared'/>
+    <source path='jsonrpc/shared'/>
+    <source path='websocket/shared'/>
 </module>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
@@ -21,42 +21,19 @@ import com.google.inject.name.Named;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.SimpleEventBus;
 
-import org.eclipse.che.ide.api.auth.OAuthServiceClient;
-import org.eclipse.che.ide.api.auth.OAuthServiceClientImpl;
-import org.eclipse.che.ide.api.factory.FactoryServiceClient;
-import org.eclipse.che.ide.api.factory.FactoryServiceClientImpl;
-import org.eclipse.che.ide.api.git.GitServiceClient;
-import org.eclipse.che.ide.api.git.GitServiceClientImpl;
-import org.eclipse.che.ide.api.machine.MachineServiceClient;
-import org.eclipse.che.ide.api.machine.MachineServiceClientImpl;
-import org.eclipse.che.ide.api.machine.RecipeServiceClient;
-import org.eclipse.che.ide.api.machine.RecipeServiceClientImpl;
-import org.eclipse.che.ide.api.project.ProjectImportersServiceClient;
-import org.eclipse.che.ide.api.project.ProjectImportersServiceClientImpl;
-import org.eclipse.che.ide.api.project.ProjectServiceClient;
-import org.eclipse.che.ide.api.project.ProjectServiceClientImpl;
-import org.eclipse.che.ide.api.project.ProjectTemplateServiceClient;
-import org.eclipse.che.ide.api.project.ProjectTemplateServiceClientImpl;
-import org.eclipse.che.ide.api.project.ProjectTypeServiceClient;
-import org.eclipse.che.ide.api.project.ProjectTypeServiceClientImpl;
-import org.eclipse.che.ide.api.ssh.SshServiceClient;
-import org.eclipse.che.ide.api.ssh.SshServiceClientImpl;
-import org.eclipse.che.ide.api.user.PreferencesServiceClient;
-import org.eclipse.che.ide.api.user.PreferencesServiceClientImpl;
-import org.eclipse.che.ide.api.user.UserProfileServiceClient;
-import org.eclipse.che.ide.api.user.UserProfileServiceClientImpl;
-import org.eclipse.che.ide.api.user.UserServiceClient;
-import org.eclipse.che.ide.api.user.UserServiceClientImpl;
-import org.eclipse.che.ide.api.workspace.WorkspaceServiceClient;
-import org.eclipse.che.ide.api.workspace.WorkspaceServiceClientImpl;
 import org.eclipse.che.ide.Resources;
 import org.eclipse.che.ide.actions.ActionManagerImpl;
 import org.eclipse.che.ide.actions.find.FindActionView;
 import org.eclipse.che.ide.actions.find.FindActionViewImpl;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.auth.OAuthServiceClient;
+import org.eclipse.che.ide.api.auth.OAuthServiceClientImpl;
 import org.eclipse.che.ide.api.component.Component;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
+import org.eclipse.che.ide.api.data.tree.NodeInterceptor;
+import org.eclipse.che.ide.api.data.tree.settings.SettingsProvider;
+import org.eclipse.che.ide.api.data.tree.settings.impl.DummySettingsProvider;
 import org.eclipse.che.ide.api.debug.DebuggerServiceClient;
 import org.eclipse.che.ide.api.debug.DebuggerServiceClientImpl;
 import org.eclipse.che.ide.api.dialogs.ChoiceDialog;
@@ -66,12 +43,23 @@ import org.eclipse.che.ide.api.dialogs.InputDialog;
 import org.eclipse.che.ide.api.dialogs.MessageDialog;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorRegistry;
+import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
+import org.eclipse.che.ide.api.event.ng.FileUpdateEventRequestReceiver;
+import org.eclipse.che.ide.api.event.ng.JsonRpcWebSocketAgentEventListener;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 import org.eclipse.che.ide.api.extension.ExtensionRegistry;
+import org.eclipse.che.ide.api.factory.FactoryServiceClient;
+import org.eclipse.che.ide.api.factory.FactoryServiceClientImpl;
 import org.eclipse.che.ide.api.filetypes.FileType;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
+import org.eclipse.che.ide.api.git.GitServiceClient;
+import org.eclipse.che.ide.api.git.GitServiceClientImpl;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
+import org.eclipse.che.ide.api.machine.MachineServiceClient;
+import org.eclipse.che.ide.api.machine.MachineServiceClientImpl;
+import org.eclipse.che.ide.api.machine.RecipeServiceClient;
+import org.eclipse.che.ide.api.machine.RecipeServiceClientImpl;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.oauth.OAuth2Authenticator;
 import org.eclipse.che.ide.api.oauth.OAuth2AuthenticatorRegistry;
@@ -85,9 +73,14 @@ import org.eclipse.che.ide.api.parts.WorkBenchView;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.preferences.PreferencePagePresenter;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
-import org.eclipse.che.ide.api.data.tree.NodeInterceptor;
-import org.eclipse.che.ide.api.data.tree.settings.SettingsProvider;
-import org.eclipse.che.ide.api.data.tree.settings.impl.DummySettingsProvider;
+import org.eclipse.che.ide.api.project.ProjectImportersServiceClient;
+import org.eclipse.che.ide.api.project.ProjectImportersServiceClientImpl;
+import org.eclipse.che.ide.api.project.ProjectServiceClient;
+import org.eclipse.che.ide.api.project.ProjectServiceClientImpl;
+import org.eclipse.che.ide.api.project.ProjectTemplateServiceClient;
+import org.eclipse.che.ide.api.project.ProjectTemplateServiceClientImpl;
+import org.eclipse.che.ide.api.project.ProjectTypeServiceClient;
+import org.eclipse.che.ide.api.project.ProjectTypeServiceClientImpl;
 import org.eclipse.che.ide.api.project.type.ProjectTemplateRegistry;
 import org.eclipse.che.ide.api.project.type.ProjectTypeRegistry;
 import org.eclipse.che.ide.api.project.type.wizard.PreSelectedProjectTypeManager;
@@ -97,16 +90,22 @@ import org.eclipse.che.ide.api.project.wizard.ImportProjectNotificationSubscribe
 import org.eclipse.che.ide.api.project.wizard.ImportWizardRegistrar;
 import org.eclipse.che.ide.api.project.wizard.ImportWizardRegistry;
 import org.eclipse.che.ide.api.project.wizard.ProjectNotificationSubscriber;
+import org.eclipse.che.ide.api.reference.FqnProvider;
 import org.eclipse.che.ide.api.resources.ResourceInterceptor;
 import org.eclipse.che.ide.api.resources.modification.ClipboardManager;
-import org.eclipse.che.ide.part.explorer.project.RevealNodesPersistenceComponent;
-import org.eclipse.che.ide.part.explorer.project.TreeResourceRevealer;
-import org.eclipse.che.ide.resources.impl.ClipboardManagerImpl;
-import org.eclipse.che.ide.resources.impl.ResourceManager;
-import org.eclipse.che.ide.api.reference.FqnProvider;
 import org.eclipse.che.ide.api.selection.SelectionAgent;
+import org.eclipse.che.ide.api.ssh.SshServiceClient;
+import org.eclipse.che.ide.api.ssh.SshServiceClientImpl;
 import org.eclipse.che.ide.api.theme.Theme;
 import org.eclipse.che.ide.api.theme.ThemeAgent;
+import org.eclipse.che.ide.api.user.PreferencesServiceClient;
+import org.eclipse.che.ide.api.user.PreferencesServiceClientImpl;
+import org.eclipse.che.ide.api.user.UserProfileServiceClient;
+import org.eclipse.che.ide.api.user.UserProfileServiceClientImpl;
+import org.eclipse.che.ide.api.user.UserServiceClient;
+import org.eclipse.che.ide.api.user.UserServiceClientImpl;
+import org.eclipse.che.ide.api.workspace.WorkspaceServiceClient;
+import org.eclipse.che.ide.api.workspace.WorkspaceServiceClientImpl;
 import org.eclipse.che.ide.client.StartUpActionsProcessor;
 import org.eclipse.che.ide.context.AppContextImpl;
 import org.eclipse.che.ide.editor.EditorAgentImpl;
@@ -116,6 +115,20 @@ import org.eclipse.che.ide.hotkeys.dialog.HotKeysDialogView;
 import org.eclipse.che.ide.hotkeys.dialog.HotKeysDialogViewImpl;
 import org.eclipse.che.ide.icon.DefaultIconsComponent;
 import org.eclipse.che.ide.icon.IconRegistryImpl;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestReceiver;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestTransmitter;
+import org.eclipse.che.ide.jsonrpc.JsonRpcResponseReceiver;
+import org.eclipse.che.ide.jsonrpc.JsonRpcResponseTransmitter;
+import org.eclipse.che.ide.jsonrpc.impl.BasicJsonRpcObjectValidator;
+import org.eclipse.che.ide.jsonrpc.impl.JsonRpcDispatcher;
+import org.eclipse.che.ide.jsonrpc.impl.JsonRpcInitializer;
+import org.eclipse.che.ide.jsonrpc.impl.JsonRpcObjectValidator;
+import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcDispatcher;
+import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcInitializer;
+import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcRequestDispatcher;
+import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcRequestTransmitter;
+import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcResponseDispatcher;
+import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcResponseTransmitter;
 import org.eclipse.che.ide.keybinding.KeyBindingManager;
 import org.eclipse.che.ide.menu.MainMenuView;
 import org.eclipse.che.ide.menu.MainMenuViewImpl;
@@ -142,6 +155,8 @@ import org.eclipse.che.ide.part.explorer.project.DefaultNodeInterceptor;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerView;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerViewImpl;
+import org.eclipse.che.ide.part.explorer.project.RevealNodesPersistenceComponent;
+import org.eclipse.che.ide.part.explorer.project.TreeResourceRevealer;
 import org.eclipse.che.ide.preferences.PreferencesComponent;
 import org.eclipse.che.ide.preferences.PreferencesManagerImpl;
 import org.eclipse.che.ide.preferences.PreferencesView;
@@ -167,6 +182,8 @@ import org.eclipse.che.ide.projecttype.ProjectTypeRegistryImpl;
 import org.eclipse.che.ide.projecttype.wizard.PreSelectedProjectTypeManagerImpl;
 import org.eclipse.che.ide.projecttype.wizard.ProjectWizardFactory;
 import org.eclipse.che.ide.projecttype.wizard.ProjectWizardRegistryImpl;
+import org.eclipse.che.ide.resources.impl.ClipboardManagerImpl;
+import org.eclipse.che.ide.resources.impl.ResourceManager;
 import org.eclipse.che.ide.resources.tree.ResourceNode;
 import org.eclipse.che.ide.rest.RestContext;
 import org.eclipse.che.ide.rest.RestContextProvider;
@@ -197,9 +214,9 @@ import org.eclipse.che.ide.ui.dialogs.message.MessageDialogFooter;
 import org.eclipse.che.ide.ui.dialogs.message.MessageDialogPresenter;
 import org.eclipse.che.ide.ui.dialogs.message.MessageDialogView;
 import org.eclipse.che.ide.ui.dialogs.message.MessageDialogViewImpl;
+import org.eclipse.che.ide.ui.dropdown.DropDownListFactory;
 import org.eclipse.che.ide.ui.dropdown.DropDownWidget;
 import org.eclipse.che.ide.ui.dropdown.DropDownWidgetImpl;
-import org.eclipse.che.ide.ui.dropdown.DropDownListFactory;
 import org.eclipse.che.ide.ui.loaders.initialization.LoaderView;
 import org.eclipse.che.ide.ui.loaders.initialization.LoaderViewImpl;
 import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
@@ -214,6 +231,18 @@ import org.eclipse.che.ide.upload.file.UploadFileViewImpl;
 import org.eclipse.che.ide.upload.folder.UploadFolderFromZipView;
 import org.eclipse.che.ide.upload.folder.UploadFolderFromZipViewImpl;
 import org.eclipse.che.ide.util.executor.UserActivityManager;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageReceiver;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageTransmitter;
+import org.eclipse.che.ide.websocket.ng.impl.BasicWebSocketMessageTransmitter;
+import org.eclipse.che.ide.websocket.ng.impl.BasicWebSocketTransmissionValidator;
+import org.eclipse.che.ide.websocket.ng.impl.BasicWebSocketEndpoint;
+import org.eclipse.che.ide.websocket.ng.impl.DelayableWebSocket;
+import org.eclipse.che.ide.websocket.ng.impl.SessionWebSocketInitializer;
+import org.eclipse.che.ide.websocket.ng.impl.WebSocket;
+import org.eclipse.che.ide.websocket.ng.impl.WebSocketCreator;
+import org.eclipse.che.ide.websocket.ng.impl.WebSocketEndpoint;
+import org.eclipse.che.ide.websocket.ng.impl.WebSocketInitializer;
+import org.eclipse.che.ide.websocket.ng.impl.WebSocketTransmissionValidator;
 import org.eclipse.che.ide.workspace.PartStackPresenterFactory;
 import org.eclipse.che.ide.workspace.PartStackViewFactory;
 import org.eclipse.che.ide.workspace.WorkBenchControllerFactory;
@@ -285,6 +314,10 @@ public class CoreGinModule extends AbstractGinModule {
         configureEditorAPI();
         configureProjectTree();
 
+        configureJsonRpc();
+        configureWebSocket();
+        configureClientServerEventService();
+
         GinMultibinder<PersistenceComponent> persistenceComponentsMultibinder =
                 GinMultibinder.newSetBinder(binder(), PersistenceComponent.class);
         persistenceComponentsMultibinder.addBinding().to(ShowHiddenFilesPersistenceComponent.class);
@@ -299,6 +332,55 @@ public class CoreGinModule extends AbstractGinModule {
         bind(ClipboardManager.class).to(ClipboardManagerImpl.class);
 
         GinMultibinder.newSetBinder(binder(), ResourceInterceptor.class).addBinding().to(ResourceInterceptor.NoOpInterceptor.class);
+    }
+
+    private void configureClientServerEventService() {
+        bind(ClientServerEventService.class).asEagerSingleton();
+
+        GinMapBinder<String, JsonRpcRequestReceiver> requestReceivers =
+                GinMapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+
+        requestReceivers.addBinding("event:file-updated").to(FileUpdateEventRequestReceiver.class);
+    }
+
+    private void configureJsonRpc() {
+        bind(JsonRpcWebSocketAgentEventListener.class).asEagerSingleton();
+
+        bind(JsonRpcInitializer.class).to(WebSocketJsonRpcInitializer.class);
+
+        bind(JsonRpcRequestTransmitter.class).to(WebSocketJsonRpcRequestTransmitter.class);
+        bind(JsonRpcResponseTransmitter.class).to(WebSocketJsonRpcResponseTransmitter.class);
+
+        bind(JsonRpcObjectValidator.class).to(BasicJsonRpcObjectValidator.class);
+
+        GinMapBinder<String, JsonRpcDispatcher> dispatchers = GinMapBinder.newMapBinder(binder(), String.class, JsonRpcDispatcher.class);
+        dispatchers.addBinding("request").to(WebSocketJsonRpcRequestDispatcher.class);
+        dispatchers.addBinding("response").to(WebSocketJsonRpcResponseDispatcher.class);
+
+        GinMapBinder<String, JsonRpcRequestReceiver> requestReceivers =
+                GinMapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+
+        GinMapBinder<String, JsonRpcResponseReceiver> responseReceivers =
+                GinMapBinder.newMapBinder(binder(), String.class, JsonRpcResponseReceiver.class);
+    }
+
+    private void configureWebSocket() {
+        bind(WebSocketInitializer.class).to(SessionWebSocketInitializer.class);
+
+        bind(WebSocketEndpoint.class).to(BasicWebSocketEndpoint.class);
+
+        bind(WebSocketTransmissionValidator.class).to(BasicWebSocketTransmissionValidator.class);
+
+        bind(WebSocketMessageTransmitter.class).to(BasicWebSocketMessageTransmitter.class);
+
+        install(new GinFactoryModuleBuilder()
+                        .implement(WebSocket.class, DelayableWebSocket.class)
+                        .build(WebSocketCreator.class));
+
+        GinMapBinder<String, WebSocketMessageReceiver> receivers =
+                GinMapBinder.newMapBinder(binder(), String.class, WebSocketMessageReceiver.class);
+
+        receivers.addBinding("jsonrpc-2.0").to(WebSocketJsonRpcDispatcher.class);
     }
 
     private void configureComponents() {

--- a/ide/commons-gwt/pom.xml
+++ b/ide/commons-gwt/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>
@@ -67,6 +71,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>
@@ -79,6 +88,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcRequestReceiver.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcRequestReceiver.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+
+/**
+ * The implementation of this interface receives JSON RPC requests according to
+ * the mapping. The mapping is defined via MapBinder in one of Gin modules that
+ * are used in the application. Example is simple:
+ *
+ * <pre>
+ *     <code>
+ *         GinMapBinder<String, JsonRpcRequestReceiver> requestReceivers =
+ *         GinMapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+ *         requestReceivers.addBinding("method-name").to(CustomJsonRpcRequestReceiver.class)
+ *     </code>
+ * </pre>
+ *
+ * All JSON RPC requests that has their method names equal to "method-name" will be
+ * processed by instance of <code>CustomJsonRpcRequestReceiver</code>. Please note
+ * that you can use regular expressions for method names in order to be able to map
+ * single receiver implementation to a several kinds of requests.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcRequestReceiver {
+    /**
+     * Receives a JSON RPC request
+     *
+     * @param request request instance
+     */
+    void receive(JsonRpcRequest request);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcRequestTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcRequestTransmitter.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+
+/**
+ * Transmits a JSON RPC request.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcRequestTransmitter {
+    /**
+     * Transmits a JSON RPC request.
+     *
+     * @param request JSON RPC request instance
+     */
+    void transmit(JsonRpcRequest request);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcResponseReceiver.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcResponseReceiver.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+
+/**
+ * The implementation of this interface receives JSON RPC responses according to
+ * the mapping. The mapping is defined via MapBinder in one of Gin modules that
+ * are used in the application. Example is simple:
+ *
+ * <pre>
+ *     <code>
+ *         GinMapBinder<String, JsonRpcRequestReceiver> responseReceivers =
+ *         GinMapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+ *         responseReceivers.addBinding("method-name").to(CustomJsonRpcResponseReceiver.class)
+ *     </code>
+ * </pre>
+ *
+ * In fact JSON RPC responses has no method defined in their body, though it is quite
+ * possible to bind requests and responses by their identifiers thus we can know which
+ * response correspond to which method. So responses that has their method names equal
+ * to "method-name" will be processed by instance of <code>CustomJsonRpcResponseReceiver</code>.
+ * Please note that you can use regular expressions for method names in order to be able
+ * to map single receiver implementation to a several kinds of requests.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcResponseReceiver {
+    /**
+     * Receive JSON RPC response
+     *
+     * @param response response instance
+     */
+    void receive(JsonRpcResponse response);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcResponseTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcResponseTransmitter.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc;
+
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+
+/**
+ * Transmits a JSON RPC response to an endpoint or broadcast it.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcResponseTransmitter {
+    /**
+     * Transmits a JSON RPC response
+     *
+     * @param response JSON RPC response instance
+     */
+    void transmit(JsonRpcResponse response);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/BasicJsonRpcObjectValidator.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/BasicJsonRpcObjectValidator.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import com.google.gwt.json.client.JSONParser;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Basic implementation of JSON RPC object validator. Validation rules are simple:
+ *
+ * <ul>
+ * <li><code>type</code> must not be <code>null</code></li>
+ * <li><code>type</code> must not be empty</li>
+ * <li><code>type</code> must be registered (mapped to a corresponding receiver implementation)</li>
+ * <li><code>message</code> must not be <code>null</code></li>
+ * <li><code>message</code> must not be empty</li>
+ * <li><code>message</code> must be a valid JSON</li>
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicJsonRpcObjectValidator implements JsonRpcObjectValidator {
+    private final Set<String> registeredTypes;
+
+    @Inject
+    public BasicJsonRpcObjectValidator(Map<String, JsonRpcDispatcher> dispatchers) {
+        this.registeredTypes = dispatchers.keySet();
+    }
+
+
+    @Override
+    public void validate(JsonRpcObject object) {
+        validateType(object.getType());
+        validateMessage(object.getMessage());
+    }
+
+    private void validateType(String type) {
+        if (registeredTypes.contains(type)) {
+            Log.debug(getClass(), "Json rpc object type {} is among registered", type);
+        } else {
+            logError("Json rpc object is of not registered type");
+        }
+    }
+
+    private void validateMessage(String message) {
+        validateNull(message);
+        validateEmpty(message);
+        validateJson(message);
+    }
+
+    private void validateNull(String message) {
+        if (message == null) {
+            logError("Json rpc object message is null");
+        } else {
+            Log.debug(getClass(), "Json rpc object message is not null");
+        }
+    }
+
+    private void validateEmpty(String message) {
+        if (message.isEmpty()) {
+            logError("Json rpc object message is empty");
+        } else {
+            Log.debug(getClass(), "Json rpc object message is not empty");
+        }
+    }
+
+    private void validateJson(String message) {
+        boolean error = false;
+
+        try {
+            JSONParser.parseStrict(message);
+        } catch (Throwable e) {
+            error = true;
+        }
+
+        if (error) {
+            logError("Json rpc object message is not a valid json");
+        } else {
+            Log.debug(getClass(), "Json rpc object message is a valid json");
+        }
+    }
+
+    private void logError(String error) {
+        Log.error(getClass(), error);
+        throw new IllegalArgumentException(error);
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcDispatcher.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcDispatcher.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+
+/**
+ * There are two implementations of this interface:
+ *
+ * <ul>
+ * <li>{@link WebSocketJsonRpcRequestDispatcher}</li>
+ * <li>{@link WebSocketJsonRpcResponseDispatcher}</li>
+ * </ul>
+ *
+ * Each implementation is used to dispatch messages of {@link JsonRpcObject}
+ * of corresponding type: requests or response.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcDispatcher {
+    /**
+     * Dispatches a message
+     *
+     * @param message
+     *         message
+     */
+    void dispatch(String message);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcInitializer.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcInitializer.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import javax.inject.Singleton;
+import java.util.Map;
+
+/**
+ * Initializes and terminates JSON RPC services.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public interface JsonRpcInitializer {
+    /**
+     * Initialize JSON RPC services with properties contained
+     * in a map as simple key->value pairs.
+     *
+     * @param properties properties map
+     */
+    void initialize(Map<String, String> properties);
+
+    /**
+     * Terminates JSON RPC services
+     */
+    void terminate();
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcObjectValidator.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcObjectValidator.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+
+import javax.inject.Singleton;
+
+/**
+ * It is used to make sure that {@link JsonRpcObject} is a valid entity.
+ * Implementation of this interface must be called before any other operation
+ * is performed to avoid any kind of inconsistency.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface JsonRpcObjectValidator {
+    void validate(JsonRpcObject object);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcRequestRegistry.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcRequestRegistry.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Binds request identifiers with request methods. Registry is used by response receivers
+ * to find out what method call is being answered. This is mostly needed because JSON RPC
+ * specification does not define method section in JSON RPC responses so there is no method
+ * name that can be directly mapped to a corresponding receiver.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class JsonRpcRequestRegistry {
+    private final Map<Integer, String> requests = new HashMap<>();
+
+    /**
+     * Add request identifier - request method binding to the registry.
+     *
+     * @param id request identifier
+     * @param method request method
+     */
+    public void add(Integer id, String method) {
+        Log.debug(getClass(), "Binding ID: ", id, " to method: ", method);
+
+        requests.put(id, method);
+    }
+
+    /**
+     * Extracts request method name bound to request identifier
+     *
+     * @param id request identifier
+     *
+     * @return request method name
+     */
+    public String extractFor(Integer id) {
+        Log.debug(getClass(), "Extracting method with ID: ", id);
+
+        return requests.remove(id);
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcDispatcher.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcDispatcher.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageReceiver;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Receives raw JSON RPC objects ({@link JsonRpcObject}) extracted from WEB SOCKET
+ * transmissions ({@link WebSocketTransmission}) and dispatches them among more specific
+ * dispatchers {@link JsonRpcDispatcher}) according to their type (e.g. JSON RPC
+ * request/response dispatchers).
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcDispatcher implements WebSocketMessageReceiver {
+    private final Map<String, JsonRpcDispatcher> dispatchers;
+    private final JsonRpcObjectValidator         validator;
+    private final DtoFactory                     dtoFactory;
+
+    @Inject
+    public WebSocketJsonRpcDispatcher(Map<String, JsonRpcDispatcher> dispatchers, JsonRpcObjectValidator validator, DtoFactory dtoFactory) {
+        this.dispatchers = dispatchers;
+        this.validator = validator;
+        this.dtoFactory = dtoFactory;
+    }
+
+    @Override
+    public void receive(String rawJsonRpcObject) {
+        final JsonRpcObject jsonRpcObject = dtoFactory.createDtoFromJson(rawJsonRpcObject, JsonRpcObject.class);
+        validator.validate(jsonRpcObject);
+
+        final String type = jsonRpcObject.getType();
+        final String message = jsonRpcObject.getMessage();
+
+        for (Entry<String, JsonRpcDispatcher> entry : dispatchers.entrySet()) {
+            final String typeCandidate = entry.getKey();
+            if (Objects.equals(typeCandidate, type)) {
+                final JsonRpcDispatcher dispatcher = entry.getValue();
+                Log.info(getClass(), "Matching json rpc message dispatcher: " + dispatcher.getClass());
+                dispatcher.dispatch(message);
+
+                return;
+            }
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcInitializer.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcInitializer.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.websocket.ng.impl.SessionWebSocketInitializer;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcInitializer implements JsonRpcInitializer {
+    private final SessionWebSocketInitializer webSocketInitializer;
+
+    @Inject
+    public WebSocketJsonRpcInitializer(SessionWebSocketInitializer webSocketInitializer) {
+        this.webSocketInitializer = webSocketInitializer;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        Log.info(getClass(), "Initializing with properties: " + properties);
+
+        webSocketInitializer.initialize(properties);
+    }
+
+    @Override
+    public void terminate() {
+        Log.info(getClass(), "Terminating");
+
+        webSocketInitializer.terminate();
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcher.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcher.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import com.google.gwt.regexp.shared.RegExp;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestReceiver;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static com.google.gwt.regexp.shared.RegExp.compile;
+
+/**
+ * Dispatches JSON RPC requests among all registered implementations of {@link JsonRpcRequestReceiver}
+ * according to their mappings.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcRequestDispatcher implements JsonRpcDispatcher {
+    private final Map<RegExp, JsonRpcRequestReceiver> receivers = new HashMap<>();
+
+    private final DtoFactory dtoFactory;
+
+    @Inject
+    public WebSocketJsonRpcRequestDispatcher(Map<String, JsonRpcRequestReceiver> receivers, DtoFactory dtoFactory) {
+        for (Entry<String, JsonRpcRequestReceiver> entry : receivers.entrySet()) {
+            final RegExp regExp = compile(entry.getKey());
+            final JsonRpcRequestReceiver receiver = entry.getValue();
+            this.receivers.put(regExp, receiver);
+        }
+
+        this.dtoFactory = dtoFactory;
+    }
+
+    @Override
+    public void dispatch(String message) {
+        final JsonRpcRequest request = dtoFactory.createDtoFromJson(message, JsonRpcRequest.class);
+        final String method = request.getMethod();
+
+        for (Entry<RegExp, JsonRpcRequestReceiver> entry : receivers.entrySet()) {
+            final RegExp regExp = entry.getKey();
+            if (regExp.test(method)) {
+                final JsonRpcRequestReceiver receiver = entry.getValue();
+                Log.debug(getClass(), "Matching request receiver: ", receiver.getClass());
+                receiver.receive(request);
+            }
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcher.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcher.java
@@ -22,6 +22,7 @@ import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import static com.google.gwt.regexp.shared.RegExp.compile;
 
@@ -33,18 +34,13 @@ import static com.google.gwt.regexp.shared.RegExp.compile;
  */
 @Singleton
 public class WebSocketJsonRpcRequestDispatcher implements JsonRpcDispatcher {
-    private final Map<RegExp, JsonRpcRequestReceiver> receivers = new HashMap<>();
+    private final Map<String, JsonRpcRequestReceiver> receivers;
 
     private final DtoFactory dtoFactory;
 
     @Inject
     public WebSocketJsonRpcRequestDispatcher(Map<String, JsonRpcRequestReceiver> receivers, DtoFactory dtoFactory) {
-        for (Entry<String, JsonRpcRequestReceiver> entry : receivers.entrySet()) {
-            final RegExp regExp = compile(entry.getKey());
-            final JsonRpcRequestReceiver receiver = entry.getValue();
-            this.receivers.put(regExp, receiver);
-        }
-
+        this.receivers = receivers;
         this.dtoFactory = dtoFactory;
     }
 
@@ -53,9 +49,9 @@ public class WebSocketJsonRpcRequestDispatcher implements JsonRpcDispatcher {
         final JsonRpcRequest request = dtoFactory.createDtoFromJson(message, JsonRpcRequest.class);
         final String method = request.getMethod();
 
-        for (Entry<RegExp, JsonRpcRequestReceiver> entry : receivers.entrySet()) {
-            final RegExp regExp = entry.getKey();
-            if (regExp.test(method)) {
+        for (Entry<String, JsonRpcRequestReceiver> entry : receivers.entrySet()) {
+            final String candidate = entry.getKey();
+            if (Objects.equals(candidate, method)) {
                 final JsonRpcRequestReceiver receiver = entry.getValue();
                 Log.debug(getClass(), "Matching request receiver: ", receiver.getClass());
                 receiver.receive(request);

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestTransmitter.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestTransmitter;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+
+/**
+ * Transmits JSON RPC requests through to {@link WebSocketJsonRpcTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcRequestTransmitter implements JsonRpcRequestTransmitter {
+    private final WebSocketJsonRpcTransmitter transmitter;
+    private final JsonRpcRequestRegistry      requestRegistry;
+
+    @Inject
+    public WebSocketJsonRpcRequestTransmitter(WebSocketJsonRpcTransmitter transmitter,
+                                              JsonRpcRequestRegistry requestRegistry) {
+        this.transmitter = transmitter;
+        this.requestRegistry = requestRegistry;
+    }
+
+    @Override
+    public void transmit(JsonRpcRequest request) {
+        final Integer id = request.getId();
+        final String method = request.getMethod();
+
+        if (id != null) {
+            requestRegistry.add(id, method);
+        }
+
+        Log.info(getClass(), "Transmitting a request " + request.toString());
+        transmitter.transmit("request", request.toString());
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseDispatcher.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseDispatcher.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import com.google.gwt.regexp.shared.RegExp;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.JsonRpcResponseReceiver;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Dispatches JSON RPC responses among all registered implementations of {@link JsonRpcResponseReceiver}
+ * according to their mappings.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcResponseDispatcher implements JsonRpcDispatcher {
+    private final Map<RegExp, JsonRpcResponseReceiver> receivers = new HashMap<>();
+
+    private final JsonRpcRequestRegistry registry;
+    private final DtoFactory             dtoFactory;
+
+    @Inject
+    public WebSocketJsonRpcResponseDispatcher(Map<String, JsonRpcResponseReceiver> receivers,
+                                              JsonRpcRequestRegistry registry,
+                                              DtoFactory dtoFactory) {
+
+        for (Map.Entry<String, JsonRpcResponseReceiver> entry : receivers.entrySet()) {
+            final RegExp regExp = RegExp.compile(entry.getKey());
+            final JsonRpcResponseReceiver receiver = entry.getValue();
+            this.receivers.put(regExp, receiver);
+        }
+
+        this.registry = registry;
+        this.dtoFactory = dtoFactory;
+    }
+
+    @Override
+    public void dispatch(String message) {
+        final JsonRpcResponse response = dtoFactory.createDtoFromJson(message, JsonRpcResponse.class);
+        final String method = registry.extractFor(response.getId());
+
+        for (Map.Entry<RegExp, JsonRpcResponseReceiver> entry : receivers.entrySet()) {
+            final RegExp regExp = entry.getKey();
+            if (regExp.test(method)) {
+                final JsonRpcResponseReceiver receiver = entry.getValue();
+                Log.debug(getClass(), "Matching response receiver: ", receiver.getClass());
+                receiver.receive(response);
+            }
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseTransmitter.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.eclipse.che.ide.jsonrpc.JsonRpcResponseTransmitter;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+
+/**
+ * Transmits JSON RPC responses to {@link WebSocketJsonRpcTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcResponseTransmitter implements JsonRpcResponseTransmitter {
+    private final WebSocketJsonRpcTransmitter transmitter;
+
+    @Inject
+    public WebSocketJsonRpcResponseTransmitter(WebSocketJsonRpcTransmitter transmitter) {
+        this.transmitter = transmitter;
+    }
+
+    @Override
+    public void transmit(JsonRpcResponse response) {
+        Log.info(getClass(), "Transmitting a response " + response.toString());
+        transmitter.transmit("response", response.toString());
+    }
+
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcTransmitter.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageTransmitter;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+
+/**
+ * Transmits JSON RPC objects to {@link WebSocketMessageTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketJsonRpcTransmitter {
+    private final WebSocketMessageTransmitter transmitter;
+    private final DtoFactory                  dtoFactory;
+    private final JsonRpcObjectValidator      validator;
+
+    @Inject
+    public WebSocketJsonRpcTransmitter(WebSocketMessageTransmitter transmitter, DtoFactory dtoFactory, JsonRpcObjectValidator validator) {
+        this.transmitter = transmitter;
+        this.dtoFactory = dtoFactory;
+        this.validator = validator;
+    }
+
+    public void transmit(String type, String message) {
+        Log.debug(getClass(), "Transmitting a json rpc object. Message: " + message + "of type: " + message);
+
+        final JsonRpcObject jsonRpcObject = dtoFactory.createDto(JsonRpcObject.class).withType(type).withMessage(message);
+        validator.validate(jsonRpcObject);
+
+        transmitter.transmit("jsonrpc-2.0", jsonRpcObject.toString());
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/WebSocketMessageReceiver.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/WebSocketMessageReceiver.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng;
+
+/**
+ * The implementation of this interface receives WEB SOCKET messages corresponding
+ * to the registered protocol according to the defined mapping. The protocol must
+ * be mapped via MapBinder in an ordinary Gin module, for example:
+ *
+ * <pre>
+ *     <code>
+ *         GinMapBinder<String, WebSocketMessageReceiver> receivers =
+ *         GinMapBinder.newMapBinder(binder(), String.class, WebSocketMessageReceiver.class);
+ *         receivers.addBinding("protocol-name").to(CustomWebSocketMessageReceiver.class);
+ *     </code>
+ * </pre>
+ *
+ * All WEB SOCKET transmissions with the protocol field equal to "protocol-name" will
+ * be processed with the <code>CustomWebSocketMessageReceiver</code> instance.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketMessageReceiver {
+    void receive(String message);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/WebSocketMessageTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/WebSocketMessageTransmitter.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng;
+
+/**
+ * Transmits WEB SOCKET messages
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketMessageTransmitter {
+    /**
+     * Transmits WEB SOCKET messages
+     *
+     * @param protocol
+     *         message protocol
+     * @param message
+     *         message body
+     */
+    void transmit(String protocol, String message);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketEndpoint.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketEndpoint.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Duplex WEB SOCKET endpoint, handles messages, errors, session open/close events.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicWebSocketEndpoint implements WebSocketEndpoint {
+    private final WebSocketConnectionSustainer    sustainer;
+    private final PendingMessagesReSender         reSender;
+    private final WebSocketTransmissionDispatcher dispatcher;
+
+    @Inject
+    public BasicWebSocketEndpoint(WebSocketConnectionSustainer sustainer,
+                                  PendingMessagesReSender pending,
+                                  WebSocketTransmissionDispatcher dispatcher) {
+        this.sustainer = sustainer;
+        this.reSender = pending;
+        this.dispatcher = dispatcher;
+    }
+
+    @Override
+    public void onOpen() {
+        Log.info(getClass(), "Session opened.");
+
+        sustainer.reset();
+        reSender.resend();
+    }
+
+    @Override
+    public void onClose() {
+        Log.info(getClass(), "Session closed.");
+
+        sustainer.sustain();
+    }
+
+    @Override
+    public void onError() {
+        Log.warn(getClass(), "Error occurred.");
+    }
+
+    @Override
+    public void onMessage(String message) {
+        Log.info(getClass(), "Message received: " + message);
+
+        dispatcher.dispatch(message);
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketMessageTransmitter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketMessageTransmitter.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageTransmitter;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Transmits messages over WEB SOCKET to a specific endpoint or broadcasts them.
+ * If WEB SOCKET session is not opened adds messages to re-sender to try to send
+ * them when session will be opened again.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicWebSocketMessageTransmitter implements WebSocketMessageTransmitter {
+    private final WebSocketConnection            connection;
+    private final PendingMessagesReSender        reSender;
+    private final WebSocketTransmissionValidator validator;
+    private final DtoFactory                     dtoFactory;
+
+    @Inject
+    public BasicWebSocketMessageTransmitter(WebSocketConnection connection,
+                                            PendingMessagesReSender reSender,
+                                            WebSocketTransmissionValidator validator,
+                                            DtoFactory dtoFactory) {
+        this.connection = connection;
+        this.reSender = reSender;
+        this.validator = validator;
+        this.dtoFactory = dtoFactory;
+    }
+
+    @Override
+    public void transmit(String protocol, String message) {
+        final WebSocketTransmission transmission = dtoFactory.createDto(WebSocketTransmission.class).withProtocol(protocol).withMessage(message);
+        validator.validate(transmission);
+
+        if (connection.isOpen()) {
+            Log.debug(getClass(), "Connection is opened, transmitting");
+
+            connection.send(transmission);
+
+        } else {
+            Log.debug(getClass(), "Connection is closed, adding to pending");
+
+            reSender.add(transmission);
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketTransmissionValidator.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketTransmissionValidator.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import com.google.gwt.json.client.JSONParser;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageReceiver;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Basic implementation of WEB SOCKET transmission validator, validation rules are the following:
+ *
+ * <ul>
+ * <li><code>protocol</code> must be not <code>null</code></li>
+ * <li><code>protocol</code> must be not empty</li>
+ * <li><code>protocol</code> must be registered (mapped to a corresponding receiver implementation</li>
+ * <li><code>message</code> must be not <code>null</code></li>
+ * <li><code>message</code> must be not empty</li>
+ * <li><code>message</code> must be a valid JSON</li>
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class BasicWebSocketTransmissionValidator implements WebSocketTransmissionValidator {
+
+    private final Set<String> protocols;
+
+    @Inject
+    public BasicWebSocketTransmissionValidator(Map<String, WebSocketMessageReceiver> receivers) {
+        this.protocols = receivers.keySet();
+    }
+
+
+    @Override
+    public void validate(WebSocketTransmission transmission) {
+        validateProtocol(transmission.getProtocol());
+        validateMessage(transmission.getMessage());
+    }
+
+    private void validateProtocol(String protocol) {
+        if (protocols.contains(protocol)) {
+            Log.debug(getClass(), "Web socket transmission protocol {} is among registered", protocol);
+        } else {
+            logError("Web socket transmission of not registered protocol");
+        }
+    }
+
+    private void validateMessage(String message) {
+        validateNull(message);
+        validateEmpty(message);
+        validateJson(message);
+    }
+
+    private void validateNull(String message) {
+        if (message == null) {
+            logError("Web socket transmission message is null");
+        } else {
+            Log.debug(getClass(), "Web socket transmission message is not null");
+        }
+    }
+
+    private void validateEmpty(String message) {
+        if (message.isEmpty()) {
+            logError("Web socket transmission message is empty");
+        } else {
+            Log.debug(getClass(), "Web socket transmission message is not empty");
+        }
+    }
+
+    private void validateJson(String message) {
+        boolean error = false;
+
+        try {
+            JSONParser.parseStrict(message);
+        } catch (Exception e) {
+            error = true;
+        }
+
+        if (error) {
+            logError("Web socket transmission message is not a valid json");
+        } else {
+            Log.debug(getClass(), "Web socket transmission message is a valid json");
+        }
+    }
+
+    private void logError(String error) {
+        Log.error(getClass(), error);
+        throw new IllegalArgumentException(error);
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/DelayableWebSocket.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/DelayableWebSocket.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import com.google.gwt.user.client.Timer;
+import com.google.inject.assistedinject.Assisted;
+
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+
+/**
+ * Yet another {@link WebSocketJsoWrapper} wrapper to benefit from
+ * dependency injection provided by Gin. This implementation allows
+ * setting a delay for opening a connection. It is convenient when
+ * you are reconnecting.
+ *
+ * @author Dmitry Kuleshov
+ */
+public class DelayableWebSocket implements WebSocket {
+    private final String            url;
+    private final Integer           delay;
+    private final WebSocketEndpoint endpoint;
+
+    private WebSocketJsoWrapper webSocketJsoWrapper;
+
+    @Inject
+    public DelayableWebSocket(@Assisted String url, @Assisted Integer delay, WebSocketEndpoint endpoint) {
+        this.url = url;
+        this.delay = delay;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public void open() {
+        if (isClosed() || isClosing()) {
+            if (delay == 0) {
+                webSocketJsoWrapper = WebSocketJsoWrapper.connect(url, endpoint);
+            } else {
+                new Timer() {
+                    @Override
+                    public void run() {
+                        webSocketJsoWrapper = WebSocketJsoWrapper.connect(url, endpoint);
+                    }
+                }.schedule(delay);
+            }
+        } else {
+            Log.warn(getClass(), "Opening already opened or connecting web socket.");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (isOpen()) {
+            webSocketJsoWrapper.close();
+        } else {
+            Log.warn(getClass(), "Closing connection that is not opened.");
+        }
+    }
+
+    @Override
+    public void send(final String message) {
+        if (isOpen()) {
+            webSocketJsoWrapper.send(message);
+        } else {
+            Log.error(getClass(), "Sending message to not opened connection.");
+        }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return webSocketJsoWrapper == null || webSocketJsoWrapper.isClosed();
+    }
+
+    @Override
+    public boolean isClosing() {
+        return webSocketJsoWrapper == null || webSocketJsoWrapper.isClosing();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return webSocketJsoWrapper != null && webSocketJsoWrapper.isOpen();
+    }
+
+    @Override
+    public boolean isConnecting() {
+        return webSocketJsoWrapper != null && webSocketJsoWrapper.isConnecting();
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/PendingMessagesReSender.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/PendingMessagesReSender.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Instance is responsible for resending messages that were sent during the period
+ * when web socket session was closed.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class PendingMessagesReSender {
+    private static final int MAX_MESSAGES = 100;
+
+    private final List<WebSocketTransmission> messages = new LinkedList<>();
+
+    private final WebSocketConnection connection;
+
+    @Inject
+    public PendingMessagesReSender(WebSocketConnection connection) {
+        this.connection = connection;
+    }
+
+    public void add(WebSocketTransmission message) {
+        if (messages.size() <= MAX_MESSAGES) {
+            messages.add(message);
+        }
+    }
+
+    public void resend() {
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        final List<WebSocketTransmission> backing = new ArrayList<>(messages);
+        messages.clear();
+
+        for (WebSocketTransmission message : backing) {
+            if (connection.isOpen()) {
+                connection.send(message);
+            } else {
+                messages.add(message);
+            }
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/SessionWebSocketInitializer.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/SessionWebSocketInitializer.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+
+import static org.eclipse.che.ide.websocket.ng.impl.WebSocketConnection.IMMEDIATELY;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class SessionWebSocketInitializer implements WebSocketInitializer {
+    private final WebSocketConnection          connection;
+    private final WebSocketConnectionSustainer sustainer;
+
+    @Inject
+    public SessionWebSocketInitializer(WebSocketConnection connection, WebSocketConnectionSustainer sustainer) {
+        this.connection = connection;
+        this.sustainer = sustainer;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        Log.info(getClass(), "Initializing with properties: " + properties);
+
+        final String url = properties.get("url");
+
+        sustainer.enable();
+        connection.initialize(url).open(IMMEDIATELY);
+    }
+
+    @Override
+    public void terminate() {
+        Log.info(getClass(), "Stopping");
+
+        sustainer.disable();
+        connection.close();
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocket.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocket.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+/**
+ * This interface is purposed to split WEB SOCKET API and implementations,
+ * that is needed because here we are wrapping native implementations which
+ * potentially may require switching to some javascript library.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocket {
+    /**
+     * Open a WEB SOCKET connection
+     */
+    void open();
+
+    /**
+     * Close a WEB SOCKET connection
+     */
+    void close();
+
+    /**
+     * Send a text message over WEB SOCKET
+     *
+     * @param message text message to send
+     */
+    void send(final String message);
+
+    /**
+     * Checks if WEB SOCKET connection is closed
+     *
+     * @return <code>true</code> if closed
+     */
+    boolean isClosed();
+
+    /**
+     * Checks if WEB SOCKET connection is closing
+     *
+     * @return <code>true</code> if closing
+     */
+    boolean isClosing();
+
+    /**
+     * Checks if WEB SOCKET connection is open
+     *
+     * @return <code>true</code> if open
+     */
+    boolean isOpen();
+
+    /**
+     * Checks if WEB SOCKET connection is connecting
+     *
+     * @return <code>true</code> if connecting
+     */
+    boolean isConnecting();
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnection.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnection.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import com.google.inject.Inject;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Singleton;
+
+/**
+ * Entry point for high level WEB SOCKET connection operations.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketConnection {
+    public static final int IMMEDIATELY = 0;
+
+    private final WebSocketCreator webSocketCreator;
+
+    private WebSocket webSocket;
+    private String    url;
+
+    @Inject
+    public WebSocketConnection(WebSocketCreator webSocketCreator) {
+        this.webSocketCreator = webSocketCreator;
+    }
+
+    public WebSocketConnection initialize(String url){
+        this.url = url;
+        return this;
+    }
+
+    public void open(int delay) {
+        if (url == null){
+            Log.error(WebSocketConnection.class, "Cannot open connection because no URL is set");
+
+            throw new IllegalStateException("No URL is set");
+        }
+
+        webSocket = webSocketCreator.create(url, delay);
+        webSocket.open();
+
+        Log.info(getClass(), "Opening connection. Url: " + url);
+    }
+
+    public void close() {
+        webSocket.close();
+
+        Log.info(WebSocketConnection.class, "Closing connection.");
+    }
+
+    public void send(WebSocketTransmission message) {
+        webSocket.send(message.toString());
+
+        Log.info(getClass(), "Sending message: " + message);
+    }
+
+    public boolean isOpen() {
+        return webSocket != null && webSocket.isOpen();
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnectionSustainer.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnectionSustainer.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Responsible for keeping connection alive and reconnecting if needed.
+ * If connection is closed and sustainer is active it tries to reconnect
+ * according to its properties:
+ *
+ * <ul>
+ * <li>reconnection delay - 500 milliseconds</li>
+ * <li>reconnection limit - 5 attempts</li>
+ * </ul>
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketConnectionSustainer {
+    private static final int RECONNECTION_DELAY = 500;
+    private static final int RECONNECTION_LIMIT = 5;
+
+    private final WebSocketConnection connection;
+
+    private boolean active;
+    private int     attempt;
+
+    @Inject
+    public WebSocketConnectionSustainer(WebSocketConnection connection) {
+        this.connection = connection;
+    }
+
+    public void reset() {
+        Log.info(getClass(), "Resetting number of reconnection attempt number. Previous was: " + attempt);
+        attempt = 0;
+    }
+
+    public void sustain() {
+        if (++attempt > RECONNECTION_LIMIT) {
+            Log.info(getClass(), "Exceeding reconnection limit.");
+            disable();
+        }
+
+        if (active) {
+            Log.info(getClass(), "Sustaining connection. Current attempt number: " + attempt);
+            connection.open(RECONNECTION_DELAY);
+        }
+    }
+
+    public void enable() {
+        if (!active) {
+            Log.info(getClass(), "Sustainer enabled.");
+            active = true;
+        }
+    }
+
+    public void disable() {
+        if (active) {
+            Log.info(getClass(), "Sustainer disabled");
+            active = false;
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketCreator.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketCreator.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketCreator {
+    WebSocket create(String url, Integer delay);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketEndpoint.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketEndpoint.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+/**
+ * Handles WEB SOCKET related events
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketEndpoint {
+    /**
+     * Is called when connection is opened
+     */
+    void onOpen();
+
+    /**
+     * Is called when connection is closed
+     */
+    void onClose();
+
+    /**
+     * Is called when connection has errors
+     */
+    void onError();
+
+    /**
+     * Is called when connection receives a text message
+     */
+    void onMessage(String message);
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketInitializer.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketInitializer.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import javax.inject.Singleton;
+import java.util.Map;
+
+/**
+ * Initializes and terminates WEB SOCKET services.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public interface WebSocketInitializer {
+    /**
+     * Initialize WEB SOCKET services with properties contained
+     * in a map as simple key->value pairs.
+     *
+     * @param properties properties map
+     */
+    void initialize(Map<String, String> properties);
+
+    /**
+     * Terminates WEB SOCKET services
+     */
+    void terminate();
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketJsoWrapper.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketJsoWrapper.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Very simple native javascript websocket wrapper
+ *
+ * @author Dmitry Kuleshov
+ */
+public class WebSocketJsoWrapper extends JavaScriptObject {
+    protected WebSocketJsoWrapper() {
+    }
+
+    public static native WebSocketJsoWrapper connect(String url, WebSocketEndpoint endpoint) /*-{
+        var webSocket = new WebSocket(url);
+        webSocket.onopen = function () {
+            endpoint.@org.eclipse.che.ide.websocket.ng.impl.WebSocketEndpoint::onOpen()();
+        };
+
+        webSocket.onclose = function () {
+            endpoint.@org.eclipse.che.ide.websocket.ng.impl.WebSocketEndpoint::onClose()();
+        };
+
+        webSocket.onerror = function () {
+            endpoint.@org.eclipse.che.ide.websocket.ng.impl.WebSocketEndpoint::onError()();
+        };
+
+        webSocket.onmessage = function (event) {
+            endpoint.@org.eclipse.che.ide.websocket.ng.impl.WebSocketEndpoint::onMessage(Ljava/lang/String;)(event.data);
+        };
+        return webSocket;
+    }-*/;
+
+    public final native void close() /*-{
+        this.close();
+    }-*/;
+
+    public final native boolean isClosed() /*-{
+        return this.readyState == this.CLOSED;
+    }-*/;
+
+    public final native boolean isClosing() /*-{
+        return this.readyState == this.CLOSING;
+    }-*/;
+
+    public final native boolean isOpen() /*-{
+        return this.readyState == this.OPEN;
+    }-*/;
+
+    public final native boolean isConnecting() /*-{
+        return this.readyState == this.CONNECTING;
+    }-*/;
+
+    public final native void send(final String data) /*-{
+        this.send(data);
+    }-*/;
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketTransmissionDispatcher.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketTransmissionDispatcher.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageReceiver;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Dispatches a {@link WebSocketTransmission} messages among registered receivers
+ * ({@link WebSocketMessageReceiver}) according to WEB SOCKET transmission protocol
+ * field value.
+ *
+ * @author Dmitry Kuleshov
+ */
+@Singleton
+public class WebSocketTransmissionDispatcher {
+    private final Map<String, WebSocketMessageReceiver> receivers;
+    private final WebSocketTransmissionValidator        validator;
+    private final DtoFactory                            dtoFactory;
+
+
+    @Inject
+    public WebSocketTransmissionDispatcher(Map<String, WebSocketMessageReceiver> receivers,
+                                           WebSocketTransmissionValidator validator,
+                                           DtoFactory dtoFactory) {
+        this.receivers = receivers;
+        this.dtoFactory = dtoFactory;
+        this.validator = validator;
+    }
+
+    public void dispatch(String rawTransmission) {
+        final WebSocketTransmission transmission = dtoFactory.createDtoFromJson(rawTransmission, WebSocketTransmission.class);
+        validator.validate(transmission);
+
+        final String protocol = transmission.getProtocol();
+        final String message = transmission.getMessage();
+
+        Log.info(getClass(), "Receiving a web socket transmission. Type: " + protocol + " Message: " + message);
+
+        for (Entry<String, WebSocketMessageReceiver> entry : receivers.entrySet()) {
+            final String protocolCandidate = entry.getKey();
+            if (Objects.equals(protocol, protocolCandidate)) {
+                final WebSocketMessageReceiver receiver = entry.getValue();
+                Log.info(getClass(), "Matching web socket transmission receiver: " + receiver.getClass());
+                receiver.receive(message);
+
+                return;
+            }
+        }
+    }
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketTransmissionValidator.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketTransmissionValidator.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+
+/**
+ * It is used to make sure that {@link WebSocketTransmission} is a valid entity.
+ * Implementation of this interface must be called before any other operation
+ * is performed to avoid any kind of inconsistency.
+ *
+ * @author Dmitry Kuleshov
+ */
+public interface WebSocketTransmissionValidator {
+    void validate(WebSocketTransmission message);
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/BasicJsonRpcObjectValidatorTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/BasicJsonRpcObjectValidatorTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static java.util.Collections.singleton;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link BasicJsonRpcObjectValidator}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BasicJsonRpcObjectValidatorTest {
+    private static final String REGISTERED_TYPE     = "registered-type";
+    private static final String NOT_REGISTERED_TYPE = "not-registered-type";
+    private static final String VALID_JSON          = "{ \"name\": \"value\" }";
+    private static final String NOT_VALID_JSON      = "not a json value";
+    @Mock
+    private Map<String, JsonRpcDispatcher> dispatchers;
+
+    private BasicJsonRpcObjectValidator    validator;
+
+    @Mock
+    private JsonRpcObject object;
+
+    @Before
+    public void before() {
+        when(dispatchers.keySet()).thenReturn(singleton(REGISTERED_TYPE));
+
+        validator = new BasicJsonRpcObjectValidator(dispatchers);
+
+        when(object.getType()).thenReturn(REGISTERED_TYPE);
+        when(object.getMessage()).thenReturn(VALID_JSON);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTypeIsNull() {
+        when(object.getType()).thenReturn(null);
+
+        validator.validate(object);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTypeIsEmpty() {
+        when(object.getType()).thenReturn("");
+
+        validator.validate(object);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTypeIsNotRegistered() {
+        when(object.getType()).thenReturn(NOT_REGISTERED_TYPE);
+
+        validator.validate(object);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNull() {
+        when(object.getMessage()).thenReturn(null);
+
+        validator.validate(object);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsEmpty() {
+        when(object.getMessage()).thenReturn("");
+
+        validator.validate(object);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @Ignore
+    public void shouldThrowExceptionIfMessageIsNotAJson() {
+        when(object.getMessage()).thenReturn(NOT_VALID_JSON);
+
+        validator.validate(object);
+    }
+
+    @Test
+    @Ignore
+    public void shouldNotThrowExceptionIfObjectIsValid() {
+        validator.validate(object);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcRequestRegistryTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/JsonRpcRequestRegistryTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test for {@link JsonRpcRequestRegistry}
+ *
+ * @author Dmitry Kuleshov
+ */
+public class JsonRpcRequestRegistryTest {
+    private static final String METHOD_NAME = "method-name";
+    private static final int    REQUEST_ID  = 1;
+
+    private JsonRpcRequestRegistry registry;
+
+    @Before
+    public void before() {
+        registry = new JsonRpcRequestRegistry();
+    }
+
+    @Test
+    public void shouldProperlyRegister() {
+        registry.add(REQUEST_ID, METHOD_NAME);
+
+        assertEquals(METHOD_NAME, registry.extractFor(1));
+    }
+
+    @Test
+    public void shouldProperlyExtract() {
+        registry.add(REQUEST_ID, METHOD_NAME);
+
+        assertEquals(METHOD_NAME, registry.extractFor(1));
+        assertNull(registry.extractFor(1));
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcDispatcherTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcDispatcherTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcDispatcherTest {
+    private static final String MESSAGE                  = "message";
+    private static final String REGISTERED_TYPE          = "registered-type";
+    private static final String RAW_JSON_RPC_OBJECT_SUBB = "raw-json-rpc-object-subb";
+
+    @Mock
+    private Map<String, JsonRpcDispatcher> dispatchers;
+    @Mock
+    private JsonRpcObjectValidator         validator;
+    @Mock
+    private DtoFactory                     dtoFactory;
+    @InjectMocks
+    private WebSocketJsonRpcDispatcher     dispatcher;
+
+    @Mock
+    private JsonRpcObject     object;
+    @Mock
+    private JsonRpcDispatcher jsonRpcDispatcher;
+
+    @Before
+    public void before() {
+        when(dtoFactory.createDtoFromJson(anyString(), any())).thenReturn(object);
+        when(object.getType()).thenReturn(REGISTERED_TYPE);
+        when(object.getMessage()).thenReturn(MESSAGE);
+
+        when(dispatchers.entrySet()).thenReturn(singletonMap(REGISTERED_TYPE, jsonRpcDispatcher).entrySet());
+    }
+
+    @Test
+    public void should() {
+        dispatcher.receive("");
+    }
+
+    @Test
+    public void shouldCreateDtoOnReceive() {
+        dispatcher.receive(RAW_JSON_RPC_OBJECT_SUBB);
+
+        verify(dtoFactory).createDtoFromJson(eq(RAW_JSON_RPC_OBJECT_SUBB), eq(JsonRpcObject.class));
+    }
+
+    @Test
+    public void shouldValidateOnReceive() {
+        dispatcher.receive(RAW_JSON_RPC_OBJECT_SUBB);
+
+        verify(validator).validate(eq(object));
+    }
+
+    @Test
+    public void shouldDispatchIfMatchFound() {
+        dispatcher.receive(RAW_JSON_RPC_OBJECT_SUBB);
+
+        verify(jsonRpcDispatcher).dispatch(MESSAGE);
+    }
+
+    @Test
+    public void shouldNotDispatchIfMatchNotFound() {
+        when(object.getType()).thenReturn("not-"+REGISTERED_TYPE);
+
+        dispatcher.receive(RAW_JSON_RPC_OBJECT_SUBB);
+
+        verify(jsonRpcDispatcher, never()).dispatch(MESSAGE);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcInitializerTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcInitializerTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.ide.websocket.ng.impl.SessionWebSocketInitializer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for {@link WebSocketJsonRpcInitializer}
+ *
+ * @author Dmitry Kuleshov
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcInitializerTest {
+    @Mock
+    private SessionWebSocketInitializer webSocketInitializer;
+    @InjectMocks
+    private WebSocketJsonRpcInitializer jsonRpcInitializer;
+
+    @Test
+    public void shouldRunWebSocketInitializeWithCorrectProperties(){
+        final Map<String, String> map = singletonMap("test-key", "test-value");
+
+        jsonRpcInitializer.initialize(map);
+
+        verify(webSocketInitializer).initialize(eq(map));
+    }
+
+    @Test
+    public void shouldRunWebSocketTerminate(){
+        jsonRpcInitializer.terminate();
+
+        verify(webSocketInitializer).terminate();
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.JsonRpcRequestReceiver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link WebSocketJsonRpcRequestDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcRequestDispatcherTest {
+    private static final String MESSAGE = "message";
+
+    @Mock
+    private Map<String, JsonRpcRequestReceiver> receivers;
+    @Mock
+    private DtoFactory                          dtoFactory;
+
+    private WebSocketJsonRpcRequestDispatcher dispatcher;
+
+    @Mock
+    private JsonRpcRequest         request;
+    @Mock
+    private JsonRpcRequestReceiver receiver;
+
+    @Before
+    public void before() {
+        when(request.getMethod()).thenReturn("");
+        when(dtoFactory.createDtoFromJson(anyString(), any())).thenReturn(request);
+        when(receivers.entrySet()).thenReturn(emptySet());
+
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
+    }
+
+    @Test
+    public void shouldRunDtoFactoryToCreateRequest() {
+        dispatcher.dispatch(MESSAGE);
+    }
+
+    @Test
+    public void shouldRunMatchingReceiver() {
+        when(request.getMethod()).thenReturn("test-method");
+        when(receivers.entrySet()).thenReturn(singletonMap("test-method", receiver).entrySet());
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
+
+        dispatcher.dispatch(MESSAGE);
+
+        verify(receiver).receive(request);
+    }
+
+    @Test
+    public void shouldRunMatchingReceiverWithRegExpedName() {
+        final Map<String, JsonRpcRequestReceiver> map = Collections.singletonMap("test-met*", receiver);
+        when(receivers.entrySet()).thenReturn(map.entrySet());
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
+
+
+        when(request.getMethod()).thenReturn("test-method");
+        dispatcher.dispatch(MESSAGE);
+        when(request.getMethod()).thenReturn("test-metho");
+        dispatcher.dispatch(MESSAGE);
+        when(request.getMethod()).thenReturn("test-meth");
+        dispatcher.dispatch(MESSAGE);
+
+        verify(receiver, times(3)).receive(request);
+    }
+
+    @Test
+    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
+        Map<String, JsonRpcRequestReceiver> map = new HashMap<>();
+        map.put("test-met*", receiver);
+        map.put("test-me*", receiver);
+        map.put("test-m*", receiver);
+
+        when(receivers.entrySet()).thenReturn(map.entrySet());
+        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
+
+
+        when(request.getMethod()).thenReturn("test-method");
+        dispatcher.dispatch(MESSAGE);
+
+        verify(receiver, times(3)).receive(request);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestDispatcherTest.java
@@ -16,6 +16,7 @@ import org.eclipse.che.ide.jsonrpc.JsonRpcRequestReceiver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -44,7 +45,7 @@ public class WebSocketJsonRpcRequestDispatcherTest {
     private Map<String, JsonRpcRequestReceiver> receivers;
     @Mock
     private DtoFactory                          dtoFactory;
-
+    @InjectMocks
     private WebSocketJsonRpcRequestDispatcher dispatcher;
 
     @Mock
@@ -57,8 +58,6 @@ public class WebSocketJsonRpcRequestDispatcherTest {
         when(request.getMethod()).thenReturn("");
         when(dtoFactory.createDtoFromJson(anyString(), any())).thenReturn(request);
         when(receivers.entrySet()).thenReturn(emptySet());
-
-        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
     }
 
     @Test
@@ -75,39 +74,5 @@ public class WebSocketJsonRpcRequestDispatcherTest {
         dispatcher.dispatch(MESSAGE);
 
         verify(receiver).receive(request);
-    }
-
-    @Test
-    public void shouldRunMatchingReceiverWithRegExpedName() {
-        final Map<String, JsonRpcRequestReceiver> map = Collections.singletonMap("test-met*", receiver);
-        when(receivers.entrySet()).thenReturn(map.entrySet());
-        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
-
-
-        when(request.getMethod()).thenReturn("test-method");
-        dispatcher.dispatch(MESSAGE);
-        when(request.getMethod()).thenReturn("test-metho");
-        dispatcher.dispatch(MESSAGE);
-        when(request.getMethod()).thenReturn("test-meth");
-        dispatcher.dispatch(MESSAGE);
-
-        verify(receiver, times(3)).receive(request);
-    }
-
-    @Test
-    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
-        Map<String, JsonRpcRequestReceiver> map = new HashMap<>();
-        map.put("test-met*", receiver);
-        map.put("test-me*", receiver);
-        map.put("test-m*", receiver);
-
-        when(receivers.entrySet()).thenReturn(map.entrySet());
-        dispatcher = new WebSocketJsonRpcRequestDispatcher(receivers, dtoFactory);
-
-
-        when(request.getMethod()).thenReturn("test-method");
-        dispatcher.dispatch(MESSAGE);
-
-        verify(receiver, times(3)).receive(request);
     }
 }

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestTransmitterTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcRequestTransmitterTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcRequestTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcRequestTransmitterTest {
+    private static final String TYPE        = "request";
+    private static final int    ID          = 0;
+    private static final String METHOD_NAME = "method-name";
+    private static final String MESSAGE     = "message";
+    @Mock
+    private WebSocketJsonRpcTransmitter        transmitter;
+    @Mock
+    private DtoFactory                         dtoFactory;
+    @Mock
+    private JsonRpcRequestRegistry             requestRegistry;
+    @InjectMocks
+    private WebSocketJsonRpcRequestTransmitter jsonRpcTransmitter;
+
+    @Mock
+    private WebSocketTransmission transmission;
+    @Mock
+    private JsonRpcRequest        request;
+
+    @Before
+    public void before() {
+        when(request.getId()).thenReturn(ID);
+        when(request.getMethod()).thenReturn(METHOD_NAME);
+        when(request.toString()).thenReturn(MESSAGE);
+
+        when(transmission.withProtocol(anyString())).thenReturn(transmission);
+        when(transmission.withMessage(anyString())).thenReturn(transmission);
+
+        when(dtoFactory.createDto(WebSocketTransmission.class)).thenReturn(transmission);
+    }
+
+    @Test
+    public void shouldAddMethodToRequestRegistry() {
+        jsonRpcTransmitter.transmit(request);
+
+        verify(requestRegistry).add(ID, METHOD_NAME);
+    }
+
+    @Test
+    public void shouldRunWebSocketTransmitter() {
+        jsonRpcTransmitter.transmit(request);
+
+        verify(transmitter).transmit(TYPE, MESSAGE);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseDispatcherTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseDispatcherTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.JsonRpcResponseReceiver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link WebSocketJsonRpcResponseDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcResponseDispatcherTest {
+    private static final String MESSAGE     = "message";
+    private static final int    RESPONSE_ID = 0;
+
+    @Mock
+    private Map<String, JsonRpcResponseReceiver> receivers;
+    @Mock
+    private DtoFactory                           dtoFactory;
+    @Mock
+    private JsonRpcRequestRegistry               registry;
+    @InjectMocks
+    private WebSocketJsonRpcResponseDispatcher   dispatcher;
+
+    @Mock
+    private JsonRpcResponse         response;
+    @Mock
+    private JsonRpcResponseReceiver receiver;
+
+    @Before
+    public void before() {
+        when(response.getId()).thenReturn(RESPONSE_ID);
+        when(registry.extractFor(RESPONSE_ID)).thenReturn("");
+        when(dtoFactory.createDtoFromJson(anyString(), any())).thenReturn(response);
+        when(receivers.entrySet()).thenReturn(emptySet());
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(receivers, registry, dtoFactory);
+    }
+
+    @Test
+    public void shouldRunDtoFactoryToCreateRequest() {
+        dispatcher.dispatch(MESSAGE);
+    }
+
+    @Test
+    public void shouldRunMatchingReceiver() {
+        when(registry.extractFor(RESPONSE_ID)).thenReturn("test-method");
+        when(receivers.entrySet()).thenReturn(singletonMap("test-method", receiver).entrySet());
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(receivers, registry, dtoFactory);
+
+
+        dispatcher.dispatch(MESSAGE);
+
+        verify(receiver).receive(response);
+    }
+
+    @Test
+    public void shouldRunMatchingReceiverWithRegExpedName() {
+        final Map<String, JsonRpcResponseReceiver> map = Collections.singletonMap("test-met*", receiver);
+        when(receivers.entrySet()).thenReturn(map.entrySet());
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(receivers, registry, dtoFactory);
+
+
+        when(registry.extractFor(RESPONSE_ID)).thenReturn("test-method");
+        dispatcher.dispatch(MESSAGE);
+        when(registry.extractFor(RESPONSE_ID)).thenReturn("test-metho");
+        dispatcher.dispatch(MESSAGE);
+        when(registry.extractFor(RESPONSE_ID)).thenReturn("test-meth");
+        dispatcher.dispatch(MESSAGE);
+
+        verify(receiver, times(3)).receive(response);
+    }
+
+    @Test
+    public void shouldRunMatchingSeveralReceiverWithRegExpedName() {
+        Map<String, JsonRpcResponseReceiver> map = new HashMap<>();
+        map.put("test-met*", receiver);
+        map.put("test-me*", receiver);
+        map.put("test-m*", receiver);
+
+        when(receivers.entrySet()).thenReturn(map.entrySet());
+        dispatcher = new WebSocketJsonRpcResponseDispatcher(receivers, registry, dtoFactory);
+
+        when(registry.extractFor(RESPONSE_ID)).thenReturn("test-method");
+        dispatcher.dispatch(MESSAGE);
+
+        verify(receiver, times(3)).receive(response);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseTransmitterTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcResponseTransmitterTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcResponse;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcResponseTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcResponseTransmitterTest {
+    private static final String MESSAGE = "message";
+    private static final String TYPE    = "response";
+
+    @Mock
+    private WebSocketJsonRpcTransmitter         transmitter;
+    @Mock
+    private DtoFactory                          dtoFactory;
+    @InjectMocks
+    private WebSocketJsonRpcResponseTransmitter jsonRpcTransmitter;
+
+    @Mock
+    private WebSocketTransmission transmission;
+    @Mock
+    private JsonRpcResponse       response;
+
+    @Before
+    public void before() {
+        when(response.toString()).thenReturn(MESSAGE);
+
+        when(transmission.withProtocol(anyString())).thenReturn(transmission);
+        when(transmission.withMessage(anyString())).thenReturn(transmission);
+
+        when(dtoFactory.createDto(WebSocketTransmission.class)).thenReturn(transmission);
+    }
+
+    @Test
+    public void shouldRunWebSocketTransmitter() {
+        jsonRpcTransmitter.transmit(response);
+
+        verify(transmitter).transmit(TYPE, MESSAGE);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcTransmitterTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/impl/WebSocketJsonRpcTransmitterTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc.impl;
+
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcObject;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageTransmitter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketJsonRpcTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketJsonRpcTransmitterTest {
+    private static final String PROTOCOL = "jsonrpc-2.0";
+    private static final String MESSAGE  = "message";
+    private static final String TYPE     = "registered-type";
+    @Mock
+    private WebSocketMessageTransmitter transmitter;
+    @Mock
+    private DtoFactory                  dtoFactory;
+    @Mock
+    private JsonRpcObjectValidator      validator;
+    @InjectMocks
+    private WebSocketJsonRpcTransmitter jsonRpcTransmitter;
+
+    @Mock
+    private JsonRpcObject object;
+
+    @Before
+    public void before() {
+        when(dtoFactory.createDto(eq(JsonRpcObject.class))).thenReturn(object);
+        when(object.toString()).thenReturn(MESSAGE);
+        when(object.withMessage(anyString())).thenReturn(object);
+        when(object.withType(anyString())).thenReturn(object);
+    }
+
+    @Test
+    public void shouldCreateJsonRpcObject() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE);
+
+        verify(dtoFactory).createDto(JsonRpcObject.class);
+    }
+
+    @Test
+    public void shouldProperlySetJsonRpcObjectProperties() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE);
+
+        verify(object).withType(TYPE);
+        verify(object).withMessage(MESSAGE);
+    }
+
+    @Test
+    public void shouldValidateJsonRpcObject() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE);
+
+        verify(validator).validate(object);
+    }
+
+    @Test
+    public void shouldTransmitJsonRpcObject() {
+        jsonRpcTransmitter.transmit(TYPE, MESSAGE);
+
+        verify(transmitter).transmit(PROTOCOL, MESSAGE);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketEndpointTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketEndpointTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link BasicWebSocketEndpoint}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BasicWebSocketEndpointTest {
+    private static final String MESSAGE = "message";
+
+    @Mock
+    private WebSocketConnectionSustainer    sustainer;
+    @Mock
+    private WebSocketTransmissionDispatcher dispatcher;
+    @Mock
+    private PendingMessagesReSender         reSender;
+    @InjectMocks
+    private BasicWebSocketEndpoint          endpoint;
+
+    @Test
+    public void shouldResetSustainerOnOpen() {
+        endpoint.onOpen();
+
+        verify(sustainer).reset();
+    }
+
+    @Test
+    public void shouldResendMessagesOnOpen() {
+        endpoint.onOpen();
+
+        verify(reSender).resend();
+    }
+
+    @Test
+    public void shouldSustainSessionOnClose() {
+        endpoint.onClose();
+
+        verify(sustainer).sustain();
+    }
+
+    @Test
+    public void shouldRunReceiverOnMessage() {
+        endpoint.onMessage(MESSAGE);
+
+        verify(dispatcher).dispatch(eq(MESSAGE));
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketMessageTransmitterTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketMessageTransmitterTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link BasicWebSocketMessageTransmitter}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BasicWebSocketMessageTransmitterTest {
+    private static final String MESSAGE  = "message";
+    private static final String PROTOCOL = "protocol";
+
+    @Mock
+    private WebSocketConnection              session;
+    @Mock
+    private PendingMessagesReSender          reSender;
+    @Mock
+    private WebSocketTransmissionValidator   validator;
+    @Mock
+    private DtoFactory                       dtoFactory;
+    @InjectMocks
+    private BasicWebSocketMessageTransmitter transmitter;
+
+    @Mock
+    private WebSocketTransmission transmission;
+
+    @Before
+    public void before() {
+        when(dtoFactory.createDto(eq(WebSocketTransmission.class))).thenReturn(transmission);
+
+        when(transmission.getMessage()).thenReturn(MESSAGE);
+        when(transmission.withMessage(anyString())).thenReturn(transmission);
+        when(transmission.withProtocol(anyString())).thenReturn(transmission);
+    }
+
+    @Test
+    public void shouldValidateTransmission() {
+        when(session.isOpen()).thenReturn(true);
+
+        transmitter.transmit(PROTOCOL, MESSAGE);
+
+        verify(validator).validate(transmission);
+    }
+
+    @Test
+    public void shouldSendMessageIfSessionIsOpen() {
+        when(session.isOpen()).thenReturn(true);
+
+        transmitter.transmit(PROTOCOL, MESSAGE);
+
+        verify(session).send(transmission);
+        verify(reSender, never()).add(any(WebSocketTransmission.class));
+    }
+
+    @Test
+    public void shouldAddMessageToPendingIfSessionIsNotOpened() {
+        when(session.isOpen()).thenReturn(false);
+
+        transmitter.transmit(PROTOCOL, MESSAGE);
+
+        verify(session, never()).send(any(WebSocketTransmission.class));
+        verify(reSender).add(transmission);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketTransmissionValidatorTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/BasicWebSocketTransmissionValidatorTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.impl.BasicWebSocketTransmissionValidator;
+import org.eclipse.che.api.core.websocket.impl.WebSocketTransmissionValidator;
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Tests for {@link BasicWebSocketTransmissionValidator}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+class BasicWebSocketTransmissionValidatorTest {
+    private static final String VALID_JSON              = "{ \"name\": \"value\" }";
+    private static final String NOT_VALID_JSON          = "not valid json";
+    private static final String REGISTERED_PROTOCOL     = "registered-protocol";
+    private static final String NOT_REGISTERED_PROTOCOL = "not-registered-protocol";
+    @Mock
+    private Map<String, WebSocketMessageReceiver> receivers;
+    @InjectMocks
+    private WebSocketTransmissionValidator        validator;
+
+    @Mock
+    private WebSocketTransmission message;
+
+    @Before
+    public void before() {
+        when(receivers.keySet()).thenReturn(Collections.singleton(REGISTERED_PROTOCOL));
+    }
+
+    @Before
+    public void beforeMethod() {
+        when(message.getProtocol()).thenReturn(REGISTERED_PROTOCOL);
+        when(message.getMessage()).thenReturn(VALID_JSON);
+    }
+
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfProtocolIsNull() {
+        when(message.getProtocol()).thenReturn(null);
+
+        validator.validate(message);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfProtocolIsEmpty() {
+        when(message.getProtocol()).thenReturn("");
+
+        validator.validate(message);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNull() {
+        when(message.getMessage()).thenReturn(null);
+
+        validator.validate(message);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsEmpty() {
+        when(message.getMessage()).thenReturn("");
+
+        validator.validate(message);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfProtocolIsNotRegistered() {
+        when(message.getProtocol()).thenReturn(NOT_REGISTERED_PROTOCOL);
+
+        validator.validate(message);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfMessageIsNotValidJson() {
+        when(message.getMessage()).thenReturn(NOT_VALID_JSON);
+
+        validator.validate(message);
+    }
+
+    @Test
+    public void validateTransmissionShouldPassForValidWebSocketMessage() {
+        validator.validate(message);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/PendingMessagesReSenderTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/PendingMessagesReSenderTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link PendingMessagesReSender}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PendingMessagesReSenderTest {
+    @Mock
+    private WebSocketConnection     connection;
+    @InjectMocks
+    private PendingMessagesReSender reSender;
+
+    @Test
+    public void shouldResendAllMessages() {
+        reSender.add(mock(WebSocketTransmission.class));
+        reSender.add(mock(WebSocketTransmission.class));
+        reSender.add(mock(WebSocketTransmission.class));
+
+        when(connection.isOpen()).thenReturn(true);
+
+        reSender.resend();
+        verify(connection, times(3)).send(any(WebSocketTransmission.class));
+
+        reSender.resend();
+        verify(connection, times(3)).send(any(WebSocketTransmission.class));
+
+
+    }
+
+    @Test
+    public void shouldStopSendingIfSessionIsClosed() {
+        reSender.add(mock(WebSocketTransmission.class));
+        reSender.add(mock(WebSocketTransmission.class));
+        reSender.add(mock(WebSocketTransmission.class));
+
+        final int[] i = {0};
+        when(connection.isOpen()).thenAnswer(invocation -> (i[0]++ <= 1));
+        reSender.resend();
+        verify(connection, times(2)).send(any(WebSocketTransmission.class));
+
+        when(connection.isOpen()).thenReturn(true);
+        reSender.resend();
+
+        verify(connection, times(3)).send(any(WebSocketTransmission.class));
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/SessionWebSocketInitializerTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/SessionWebSocketInitializerTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link SessionWebSocketInitializer}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SessionWebSocketInitializerTest {
+    @Mock
+    private WebSocketConnection          connection;
+    @Mock
+    private WebSocketConnectionSustainer sustainer;
+    @InjectMocks
+    private SessionWebSocketInitializer  initializer;
+
+    @Before
+    public void before(){
+        when(connection.initialize(any())).thenReturn(connection);
+    }
+
+    @Test
+    public void shouldInitializeControllerOnInitialize() {
+        initializer.initialize(singletonMap("url", "url-value"));
+
+        verify(connection).initialize((eq("url-value")));
+    }
+
+    @Test
+    public void shouldOpenConnectionOnInitialize() {
+        initializer.initialize(emptyMap());
+
+        verify(connection).open(WebSocketConnection.IMMEDIATELY);
+    }
+
+    @Test
+    public void shouldEnableSustainerOnInitialize() {
+        initializer.initialize(emptyMap());
+
+        verify(sustainer).enable();
+    }
+
+    @Test
+    public void shouldCloseSessionOnTerminate() {
+        initializer.terminate();
+
+        verify(connection).close();
+    }
+
+    @Test
+    public void shouldDisableSustainerOnInitialize() {
+        initializer.terminate();
+
+        verify(sustainer).disable();
+    }
+
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnectionSustainerTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnectionSustainerTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.util.stream.IntStream.range;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for {@link WebSocketConnectionSustainer}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketConnectionSustainerTest {
+
+    @Mock
+    private WebSocketConnection          connection;
+    @Spy
+    @InjectMocks
+    private WebSocketConnectionSustainer sustainer;
+
+    @Before
+    public void before() {
+        sustainer.enable();
+    }
+
+    @Test
+    public void shouldDisableSustainerOnExceedingLimits() {
+        range(0, 5).forEach(value -> sustainer.sustain());
+
+        sustainer.sustain();
+
+        verify(sustainer).disable();
+    }
+
+    @Test
+    public void shouldResetAttemptsOnSustainerReset() {
+        range(0, 5).forEach(value -> sustainer.sustain());
+
+        sustainer.reset();
+
+        range(0, 5).forEach(value -> sustainer.sustain());
+
+        verify(sustainer, never()).disable();
+    }
+
+    @Test
+    public void shouldOpenConnectionOnSustain() {
+        sustainer.sustain();
+
+        verify(connection).open(500);
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnectionTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketConnectionTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WebSocketConnection}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketConnectionTest {
+    private static final String URL     = "url";
+    private static final int    DELAY   = 0;
+    private static final String MESSAGE = "message";
+    @Mock
+    private WebSocketCreator    connector;
+    @InjectMocks
+    private WebSocketConnection connection;
+
+    @Mock
+    private WebSocket webSocket;
+
+    @Before
+    public void before() {
+        when(connector.create(anyString(), any())).thenReturn(webSocket);
+
+        connection.initialize(URL);
+        connection.open(DELAY);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionIfNoUrlIsSetWhenTryToOpen() {
+        connection.initialize(null);
+        connection.open(DELAY);
+    }
+
+    @Test
+    public void shouldCreateConnectionOnOpen() {
+        verify(connector).create(URL, DELAY);
+    }
+
+    @Test
+    public void shouldOpenConnectionOnOpen() {
+        verify(webSocket).open();
+    }
+
+    @Test
+    public void shouldCloseConnectionOnClose() {
+        connection.close();
+
+        verify(webSocket).close();
+    }
+
+    @Test
+    public void shouldSendMessageOnSend() {
+        final WebSocketTransmission message = mock(WebSocketTransmission.class);
+        when(message.toString()).thenReturn(MESSAGE);
+
+        connection.send(message);
+
+        verify(webSocket).send(MESSAGE);
+    }
+
+
+    @Test
+    public void shouldBeOpenWhenConnectionIsOpen() {
+        when(webSocket.isOpen()).thenReturn(true);
+
+        assertTrue(connection.isOpen());
+
+        verify(webSocket).isOpen();
+    }
+
+    @Test
+    public void shouldBeNotOpenWhenConnectionIsNull() {
+        when(connector.create(anyString(), any())).thenReturn(null);
+        new WebSocketConnection(connector).isOpen();
+
+        assertFalse(connection.isOpen());
+    }
+
+    @Test
+    public void shouldBeNotOpenWhenConnectionIsNotOpen() {
+        when(webSocket.isOpen()).thenReturn(false);
+
+        assertFalse(connection.isOpen());
+
+        verify(webSocket).isOpen();
+    }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketTransmissionDispatcherTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/ng/impl/WebSocketTransmissionDispatcherTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.websocket.ng.impl;
+
+import org.eclipse.che.api.core.websocket.shared.WebSocketTransmission;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.websocket.ng.WebSocketMessageReceiver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link WebSocketTransmissionDispatcher}
+ *
+ * @author Dmitry Kuleshov
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebSocketTransmissionDispatcherTest {
+    private static final String REGISTERED_PROTOCOL     = "registered-protocol";
+    private static final String NOT_REGISTERED_PROTOCOL = "not-registered-protocol";
+    private static final String MESSAGE                 = "message";
+    private static final String RAW_TRANSMISSION        = "raw_transmission";
+    @Mock
+    private Map<String, WebSocketMessageReceiver> receivers;
+    @Mock
+    private WebSocketTransmissionValidator        validator;
+    @Mock
+    private DtoFactory                            dtoFactory;
+    @InjectMocks
+    private WebSocketTransmissionDispatcher       dispatcher;
+
+    @Mock
+    private WebSocketTransmission    transmission;
+    @Mock
+    private WebSocketMessageReceiver receiver;
+
+    @Before
+    public void before() {
+        when(dtoFactory.createDtoFromJson(any(), eq(WebSocketTransmission.class))).thenReturn(transmission);
+
+        when(transmission.getProtocol()).thenReturn(REGISTERED_PROTOCOL);
+        when(transmission.getMessage()).thenReturn(MESSAGE);
+
+        when(receivers.entrySet()).thenReturn(singletonMap(REGISTERED_PROTOCOL, receiver).entrySet());
+    }
+
+    @Test
+    public void shouldCreateWebSocketTransmission() {
+        dispatcher.dispatch(RAW_TRANSMISSION);
+
+        verify(dtoFactory).createDtoFromJson(RAW_TRANSMISSION, WebSocketTransmission.class);
+    }
+
+    @Test
+    public void shouldValidateWebSocketTransmission() {
+        dispatcher.dispatch(RAW_TRANSMISSION);
+
+        verify(validator).validate(transmission);
+    }
+
+    @Test
+    public void shouldRunReceiverOnMatch() {
+        dispatcher.dispatch(RAW_TRANSMISSION);
+
+        verify(receiver).receive(MESSAGE);
+    }
+
+    @Test
+    public void shouldNotRunReceiverOnNoMatch() {
+        when(receivers.entrySet()).thenReturn(singletonMap(NOT_REGISTERED_PROTOCOL, receiver).entrySet());
+
+        dispatcher.dispatch(RAW_TRANSMISSION);
+
+        verify(receiver, never()).receive(MESSAGE);
+    }
+}

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/FileClosedDto.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/FileClosedDto.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto.event;
+
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface FileClosedDto {
+    String getPath();
+
+    FileClosedDto withPath(String path);
+}

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/FileOpenedDto.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/FileOpenedDto.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto.event;
+
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface FileOpenedDto {
+    String getPath();
+
+    FileOpenedDto withPath(String path);
+}

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/FileUpdatedDto.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/FileUpdatedDto.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto.event;
+
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface FileUpdatedDto {
+    String getPath();
+
+    FileUpdatedDto withPath(String path);
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -99,10 +99,10 @@ public class ProjectApiModule extends AbstractModule {
         highLevelVfsEventDetectorMultibinder.addBinding().to(GitCheckoutHiEventDetector.class);
         highLevelVfsEventDetectorMultibinder.addBinding().to(OpenedFileContentUpdateEventDetector.class);
 
-        MapBinder<String, JsonRpcRequestReceiver> notificationReceivers =
+        MapBinder<String, JsonRpcRequestReceiver> requestReceivers =
                 MapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
 
-        notificationReceivers.addBinding("event:file-opened").to(OpenedFileContentUpdateEventDetector.class);
-        notificationReceivers.addBinding("event:file-closed").to(OpenedFileContentUpdateEventDetector.class);
+        requestReceivers.addBinding("event:file-opened").to(OpenedFileContentUpdateEventDetector.class);
+        requestReceivers.addBinding("event:file-closed").to(OpenedFileContentUpdateEventDetector.class);
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -12,9 +12,11 @@ package org.eclipse.che.api.project.server;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestReceiver;
 import org.eclipse.che.api.project.server.handlers.CreateBaseProjectTypeHandler;
 import org.eclipse.che.api.project.server.handlers.ProjectHandler;
 import org.eclipse.che.api.project.server.importer.ProjectImporter;
@@ -27,12 +29,13 @@ import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
 import org.eclipse.che.api.vfs.impl.file.DefaultFileWatcherNotificationHandler;
 import org.eclipse.che.api.vfs.impl.file.FileWatcherNotificationHandler;
 import org.eclipse.che.api.vfs.impl.file.LocalVirtualFileSystemProvider;
-import org.eclipse.che.api.vfs.impl.file.event.GitCheckoutHiEventDetector;
 import org.eclipse.che.api.vfs.impl.file.event.HiEventDetector;
 import org.eclipse.che.api.vfs.impl.file.event.HiEventService;
 import org.eclipse.che.api.vfs.impl.file.event.LoEventListener;
 import org.eclipse.che.api.vfs.impl.file.event.LoEventService;
-import org.eclipse.che.api.vfs.impl.file.event.PomModifiedHiEventDetector;
+import org.eclipse.che.api.vfs.impl.file.event.detectors.GitCheckoutHiEventDetector;
+import org.eclipse.che.api.vfs.impl.file.event.detectors.OpenedFileContentUpdateEventDetector;
+import org.eclipse.che.api.vfs.impl.file.event.detectors.PomModifiedHiEventDetector;
 import org.eclipse.che.api.vfs.search.MediaTypeFilter;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
 import org.eclipse.che.api.vfs.search.impl.FSLuceneSearcherProvider;
@@ -80,6 +83,10 @@ public class ProjectApiModule extends AbstractModule {
 
         bind(FileWatcherNotificationHandler.class).to(DefaultFileWatcherNotificationHandler.class);
 
+        configureVfsEvent();
+    }
+
+    private void configureVfsEvent() {
         bind(LoEventListener.class);
         bind(LoEventService.class);
         bind(HiEventService.class);
@@ -87,7 +94,15 @@ public class ProjectApiModule extends AbstractModule {
         Multibinder<HiEventDetector<?>> highLevelVfsEventDetectorMultibinder =
                 Multibinder.newSetBinder(binder(), new TypeLiteral<HiEventDetector<?>>() {
                 });
+
         highLevelVfsEventDetectorMultibinder.addBinding().to(PomModifiedHiEventDetector.class);
         highLevelVfsEventDetectorMultibinder.addBinding().to(GitCheckoutHiEventDetector.class);
+        highLevelVfsEventDetectorMultibinder.addBinding().to(OpenedFileContentUpdateEventDetector.class);
+
+        MapBinder<String, JsonRpcRequestReceiver> notificationReceivers =
+                MapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
+
+        notificationReceivers.addBinding("event:file-opened").to(OpenedFileContentUpdateEventDetector.class);
+        notificationReceivers.addBinding("event:file-closed").to(OpenedFileContentUpdateEventDetector.class);
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/GitCheckoutHiEventDetector.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/GitCheckoutHiEventDetector.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.vfs.impl.file.event;
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
 
 import com.google.common.annotations.Beta;
 
@@ -17,6 +17,11 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.project.shared.dto.event.GitBranchCheckoutEventDto;
 import org.eclipse.che.api.vfs.Path;
 import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
+import org.eclipse.che.api.vfs.impl.file.event.EventTreeNode;
+import org.eclipse.che.api.vfs.impl.file.event.HiEvent;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventBroadcaster;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventClientBroadcaster;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventDetector;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/OpenedFileContentUpdateEventDetector.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/OpenedFileContentUpdateEventDetector.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
+
+import com.google.common.annotations.Beta;
+
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestReceiver;
+import org.eclipse.che.api.core.jsonrpc.JsonRpcRequestTransmitter;
+import org.eclipse.che.api.core.jsonrpc.shared.JsonRpcRequest;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.project.server.notification.ProjectItemModifiedEvent;
+import org.eclipse.che.api.project.shared.dto.event.FileClosedDto;
+import org.eclipse.che.api.project.shared.dto.event.FileOpenedDto;
+import org.eclipse.che.api.project.shared.dto.event.FileUpdatedDto;
+import org.eclipse.che.api.vfs.impl.file.event.EventTreeNode;
+import org.eclipse.che.api.vfs.impl.file.event.HiEvent;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventDetector;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.empty;
+import static org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType.MODIFIED;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author Dmitry Kuleshov
+ */
+@Beta
+@Singleton
+public class OpenedFileContentUpdateEventDetector implements HiEventDetector<FileUpdatedDto>,
+                                                             JsonRpcRequestReceiver,
+                                                             EventSubscriber<ProjectItemModifiedEvent> {
+
+    private static final Logger LOG = getLogger(OpenedFileContentUpdateEventDetector.class);
+
+    //TODO improve to keep all endpoints for opened file
+    private final Map<String, Integer> endpointRegistry  = new HashMap<>();
+    private final Set<String>          ignoranceRegistry = new HashSet<>();
+
+    private final JsonRpcRequestTransmitter transmitter;
+
+    @Inject
+    public OpenedFileContentUpdateEventDetector(JsonRpcRequestTransmitter transmitter, EventService eventService) {
+        this.transmitter = transmitter;
+        eventService.subscribe(this);
+    }
+
+    @Override
+    public Optional<HiEvent<FileUpdatedDto>> detect(EventTreeNode eventTreeNode) {
+        if (!eventTreeNode.isRoot() || eventTreeNode.getChildren().isEmpty()) {
+            return empty();
+        }
+
+        final Collection<String> registeredFiles = endpointRegistry.keySet();
+
+        final List<EventTreeNode> files = eventTreeNode.stream()
+                                                       .filter(EventTreeNode::modificationOccurred)
+                                                       .filter(EventTreeNode::isFile)
+                                                       .filter(event -> registeredFiles.contains(event.getPath()))
+                                                       .filter(event -> MODIFIED.equals(event.getLastEventType()))
+                                                       .collect(Collectors.toList());
+
+
+        for (EventTreeNode file : files) {
+            final String path = file.getPath();
+
+            if (!ignoranceRegistry.contains(path)) {
+
+                final Integer endpoint = endpointRegistry.get(path);
+
+                final FileUpdatedDto fileUpdatedDto = DtoFactory.getInstance()
+                                                                .createDto(FileUpdatedDto.class)
+                                                                .withPath(path);
+
+                final JsonRpcRequest notification = DtoFactory.getInstance()
+                                                              .createDto(JsonRpcRequest.class)
+                                                              .withMethod("event:file-updated")
+                                                              .withJsonrpc("2.0")
+                                                              .withParams(fileUpdatedDto.toString());
+                transmitter.transmit(notification, endpoint);
+            } else {
+                ignoranceRegistry.remove(path);
+            }
+        }
+        return Optional.empty();
+    }
+
+
+    @Override
+    public void onEvent(ProjectItemModifiedEvent event) {
+        if (ProjectItemModifiedEvent.EventType.UPDATED.equals(event.getType())) {
+            ignoranceRegistry.add(event.getPath());
+        }
+    }
+
+    @Override
+    public void receive(JsonRpcRequest request, Integer endpoint) {
+        final String params = request.getParams();
+        final String method = request.getMethod();
+
+
+        if (method.equals("event:file-opened")) {
+            final FileOpenedDto dto = DtoFactory.getInstance().createDtoFromJson(params, FileOpenedDto.class);
+            endpointRegistry.put(dto.getPath(), endpoint);
+        } else {
+            final FileClosedDto dto = DtoFactory.getInstance().createDtoFromJson(params, FileClosedDto.class);
+            endpointRegistry.remove(dto.getPath());
+        }
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/PomModifiedHiEventDetector.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/PomModifiedHiEventDetector.java
@@ -8,12 +8,17 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.vfs.impl.file.event;
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
 
 import com.google.common.annotations.Beta;
 import com.google.inject.Inject;
 
 import org.eclipse.che.api.project.shared.dto.event.PomModifiedEventDto;
+import org.eclipse.che.api.vfs.impl.file.event.EventTreeNode;
+import org.eclipse.che.api.vfs.impl.file.event.HiEvent;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventBroadcaster;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventDetector;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventServerPublisher;
 
 import java.util.Optional;
 

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/event/detectors/GitCheckoutHiEventDetectorTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/event/detectors/GitCheckoutHiEventDetectorTest.java
@@ -8,12 +8,14 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.vfs.impl.file.event;
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
 
 import org.eclipse.che.api.project.shared.dto.event.GitBranchCheckoutEventDto;
 import org.eclipse.che.api.vfs.VirtualFile;
 import org.eclipse.che.api.vfs.VirtualFileSystem;
 import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
+import org.eclipse.che.api.vfs.impl.file.event.HiEvent;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventClientBroadcaster;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +39,6 @@ import static org.mockito.Mockito.when;
  * Test for {@link GitCheckoutHiEventDetector}
  *
  * @author Dmitry Kuleshov
- *
  * @since 4.5
  */
 @RunWith(MockitoJUnitRunner.class)

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/event/detectors/HiVfsEventDetectorTestHelper.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/event/detectors/HiVfsEventDetectorTestHelper.java
@@ -8,9 +8,11 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.vfs.impl.file.event;
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
 
 import org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType;
+import org.eclipse.che.api.vfs.impl.file.event.EventTreeNode;
+import org.eclipse.che.api.vfs.impl.file.event.LoEvent;
 import org.eclipse.che.api.vfs.impl.file.event.LoEvent.ItemType;
 
 import static org.eclipse.che.api.vfs.impl.file.event.EventTreeHelper.addEventAndCreatePrecedingNodes;
@@ -19,7 +21,6 @@ import static org.eclipse.che.api.vfs.impl.file.event.LoEvent.newInstance;
 
 /**
  * @author Dmitry Kuleshov
- *
  * @since 4.5
  */
 abstract class HiVfsEventDetectorTestHelper {
@@ -35,12 +36,11 @@ abstract class HiVfsEventDetectorTestHelper {
                   FileWatcherEventType eventType,
                   ItemType itemType) {
 
-        LoEvent loEvent = newInstance()
-                .withName(name)
-                .withPath(path)
-                .withEventType(eventType)
-                .withItemType(itemType)
-                .withTime(System.currentTimeMillis());
+        LoEvent loEvent = newInstance().withName(name)
+                                       .withPath(path)
+                                       .withEventType(eventType)
+                                       .withItemType(itemType)
+                                       .withTime(System.currentTimeMillis());
 
         addEventAndCreatePrecedingNodes(root, loEvent);
     }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/event/detectors/PomModifiedHiEventDetectorTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/impl/file/event/detectors/PomModifiedHiEventDetectorTest.java
@@ -8,9 +8,11 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.vfs.impl.file.event;
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
 
 import org.eclipse.che.api.project.shared.dto.event.PomModifiedEventDto;
+import org.eclipse.che.api.vfs.impl.file.event.HiEvent;
+import org.eclipse.che.api.vfs.impl.file.event.HiEventServerPublisher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +35,6 @@ import static org.junit.Assert.assertTrue;
  * Test for {@link PomModifiedHiEventDetector}
  *
  * @author Dmitry Kuleshov
- *
  * @since 4.5
  */
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
## Overview

There is a need in a simple, extensible, text-based and as symmetrical as possible approach that we could use to transport relevant data and call for remote procedures (RPC) between two endpoints: client (IDE) and server (workspace agent).
- Simplicity is required on two levels
  - Easy support in future releases
  - No pain for end-users (che developers)
- Extensibility obviously should make it a long living solution - save time and materials
- Using some variation of text-based data transfer formats seems to be suitable here: simple and clear enough to be read by human along with sufficient efficiency. 
- Bidirectional conversation: the client and the server both must have an equal ability to send and receive messages

In order to achieve those goals I have the following considerations:
- To be able to send messages in both directions on demand I think WEB SOCKETS protocol would be the most comfortable.
- As a human readable text-base data transfer format that also can be used for RPC we can use  JSON RPC 2.0 protocol or something similar but simpler.
- Simplicity and extensibility should be a result of proper making use of DI pattern implemented by  Guice and Gin.

So the solution should have two levels of abstraction: web socket based transport (low level) and Json RPC (high level). While a user works with simple enough high level RPC entities, the real magic happens on web socket level. The API of both levels must be independent of each other so it could be possible and easy enough to use them separately (e.g for Json RPC implementation to use another transport or for web socket based transport support other protocols (except Json RPC). 
Next, we will consider brief specification details associated with these abstractions, presented as a set of requirements or short rules.
## Web socket based transport (low level)

_Based on and extends [web socket specification](https://tools.ietf.org/html/rfc6455)._
### Functional specification
#### Conversation
- Conversation happens between two endpoints
- Conversation happens via web socket protocol
- Conversation is a consequential sending and receiving of web socket transmission
#### Conversation endpoints
- Conversation has two participants: client (IDE) and server (workspace agent)
- Endpoints are equal and can perform same set of operations:
  - send transmission
  - receive transmission
- Server side endpoint (workspace agent) can take part in several conversations with several clients (IDE)
- Client side endpoint (IDE) can take part in one conversation with server side (workspace agent)
- There can be a several conversations client web socket conversations to a single server (workspace agent)
- Each client side (IDE) endpoint must provide a number to make it possible to be identified by server side during multiple conversations
#### Web socket transmission
- Web socket transmission is a JSON valid message
- Web socket transmission has two properties:
  - Protocol
  - Message
##### Protocol
- Protocol value must be recognized by the system and have a corresponding protocol implementation
- Protocol is a `String` value
- Protocol must not be empty
- Protocol must not be `null`
##### Message
- Message value is a string that a corresponding protocol implementation knows what to do with
- Message is a `String` value
- Message must not be empty
- Message must not be `null`
#### Examples:
- Example of web socket transmission:

``` json
{
    "protocol": "coffeemaker",
    "message": "could  you please make me some coffee?"
}
```

That means:
- Web socket transmission protocol is "coffeemaker"
- There is an implementation of this protocol in the system
- The implementation knows what to do with web socket transmission message
- Which is "could you please make me some coffee?"
### How to use
- If you want to make your own protocol implementation that will receive web socket transmissions you must provide and register an implementation of `WebSocketMessageReceiver` in `Guice` or `Gin` configuration modules: 

``` java
// GWT side
 GinMapBinder<String, WebSocketMessageReceiver> receivers =
GinMapBinder.newMapBinder(binder(), String.class, WebSocketMessageReceiver.class);
receivers.addBinding("coffeemaker").to(CoffeeMakerMessageReceiver.class);
```

``` java
// Server side
 MapBinder<String, WebSocketMessageReceiver> receivers =
MapBinder.newMapBinder(binder(), String.class, WebSocketMessageReceiver.class);
receivers.addBinding("coffeemaker").to(CoffeeMakerMessageReceiver.class);
```

Where "coffeemaker" is the name of the protocol that will be used in web socket transmissions.
- In order to send web socket transmissions you must use provided `WebSocketMessageTransmitter` implementation. Again it can be injected using `Guice`or `Gin` routines.
## Json RPC (high level)

_Based on [Json RPC specification](http://www.jsonrpc.org/specification)_
### Functional specification
#### Conversation
- Conversation happens between two endpoints
- Conversation happens via Json RPC protocol
- Conversation is a consequential sending and receiving of Json RPC requests and responses
#### Conversation endpoints
- Conversation has two participants: client (IDE) and server (workspace agent)
-  Endpoints are equal and can perform same set of operations:
  - send Json RPC request
  - send Json RPC response
  - receive Json RPC request
  - receive Json RPC response
- Server side endpoint (workspace agent) can take part in several conversations with several clients (IDE)
- Client side endpoint (IDE) can take part in one conversation with server side (workspace agent)
- There can be a several conversations client web socket conversations to a single server (workspace agent)
- Each client side (IDE) endpoint must provide a number to make it possible to be identified by server side during multiple conversations
#### Json RPC request and response
- Json RPC request and response are defined in  [Json RPC specification](http://www.jsonrpc.org/specification). 
### How to use
- In order to receive Json Rpc requests you must provide and register an implementation of `JsonRpcRequestReceiver`:

``` java
// GWT side
GinMapBinder<String, JsonRpcRequestReceiver> requestReceivers =
GinMapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
requestReceivers.addBinding("method-name").to(CustomRequestReceiver.class);
```

``` java
// Server side
MapBinder<String, JsonRpcRequestReceiver> requestReceivers =
MapBinder.newMapBinder(binder(), String.class, JsonRpcRequestReceiver.class);
requestReceivers.addBinding("method-name").to(CustomRequestReceiver.class);
```

Where "method-name" is a method property of Json RPC request.
- In order to receive Json Rpc responses you must provide and register an implementation of `JsonRpcResponseReceiver`:

``` java
// GWT side
GinMapBinder<String, JsonRpcResponseReceiver> responseReceiver =
GinMapBinder.newMapBinder(binder(), String.class, JsonRpcResponseReceiver.class);
responseReceiver.addBinding("method-name").to(CustomResponseReceiver.class);
```

``` java
// Server side
MapBinder<String, JsonRpcResponseReceiver> requestReceivers = MapBinder.newMapBinder(binder(), String.class, JsonRpcResponseReceiver.class);
responseReceiver.addBinding("method-name").to(CustomResponseReceiver.class);
```

Where "method-name" is a method property of Json RPC request that this response answers to.
- To send Json RPC request inject provided instance of `JsonRpcRequestTransmitter` interface.
- To send Json RPC response inject provided instance of `JsonRpcResponseTransmitter` interface.
### Examples:
- Example of Json RPC request:

``` json
{ 
   "jsonrpc": "2.0", 
   "method": "subtract", 
   "params": [42, 23], 
   "id": 1
}
```
- Example of Json RPC response

``` json
{
   "jsonrpc": "2.0",
   "result": 19,
   "id": 1
}
```
## Further considerations

There is a number of functionality or improvements that I see useful but not covered by this pull request:
- This implementation and specification does not guarantee message deliverance on web socket level shifting the responsibility to high level protocols. So it may be quite useful if we could provide any mechanism that guarantees such deliverance on low level to simplify high level protocols implementation even more.
- The support of Json RPC protocol is not complete as there is no need for that at the moment though it may become important and required in future:
  - Json RPC errors are supported partially
  - Json RPC validation
  - Json RPC batch requests
- Some of Json RPC routines related to request/response generation can be improved/simplified by generalization
- There is quite a big amount of functional duplication on GWT and server side caused by different approaches in coding and build/compile mechanism but also because of partially asymmetric interaction mechanism between endpoints (several to one conversations). At the moment I don't think that is not an urgent problem but probably this can and should be improved in future.
- As @evoevodin suggested, there are some places where we can automate processes and free end user of extra routines:
  - Json Rpc requests and responses IDs can be automatically read on reception and assigned on transmission
  - Json Rpc request body (params) can be automatically created parsing `String` and instantiating corresponding `DTO`s by specifying appropriate `DTO` class as generic type for receivers
- At the moment there is no guaranties as of the order of transmissions (mostly because of transport algorithms simplification concerns) passed to web socket layer, but that is quite obvious that we can benefit of having such ones in future ( @evoevodin ) 
