### PR TITLE
CHE-2136: Add password encryption during user create/update

### DIFF
--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/DtoConverter.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/DtoConverter.java
@@ -29,8 +29,7 @@ public final class DtoConverter {
                          .withId(user.getId())
                          .withEmail(user.getEmail())
                          .withName(user.getName())
-                         .withAliases(user.getAliases())
-                         .withPassword("<none>");
+                         .withAliases(user.getAliases());
     }
 
     private DtoConverter() {}

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/UserDaoTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/UserDaoTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
@@ -367,6 +366,43 @@ public class UserDaoTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void shouldThrowNpeWhenRemovingNull() throws Exception {
         userDao.remove(null);
+    }
+
+    @Test(dependsOnMethods = "shouldGetUserById")
+    public void shouldReturnUserWithNullPasswordWhenGetUserById() throws Exception {
+        assertEquals(userDao.getById(users[0].getId()).getPassword(), null);
+    }
+
+    @Test(dependsOnMethods = "shouldGetUserByAlias")
+    public void shouldReturnUserWithNullPasswordWhenGetUserByAliases() throws Exception {
+        assertEquals(userDao.getByAlias(users[0].getAliases().get(0)).getPassword(), null);
+    }
+
+    @Test(dependsOnMethods = "shouldGetUserByName")
+    public void shouldReturnUserWithNullPasswordWhenGetUserByName() throws Exception {
+        assertEquals(userDao.getByName(users[0].getName()).getPassword(), null);
+    }
+
+    @Test(dependsOnMethods = "shouldGetUserByEmail")
+    public void shouldReturnUserWithNullPasswordWhenGetUserByEmail() throws Exception {
+        assertEquals(userDao.getByEmail(users[0].getEmail()).getPassword(), null);
+    }
+
+    @Test(dependsOnMethods = {"shouldGetUserByNameAndPassword",
+                              "shouldGetUserByEmailAndPassword"})
+    public void shouldReturnUserWithNullPasswordWhenGetUserByAliasAndPassword() throws Exception {
+        final UserImpl user = users[0];
+        assertEquals(userDao.getByAliasAndPassword(user.getName(), user.getPassword()).getPassword(), null);
+        assertEquals(userDao.getByAliasAndPassword(user.getEmail(), user.getPassword()).getPassword(), null);
+    }
+
+    @Test(dependsOnMethods = "getAllShouldReturnAllUsersWithinSingleResponse")
+    public void shouldReturnUserWithNullPasswordWhenGetAllUser() throws Exception {
+        assertEquals(userDao.getAll(users.length, 0)
+                            .getItems()
+                            .stream()
+                            .filter(u -> u.getPassword() == null)
+                            .count(), users.length);
     }
 
     private static void assertEqualsNoPassword(User actual, User expected) {


### PR DESCRIPTION
### What does this PR do?

Provides user's password ecryption during update/create, erases passwords from each user instance that taken from JpaUserDao
### What issues does this PR fix or reference?
#2136
### Previous behavior

users passwords stored plainly without encryption
### Tests written?

Yes

@skabashnyuk, @evoevodin please take a look
