### PR TITLE
Pack ws-agent binaries in tar.gz archive

### DIFF
--- a/assembly/assembly-wsagent-server/src/assembly/assembly.xml
+++ b/assembly/assembly-wsagent-server/src/assembly/assembly.xml
@@ -15,6 +15,7 @@
     <id>tomcat-zip</id>
     <formats>
         <format>zip</format>
+        <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>


### PR DESCRIPTION
Tho goal is to reduce number of installing components in the container.

@skabashnyuk 
@sleshchenko 
pls review
