### PR TITLE
CHE-2135: Change log level for RemoteOAuthTokenProvider#getToken.

### DIFF
--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/RemoteOAuthTokenProvider.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/RemoteOAuthTokenProvider.java
@@ -69,7 +69,7 @@ public class RemoteOAuthTokenProvider implements OAuthTokenProvider {
             LOG.warn("Token not found for user {}", userId);
             return null;
         } catch (ServerException | UnauthorizedException | ForbiddenException | ConflictException | BadRequestException e) {
-            LOG.error("Exception on token retrieval, message : {}", e.getLocalizedMessage());
+            LOG.warn("Exception on token retrieval, message : {}", e.getLocalizedMessage());
             return null;
         }
     }


### PR DESCRIPTION
### What does this PR do?

Change log level for RemoteOAuthTokenProvider#getToken from "Error" to "Info".
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2135
### PR type
- [ ] Minor change = no change to existing features or docs
### Minor change checklist
- [ ] API updated
