### PR TITLE
Fix errors in che-in-che stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/images/type-che.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/images/type-che.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 254.1 293.5" style="enable-background:new 0 0 254.1 293.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#525C86;}
+	.st1{fill:#FDB940;}
+</style>
+<g>
+	<polygon class="st0" points="0,128.7 0,220.1 127.1,293.5 254.1,220.1 254.1,128.7 127.1,202.1 	"/>
+	<polygon class="st1" points="127.1,0 0,73.4 0,164.7 127.1,91.4 175,119 254.1,73.4 	"/>
+</g>
+</svg>

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -3,20 +3,21 @@
     "id": "che-in-che",
     "creator": "ide",
     "name": "Eclipse Che",
-    "description": "Utilities to build Che with Che. Alpine, JDK 8, maven, git, docker.",
+    "description": "Utilities to build Che in Che with Docker, JDK 8, and Maven.",
     "scope": "general",
     "tags": [
+      "Docker",
       "Java",
       "JDK",
       "Maven",
-      "Tomcat",
-      "Subversion",
-      "Ubuntu",
-      "Git",
-      "Che",
-      "Docker"
+      "Alpine",
+      "Git"
     ],
     "components": [
+      {
+        "name": "Docker",
+        "version": "1.12.0"
+      },
       {
         "name": "JDK",
         "version": "1.8.0_92"
@@ -24,19 +25,11 @@
       {
         "name": "Maven",
         "version": "3.3.9"
-      },
-      {
-        "name": "Tomcat",
-        "version": "8.0.29"
-      },
-      {
-        "name": "Docker",
-        "version": "1.12.0"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/alpine-jdk:nightly"
+      "origin": "codenvy/alpine_jdk8"
     },
     "workspaceConfig": {
       "environments": [
@@ -47,7 +40,7 @@
             {
               "name": "default",
               "limits": {
-                "ram": 1000
+                "ram": 2000
               },
               "source": {
                 "location": "stub",
@@ -59,15 +52,39 @@
           ]
         }
       ],
-      "name": "Che in Che",
+      "name": "default",
       "defaultEnv": "default",
       "description": null,
       "commands": [
         {
-          "commandLine": "mvn clean install -f ${current.project.path}",
-          "name": "build",
-          "type": "mvn"
+          "commandLine": "sudo docker rename che-server che-host;sudo apk update; sudo apk add curl;export HOST_IP=$(curl -s https://4.ifcfg.me/)",
+          "name": "1. Setup Che in Che",
+          "type": "custom"
+        },
+        {
+          "commandLine": "mvn clean install -f /projects/che/assembly/assembly-main",
+          "name": "2. Build Che in Che",
+          "type": "custom"
+        },
+        {
+          "commandLine": 'export CHE_BIN_PATH=$(ls -d /projects/che/assembly/assembly-main/target/eclipse-che-*/eclipse-che-*); sudo docker run -t -v /var/run/docker.sock:/var/run/docker.sock --env CHE_LOCAL_BINARY=${CHE_BIN_PATH//projects/"home/user/che/workspaces/che"} --env CHE_HOST_IP=$HOST_IP --env CHE_PORT=54321 codenvy/che-launcher start',
+          "name": "3. Run Che in Che",
+          "type": "custom",
+          "attributes": {
+              "previewUrl": "http://<host.ip>:54321/"
+            }
+        },
+        {
+          "commandLine": "sudo docker run -t -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-launcher stop",
+          "name": "4. Stop Che in Che",
+          "type": "custom"
+        },
+        {
+          "commandLine": "sudo docker rm -f che-server",
+          "name": "** Kill Che in Che **",
+          "type": "custom"
         }
+
       ]
     },
     "acl": [
@@ -79,7 +96,7 @@
       }
     ],
     "stackIcon": {
-      "name": "type-java.svg",
+      "name": "type-che.svg",
       "mediaType": "image/svg+xml"
     }
   },


### PR DESCRIPTION
1. Adds an SVG file for the che stack to appear in the dashboard
2. Fixes some errors in the stack.

In order to make this work, user will need to:
1. Checkout github.com/eclipse/che-dockerfiles
2. In the recipes/alpine_jdk8 directory:

docker build -t codenvy/alpine_jdk8 .

You can then run Che and the stack will work.

Note - we are still missing improvements to the commands that appear to help automate the configuration of the commands.  Currently, you need to provide the host mount in the command that points to the location of the source code on the host in order to be able to build it.
