### PR TITLE
CHE-1866: Fix wrong viewing of git compare

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithBranchAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithBranchAction.java
@@ -16,6 +16,7 @@ import com.google.inject.Singleton;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.compare.branchList.BranchListPresenter;
 
@@ -43,9 +44,10 @@ public class CompareWithBranchAction extends GitAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         final Project project = appContext.getRootProject();
+        final Resource resource = appContext.getResource();
 
         checkState(project != null, "Null project occurred");
 
-        presenter.showBranches(project);
+        presenter.showBranches(project, resource);
     }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithLatestAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithLatestAction.java
@@ -23,17 +23,17 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.compare.ComparePresenter;
 import org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status;
 import org.eclipse.che.ide.ext.git.client.compare.changedList.ChangedListPresenter;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
-
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.git.shared.DiffRequest.DiffType.NAME_STATUS;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
@@ -78,10 +78,20 @@ public class CompareWithLatestAction extends GitAction {
     public void actionPerformed(ActionEvent e) {
 
         final Project project = appContext.getRootProject();
+        final Resource resource = appContext.getResource();
 
         checkState(project != null, "Null project occurred");
+        checkState(project.getLocation().isPrefixOf(resource.getLocation()), "Given selected item is not descendant of given project");
 
-        service.diff(appContext.getDevMachine(), project.getLocation(), Collections.<String>emptyList(), NAME_STATUS, false, 0, REVISION, false)
+        final String selectedItemPath = resource.getLocation()
+                                                .removeFirstSegments(project.getLocation().segmentCount())
+                                                .removeTrailingSeparator()
+                                                .toString();
+
+        service.diff(appContext.getDevMachine(),
+                     project.getLocation(),
+                     selectedItemPath.isEmpty() ? null : singletonList(selectedItemPath),
+                     NAME_STATUS, false, 0, REVISION, false)
                .then(new Operation<String>() {
                    @Override
                    public void apply(String diff) throws OperationException {
@@ -109,11 +119,11 @@ public class CompareWithLatestAction extends GitAction {
                        }
                    }
                })
-        .catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError arg) throws OperationException {
-                notificationManager.notify(locale.diffFailed(), FAIL, NOT_EMERGE_MODE);
-            }
-        });
+               .catchError(new Operation<PromiseError>() {
+                   @Override
+                   public void apply(PromiseError arg) throws OperationException {
+                       notificationManager.notify(locale.diffFailed(), FAIL, NOT_EMERGE_MODE);
+                   }
+               });
     }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchList/BranchListPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchList/BranchListPresenter.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.compare.ComparePresenter;
 import org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status;
@@ -33,11 +34,12 @@ import org.eclipse.che.ide.extension.machine.client.processes.ConsolesPanelPrese
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 
 import javax.validation.constraints.NotNull;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.git.shared.BranchListRequest.LIST_ALL;
 import static org.eclipse.che.api.git.shared.DiffRequest.DiffType.NAME_STATUS;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
@@ -64,8 +66,9 @@ public class BranchListPresenter implements BranchListView.ActionDelegate {
     private final AppContext               appContext;
     private final NotificationManager      notificationManager;
 
-    private Branch  selectedBranch;
-    private Project project;
+    private Branch   selectedBranch;
+    private Project  project;
+    private Resource selectedItem;
 
     @Inject
     public BranchListPresenter(BranchListView view,
@@ -93,8 +96,11 @@ public class BranchListPresenter implements BranchListView.ActionDelegate {
     }
 
     /** Open dialog and shows branches to compare. */
-    public void showBranches(Project project) {
+    public void showBranches(Project project, Resource selectedItem) {
+        checkState(project.getLocation().isPrefixOf(selectedItem.getLocation()), "Given selected item is not descendant of given project");
+
         this.project = project;
+        this.selectedItem = selectedItem;
 
         getBranches();
     }
@@ -108,9 +114,15 @@ public class BranchListPresenter implements BranchListView.ActionDelegate {
     /** {@inheritDoc} */
     @Override
     public void onCompareClicked() {
+
+        final String selectedItemPath = selectedItem.getLocation()
+                                                    .removeFirstSegments(project.getLocation().segmentCount())
+                                                    .removeTrailingSeparator()
+                                                    .toString();
+
         service.diff(appContext.getDevMachine(),
                      project.getLocation(),
-                     Collections.<String>emptyList(),
+                     selectedItemPath.isEmpty() ? null : singletonList(selectedItemPath),
                      NAME_STATUS,
                      false,
                      0,


### PR DESCRIPTION
### What does this PR do?

Fix problem with wrong Git compare viewing.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1866
### Previous Behavior

Git compare didn't respect selected file in editor part or in project explorer
### New Behavior

Git compare opens change list according to selected file in editor part or in project explorer

@azatsarynnyy  @RomanNikitenko Please review
