### PR TITLE
#953: Extend macro list

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
@@ -56,6 +56,7 @@ import org.eclipse.che.ide.api.git.GitServiceClient;
 import org.eclipse.che.ide.api.git.GitServiceClientImpl;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
 import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
 import org.eclipse.che.ide.api.machine.MachineServiceClient;
 import org.eclipse.che.ide.api.machine.MachineServiceClientImpl;
@@ -114,6 +115,11 @@ import org.eclipse.che.ide.client.StartUpActionsProcessor;
 import org.eclipse.che.ide.context.AppContextImpl;
 import org.eclipse.che.ide.editor.EditorAgentImpl;
 import org.eclipse.che.ide.editor.EditorRegistryImpl;
+import org.eclipse.che.ide.editor.macro.EditorCurrentFileNameProvider;
+import org.eclipse.che.ide.editor.macro.EditorCurrentFilePathProvider;
+import org.eclipse.che.ide.editor.macro.EditorCurrentFileRelativePathProvider;
+import org.eclipse.che.ide.editor.macro.EditorCurrentProjectNameProvider;
+import org.eclipse.che.ide.editor.macro.EditorCurrentProjectTypeProvider;
 import org.eclipse.che.ide.editor.synchronization.EditorContentSynchronizer;
 import org.eclipse.che.ide.editor.synchronization.EditorContentSynchronizerImpl;
 import org.eclipse.che.ide.editor.synchronization.EditorGroupSychronizationFactory;
@@ -140,6 +146,7 @@ import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcResponseDispatcher;
 import org.eclipse.che.ide.jsonrpc.impl.WebSocketJsonRpcResponseTransmitter;
 import org.eclipse.che.ide.keybinding.KeyBindingManager;
 import org.eclipse.che.ide.machine.CommandPropertyValueProviderRegistryImpl;
+import org.eclipse.che.ide.machine.macro.ServerMacroProvider;
 import org.eclipse.che.ide.menu.MainMenuView;
 import org.eclipse.che.ide.menu.MainMenuViewImpl;
 import org.eclipse.che.ide.menu.StatusPanelGroupView;
@@ -167,6 +174,11 @@ import org.eclipse.che.ide.part.explorer.project.ProjectExplorerView;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerViewImpl;
 import org.eclipse.che.ide.part.explorer.project.RevealNodesPersistenceComponent;
 import org.eclipse.che.ide.part.explorer.project.TreeResourceRevealer;
+import org.eclipse.che.ide.part.explorer.project.macro.ExplorerCurrentFileNameProvider;
+import org.eclipse.che.ide.part.explorer.project.macro.ExplorerCurrentFilePathProvider;
+import org.eclipse.che.ide.part.explorer.project.macro.ExplorerCurrentFileRelativePathProvider;
+import org.eclipse.che.ide.part.explorer.project.macro.ExplorerCurrentProjectNameProvider;
+import org.eclipse.che.ide.part.explorer.project.macro.ExplorerCurrentProjectTypeProvider;
 import org.eclipse.che.ide.preferences.PreferencesComponent;
 import org.eclipse.che.ide.preferences.PreferencesManagerImpl;
 import org.eclipse.che.ide.preferences.PreferencesView;
@@ -468,6 +480,17 @@ public class CoreGinModule extends AbstractGinModule {
 
         // Machine
         bind(CommandPropertyValueProviderRegistry.class).to(CommandPropertyValueProviderRegistryImpl.class).in(Singleton.class);
+        GinMultibinder<CommandPropertyValueProvider> macroProviders = GinMultibinder.newSetBinder(binder(), CommandPropertyValueProvider.class);
+        macroProviders.addBinding().to(EditorCurrentFileNameProvider.class);
+        macroProviders.addBinding().to(EditorCurrentFilePathProvider.class);
+        macroProviders.addBinding().to(EditorCurrentFileRelativePathProvider.class);
+        macroProviders.addBinding().to(EditorCurrentProjectNameProvider.class);
+        macroProviders.addBinding().to(EditorCurrentProjectTypeProvider.class);
+        macroProviders.addBinding().to(ExplorerCurrentFileNameProvider.class);
+        macroProviders.addBinding().to(ExplorerCurrentFilePathProvider.class);
+        macroProviders.addBinding().to(ExplorerCurrentFileRelativePathProvider.class);
+        macroProviders.addBinding().to(ExplorerCurrentProjectNameProvider.class);
+        macroProviders.addBinding().to(ExplorerCurrentProjectTypeProvider.class);
     }
 
     /** Configure Core UI components, resources and views */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -62,6 +62,10 @@ import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.KeyBuilder;
 import org.eclipse.che.ide.connection.WsConnectionListener;
+import org.eclipse.che.ide.machine.macro.ServerHostNameMacroProvider;
+import org.eclipse.che.ide.machine.macro.ServerMacroProvider;
+import org.eclipse.che.ide.machine.macro.ServerPortMacroProvider;
+import org.eclipse.che.ide.machine.macro.ServerProtocolMacroProvider;
 import org.eclipse.che.ide.part.editor.actions.SwitchNextEditorAction;
 import org.eclipse.che.ide.part.editor.actions.SwitchPreviousEditorAction;
 import org.eclipse.che.ide.imageviewer.ImageViewerProvider;
