### PR TITLE
Basic PHP plugin

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -198,6 +198,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-php-lang-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-php-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-product-info</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-ide-war/src/main/resources/org/eclipse/che/ide/IDE.gwt.xml
+++ b/assembly/assembly-ide-war/src/main/resources/org/eclipse/che/ide/IDE.gwt.xml
@@ -62,6 +62,7 @@
     <inherits name='org.eclipse.che.plugin.product.info.ProductInfo'/>
     <inherits name='org.eclipse.che.plugin.cpp.Cpp'/>
     <inherits name='org.eclipse.che.plugin.csharp.CSharp'/>
+    <inherits name='org.eclipse.che.plugin.php.Php'/>
     <inherits name='org.eclipse.che.plugin.python.Python'/>
     <inherits name='org.eclipse.che.plugin.java.plain.PlainJava'/>
     <inherits name='org.eclipse.che.plugin.nodejs.NodeJs'/>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -170,6 +170,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-php-lang-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-php-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-python-lang-server</artifactId>
         </dependency>
         <dependency>

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -696,7 +696,7 @@
     "displayName": "web-php-simple",
     "path": "/web-php-simple",
     "description": "A hello world PHP script.",
-    "projectType": "blank",
+    "projectType": "php",
     "mixins": [],
     "attributes": {
       "language": [
@@ -748,7 +748,7 @@
     "displayName": "web-php-gae-simple",
     "path": "/web-php-gae-simple",
     "description": "A hello world PHP script to deploy to GAE.",
-    "projectType": "blank",
+    "projectType": "php",
     "mixins": [],
     "attributes": {
       "language": [

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -1029,7 +1029,7 @@
     "displayName": "laravel",
     "path": "/laravel",
     "description": "A simple application created by Laravel. Execute the '1. Create and run project' command to create the sample project.",
-    "projectType": "blank",
+    "projectType": "php",
     "mixins": [],
     "attributes": {
       "language": [
@@ -1125,7 +1125,7 @@
     "displayName": "codeigniter",
     "path": "/codeigniter",
     "description": "A simple application created by Codeigniter. Execute the '1. Create and run project' command to create the sample project.",
-    "projectType": "blank",
+    "projectType": "php",
     "mixins": [],
     "attributes": {
       "language": [
@@ -1170,7 +1170,7 @@
     "displayName": "symfony",
     "path": "/symfony",
     "description": "A simple application created by Symfony. Execute the '1. Create and run project' command to create the sample project.",
-    "projectType": "blank",
+    "projectType": "php",
     "mixins": [],
     "attributes": {
       "language": [

--- a/plugins/plugin-php/che-plugin-php-lang-ide/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-php-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>4.7.0-RC2-SNAPSHOT</version>
+        <version>5.0.0-M3-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-php-lang-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-php/che-plugin-php-lang-ide/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-php-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.7.0-RC2-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-php-lang-ide</artifactId>
+    <packaging>jar</packaging>
+    <name>Che Plugin :: PHP :: IDE</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.gwt.inject</groupId>
+            <artifactId>gin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-app</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-php-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.vectomatic</groupId>
+            <artifactId>lib-gwt-svg</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpExtension.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpExtension.java
@@ -35,7 +35,7 @@ public class PhpExtension {
 
     @Inject
     public PhpExtension(FileTypeRegistry fileTypeRegistry,
-                           @Named("PhpFileType") FileType phpFile) {
+                        @Named("PhpFileType") FileType phpFile) {
         fileTypeRegistry.registerFileType(phpFile);
     }
 

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpExtension.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpExtension.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.DefaultActionGroup;
+import org.eclipse.che.ide.api.constraints.Constraints;
+import org.eclipse.che.ide.api.extension.Extension;
+import org.eclipse.che.ide.api.filetypes.FileType;
+import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
+import org.eclipse.che.ide.api.icon.Icon;
+import org.eclipse.che.ide.api.icon.IconRegistry;
+import org.eclipse.che.plugin.php.ide.action.CreatePhpSourceFileAction;
+
+import static org.eclipse.che.ide.api.action.IdeActions.GROUP_FILE_NEW;
+
+/**
+ * @author Kaloyan Raev
+ */
+@Extension(title = "PHP")
+public class PhpExtension {
+
+    public static String PHP_CATEGORY = "PHP";
+
+    @Inject
+    public PhpExtension(FileTypeRegistry fileTypeRegistry,
+                           @Named("PhpFileType") FileType phpFile) {
+        fileTypeRegistry.registerFileType(phpFile);
+    }
+
+    @Inject
+    private void prepareActions(CreatePhpSourceFileAction phpSourceFileAction,
+                                ActionManager actionManager,
+                                PhpResources resources,
+                                IconRegistry iconRegistry) {
+
+        DefaultActionGroup newGroup = (DefaultActionGroup)actionManager.getAction(GROUP_FILE_NEW);
+
+        actionManager.registerAction("newPhpFile", phpSourceFileAction);
+        newGroup.add(phpSourceFileAction, Constraints.FIRST);
+        iconRegistry.registerIcon(new Icon(PHP_CATEGORY + ".samples.category.icon", resources.category()));
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpLocalizationConstant.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpLocalizationConstant.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide;
+
+import com.google.gwt.i18n.client.Messages;
+
+/**
+ * Localization constants. Interface to represent the constants defined in resource bundle:
+ * 'PhpLocalizationConstant.properties'.
+ *
+ * @author Kaloyan Raev
+ */
+public interface PhpLocalizationConstant extends Messages {
+
+
+    @Key("php.action.create.php.file.title")
+    @DefaultMessage("PHP File")
+    String createPhpFileActionTitle();
+
+    @Key("php.action.create.php.file.description")
+    @DefaultMessage("Create PHP File")
+    String createPhpFileActionDescription();
+
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpResources.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/PhpResources.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.ClientBundle;
+
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+/**
+ * @author Kaloyan Raev
+ */
+public interface PhpResources extends ClientBundle {
+    PhpResources INSTANCE = GWT.create(PhpResources.class);
+
+    @Source("svg/php_file.svg")
+    SVGResource phpFile();
+
+    @Source("svg/category.svg")
+    SVGResource category();
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/CreatePhpSourceFileAction.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/CreatePhpSourceFileAction.java
@@ -21,7 +21,6 @@ import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.plugin.php.ide.PhpLocalizationConstant;
 import org.eclipse.che.plugin.php.ide.PhpResources;
 import org.eclipse.che.plugin.php.shared.Constants;
-import org.vectomatic.dom.svg.ui.SVGResource;
 
 /**
  * Action to create new PHP source file.
@@ -37,12 +36,12 @@ public class CreatePhpSourceFileAction extends NewPhplikeResourceAction {
 
     @Inject
     public CreatePhpSourceFileAction(PhpLocalizationConstant localizationConstant,
-                                        PhpResources resources,
-                                        DialogFactory dialogFactory,
-                                        CoreLocalizationConstant coreLocalizationConstant,
-                                        EventBus eventBus,
-                                        AppContext appContext,
-                                        NotificationManager notificationManager) {
+                                     PhpResources resources,
+                                     DialogFactory dialogFactory,
+                                     CoreLocalizationConstant coreLocalizationConstant,
+                                     EventBus eventBus,
+                                     AppContext appContext,
+                                     NotificationManager notificationManager) {
         super(localizationConstant.createPhpFileActionTitle(),
               localizationConstant.createPhpFileActionDescription(),
               resources.phpFile(),

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/CreatePhpSourceFileAction.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/CreatePhpSourceFileAction.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide.action;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.dialogs.DialogFactory;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.plugin.php.ide.PhpLocalizationConstant;
+import org.eclipse.che.plugin.php.ide.PhpResources;
+import org.eclipse.che.plugin.php.shared.Constants;
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+/**
+ * Action to create new PHP source file.
+ *
+ * @author Kaloyan Raev
+ */
+@Singleton
+public class CreatePhpSourceFileAction extends NewPhplikeResourceAction {
+
+
+    private static final String DEFAULT_CONTENT = "<?php\n" +
+                                                  "\n";
+
+    @Inject
+    public CreatePhpSourceFileAction(PhpLocalizationConstant localizationConstant,
+                                        PhpResources resources,
+                                        DialogFactory dialogFactory,
+                                        CoreLocalizationConstant coreLocalizationConstant,
+                                        EventBus eventBus,
+                                        AppContext appContext,
+                                        NotificationManager notificationManager) {
+        super(localizationConstant.createPhpFileActionTitle(),
+              localizationConstant.createPhpFileActionDescription(),
+              resources.phpFile(),
+              dialogFactory,
+              coreLocalizationConstant,
+              eventBus,
+              appContext,
+              notificationManager);
+    }
+
+    @Override
+    protected String getExtension() {
+        return Constants.PHP_EXT;
+    }
+
+    @Override
+    protected String getDefaultContent() {
+        return DEFAULT_CONTENT;
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/NewPhplikeResourceAction.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/NewPhplikeResourceAction.java
@@ -40,13 +40,13 @@ public abstract class NewPhplikeResourceAction extends AbstractNewResourceAction
      * @param svgIcon
      */
     public NewPhplikeResourceAction(String title,
-                                       String description,
-                                       SVGResource svgIcon,
-                                       DialogFactory dialogFactory,
-                                       CoreLocalizationConstant coreLocalizationConstant,
-                                       EventBus eventBus,
-                                       AppContext appContext,
-                                       NotificationManager notificationManager) {
+                                    String description,
+                                    SVGResource svgIcon,
+                                    DialogFactory dialogFactory,
+                                    CoreLocalizationConstant coreLocalizationConstant,
+                                    EventBus eventBus,
+                                    AppContext appContext,
+                                    NotificationManager notificationManager) {
         super(title, description, svgIcon, dialogFactory, coreLocalizationConstant, eventBus, appContext, notificationManager);
         this.appContext = appContext;
     }

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/NewPhplikeResourceAction.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/action/NewPhplikeResourceAction.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide.action;
+
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.dialogs.DialogFactory;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.newresource.AbstractNewResourceAction;
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+/**
+ * Base class for new PHP resource
+ *
+ * Show/hide action depend on project type
+ *
+ * @author Kaloyan Raev
+ */
+public abstract class NewPhplikeResourceAction extends AbstractNewResourceAction {
+
+    protected final AppContext appContext;
+
+    /**
+     * Creates new action.
+     *
+     * @param title
+     *         action's title
+     * @param description
+     *         action's description
+     * @param svgIcon
+     */
+    public NewPhplikeResourceAction(String title,
+                                       String description,
+                                       SVGResource svgIcon,
+                                       DialogFactory dialogFactory,
+                                       CoreLocalizationConstant coreLocalizationConstant,
+                                       EventBus eventBus,
+                                       AppContext appContext,
+                                       NotificationManager notificationManager) {
+        super(title, description, svgIcon, dialogFactory, coreLocalizationConstant, eventBus, appContext, notificationManager);
+        this.appContext = appContext;
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/inject/PhpGinModule.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/inject/PhpGinModule.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide.inject;
+
+import com.google.gwt.inject.client.AbstractGinModule;
+import com.google.gwt.inject.client.multibindings.GinMultibinder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+
+import org.eclipse.che.ide.api.extension.ExtensionGinModule;
+import org.eclipse.che.ide.api.filetypes.FileType;
+import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar;
+import org.eclipse.che.plugin.php.shared.Constants;
+import org.eclipse.che.plugin.php.ide.PhpResources;
+import org.eclipse.che.plugin.php.ide.project.PhpProjectWizardRegistrar;
+
+
+/**
+ * @author Kaloyan Raev
+ */
+@ExtensionGinModule
+public class PhpGinModule extends AbstractGinModule {
+
+    /** {@inheritDoc} */
+    @Override
+    protected void configure() {
+        GinMultibinder.newSetBinder(binder(), ProjectWizardRegistrar.class).addBinding().to(PhpProjectWizardRegistrar.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named("PhpFileType")
+    protected FileType provideCppFile() {
+        return new FileType(PhpResources.INSTANCE.phpFile(), Constants.PHP_EXT);
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/project/PhpProjectWizardRegistrar.java
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/java/org/eclipse/che/plugin/php/ide/project/PhpProjectWizardRegistrar.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.ide.project;
+
+import com.google.inject.Provider;
+
+import org.eclipse.che.ide.api.project.MutableProjectConfig;
+import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardRegistrar;
+import org.eclipse.che.ide.api.wizard.WizardPage;
+import org.eclipse.che.plugin.php.ide.PhpExtension;
+import org.eclipse.che.plugin.php.shared.Constants;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Provides information for registering PHP_PROJECT_TYPE_ID project type into project wizard.
+ *
+ * @author Kaloyan Raev
+ */
+public class PhpProjectWizardRegistrar implements ProjectWizardRegistrar {
+
+    private final List<Provider<? extends WizardPage<MutableProjectConfig>>> wizardPages;
+
+    public PhpProjectWizardRegistrar() {
+        wizardPages = new ArrayList<>();
+    }
+
+    @NotNull
+    public String getProjectTypeId() {
+        return Constants.PHP_PROJECT_TYPE_ID;
+    }
+
+    @NotNull
+    public String getCategory() {
+        return PhpExtension.PHP_CATEGORY;
+    }
+
+    @NotNull
+    public List<Provider<? extends WizardPage<MutableProjectConfig>>> getWizardPages() {
+        return wizardPages;
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/resources/org/eclipse/che/plugin/php/Php.gwt.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/resources/org/eclipse/che/plugin/php/Php.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
+<module>
+    <inherits name="com.google.gwt.user.User"/>
+    <inherits name="com.google.gwt.http.HTTP"/>
+    <inherits name="com.google.gwt.i18n.I18N"/>
+    <inherits name="com.google.gwt.json.JSON"/>
+    <inherits name='org.eclipse.che.ide.Api'/>
+    <inherits name='org.eclipse.che.ide.ui.CodenvyUI'/>
+    <inherits name="com.google.gwt.inject.Inject"/>
+    <inherits name="org.eclipse.che.api.project.Project"/>
+    <inherits name="org.eclipse.che.ide.Core"/>
+
+    <source path="ide"/>
+    <source path="shared"/>
+</module>

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/resources/org/eclipse/che/plugin/php/ide/svg/category.svg
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/resources/org/eclipse/che/plugin/php/ide/svg/category.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="phpFile" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     width="16px" height="16px" viewBox="7 7 18 18" enable-background="new 0 0 32 32" xml:space="preserve">
+    <g>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#9A5CFF" d="M12.978,14.27l0.516,6.885c0,0.284,0.248,0.427,0.516,0.427
+                    c1.166,0,1.815-0.003,2.98,0v-1.487c0-0.825,0.675-1.5,1.499-1.5h0.001c0.825,0,1.499,0.675,1.499,1.5v1.495
+                    c1.171,0.003,1.845-0.008,3.016-0.008c0.267,0,0.498-0.16,0.498-0.427L24,16.475c0-1.903-1.156-3.556-2.81-4.178
+                    c0.037,0.196,0.071,0.374,0.089,0.587c0.071,1.084-0.337,2.168-1.102,2.916c-0.676,0.676-1.564,1.048-2.524,1.048
+                    c-0.054,0-0.09,0-0.143,0c-0.995-0.035-1.92-0.444-2.631-1.155c-0.195-0.195-0.195-0.516,0-0.711c0.195-0.195,0.516-0.195,0.711,0
+                    c0.533,0.534,1.227,0.854,1.973,0.872c0.748,0.036,1.423-0.231,1.938-0.747c0.552-0.551,0.854-1.351,0.8-2.152
+                    c-0.035-0.675-0.303-1.208-0.782-1.563C17.065,9.469,8,10.057,8,16.034v0.818c0,0.267,0.231,0.427,0.533,0.427h0.96
+                    c0.267,0,0.497-0.23,0.497-0.515c0-1.174,1.032-2.507,2.4-2.507C12.575,14.256,12.771,14.261,12.978,14.27z"/>
+    </g>
+</svg>

--- a/plugins/plugin-php/che-plugin-php-lang-ide/src/main/resources/org/eclipse/che/plugin/php/ide/svg/php_file.svg
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/src/main/resources/org/eclipse/che/plugin/php/ide/svg/php_file.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="phpFile" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     width="16px" height="16px" viewBox="7 7 18 18" enable-background="new 0 0 32 32" xml:space="preserve">
+    <g>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#9A5CFF" d="M12.978,14.27l0.516,6.885c0,0.284,0.248,0.427,0.516,0.427
+                    c1.166,0,1.815-0.003,2.98,0v-1.487c0-0.825,0.675-1.5,1.499-1.5h0.001c0.825,0,1.499,0.675,1.499,1.5v1.495
+                    c1.171,0.003,1.845-0.008,3.016-0.008c0.267,0,0.498-0.16,0.498-0.427L24,16.475c0-1.903-1.156-3.556-2.81-4.178
+                    c0.037,0.196,0.071,0.374,0.089,0.587c0.071,1.084-0.337,2.168-1.102,2.916c-0.676,0.676-1.564,1.048-2.524,1.048
+                    c-0.054,0-0.09,0-0.143,0c-0.995-0.035-1.92-0.444-2.631-1.155c-0.195-0.195-0.195-0.516,0-0.711c0.195-0.195,0.516-0.195,0.711,0
+                    c0.533,0.534,1.227,0.854,1.973,0.872c0.748,0.036,1.423-0.231,1.938-0.747c0.552-0.551,0.854-1.351,0.8-2.152
+                    c-0.035-0.675-0.303-1.208-0.782-1.563C17.065,9.469,8,10.057,8,16.034v0.818c0,0.267,0.231,0.427,0.533,0.427h0.96
+                    c0.267,0,0.497-0.23,0.497-0.515c0-1.174,1.032-2.507,2.4-2.507C12.575,14.256,12.771,14.261,12.978,14.27z"/>
+    </g>
+</svg>

--- a/plugins/plugin-php/che-plugin-php-lang-server/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-php-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>4.7.0-RC2-SNAPSHOT</version>
+        <version>5.0.0-M3-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-php-lang-server</artifactId>
     <name>Che Plugin :: PHP :: Extension Server</name>

--- a/plugins/plugin-php/che-plugin-php-lang-server/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-server/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-php-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.7.0-RC2-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-php-lang-server</artifactId>
+    <name>Che Plugin :: PHP :: Extension Server</name>
+    <properties>
+        <findbugs.failonerror>false</findbugs.failonerror>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-project</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-php-lang-shared</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/inject/PhpModule.java
+++ b/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/inject/PhpModule.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.inject;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+import org.eclipse.che.api.project.server.type.ProjectTypeDef;
+import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.plugin.php.projecttype.PhpProjectType;
+
+/**
+ * @author Kaloyan Raev
+ */
+@DynaModule
+public class PhpModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder<ProjectTypeDef> projectTypeMultibinder = Multibinder.newSetBinder(binder(), ProjectTypeDef.class);
+        projectTypeMultibinder.addBinding().to(PhpProjectType.class);
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/projecttype/PhpProjectType.java
+++ b/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/projecttype/PhpProjectType.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.projecttype;
+
+import com.google.inject.Inject;
+
+import org.eclipse.che.api.project.server.type.ProjectTypeDef;
+import org.eclipse.che.plugin.php.shared.Constants;
+
+/**
+ * PHP project type
+ * @author Kaloyan Raev
+ */
+public class PhpProjectType extends ProjectTypeDef {
+    @Inject
+    public PhpProjectType() {
+        super(Constants.PHP_PROJECT_TYPE_ID, "PHP", true, false, true);
+        addConstantDefinition(Constants.LANGUAGE, "language", Constants.PHP_LANG);
+    }
+}

--- a/plugins/plugin-php/che-plugin-php-lang-shared/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-shared/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-php-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.7.0-RC2-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-php-lang-shared</artifactId>
+    <name>Che Plugin :: PHP :: Shared</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/plugins/plugin-php/che-plugin-php-lang-shared/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-php-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>4.7.0-RC2-SNAPSHOT</version>
+        <version>5.0.0-M3-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-php-lang-shared</artifactId>
     <name>Che Plugin :: PHP :: Shared</name>

--- a/plugins/plugin-php/che-plugin-php-lang-shared/src/main/java/org/eclipse/che/plugin/php/shared/Constants.java
+++ b/plugins/plugin-php/che-plugin-php-lang-shared/src/main/java/org/eclipse/che/plugin/php/shared/Constants.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.php.shared;
+
+/**
+ * @author Kaloyan Raev
+ */
+public final class Constants {
+
+    /** Language attribute name */
+    public static String LANGUAGE            = "language";
+
+    /** PHP Project Type ID */
+    public static String PHP_PROJECT_TYPE_ID = "php";
+
+    /** PHP Language */
+    public static String PHP_LANG = "php";
+
+    /** Default extension for PHP files */
+    public static String PHP_EXT = "php";
+
+    private Constants() {}
+}

--- a/plugins/plugin-php/pom.xml
+++ b/plugins/plugin-php/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>4.7.0-RC2-SNAPSHOT</version>
+        <version>5.0.0-M3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-php-parent</artifactId>

--- a/plugins/plugin-php/pom.xml
+++ b/plugins/plugin-php/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>4.7.0-RC2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>che-plugin-php-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Che Plugin :: PHP :: Parent</name>
+    <modules>
+        <module>che-plugin-php-lang-shared</module>
+        <module>che-plugin-php-lang-server</module>
+        <module>che-plugin-php-lang-ide</module>
+    </modules>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.che.core</groupId>
+                    <artifactId>che-core-api-dto-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -46,6 +46,7 @@
         <module>plugin-cpp</module>
         <module>plugin-csharp</module>
         <module>plugin-nodejs</module>
+        <module>plugin-php</module>
         <module>plugin-ssh-machine</module>
         <module>plugin-ssh-key</module>
         <module>plugin-languageserver</module>

--- a/pom.xml
+++ b/pom.xml
@@ -618,6 +618,21 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-php-lang-ide</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-php-lang-server</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-php-lang-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-product-info</artifactId>
                 <version>${che.version}</version>
             </dependency>


### PR DESCRIPTION
### What does this PR do?

This is the first step of providing better PHP language support in Che.
This basic plugin is created after the existing Python plugin and
provides the PHP project type and the "New PHP File" action.
### What issues does this PR fix or reference?
1. Adds the PHP project type.
2. Adds the New PHP File action.
### New Behavior

This content may also be included in the release notes.
### Tests written?

No
### Docs requirements?

Include the content for all the docs changes required. 
1.  User docs changes
- https://eclipse-che.readme.io/docs/workspace

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.
