### PR TITLE
Revert back context menu for Processes panel

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineExtension.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineExtension.java
@@ -45,6 +45,9 @@ import org.eclipse.che.ide.extension.machine.client.actions.SwitchPerspectiveAct
 import org.eclipse.che.ide.extension.machine.client.command.custom.CustomCommandType;
 import org.eclipse.che.ide.extension.machine.client.command.valueproviders.ServerPortProvider;
 import org.eclipse.che.ide.extension.machine.client.machine.MachineStatusNotifier;
+import org.eclipse.che.ide.extension.machine.client.processes.actions.CloseConsoleAction;
+import org.eclipse.che.ide.extension.machine.client.processes.actions.ReRunProcessAction;
+import org.eclipse.che.ide.extension.machine.client.processes.actions.StopProcessAction;
 import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPanelPresenter;
 import org.eclipse.che.ide.extension.machine.client.targets.EditTargetsAction;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
@@ -140,7 +143,10 @@ public class MachineExtension {
                                 NewTerminalAction newTerminalAction,
                                 EditTargetsAction editTargetsAction,
                                 IconRegistry iconRegistry,
-                                MachineResources machineResources) {
+                                MachineResources machineResources,
+                                ReRunProcessAction reRunProcessAction,
+                                StopProcessAction stopProcessAction,
+                                CloseConsoleAction closeConsoleAction) {
         final DefaultActionGroup mainMenu = (DefaultActionGroup)actionManager.getAction(GROUP_MAIN_MENU);
 
         final DefaultActionGroup workspaceMenu = (DefaultActionGroup)actionManager.getAction(GROUP_WORKSPACE);
@@ -202,6 +208,16 @@ public class MachineExtension {
         final DefaultActionGroup commandList = new DefaultActionGroup(GROUP_COMMANDS_DROPDOWN, true, actionManager);
         actionManager.registerAction(GROUP_COMMANDS_LIST, commandList);
         commandList.add(editCommandsAction, FIRST);
+
+
+        // Consoles tree context menu group
+        DefaultActionGroup consolesTreeContextMenu =
+                (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_CONSOLES_TREE_CONTEXT_MENU);
+
+        consolesTreeContextMenu.add(reRunProcessAction);
+        consolesTreeContextMenu.add(stopProcessAction);
+        consolesTreeContextMenu.add(closeConsoleAction);
+
 
         // Define hot-keys
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.F12).build(), "newTerminal");

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.java
@@ -112,6 +112,25 @@ public interface MachineLocalizationConstant extends Messages {
     String notificationMachineDestroyed(String machineId);
 
 
+    @Key("control.rerun.title")
+    String reRunControlTitle();
+
+    @Key("control.rerun.description")
+    String reRunControlDescription();
+
+    @Key("control.stop.title")
+    String stopControlTitle();
+
+    @Key("control.stop.description")
+    String stopControlDescription();
+
+    @Key("control.close.title")
+    String closeControlTitle();
+
+    @Key("control.close.description")
+    String closeControlDescription();
+
+
     /* MachinePanelPresenter */
     @Key("view.machinePanel.title")
     String machinePanelTitle();

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/actions/CloseConsoleAction.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/actions/CloseConsoleAction.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.extension.machine.client.processes.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.parts.PartStackUIResources;
+import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
+import org.eclipse.che.ide.extension.machine.client.processes.ProcessTreeNode;
+import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPanelPresenter;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Stop selected process and close the console action.
+ *
+ * @author Vitaliy Guliy
+ */
+@Singleton
+public class CloseConsoleAction extends AbstractPerspectiveAction {
+
+    private final ProcessesPanelPresenter processesPanelPresenter;
+
+    @Inject
+    public CloseConsoleAction(ProcessesPanelPresenter processesPanelPresenter,
+                              MachineLocalizationConstant locale,
+                              PartStackUIResources partStackUIResources) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID),
+                locale.closeControlTitle(),
+                locale.closeControlDescription(),
+                null,
+                partStackUIResources.closeIcon());
+        this.processesPanelPresenter = processesPanelPresenter;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (processesPanelPresenter.getContextTreeNode() == null) {
+            return;
+        }
+
+        if (ProcessTreeNode.ProcessNodeType.COMMAND_NODE == processesPanelPresenter.getContextTreeNode().getType()) {
+            processesPanelPresenter.onCloseCommandOutputClick(processesPanelPresenter.getContextTreeNode());
+        } else if (ProcessTreeNode.ProcessNodeType.TERMINAL_NODE == processesPanelPresenter.getContextTreeNode().getType()) {
+            processesPanelPresenter.onCloseTerminal(processesPanelPresenter.getContextTreeNode());
+        }
+    }
+
+    @Override
+    public void updateInPerspective(ActionEvent event) {
+        ProcessTreeNode processTreeNode = processesPanelPresenter.getContextTreeNode();
+
+        if (processTreeNode == null) {
+            event.getPresentation().setEnabled(false);
+            event.getPresentation().setVisible(false);
+            return;
+        }
+
+        if (ProcessTreeNode.ProcessNodeType.COMMAND_NODE == processTreeNode.getType() ||
+            ProcessTreeNode.ProcessNodeType.TERMINAL_NODE == processTreeNode.getType()) {
+            event.getPresentation().setEnabled(true);
+            event.getPresentation().setVisible(true);
+            return;
+        }
+
+        event.getPresentation().setEnabled(false);
+        event.getPresentation().setVisible(false);
+    }
+
+}

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/actions/ReRunProcessAction.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/actions/ReRunProcessAction.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.extension.machine.client.processes.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.outputconsole.OutputConsole;
+import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
+import org.eclipse.che.ide.extension.machine.client.MachineResources;
+import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandOutputConsolePresenter;
+import org.eclipse.che.ide.extension.machine.client.processes.ProcessTreeNode;
+import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPanelPresenter;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Re-run selected process action.
+ *
+ * @author Vitaliy Guliy
+ */
+@Singleton
+public class ReRunProcessAction extends AbstractPerspectiveAction {
+
+    private ProcessesPanelPresenter processesPanelPresenter;
+
+    @Inject
+    public ReRunProcessAction(ProcessesPanelPresenter processesPanelPresenter,
+                              MachineLocalizationConstant locale,
+                              MachineResources machineResources) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID),
+                locale.reRunControlTitle(),
+                locale.reRunControlDescription(),
+                null,
+                machineResources.reRunIcon());
+        this.processesPanelPresenter = processesPanelPresenter;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        OutputConsole outputConsole = processesPanelPresenter.getContextOutputConsole();
+        if (outputConsole != null && outputConsole instanceof CommandOutputConsolePresenter) {
+            CommandOutputConsolePresenter commandOutputConsolePresenter = (CommandOutputConsolePresenter)outputConsole;
+            commandOutputConsolePresenter.reRunProcessButtonClicked();
+        }
+    }
+
+    @Override
+    public void updateInPerspective(ActionEvent event) {
+        ProcessTreeNode processTreeNode = processesPanelPresenter.getContextTreeNode();
+
+        if (processTreeNode == null) {
+            event.getPresentation().setEnabled(false);
+            event.getPresentation().setVisible(false);
+            return;
+        }
+
+        if (processesPanelPresenter.getContextOutputConsole() instanceof CommandOutputConsolePresenter) {
+            event.getPresentation().setEnabled(true);
+            event.getPresentation().setVisible(true);
+            return;
+        }
+
+        event.getPresentation().setEnabled(false);
+        event.getPresentation().setVisible(false);
+    }
+
+}

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/actions/StopProcessAction.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/actions/StopProcessAction.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.extension.machine.client.processes.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.outputconsole.OutputConsole;
+import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
+import org.eclipse.che.ide.extension.machine.client.MachineResources;
+import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandOutputConsolePresenter;
+import org.eclipse.che.ide.extension.machine.client.processes.ProcessTreeNode;
+import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPanelPresenter;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Stop selected process action.
+ *
+ * @author Vitaliy Guliy
+ */
+@Singleton
+public class StopProcessAction extends AbstractPerspectiveAction {
+
+    private ProcessesPanelPresenter processesPanelPresenter;
+
+    @Inject
+    public StopProcessAction(ProcessesPanelPresenter processesPanelPresenter,
+                             MachineLocalizationConstant locale,
+                             MachineResources machineResources) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID),
+                locale.stopControlTitle(),
+                locale.stopControlDescription(),
+                null,
+                machineResources.stopIcon());
+        this.processesPanelPresenter = processesPanelPresenter;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        OutputConsole outputConsole = processesPanelPresenter.getContextOutputConsole();
+        if (outputConsole != null && outputConsole instanceof CommandOutputConsolePresenter) {
+            CommandOutputConsolePresenter commandOutputConsolePresenter = (CommandOutputConsolePresenter)outputConsole;
+            commandOutputConsolePresenter.stopProcessButtonClicked();
+        }
+    }
+
+    @Override
+    public void updateInPerspective(ActionEvent event) {
+        ProcessTreeNode processTreeNode = processesPanelPresenter.getContextTreeNode();
+
+        if (processTreeNode == null) {
+            event.getPresentation().setEnabled(false);
+            event.getPresentation().setVisible(false);
+            return;
+        }
+
+        if (processesPanelPresenter.getContextOutputConsole() instanceof CommandOutputConsolePresenter &&
+            !processesPanelPresenter.getContextOutputConsole().isFinished()) {
+            event.getPresentation().setEnabled(true);
+            event.getPresentation().setVisible(true);
+            return;
+        }
+
+        event.getPresentation().setEnabled(false);
+        event.getPresentation().setVisible(false);
+    }
+
+}

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelView.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelView.java
@@ -138,5 +138,17 @@ public interface ProcessesPanelView extends View<ProcessesPanelView.ActionDelega
         void onCloseCommandOutputClick(ProcessTreeNode node);
 
         void onCommandTabClosing(ProcessTreeNode node, SubPanel.RemoveCallback removeCallback);
