### PR TITLE
Add Bitnami stacks and blank project for use with the generators

### DIFF
--- a/ide/che-core-ide-stacks/pom.xml
+++ b/ide/che-core-ide-stacks/pom.xml
@@ -22,5 +22,18 @@
     <artifactId>che-core-ide-stacks</artifactId>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: STACKS</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/type-bitnami.svg</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 

--- a/ide/che-core-ide-stacks/src/main/resources/images/type-bitnami.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/images/type-bitnami.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2016 Bitrock Inc. All rights reserved.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   enable-background="new"
+   viewBox="0 0 512 512"
+   height="512"
+   width="512"
+   xml:space="preserve"
+   id="svg2"
+   version="1.1"><title
+     id="title1">Bitnami</title><metadata
+     id="metadata1"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title>Bitnami</dc:title><dc:creator><cc:Agent><dc:title>Bitnami</dc:title></cc:Agent></dc:creator><dc:contributor><cc:Agent><dc:title>Alvaro Manuel Recio Perez</dc:title></cc:Agent></dc:contributor><cc:license
+           rdf:resource="http://www.eclipse.org/legal/epl-v10.html" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs1" /><path
+     id="bitnami"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.46938807;image-rendering:auto"
+     d="m 311.70134,223.54007 0,64.31696 -27.84598,16.0803 -27.84973,16.07654 -27.85536,-16.07654 -27.83894,-16.0803 0,-64.31696 27.83894,-16.07466 27.85536,-16.0803 27.84973,16.0803 27.84598,16.07466 M 281.7065,6.9611347 C 340.76866,41.062177 399.8327,75.16228 458.89674,109.26238 c 16.72899,9.6572 25.61826,25.53049 25.61826,45.80571 0,67.84113 0,135.67333 0,203.50929 0,19.23553 -8.70762,34.36578 -25.22069,43.89483 -58.95561,34.04002 -117.92248,68.08516 -176.88232,102.12499 -17.16552,9.90847 -35.74108,9.86631 -53.00376,-0.1027 C 170.58405,470.53906 111.76972,436.57278 52.95296,402.61725 38.977682,394.54565 27.484997,378.30811 27.484997,357.79961 c 0,-119.43532 0,-92.32253 0,-211.75785 0,-18.60326 8.77352,-27.99477 25.205763,-37.48158 l 70.66862,-40.80766 c 0,87.95347 0,176.86073 0,264.81748 l 132.64437,76.57456 132.63311,-76.57456 0,-153.1632 -132.63311,-76.57456 -55.75109,32.18782 0,-110.710343 c 10.03692,-5.792249 20.07197,-11.589191 30.10326,-17.3814403 15.65503,-9.040414 34.92529,-9.444087 51.35058,0.03286"><title
+       id="title2">Bitnami</title></path></svg>

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1652,5 +1652,548 @@
         ]
       }
     ]
