### PR TITLE
Separate CHE_VERSION from CHE_UTILITY_VERSION

### DIFF
--- a/che.sh
+++ b/che.sh
@@ -14,6 +14,15 @@ init_logging() {
   GREEN='\033[0;32m'
   RED='\033[0;31m'
   NC='\033[0m'
+
+  # Turns on stack trace
+  DEFAULT_CHE_CLI_DEBUG="false"
+  CHE_CLI_DEBUG=${CHE_CLI_DEBUG:-${DEFAULT_CHE_CLI_DEBUG}}
+
+  # Activates console output
+  DEFAULT_CHE_CLI_INFO="true"
+  CHE_CLI_INFO=${CHE_CLI_INFO:-${DEFAULT_CHE_CLI_INFO}}
+
 }
 
 error_exit() {
@@ -33,19 +42,12 @@ check_docker() {
 
   # Prep script by getting default image
   if [ "$(docker images -q alpine 2> /dev/null)" = "" ]; then
-    info "ECLIPSE CHE: PULLING IMAGE alpine:latest"
+    info "Pulling image alpine:latest"
     docker pull alpine > /dev/null 2>&1
   fi
 }
 
 init_global_variables() {
-
-  # Turns on stack traces
-  DEFAULT_CHE_CLI_DEBUG="false"
-
-  # Activates console output
-  DEFAULT_CHE_CLI_INFO="true"
-
   # Name used in INFO statements
   DEFAULT_CHE_PRODUCT_NAME="ECLIPSE CHE"
 
@@ -65,9 +67,8 @@ init_global_variables() {
   DEFAULT_CHE_CLI_ACTION="help"
   DEFAULT_IS_INTERACTIVE="true"
   DEFAULT_IS_PSEUDO_TTY="true"
+  DEFAULT_CHE_DATA_FOLDER="/home/user/che"
 
-  CHE_CLI_DEBUG=${CHE_CLI_DEBUG:-${DEFAULT_CHE_CLI_DEBUG}}
-  CHE_CLI_INFO=${CHE_CLI_INFO:-${DEFAULT_CHE_CLI_INFO}}
   CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
   CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
   CHE_LAUNCHER_IMAGE_NAME=${CHE_LAUNCHER_IMAGE_NAME:-${DEFAULT_CHE_LAUNCHER_IMAGE_NAME}}
@@ -83,6 +84,16 @@ init_global_variables() {
   CHE_CLI_ACTION=${CHE_CLI_ACTION:-${DEFAULT_CHE_CLI_ACTION}}
   IS_INTERACTIVE=${IS_INTERACTIVE:-${DEFAULT_IS_INTERACTIVE}}
   IS_PSEUDO_TTY=${IS_PSEUDO_TTY:-${DEFAULT_IS_PSEUDO_TTY}}
+  CHE_DATA_FOLDER=${CHE_DATA_FOLDER:-${DEFAULT_CHE_DATA_FOLDER}}
+
+  # If Windows & boot2docker, then CHE_DATA_FOLDER must be subdirectory of %userprofile%
+#  if [ has_docker_for_windows_client && is_boot2docker ]; then
+
+#    if [[ $CHE_DATA_FOLDER != $USERPROFILE* ]]; then
+ #     echo "nope"
+  #    CHE_DATA_FOLDER="$USERPROFILE"/che
+  #  fi
+ # fi
 
   GLOBAL_NAME_MAP=$(docker info | grep "Name:" | cut -d" " -f2)
   GLOBAL_HOST_ARCH=$(docker version --format {{.Client}} | cut -d" " -f5)
@@ -819,11 +830,11 @@ print_che_cli_debug() {
   info "CHE_UTILITY_VERSION       = ${CHE_UTILITY_VERSION}"
   info "DOCKER_INSTALL_TYPE       = $(get_docker_install_type)"
   info "DOCKER_HOST_IP            = ${GLOBAL_GET_DOCKER_HOST_IP}"
+  info "IS_NATIVE                 = $(is_native && echo "YES" || echo "NO")"
+  info "IS_WINDOWS                = $(has_docker_for_windows_client && echo "YES" || echo "NO")"
   info "IS_DOCKER_FOR_WINDOWS     = $(is_docker_for_windows && echo "YES" || echo "NO")"
   info "IS_DOCKER_FOR_MAC         = $(is_docker_for_mac && echo "YES" || echo "NO")"
   info "IS_BOOT2DOCKER            = $(is_boot2docker && echo "YES" || echo "NO")"
-  info "IS_NATIVE                 = $(is_native && echo "YES" || echo "NO")"
-  info "IS_WINDOWS                = $(has_docker_for_windows_client && echo "YES" || echo "NO")"
   info "HAS_DOCKER_FOR_WINDOWS_IP = $(has_docker_for_windows_ip && echo "YES" || echo "NO")"
   info "IS_MOBY_VM                = $(is_moby_vm && echo "YES" || echo "NO")"
   info "HAS_CHE_ENV_VARIABLES     = $(has_che_env_variables && echo "YES" || echo "NO")"

--- a/che.sh
+++ b/che.sh
@@ -329,7 +329,7 @@ has_docker_for_windows_client(){
 get_full_path() {
   debug $FUNCNAME
   # "/some/path" => /some/path
-  OUTPUT_PATH=${1//\"}
+  #OUTPUT_PATH=${1//\"}
 
   # create full directory path
   echo "$(cd "$(dirname "${OUTPUT_PATH}")"; pwd)/$(basename "$1")"

--- a/che.sh
+++ b/che.sh
@@ -40,8 +40,11 @@ check_docker() {
 
 init_global_variables() {
 
-  # Name used in INFO statements
+  # Turns on stack traces
   DEFAULT_CHE_CLI_DEBUG="false"
+
+  # Activates console output
+  DEFAULT_CHE_CLI_INFO="true"
 
   # Name used in INFO statements
   DEFAULT_CHE_PRODUCT_NAME="ECLIPSE CHE"
@@ -64,6 +67,7 @@ init_global_variables() {
   DEFAULT_IS_PSEUDO_TTY="true"
 
   CHE_CLI_DEBUG=${CHE_CLI_DEBUG:-${DEFAULT_CHE_CLI_DEBUG}}
+  CHE_CLI_INFO=${CHE_CLI_INFO:-${DEFAULT_CHE_CLI_INFO}}
   CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
   CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
   CHE_LAUNCHER_IMAGE_NAME=${CHE_LAUNCHER_IMAGE_NAME:-${DEFAULT_CHE_LAUNCHER_IMAGE_NAME}}
@@ -122,7 +126,9 @@ usage () {
 }
 
 info() {
-  printf  "${GREEN}INFO:${NC} %s\n" "${1}"
+  if is_info; then
+    printf  "${GREEN}INFO:${NC} %s\n" "${1}"
+  fi
 }
 
 debug() {
@@ -133,6 +139,14 @@ debug() {
 
 error() {
   printf  "${RED}ERROR:${NC} %s\n" "${1}"
+}
+
+is_info() {
+  if [ "${CHE_CLI_INFO}" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 is_debug() {
@@ -409,8 +423,10 @@ get_list_of_che_system_environment_variables() {
     echo "CHE_SERVER_CONTAINER_NAME=${CHE_SERVER_CONTAINER_NAME}" >> $DOCKER_ENV
     echo "CHE_SERVER_IMAGE_NAME=${CHE_SERVER_IMAGE_NAME}" >> $DOCKER_ENV
     echo "CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME}" >> $DOCKER_ENV
-    echo "CHE_MINI_PRODUCT_NAME=${CHE_PRODUCT_NAME}" >> $DOCKER_ENV
+    echo "CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME}" >> $DOCKER_ENV
     echo "CHE_VERSION=${CHE_VERSION}" >> $DOCKER_ENV
+    echo "CHE_CLI_INFO=${CHE_CLI_INFO}" >> $DOCKER_ENV
+    echo "CHE_CLI_DEBUG=${CHE_CLI_DEBUG}" >> $DOCKER_ENV
 
     CHE_VARIABLES=$(env | grep CHE_)
 

--- a/che.sh
+++ b/che.sh
@@ -26,7 +26,6 @@ error_exit() {
 }
 
 check_docker() {
-  debug $FUNCNAME
   if ! docker ps > /dev/null 2>&1; then
     output=$(docker ps)
     error_exit "Error - Docker not installed properly: \n${output}"
@@ -332,7 +331,7 @@ get_full_path() {
   #OUTPUT_PATH=${1//\"}
 
   # create full directory path
-  echo "$(cd "$(dirname "${OUTPUT_PATH}")"; pwd)/$(basename "$1")"
+  echo "$(cd "$(dirname "${1}")"; pwd)/$(basename "$1")"
 }
 
 convert_windows_to_posix() {

--- a/che.sh
+++ b/che.sh
@@ -192,8 +192,8 @@ docker_run() {
 docker_run_with_env_file() {
   debug $FUNCNAME
   get_list_of_che_system_environment_variables
-  docker_run --env-file=tmp "$@"
-  rm -rf $PWD/tmp > /dev/null
+  docker_run --env-file=tmpgibberish "$@"
+  rm -rf $PWD/tmpgibberish > /dev/null
 }
 
 docker_run_with_pseudo_tty() {
@@ -412,7 +412,7 @@ get_list_of_che_system_environment_variables() {
 
   # See: http://stackoverflow.com/questions/4128235/what-is-the-exact-meaning-of-ifs-n
   IFS=$'\n'
-  DOCKER_ENV=$(get_mount_path $PWD)/tmp
+  DOCKER_ENV=$(get_mount_path $PWD)/tmpgibberish
   touch $DOCKER_ENV
   
   if has_default_profile; then

--- a/che.sh
+++ b/che.sh
@@ -580,9 +580,7 @@ execute_profile(){
       mv -f ~/.che/profiles/tmp ~/.che/profiles/"${3}"
 
 
-      info ""
       info "Added new ${CHE_MINI_PRODUCT_NAME} CLI profile ~/.che/profiles/${3}."
-      info ""
     ;;
     update)
       if [ ! -f ~/.che/profiles/"${3}" ]; then
@@ -605,9 +603,7 @@ execute_profile(){
 
       rm ~/.che/profiles/"${3}" > /dev/null
 
-      info ""
       info "Removed ${CHE_MINI_PRODUCT_NAME} CLI profile ~/.che/profiles/${3}."
-      info ""
     ;;
     info)
       if [ ! -f ~/.che/profiles/"${3}" ]; then


### PR DESCRIPTION
MUST BE MERGED WITH: https://github.com/eclipse/che-dockerfiles/pull/8
1: Creates a separate configuration for the version of the Che server `CHE_VERSION` which is passed along to the Che launcher apart from the version used for Che utilities `CHE_UTILITY_VERSION`. This allows utilities to be versioned and released differently from the Che server. These were hard coupled before.  

2: Prints out the name of the profile that is loaded, if one is loaded at the beginning, giving users a heads up that their execution is governed by a profile.

3: Fixes an issue where the networking connectivity check was hard coded the Che server image to be used.

4: Adds a `--force` option to the `che update` command which, if provided, will delete the image before doing a docker pull. Solves some issues with caching.

5: Adds `CHE_CLI_DEBUG` option. If true, will print out stack trace as execution goes through.

6: Adds `CHE_CLI_INFO` flag, which if disabled, will not print any INFO messages. This flag is packaged in the environment package sent to utilities.
