### PR TITLE
Remove *.sh from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ test-output/
 *.exe
 *.o
 *.so
-*.sh
 
 # Packages #
 ############


### PR DESCRIPTION
As we have lot of sh scripts in that repo it is really hard to manage them if it's ignored.

@skabashnyuk @TylerJewell 
