### PR TITLE
Register macro to provide workspace name

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
@@ -283,6 +283,7 @@ import org.eclipse.che.ide.workspace.WorkspaceViewImpl;
 import org.eclipse.che.ide.workspace.WorkspaceWidgetFactory;
 import org.eclipse.che.ide.workspace.create.recipewidget.RecipeWidget;
 import org.eclipse.che.ide.workspace.create.recipewidget.RecipeWidgetImpl;
+import org.eclipse.che.ide.workspace.macro.WorkspaceNameMacroProvider;
 import org.eclipse.che.ide.workspace.perspectives.general.PerspectiveViewImpl;
 import org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective;
 import org.eclipse.che.ide.workspace.start.workspacewidget.WorkspaceWidget;
@@ -491,6 +492,7 @@ public class CoreGinModule extends AbstractGinModule {
         macroProviders.addBinding().to(ExplorerCurrentFileRelativePathProvider.class);
         macroProviders.addBinding().to(ExplorerCurrentProjectNameProvider.class);
         macroProviders.addBinding().to(ExplorerCurrentProjectTypeProvider.class);
+        macroProviders.addBinding().to(WorkspaceNameMacroProvider.class);
     }
 
     /** Configure Core UI components, resources and views */


### PR DESCRIPTION
### What does this PR do?

Registers macro provider for workspace name.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2293
### New behavior

Macro provides workspace name for using in commands.

Macro: `${workspace.name}`

@vparfonov @ashumilova  review it, plz.