@@ -339,6 +343,19 @@ public class StandardComponentInitializer {
 
     @Inject
     private TreeResourceRevealer treeResourceRevealer; //just to work with it
+
+    // do not remove the injections below
+    @Inject
+    private ServerMacroProvider serverMacroProvider;
+
+    @Inject
+    private ServerProtocolMacroProvider serverProtocolMacroProvider;
+
+    @Inject
+    private ServerHostNameMacroProvider serverHostNameMacroProvider;
+
+    @Inject
+    private ServerPortMacroProvider serverPortMacroProvider;
 
 
     /** Instantiates {@link StandardComponentInitializer} an creates standard content. */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/AbstractEditorMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/AbstractEditorMacroProvider.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.annotations.Beta;
+
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+
+/**
+ * Base macro provider which belongs to the current opened editor. Provides easy access to the opened virtual file
+ * to allow fetch necessary information to use in custom commands, preview urls, etc.
+ *
+ * @author Vlad Zhukovskyi
+ * @see EditorAgent
+ * @see CommandPropertyValueProvider
+ * @see EditorCurrentFileNameProvider
+ * @see EditorCurrentFilePathProvider
+ * @see EditorCurrentFileRelativePathProvider
+ * @see EditorCurrentProjectNameProvider
+ * @see EditorCurrentProjectTypeProvider
+ * @since 4.7.0
+ */
+@Beta
+public abstract class AbstractEditorMacroProvider implements CommandPropertyValueProvider {
+
+    private EditorAgent editorAgent;
+
+    public AbstractEditorMacroProvider(EditorAgent editorAgent) {
+        this.editorAgent = editorAgent;
+    }
+
+    /**
+     * Returns the active editor or null if no active editor was found.
+     *
+     * @return active editor or {@code null}
+     */
+    public EditorPartPresenter getActiveEditor() {
+        return editorAgent.getActiveEditor();
+    }
+
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileNameProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileNameProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+
+/**
+ * Provider which is responsible for retrieving the file name from the opened editor.
+ *
+ * Macro provided: <code>${editor.current.file.name}</code>
+ *
+ * @see AbstractEditorMacroProvider
+ * @see EditorAgent
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class EditorCurrentFileNameProvider extends AbstractEditorMacroProvider {
+
+    public static final String KEY = "${editor.current.file.name}";
+
+    private PromiseProvider promises;
+
+    @Inject
+    public EditorCurrentFileNameProvider(EditorAgent editorAgent,
+                                         PromiseProvider promises) {
+        super(editorAgent);
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        final EditorPartPresenter editor = getActiveEditor();
+
+        if (editor == null) {
+            return promises.resolve("");
+        }
+
+        return promises.resolve(editor.getEditorInput().getFile().getName());
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentFilePathProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentFilePathProvider.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.resource.Path;
+
+/**
+ * Provider which is responsible for retrieving the absolute file path from the opened editor.
+ *
+ * Macro provided: <code>${editor.current.file.path}</code>
+ *
+ * @see AbstractEditorMacroProvider
+ * @see EditorAgent
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class EditorCurrentFilePathProvider extends AbstractEditorMacroProvider {
+
+    public static final String KEY = "${editor.current.file.path}";
+
+    private PromiseProvider promises;
+    private AppContext      appContext;
+
+    @Inject
+    public EditorCurrentFilePathProvider(EditorAgent editorAgent,
+                                         PromiseProvider promises,
+                                         AppContext appContext) {
+        super(editorAgent);
+        this.promises = promises;
+        this.appContext = appContext;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        final EditorPartPresenter editor = getActiveEditor();
+
+        if (editor == null) {
+            return promises.resolve("");
+        }
+
+        final Path absolutePath = appContext.getProjectsRoot().append(editor.getEditorInput().getFile().getLocation());
+
+        return promises.resolve(absolutePath.toString());
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileRelativePathProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileRelativePathProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+
+/**
+ * Provider which is responsible for retrieving the relative to the {@code /projects} folder file path from the opened editor.
+ *
+ * Macro provided: <code>${editor.current.file.relpath}</code>
+ *
+ * @see AbstractEditorMacroProvider
+ * @see EditorAgent
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class EditorCurrentFileRelativePathProvider extends AbstractEditorMacroProvider {
+
+    public static final String KEY = "${editor.current.file.relpath}";
+
+    private PromiseProvider promises;
+
+    @Inject
+    public EditorCurrentFileRelativePathProvider(EditorAgent editorAgent,
+                                                 PromiseProvider promises) {
+        super(editorAgent);
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        final EditorPartPresenter editor = getActiveEditor();
+
+        if (editor == null) {
+            return promises.resolve("");
+        }
+
+        return promises.resolve(editor.getEditorInput().getFile().getLocation().toString());
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectNameProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectNameProvider.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.api.resources.VirtualFile;
+
+/**
+ * Provider which is responsible for retrieving the project name of the file from the opened editor.
+ *
+ * Macro provided: <code>${editor.current.project.name}</code>
+ *
+ * @see AbstractEditorMacroProvider
+ * @see EditorAgent
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class EditorCurrentProjectNameProvider extends AbstractEditorMacroProvider {
+
+    public static final String KEY = "${editor.current.project.name}";
+
+    private PromiseProvider promises;
+
+    @Inject
+    public EditorCurrentProjectNameProvider(EditorAgent editorAgent,
+                                            PromiseProvider promises) {
+        super(editorAgent);
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        final EditorPartPresenter editor = getActiveEditor();
+
+        if (editor == null) {
+            return promises.resolve("");
+        }
+
+        final VirtualFile file = editor.getEditorInput().getFile();
+
+        if (file instanceof Resource) {
+            final Optional<Project> project = ((Resource)file).getRelatedProject();
+
+            if (!project.isPresent()) {
+                return promises.resolve("");
+            }
+
+            return promises.resolve(project.get().getName());
+        }
+
+        return promises.resolve("");
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectTypeProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectTypeProvider.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.api.resources.VirtualFile;
+
+/**
+ * Provider which is responsible for retrieving the project type of the file from the opened editor.
+ *
+ * Macro provided: <code>${editor.current.project.type}</code>
+ *
+ * @see AbstractEditorMacroProvider
+ * @see EditorAgent
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class EditorCurrentProjectTypeProvider extends AbstractEditorMacroProvider {
+
+    public static final String KEY = "${editor.current.project.type}";
+
+    private PromiseProvider promises;
+
+    @Inject
+    public EditorCurrentProjectTypeProvider(EditorAgent editorAgent,
+                                            PromiseProvider promises) {
+        super(editorAgent);
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        final EditorPartPresenter editor = getActiveEditor();
+
+        if (editor == null) {
+            return promises.resolve("");
+        }
+
+        final VirtualFile file = editor.getEditorInput().getFile();
+
+        if (file instanceof Resource) {
+            final Optional<Project> project = ((Resource)file).getRelatedProject();
+
+            if (!project.isPresent()) {
+                return promises.resolve("");
+            }
+
+            return promises.resolve(project.get().getType());
+        }
+
+        return promises.resolve("");
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/CustomCommandPropertyValueProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/CustomCommandPropertyValueProvider.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Objects;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.js.Promises;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Custom macro provider which allows to register user's macro with the provided value.
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @since 4.7.0
+ */
+@Beta
+public class CustomCommandPropertyValueProvider implements CommandPropertyValueProvider {
+
+    private final String key;
+    private final String value;
+
+    public CustomCommandPropertyValueProvider(String key, String value) {
+        this.key = checkNotNull(key, "Key should not be null");
+        this.value = checkNotNull(value, "Value should not be null");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        return Promises.resolve(value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomCommandPropertyValueProvider that = (CustomCommandPropertyValueProvider)o;
+        return Objects.equal(key, that.key) &&
+               Objects.equal(value, that.value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(key, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "CustomCommandPropertyValueProvider{" +
+               "key='" + key + '\'' +
+               ", value='" + value + '\'' +
+               '}';
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/AbstractServerMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/AbstractServerMacroProvider.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
+import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
+
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Base macro provider which belongs to the current server configuration. Provides easy access to the developer machine
+ * to allow fetch necessary information to use in custom commands, preview urls, etc.
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProviderRegistry
+ * @see CommandPropertyValueProvider
+ * @see ServerHostNameMacroProvider
+ * @see ServerMacroProvider
+ * @see ServerPortMacroProvider
+ * @see ServerProtocolMacroProvider
+ * @since 4.7.0
+ */
+@Beta
+public abstract class AbstractServerMacroProvider implements WsAgentStateHandler {
+
+    private final CommandPropertyValueProviderRegistry providerRegistry;
+    private final AppContext                           appContext;
+
+    public AbstractServerMacroProvider(CommandPropertyValueProviderRegistry providerRegistry,
+                                       EventBus eventBus,
+                                       AppContext appContext) {
+        this.providerRegistry = providerRegistry;
+        this.appContext = appContext;
+
+        eventBus.addHandler(WsAgentStateEvent.TYPE, this);
+    }
+
+    /**
+     * Register macro providers which returns the implementation.
+     *
+     * @see AbstractServerMacroProvider#getMacroProviders(DevMachine)
+     * @since 4.7.0
+     */
+    private void registerProviders() {
+        final DevMachine devMachine = appContext.getDevMachine();
+
+        if (devMachine == null) {
+            return;
+        }
+
+        final Set<CommandPropertyValueProvider> providers = getMacroProviders(devMachine);
+        checkNotNull(providers);
+
+        if (providers.isEmpty()) {
+            return;
+        }
+
+        providerRegistry.register(providers);
+    }
+
+    /**
+     * Unregister macro providers which the implementation returns.
+     *
+     * @see AbstractServerMacroProvider#getMacroProviders(DevMachine)
+     * @since 4.7.0
+     */
+    private void unregisterProviders() {
+        final DevMachine devMachine = appContext.getDevMachine();
+
+        if (devMachine == null) {
+            return;
+        }
+
+        for (CommandPropertyValueProvider provider : getMacroProviders(devMachine)) {
+            providerRegistry.unregister(provider);
+        }
+    }
+
+    /**
+     * Returns the macros which implementation provides based on the information from the developer machine.
+     *
+     * @param devMachine
+     *         current developer machine
+     * @return set of unique macro providers
+     * @see DevMachine
+     * @see CommandPropertyValueProvider
+     * @since 4.7.0
+     */
+    public abstract Set<CommandPropertyValueProvider> getMacroProviders(DevMachine devMachine);
+
+    /** {@inheritDoc} */
+    @Override
+    public void onWsAgentStarted(WsAgentStateEvent event) {
+        registerProviders();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onWsAgentStopped(WsAgentStateEvent event) {
+        unregisterProviders();
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerHostNameMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerHostNameMacroProvider.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provider which is responsible for the retrieving the hostname (reference) of the registered server.
+ * <p>
+ * Macro provided: <code>${server.[port].hostname}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see AbstractServerMacroProvider
+ * @see DevMachine
+ * @see Server#getRef()
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ServerHostNameMacroProvider extends AbstractServerMacroProvider {
+
+    public static final String KEY = "${server.%.hostname}";
+
+    @Inject
+    public ServerHostNameMacroProvider(CommandPropertyValueProviderRegistry providerRegistry,
+                                       EventBus eventBus,
+                                       AppContext appContext) {
+        super(providerRegistry, eventBus, appContext);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<CommandPropertyValueProvider> getMacroProviders(DevMachine devMachine) {
+        final Set<CommandPropertyValueProvider> providers = Sets.newHashSet();
+
+        for (Map.Entry<String, ? extends Server> entry : devMachine.getDescriptor().getRuntime().getServers().entrySet()) {
+
+            if (Strings.isNullOrEmpty(entry.getValue().getRef())) {
+                continue;
+            }
+
+            CommandPropertyValueProvider macroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", entry.getKey()),
+                                                                                                entry.getValue().getRef());
+
+            providers.add(macroProvider);
+
+            // register port without "/tcp" suffix
+            if (entry.getKey().endsWith("/tcp")) {
+                final String port = entry.getKey().substring(0, entry.getKey().length() - 4);
+
+                CommandPropertyValueProvider shortMacroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", port),
+                                                                                                         entry.getValue().getRef());
+
+                providers.add(shortMacroProvider);
+            }
+        }
+
+        return providers;
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerMacroProvider.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provider which is responsible for the retrieving the address of the registered server.
+ * <p>
+ * Macro provided: <code>${server.[port]}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see AbstractServerMacroProvider
+ * @see DevMachine
+ * @see Server#getAddress()
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ServerMacroProvider extends AbstractServerMacroProvider {
+
+    public static final String KEY = "${server.%}";
+
+    @Inject
+    public ServerMacroProvider(CommandPropertyValueProviderRegistry providerRegistry,
+                               EventBus eventBus,
+                               AppContext appContext) {
+        super(providerRegistry, eventBus, appContext);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<CommandPropertyValueProvider> getMacroProviders(DevMachine devMachine) {
+        final Set<CommandPropertyValueProvider> providers = Sets.newHashSet();
+
+        for (Map.Entry<String, ? extends Server> entry : devMachine.getDescriptor().getRuntime().getServers().entrySet()) {
+            CommandPropertyValueProvider macroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", entry.getKey()),
+                                                                                                entry.getValue().getAddress());
+
+            providers.add(macroProvider);
+
+            // register port without "/tcp" suffix
+            if (entry.getKey().endsWith("/tcp")) {
+                final String port = entry.getKey().substring(0, entry.getKey().length() - 4);
+
+                CommandPropertyValueProvider shortMacroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", port),
+                                                                                                         entry.getValue().getAddress());
+
+                providers.add(shortMacroProvider);
+            }
+        }
+
+        return providers;
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerPortMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerPortMacroProvider.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provider which is responsible for the retrieving the port of the registered server.
+ * <p>
+ * Macro provided: <code>${server.[port].port}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see AbstractServerMacroProvider
+ * @see DevMachine
+ * @see Server#getAddress()
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ServerPortMacroProvider extends AbstractServerMacroProvider {
+
+    public static final String KEY = "${server.%.port}";
+
+    @Inject
+    public ServerPortMacroProvider(CommandPropertyValueProviderRegistry providerRegistry,
+                                   EventBus eventBus,
+                                   AppContext appContext) {
+        super(providerRegistry, eventBus, appContext);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<CommandPropertyValueProvider> getMacroProviders(DevMachine devMachine) {
+        final Set<CommandPropertyValueProvider> providers = Sets.newHashSet();
+
+        for (Map.Entry<String, ? extends Server> entry : devMachine.getDescriptor().getRuntime().getServers().entrySet()) {
+
+            if (!entry.getValue().getAddress().contains(":")) {
+                continue;
+            }
+
+            final String externalPort = entry.getValue().getAddress().split(":")[1];
+
+            CommandPropertyValueProvider macroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", entry.getKey()),
+                                                                                                externalPort);
+
+            providers.add(macroProvider);
+
+            // register port without "/tcp" suffix
+            if (entry.getKey().endsWith("/tcp")) {
+                final String port = entry.getKey().substring(0, entry.getKey().length() - 4);
+
+                CommandPropertyValueProvider shortMacroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", port),
+                                                                                                         externalPort);
+
+                providers.add(shortMacroProvider);
+            }
+        }
+
+        return providers;
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerProtocolMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/machine/macro/ServerProtocolMacroProvider.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provider which is responsible for the retrieving the protocol of the registered server.
+ * <p>
+ * Macro provided: <code>${server.[port].protocol}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see AbstractServerMacroProvider
+ * @see DevMachine
+ * @see Server#getProtocol()
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ServerProtocolMacroProvider extends AbstractServerMacroProvider {
+
+    public static final String KEY = "${server.%.protocol}";
+
+    @Inject
+    public ServerProtocolMacroProvider(CommandPropertyValueProviderRegistry providerRegistry,
+                                       EventBus eventBus,
+                                       AppContext appContext) {
+        super(providerRegistry, eventBus, appContext);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<CommandPropertyValueProvider> getMacroProviders(DevMachine devMachine) {
+        final Set<CommandPropertyValueProvider> providers = Sets.newHashSet();
+
+        for (Map.Entry<String, ? extends Server> entry : devMachine.getDescriptor().getRuntime().getServers().entrySet()) {
+
+            if (Strings.isNullOrEmpty(entry.getValue().getProtocol())) {
+                continue;
+            }
+
+            CommandPropertyValueProvider macroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", entry.getKey()),
+                                                                                                entry.getValue().getProtocol());
+
+            providers.add(macroProvider);
+
+            // register port without "/tcp" suffix
+            if (entry.getKey().endsWith("/tcp")) {
+                final String port = entry.getKey().substring(0, entry.getKey().length() - 4);
+
+                CommandPropertyValueProvider shortMacroProvider = new CustomCommandPropertyValueProvider(KEY.replace("%", port),
+                                                                                                         entry.getValue().getProtocol());
+
+                providers.add(shortMacroProvider);
+            }
+        }
+
+        return providers;
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileNameProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileNameProvider.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
+
+/**
+ * Provider which is responsible for retrieving the resource name from the project explorer.
+ * <p>
+ * Macro provided: <code>${explorer.current.file.name}</code>
+ * <p>
+ * In case if project explorer has more than one selected file, comma separated file list is returned.
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @see ProjectExplorerPresenter
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ExplorerCurrentFileNameProvider implements CommandPropertyValueProvider {
+
+    public static final String KEY = "${explorer.current.file.name}";
+
+    private Predicate<Node> resNodePredicate = new Predicate<Node>() {
+        @Override
+        public boolean apply(@Nullable Node input) {
+            checkNotNull(input);
+
+            return input instanceof ResourceNode;
+        }
+    };
+
+    private Function<Node, Resource> nodeToResourceFun = new Function<Node, Resource>() {
+        @Nullable
+        @Override
+        public Resource apply(@Nullable Node input) {
+            checkNotNull(input);
+            checkState(input instanceof ResourceNode);
+
+            return ((ResourceNode)input).getData();
+        }
+    };
+
+    private Function<Resource, String> resourceToNameFun = new Function<Resource, String>() {
+        @Nullable
+        @Override
+        public String apply(@Nullable Resource input) {
+            checkNotNull(input);
+
+            return input.getName();
+        }
+    };
+
+    private ProjectExplorerPresenter projectExplorer;
+    private PromiseProvider          promises;
+
+    @Inject
+    public ExplorerCurrentFileNameProvider(ProjectExplorerPresenter projectExplorer,
+                                           PromiseProvider promises) {
+        this.projectExplorer = projectExplorer;
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+
+        List<Node> selectedNodes = projectExplorer.getTree().getSelectionModel().getSelectedNodes();
+
+        if (selectedNodes.isEmpty()) {
+            return promises.resolve("");
+        }
+
+        final Iterable<Resource> resources = transform(filter(selectedNodes, resNodePredicate), nodeToResourceFun);
+        final String commaSeparated = Joiner.on(", ").join(transform(resources, resourceToNameFun));
+
+        return promises.resolve(commaSeparated);
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFilePathProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFilePathProvider.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
+
+/**
+ * Provider which is responsible for retrieving the resource path from the project explorer.
+ * <p>
+ * Macro provided: <code>${explorer.current.file.path}</code>
+ * <p>
+ * In case if project explorer has more than one selected file, comma separated file list is returned.
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @see ProjectExplorerPresenter
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ExplorerCurrentFilePathProvider implements CommandPropertyValueProvider {
+
+    public static final String KEY = "${explorer.current.file.path}";
+
+    private Predicate<Node> resNodePredicate = new Predicate<Node>() {
+        @Override
+        public boolean apply(@Nullable Node input) {
+            checkNotNull(input);
+
+            return input instanceof ResourceNode;
+        }
+    };
+
+    private Function<Node, Resource> nodeToResourceFun = new Function<Node, Resource>() {
+        @Nullable
+        @Override
+        public Resource apply(@Nullable Node input) {
+            checkNotNull(input);
+            checkState(input instanceof ResourceNode);
+
+            return ((ResourceNode)input).getData();
+        }
+    };
+
+    private Function<Resource, String> resourceToAbsolutePathFun = new Function<Resource, String>() {
+        @Nullable
+        @Override
+        public String apply(@Nullable Resource input) {
+            checkNotNull(input);
+
+            return appContext.getProjectsRoot().append(input.getLocation()).toString();
+        }
+    };
+
+    private ProjectExplorerPresenter projectExplorer;
+    private PromiseProvider          promises;
+    private AppContext               appContext;
+
+    @Inject
+    public ExplorerCurrentFilePathProvider(ProjectExplorerPresenter projectExplorer,
+                                           PromiseProvider promises,
+                                           AppContext appContext) {
+        this.projectExplorer = projectExplorer;
+        this.promises = promises;
+        this.appContext = appContext;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+
+        List<Node> selectedNodes = projectExplorer.getTree().getSelectionModel().getSelectedNodes();
+
+        if (selectedNodes.isEmpty()) {
+            return promises.resolve("");
+        }
+
+        final Iterable<Resource> resources = transform(filter(selectedNodes, resNodePredicate), nodeToResourceFun);
+        final String commaSeparated = Joiner.on(", ").join(transform(resources, resourceToAbsolutePathFun));
+
+        return promises.resolve(commaSeparated);
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileRelativePathProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileRelativePathProvider.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
+
+/**
+ * Provider which is responsible for retrieving the resource relative path from the project explorer.
+ * <p>
+ * Macro provided: <code>${explorer.current.file.relpath}</code>
+ * <p>
+ * In case if project explorer has more than one selected file, comma separated file list is returned.
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @see ProjectExplorerPresenter
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ExplorerCurrentFileRelativePathProvider implements CommandPropertyValueProvider {
+
+    public static final String KEY = "${explorer.current.file.relpath}";
+
+    private Predicate<Node> resNodePredicate = new Predicate<Node>() {
+        @Override
+        public boolean apply(@Nullable Node input) {
+            checkNotNull(input);
+
+            return input instanceof ResourceNode;
+        }
+    };
+
+    private Function<Node, Resource> nodeToResourceFun = new Function<Node, Resource>() {
+        @Nullable
+        @Override
+        public Resource apply(@Nullable Node input) {
+            checkNotNull(input);
+            checkState(input instanceof ResourceNode);
+
+            return ((ResourceNode)input).getData();
+        }
+    };
+
+    private Function<Resource, String> resourceToPathFun = new Function<Resource, String>() {
+        @Nullable
+        @Override
+        public String apply(@Nullable Resource input) {
+            checkNotNull(input);
+
+            return input.getLocation().toString();
+        }
+    };
+
+    private ProjectExplorerPresenter projectExplorer;
+    private PromiseProvider          promises;
+
+    @Inject
+    public ExplorerCurrentFileRelativePathProvider(ProjectExplorerPresenter projectExplorer,
+                                                   PromiseProvider promises) {
+        this.projectExplorer = projectExplorer;
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+
+        List<Node> selectedNodes = projectExplorer.getTree().getSelectionModel().getSelectedNodes();
+
+        if (selectedNodes.isEmpty()) {
+            return promises.resolve("");
+        }
+
+        final Iterable<Resource> resources = transform(filter(selectedNodes, resNodePredicate), nodeToResourceFun);
+        final String commaSeparated = Joiner.on(", ").join(transform(resources, resourceToPathFun));
+
+        return promises.resolve(commaSeparated);
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectNameProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectNameProvider.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+
+import java.util.List;
+
+/**
+ * Provider which is responsible for retrieving the resource's project name from the project explorer.
+ * <p>
+ * Macro provided: <code>${explorer.current.project.name}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @see ProjectExplorerPresenter
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ExplorerCurrentProjectNameProvider implements CommandPropertyValueProvider {
+
+    public static final String KEY = "${explorer.current.project.name}";
+
+    private ProjectExplorerPresenter projectExplorer;
+    private PromiseProvider          promises;
+
+    @Inject
+    public ExplorerCurrentProjectNameProvider(ProjectExplorerPresenter projectExplorer,
+                                              PromiseProvider promises) {
+        this.projectExplorer = projectExplorer;
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+
+        List<Node> selectedNodes = projectExplorer.getTree().getSelectionModel().getSelectedNodes();
+
+        if (selectedNodes.isEmpty() || selectedNodes.size() > 1) {
+            return promises.resolve("");
+        }
+
+        final Node node = selectedNodes.get(0);
+
+        if (node instanceof ResourceNode) {
+            final Optional<Project> project = ((ResourceNode)node).getData().getRelatedProject();
+
+            if (!project.isPresent()) {
+                return promises.resolve("");
+            }
+
+            return promises.resolve(project.get().getName());
+        }
+
+        return promises.resolve("");
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectTypeProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectTypeProvider.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+
+import java.util.List;
+
+/**
+ * Provider which is responsible for retrieving the resource's project type from the project explorer.
+ * <p>
+ * Macro provided: <code>${explorer.current.project.type}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @see ProjectExplorerPresenter
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class ExplorerCurrentProjectTypeProvider implements CommandPropertyValueProvider {
+
+    public static final String KEY = "${explorer.current.project.type}";
+
+    private ProjectExplorerPresenter projectExplorer;
+    private PromiseProvider          promises;
+
+    @Inject
+    public ExplorerCurrentProjectTypeProvider(ProjectExplorerPresenter projectExplorer,
+                                              PromiseProvider promises) {
+        this.projectExplorer = projectExplorer;
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+
+        List<Node> selectedNodes = projectExplorer.getTree().getSelectionModel().getSelectedNodes();
+
+        if (selectedNodes.isEmpty() || selectedNodes.size() > 1) {
+            return promises.resolve("");
+        }
+
+        final Node node = selectedNodes.get(0);
+
+        if (node instanceof ResourceNode) {
+            final Optional<Project> project = ((ResourceNode)node).getData().getRelatedProject();
+
+            if (!project.isPresent()) {
+                return promises.resolve("");
+            }
+
+            return promises.resolve(project.get().getType());
+        }
+
+        return promises.resolve("");
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/macro/WorkspaceNameMacroProvider.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/macro/WorkspaceNameMacroProvider.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.workspace.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+
+/**
+ * Provider which is responsible for retrieving the workspace name.
+ *
+ * Macro provided: <code>${workspace.name}</code>
+ *
+ * @author Vlad Zhukovskyi
+ * @see CommandPropertyValueProvider
+ * @since 4.7.0
+ */
+@Beta
+@Singleton
+public class WorkspaceNameMacroProvider implements CommandPropertyValueProvider {
+
+    public static final String KEY = "${workspace.name}";
+
+    private final AppContext      appContext;
+    private final PromiseProvider promises;
+
+    @Inject
+    public WorkspaceNameMacroProvider(AppContext appContext, PromiseProvider promises) {
+        this.appContext = appContext;
+        this.promises = promises;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Promise<String> getValue() {
+        return promises.resolve(appContext.getWorkspaceName());
+    }
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/AbstractEditorMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/AbstractEditorMacroProviderTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import com.google.common.base.Optional;
+
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorInput;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.resource.Path;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vlad Zhukovskyi
+ */
+public abstract class AbstractEditorMacroProviderTest {
+
+    public static final String FILE_NAME     = "name";
+    public static final String FILE_PATH     = "/project/name";
+    public static final String PROJECTS_ROOT = "/projects";
+    public static final String PROJECT_NAME  = "project-name";
+    public static final String PROJECT_TYPE  = "type";
+
+    @Mock
+    protected EditorAgent editorAgent;
+
+    @Mock
+    protected PromiseProvider promiseProvider;
+
+    @Mock
+    protected EditorPartPresenter activeEditor;
+
+    @Mock
+    protected File activeFile;
+
+    @Mock
+    protected EditorInput activeEditorInput;
+
+    @Mock
+    protected AppContext appContext;
+
+    @Mock
+    protected Project project;
+
+    protected abstract AbstractEditorMacroProvider getProvider();
+
+    protected void initEditorWithTestFile() {
+        when(editorAgent.getActiveEditor()).thenReturn(activeEditor);
+        when(activeEditor.getEditorInput()).thenReturn(activeEditorInput);
+        when(activeEditorInput.getFile()).thenReturn(activeFile);
+        when(activeFile.getName()).thenReturn(FILE_NAME);
+        when(activeFile.getLocation()).thenReturn(Path.valueOf(FILE_PATH));
+        when(appContext.getProjectsRoot()).thenReturn(Path.valueOf(PROJECTS_ROOT));
+        when(activeFile.getRelatedProject()).thenReturn(Optional.of(project));
+        when(project.getName()).thenReturn(PROJECT_NAME);
+        when(project.getType()).thenReturn(PROJECT_TYPE);
+    }
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileNameProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileNameProviderTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link EditorCurrentFileNameProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EditorCurrentFileNameProviderTest extends AbstractEditorMacroProviderTest {
+
+    private EditorCurrentFileNameProvider provider;
+
+    @Override
+    protected AbstractEditorMacroProvider getProvider() {
+        return provider;
+    }
+
+    @Before
+    public void init() throws Exception {
+        provider = new EditorCurrentFileNameProvider(editorAgent, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), EditorCurrentFileNameProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initEditorWithTestFile();
+
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(FILE_NAME));
+    }
+
+    @Test
+    public void getEmptyValue() throws Exception {
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentFilePathProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentFilePathProviderTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import org.eclipse.che.ide.resource.Path;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link EditorCurrentFilePathProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EditorCurrentFilePathProviderTest extends AbstractEditorMacroProviderTest {
+
+    private EditorCurrentFilePathProvider provider;
+
+    @Override
+    protected AbstractEditorMacroProvider getProvider() {
+        return provider;
+    }
+
+    @Before
+    public void init() throws Exception {
+        provider = new EditorCurrentFilePathProvider(editorAgent, promiseProvider, appContext);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), EditorCurrentFilePathProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initEditorWithTestFile();
+
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(Path.valueOf(PROJECTS_ROOT).append(FILE_PATH).toString()));
+    }
+
+    @Test
+    public void getEmptyValue() throws Exception {
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileRelativePathProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentFileRelativePathProviderTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link EditorCurrentFileRelativePathProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EditorCurrentFileRelativePathProviderTest extends AbstractEditorMacroProviderTest {
+
+    private EditorCurrentFileRelativePathProvider provider;
+
+    @Override
+    protected AbstractEditorMacroProvider getProvider() {
+        return provider;
+    }
+
+    @Before
+    public void init() throws Exception {
+        provider = new EditorCurrentFileRelativePathProvider(editorAgent, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), EditorCurrentFileRelativePathProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initEditorWithTestFile();
+
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(FILE_PATH));
+    }
+
+    @Test
+    public void getEmptyValue() throws Exception {
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectNameProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectNameProviderTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link EditorCurrentProjectNameProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EditorCurrentProjectNameProviderTest extends AbstractEditorMacroProviderTest {
+
+    private EditorCurrentProjectNameProvider provider;
+
+    @Override
+    protected AbstractEditorMacroProvider getProvider() {
+        return provider;
+    }
+
+    @Before
+    public void init() throws Exception {
+        provider = new EditorCurrentProjectNameProvider(editorAgent, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), EditorCurrentProjectNameProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initEditorWithTestFile();
+
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(PROJECT_NAME));
+    }
+
+    @Test
+    public void getEmptyValue() throws Exception {
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectTypeProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/macro/EditorCurrentProjectTypeProviderTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.macro;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link EditorCurrentProjectTypeProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EditorCurrentProjectTypeProviderTest extends AbstractEditorMacroProviderTest {
+
+    private EditorCurrentProjectTypeProvider provider;
+
+    @Override
+    protected AbstractEditorMacroProvider getProvider() {
+        return provider;
+    }
+
+    @Before
+    public void init() throws Exception {
+        provider = new EditorCurrentProjectTypeProvider(editorAgent, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), EditorCurrentProjectTypeProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initEditorWithTestFile();
+
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(PROJECT_TYPE));
+    }
+
+    @Test
+    public void getEmptyValue() throws Exception {
+        provider.getValue();
+
+        verify(editorAgent).getActiveEditor();
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/CustomCommandPropertyValueProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/CustomCommandPropertyValueProviderTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the {@link CustomCommandPropertyValueProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class CustomCommandPropertyValueProviderTest {
+
+    public static final String KEY   = "key";
+    public static final String VALUE = "value";
+
+    private CustomCommandPropertyValueProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        provider = new CustomCommandPropertyValueProvider(KEY, VALUE);
+    }
+
+    @Test
+    public void getKey() throws Exception {
+        assertSame(provider.getKey(), KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        provider.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String value) throws OperationException {
+                assertSame(value, VALUE);
+            }
+        });
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerHostNameMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerHostNameMacroProviderTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.machine.shared.Constants;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link ServerHostNameMacroProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ServerHostNameMacroProviderTest {
+
+    public static final String WS_AGENT_PORT = Constants.WS_AGENT_PORT; // 4401/tcp
+    public static final String PORT          = "1234";
+    public static final String ADDRESS       = "127.0.0.1" + ":" + PORT;
+    public static final String PROTOCOL      = "protocol";
+    public static final String REF           = "ref";
+
+    @Mock
+    private CommandPropertyValueProviderRegistry commandPropertyValueProviderRegistry;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private AppContext appContext;
+
+    @Mock
+    private DevMachine devMachine;
+
+    @Mock
+    private Machine machine;
+
+    @Mock
+    private MachineRuntimeInfo machineRuntimeInfo;
+
+    @Mock
+    private Server server;
+
+    private ServerHostNameMacroProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        provider = new ServerHostNameMacroProvider(commandPropertyValueProviderRegistry, eventBus, appContext);
+
+        registerProvider();
+    }
+
+    @Test
+    public void getMacroProviders() throws Exception {
+        final Set<CommandPropertyValueProvider> providers = provider.getMacroProviders(devMachine);
+
+        assertEquals(providers.size(), 2);
+
+        final Iterator<CommandPropertyValueProvider> iterator = providers.iterator();
+
+        final CommandPropertyValueProvider provider1 = iterator.next();
+
+        assertTrue(provider1 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider1.getKey(), ServerHostNameMacroProvider.KEY.replace("%", WS_AGENT_PORT.substring(0, WS_AGENT_PORT.length() - 4)));
+
+        provider1.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, PROTOCOL);
+            }
+        });
+
+        final CommandPropertyValueProvider provider2 = iterator.next();
+
+        assertTrue(provider2 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider2.getKey(), ServerHostNameMacroProvider.KEY.replace("%", WS_AGENT_PORT));
+
+        provider2.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, PROTOCOL);
+            }
+        });
+    }
+
+    protected void registerProvider() {
+        when(devMachine.getDescriptor()).thenReturn(machine);
+        when(machine.getRuntime()).thenReturn(machineRuntimeInfo);
+        doReturn(Collections.<String, Server>singletonMap(WS_AGENT_PORT, server)).when(machineRuntimeInfo).getServers();
+        when(server.getAddress()).thenReturn(ADDRESS);
+        when(server.getProtocol()).thenReturn(PROTOCOL);
+        when(server.getRef()).thenReturn(REF);
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerMacroProviderTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.apache.commons.collections.map.HashedMap;
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.machine.shared.Constants;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.machine.DevMachineServer;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link ServerMacroProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ServerMacroProviderTest {
+
+    public static final String WS_AGENT_PORT = Constants.WS_AGENT_PORT; // 4401/tcp
+    public static final String ADDRESS       = "127.0.0.1";
+
+    @Mock
+    private CommandPropertyValueProviderRegistry commandPropertyValueProviderRegistry;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private AppContext appContext;
+
+    @Mock
+    private DevMachine devMachine;
+
+    @Mock
+    private Machine machine;
+
+    @Mock
+    private MachineRuntimeInfo machineRuntimeInfo;
+
+    @Mock
+    private Server server;
+
+    private ServerMacroProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        provider = new ServerMacroProvider(commandPropertyValueProviderRegistry, eventBus, appContext);
+
+        registerProvider();
+    }
+
+    @Test
+    public void getMacroProviders() throws Exception {
+        final Set<CommandPropertyValueProvider> providers = provider.getMacroProviders(devMachine);
+
+        assertEquals(providers.size(), 2);
+
+        final Iterator<CommandPropertyValueProvider> iterator = providers.iterator();
+
+        final CommandPropertyValueProvider provider1 = iterator.next();
+
+        assertTrue(provider1 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider1.getKey(), ServerMacroProvider.KEY.replace("%", WS_AGENT_PORT.substring(0, WS_AGENT_PORT.length() - 4)));
+
+        provider1.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, ADDRESS);
+            }
+        });
+
+        final CommandPropertyValueProvider provider2 = iterator.next();
+
+        assertTrue(provider2 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider2.getKey(), ServerMacroProvider.KEY.replace("%", WS_AGENT_PORT));
+
+        provider2.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, ADDRESS);
+            }
+        });
+    }
+
+    protected void registerProvider() {
+        when(devMachine.getDescriptor()).thenReturn(machine);
+        when(machine.getRuntime()).thenReturn(machineRuntimeInfo);
+        doReturn(Collections.<String, Server>singletonMap(WS_AGENT_PORT, server)).when(machineRuntimeInfo).getServers();
+        when(server.getAddress()).thenReturn(ADDRESS);
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerPortMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerPortMacroProviderTest.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.machine.shared.Constants;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link ServerPortMacroProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ServerPortMacroProviderTest {
+
+    public static final String WS_AGENT_PORT = Constants.WS_AGENT_PORT; // 4401/tcp
+    public static final String PORT          = "1234";
+    public static final String ADDRESS       = "127.0.0.1" + ":" + PORT;
+
+    @Mock
+    private CommandPropertyValueProviderRegistry commandPropertyValueProviderRegistry;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private AppContext appContext;
+
+    @Mock
+    private DevMachine devMachine;
+
+    @Mock
+    private Machine machine;
+
+    @Mock
+    private MachineRuntimeInfo machineRuntimeInfo;
+
+    @Mock
+    private Server server;
+
+    private ServerPortMacroProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        provider = new ServerPortMacroProvider(commandPropertyValueProviderRegistry, eventBus, appContext);
+
+        registerProvider();
+    }
+
+    @Test
+    public void getMacroProviders() throws Exception {
+        final Set<CommandPropertyValueProvider> providers = provider.getMacroProviders(devMachine);
+
+        assertEquals(providers.size(), 2);
+
+        final Iterator<CommandPropertyValueProvider> iterator = providers.iterator();
+
+        final CommandPropertyValueProvider provider1 = iterator.next();
+
+        assertTrue(provider1 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider1.getKey(), ServerPortMacroProvider.KEY.replace("%", WS_AGENT_PORT.substring(0, WS_AGENT_PORT.length() - 4)));
+
+        provider1.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, PORT);
+            }
+        });
+
+        final CommandPropertyValueProvider provider2 = iterator.next();
+
+        assertTrue(provider2 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider2.getKey(), ServerPortMacroProvider.KEY.replace("%", WS_AGENT_PORT));
+
+        provider2.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, PORT);
+            }
+        });
+    }
+
+    protected void registerProvider() {
+        when(devMachine.getDescriptor()).thenReturn(machine);
+        when(machine.getRuntime()).thenReturn(machineRuntimeInfo);
+        doReturn(Collections.<String, Server>singletonMap(WS_AGENT_PORT, server)).when(machineRuntimeInfo).getServers();
+        when(server.getAddress()).thenReturn(ADDRESS);
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerProtocolMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/machine/macro/ServerProtocolMacroProviderTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.machine.macro;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.machine.shared.Constants;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProvider;
+import org.eclipse.che.ide.api.machine.CommandPropertyValueProviderRegistry;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.machine.CustomCommandPropertyValueProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link ServerProtocolMacroProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ServerProtocolMacroProviderTest {
+
+    public static final String WS_AGENT_PORT = Constants.WS_AGENT_PORT; // 4401/tcp
+    public static final String PORT          = "1234";
+    public static final String ADDRESS       = "127.0.0.1" + ":" + PORT;
+    public static final String PROTOCOL      = "protocol";
+
+    @Mock
+    private CommandPropertyValueProviderRegistry commandPropertyValueProviderRegistry;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private AppContext appContext;
+
+    @Mock
+    private DevMachine devMachine;
+
+    @Mock
+    private Machine machine;
+
+    @Mock
+    private MachineRuntimeInfo machineRuntimeInfo;
+
+    @Mock
+    private Server server;
+
+    private ServerProtocolMacroProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        provider = new ServerProtocolMacroProvider(commandPropertyValueProviderRegistry, eventBus, appContext);
+
+        registerProvider();
+    }
+
+    @Test
+    public void getMacroProviders() throws Exception {
+        final Set<CommandPropertyValueProvider> providers = provider.getMacroProviders(devMachine);
+
+        assertEquals(providers.size(), 2);
+
+        final Iterator<CommandPropertyValueProvider> iterator = providers.iterator();
+
+        final CommandPropertyValueProvider provider1 = iterator.next();
+
+        assertTrue(provider1 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider1.getKey(), ServerProtocolMacroProvider.KEY.replace("%", WS_AGENT_PORT));
+
+        provider1.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, PROTOCOL);
+            }
+        });
+
+        final CommandPropertyValueProvider provider2 = iterator.next();
+
+        assertTrue(provider2 instanceof CustomCommandPropertyValueProvider);
+        assertEquals(provider2.getKey(), ServerProtocolMacroProvider.KEY.replace("%", WS_AGENT_PORT.substring(0, WS_AGENT_PORT.length() - 4)));
+
+        provider2.getValue().then(new Operation<String>() {
+            @Override
+            public void apply(String address) throws OperationException {
+                assertEquals(address, PROTOCOL);
+            }
+        });
+    }
+
+    protected void registerProvider() {
+        when(devMachine.getDescriptor()).thenReturn(machine);
+        when(machine.getRuntime()).thenReturn(machineRuntimeInfo);
+        doReturn(Collections.<String, Server>singletonMap(WS_AGENT_PORT, server)).when(machineRuntimeInfo).getServers();
+        when(server.getAddress()).thenReturn(ADDRESS);
+        when(server.getProtocol()).thenReturn(PROTOCOL);
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/AbstractExplorerMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/AbstractExplorerMacroProviderTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+import org.eclipse.che.ide.ui.smartTree.SelectionModel;
+import org.eclipse.che.ide.ui.smartTree.Tree;
+import org.junit.Before;
+import org.mockito.Mock;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vlad Zhukovskyi
+ */
+public class AbstractExplorerMacroProviderTest {
+
+    public static final String FILE_1_NAME   = "file_1";
+    public static final String FILE_2_NAME   = "file_2";
+    public static final String FILE_1_PATH   = "/project/file_1";
+    public static final String FILE_2_PATH   = "/project/file_2";
+    public static final String PROJECTS_ROOT = "/projects";
+    public static final String PROJECT_NAME  = "project-name";
+    public static final String PROJECT_TYPE  = "type";
+
+    @Mock
+    PromiseProvider promiseProvider;
+
+    @Mock
+    AppContext appContext;
+
+    @Mock
+    ProjectExplorerPresenter projectExplorer;
+
+    @Mock
+    Tree tree;
+
+    @Mock
+    SelectionModel selectionModel;
+
+    @Mock
+    ResourceNode node1;
+
+    @Mock
+    ResourceNode node2;
+
+    @Mock
+    File file1;
+
+    @Mock
+    File file2;
+
+    @Mock
+    Project project;
+
+    @Before
+    public void init() throws Exception {
+        when(projectExplorer.getTree()).thenReturn(tree);
+        when(tree.getSelectionModel()).thenReturn(selectionModel);
+        when(appContext.getProjectsRoot()).thenReturn(Path.valueOf(PROJECTS_ROOT));
+    }
+
+    protected void initWithNoFiles() throws Exception {
+        when(selectionModel.getSelectedNodes()).thenReturn(Collections.<Node>emptyList());
+    }
+
+    protected void initWithOneFile() throws Exception {
+        when(selectionModel.getSelectedNodes()).thenReturn(Lists.<Node>newArrayList(node1));
+        when(node1.getData()).thenReturn(file1);
+        when(file1.getName()).thenReturn(FILE_1_NAME);
+        when(file1.getLocation()).thenReturn(Path.valueOf(FILE_1_PATH));
+        when(file1.getRelatedProject()).thenReturn(Optional.of(project));
+        when(project.getName()).thenReturn(PROJECT_NAME);
+        when(project.getType()).thenReturn(PROJECT_TYPE);
+    }
+
+    protected void initWithTwoFiles() throws Exception {
+        when(selectionModel.getSelectedNodes()).thenReturn(Lists.<Node>newArrayList(node1, node2));
+        when(node1.getData()).thenReturn(file1);
+        when(node2.getData()).thenReturn(file2);
+        when(file1.getName()).thenReturn(FILE_1_NAME);
+        when(file1.getLocation()).thenReturn(Path.valueOf(FILE_1_PATH));
+        when(file1.getRelatedProject()).thenReturn(Optional.of(project));
+        when(project.getName()).thenReturn(PROJECT_NAME);
+        when(project.getType()).thenReturn(PROJECT_TYPE);
+        when(file2.getName()).thenReturn(FILE_2_NAME);
+        when(file2.getLocation()).thenReturn(Path.valueOf(FILE_2_PATH));
+        when(file2.getRelatedProject()).thenReturn(Optional.of(project));
+        when(project.getName()).thenReturn(PROJECT_NAME);
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileNameProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileNameProviderTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.base.Joiner;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link ExplorerCurrentFileNameProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ExplorerCurrentFileNameProviderTest extends AbstractExplorerMacroProviderTest {
+
+    private ExplorerCurrentFileNameProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        super.init();
+        provider = new ExplorerCurrentFileNameProvider(projectExplorer, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), ExplorerCurrentFileNameProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initWithOneFile();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(FILE_1_NAME));
+    }
+
+    @Test
+    public void getMultipleValues() throws Exception {
+        initWithTwoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(Joiner.on(", ").join(FILE_1_NAME, FILE_2_NAME)));
+    }
+
+    @Test
+    public void getEmptyValues() throws Exception {
+        initWithNoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFilePathProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFilePathProviderTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.base.Joiner;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.ide.resource.Path;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link ExplorerCurrentFilePathProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ExplorerCurrentFilePathProviderTest extends AbstractExplorerMacroProviderTest {
+
+    private ExplorerCurrentFilePathProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        super.init();
+        provider = new ExplorerCurrentFilePathProvider(projectExplorer, promiseProvider, appContext);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), ExplorerCurrentFilePathProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initWithOneFile();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(Path.valueOf(PROJECTS_ROOT).append(FILE_1_PATH).toString()));
+    }
+
+    @Test
+    public void getMultipleValues() throws Exception {
+        initWithTwoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(Joiner.on(", ").join(Path.valueOf(PROJECTS_ROOT).append(FILE_1_PATH).toString(),
+                                                                Path.valueOf(PROJECTS_ROOT).append(FILE_2_PATH).toString())));
+    }
+
+    @Test
+    public void getEmptyValues() throws Exception {
+        initWithNoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileRelativePathProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentFileRelativePathProviderTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.common.base.Joiner;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link ExplorerCurrentFileRelativePathProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ExplorerCurrentFileRelativePathProviderTest extends AbstractExplorerMacroProviderTest {
+
+    private ExplorerCurrentFileRelativePathProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        super.init();
+        provider = new ExplorerCurrentFileRelativePathProvider(projectExplorer, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), ExplorerCurrentFileRelativePathProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initWithOneFile();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(FILE_1_PATH));
+    }
+
+    @Test
+    public void getMultipleValues() throws Exception {
+        initWithTwoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(Joiner.on(", ").join(FILE_1_PATH, FILE_2_PATH)));
+    }
+
+    @Test
+    public void getEmptyValues() throws Exception {
+        initWithNoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectNameProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectNameProviderTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link ExplorerCurrentProjectNameProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ExplorerCurrentProjectNameProviderTest extends AbstractExplorerMacroProviderTest {
+
+    private ExplorerCurrentProjectNameProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        super.init();
+        provider = new ExplorerCurrentProjectNameProvider(projectExplorer, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), ExplorerCurrentProjectNameProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initWithOneFile();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(PROJECT_NAME));
+    }
+
+    @Test
+    public void getMultipleValues() throws Exception {
+        initWithTwoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+    @Test
+    public void getEmptyValues() throws Exception {
+        initWithNoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectTypeProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/explorer/project/macro/ExplorerCurrentProjectTypeProviderTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.explorer.project.macro;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the {@link ExplorerCurrentProjectTypeProvider}
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class ExplorerCurrentProjectTypeProviderTest extends AbstractExplorerMacroProviderTest {
+
+    private ExplorerCurrentProjectTypeProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        super.init();
+        provider = new ExplorerCurrentProjectTypeProvider(projectExplorer, promiseProvider);
+    }
+
+    @Test
+    public void testGetKey() throws Exception {
+        assertSame(provider.getKey(), ExplorerCurrentProjectTypeProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        initWithOneFile();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(PROJECT_TYPE));
+    }
+
+    @Test
+    public void getMultipleValues() throws Exception {
+        initWithTwoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+    @Test
+    public void getEmptyValues() throws Exception {
+        initWithNoFiles();
+
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(""));
+    }
+
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/macro/WorkspaceNameMacroProviderTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/macro/WorkspaceNameMacroProviderTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.workspace.macro;
+
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link WorkspaceNameMacroProvider}.
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WorkspaceNameMacroProviderTest {
+
+    public static final String WS_NAME = "workspace";
+
+    @Mock
+    AppContext appContext;
+
+    @Mock
+    PromiseProvider promiseProvider;
+
+    private WorkspaceNameMacroProvider provider;
+
+    @Before
+    public void init() throws Exception {
+        when(appContext.getWorkspaceName()).thenReturn(WS_NAME);
+
+        provider = new WorkspaceNameMacroProvider(appContext, promiseProvider);
+    }
+
+    @Test
+    public void getKey() throws Exception {
+        assertSame(provider.getKey(), WorkspaceNameMacroProvider.KEY);
+    }
+
+    @Test
+    public void getValue() throws Exception {
+        provider.getValue();
+
+        verify(promiseProvider).resolve(eq(WS_NAME));
+    }
+
+}


### PR DESCRIPTION
This PR extends existed list of macros, by adding new ones.

Related issue: https://github.com/eclipse/che/issues/953

Created new macros to provide various information from basic part.

It includes:

```
${editor.current.file.name} -- Currently selected file in editor with context
${editor.current.file.path}  -- Absolute path to the selected file in editor with context
${editor.current.file.relpath} -- Path relative to the /projects folder in editor with context
${editor.current.project.name} -- Project name of the file currently selected in editor with context
${editor.current.project.type} -- Project type of the file currently selected in editor with context
${explorer.current.file.name} -- Currently selected file in project tree
${explorer.current.file.path}  -- Absolute path to the selected file in project tree
${explorer.current.file.relpath} -- Path relative to the /projects folder in project tree
${explorer.current.project.name} -- Project name of the file currently selected in explorer
${explorer.current.project.type} -- Project type of the file currently selected in explorer
${server.<name>} -- Returns protocol, hostname and port of an internal server
${server.<name>.protocol} -- Returns protocol of a server registered by name
${server.<name>.hostname} -- Returns hostname of a server registered by name
${server.<name>.port} -- Returns port of a server registered by name
${workspace.name} -- Returns the name of the workspace
```

@vparfonov @ashumilova @azatsarynnyy review it, please.
