### PR TITLE
Avoid using deprecated 'keyIdentifier' property of 'KeyboardEvent'

### DIFF
--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/input/SignalEventImpl.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/input/SignalEventImpl.java
@@ -337,7 +337,7 @@ public class SignalEventImpl implements SignalEvent {
     }-*/;
 
     public static native String getKeyIdentifier(Event event) /*-{
-        return event.keyIdentifier
+        return event.key
     }-*/;
 
     /** @return Event type as a string, e.g. "keypress" */


### PR DESCRIPTION
Chrome 52 shows the warning:

> 'KeyboardEvent.keyIdentifier' is deprecated and will be removed in M53, around September 2016. See https://www.chromestatus.com/features/5316065118650368 for more details.

This PR replaces using deprecated **keyIdentifier** property by using recommended **key** property.

@vparfonov 
