### PR TITLE
CODENVY-562: Clean up container if it failed to start

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -280,8 +280,7 @@ public class DockerInstance extends AbstractInstance {
                 node.unbindWorkspace();
             }
 
-            docker.killContainer(container);
-
+            // kill container is not needed here, because we removing container with force flag
             docker.removeContainer(RemoveContainerParams.create(container)
                                                         .withRemoveVolumes(true)
                                                         .withForce(true));


### PR DESCRIPTION
### What does this PR do?

Fix bug, when Codenvy system newer removes containers which failed to start.
### What issues does this PR fix or reference?

[Codenvy/562](https://github.com/codenvy/codenvy/issues/562)
### Previous Behavior

All failed containers are not cleaned. Swarm reserves memory for them and after some time system will fail to start any new container (because all memory is reserved for dead containers).
### New Behavior

Removes all containers which are failed to start
### Tests written?

No
### Docs requirements?

No
