### PR TITLE
CHE-2336: add an action for downloading all projects from the ws

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadWsAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadWsAction.java
@@ -19,34 +19,29 @@ import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.resources.Project;
-import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.download.DownloadContainer;
 
 import javax.validation.constraints.NotNull;
 
 import static java.util.Collections.singletonList;
-import static org.eclipse.che.ide.api.resources.Resource.PROJECT;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
 /**
- * Download selected root project in the application context.
+ * Download all projects from the workspace.
  *
- * @author Roman Nikitenko
- * @author Dmitry Shnurenko
- * @author Vlad Zhukovskyi
- * @see AppContext#getRootProject()
+ * @author Valeriy Svydenko
  */
 @Singleton
-public class DownloadProjectAction extends AbstractPerspectiveAction {
+public class DownloadWsAction extends AbstractPerspectiveAction {
 
-    private final AppContext               appContext;
-    private       DownloadContainer        downloadContainer;
+    private final AppContext        appContext;
+    private final DownloadContainer downloadContainer;
 
     @Inject
-    public DownloadProjectAction(AppContext appContext,
-                                 CoreLocalizationConstant locale,
-                                 Resources resources,
-                                 DownloadContainer downloadContainer) {
+    public DownloadWsAction(AppContext appContext,
+                            CoreLocalizationConstant locale,
+                            Resources resources,
+                            DownloadContainer downloadContainer) {
         super(singletonList(PROJECT_PERSPECTIVE_ID),
               locale.downloadProjectAsZipName(),
               locale.downloadProjectAsZipDescription(),
@@ -59,22 +54,14 @@ public class DownloadProjectAction extends AbstractPerspectiveAction {
     /** {@inheritDoc} */
     @Override
     public void actionPerformed(ActionEvent e) {
-        final Resource resource = appContext.getResource();
-
-        if (resource == null || resource.getResourceType() != PROJECT) {
-            return;
-        }
-        final Project project = (Project)resource;
-
-        downloadContainer.setUrl(project.getURL());
+        downloadContainer.setUrl(appContext.getDevMachine().getWsAgentBaseUrl() + "/project/export/");
     }
 
     /** {@inheritDoc} */
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
-        final Resource[] resources = appContext.getResources();
-
+        final Project[] projects = appContext.getProjects();
         e.getPresentation().setVisible(true);
-        e.getPresentation().setEnabled(resources != null && resources.length == 1 && resources[0].getResourceType() == PROJECT);
+        e.getPresentation().setEnabled(projects != null && projects.length > 0);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -24,6 +24,7 @@ import org.eclipse.che.ide.actions.CreateProjectAction;
 import org.eclipse.che.ide.actions.DeleteResourceAction;
 import org.eclipse.che.ide.actions.DownloadProjectAction;
 import org.eclipse.che.ide.actions.DownloadResourceAction;
+import org.eclipse.che.ide.actions.DownloadWsAction;
 import org.eclipse.che.ide.actions.EditFileAction;
 import org.eclipse.che.ide.actions.ExpandEditorAction;
 import org.eclipse.che.ide.actions.FormatterAction;
@@ -219,6 +220,9 @@ public class StandardComponentInitializer {
     private DownloadProjectAction downloadProjectAction;
 
     @Inject
+    private DownloadWsAction downloadWsAction;
+
+    @Inject
     private DownloadResourceAction downloadResourceAction;
 
     @Inject
@@ -411,8 +415,8 @@ public class StandardComponentInitializer {
         actionManager.registerAction("createProject", createProjectAction);
         workspaceGroup.add(createProjectAction);
 
-        actionManager.registerAction("downloadAsZipAction", downloadProjectAction);
-        workspaceGroup.add(downloadProjectAction);
+        actionManager.registerAction("downloadWsAsZipAction", downloadWsAction);
+        workspaceGroup.add(downloadWsAction);
 
         workspaceGroup.addSeparator();
 
@@ -448,6 +452,7 @@ public class StandardComponentInitializer {
         actionManager.registerAction("convertFolderToProject", convertFolderToProjectAction);
         projectGroup.add(convertFolderToProjectAction);
 
+        actionManager.registerAction("downloadAsZipAction", downloadProjectAction);
         projectGroup.add(downloadProjectAction);
 
         actionManager.registerAction("showHideHiddenFiles", showHiddenFilesAction);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/DownloadWsActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/DownloadWsActionTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.Presentation;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.download.DownloadContainer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Valeriy Svydenko
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class DownloadWsActionTest {
+    @Mock
+    private AppContext               appContext;
+    @Mock
+    private DownloadContainer        downloadContainer;
+    @Mock
+    private CoreLocalizationConstant locale;
+    @Mock
+    private Resources                resources;
+    @Mock
+    private ActionEvent              actionEvent;
+    @Mock
+    private Presentation             presentation;
+
+    @InjectMocks
+    private DownloadWsAction action;
+
+    @Test
+    public void actionShouldBeInitialized() throws Exception {
+        verify(locale).downloadProjectAsZipName();
+        verify(locale).downloadProjectAsZipDescription();
+        verify(resources).downloadZip();
+    }
+
+    @Test
+    public void actionShouldBePerformed() throws Exception {
+        String baseUrl = "baseUrl";
+
+        DevMachine devMachine = mock(DevMachine.class);
+        when(appContext.getDevMachine()).thenReturn(devMachine);
+        when(devMachine.getWsAgentBaseUrl()).thenReturn(baseUrl);
+
+        action.actionPerformed(actionEvent);
+
+        verify(downloadContainer).setUrl(eq("baseUrl/project/export/"));
+    }
+
+    @Test
+    public void actionShouldBeEnable() throws Exception {
+        Project project = mock(Project.class);
+
+        when(actionEvent.getPresentation()).thenReturn(presentation);
+        Project[] projects = new Project[1];
+        projects[0] = project;
+        when(appContext.getProjects()).thenReturn(projects);
+
+        action.updateInPerspective(actionEvent);
+
+        verify(presentation).setVisible(true);
+        verify(presentation).setEnabled(true);
+    }
+
+    @Test
+    public void actionShouldNotBeEnabledIfWsIsEmpty() throws Exception {
+        when(actionEvent.getPresentation()).thenReturn(presentation);
+        Project[] projects = new Project[0];
+        when(appContext.getProjects()).thenReturn(projects);
+
+        action.updateInPerspective(actionEvent);
+
+        verify(presentation).setVisible(true);
+        verify(presentation).setEnabled(false);
+    }
+
+    @Test
+    public void actionShouldNotBeEnabledIfListOfProjectsIsNull() throws Exception {
+        when(actionEvent.getPresentation()).thenReturn(presentation);
+        when(appContext.getProjects()).thenReturn(null);
+
+        action.updateInPerspective(actionEvent);
+
+        verify(presentation).setVisible(true);
+        verify(presentation).setEnabled(false);
+    }
+}


### PR DESCRIPTION
### What does this PR do?
- Add an ability to download all projects from the ws (Workspace - Download as Zip...)
- Fix some problems with downloading one project (Project - Download as Zip...)
### What issues does this PR fix or reference?

https://github.com/codenvy/artik-ide/issues/115
https://github.com/eclipse/che/issues/2336
### Previous behavior

The action downloaded only root project
### New behavior

Project - Download as Zip... action downloads selected project
Workspace - Download as Zip... action downloads all projects from ws
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [x] Tests passed

@vparfonov please review