+  },
+  {
+    "id": "bitnami-express",
+    "creator": "Bitnami",
+    "name": "Bitnami Express",
+    "description": "Default Express stack with Node.js 6.4.0, Express 4.14.0, MongoDB 3.2.7.",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "Node.JS",
+      "NPM",
+      "Express"
+    ],
+    "components": [
+      {
+        "name": "Node.JS",
+        "version": "6.4.0"
+      },
+      {
+        "name": "NPM",
+        "version": "---"
+      },
+      {
+        "name": "Express",
+        "version": "4.14.0"
+      },
+      {
+        "name": "MongoDB",
+        "version": "3.2.7"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-express:che-4.14.0-r1"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-express:che-4.14.0-r1",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "bitnami-swift",
+    "creator": "Bitnami",
+    "name": "Bitnami Swift",
+    "description": "Default Swift stack with Swift 3.0-PREVIEW-6",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "Swift"
+    ],
+    "components": [
+      {
+        "name": "Swift",
+        "version": "3.0-PREVIEW-6"
+      },
+      {
+        "name": "JDK",
+        "version": "1.8.0_91"
+      },
+      {
+        "name": "Python",
+        "version": "2.7.12rc1"
+      },
+      {
+        "name": "CLANG",
+        "version": "---"
+      },
+      {
+        "name": "libxml2",
+        "version": "---"
+      },
+      {
+        "name": "libedit2",
+        "version": "---"
+      },
+      {
+        "name": "libicu52",
+        "version": "---"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-swift:che-3.0-PREVIEW-6-r2"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-swift:che-3.0-PREVIEW-6-r2",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "bitnami-laravel",
+    "creator": "Bitnami",
+    "name": "Bitnami Laravel",
+    "description": "Default Laravel stack with PHP 7.0.10, Laravel 5.2.31, MariaDB 10.1.14.",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "Node.JS",
+      "Laravel",
+      "PHP",
+      "MariaDB"
+    ],
+    "components": [
+      {
+        "name": "PHP",
+        "version": "7.0.10"
+      },
+      {
+        "name": "Laravel",
+        "version": "5.2.31"
+      },
+      {
+        "name": "MariaDB",
+        "version": "10.1.14"
+      },
+      {
+        "name": "Gulp",
+        "version": "---"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-laravel:che-5.2.31-r5"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-laravel:che-5.2.31-r5",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "bitnami-rails",
+    "creator": "Bitnami",
+    "name": "Bitnami Rails",
+    "description": "Bitnami Rails stack with Ruby 2.3.1, Rails 5.0.0.1, MariaDB 10.1.14.",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "BitnamiRails",
+      "MariaDB",
+      "Ruby"
+    ],
+    "components": [
+      {
+        "name": "MariaDb",
+        "version": "10.1.14"
+      },
+      {
+        "name": "Ruby",
+        "version": "2.3.1"
+      },
+      {
+        "name": "Rails",
+        "version": "5.0.0.1"
+      },
+      {
+        "name": "MySQL Client",
+        "version": "10.1.13"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-rails:che-5.0.0.1-r0"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-rails:che-5.0.0.1-r0",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "bitnami-codeigniter",
+    "creator": "Bitnami",
+    "name": "Bitnami Codeigniter",
+    "description": "Default CodeIgniter stack with PHP 7.0.10, CodeIgniter 3.1.0, MariaDB 10.1.14.",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "CodeIgniter",
+      "MariaDB",
+      "PHP"
+    ],
+    "components": [
+      {
+        "name": "PHP",
+        "version": "7.0.10"
+      },
+      {
+        "name": "Codeigniter",
+        "version": "3.1.0"
+      },
+      {
+        "name": "MariaDB",
+        "version": "10.1.14"
+      },
+      {
+        "name": "MySQL Client",
+        "version": "10.1.13"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-codeigniter:che-3.1.0-r2"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-codeigniter:che-3.1.0-r2",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "bitnami-symfony",
+    "creator": "Bitnami",
+    "name": "Bitnami Symfony",
+    "description": "Default Symfony stack with PHP 7.0.10, Symfony 3.1.3, MariaDB 10.1.14.",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "Symfony",
+      "PHP",
+      "MariaDB"
+    ],
+    "components": [
+      {
+        "name": "PHP",
+        "version": "7.0.10"
+      },
+      {
+        "name": "Symfony",
+        "version": "3.1.3"
+      },
+      {
+        "name": "MariaDB",
+        "version": "10.1.14"
+      },
+      {
+        "name": "MySQL Client",
+        "version": "10.1.13"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-symfony:che-3.1.3-r0"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-symfony:che-3.1.3-r0",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "bitnami-java-play",
+    "creator": "Bitnami",
+    "name": "Bitnami Play for Java",
+    "description": "Default Play stack with OpenJDK 1.8.0 and Play 2.55.",
+    "scope": "advanced",
+    "tags": [
+      "Ubuntu",
+      "Activator",
+      "Play",
+      "Java"
+    ],
+    "components": [
+      {
+        "name": "OpenJDK",
+        "version": "1.8.0"
+      },
+      {
+        "name": "Play",
+        "version": "2.55"
+      },
+      {
+        "name": "Node",
+        "version": "6.4.0"
+      },
+      {
+        "name": "Activator",
+        "version": "1.13.10"
+      },
+      {
+        "name": "Git",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "bitnami/che-java-play:che-2.55-r3"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "bitnami/che-java-play:che-2.55-r3",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": []
+    },
+    "acl": [
+      {
+        "user": "*",
+        "actions": [
+          "search"
+        ]
+      }
+    ],
+    "stackIcon": {
+      "name": "type-bitnami.svg",
+      "mediaType": "image/svg+xml"
+    }
   }
 ]

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -931,5 +931,334 @@
     "tags": [
       "TomEE"
     ]
+  },
+  {
+    "name": "express",
+    "displayName": "express",
+    "path": "/express",
+    "description": "A simple application created by the express-generator tool. Execute the '1. Create and run project' command to create the sample project.",
+    "projectType": "node-js",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "node.JS"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create and run project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && npm install express@4.13.4 && express -f . && cp -rn /bitnami/mongodb/conf ${current.project.path} && npm install mongodb@2.1.18 --save && npm install && counter=0; until nc -z localhost 27017; do counter=$((counter+1)); if [ $counter == 10 ]; then echo \"Error: Couldn't connect to MongoDB.\"; exit 1; fi; echo \"Trying to connect to MongoDB at localhost. Attempt $counter.\"; sleep 5; done; echo \"Connected to MongoDB database. Starting application server.\" && npm start",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}"
+        }
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && npm start",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}"
+        }
+      },
+      {
+        "name": "3. Stop",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && pkill -u bitnami node && echo \"Web server stopped.\"",
+        "attributes": {}
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Express"
+    ]
+  },
+  {
+    "name": "swift",
+    "displayName": "swift",
+    "path": "/swift",
+    "description": "A hello world application created by Swift. Execute the '1. Create project' command to create the sample project.",
+    "projectType": "blank",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "swift"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && mkdir ${current.project.path}/app_template && cd ${current.project.path}/app_template && swift-package init --type executable && swift build && echo \"Project built successfully.\"",
+        "attributes": {}
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path}/app_template && swift build && ./.build/debug/app_template",
+        "attributes": {}
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Swift"
+    ]
+  },
+  {
+    "name": "laravel",
+    "displayName": "laravel",
+    "path": "/laravel",
+    "description": "A simple application created by Laravel. Execute the '1. Create and run project' command to create the sample project.",
+    "projectType": "blank",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create and run project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami start mariadb && cp -a /tmp/laravel-sample/. ${current.project.path} && cd ${current.project.path} && composer update && php artisan migrate && php artisan serve --host=0.0.0.0 --port=3000",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}/"
+        }
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && php artisan serve --host=0.0.0.0 --port=3000",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}/"
+        }
+      },
+      {
+        "name": "3. Stop",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && pkill -u bitnami php && echo \"Web server stopped.\"",
+        "attributes": {}
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Laravel"
+    ]
+  },
+  {
+    "name": "rails_app",
+    "displayName": "rails_app",
+    "path": "/rails_app",
+    "description": "A simple application created by Rails. Execute the '1. Create and run project' command to create the sample project.",
+    "projectType": "blank",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "ruby"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create and run project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami start mariadb && cd ${current.project.path} && mv README.md README-CHE.md && rails new . --skip-bundle --database mysql && sed -Ei 's/\\s*#\\s*gem(.*)therubyracer/gem\\1therubyracer/' Gemfile && bundle install && bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0 -p 3000",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}/"
+        }
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && bundle exec rails server -b 0.0.0.0 -p 3000",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}/"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "BitnamiRails"
+    ]
+  },
+  {
+    "name": "codeigniter",
+    "displayName": "codeigniter",
+    "path": "/codeigniter",
+    "description": "A simple application created by Codeigniter. Execute the '1. Create and run project' command to create the sample project.",
+    "projectType": "blank",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create and run project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami execute codeigniter createProject --force codeigniter | grep -v undefined && php -S 0.0.0.0:8000 -t ${current.project.path}",
+        "attributes": {
+           "previewUrl": "http://${server.port.8000}/"
+        }
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && php -S 0.0.0.0:8000 -t ${current.project.path}",
+        "attributes": {
+           "previewUrl": "http://${server.port.8000}/"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "CodeIgniter"
+    ]
+  },
+  {
+    "name": "symfony",
+    "displayName": "symfony",
+    "path": "/symfony",
+    "description": "A simple application created by Symfony. Execute the '1. Create and run project' command to create the sample project.",
+    "projectType": "blank",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create and run project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root nami execute symfony createProject --force symfony | grep -v undefined && ln -fs ${current.project.path}/web/app.php ${current.project.path}/web/index.php && php -S 0.0.0.0:8000 -t ${current.project.path}/web",
+        "attributes": {
+           "previewUrl": "http://${server.port.8000}/"
+        }
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && php -S 0.0.0.0:8000 -t ${current.project.path}/web",
+        "attributes": {
+           "previewUrl": "http://${server.port.8000}/"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Symfony"
+    ]
+  },
+  {
+    "name": "java-play",
+    "displayName": "java-play",
+    "path": "/java-play",
+    "description": "A simple application created by Play. Execute the '1. Create and run project' command to create the sample project.",
+    "projectType": "blank",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "parameters": {
+        "keepVcs": "false"
+      }
+    },
+    "commands": [
+      {
+        "name": "1. Create and run project",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami execute activator createProject --force $(basename ${current.project.path}) play-java | grep -v undefined && cd ${current.project.path} && /opt/bitnami/activator/bin/activator -Dsbt.log.noformat=true -Doffline=true -Dhttp.host=0.0.0.0 -Dhttp.port=9000 ~run",
+        "attributes": {
+           "previewUrl": "http://${server.port.9000}/"
+        }
+      },
+      {
+        "name": "2. Run",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && /opt/bitnami/activator/bin/activator -Doffline=true -Dhttp.host=0.0.0.0 -Dhttp.port=9000 -Dsbt.log.noformat=true ~run",
+        "attributes": {
+           "previewUrl": "http://${server.port.9000}/"
+        }
+      },
+      {
+        "name": "3. Stop",
+        "type": "custom",
+        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && pkill -u bitnami activator && echo \"Web server stopped.\"",
+        "attributes": {}
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Play"
+    ]
   }
 ]


### PR DESCRIPTION
### What does this PR do?

Add several Bitnami Stacks (Express 4.14.0, Swift 3.0-PREVIEW-6, Laravel 5.2.31, Rails 5.0.0.1, CodeIgniter 3.1.0, Symfony 3.1.3, and Play 2.55), and a "blank" sample application intended to be populated by the generators, which can be run as a Che command.
### What issues does this PR fix or reference?

It doesn't reference an issue.
### New behavior

Express stack added to Stack Library. Express sample added to samples.
### PR type
- [X] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [ ] Tests passed
### Major change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Documentation provided (include here or link to docs)
- [ ] Tests provided / updated
- [ ] Tests passed

Signed-off-by: Alvaro Manuel Recio Perez amrecio@gmail.com
