### PR TITLE
Deactivation of che-long-touch behaviour in navbar

### DIFF
--- a/dashboard/src/app/navbar/navbar.html
+++ b/dashboard/src/app/navbar/navbar.html
@@ -23,7 +23,7 @@
         <section class="left-sidebar-menu" layout="column" layout-align="center center">
           <md-list layout="column">
             <md-list-item flex class="navbar-subsection-item">
-              <md-button nav-bar-selected flex che-reload-href che-on-long-touch="navbarCtrl.openLinkInNewTab('{{navbarCtrl.menuItemUrl.dashboard}}')" ng-href="{{navbarCtrl.menuItemUrl.dashboard}}" layout-align="left"
+              <md-button nav-bar-selected flex che-reload-href ng-href="{{navbarCtrl.menuItemUrl.dashboard}}" layout-align="left"
                          target="_self">
                 <div class="navbar-item" layout="row" layout-align="start center">
                   <md-icon md-font-icon="navbar-icon chefont cheico-dashboard" aria-label="Dashboard"></md-icon>
@@ -33,7 +33,6 @@
             </md-list-item>
             <md-list-item flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href
-                         che-on-long-touch="navbarCtrl.openLinkInNewTab('{{navbarCtrl.menuItemUrl.workspaces}}')"
                          ng-href="{{navbarCtrl.menuItemUrl.workspaces}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center">
                   <md-icon md-font-icon="navbar-icon chefont cheico-workspace"></md-icon>
@@ -44,7 +43,6 @@
             </md-list-item>
             <md-list-item flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href
-                         che-on-long-touch="navbarCtrl.openLinkInNewTab('{{navbarCtrl.menuItemUrl.administration}}')"
                          ng-href="{{navbarCtrl.menuItemUrl.administration}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center">
                   <md-icon md-font-icon="navbar-icon material-design icon-ic_settings_24px"></md-icon>

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.html
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.html
@@ -26,7 +26,6 @@
                               navbar-dropdown-external-class="recent-workspaces-menu"
                               navbar-dropdown-offset="30 22">
           <md-button nav-bar-selected flex che-reload-href
-                     che-on-long-touch="navbarRecentWorkspacesController.openLinkInNewTab(workspace.id)"
                      ng-href="{{navbarRecentWorkspacesController.getIdeLink(workspace.id)}}" layout-align="left"
                      target="_self">
             <div class="navbar-item" layout="row" layout-align="start center">


### PR DESCRIPTION
### What does this PR do?

Remove the long-click/long-touch behaviour from the left navbar. 
### Previous behavior

Possible to open an item from the left navbar in a new tab by doing a long-click or long-touch on it.
### New behavior

This behaviour is removed. 
### PR type
- [ ] Minor change = no change to existing features or docs
