### PR TITLE
CHE-1818: Add new WS environment types, machines attributes

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/MachineConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/MachineConfig.java
@@ -45,7 +45,7 @@ public interface MachineConfig {
      * Machine limits such as RAM size.
      */
     @Nullable
-    Limits getLimits();
+    MachineLimits getLimits();
 
     /**
      * Get configuration of servers inside of machine.

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/MachineLimits.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/MachineLimits.java
@@ -16,7 +16,7 @@ package org.eclipse.che.api.core.model.machine;
  * @author Alexander Garagatyi
  */
 @Deprecated
-public interface Limits {
+public interface MachineLimits {
     /** Get memory size (in megabytes) that is allocated for starting machine. */
     int getRam();
 }

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/ExtendedMachine.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/ExtendedMachine.java
@@ -28,4 +28,9 @@ public interface ExtendedMachine {
      * Returns mapping of references to configurations of servers deployed into machine.
      */
     Map<String, ? extends ServerConf2> getServers();
+
+    /**
+     * Returns attributes of resources of machine.
+     */
+    Map<String, String> getAttributes();
 }

--- a/dashboard/src/components/api/che-workspace.factory.js
+++ b/dashboard/src/components/api/che-workspace.factory.js
@@ -259,8 +259,8 @@ export class CheWorkspace {
       defaultEnvironment = {
         'name': config.defaultEnv,
         'recipe': null,
-        'machines': {"devmachine" : {"agents" : ["ws-agent"]}}
-      }
+        'machines': {"dev-machine" : {"agents" : ["ws-agent"]}}
+      };
 
       config.environments[config.defaultEnv] =  defaultEnvironment;
     }
@@ -269,7 +269,7 @@ export class CheWorkspace {
       defaultEnvironment.recipe = {
         'type': 'compose',
         'contentType': source.format
-      }
+      };
 
       defaultEnvironment.recipe.content = source.content || null;
       defaultEnvironment.recipe.location = source.location || null;
@@ -279,8 +279,8 @@ export class CheWorkspace {
       return config;
     }
 
-    let devMachine = this.lodash.find(defaultEnvironment.machines, (config) => {
-      return config.dev;
+    let devMachine = this.lodash.find(defaultEnvironment.machines, (machine) => {
+      return machine.agents.includes('ws-agent');
     });
 
     //Check dev machine is provided and add if there is no:

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenter.java
@@ -37,9 +37,9 @@ import org.eclipse.che.ide.workspace.DefaultWorkspaceComponent;
 import org.eclipse.che.ide.workspace.create.CreateWorkspaceView.HidePopupCallBack;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.machine.shared.Constants.WS_MACHINE_NAME;
 
@@ -51,9 +51,10 @@ import static org.eclipse.che.api.machine.shared.Constants.WS_MACHINE_NAME;
 @Singleton
 public class CreateWorkspacePresenter implements CreateWorkspaceView.ActionDelegate {
 
-    private static final RegExp FILE_NAME   = RegExp.compile("^[A-Za-z0-9_\\s-\\.]+$");
-    private static final String URL_PATTERN = "^((ftp|http|https)://[\\w@.\\-\\_]+(:\\d{1,5})?(/[\\w#!:.?+=&%@!\\_\\-/]+)*){1}$";
-    private static final RegExp URL         = RegExp.compile(URL_PATTERN);
+    private static final   RegExp FILE_NAME          = RegExp.compile("^[A-Za-z0-9_\\s-\\.]+$");
+    private static final   String URL_PATTERN        = "^((ftp|http|https)://[\\w@.\\-\\_]+(:\\d{1,5})?(/[\\w#!:.?+=&%@!\\_\\-/]+)*){1}$";
+    private static final   RegExp URL                = RegExp.compile(URL_PATTERN);
+    protected static final String MEMORY_LIMIT_BYTES = Long.toString(2000L * 1024L * 1024L);
 
     static final String RECIPE_TYPE     = "docker";
     static final int    SKIP_COUNT      = 0;
@@ -229,12 +230,12 @@ public class CreateWorkspacePresenter implements CreateWorkspaceView.ActionDeleg
         String wsName = view.getWorkspaceName();
 
         EnvironmentRecipeDto recipe = dtoFactory.createDto(EnvironmentRecipeDto.class)
-                                                .withType("compose")
-                                                .withLocation(view.getRecipeUrl())
-                                                .withContentType("application/x-yaml");
+                                                .withType("dockerimage")
+                                                .withLocation(view.getRecipeUrl());
 
         ExtendedMachineDto machine = dtoFactory.createDto(ExtendedMachineDto.class)
-                                               .withAgents(Collections.singletonList("ws-agent"));
+                                               .withAgents(singletonList("ws-agent"))
+                                               .withAttributes(singletonMap("memoryLimitBytes", MEMORY_LIMIT_BYTES));
 
         EnvironmentDto environment = dtoFactory.createDto(EnvironmentDto.class)
                                                .withRecipe(recipe)

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenterTest.java
@@ -14,9 +14,9 @@ import com.google.gwt.core.client.Callback;
 import com.google.inject.Provider;
 
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
-import org.eclipse.che.api.machine.shared.dto.LimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
+import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
 import org.eclipse.che.api.machine.shared.dto.recipe.RecipeDescriptor;
 import org.eclipse.che.api.promises.client.Operation;
@@ -101,7 +101,7 @@ public class CreateWorkspacePresenterTest {
     @Mock
     private DefaultWorkspaceComponent       workspaceComponent;
     @Mock
-    private LimitsDto                       limitsDto;
+    private MachineLimitsDto                limitsDto;
 
     //DTOs
     private MachineConfigDto   machineConfigDto;
@@ -118,8 +118,6 @@ public class CreateWorkspacePresenterTest {
     private CommandDto         commandDto;
     @Mock
     private WorkspaceDto  usersWorkspaceDto;
-
-
 
     @Captor
     private ArgumentCaptor<Operation<List<RecipeDescriptor>>> recipeOperation;
@@ -141,7 +139,7 @@ public class CreateWorkspacePresenterTest {
         when(machineSourceDto.withType(anyString())).thenReturn(machineSourceDto);
         when(machineSourceDto.withLocation(anyString())).thenReturn(machineSourceDto);
 
-        when(dtoFactory.createDto(LimitsDto.class)).thenReturn(limitsDto);
+        when(dtoFactory.createDto(MachineLimitsDto.class)).thenReturn(limitsDto);
         when(limitsDto.withRam(anyInt())).thenReturn(limitsDto);
 
         when(dtoFactory.createDto(MachineConfigDto.class)).thenReturn(machineConfigDto);

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -39,13 +39,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/alpine-jdk\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/alpine-jdk8",
+            "type": "dockerimage"
           }
         }
       },
@@ -138,13 +140,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_jdk8\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_jdk8",
+            "type": "dockerimage"
           }
         }
       },
@@ -197,13 +201,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_jdk8\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_jdk8",
+            "type": "dockerimage"
           }
         }
       },
@@ -261,13 +267,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_android\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_android",
+            "type": "dockerimage"
           }
         }
       },
@@ -334,13 +342,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/cpp_gcc\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/cpp_gcc",
+            "type": "dockerimage"
           }
         }
       },
@@ -401,13 +411,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/dotnet_core\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/dotnet_core",
+            "type": "dockerimage"
           }
         }
       },
