### PR TITLE
Fixed test failures related to file watcher and corrected logic in file watcher 

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/FileTreeWatcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/FileTreeWatcher.java
@@ -225,6 +225,10 @@ public class FileTreeWatcher {
                 for (Path entry : entries) {
                     watchedDirectory
                             .addItem(new DirectoryItem(entry.getFileName(), Files.isDirectory(entry), getLastModifiedInMillis(entry)));
+
+                    if (Files.isDirectory(entry)) {
+                        setupDirectoryWatcher(entry);
+                    }
                 }
             }
             watchedDirectories.put(directory, watchedDirectory);

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -941,7 +941,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testDeleteProjectsConcurrently() throws Exception {
-        int threadNumber = 100;
+        int threadNumber = 5 * (Runtime.getRuntime().availableProcessors() + 1);
         ExecutorService executor = Executors.newFixedThreadPool(threadNumber);
         CountDownLatch countDownLatch = new CountDownLatch(threadNumber);
         List<Future<ContainerResponse>> futures = new LinkedList<>();
@@ -981,6 +981,8 @@ public class ProjectServiceTest {
         for (Future<ContainerResponse> future : futures) {
             assertEquals(future.get().getStatus(), 204, "Error: " + future.get().getEntity());
         }
+
+        executor.shutdown();
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
- Fixes random failures of `testDeleteProjectsConcurrently` in `org.eclipse.che.api.project.server.ProjectServiceTest` 
- Makes `org.eclipse.che.api.vfs.impl.file.FileTreeWatcher` to recursively add sub-directories to watched directories map
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2006
### Tests written?

Yes
