### PR TITLE
Optimize che-launcher for perf

### DIFF
--- a/dockerfiles/che-launcher/build.sh
+++ b/dockerfiles/che-launcher/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright (c) 2012-2016 Codenvy, S.A., Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+if [ "latest" = "$1" ]
+then
+  TAG="latest"
+else
+  TAG="nightly"
+fi
+
+docker build -t codenvy/che-launcher:$TAG .

--- a/dockerfiles/che-launcher/launcher.sh
+++ b/dockerfiles/che-launcher/launcher.sh
@@ -26,6 +26,16 @@ init_global_variables() {
   CHE_SERVER_IMAGE_NAME="codenvy/che-server"
   CHE_LAUNCHER_IMAGE_NAME="codenvy/che-launcher"
 
+  # Set variables that use docker as utilities to avoid over container execution
+  ETH0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth0" | \
+                                                            grep "inet addr:" | \
+                                                            cut -d: -f2 | \
+                                                            cut -d" " -f1)
+  # Used to self-determine container version
+  LAUNCHER_CONTAINER_ID=$(get_che_launcher_container_id)
+  LAUNCHER_IMAGE_NAME=$(docker inspect --format='{{.Config.Image}}' "${LAUNCHER_CONTAINER_ID}")
+  LAUNCHER_IMAGE_VERSION=$(echo "${LAUNCHER_IMAGE_NAME}" | cut -d : -f2 -s)
+
   # Possible Docker install types are:
   #     native, boot2docker or moby
   DOCKER_INSTALL_TYPE=$(get_docker_install_type)

--- a/dockerfiles/che-launcher/launcher.sh
+++ b/dockerfiles/che-launcher/launcher.sh
@@ -27,17 +27,17 @@ init_global_variables() {
   CHE_LAUNCHER_IMAGE_NAME="codenvy/che-launcher"
 
   # Set variables that use docker as utilities to avoid over container execution
-  ETH0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth0" | \
+  ETH0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth0 2> /dev/null" | \
                                                             grep "inet addr:" | \
                                                             cut -d: -f2 | \
                                                             cut -d" " -f1)
 
-  ETH1_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth1" | \
+  ETH1_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth1 2> /dev/null" | \
                                                             grep "inet addr:" | \
                                                             cut -d: -f2 | \
-                                                            cut -d" " -f1)
+                                                            cut -d" " -f1) 
 
-  DOCKER0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig docker0" | \
+  DOCKER0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig docker0 2> /dev/null" | \
                                                               grep "inet addr:" | \
                                                               cut -d: -f2 | \
                                                               cut -d" " -f1)

--- a/dockerfiles/che-launcher/launcher.sh
+++ b/dockerfiles/che-launcher/launcher.sh
@@ -31,6 +31,17 @@ init_global_variables() {
                                                             grep "inet addr:" | \
                                                             cut -d: -f2 | \
                                                             cut -d" " -f1)
+
+  ETH1_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth1" | \
+                                                            grep "inet addr:" | \
+                                                            cut -d: -f2 | \
+                                                            cut -d" " -f1)
+
+  DOCKER0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig docker0" | \
+                                                              grep "inet addr:" | \
+                                                              cut -d: -f2 | \
+                                                              cut -d" " -f1)
+
   # Used to self-determine container version
   LAUNCHER_CONTAINER_ID=$(get_che_launcher_container_id)
   LAUNCHER_IMAGE_NAME=$(docker inspect --format='{{.Config.Image}}' "${LAUNCHER_CONTAINER_ID}")

--- a/dockerfiles/che-launcher/launcher_cmds.sh
+++ b/dockerfiles/che-launcher/launcher_cmds.sh
@@ -118,8 +118,9 @@ print_debug_info() {
     debug "CHE SERVER CONTAINER ID   = $(get_che_server_container_id)"
     debug "CHE CONF FOLDER           = $(get_che_container_conf_folder)"
     debug "CHE DATA FOLDER           = $(get_che_container_data_folder)"
-    debug "CHE DASHBOARD URL         = http://${CHE_HOSTNAME}:${CHE_PORT}"
-    debug "CHE API URL               = http://${CHE_HOSTNAME}:${CHE_PORT}/api"
+    CURRENT_CHE_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort }}' ${CHE_SERVER_CONTAINER_NAME})
+    debug "CHE DASHBOARD URL         = http://${DEFAULT_CHE_HOSTNAME}:${CURRENT_CHE_PORT}"  
+    debug "CHE API URL               = http://${DEFAULT_CHE_HOSTNAME}:${CURRENT_CHE_PORT}/api"
     debug 'CHE LOGS                  = run `docker logs -f '${CHE_SERVER_CONTAINER_NAME}'`'
   fi
   debug ""

