### PR TITLE
Fix refs patern in GitCheckoutHiEventDetector

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/GitCheckoutHiEventDetector.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/GitCheckoutHiEventDetector.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static java.io.File.separator;
 import static java.util.Optional.empty;
 import static java.util.regex.Pattern.compile;
 import static org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType.MODIFIED;
@@ -65,7 +64,7 @@ public class GitCheckoutHiEventDetector implements HiEventDetector<GitBranchChec
     private static final String  HEAD_FILE                = "HEAD";
     private static final String  GIT_OPERATION_WS_CHANNEL = "git-operations-channel";
     private static final int     PRIORITY                 = 50;
-    private static final Pattern PATTERN                  = compile("ref: refs" + separator + "heads" + separator);
+    private static final Pattern PATTERN                  = compile("ref: refs/heads/");
 
     private final VirtualFileSystemProvider virtualFileSystemProvider;
     private final HiEventBroadcaster        broadcaster;


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
### Previous Behavior

Slashes in git refs failed in windows environments due to backslash being put inside reges 'ref: refs\heads\'
### New Behavior

Use fixed salsh literal as defined by git, regardless of execution environment
