### PR TITLE
CHE-1848: name of workspace is displayed correctly

### DIFF
--- a/dashboard/src/components/widget/toolbar/che-toolbar.styl
+++ b/dashboard/src/components/widget/toolbar/che-toolbar.styl
@@ -35,7 +35,6 @@ $toolbar-height = 60px
 
 .che-toolbar-title
   white-space nowrap
-  text-transform capitalize
 
 .che-toolbar-title-icons
   margin-left 10px


### PR DESCRIPTION
### What does this PR do?

It removes text transformation from workspace title in toolbar.
### What issues does this PR fix or reference?

[https://github.com/eclipse/che/issues/1848](https://github.com/eclipse/che/issues/1848)

Signed-off-by: Oleksii Kurinnyi okurinnyi@codenvy.com
