### PR TITLE
CODENVY-515: Add ability to save workspace snapshots in AWS ECR

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -737,6 +737,18 @@ public class WorkspaceManager {
                 SnapshotImpl snapshot = runtimes.saveMachine(namespace,
                                                              workspaceId,
                                                              machine.getId());
+                try {
+                    SnapshotImpl oldSnapshot = snapshotDao.getSnapshot(snapshot.getWorkspaceId(),
+                                                                       snapshot.getEnvName(),
+                                                                       snapshot.getMachineName());
+                    try {
+                        runtimes.removeSnapshot(oldSnapshot);
+                    } catch (ServerException srvEx) {
+                        LOG.warn("Failed to remove old snapshot {}.", oldSnapshot);
+                    }
+                    snapshotDao.removeSnapshot(oldSnapshot.getId());
+                } catch (NotFoundException ignore) {}
+
                 snapshotDao.saveSnapshot(snapshot);
             } catch (ApiException apiEx) {
                 if (machine.getConfig().isDev()) {


### PR DESCRIPTION
### What does this PR do?

Moves logic of creation and pushing workspace snapshots to remote docker registry into separate method.
Adds old snapshots removing.
### What issues does this PR fix or reference?

https://github.com/codenvy/codenvy/issues/515
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [x] Tests provided / updated
- [x] Tests passed
### Major change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Documentation provided (include here or link to docs)
- [ ] Tests provided / updated
- [ ] Tests passed
