### PR TITLE
Don't show start ws dialog on stop ws event

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/create/CreateWorkspaceViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/create/CreateWorkspaceViewImpl.java
@@ -108,9 +108,6 @@ class CreateWorkspaceViewImpl extends Window implements CreateWorkspaceView, Rec
 
         setTitle(locale.createWsTitle());
 
-        hideCrossButton();
-        setHideOnEscapeEnabled(false);
-
         wsName.setText(locale.createWsDefaultName());
 
         predefinedRecipes.getElement().setPropertyString("placeholder", locale.placeholderChoosePredefined());

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspaceViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspaceViewImpl.java
@@ -74,9 +74,6 @@ class StartWorkspaceViewImpl extends Window implements StartWorkspaceView {
 
         workspaces.getElement().setPropertyString("placeholder", locale.placeholderSelectWsToStart());
 
-        hideCrossButton();
-        setHideOnEscapeEnabled(false);
-
         startButton = createButton(locale.startWsButton(), "start-workspace-button", new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {

--- a/plugins/plugin-sdk/che-plugin-sdk-env-local/src/main/java/org/eclipse/che/env/local/client/inject/LocalEnvironmentGinModule.java
+++ b/plugins/plugin-sdk/che-plugin-sdk-env-local/src/main/java/org/eclipse/che/env/local/client/inject/LocalEnvironmentGinModule.java
@@ -26,6 +26,5 @@ public class LocalEnvironmentGinModule extends AbstractGinModule {
     @Override
     protected void configure() {
         bind(ConnectionClosedInformer.class).to(CheConnectionClosedInformer.class).in(Singleton.class);
-        bind(CheWorkspaceStoppedHandler.class).asEagerSingleton();
     }
 }


### PR DESCRIPTION
### What does this PR do?

Don't show start ws dialog on stop ws event
Make Start workspace/Create Workspace form closable  
### What issues does this PR fix or reference?
#1987
### Previous Behavior

If Workspace stopped with error "Start workspace" dialog cover error information popup 
### New Behavior

Show "Start workspace" dialog only after closing error dialog

Signed-off-by: Vitaly Parfonov vparfonov@codenvy.com