+
+        /**
+         * Is called when user clicked right mouse button.
+         *
+         * @param mouseX
+         *          mouse x coordinate
+         * @param mouseY
+         *          mouse y coordinate
+         * @param node
+         *          process tree node
+         */
+        void onContextMenu(int mouseX, int mouseY, ProcessTreeNode node);
     }
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelViewImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelViewImpl.java
@@ -147,6 +147,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
             @Override
             public void onNodeContextMenu(int mouseX, int mouseY, TreeNodeElement<ProcessTreeNode> node) {
+                delegate.onContextMenu(mouseX, mouseY, node.getData());
             }
 
             @Override

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.properties
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.properties
@@ -43,6 +43,13 @@ control.terminal.create.text=New terminal
 control.terminal.create.description=Open new terminal
 control.connect.ssh=Connect via SSH
 
+control.close.title = Close
+control.close.description = Close
+control.rerun.title = Re-Run
+control.rerun.description = Re-Run
+control.stop.title = Stop
+control.stop.description = Stop
+
 ##### Messages #####
 messages.noDevMachine = No running machine to execute the command on.
 messages.machine.not.found=Machine {0} not found

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
@@ -51,6 +51,7 @@ import org.eclipse.che.ide.extension.machine.client.outputspanel.console.Command
 import org.eclipse.che.ide.extension.machine.client.perspective.terminal.TerminalPresenter;
 import org.eclipse.che.ide.extension.machine.client.processes.ProcessFinishedEvent;
 import org.eclipse.che.ide.extension.machine.client.processes.ProcessTreeNode;
