### PR TITLE
#1287 PHP Language Server

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerAgentsApplier.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerAgentsApplier.java
@@ -62,6 +62,7 @@ public class DockerAgentsApplier {
         }
 
         apply(machine, AgentKeyImpl.of("org.eclipse.che.ls.json"), agentsCompleted, agentsInProgress);
+        apply(machine, AgentKeyImpl.of("org.eclipse.che.ls.php"), agentsCompleted, agentsInProgress);
         apply(machine, AgentKeyImpl.of("org.eclipse.che.ls.csharp"), agentsCompleted, agentsInProgress);
     }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-server/src/main/java/org/eclipse/che/plugin/languageserver/server/LanguageServerModule.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-server/src/main/java/org/eclipse/che/plugin/languageserver/server/LanguageServerModule.java
@@ -17,6 +17,7 @@ import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.plugin.languageserver.server.launcher.CSharpLanguageServerLauncher;
 import org.eclipse.che.plugin.languageserver.server.launcher.JsonLanguageServerLauncher;
 import org.eclipse.che.plugin.languageserver.server.launcher.LanguageServerLauncher;
+import org.eclipse.che.plugin.languageserver.server.launcher.PhpLanguageServerLauncher;
 import org.eclipse.che.plugin.languageserver.server.messager.InitializeEventMessenger;
 import org.eclipse.che.plugin.languageserver.server.messager.PublishDiagnosticsParamsMessenger;
 import org.eclipse.che.plugin.languageserver.server.registry.LanguageServerRegistry;
@@ -33,6 +34,7 @@ public class LanguageServerModule extends AbstractModule {
     @Override
     protected void configure() {
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(JsonLanguageServerLauncher.class);
+        Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(PhpLanguageServerLauncher.class);
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(CSharpLanguageServerLauncher.class);
 
         bind(LanguageServerRegistry.class).to(LanguageServerRegistryImpl.class);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-server/src/main/java/org/eclipse/che/plugin/languageserver/server/launcher/PhpLanguageServerLauncher.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-server/src/main/java/org/eclipse/che/plugin/languageserver/server/launcher/PhpLanguageServerLauncher.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.languageserver.server.launcher;
+
+import io.typefox.lsapi.LanguageDescription;
+import io.typefox.lsapi.impl.LanguageDescriptionImpl;
+import io.typefox.lsapi.services.json.JsonBasedLanguageServer;
+
+import com.google.inject.Singleton;
+
+import org.eclipse.che.plugin.languageserver.server.exception.LanguageServerException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.util.Arrays.asList;
+
+/**
+ * @author Evgen Vidolob
+ * @author Anatolii Bazko
+ * @author Kaloyan Raev
+ */
+@Singleton
+public class PhpLanguageServerLauncher extends LanguageServerLauncherTemplate {
+
+    public static final String   LANGUAGE_ID = "php";
+    public static final String[] EXTENSIONS  = new String[] {"php"};
+    public static final String[] MIME_TYPES  = new String[] {"text/x-php"};
+
+    private static final LanguageDescriptionImpl description;
+
+    static {
+        description = new LanguageDescriptionImpl();
+        description.setFileExtensions(asList(EXTENSIONS));
+        description.setLanguageId(LANGUAGE_ID);
+        description.setMimeTypes(asList(MIME_TYPES));
+    }
+
+    @Override
+    public LanguageDescription getLanguageDescription() {
+        return description;
+    }
+
+    protected JsonBasedLanguageServer connectToLanguageServer(Process languageServerProcess) {
+        JsonBasedLanguageServer languageServer = new JsonBasedLanguageServer();
+        languageServer.connect(languageServerProcess.getInputStream(), languageServerProcess.getOutputStream());
+        return languageServer;
+    }
+
+    protected Process startLanguageServerProcess(String projectPath) throws LanguageServerException {
+        Path launchFile = Paths.get(System.getenv("HOME"), "che-agents/ls-php/launch.sh");
+
+        ProcessBuilder processBuilder = new ProcessBuilder(launchFile.toString());
+        processBuilder.redirectInput(ProcessBuilder.Redirect.PIPE);
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        try {
+            return processBuilder.start();
+        } catch (IOException e) {
+            throw new LanguageServerException("Can't start PHP language server", e);
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Registers a language server for the PHP editor.

The PHP Crane project is used for the language server: https://github.com/HvyIndustries/crane

The remote agent registry on https://codenvy.com/update/repository/ must be updated in the following way:
1. The attached `agent.json` file must be served on https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.php
Attachment: [agent.json.zip](https://github.com/eclipse/che/files/447227/agent.json.zip)
2. The attached `vscode-crane-server.tar.gz` file must be served on https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.php.binaries
Attachment: [vscode-crane-server.tar.gz](https://github.com/eclipse/che/files/447230/vscode-crane-server.tar.gz)
### What issues does this PR fix or reference?

This PR is in relation to #1287.
### New behavior

Language server capabilities for PHP.
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [ ] Tests passed

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
