### PR TITLE
che-1865: Fix disable compare button in the compare widget when we have changed few files

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changedList/ChangedListPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changedList/ChangedListPresenter.java
@@ -67,11 +67,13 @@ public class ChangedListPresenter implements ChangedListView.ActionDelegate {
     public void show(Map<String, Status> changedFiles, String revision, Project project) {
         this.changedFiles = changedFiles;
         this.project = project;
+        this.revision = revision;
+
+        view.setEnableCompareButton(false);
+        view.setEnableExpandCollapseButtons(treeViewEnabled);
+
         view.showDialog();
         viewChangedFiles();
-        view.setEnableExpandCollapseButtons(treeViewEnabled);
-        view.setEnableCompareButton(false);
-        this.revision = revision;
     }
 
     /** {@inheritDoc} */
@@ -119,12 +121,6 @@ public class ChangedListPresenter implements ChangedListView.ActionDelegate {
         view.setEnableCompareButton(true);
         this.file = node.getName();
         this.status = ((ChangedFileNode)node).getStatus();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void onNodeNotSelected() {
-        view.setEnableCompareButton(false);
     }
 
     private void viewChangedFiles() {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changedList/ChangedListView.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changedList/ChangedListView.java
@@ -50,9 +50,6 @@ public interface ChangedListView extends View<ChangedListView.ActionDelegate> {
          */
         void onNodeSelected(@NotNull Node node);
 
-        /** Performs any action in response to the user do not have any selected node. */
-        void onNodeNotSelected();
-
         /** Performs any actions appropriate in response to the user double clicked on the file node. */
         void onFileNodeDoubleClicked();
     }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changedList/ChangedListViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changedList/ChangedListViewImpl.java
@@ -99,9 +99,7 @@ public class ChangedListViewImpl extends Window implements ChangedListView {
             public void onSelectionChanged(SelectionChangedEvent event) {
                 List<Node> selection = event.getSelection();
                 if (!selection.isEmpty()) {
-                    delegate.onNodeSelected(event.getSelection().get(0));
-                } else {
-                    delegate.onNodeNotSelected();
+                    delegate.onNodeSelected(selection.get(0));
                 }
             }
         });
@@ -138,9 +136,6 @@ public class ChangedListViewImpl extends Window implements ChangedListView {
         for (String file : items.keySet()) {
             tree.getNodeStorage().add(new ChangedFileNode(file, items.get(file), nodesResources, delegate, false));
         }
-        if (tree.getSelectionModel().getSelectedNodes() == null) {
-            delegate.onNodeNotSelected();
-        }
     }
 
     @Override
@@ -154,9 +149,6 @@ public class ChangedListViewImpl extends Window implements ChangedListView {
             for (Node node : nodes) {
                 tree.getNodeStorage().add(node);
             }
-        }
-        if (tree.getSelectionModel().getSelectedNodes() == null) {
-            delegate.onNodeNotSelected();
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Fix disable compare button when we have changed few files and open compare widget. By default tree with changes select first element and compare button should be enabled.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1865
### Tests written?

No
### Docs requirements?

Include the content for all the docs changes required. 
1.  API changes  : without changes
2.  User docs changes  :  without changes

@vinokurig  review please

Signed-off-by: Aleksandr Andrienko aandrienko@codenvy.com
