### PR TITLE
Enable syntax highlighting for *.phtml files

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
@@ -123,6 +123,7 @@ public class ExtensionFileTypeIdentifier implements FileTypeIdentifier {
         this.mappings.put("pm", makeList("text/x-perl"));// perl module
 
         this.mappings.put("php", makeList("text/x-php"));
+        this.mappings.put("phtml", makeList("text/x-php"));
         this.mappings.put("ejs", makeList("application/x-ejs"));
         this.mappings.put("jsp", makeList("application/x-jsp"));
         this.mappings.put("asp", makeList("application/x-aspx"));


### PR DESCRIPTION
### What does this PR do?

This pull requests enables syntax highlighting for *.phtml files in the same way like it's for *.php files.
### What issues does this PR fix or reference?
1. Open phtml file e.g. https://raw.githubusercontent.com/kaloyan-raev/AstroSplash/master/templates/app/index.phtml
2. No highlighting
### Previous behavior

No syntax highlighting for phtml files.
### New behavior

Syntax highlighting for phtml files is working.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Signed-off-by: Michal Niewrzal michal.n@zend.com
