### PR TITLE
InitializeParams should include an empty ClientCapabilities

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-server/src/main/java/org/eclipse/che/plugin/languageserver/server/registry/ServerInitializerImpl.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-server/src/main/java/org/eclipse/che/plugin/languageserver/server/registry/ServerInitializerImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.che.plugin.languageserver.server.registry;
 import io.typefox.lsapi.InitializeResult;
 import io.typefox.lsapi.LanguageDescription;
 import io.typefox.lsapi.ServerCapabilities;
+import io.typefox.lsapi.impl.ClientCapabilitiesImpl;
 import io.typefox.lsapi.impl.InitializeParamsImpl;
 import io.typefox.lsapi.impl.InitializeResultImpl;
 import io.typefox.lsapi.impl.LanguageDescriptionImpl;
@@ -155,6 +156,7 @@ public class ServerInitializerImpl implements ServerInitializer {
         InitializeParamsImpl initializeParams = new InitializeParamsImpl();
         initializeParams.setProcessId(PROCESS_ID);
         initializeParams.setRootPath(projectPath);
+        initializeParams.setCapabilities(new ClientCapabilitiesImpl());
         initializeParams.setClientName(CLIENT_NAME);
         return initializeParams;
     }


### PR DESCRIPTION
### What does this PR do?

Sets client capabilities property in the InitializeParams object.
### What issues does this PR fix or reference?

https://github.com/felixfbecker/php-language-server/pull/6#issuecomment-244361113
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [ ] Tests passed

The protocol specifies that the InitializeParams object contains a
capabilities property. Eclipse Che does not define it, so there are
language servers that fails to initialize because of this.

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
