### PR TITLE
Allow mounting of multiple volumes to mount properties

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -74,6 +74,7 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -185,6 +186,11 @@ public class DockerInstanceProvider implements InstanceProvider {
 
         allMachinesSystemVolumes = removeEmptyAndNullValues(allMachinesSystemVolumes);
         devMachineSystemVolumes = removeEmptyAndNullValues(devMachineSystemVolumes);
+
+        Set<String> volumes = new HashSet<>();
+        devMachineSystemVolumes.forEach((volume) -> Arrays.asList(volume.split(";")).stream().forEach((entry) -> volumes.add(entry)));
+        devMachineSystemVolumes = volumes;
+
         if (SystemInfo.isWindows()) {
             allMachinesSystemVolumes = escapePaths(allMachinesSystemVolumes);
             devMachineSystemVolumes = escapePaths(devMachineSystemVolumes);


### PR DESCRIPTION
### What does this PR do?

allow to specify multiples volumes to mount for all mount properties
including`che.properties` `machine.server.extra.volume` property
### New behavior

Volumes names can be separated by semi colon character ;
machine.server.extra.volume=/tmp/foo:/tmp/foo;/tmp/dummy:/tmp.dummy
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist
- [ ] New API required? no
- [ ] API updated
- [x] Tests provided / updated
- [x] Tests passed

Change-Id: Ic029b47511f784d41e906e0c2b570869466f605e
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