--- a/dockerfiles/che-launcher/launcher_cmds.sh
+++ b/dockerfiles/che-launcher/launcher_cmds.sh
@@ -105,7 +105,7 @@ print_debug_info() {
   debug "---------  PLATFORM INFO  -------------"
   debug "DOCKER_INSTALL_TYPE       = ${DOCKER_INSTALL_TYPE}"
   debug "DOCKER_HOST_OS            = $(get_docker_host_os)"
-  debug "DOCKER_HOST_IP            = $(get_docker_host_ip)"
+  debug "DOCKER_HOST_IP            = ${DEFAULT_DOCKER_HOST_IP}"
   debug "DOCKER_DAEMON_VERSION     = $(get_docker_daemon_version)"
   debug ""
   debug ""

--- a/dockerfiles/che-launcher/launcher_funcs.sh
+++ b/dockerfiles/che-launcher/launcher_funcs.sh
@@ -135,22 +135,15 @@ get_docker_install_type() {
 get_docker_host_ip() {
   case $(get_docker_install_type) in
    boot2docker)
-     NETWORK_IF="eth1"
+     echo $ETH1_ADDRESS
    ;;
    native)
-     NETWORK_IF="docker0"
+     echo $DOCKER0_ADDRESS
    ;;
    *)
-     NETWORK_IF="eth0"
+     echo $ETH0_ADDRESS
    ;;
   esac
-
-  docker run --rm --net host \
-            alpine sh -c \
-            "ip a show ${NETWORK_IF}" | \
-            grep 'inet ' | \
-            cut -d/ -f1 | \
-            awk '{ print $2}'
 }
 
 get_docker_host_os() {

--- a/dockerfiles/che-launcher/launcher_funcs.sh
+++ b/dockerfiles/che-launcher/launcher_funcs.sh
@@ -52,10 +52,6 @@ get_che_launcher_container_id() {
 }
 
 get_che_launcher_version() {
-  LAUNCHER_CONTAINER_ID=$(get_che_launcher_container_id)
-  LAUNCHER_IMAGE_NAME=$(docker inspect --format='{{.Config.Image}}' "${LAUNCHER_CONTAINER_ID}")
-  LAUNCHER_IMAGE_VERSION=$(echo "${LAUNCHER_IMAGE_NAME}" | cut -d : -f2 -s)
-
   if [ -n "${LAUNCHER_IMAGE_VERSION}" ]; then
     echo "${LAUNCHER_IMAGE_VERSION}"
   else
@@ -72,7 +68,6 @@ is_boot2docker() {
 }
 
 has_docker_for_windows_ip() {
-  ETH0_ADDRESS=$(docker run --net host alpine /bin/sh -c "ifconfig eth0" | grep "inet addr:" | cut -d: -f2 | cut -d" " -f1)
   if [ "${ETH0_ADDRESS}" = "10.0.75.2" ]; then
     return 0
   else
@@ -169,7 +164,7 @@ get_docker_daemon_version() {
 get_che_hostname() {
   INSTALL_TYPE=$(get_docker_install_type)
   if [ "${INSTALL_TYPE}" = "boot2docker" ]; then
-    get_docker_host_ip
+    echo $DEFAULT_DOCKER_HOST_IP
   else
     echo "localhost"
   fi


### PR DESCRIPTION
### What does this PR do?

This pull request implements optimizations to minimize the number of times that `docker run` is called within the `che-launcher` utility. Previously, there were numerous helper functions that have embedded `docker run` commands. If these functions were repeatedly called, we were launching unnecessary containers when one invocation will do.

Also fixes a small error where one of the docker run commands did not have a `--rm` leaving a lot of lingering exited containers on the user's system.

Also adds in a build.sh into the directory to perform a build of the image.
