### PR TITLE
CHE-1485 allow special characters in file names and folder names + fix an encoding issue

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
@@ -264,7 +264,7 @@ public class ProjectServiceClientImpl implements ProjectServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> copy(Path source, Path target, String newName, boolean overwrite) {
-        final String url = getBaseUrl() + COPY + path(source.toString()) + "?to=" + target.toString();
+        final String url = getBaseUrl() + COPY + path(source.toString()) + "?to=" + URL.encodeQueryString(target.toString());
 
         final CopyOptions copyOptions = dtoFactory.createDto(CopyOptions.class);
         copyOptions.setName(newName);
@@ -278,7 +278,7 @@ public class ProjectServiceClientImpl implements ProjectServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> move(Path source, Path target, String newName, boolean overwrite) {
-        final String url = getBaseUrl() + MOVE + path(source.toString()) + "?to=" + target.toString();
+        final String url = getBaseUrl() + MOVE + path(source.toString()) + "?to=" + URL.encodeQueryString(target.toString());
 
         final MoveOptions moveOptions = dtoFactory.createDto(MoveOptions.class);
         moveOptions.setName(newName);

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.project;
 
+import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
@@ -211,7 +212,7 @@ public class ProjectServiceClientImpl implements ProjectServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<ItemReference> createFile(Path path, String content) {
-        final String url = getBaseUrl() + FILE + path(path.parent().toString()) + "?name=" + path.lastSegment();
+        final String url = getBaseUrl() + FILE + path(path.parent().toString()) + "?name=" + URL.encodeQueryString(path.lastSegment());
 
         return reqFactory.createPostRequest(url, null)
                          .data(content)

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/NameUtils.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/NameUtils.java
@@ -19,8 +19,8 @@ import com.google.gwt.regexp.shared.RegExp;
  * @author Artem Zatsarynnyi
  */
 public class NameUtils {
-    private static RegExp FILE_NAME    = RegExp.compile("^[\\sA-Za-z0-9_\\-\\.]+$");
-    private static RegExp FOLDER_NAME  = RegExp.compile("^[\\sA-Za-z0-9_\\-\\.]+$");
+    private static RegExp FILE_NAME    = RegExp.compile("^((?![*:\\/\\\\\"?<>|\0]).)+$");
+    private static RegExp FOLDER_NAME  = FILE_NAME;
     private static RegExp PROJECT_NAME = RegExp.compile("^[A-Za-z0-9_\\-\\.]+$");
 
     private NameUtils() {

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.util;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the NameUtils class
+ *
+ * @see NameUtils
+ * @author Paul-Julien Vauthier
+ */
+public class NameUtilsTest {
+
+    private static String[] VALID_FILENAMES = new String[]{
+            "README",
+            "readme.md",
+            "che.xml",
+            "évacuation.html",
+            "私の自転車.png",
+            "I love maths.jpeg"
+    };
+
+    private static String[] INVALID_FILENAMES = new String[]{
+            "\0",
+            "a/b",
+            "/",
+            "\\",
+            "*",
+            "?",
+            "|",
+            "<",
+            ">",
+            "I<3Math.png",
+            ""
+    };
+
+    @Test(dataProvider = "ValidFilenames")
+    public void validFilenamesShouldGetValidated(String validFilename) {
+        assertTrue(validFilename + " is supposed to be valid", NameUtils.checkFileName(validFilename));
+    }
+
+    @Test(dataProvider = "InvalidFilenames")
+    public void invalidFilenamesShouldNotGetValidated(String invalidFileName) {
+        assertFalse(invalidFileName + " is supposed to be invalid", NameUtils.checkFileName(invalidFileName));
+    }
+
+    @Test(dataProvider = "ValidFilenames")
+    public void validFolderNamesShouldGetValidated(String validFolderName) {
+        assertTrue(validFolderName + " is supposed to be valid", NameUtils.checkFileName(validFolderName));
+    }
+
+    @Test(dataProvider = "InvalidFilenames")
+    public void invalidFolderNamesShouldNotGetValidated(String invalidFolderName) {
+        assertFalse(invalidFolderName + " is supposed to be invalid", NameUtils.checkFileName(invalidFolderName));
+    }
+
+    @DataProvider(name = "ValidFilenames")
+    public Object[][] getValidFilenames() {
+        return toDataProviderData(VALID_FILENAMES);
+    }
+
+    @DataProvider(name = "InvalidFilenames")
+    public Object[][] getInvalidFilenames() {
+        return toDataProviderData(INVALID_FILENAMES);
+    }
+
+    private Object[][] toDataProviderData(String[] strings) {
+        Object[][] data = new Object[strings.length][];
+        for (int i = 0; i < strings.length; i++) {
+            data[i] = new Object[] { strings[i] };
+        }
+        return data;
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?

It allows user to create files and folders that contains special (non-ASCII) characters expects the one that are not allowed in Linux or Windows. 
### What issues does this PR fix or reference?

[CHE-1485 Struggling working with Japanese filenames](https://github.com/eclipse/che/issues/1706)
### Previous Behavior

File/Folder names with special characters were marked as invalid
### New Behavior

File/Folder names with special characters are now valid
### Tests written?

Yes
### Docs requirements?

None

![image](https://cloud.githubusercontent.com/assets/1108235/17834857/eec6968e-6753-11e6-8fd4-ea186125e18f.png)

Note that Japanese names for example makes the terminal to behave a bit weirdly. However by getting into the container it is fine (see screenshot). 