@@ -478,13 +490,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_go\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_go",
+            "type": "dockerimage"
           }
         }
       },
@@ -553,13 +567,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/hadoop-dev\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/hadoop-dev",
+            "type": "dockerimage"
           }
         }
       },
@@ -636,13 +652,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/node\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/node",
+            "type": "dockerimage"
           }
         }
       },
@@ -667,7 +685,7 @@
     "id": "php-default",
     "creator": "ide",
     "name": "PHP",
-    "description": "Default PHP Stack with PHP 5.5, most popular extensions and composer.",
+    "description": "Default PHP Stack with PHP 5.5, most popular extensions and dockerimager.",
     "scope": "general",
     "tags": [
       "Ubuntu",
@@ -676,7 +694,7 @@
       "mysql",
       "sqlite",
       "Apaide",
-      "Composer"
+      "dockerimager"
     ],
     "components": [
       {
@@ -696,7 +714,7 @@
         "version": "---"
       },
       {
-        "name": "Composer",
+        "name": "dockerimager",
         "version": "---"
       }
     ],
@@ -712,13 +730,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/php\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/php",
+            "type": "dockerimage"
           }
         }
       },
@@ -799,13 +819,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_python:latest\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_python:latest",
+            "type": "dockerimage"
           }
         }
       },
@@ -875,13 +897,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_rails\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_rails",
+            "type": "dockerimage"
           }
         }
       },
@@ -947,13 +971,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/debian_jre\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/debian_jre",
+            "type": "dockerimage"
           }
         }
       },
@@ -1014,13 +1040,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/centos_jdk8\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/centos_jdk8",
+            "type": "dockerimage"
           }
         }
       },
@@ -1092,13 +1120,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/debian_jdk8\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/debian_jdk8",
+            "type": "dockerimage"
           }
         }
       },
@@ -1157,7 +1187,7 @@
         "version": "---"
       },
       {
-        "name": "Composer",
+        "name": "dockerimager",
         "version": "---"
       }
     ],
@@ -1173,13 +1203,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/php:gae\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/php:gae",
+            "type": "dockerimage"
           }
         }
       },
@@ -1244,13 +1276,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_python:2.7\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_python:2.7",
+            "type": "dockerimage"
           }
         }
       },
@@ -1312,13 +1346,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_python:gae_python2.7\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_python:gae_python2.7",
+            "type": "dockerimage"
           }
         }
       },
@@ -1399,13 +1435,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/selenium\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/selenium",
+            "type": "dockerimage"
           }
         }
       },
@@ -1463,13 +1501,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: tomitribe/ubuntu_tomee_173_jdk8\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "tomitribe/ubuntu_tomee_173_jdk8",
+            "type": "dockerimage"
           }
         }
       },
@@ -1520,13 +1560,15 @@
               "agents": [
                 "ws-agent"
               ],
-              "servers": {}
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "content": "services:\n  dev-machine:\n    image: codenvy/ubuntu_jre\n    mem_limit: 2147483648",
-            "contentType": "application/x-yaml",
-            "type": "compose"
+            "location": "codenvy/ubuntu_jre",
+            "type": "dockerimage"
           }
         }
       },

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
@@ -20,7 +20,7 @@ import org.eclipse.che.api.core.model.machine.ServerConf;
 import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.exception.InvalidRecipeException;
 import org.eclipse.che.api.machine.server.exception.MachineException;
-import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
@@ -452,7 +452,7 @@ public class DockerInstanceProviderTest {
                                                       MACHINE_NAME,
                                                       "machineType",
                                                       machineSource,
-                                                      new LimitsImpl(MEMORY_LIMIT_MB),
+                                                      new MachineLimitsImpl(MEMORY_LIMIT_MB),
                                                       asList(new ServerConfImpl("ref1", "8080", "https", null),
                                                              new ServerConfImpl("ref2", "9090/udp", "someprotocol", null)),
                                                       Collections.singletonMap("key1", "value1")),
@@ -490,7 +490,7 @@ public class DockerInstanceProviderTest {
                                                       MACHINE_NAME,
                                                       "machineType",
                                                       machineSource,
-                                                      new LimitsImpl(MEMORY_LIMIT_MB),
+                                                      new MachineLimitsImpl(MEMORY_LIMIT_MB),
                                                       asList(new ServerConfImpl("ref1", "8080", "https", null),
                                                              new ServerConfImpl("ref2", "9090/udp", "someprotocol", null)),
                                                       Collections.singletonMap("key1", "value1")),
