### PR TITLE
Fix NPE on factory links injection

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -461,10 +461,12 @@ public class FactoryService extends Service {
      */
     private FactoryDto injectLinks(FactoryDto factory, Set<FactoryImage> images) {
         String username = null;
-        try {
-            username = userManager.getById(factory.getCreator().getUserId()).getName();
-        } catch (ApiException ignored) {
-            // when impossible to get username then named factory link won't be injected
+        if (factory.getCreator() != null && factory.getCreator().getUserId() != null) {
+            try {
+                username = userManager.getById(factory.getCreator().getUserId()).getName();
+            } catch (ApiException ignored) {
+                // when impossible to get username then named factory link won't be injected
+            }
         }
         return factory.withLinks(images != null && !images.isEmpty()
                                  ? createLinks(factory, images, getServiceContext(), username)


### PR DESCRIPTION
If factory is created in resolver method, it's gonna have null creator. Prevent NPE by checking it