+import org.eclipse.che.ide.extension.machine.client.processes.actions.ConsoleTreeContextMenuFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,37 +91,39 @@ public class ProcessesPanelPresenterTest {
     private static final int    PID            = 101;
 
     @Mock
-    private DtoFactory                  dtoFactory;
+    private DtoFactory                    dtoFactory;
     @Mock
-    private CommandConsoleFactory       commandConsoleFactory;
+    private CommandConsoleFactory         commandConsoleFactory;
     @Mock
-    private CommandTypeRegistry         commandTypeRegistry;
+    private CommandTypeRegistry           commandTypeRegistry;
     @Mock
-    private DialogFactory               dialogFactory;
+    private ConsoleTreeContextMenuFactory consoleTreeContextMenuFactory;
     @Mock
-    private WorkspaceAgent              workspaceAgent;
+    private DialogFactory                 dialogFactory;
     @Mock
-    private NotificationManager         notificationManager;
+    private WorkspaceAgent                workspaceAgent;
     @Mock
-    private MachineLocalizationConstant localizationConstant;
+    private NotificationManager           notificationManager;
     @Mock
-    private TerminalFactory             terminalFactory;
+    private MachineLocalizationConstant   localizationConstant;
     @Mock
-    private ProcessesPanelView          view;
+    private TerminalFactory               terminalFactory;
     @Mock
-    private MachineResources            resources;
+    private ProcessesPanelView            view;
     @Mock
-    private AppContext                  appContext;
+    private MachineResources              resources;
     @Mock
-    private MachineServiceClient        machineService;
+    private AppContext                    appContext;
     @Mock
-    private EntityFactory               entityFactory;
+    private MachineServiceClient          machineService;
     @Mock
-    private EventBus                    eventBus;
+    private EntityFactory                 entityFactory;
     @Mock
-    private WorkspaceDto                workspace;
+    private EventBus                      eventBus;
     @Mock
-    private OutputConsole               outputConsole;
+    private WorkspaceDto                  workspace;
+    @Mock
+    private OutputConsole                 outputConsole;
 
     @Mock
     private Promise<List<MachineDto>> machinesPromise;
@@ -175,7 +178,8 @@ public class ProcessesPanelPresenterTest {
                                                 commandConsoleFactory,
                                                 dialogFactory,
                                                 dtoFactory,
-                                                commandTypeRegistry);
+                                                commandTypeRegistry,
+                                                consoleTreeContextMenuFactory);
     }
 
     @Test
@@ -382,17 +386,14 @@ public class ProcessesPanelPresenterTest {
 
         presenter.addCommandOutput(MACHINE_ID, outputConsole);
 
-        verify(view, never()).addProcessNode(anyObject());
-        verify(view, never()).setProcessesData(anyObject());
-
         verify(outputConsole).go(acceptsOneWidgetCaptor.capture());
         IsWidget widget = mock(IsWidget.class);
         acceptsOneWidgetCaptor.getValue().setWidget(widget);
 
         verify(view).hideProcessOutput(eq(commandId));
-        verify(view).addWidget(eq(commandId), anyString(), anyObject(), eq(widget), anyBoolean());
-        verify(view).selectNode(anyObject());
-        verify(view).getNodeById(eq(commandId));
+        verify(view).addWidget(anyString(), anyString(), anyObject(), eq(widget), anyBoolean());
+        verify(view, times(2)).selectNode(anyObject());
+        verify(view).getNodeById(anyString());
     }
 
     @Test


### PR DESCRIPTION
We've had context menu in Consoles panel but this menu hasn't been moved to the Processes panel.
This PR reverts back context menu to the Processes panel.

@vparfonov plz, review