@@ -2013,7 +2013,7 @@ public class DockerInstanceProviderTest {
     }
 
     private void createInstanceFromRecipe(int memorySizeInMB) throws Exception {
-        createInstanceFromRecipe(getMachineBuilder().setConfig(getMachineConfigBuilder().setLimits(new LimitsImpl(memorySizeInMB))
+        createInstanceFromRecipe(getMachineBuilder().setConfig(getMachineConfigBuilder().setLimits(new MachineLimitsImpl(memorySizeInMB))
                                                                                         .build())
                                                     .build());
     }
@@ -2032,7 +2032,7 @@ public class DockerInstanceProviderTest {
     }
 
     private void createInstanceFromSnapshot(int memorySizeInMB) throws NotFoundException, MachineException {
-        createInstanceFromSnapshot(getMachineBuilder().setConfig(getMachineConfigBuilder().setLimits(new LimitsImpl(memorySizeInMB))
+        createInstanceFromSnapshot(getMachineBuilder().setConfig(getMachineConfigBuilder().setLimits(new MachineLimitsImpl(memorySizeInMB))
                                                                                           .build())
                                                       .build());
     }
@@ -2103,7 +2103,7 @@ public class DockerInstanceProviderTest {
                                                                             MACHINE_NAME,
                                                                             "machineType",
                                                                             new MachineSourceImpl(DOCKER_FILE_TYPE).setContent("FROM codenvy"),
-                                                                            new LimitsImpl(MEMORY_LIMIT_MB),
+                                                                            new MachineLimitsImpl(MEMORY_LIMIT_MB),
                                                                             asList(new ServerConfImpl("ref1",
                                                                                                       "8080",
                                                                                                       "https",

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceTest.java
@@ -16,7 +16,7 @@ import org.eclipse.che.api.core.model.machine.MachineSource;
 import org.eclipse.che.api.core.model.machine.MachineStatus;
 import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.exception.MachineException;
-import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
@@ -250,7 +250,7 @@ public class DockerInstanceTest {
                                 .setName(name)
                                 .setType(type)
                                 .setSource(new MachineSourceImpl("docker").setLocation("location"))
-                                .setLimits(new LimitsImpl(64))
+                                .setLimits(new MachineLimitsImpl(64))
                                 .build();
     }
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImpl.java
@@ -17,7 +17,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.machine.MachineSource;
-import org.eclipse.che.api.machine.shared.dto.LimitsDto;
+import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
 import org.eclipse.che.api.promises.client.Operation;
@@ -130,7 +130,7 @@ public class MachineManagerImpl implements MachineManager {
                               final boolean isDev,
                               final String machineType) {
 
-        LimitsDto limitsDto = dtoFactory.createDto(LimitsDto.class).withRam(1024);
+        MachineLimitsDto limitsDto = dtoFactory.createDto(MachineLimitsDto.class).withRam(1024);
         if (isDev) {
             limitsDto.withRam(3072);
         }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/targets/categories/ssh/SshCategoryPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/targets/categories/ssh/SshCategoryPresenter.java
@@ -15,7 +15,7 @@ import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
-import org.eclipse.che.api.machine.shared.dto.LimitsDto;
+import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
@@ -423,7 +423,7 @@ public class SshCategoryPresenter implements CategoryPage, TargetManager, SshVie
 
         String recipeURL = selectedTarget.getRecipe().getLink("get recipe script").getHref();
 
-        LimitsDto limitsDto = dtoFactory.createDto(LimitsDto.class).withRam(1024);
+        MachineLimitsDto limitsDto = dtoFactory.createDto(MachineLimitsDto.class).withRam(1024);
         MachineSourceDto sourceDto = dtoFactory.createDto(MachineSourceDto.class).withType("ssh-config").withLocation(recipeURL);
 
         MachineConfigDto configDto = dtoFactory.createDto(MachineConfigDto.class)

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImplTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManagerImplTest.java
@@ -14,7 +14,7 @@ import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.machine.MachineSource;
-import org.eclipse.che.api.machine.shared.dto.LimitsDto;
+import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
 import org.eclipse.che.api.promises.client.Operation;
@@ -137,8 +137,8 @@ public class MachineManagerImplTest {
         when(machineSourceDto.withLocation(eq(SOURCE_LOCATION))).thenReturn(machineSourceDto);
         when(machineSourceDto.withContent(eq(SOURCE_CONTENT))).thenReturn(machineSourceDto);
         when(dtoFactory.createDto(MachineSourceDto.class)).thenReturn(machineSourceDto);
-        LimitsDto limitsDto = mock(LimitsDto.class);
-        when(dtoFactory.createDto(LimitsDto.class)).thenReturn(limitsDto);
+        MachineLimitsDto limitsDto = mock(MachineLimitsDto.class);
+        when(dtoFactory.createDto(MachineLimitsDto.class)).thenReturn(limitsDto);
         when(limitsDto.withRam(anyInt())).thenReturn(limitsDto);
 
         MachineConfigDto machineConfigDto = mock(MachineConfigDto.class);

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/builder/FactoryBuilderTest.java
@@ -181,7 +181,8 @@ public class FactoryBuilderTest {
                                                                                       .withContentType("application/x-yaml")
                                                                                       .withContent("some content"))
                                         .withMachines(singletonMap("devmachine",
-                                                                   newDto(ExtendedMachineDto.class).withAgents(singletonList("ws-agent"))));
+                                                                   newDto(ExtendedMachineDto.class).withAgents(singletonList("ws-agent"))
+                                                                                                   .withAttributes(singletonMap("memoryLimitBytes", "" + 512L * 1024L * 1024L))));
 
         WorkspaceConfigDto workspaceConfig = dto.createDto(WorkspaceConfigDto.class)
                                                 .withProjects(singletonList(project))

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineConfigDto.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineConfigDto.java
@@ -62,11 +62,11 @@ public interface MachineConfigDto extends MachineConfig, Hyperlinks {
 
     @Override
     @FactoryParameter(obligation = OPTIONAL)
-    LimitsDto getLimits();
+    MachineLimitsDto getLimits();
 
-    void setLimits(LimitsDto limits);
+    void setLimits(MachineLimitsDto limits);
 
-    MachineConfigDto withLimits(LimitsDto limits);
+    MachineConfigDto withLimits(MachineLimitsDto limits);
 
     @Override
     List<ServerConfDto> getServers();

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineLimitsDto.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/MachineLimitsDto.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.shared.dto;
 
-import org.eclipse.che.api.core.model.machine.Limits;
+import org.eclipse.che.api.core.model.machine.MachineLimits;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -18,6 +18,6 @@ import org.eclipse.che.dto.shared.DTO;
  */
 @Deprecated
 @DTO
-public interface LimitsDto extends Limits {
-    LimitsDto withRam(int memorySizeMB);
+public interface MachineLimitsDto extends MachineLimits {
+    MachineLimitsDto withRam(int memorySizeMB);
 }

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/DtoConverter.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/DtoConverter.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.server;
 
-import org.eclipse.che.api.core.model.machine.Limits;
+import org.eclipse.che.api.core.model.machine.MachineLimits;
 import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.machine.MachineProcess;
@@ -19,7 +19,7 @@ import org.eclipse.che.api.core.model.machine.MachineSource;
 import org.eclipse.che.api.core.model.machine.Server;
 import org.eclipse.che.api.core.model.machine.ServerConf;
 import org.eclipse.che.api.core.model.machine.Snapshot;
-import org.eclipse.che.api.machine.shared.dto.LimitsDto;
+import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
@@ -65,10 +65,10 @@ public final class DtoConverter {
     }
 
     /**
-     * Converts {@link Limits} to {@link LimitsDto}.
+     * Converts {@link MachineLimits} to {@link MachineLimitsDto}.
      */
-    public static LimitsDto asDto(Limits limits) {
-        return newDto(LimitsDto.class).withRam(limits.getRam());
+    public static MachineLimitsDto asDto(MachineLimits machineLimits) {
+        return newDto(MachineLimitsDto.class).withRam(machineLimits.getRam());
     }
 
     /**

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineConfigImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineConfigImpl.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.server.model.impl;
 
-import org.eclipse.che.api.core.model.machine.Limits;
+import org.eclipse.che.api.core.model.machine.MachineLimits;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.machine.MachineSource;
 import org.eclipse.che.api.core.model.machine.ServerConf;
@@ -38,7 +38,7 @@ public class MachineConfigImpl implements MachineConfig {
     private String               name;
     private String               type;
     private MachineSourceImpl    source;
-    private LimitsImpl           limits;
+    private MachineLimitsImpl    limits;
     private List<ServerConfImpl> servers;
     private Map<String, String>  envVariables;
 
@@ -49,7 +49,7 @@ public class MachineConfigImpl implements MachineConfig {
                              String name,
                              String type,
                              MachineSource source,
-                             Limits limits,
+                             MachineLimits machineLimits,
                              List<? extends ServerConf> servers,
                              Map<String, String> envVariables) {
         this.dev = dev;
@@ -64,7 +64,7 @@ public class MachineConfigImpl implements MachineConfig {
         if (source != null) {
             this.source = new MachineSourceImpl(source);
         }
-        this.limits = new LimitsImpl(limits);
+        this.limits = new MachineLimitsImpl(machineLimits);
 
     }
 
@@ -107,7 +107,7 @@ public class MachineConfigImpl implements MachineConfig {
     }
 
     @Override
-    public LimitsImpl getLimits() {
+    public MachineLimitsImpl getLimits() {
         return limits;
     }
 
@@ -127,8 +127,8 @@ public class MachineConfigImpl implements MachineConfig {
         return envVariables;
     }
 
-    public void setLimits(Limits limits) {
-        this.limits = new LimitsImpl(limits);
+    public void setLimits(MachineLimits machineLimits) {
+        this.limits = new MachineLimitsImpl(machineLimits);
     }
 
     @Override
@@ -165,7 +165,7 @@ public class MachineConfigImpl implements MachineConfig {
                ", name='" + name + '\'' +
                ", type='" + type + '\'' +
                ", source=" + source +
-               ", limits=" + limits +
+               ", machineLimits=" + limits +
                ", servers=" + getServers() +
                ", envVariables=" + getEnvVariables() +
                '}';
@@ -182,7 +182,7 @@ public class MachineConfigImpl implements MachineConfig {
         private String                     name;
         private String                     type;
         private MachineSource              source;
-        private Limits                     limits;
+        private MachineLimits              machineLimits;
         private List<? extends ServerConf> servers;
         private Map<String, String>        envVariables;
 
@@ -191,7 +191,7 @@ public class MachineConfigImpl implements MachineConfig {
                                          name,
                                          type,
                                          source,
-                                         limits,
+                                         machineLimits,
                                          servers,
                                          envVariables);
         }
@@ -201,7 +201,7 @@ public class MachineConfigImpl implements MachineConfig {
             name = machineConfig.getName();
             type = machineConfig.getType();
             source = machineConfig.getSource();
-            limits = machineConfig.getLimits();
+            machineLimits = machineConfig.getLimits();
             servers = machineConfig.getServers();
             envVariables = machineConfig.getEnvVariables();
             return this;
@@ -227,8 +227,8 @@ public class MachineConfigImpl implements MachineConfig {
             return this;
         }
 
-        public MachineConfigImplBuilder setLimits(Limits limits) {
-            this.limits = limits;
+        public MachineConfigImplBuilder setLimits(MachineLimits machineLimits) {
+            this.machineLimits = machineLimits;
             return this;
         }
 

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineLimitsImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineLimitsImpl.java
@@ -10,24 +10,24 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.server.model.impl;
 
-import org.eclipse.che.api.core.model.machine.Limits;
+import org.eclipse.che.api.core.model.machine.MachineLimits;
 
 /**
  * @author Alexander Garagatyi
  */
 @Deprecated
-public class LimitsImpl implements Limits {
+public class MachineLimitsImpl implements MachineLimits {
     private final int memory;
 
-    public LimitsImpl(Limits limits) {
-        if(limits != null) {
-            memory = limits.getRam();
+    public MachineLimitsImpl(MachineLimits machineLimits) {
+        if(machineLimits != null) {
+            memory = machineLimits.getRam();
         } else {
             memory = 0;
         }
     }
 
-    public LimitsImpl(int memory) {
+    public MachineLimitsImpl(int memory) {
         this.memory = memory;
     }
 
@@ -39,9 +39,9 @@ public class LimitsImpl implements Limits {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof LimitsImpl)) return false;
+        if (!(o instanceof MachineLimitsImpl)) return false;
 
-        LimitsImpl limits = (LimitsImpl)o;
+        MachineLimitsImpl limits = (MachineLimitsImpl)o;
 
         return memory == limits.memory;
 

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/recipe/RecipeService.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/recipe/RecipeService.java
@@ -101,7 +101,7 @@ public class RecipeService extends Service {
 
     @GET
     @Path("/{id}/script")
-    @Produces(TEXT_PLAIN)
+    @Produces(TEXT_PLAIN + "; charset=utf-8")
     public String getRecipeScript(@PathParam("id") String id) throws ApiException {
         final ManagedRecipe recipe = recipeDao.getById(id);
         return recipe.getScript();

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/EnvironmentRecipeDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/EnvironmentRecipeDto.java
@@ -32,7 +32,7 @@ public interface EnvironmentRecipeDto extends EnvironmentRecipe {
     EnvironmentRecipeDto withType(String type);
 
     @Override
-    @FactoryParameter(obligation = MANDATORY)
+    @FactoryParameter(obligation = OPTIONAL)
     String getContentType();
 
     void setContentType(String contentType);

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/ExtendedMachineDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/ExtendedMachineDto.java
@@ -39,4 +39,12 @@ public interface ExtendedMachineDto extends ExtendedMachine {
     void setServers(Map<String, ServerConf2Dto> servers);
 
     ExtendedMachineDto withServers(Map<String, ServerConf2Dto> servers);
+
+    @Override
+    @FactoryParameter(obligation = OPTIONAL)
+    Map<String, String> getAttributes();
+
+    void setAttributes(Map<String, String> attributes);
+
+    ExtendedMachineDto withAttributes(Map<String, String> attributes);
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/EnvironmentParser.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/EnvironmentParser.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.environment.server;
+
+import com.google.common.base.Joiner;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.Environment;
+import org.eclipse.che.api.core.model.workspace.EnvironmentRecipe;
+import org.eclipse.che.api.core.model.workspace.ExtendedMachine;
+import org.eclipse.che.api.environment.server.compose.ComposeFileParser;
+import org.eclipse.che.api.environment.server.compose.model.BuildContextImpl;
+import org.eclipse.che.api.environment.server.compose.model.ComposeEnvironmentImpl;
+import org.eclipse.che.api.environment.server.compose.model.ComposeServiceImpl;
+import org.eclipse.che.api.machine.server.util.RecipeDownloader;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+/**
+ * Parses {@link Environment} into {@link ComposeEnvironmentImpl}.
+ *
+ * @author Alexander Garagatyi
+ */
+public class EnvironmentParser {
+    private static final List<String> types = Arrays.asList("compose", "dockerimage", "dockerfile");
+
+    private final ComposeFileParser composeFileParser;
+    private final RecipeDownloader  recipeDownloader;
+
+    @Inject
+    public EnvironmentParser(ComposeFileParser composeFileParser,
+                             RecipeDownloader recipeDownloader) {
+        this.composeFileParser = composeFileParser;
+        this.recipeDownloader = recipeDownloader;
+    }
+
+    /**
+     * Returns list of supported types of environments.
+     */
+    public List<String> getEnvironmentTypes() {
+        return types;
+    }
+
+    /**
+     * Parses {@link Environment} into {@link ComposeEnvironmentImpl}.
+     *
+     * @param environment
+     *         environment to parse
+     * @return environment representation as compose environment
+     * @throws IllegalArgumentException
+     *         if provided environment is illegal
+     * @throws ServerException
+     *         if fetching of environment recipe content fails
+     */
+    public ComposeEnvironmentImpl parse(Environment environment) throws IllegalArgumentException,
+                                                                        ServerException {
+
+        checkNotNull(environment, "Environment should not be null");
+        checkNotNull(environment.getRecipe(), "Environment recipe should not be null");
+        checkNotNull(environment.getRecipe().getType(), "Environment recipe type should not be null");
+        checkArgument(environment.getRecipe().getContent() != null || environment.getRecipe().getLocation() != null,
+                      "Recipe of environment must contain location or content");
+
+        ComposeEnvironmentImpl composeEnvironment;
+        String envType = environment.getRecipe().getType();
+        switch (envType) {
+            case "compose":
+                composeEnvironment = parseCompose(environment.getRecipe());
+                break;
+            case "dockerimage":
+            case "dockerfile":
+                composeEnvironment = parseDocker(environment);
+                break;
+            default:
+                throw new IllegalArgumentException("Environment type " + envType + " is not supported");
+        }
+
+        composeEnvironment.getServices().forEach((name, service) -> {
+            ExtendedMachine extendedMachine = environment.getMachines().get(name);
+            if (extendedMachine != null &&
+                extendedMachine.getAttributes() != null &&
+                extendedMachine.getAttributes().containsKey("memoryLimitBytes")) {
+
+                try {
+                    service.setMemLimit(Long.parseLong(extendedMachine.getAttributes().get("memoryLimitBytes")));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            format("Value of attribute 'memoryLimitBytes' of machine '%s' is illegal", name));
+                }
+            }
+        });
+
+        return composeEnvironment;
+    }
+
+    private ComposeEnvironmentImpl parseCompose(EnvironmentRecipe recipe) throws ServerException {
+        String recipeContent = getContentOfRecipe(recipe);
+
+        return composeFileParser.parse(recipeContent, recipe.getContentType());
+    }
+
+    private ComposeEnvironmentImpl parseDocker(Environment environment) {
+        checkArgument(environment.getMachines().size() == 1,
+                      "Environment of type '%s' doesn't support multiple machines, but contains machines: %s",
+                      environment.getRecipe().getType(),
+                      Joiner.on(',').join(environment.getMachines().keySet()));
+
+        ComposeEnvironmentImpl composeEnvironment = new ComposeEnvironmentImpl();
+        ComposeServiceImpl service = new ComposeServiceImpl();
+
+        composeEnvironment.getServices().put(environment.getMachines()
+                                                        .keySet()
+                                                        .iterator()
+                                                        .next(), service);
+
+        EnvironmentRecipe recipe = environment.getRecipe();
+
+        if ("dockerimage".equals(environment.getRecipe().getType())) {
+            service.setImage(recipe.getLocation());
+        } else {
+            if (!"text/x-dockerfile".equals(recipe.getContentType())) {
+                throw new IllegalArgumentException(
+                        format("Content type '%s' of recipe of environment is unsupported. Supported values are: x-dockerfile",
+                               recipe.getContentType()));
+            }
+
+            if (recipe.getLocation() != null) {
+                service.setBuild(new BuildContextImpl().withContext(recipe.getLocation()));
+            } else {
+                // workaround: put dockerfile content into field dockerfile.
+                // Service launching code must know about that workaround
+                service.setBuild(new BuildContextImpl().withDockerfile(recipe.getContent()));
+            }
+        }
+
+        return composeEnvironment;
+    }
+
+    private String getContentOfRecipe(EnvironmentRecipe environmentRecipe) throws ServerException {
+        if (environmentRecipe.getContent() != null) {
+            return environmentRecipe.getContent();
+        } else {
+            return recipeDownloader.getRecipe(environmentRecipe.getLocation());
+        }
+    }
+
+    /**
+     * Checks that object reference is not null, throws {@link IllegalArgumentException} otherwise.
+     *
+     * <p>Exception uses error message built from error message template and error message parameters.
+     */
+    private static void checkNotNull(Object object, String errorMessageTemplate, Object... errorMessageParams) {
+        if (object == null) {
+            throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageParams));
+        }
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/compose/ComposeFileParser.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/compose/ComposeFileParser.java
@@ -15,90 +15,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.model.workspace.Environment;
-import org.eclipse.che.api.core.model.workspace.EnvironmentRecipe;
 import org.eclipse.che.api.environment.server.compose.model.ComposeEnvironmentImpl;
-import org.eclipse.che.api.machine.server.exception.MachineException;
-import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.commons.lang.IoUtil;
-import org.slf4j.Logger;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.ws.rs.core.UriBuilder;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
- * Parses containers description in an environment to {@link ComposeEnvironmentImpl}.
+ * Converters compose file to {@link ComposeEnvironmentImpl} and vise versa.
  *
  * @author Alexander Garagatyi
  */
 public class ComposeFileParser {
-    private static final Logger       LOG         = getLogger(ComposeFileParser.class);
     private static final ObjectMapper YAML_PARSER = new ObjectMapper(new YAMLFactory());
 
-    private final URI apiEndpoint;
-
-    @Inject
-    public ComposeFileParser(@Named("api.endpoint") URI apiEndpoint) {
-        this.apiEndpoint = apiEndpoint;
-    }
-
     /**
-     * Parses recipe environment into Docker Compose model.
+     * Parses compose file into Docker Compose model.
      *
-     * @param environment environment to parse
+     * @param recipeContent compose file to parse
      * @throws IllegalArgumentException
      *         when environment or environment recipe is invalid
      * @throws ServerException
      *         when environment recipe can not be retrieved
      */
-    public ComposeEnvironmentImpl parse(Environment environment) throws IllegalArgumentException,
-                                                                        ServerException {
-        checkNotNull(environment, "Environment should not be null");
-        checkNotNull(environment.getRecipe(), "Environment recipe should not be null");
-        checkNotNull(environment.getRecipe().getContentType(), "Content type of environment recipe should not be null");
-        checkArgument(environment.getRecipe().getContent() != null || environment.getRecipe().getLocation() != null,
-                      "Recipe of environment must contain location or content");
-
-        String recipeContent = getContentOfRecipe(environment.getRecipe());
-        return parseEnvironmentRecipeContent(recipeContent,
-                                             environment.getRecipe().getContentType());
-    }
-
-    /**
-     * Converts Docker Compose environment model into YAML file.
-     *
-     * @param composeEnvironment Docker Compose environment model file
-     * @throws IllegalArgumentException
-     *         when argument is null or conversion to YAML fails
-     */
-    public String toYaml(ComposeEnvironmentImpl composeEnvironment) throws IllegalArgumentException {
-        checkNotNull(composeEnvironment, "Compose environment should not be null");
-        try {
-            return YAML_PARSER.writeValueAsString(composeEnvironment);
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException(e.getLocalizedMessage(), e);
-        }
-    }
-
-    private String getContentOfRecipe(EnvironmentRecipe environmentRecipe) throws ServerException {
-        if (environmentRecipe.getContent() != null) {
-            return environmentRecipe.getContent();
-        } else {
-            return getRecipe(environmentRecipe.getLocation());
-        }
-    }
-
-    private ComposeEnvironmentImpl parseEnvironmentRecipeContent(String recipeContent, String contentType) {
+    public ComposeEnvironmentImpl parse(String recipeContent, String contentType) throws IllegalArgumentException,
+                                                                                         ServerException {
         ComposeEnvironmentImpl composeEnvironment;
         switch (contentType) {
             case "application/x-yaml":
@@ -119,32 +60,19 @@ public class ComposeFileParser {
         return composeEnvironment;
     }
 
-    private String getRecipe(String location) throws ServerException {
-        URL recipeUrl;
-        File file = null;
+    /**
+     * Converts Docker Compose environment model into YAML file.
+     *
+     * @param composeEnvironment Docker Compose environment model file
+     * @throws IllegalArgumentException
+     *         when argument is null or conversion to YAML fails
+     */
+    public String toYaml(ComposeEnvironmentImpl composeEnvironment) throws IllegalArgumentException {
+        checkNotNull(composeEnvironment, "Compose environment should not be null");
         try {
-            UriBuilder targetUriBuilder = UriBuilder.fromUri(location);
-            // add user token to be able to download user's private recipe
-            final String apiEndPointHost = apiEndpoint.getHost();
-            final String host = targetUriBuilder.build().getHost();
-            if (apiEndPointHost.equals(host)) {
-                if (EnvironmentContext.getCurrent().getSubject() != null
-                    && EnvironmentContext.getCurrent().getSubject().getToken() != null) {
-                    targetUriBuilder.queryParam("token", EnvironmentContext.getCurrent().getSubject().getToken());
-                }
-            }
-            recipeUrl = targetUriBuilder.build().toURL();
-            file = IoUtil.downloadFileWithRedirect(null, "recipe", null, recipeUrl);
-
-            return IoUtil.readAndCloseQuietly(new FileInputStream(file));
-        } catch (IOException | IllegalArgumentException e) {
-            throw new MachineException(format("Recipe downloading failed. Recipe url %s. Error: %s",
-                                              location,
-                                              e.getLocalizedMessage()));
-        } finally {
-            if (file != null && !file.delete()) {
-                LOG.error(String.format("Removal of recipe file %s failed.", file.getAbsolutePath()));
-            }
+            return YAML_PARSER.writeValueAsString(composeEnvironment);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e.getLocalizedMessage(), e);
         }
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/compose/model/ComposeEnvironmentImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/compose/model/ComposeEnvironmentImpl.java
@@ -26,14 +26,14 @@ public class ComposeEnvironmentImpl implements ComposeEnvironment {
 
     public ComposeEnvironmentImpl() {}
 
-    public ComposeEnvironmentImpl(ComposeEnvironment recipeContent) {
-        version = recipeContent.getVersion();
-        if (recipeContent.getServices() != null) {
-            services = recipeContent.getServices()
-                                    .entrySet()
-                                    .stream()
-                                    .collect(Collectors.toMap(Map.Entry::getKey,
-                                                              entry -> new ComposeServiceImpl(entry.getValue())));
+    public ComposeEnvironmentImpl(ComposeEnvironment environment) {
+        version = environment.getVersion();
+        if (environment.getServices() != null) {
+            services = environment.getServices()
+                                  .entrySet()
+                                  .stream()
+                                  .collect(Collectors.toMap(Map.Entry::getKey,
+                                                            entry -> new ComposeServiceImpl(entry.getValue())));
         }
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -168,11 +168,14 @@ public final class DtoConverter {
     public static ExtendedMachineDto asDto(ExtendedMachine machine) {
         ExtendedMachineDto machineDto = newDto(ExtendedMachineDto.class).withAgents(machine.getAgents());
         if (machine.getServers() != null) {
-            machineDto.withServers(machine.getServers()
-                                          .entrySet()
-                                          .stream()
-                                          .collect(toMap(Map.Entry::getKey,
-                                                         entry -> asDto(entry.getValue()))));
+            machineDto.setServers(machine.getServers()
+                                         .entrySet()
+                                         .stream()
+                                         .collect(toMap(Map.Entry::getKey,
+                                                        entry -> asDto(entry.getValue()))));
+        }
+        if (machine.getAttributes() != null) {
+            machineDto.setAttributes(machine.getAttributes());
         }
         return machineDto;
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -245,7 +245,7 @@ public class WorkspaceRuntimes {
             // as it may take some time to notify subscribers
             publishWorkspaceEvent(EventType.RUNNING, workspaceId, null);
             return get(workspaceId);
-        } catch (ApiException e) {
+        } catch (ApiException | RuntimeException e) {
             try {
                 environmentEngine.stop(workspaceId);
             } catch (EnvironmentNotRunningException ignore) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ExtendedMachineImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ExtendedMachineImpl.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.model.workspace.ExtendedMachine;
 import org.eclipse.che.api.core.model.workspace.ServerConf2;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,11 +26,13 @@ import java.util.stream.Collectors;
 public class ExtendedMachineImpl implements ExtendedMachine {
     private List<String>                 agents;
     private Map<String, ServerConf2Impl> servers;
+    private Map<String, String>          attributes;
 
     public ExtendedMachineImpl() {}
 
     public ExtendedMachineImpl(List<String> agents,
-                               Map<String, ? extends ServerConf2> servers) {
+                               Map<String, ? extends ServerConf2> servers,
+                               Map<String, String> attributes) {
         if (agents != null) {
             this.agents = new ArrayList<>(agents);
         }
@@ -39,19 +42,13 @@ public class ExtendedMachineImpl implements ExtendedMachine {
                                   .collect(Collectors.toMap(Map.Entry::getKey,
                                                             entry -> new ServerConf2Impl(entry.getValue())));
         }
+        if (attributes != null) {
+            this.attributes = new HashMap<>(attributes);
+        }
     }
 
     public ExtendedMachineImpl(ExtendedMachine machine) {
-        if (machine.getAgents() != null) {
-            this.agents = new ArrayList<>(machine.getAgents());
-        }
-        if (machine.getServers() != null) {
-            this.servers = machine.getServers()
-                                  .entrySet()
-                                  .stream()
-                                  .collect(Collectors.toMap(Map.Entry::getKey,
-                                                            entry -> new ServerConf2Impl(entry.getValue())));
-        }
+        this(machine.getAgents(), machine.getServers(), machine.getAttributes());
     }
 
     @Override
@@ -73,17 +70,27 @@ public class ExtendedMachineImpl implements ExtendedMachine {
     }
 
     @Override
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ExtendedMachineImpl)) return false;
         ExtendedMachineImpl that = (ExtendedMachineImpl)o;
         return Objects.equals(agents, that.agents) &&
-               Objects.equals(servers, that.servers);
+               Objects.equals(servers, that.servers) &&
+               Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(agents, servers);
+        return Objects.hash(agents, servers, attributes);
     }
 
     @Override
@@ -91,6 +98,7 @@ public class ExtendedMachineImpl implements ExtendedMachine {
         return "ExtendedMachineImpl{" +
                "agents=" + agents +
                ", servers=" + servers +
+               ", attributes=" + attributes +
                '}';
     }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceValidatorTest.java
@@ -230,7 +230,8 @@ public class DefaultWorkspaceValidatorTest {
                                                 .withServers(singletonMap("ref1",
                                                                           newDto(ServerConf2Dto.class).withPort("8080/tcp")
                                                                                                       .withProtocol("https")
-                                                                                                      .withProperties(singletonMap("some", "prop"))));
+                                                                                                      .withProperties(singletonMap("some", "prop"))))
+                                                .withAttributes(singletonMap("memoryLimitBytes", "1000000"));
         EnvironmentDto env = newDto(EnvironmentDto.class).withMachines(singletonMap("devmachine1", extendedMachine))
                                                          .withRecipe(newDto(EnvironmentRecipeDto.class).withType("type")
                                                                                                        .withContent("content")

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -19,9 +19,9 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.environment.server.MachineProcessManager;
 import org.eclipse.che.api.machine.server.dao.SnapshotDao;
 import org.eclipse.che.api.machine.server.exception.SnapshotException;
-import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
@@ -885,7 +885,9 @@ public class WorkspaceManagerTest {
                                                                                     "content",
                                                                                     null),
                                                           singletonMap("dev-machine",
-                                                                       new ExtendedMachineImpl(singletonList("ws-agent"), null)));
+                                                                       new ExtendedMachineImpl(singletonList("ws-agent"),
+                                                                                               null,
+                                                                                               new HashMap<>(singletonMap("memoryLimitBytes", "10000")))));
         return WorkspaceConfigImpl.builder()
                                   .setName("dev-workspace")
                                   .setDefaultEnv("dev-env")
@@ -899,7 +901,7 @@ public class WorkspaceManagerTest {
                                                       .setDev(false)
                                                       .setName("machineName")
                                                       .setSource(new MachineSourceImpl("type").setContent("content"))
-                                                      .setLimits(new LimitsImpl(1024))
+                                                      .setLimits(new MachineLimitsImpl(1024))
                                                       .setType("docker")
                                                       .build())
                           .setId("id")

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -21,7 +21,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.environment.server.CheEnvironmentEngine;
 import org.eclipse.che.api.environment.server.NoOpMachineInstance;
-import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
@@ -553,7 +553,7 @@ public class WorkspaceRuntimesTest {
         return MachineConfigImpl.builder()
                                 .setDev(isDev)
                                 .setType("docker")
-                                .setLimits(new LimitsImpl(1024))
+                                .setLimits(new MachineLimitsImpl(1024))
                                 .setSource(new MachineSourceImpl("git").setLocation("location"))
                                 .setName(UUID.randomUUID().toString())
                                 .build();

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -25,9 +25,9 @@ import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.api.environment.server.MachineProcessManager;
 import org.eclipse.che.api.environment.server.MachineServiceLinksInjector;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
-import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
@@ -657,7 +657,7 @@ public class WorkspaceServiceTest {
                                                               .setDev(true)
                                                               .setEnvVariables(emptyMap())
                                                               .setServers(emptyList())
-                                                              .setLimits(new LimitsImpl(1024))
+                                                              .setLimits(new MachineLimitsImpl(1024))
                                                               .setSource(new MachineSourceImpl("type").setContent("content"))
                                                               .setName(environment.getMachines()
                                                                                   .keySet()
@@ -816,7 +816,9 @@ public class WorkspaceServiceTest {
     }
 
     private static EnvironmentDto createEnvDto() {
-        ExtendedMachineImpl devMachine = new ExtendedMachineImpl(singletonList("ws-agent"), null);
+        ExtendedMachineImpl devMachine = new ExtendedMachineImpl(singletonList("ws-agent"),
+                                                                 null,
+                                                                 new HashMap<>(singletonMap("memoryLimitBytes", "10000")));
 
         return DtoConverter.asDto(new EnvironmentImpl(new EnvironmentRecipeImpl("type", "content-type", "content", null),
                                                       singletonMap("dev-machine", devMachine)));

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
@@ -72,7 +72,7 @@ public class StackLoaderTest {
         stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao);
 
         stackLoader.start();
-        verify(stackDao, times(2)).update(any());
+        verify(stackDao, times(5)).update(any());
         verify(stackDao, never()).create(any());
     }
 
@@ -86,8 +86,8 @@ public class StackLoaderTest {
         stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao);
 
         stackLoader.start();
-        verify(stackDao, times(2)).update(any());
-        verify(stackDao, times(2)).create(any());
+        verify(stackDao, times(5)).update(any());
+        verify(stackDao, times(5)).create(any());
     }
 
     @Test
@@ -100,8 +100,8 @@ public class StackLoaderTest {
         stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao);
 
         stackLoader.start();
-        verify(stackDao, times(2)).update(any());
-        verify(stackDao, times(2)).create(any());
+        verify(stackDao, times(5)).update(any());
+        verify(stackDao, times(5)).create(any());
     }
 
     @Test
@@ -155,7 +155,8 @@ public class StackLoaderTest {
                                                               .withProperties(singletonMap("key", "value")));
         Map<String, ExtendedMachineDto> machines = new HashMap<>();
         machines.put("someMachineName", newDto(ExtendedMachineDto.class).withAgents(Arrays.asList("agent1", "agent2"))
-                                                                        .withServers(servers));
+                                                                        .withServers(servers)
+                                                                        .withAttributes(singletonMap("memoryLimitBytes", "" + 512L * 1024L * 1024L)));
 
         EnvironmentDto environmentDto = newDto(EnvironmentDto.class).withRecipe(environmentRecipe)
                                                                     .withMachines(machines);

--- a/wsmaster/che-core-api-workspace/src/test/resources/stacks.json
+++ b/wsmaster/che-core-api-workspace/src/test/resources/stacks.json
@@ -39,13 +39,15 @@
                         "devmachine": {
                             "agents": [
                                 "ws-agent"
-                            ]
+                            ],
+                            "attributes" : {
+                                "memoryLimitBytes": "2147483648"
+                            }
                         }
                     },
                     "recipe": {
-                        "location": "https://raw.githubusercontent.com/eclipse/che/master/Dockerfile",
-                        "contentType": "application/x-yaml",
-                        "type": "compose"
+                        "location": "codenvy/ubuntu_jdk8",
+                        "type": "dockerimage"
                     }
                 }
             },
@@ -128,13 +130,277 @@
                         "devmachine": {
                             "agents": [
                                 "ws-agent"
-                            ]
+                            ],
+                            "attributes" : {
+                                "memoryLimitBytes": "2147483648"
+                            }
                         }
                     },
                     "recipe": {
                         "location": "https://raw.githubusercontent.com/eclipse/che/master/Dockerfile",
-                        "contentType": "application/x-yaml",
-                        "type": "compose"
+                        "type": "dockerfile",
+                        "contentType": "text/x-dockerfile"
+                    }
+                }
+            },
+            "name": "default",
+            "defaultEnv": "default",
+            "description": null,
+            "commands": [
+                {
+                    "commandLine": "mvn clean install -f ${current.project.path}",
+                    "name": "newMaven",
+                    "type": "mvn"
+                }
+            ]
+        },
+        "acl": [
+            {
+                "user": "*",
+                "actions": [
+                    "search"
+                ]
+            }
+        ]
+    },
+    {
+        "id": "node-default",
+        "creator": "ide",
+        "name": "Node",
+        "description": "Default Node Stack with Node 0.12.",
+        "scope": "general",
+        "tags": [
+            "Ubuntu",
+            "Git",
+            "Node.JS",
+            "NPM",
+            "Gulp",
+            "Bower",
+            "Grunt",
+            "Yeoman",
+            "Angular",
+            "Karma"
+        ],
+        "components": [
+            {
+                "name": "Node.JS",
+                "version": "0.12.9"
+            },
+            {
+                "name": "NPM",
+                "version": "---"
+            },
+            {
+                "name": "Gulp",
+                "version": "---"
+            },
+            {
+                "name": "Bower",
+                "version": "---"
+            },
+            {
+                "name": "Grunt",
+                "version": "---"
+            },
+            {
+                "name": "Yeoman",
+                "version": "---"
+            }
+        ],
+        "source": {
+            "type": "image",
+            "origin": "codenvy/node"
+        },
+        "workspaceConfig": {
+            "environments": {
+                "default" : {
+                    "machines": {
+                        "devmachine": {
+                            "agents": [
+                                "ws-agent"
+                            ],
+                            "attributes" : {
+                                "memoryLimitBytes": "2147483648"
+                            }
+                        }
+                    },
+                    "recipe": {
+                        "content": "FROM codenvy/ubuntu_jdk8",
+                        "type": "dockerfile",
+                        "contentType": "text/x-dockerfile"
+                    }
+                }
+            },
+            "name": "default",
+            "defaultEnv": "default",
+            "description": null,
+            "commands": [
+                {
+                    "commandLine": "mvn clean install -f ${current.project.path}",
+                    "name": "newMaven",
+                    "type": "mvn"
+                }
+            ]
+        },
+        "acl": [
+            {
+                "user": "*",
+                "actions": [
+                    "search"
+                ]
+            }
+        ]
+    },
+    {
+        "id": "compose-location",
+        "creator": "ide",
+        "name": "Node",
+        "description": "Default Node Stack with Node 0.12.",
+        "scope": "general",
+        "tags": [
+            "Ubuntu",
+            "Git",
+            "Node.JS",
+            "NPM",
+            "Gulp",
+            "Bower",
+            "Grunt",
+            "Yeoman",
+            "Angular",
+            "Karma"
+        ],
+        "components": [
+            {
+                "name": "Node.JS",
+                "version": "0.12.9"
+            },
+            {
+                "name": "NPM",
+                "version": "---"
+            },
+            {
+                "name": "Gulp",
+                "version": "---"
+            },
+            {
+                "name": "Bower",
+                "version": "---"
+            },
+            {
+                "name": "Grunt",
+                "version": "---"
+            },
+            {
+                "name": "Yeoman",
+                "version": "---"
+            }
+        ],
+        "source": {
+            "type": "image",
+            "origin": "codenvy/node"
+        },
+        "workspaceConfig": {
+            "environments": {
+                "default" : {
+                    "machines": {
+                        "devmachine": {
+                            "agents": [
+                                "ws-agent"
+                            ],
+                            "attributes" : {
+                                "memoryLimitBytes": "2147483648"
+                            }
+                        }
+                    },
+                    "recipe": {
+                        "location": "https://raw.githubusercontent.com/eclipse/che/master/Dockerfile",
+                        "type": "compose",
+                        "contentType": "application/x-yaml"
+                    }
+                }
+            },
+            "name": "default",
+            "defaultEnv": "default",
+            "description": null,
+            "commands": [
+                {
+                    "commandLine": "mvn clean install -f ${current.project.path}",
+                    "name": "newMaven",
+                    "type": "mvn"
+                }
+            ]
+        },
+        "acl": [
+            {
+                "user": "*",
+                "actions": [
+                    "search"
+                ]
+            }
+        ]
+    },
+    {
+        "id": "compose-content",
+        "creator": "ide",
+        "name": "Node",
+        "description": "Default Node Stack with Node 0.12.",
+        "scope": "general",
+        "tags": [
+            "Ubuntu",
+            "Git",
+            "Node.JS",
+            "NPM",
+            "Gulp",
+            "Bower",
+            "Grunt",
+            "Yeoman",
+            "Angular",
+            "Karma"
+        ],
+        "components": [
+            {
+                "name": "Node.JS",
+                "version": "0.12.9"
+            },
+            {
+                "name": "NPM",
+                "version": "---"
+            },
+            {
+                "name": "Gulp",
+                "version": "---"
+            },
+            {
+                "name": "Bower",
+                "version": "---"
+            },
+            {
+                "name": "Grunt",
+                "version": "---"
+            },
+            {
+                "name": "Yeoman",
+                "version": "---"
+            }
+        ],
+        "source": {
+            "type": "image",
+            "origin": "codenvy/node"
+        },
+        "workspaceConfig": {
+            "environments": {
+                "default" : {
+                    "machines": {
+                        "devmachine": {
+                            "agents": [
+                                "ws-agent"
+                            ]
+                        }
+                    },
+                    "recipe": {
+                        "content": "service:\n  devmachine:\n    image: codenvy/ubuntu_jdk8\n    mem_limit: 2147483648",
+                        "type": "compose",
+                        "contentType": "application/x-yaml"
                     }
                 }
             },

--- a/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalWorkspaceDaoTest.java
+++ b/wsmaster/wsmaster-local/src/test/java/org/eclipse/che/api/local/LocalWorkspaceDaoTest.java
@@ -104,7 +104,9 @@ public class LocalWorkspaceDaoTest {
         properties.put("prop4", "value4");
         servers.put("ref2", new ServerConf2Impl("port2", "proto2", properties));
         machines = new HashMap<>();
-        machines.put("machine1", new ExtendedMachineImpl(asList("ws-agent", "someAgent"), servers));
+        machines.put("machine1", new ExtendedMachineImpl(asList("ws-agent", "someAgent"),
+                                                         servers,
+                                                         new HashMap<>(singletonMap("memoryLimitBytes", "10000"))));
         servers = new HashMap<>();
         properties = new HashMap<>();
         properties.put("prop5", "value5");
@@ -115,7 +117,9 @@ public class LocalWorkspaceDaoTest {
         properties.put("prop8", "value8");
         servers.put("ref4", new ServerConf2Impl("port4", "proto4", properties));
         machines = new HashMap<>();
-        machines.put("machine2", new ExtendedMachineImpl(asList("ws-agent2", "someAgent2"), servers));
+        machines.put("machine2", new ExtendedMachineImpl(asList("ws-agent2", "someAgent2"),
+                                                         servers,
+                                                         new HashMap<>(singletonMap("memoryLimitBytes", "10000"))));
         env = new EnvironmentImpl();
         env.setRecipe(new EnvironmentRecipeImpl("type", "contentType", "content", null));
         env.setMachines(machines);
@@ -128,12 +132,18 @@ public class LocalWorkspaceDaoTest {
         servers.put("ref11", new ServerConf2Impl("port11", "proto11", properties));
         servers.put("ref12", new ServerConf2Impl("port12", "proto12", null));
         machines = new HashMap<>();
-        machines.put("machine11", new ExtendedMachineImpl(emptyList(), servers));
+        machines.put("machine11", new ExtendedMachineImpl(emptyList(),
+                                                          servers,
+                                                          new HashMap<>(singletonMap("memoryLimitBytes", "10000"))));
         servers.put("ref13", new ServerConf2Impl("port13", "proto13", singletonMap("prop11", "value11")));
         servers.put("ref14", new ServerConf2Impl("port4", null, null));
         servers.put("ref15", new ServerConf2Impl(null, null, null));
-        machines.put("machine12", new ExtendedMachineImpl(null, servers));
-        machines.put("machine13", new ExtendedMachineImpl(null, null));
+        machines.put("machine12", new ExtendedMachineImpl(null,
+                                                          servers,
+                                                          new HashMap<>(singletonMap("memoryLimitBytes", "10000"))));
+        machines.put("machine13", new ExtendedMachineImpl(null,
+                                                          null,
+                                                          new HashMap<>(singletonMap("memoryLimitBytes", "10000"))));
         env.setRecipe(new EnvironmentRecipeImpl("type", "contentType", "content", null));
         env.setMachines(machines);
 
@@ -181,7 +191,6 @@ public class LocalWorkspaceDaoTest {
                             .setId(generate("workspace", 16))
                             .setConfig(new WorkspaceConfigImpl("test-workspace-name",
                                                                "This is test workspace",
-//                                                               env1.getName(),
                                                                null,
                                                                commands,
                                                                projects,


### PR DESCRIPTION
This PR adds 
- attributes map to machines in environment.
- new environment types `dockerimage` and `dockerfile` with single machine

Attribute `memoryLimitBytes` sets RAM limit for machine. If RAM limit is set in the environment recipe this property overrides limit.
