### PR TITLE
CHE-1859: Fix Merge success message

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/merge/MergePresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/merge/MergePresenter.java
@@ -213,7 +213,7 @@ public class MergePresenter implements MergeView.ActionDelegate {
             }
         }
 
-        String message = "<b>" + mergeResult.getMergeStatus().getValue() + "</b>";
+        String message = mergeResult.getMergeStatus().getValue();
         String conflictText = conflictMessage.toString();
         message += (!conflictText.isEmpty()) ? constant.mergedConflicts() : "";
 


### PR DESCRIPTION
### What does this PR do?

Remove html tags from git merge message
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1859
### Previous Behavior

![mergeresult_1](https://cloud.githubusercontent.com/assets/7668752/17660089/b60f68fc-62df-11e6-9b37-242b74d4de54.png)
### New Behavior

![mergeresult_2](https://cloud.githubusercontent.com/assets/7668752/17660093/c0c99998-62df-11e6-8eed-fe4e7ca0b482.png)

@vparfonov Please review
