### PR TITLE
Che script improvements

### DIFF
--- a/che.sh
+++ b/che.sh
@@ -333,22 +333,30 @@ execute_che_launcher() {
                   --env-file=$(get_list_of_che_system_environment_variables) \
                   "${CHE_LAUNCHER_IMAGE_NAME}":"${CHE_VERSION}" "${CHE_CLI_ACTION}" || true
 
-  # Remove temporary file
+  # Remove temporary file -- only due to POSIX weirdness with --env-file
   rm -rf "tmp" > /dev/null 2>&1
 }
 
-execute_che_file() {
+execute_che_dir() {
   check_current_image_and_update_if_not_found ${CHE_FILE_IMAGE_NAME}
   CURRENT_DIRECTORY=$(get_mount_path "${PWD}")
   docker_exec run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \
+                  --env-file=$(get_list_of_che_system_environment_variables) \
                   -v "$CURRENT_DIRECTORY":"$CURRENT_DIRECTORY" \
                   "${CHE_FILE_IMAGE_NAME}":"${CHE_VERSION}" "${CURRENT_DIRECTORY}" "$@"
+
+  # Remove temporary file -- only due to POSIX weirdness with --env-file
+  rm -rf "tmp" > /dev/null 2>&1
 }
 
 execute_che_action() {
   check_current_image_and_update_if_not_found ${CHE_ACTION_IMAGE_NAME}
   docker_exec run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \
+                  --env-file=$(get_list_of_che_system_environment_variables) \
                   "${CHE_ACTION_IMAGE_NAME}":"${CHE_VERSION}" "$@"
+
+  # Remove temporary file -- only due to POSIX weirdness with --env-file
+  rm -rf "tmp" > /dev/null 2>&1
 }
 
 
@@ -383,8 +391,12 @@ mount_local_directory() {
   docker_exec run --rm -it 
                   --cap-add SYS_ADMIN \
                   --device /dev/fuse \
+                  --env-file=$(get_list_of_che_system_environment_variables) \
                   -v "${MOUNT_PATH}":/mnthost \
                   "${CHE_MOUNT_IMAGE_NAME}":"${CHE_VERSION}" "${GLOBAL_GET_DOCKER_HOST_IP}" $3
+
+  # Remove temporary file -- only due to POSIX weirdness with --env-file
+  rm -rf "tmp" > /dev/null 2>&1
 }
 
 execute_che_debug() {
@@ -726,7 +738,7 @@ case ${CHE_CLI_ACTION} in
     # remove "dir" arg by shifting it
     shift
     load_profile
-    execute_che_file "$@"
+    execute_che_dir "$@"
   ;;
   action)
     # remove "action" arg by shifting it

--- a/che.sh
+++ b/che.sh
@@ -48,7 +48,7 @@ init_global_variables() {
 
   DEFAULT_CHE_LAUNCHER_IMAGE_NAME="codenvy/che-launcher"
   DEFAULT_CHE_SERVER_IMAGE_NAME="codenvy/che-server"
-  DEFAULT_CHE_FILE_IMAGE_NAME="codenvy/che-file"
+  DEFAULT_CHE_DIR_IMAGE_NAME="codenvy/che-dir"
   DEFAULT_CHE_MOUNT_IMAGE_NAME="codenvy/che-mount"
   DEFAULT_CHE_ACTION_IMAGE_NAME="codenvy/che-action"
   DEFAULT_CHE_TEST_IMAGE_NAME="codenvy/che-test"
@@ -60,7 +60,7 @@ init_global_variables() {
   CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
   CHE_LAUNCHER_IMAGE_NAME=${CHE_LAUNCHER_IMAGE_NAME:-${DEFAULT_CHE_LAUNCHER_IMAGE_NAME}}
   CHE_SERVER_IMAGE_NAME=${CHE_SERVER_IMAGE_NAME:-${DEFAULT_CHE_SERVER_IMAGE_NAME}}
-  CHE_FILE_IMAGE_NAME=${CHE_FILE_IMAGE_NAME:-${DEFAULT_CHE_FILE_IMAGE_NAME}}
+  CHE_DIR_IMAGE_NAME=${CHE_DIR_IMAGE_NAME:-${DEFAULT_CHE_DIR_IMAGE_NAME}}
   CHE_MOUNT_IMAGE_NAME=${CHE_MOUNT_IMAGE_NAME:-${DEFAULT_CHE_MOUNT_IMAGE_NAME}}
   CHE_ACTION_IMAGE_NAME=${CHE_ACTION_IMAGE_NAME:-${DEFAULT_CHE_ACTION_IMAGE_NAME}}
   CHE_TEST_IMAGE_NAME=${CHE_TEST_IMAGE_NAME:-${DEFAULT_CHE_TEST_IMAGE_NAME}}
@@ -338,12 +338,12 @@ execute_che_launcher() {
 }
 
 execute_che_dir() {
-  check_current_image_and_update_if_not_found ${CHE_FILE_IMAGE_NAME}
+  check_current_image_and_update_if_not_found ${CHE_DIR_IMAGE_NAME}
   CURRENT_DIRECTORY=$(get_mount_path "${PWD}")
   docker_exec run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \
                   --env-file=$(get_list_of_che_system_environment_variables) \
                   -v "$CURRENT_DIRECTORY":"$CURRENT_DIRECTORY" \
-                  "${CHE_FILE_IMAGE_NAME}":"${CHE_VERSION}" "${CURRENT_DIRECTORY}" "$@"
+                  "${CHE_DIR_IMAGE_NAME}":"${CHE_VERSION}" "${CURRENT_DIRECTORY}" "$@"
 
   # Remove temporary file -- only due to POSIX weirdness with --env-file
   rm -rf "tmp" > /dev/null 2>&1
@@ -571,7 +571,7 @@ execute_profile(){
       echo "CHE_MINI_PRODUCT_NAME=$CHE_MINI_PRODUCT_NAME" > ~/.che/profiles/"${3}"
       echo "CHE_LAUNCHER_IMAGE_NAME=$CHE_LAUNCHER_IMAGE_NAME" > ~/.che/profiles/"${3}"
       echo "CHE_SERVER_IMAGE_NAME=$CHE_SERVER_IMAGE_NAME" >> ~/.che/profiles/"${3}"
-      echo "CHE_FILE_IMAGE_NAME=$CHE_FILE_IMAGE_NAME" >> ~/.che/profiles/"${3}"
+      echo "CHE_DIR_IMAGE_NAME=$CHE_DIR_IMAGE_NAME" >> ~/.che/profiles/"${3}"
       echo "CHE_MOUNT_IMAGE_NAME=$CHE_MOUNT_IMAGE_NAME" >> ~/.che/profiles/"${3}"
       echo "CHE_TEST_IMAGE_NAME=$CHE_TEST_IMAGE_NAME" >> ~/.che/profiles/"${3}"
       echo "CHE_SERVER_CONTAINER_NAME=$CHE_SERVER_CONTAINER_NAME" >> ~/.che/profiles/"${3}"
@@ -756,7 +756,9 @@ case ${CHE_CLI_ACTION} in
     load_profile
     update_che_image ${CHE_LAUNCHER_IMAGE_NAME}
     update_che_image ${CHE_MOUNT_IMAGE_NAME}
-    update_che_image ${CHE_FILE_IMAGE_NAME}
+    update_che_image ${CHE_DIR_IMAGE_NAME}
+    update_che_image ${CHE_ACTION_IMAGE_NAME}
+    update_che_image ${CHE_TEST_IMAGE_NAME}
 
     # Delegate updating che-server to the launcher
     execute_che_launcher

--- a/che.sh
+++ b/che.sh
@@ -555,6 +555,8 @@ execute_profile(){
       test -d ~/.che/profiles || mkdir -p ~/.che/profiles
       touch ~/.che/profiles/"${3}"
 
+      echo "CHE_PRODUCT_NAME=$CHE_PRODUCT_NAME" > ~/.che/profiles/"${3}"
+      echo "CHE_MINI_PRODUCT_NAME=$CHE_MINI_PRODUCT_NAME" > ~/.che/profiles/"${3}"
       echo "CHE_LAUNCHER_IMAGE_NAME=$CHE_LAUNCHER_IMAGE_NAME" > ~/.che/profiles/"${3}"
       echo "CHE_SERVER_IMAGE_NAME=$CHE_SERVER_IMAGE_NAME" >> ~/.che/profiles/"${3}"
       echo "CHE_FILE_IMAGE_NAME=$CHE_FILE_IMAGE_NAME" >> ~/.che/profiles/"${3}"

--- a/che.sh
+++ b/che.sh
@@ -40,7 +40,11 @@ check_docker() {
 
 init_global_variables() {
 
+  # Name used in INFO statements
   DEFAULT_CHE_PRODUCT_NAME="ECLIPSE CHE"
+
+  # Name used in CLI statements
+  DEFAULT_CHE_MINI_PRODUCT_NAME="che"
 
   DEFAULT_CHE_LAUNCHER_IMAGE_NAME="codenvy/che-launcher"
   DEFAULT_CHE_SERVER_IMAGE_NAME="codenvy/che-server"
@@ -48,13 +52,12 @@ init_global_variables() {
   DEFAULT_CHE_MOUNT_IMAGE_NAME="codenvy/che-mount"
   DEFAULT_CHE_ACTION_IMAGE_NAME="codenvy/che-action"
   DEFAULT_CHE_TEST_IMAGE_NAME="codenvy/che-test"
-
   DEFAULT_CHE_SERVER_CONTAINER_NAME="che-server"
-
   DEFAULT_CHE_VERSION="latest"
   DEFAULT_CHE_CLI_ACTION="help"
 
   CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
+  CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
   CHE_LAUNCHER_IMAGE_NAME=${CHE_LAUNCHER_IMAGE_NAME:-${DEFAULT_CHE_LAUNCHER_IMAGE_NAME}}
   CHE_SERVER_IMAGE_NAME=${CHE_SERVER_IMAGE_NAME:-${DEFAULT_CHE_SERVER_IMAGE_NAME}}
   CHE_FILE_IMAGE_NAME=${CHE_FILE_IMAGE_NAME:-${DEFAULT_CHE_FILE_IMAGE_NAME}}
@@ -73,30 +76,30 @@ init_global_variables() {
   GLOBAL_GET_DOCKER_HOST_IP=$(get_docker_host_ip)
 
   USAGE="
-Usage: che [COMMAND]
-           start                              Starts Che server
-           stop                               Stops Che server
-           restart                            Restart Che server
+Usage: ${CHE_MINI_PRODUCT_NAME} [COMMAND]
+           start                              Starts ${CHE_MINI_PRODUCT_NAME} server
+           stop                               Stops ${CHE_MINI_PRODUCT_NAME} server
+           restart                            Restart ${CHE_MINI_PRODUCT_NAME} server
            update                             Pulls specific version, respecting CHE_VERSION
            profile add <name>                 Add a profile to ~/.che/ 
-           profile set <name>                 Set this profile as the default for Che CLI
+           profile set <name>                 Set this profile as the default for ${CHE_MINI_PRODUCT_NAME} CLI
            profile unset                      Removes the default profile - leaves it unset
            profile rm <name>                  Remove this profile from ~/.che/
            profile update <name>              Update profile in ~/.che/
            profile info <name>                Print the profile configuration
            profile list                       List available profiles
            mount <local-path> <ws-ssh-port>   Synchronize workspace to a local directory
-           dir init                           Initialize directory with Che configuration
+           dir init                           Initialize directory with ${CHE_MINI_PRODUCT_NAME} configuration
            dir up                             Create workspace from source in current directory
            dir down                           Stop workspace running in current directory
-           dir status                         Display status about Che in current directory
-           action <action-name> [--help]      Start action on Eclipse Che instance
-           test <test-name> [--help]          Start test on Eclipse Che instance
+           dir status                         Display status of ${CHE_MINI_PRODUCT_NAME} in current directory
+           action <action-name> [--help]      Start action on ${CHE_MINI_PRODUCT_NAME} instance
+           test <test-name> [--help]          Start test on ${CHE_MINI_PRODUCT_NAME} instance
            info [ --all                       Run all debugging tests
-                  --server                    Run Che launcher and server debugging tests
-                  --networking                Test connectivity between Che sub-systems
-                  --cli                       Print CLI (this program)debugging info
-                  --create [<url>]            Test creating a workspace and project in Che
+                  --server                    Run ${CHE_MINI_PRODUCT_NAME} launcher and server debugging tests
+                  --networking                Test connectivity between ${CHE_MINI_PRODUCT_NAME} sub-systems
+                  --cli                       Print CLI (this program) debugging info
+                  --create [<url>]            Test creating a workspace and project in ${CHE_MINI_PRODUCT_NAME}
                            [<user>] 
                            [<pass>] ]
 "
@@ -324,7 +327,7 @@ execute_che_launcher() {
 
   check_current_image_and_update_if_not_found ${CHE_LAUNCHER_IMAGE_NAME}
 
-  info "${CHE_PRODUCT_NAME}: Starting launcher"
+#  info "${CHE_PRODUCT_NAME}: Starting launcher"
 
   docker_exec run -t --rm -v /var/run/docker.sock:/var/run/docker.sock \
                   --env-file=$(get_list_of_che_system_environment_variables) \
@@ -443,9 +446,6 @@ print_che_cli_debug() {
   debug "HAS_DOCKER_FOR_WINDOWS_IP = $(has_docker_for_windows_ip && echo "YES" || echo "NO")"
   debug "IS_MOBY_VM                = $(is_moby_vm && echo "YES" || echo "NO")"
   debug ""
-  debug "---------------------------------------"
-  debug "---------------------------------------"
-  debug "---------------------------------------"
 }
 
 run_connectivity_tests() {
@@ -519,7 +519,7 @@ execute_profile(){
 
   if [ ! $# -ge 2 ]; then 
     error ""
-    error "che profile: Wrong number of arguments."
+    error "${CHE_MINI_PRODUCT_NAME} profile: Wrong number of arguments."
     error ""
     return
   fi
@@ -528,7 +528,7 @@ execute_profile(){
     add|rm|set|info|update)
     if [ ! $# -eq 3 ]; then 
       error ""
-      error "che profile: Wrong number of arguments."
+      error "${CHE_MINI_PRODUCT_NAME} profile: Wrong number of arguments."
       error ""
       return
     fi
@@ -536,7 +536,7 @@ execute_profile(){
     unset|list)
     if [ ! $# -eq 2 ]; then 
       error ""
-      error "che profile: Wrong number of arguments."
+      error "${CHE_MINI_PRODUCT_NAME} profile: Wrong number of arguments."
       error ""
       return
     fi
@@ -545,39 +545,39 @@ execute_profile(){
 
   case ${2} in
     add)
-      if [ -f ~/.che/"${3}" ]; then
+      if [ -f ~/.che/profiles/"${3}" ]; then
         error ""
-        error "Profile ~/.che/${3} already exists. Nothing to do. Exiting."
+        error "Profile ~/.che/profiles/${3} already exists. Nothing to do. Exiting."
         error ""
         return
       fi
 
-      test -d ~/.che || mkdir -p ~/.che
-      touch ~/.che/"${3}"
+      test -d ~/.che/profiles || mkdir -p ~/.che/profiles
+      touch ~/.che/profiles/"${3}"
 
-      echo "CHE_LAUNCHER_IMAGE_NAME=$CHE_LAUNCHER_IMAGE_NAME" > ~/.che/"${3}"
-      echo "CHE_SERVER_IMAGE_NAME=$CHE_SERVER_IMAGE_NAME" >> ~/.che/"${3}"
-      echo "CHE_FILE_IMAGE_NAME=$CHE_FILE_IMAGE_NAME" >> ~/.che/"${3}"
-      echo "CHE_MOUNT_IMAGE_NAME=$CHE_MOUNT_IMAGE_NAME" >> ~/.che/"${3}"
-      echo "CHE_TEST_IMAGE_NAME=$CHE_TEST_IMAGE_NAME" >> ~/.che/"${3}"
-      echo "CHE_SERVER_CONTAINER_NAME=$CHE_SERVER_CONTAINER_NAME" >> ~/.che/"${3}"
+      echo "CHE_LAUNCHER_IMAGE_NAME=$CHE_LAUNCHER_IMAGE_NAME" > ~/.che/profiles/"${3}"
+      echo "CHE_SERVER_IMAGE_NAME=$CHE_SERVER_IMAGE_NAME" >> ~/.che/profiles/"${3}"
+      echo "CHE_FILE_IMAGE_NAME=$CHE_FILE_IMAGE_NAME" >> ~/.che/profiles/"${3}"
+      echo "CHE_MOUNT_IMAGE_NAME=$CHE_MOUNT_IMAGE_NAME" >> ~/.che/profiles/"${3}"
+      echo "CHE_TEST_IMAGE_NAME=$CHE_TEST_IMAGE_NAME" >> ~/.che/profiles/"${3}"
+      echo "CHE_SERVER_CONTAINER_NAME=$CHE_SERVER_CONTAINER_NAME" >> ~/.che/profiles/"${3}"
 
       # Add all other variables to the profile
-      env | grep CHE_ >> ~/.che/"${3}"
+      env | grep CHE_ >> ~/.che/profiles/"${3}"
 
       # Remove duplicates, if any
-      cat ~/.che/"${3}" | sort | uniq > ~/.che/tmp
-      mv -f ~/.che/tmp ~/.che/"${3}"
+      cat ~/.che/profiles/"${3}" | sort | uniq > ~/.che/profiles/tmp
+      mv -f ~/.che/profiles/tmp ~/.che/profiles/"${3}"
 
 
       info ""
-      info "Added new Che CLI profile ~/.che/${3}."
+      info "Added new ${CHE_MINI_PRODUCT_NAME} CLI profile ~/.che/profiles/${3}."
       info ""
     ;;
     update)
-      if [ ! -f ~/.che/"${3}" ]; then
+      if [ ! -f ~/.che/profiles/"${3}" ]; then
         error ""
-        error "Profile ~/.che/${3} does not exist. Nothing to update. Exiting."
+        error "Profile ~/.che/profiles/${3} does not exist. Nothing to update. Exiting."
         error ""
         return
       fi
@@ -586,79 +586,87 @@ execute_profile(){
       execute_profile profile add "${3}"
     ;;
     rm)
-      if [ ! -f ~/.che/"${3}" ]; then
+      if [ ! -f ~/.che/profiles/"${3}" ]; then
         error ""
-        error "Profile ~/.che/${3} does not exist. Nothing to do. Exiting."
+        error "Profile ~/.che/profiles/${3} does not exist. Nothing to do. Exiting."
         error ""
         return
       fi
 
-      rm ~/.che/"${3}" > /dev/null
+      rm ~/.che/profiles/"${3}" > /dev/null
 
       info ""
-      info "Removed Che CLI profile ~/.che/${3}."
+      info "Removed ${CHE_MINI_PRODUCT_NAME} CLI profile ~/.che/profiles/${3}."
       info ""
     ;;
     info)
-      if [ ! -f ~/.che/"${3}" ]; then
+      if [ ! -f ~/.che/profiles/"${3}" ]; then
         error ""
-        error "Profile ~/.che/${3} does not exist. Nothing to do. Exiting."
+        error "Profile ~/.che/profiles/${3} does not exist. Nothing to do. Exiting."
         error ""
         return
       fi
  
 
       debug "---------------------------------------"
-      debug "--------- CHE CLI PROFILE INFO --------"
+      debug "---------   CLI PROFILE INFO   --------"
       debug "---------------------------------------"
       debug ""
-      debug "Profile ~/.che/${3} contains:"
+      debug "Profile ~/.che/profiles/${3} contains:"
       while IFS= read line
       do
         # display $line or do somthing with $line
         debug "$line"
-      done <~/.che/"${3}"
+      done <~/.che/profiles/"${3}"
     ;;
     set)
-      if [ ! -f ~/.che/"${3}" ]; then
+      if [ ! -f ~/.che/profiles/"${3}" ]; then
         error ""
         error "Profile ~/.che/${3} does not exist. Nothing to do. Exiting."
         error ""
         return
       fi
       
-      echo "CHE_PROFILE=${3}" > ~/.che/.profile
+      echo "CHE_PROFILE=${3}" > ~/.che/profiles/.profile
 
       info ""
-      info "Set active Che CLI profile to ~/.che/${3}."
+      info "Set active ${CHE_MINI_PRODUCT_NAME} CLI profile to ~/.che/profiles/${3}."
       info ""
     ;;
     unset)
-      if [ ! -f ~/.che/.profile ]; then
+      if [ ! -f ~/.che/profiles/.profile ]; then
         error ""
         error "Default profile not set. Nothing to do. Exiting."
         error ""
         return
       fi
       
-      rm -rf ~/.che/.profile
+      rm -rf ~/.che/profiles/.profile
 
       info ""
-      info "Unset the default Che CLI profile. No profile currently set."
+      info "Unset the default ${CHE_MINI_PRODUCT_NAME} CLI profile. No profile currently set."
       info ""
     ;;
     list)
       if [ -d ~/.che ]; then
-        info ""
-        info "Available Che CLI profiles:"
-        ls ~/.che/
+        info "Available ${CHE_MINI_PRODUCT_NAME} CLI profiles:"
+        ls ~/.che/profiles
+      else
+        info "No ${CHE_MINI_PRODUCT_NAME} CLI profiles currently set."
+      fi
+
+      if has_default_profile; then
+        info "Default profile set to:"
+        get_default_profile
+      else
+        info "Default profile currently unset."
       fi
     ;;
   esac
 }
 
 has_default_profile() {
-  if [ -f ~/.che/.profile ]; then
+  if [ -f ~/.che/profiles/.profile ]; then
     return 0
   else 
     return 1
@@ -667,7 +675,7 @@ has_default_profile() {
 
 get_default_profile() {
   if [ has_default_profile ]; then
-    source ~/.che/.profile
+    source ~/.che/profiles/.profile
     echo "${CHE_PROFILE}"
   else
     echo ""
@@ -677,16 +685,16 @@ get_default_profile() {
 load_profile() {
   if has_default_profile; then
 
-    source ~/.che/.profile
+    source ~/.che/profiles/.profile
 
-    if [ ! -f ~/.che/"${CHE_PROFILE}" ]; then
+    if [ ! -f ~/.che/profiles/"${CHE_PROFILE}" ]; then
       error ""
-      error "Che CLI profile set in ~/.che/.profile to '${CHE_PROFILE}' but ~/.che/${CHE_PROFILE} does not exist."
+      error "${CHE_MINI_PRODUCT_NAME} CLI profile set in ~/.che/profiles/.profile to '${CHE_PROFILE}' but ~/.che/profiles/${CHE_PROFILE} does not exist."
       error ""
       return
     fi
 
-    source ~/.che/"${CHE_PROFILE}"
+    source ~/.che//profiles/"${CHE_PROFILE}"
   fi
 }
 


### PR DESCRIPTION
### What does this PR do?

1: Moves profiles into `~/.che/profiles/`
2: Adds syntax for `che dir` instead of `che up`.
3: Adds syntax for che action and che test.
4: Adds mini product name to output, so CLI can have different names
5: Improved execution of docker_exec command to remove repeated syntax
6: Passed environment file and profile configuration to other containers for reuse
7: Removed dockerfiles and libraries that were put into che-dockerfiles
8: Moved core Che Dockerfile into the repository root
