### PR TITLE
CHE-2045: Fix recursive clone by ssh

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -1613,8 +1613,11 @@ class JGitConnection implements GitConnection {
                     }
                 };
                 command.setTransportConfigCallback(transport -> {
-                    SshTransport sshTransport = (SshTransport)transport;
-                    sshTransport.setSshSessionFactory(sshSessionFactory);
+                    // If recursive clone is performed and git-module added by http(s) url is present in the cloned project,
+                    // transport will be instance of TransportHttp in the step of cloning this module
+                    if (transport instanceof SshTransport) {
+                        ((SshTransport)transport).setSshSessionFactory(sshSessionFactory);
+                    }
                 });
             } else {
                 if (remoteUrl != null && GIT_URL_WITH_CREDENTIALS_PATTERN.matcher(remoteUrl).matches()) {

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -15,7 +15,10 @@ import org.eclipse.che.api.git.CredentialsLoader;
 import org.eclipse.che.api.git.GitUserResolver;
 import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
 import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.SshTransport;
+import org.eclipse.jgit.transport.TransportHttp;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -28,8 +31,13 @@ import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**
@@ -98,5 +106,41 @@ public class JGitConnectionTest {
 
         //then
         verify(transportCommand, never()).setCredentialsProvider(any());
+    }
+
+    @Test
+    public void shouldSetSshSessionFactoryWhenSshTransportReceived() throws Exception{
+        //given
+        SshTransport sshTransport = mock(SshTransport.class);
+        when(sshKeyProvider.getPrivateKey(anyString())).thenReturn(new byte[0]);
+        doAnswer(invocation -> {
+            TransportConfigCallback callback = (TransportConfigCallback)invocation.getArguments()[0];
+            callback.configure(sshTransport);
+            return null;
+        }).when(transportCommand).setTransportConfigCallback(any());
+
+        //when
+        jGitConnection.executeRemoteCommand("ssh://host.xz/repo.git", transportCommand);
+
+        //then
+        verify(sshTransport).setSshSessionFactory(any());
+    }
+
+    @Test
+    public void shouldDoNothingWhenTransportHttpReceived() throws Exception{
+        //given
+        TransportHttp transportHttp = mock(TransportHttp.class);
+        when(sshKeyProvider.getPrivateKey(anyString())).thenReturn(new byte[0]);
+        doAnswer(invocation -> {
+            TransportConfigCallback callback = (TransportConfigCallback)invocation.getArguments()[0];
+            callback.configure(transportHttp);
+            return null;
+        }).when(transportCommand).setTransportConfigCallback(any());
+
+        //when
+        jGitConnection.executeRemoteCommand("ssh://host.xz/repo.git", transportCommand);
+
+        //then
+        verifyZeroInteractions(transportHttp);
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fix ClassCastException when cloning with recursive option enabled by ssh url, a project that contains git-module added by http(s) url 
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2045
### Tests written?

Yes
