### PR TITLE
Make WorkspaceImpl usable in JPA

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -34,8 +34,8 @@ public class WorkspaceImpl implements Workspace {
         return new WorkspaceImplBuilder();
     }
 
-    private final String id;
-    private final String namespace;
+    private String id;
+    private String namespace;
 
     private WorkspaceConfigImpl  config;
     private boolean              isTemporary;


### PR DESCRIPTION
### What does this PR do?

Remove 'final' modifier from fields of WorkspaceImpl
### What issues does this PR fix or reference?

JPA does not support final fields in entity classes. Removing the final modified enables using WorkspaceImpl as a JPA entity
### Previous Behavior

Mapping WorkspaceImpl as a JPA entity failed.
### New Behavior

Mapping WorkspaceImpl as a JPA entity works.
### Tests written?

No
