### PR TITLE
CHE-2325: Restore log of the running procces if refresh page (including ws-agent start log)

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/DefaultWorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/DefaultWorkspaceComponent.java
@@ -64,7 +64,7 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent  {
                                      PreferencesManager preferencesManager,
                                      DtoFactory dtoFactory,
                                      InitialLoadingInfo initialLoadingInfo,
-                                     WorkspaceEventsNotifier workspaceEventsNotifier) {
+                                     WorkspaceEventsHandler workspaceEventsHandler) {
         super(workspaceServiceClient,
               createWorkspacePresenter,
               startWorkspacePresenter,
@@ -81,7 +81,7 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent  {
               preferencesManager,
               dtoFactory,
               initialLoadingInfo,
-              workspaceEventsNotifier);
+              workspaceEventsHandler);
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/FactoryWorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/FactoryWorkspaceComponent.java
@@ -83,7 +83,7 @@ public class FactoryWorkspaceComponent extends WorkspaceComponent {
                                      PreferencesManager preferencesManager,
                                      DtoFactory dtoFactory,
                                      InitialLoadingInfo initialLoadingInfo,
-                                     WorkspaceEventsNotifier workspaceEventsNotifier) {
+                                     WorkspaceEventsHandler workspaceEventsHandler) {
         super(workspaceServiceClient,
               createWorkspacePresenter,
               startWorkspacePresenter,
@@ -100,7 +100,7 @@ public class FactoryWorkspaceComponent extends WorkspaceComponent {
               preferencesManager,
               dtoFactory,
               initialLoadingInfo,
-              workspaceEventsNotifier);
+              workspaceEventsHandler);
         this.factoryServiceClient = factoryServiceClient;
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -72,12 +72,12 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
     protected final NotificationManager       notificationManager;
     protected final StartWorkspacePresenter   startWorkspacePresenter;
 
-    private final   EventBus                  eventBus;
-    private final   LoaderPresenter           loader;
-    private final   Provider<MachineManager>  machineManagerProvider;
-    private final   MessageBusProvider        messageBusProvider;
-    private final   InitialLoadingInfo        initialLoadingInfo;
-    private final   WorkspaceEventsNotifier   workspaceEventsNotifier;
+    private final EventBus                 eventBus;
+    private final LoaderPresenter          loader;
+    private final Provider<MachineManager> machineManagerProvider;
+    private final MessageBusProvider       messageBusProvider;
+    private final InitialLoadingInfo       initialLoadingInfo;
+    private final WorkspaceEventsHandler   workspaceEventsHandler;
 
     protected Callback<Component, Exception> callback;
     protected boolean                        needToReloadComponents;
@@ -99,7 +99,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
                               PreferencesManager preferencesManager,
                               DtoFactory dtoFactory,
                               InitialLoadingInfo initialLoadingInfo,
-                              WorkspaceEventsNotifier workspaceEventsNotifier) {
+                              WorkspaceEventsHandler workspaceEventsHandler) {
         this.workspaceServiceClient = workspaceServiceClient;
         this.createWorkspacePresenter = createWorkspacePresenter;
         this.startWorkspacePresenter = startWorkspacePresenter;
@@ -116,7 +116,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
         this.preferencesManager = preferencesManager;
         this.dtoFactory = dtoFactory;
         this.initialLoadingInfo = initialLoadingInfo;
-        this.workspaceEventsNotifier = workspaceEventsNotifier;
+        this.workspaceEventsHandler = workspaceEventsHandler;
 
         this.needToReloadComponents = true;
 
@@ -169,7 +169,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
                 messageBus.removeOnOpenHandler(this);
 
                 setCurrentWorkspace(workspace);
-                workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
+                workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
 
                 final WorkspaceStatus workspaceStatus = workspace.getStatus();
                 switch (workspaceStatus) {

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/WorkspaceEventsHandlerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/WorkspaceEventsHandlerTest.java
@@ -14,10 +14,13 @@ import com.google.gwt.core.client.Callback;
 import com.google.inject.Provider;
 import com.google.web.bindery.event.shared.EventBus;
 
+import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.rest.shared.dto.LinkParameter;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
+import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineLogMessageDto;
+import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
 import org.eclipse.che.api.machine.shared.dto.event.MachineStatusEvent;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.Promise;
@@ -33,6 +36,7 @@ import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.dialogs.MessageDialog;
 import org.eclipse.che.ide.api.machine.MachineManager;
+import org.eclipse.che.ide.api.machine.MachineServiceClient;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.workspace.WorkspaceServiceClient;
@@ -41,6 +45,7 @@ import org.eclipse.che.ide.api.workspace.event.MachineStatusChangedEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStartedEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStartingEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.rest.Unmarshallable;
 import org.eclipse.che.ide.ui.loaders.initialization.InitialLoadingInfo;
@@ -91,7 +96,7 @@ import static org.mockito.Mockito.when;
  * @author Roman Nikitenko
  */
 @RunWith(MockitoJUnitRunner.class)
-public class WorkspaceEventsNotifierTest {
+public class WorkspaceEventsHandlerTest {
     private static final String MACHINE_NAME             = "machineName";
     private static final String WORKSPACE_ID             = "workspaceId";
     private static final String WORKSPACE_STATUS_CHANNEL = "channel";
@@ -122,7 +127,14 @@ public class WorkspaceEventsNotifierTest {
     @Mock
     private WorkspaceServiceClient              workspaceServiceClient;
     @Mock
-    private StartWorkspacePresenter             startWorkspacePresenter;
+    private MachineServiceClient                machineServiceClient;
+    @Mock
+    private Promise<List<MachineProcessDto>>    processPromise;
+    @Captor
+    private ArgumentCaptor<Operation<List<MachineProcessDto>>> processCaptor;
+
+    @Mock
+    private StartWorkspacePresenter startWorkspacePresenter;
 
 
     //additional mocks
@@ -141,7 +153,7 @@ public class WorkspaceEventsNotifierTest {
     @Mock
     private WorkspaceStatusEvent                 workspaceStatusEvent;
     @Mock
-    private MachineStatusEvent    machineStatusEvent;
+    private MachineStatusEvent                   machineStatusEvent;
     @Mock
     private Message                              message;
     @Mock
@@ -157,20 +169,33 @@ public class WorkspaceEventsNotifierTest {
     @Mock
     private Promise<List<WorkspaceDto>>          workspacesPromise;
 
+    @Mock
+    private AsyncRequestFactory asyncRequestFactory;
+
     @Captor
     private ArgumentCaptor<Operation<WorkspaceDto>>       workspaceCaptor;
     @Captor
     private ArgumentCaptor<Operation<List<WorkspaceDto>>> workspacesCaptor;
 
-    private WorkspaceEventsNotifier workspaceEventsNotifier;
+    private WorkspaceEventsHandler workspaceEventsHandler;
 
     @Before
     public void setUp() {
         when(loaderFactory.newLoader(anyString())).thenReturn(snapshotLoader);
-        workspaceEventsNotifier = new WorkspaceEventsNotifier(eventBus, locale, dialogFactory, dtoUnmarshallerFactory, initialLoadingInfo,
-                                                              notificationManager, messageBusProvider, machineManagerProvider,
-                                                              snapshotCreator, loaderFactory, workspaceServiceClient,
-                                                              startWorkspacePresenter, wsComponentProvider);
+        workspaceEventsHandler = new WorkspaceEventsHandler(eventBus,
+                                                            locale,
+                                                            dialogFactory,
+                                                            dtoUnmarshallerFactory,
+                                                            initialLoadingInfo,
+                                                            notificationManager,
+                                                            messageBusProvider,
+                                                            machineManagerProvider,
+                                                            machineServiceClient,
+                                                            snapshotCreator,
+                                                            loaderFactory,
+                                                            workspaceServiceClient,
+                                                            wsComponentProvider,
+                                                            asyncRequestFactory);
         when(wsComponentProvider.get()).thenReturn(workspaceComponent);
         when(workspace.getId()).thenReturn(WORKSPACE_ID);
         when(workspaceStatusEvent.getWorkspaceId()).thenReturn(WORKSPACE_ID);
@@ -181,7 +206,7 @@ public class WorkspaceEventsNotifierTest {
         when(linkParameter.getDefaultValue()).thenReturn(WORKSPACE_STATUS_CHANNEL);
     }
 
-//    @Test disabled because of GWT timer usage
+    //    @Test disabled because of GWT timer usage
     public void shouldSubscribesOnWsAgentOutputWhenWorkspaceIsStarting() throws Exception {
         WorkspaceRuntimeDto runtime = mock(WorkspaceRuntimeDto.class);
         WorkspaceConfigDto workspaceConfig = mock(WorkspaceConfigDto.class);
@@ -196,8 +221,8 @@ public class WorkspaceEventsNotifierTest {
         MachineConfigDto devMachineConfig = mock(MachineConfigDto.class);
         when(devMachineConfig.getName()).thenReturn(MACHINE_NAME);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(workspacePromise).then(workspaceCaptor.capture());
         workspaceCaptor.getValue().apply(workspace);
@@ -210,6 +235,10 @@ public class WorkspaceEventsNotifierTest {
         WorkspaceRuntimeDto runtime = mock(WorkspaceRuntimeDto.class);
         WorkspaceConfigDto workspaceConfig = mock(WorkspaceConfigDto.class);
         when(workspace.getRuntime()).thenReturn(runtime);
+        MachineDto devMachine = mock(MachineDto.class);
+        when(devMachine.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+        when(devMachine.getId()).thenReturn(MACHINE_NAME);
+        when(runtime.getDevMachine()).thenReturn(devMachine);
         when(runtime.getActiveEnv()).thenReturn(ACTIVE_ENV);
         when(workspace.getConfig()).thenReturn(workspaceConfig);
         Map<String, EnvironmentDto> environments = new HashMap<>(3);
@@ -219,17 +248,19 @@ public class WorkspaceEventsNotifierTest {
         MachineConfigDto devMachineConfig = mock(MachineConfigDto.class);
         when(devMachineConfig.getName()).thenReturn(MACHINE_NAME);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
+        when(machineServiceClient.getProcesses(WORKSPACE_ID, MACHINE_NAME)).thenReturn(processPromise);
+
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
 
         verify(messageBus).subscribe(eq(WS_AGENT_LOG_CHANNEL), (MessageHandler)anyObject());
     }
 
-//    @Test disabled because of GWT timer usage
+    //    @Test disabled because of GWT timer usage
     public void onWorkspaceStartingTest() throws Exception {
         when(workspaceStatusEvent.getEventType()).thenReturn(STARTING);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(workspacePromise).then(workspaceCaptor.capture());
         workspaceCaptor.getValue().apply(workspace);
@@ -245,8 +276,8 @@ public class WorkspaceEventsNotifierTest {
     public void onWorkspaceStartedTest() throws Exception {
         when(workspaceStatusEvent.getEventType()).thenReturn(RUNNING);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(workspacePromise).then(workspaceCaptor.capture());
         workspaceCaptor.getValue().apply(workspace);
@@ -269,8 +300,8 @@ public class WorkspaceEventsNotifierTest {
         when(dialogFactory.createMessageDialog(anyString(), anyString(), (ConfirmCallback)anyObject())).thenReturn(errorDialog);
         when(workspaceStatusEvent.getEventType()).thenReturn(ERROR);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(workspacesPromise).then(workspacesCaptor.capture());
         workspacesCaptor.getValue().apply(workspaces);
@@ -286,8 +317,8 @@ public class WorkspaceEventsNotifierTest {
     public void onWorkspaceStoppedTest() throws Exception {
         when(workspaceStatusEvent.getEventType()).thenReturn(STOPPED);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(messageBus, times(4)).unsubscribe(anyString(), (MessageHandler)anyObject());
         verify(notificationManager).notify(anyString(), eq(StatusNotification.Status.SUCCESS), eq(FLOAT_MODE));
@@ -298,8 +329,8 @@ public class WorkspaceEventsNotifierTest {
     public void onSnapshotCreatingEventReceivedTest() throws Exception {
         when(workspaceStatusEvent.getEventType()).thenReturn(SNAPSHOT_CREATING);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(snapshotLoader).show();
     }
@@ -308,8 +339,8 @@ public class WorkspaceEventsNotifierTest {
     public void onSnapshotCreatedEventReceivedTest() throws Exception {
         when(workspaceStatusEvent.getEventType()).thenReturn(SNAPSHOT_CREATED);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(snapshotLoader).hide();
         verify(snapshotCreator).successfullyCreated();
@@ -319,8 +350,8 @@ public class WorkspaceEventsNotifierTest {
     public void onSnapshotCreationErrorEventReceivedTest() throws Exception {
         when(workspaceStatusEvent.getEventType()).thenReturn(SNAPSHOT_CREATION_ERROR);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.workspaceStatusSubscriptionHandler.onMessageReceived(workspaceStatusEvent);
 
         verify(snapshotLoader).hide();
         verify(snapshotCreator).creationError(anyString());
@@ -328,8 +359,8 @@ public class WorkspaceEventsNotifierTest {
 
     @Test
     public void onEnvironmentStatusEventReceivedTest() throws Exception {
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.environmentStatusSubscriptionHandler.onMessageReceived(machineStatusEvent);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.environmentStatusSubscriptionHandler.onMessageReceived(machineStatusEvent);
 
         verify(eventBus).fireEvent(Matchers.<MachineStatusChangedEvent>anyObject());
     }
@@ -338,8 +369,8 @@ public class WorkspaceEventsNotifierTest {
     public void onEnvironmentOutputEventReceivedTest() throws Exception {
         MachineLogMessageDto machineLogMessage = mock(MachineLogMessageDto.class);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.environmentOutputSubscriptionHandler.onMessageReceived(machineLogMessage);
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.environmentOutputSubscriptionHandler.onMessageReceived(machineLogMessage);
 
         verify(eventBus).fireEvent(Matchers.<EnvironmentOutputEvent>anyObject());
         verify(machineLogMessage).getContent();
@@ -351,6 +382,10 @@ public class WorkspaceEventsNotifierTest {
         WorkspaceRuntimeDto runtime = mock(WorkspaceRuntimeDto.class);
         WorkspaceConfigDto workspaceConfig = mock(WorkspaceConfigDto.class);
         when(workspace.getRuntime()).thenReturn(runtime);
+        MachineDto devMachine = mock(MachineDto.class);
+        when(devMachine.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+        when(devMachine.getId()).thenReturn(MACHINE_NAME);
+        when(runtime.getDevMachine()).thenReturn(devMachine);
         when(runtime.getActiveEnv()).thenReturn(ACTIVE_ENV);
         when(workspace.getConfig()).thenReturn(workspaceConfig);
         Map<String, EnvironmentDto> environments = new HashMap<>(3);
@@ -360,8 +395,11 @@ public class WorkspaceEventsNotifierTest {
         MachineConfigDto devMachineConfig = mock(MachineConfigDto.class);
         when(devMachineConfig.getName()).thenReturn(MACHINE_NAME);
 
-        workspaceEventsNotifier.trackWorkspaceEvents(workspace, callback);
-        workspaceEventsNotifier.wsAgentLogSubscriptionHandler.onMessageReceived("");
+        when(machineServiceClient.getProcesses(WORKSPACE_ID, MACHINE_NAME)).thenReturn(processPromise);
+
+        workspaceEventsHandler.trackWorkspaceEvents(workspace, callback);
+        workspaceEventsHandler.wsAgentLogSubscriptionHandler.onMessageReceived("");
+        verify(processPromise).then(processCaptor.capture());
 
         verify(eventBus).fireEvent(Matchers.<EnvironmentOutputEvent> anyObject());
     }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessFinishedEvent.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessFinishedEvent.java
@@ -27,13 +27,13 @@ public class ProcessFinishedEvent extends GwtEvent<ProcessFinishedEvent.Handler>
 
     public static final Type<ProcessFinishedEvent.Handler> TYPE = new Type<>();
 
-    private final String processID;
+    private final int processID;
 
-    public ProcessFinishedEvent(String processID) {
+    public ProcessFinishedEvent(int processID) {
         this.processID = processID;
     }
 
-    public String getProcessID() {
+    public int getProcessID() {
         return processID;
     }
 

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
@@ -262,6 +262,10 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
                     onAddTerminal(appContext.getWorkspaceId(), selectedTreeNode.getParent().getId());
                 }
             }
+        } else {
+            if (appContext.getDevMachine() != null) {
+                onAddTerminal(appContext.getWorkspaceId(), appContext.getDevMachine().getId());
+            }
         }
     }
 
@@ -721,7 +725,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
                                                             .withType(machineProcessDto.getType());
 
                     final CommandType type = commandTypeRegistry.getCommandTypeById(commandDto.getType());
-                    if (type != null) {
+                    if (type != null ) {
                         final CommandConfiguration configuration = type.getConfigurationFactory().createFromDto(commandDto);
                         final CommandOutputConsole console = commandConsoleFactory.create(configuration, machine);
                         console.listenToOutput(machineProcessDto.getOutputChannel());

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
@@ -477,7 +477,7 @@ public class ProcessesPanelPresenterTest {
         when(outputConsole.isFinished()).thenReturn(true);
         presenter.consoles.put(PROCESS_ID, outputConsole);
 
-        presenter.onProcessFinished(new ProcessFinishedEvent(null));
+        presenter.onProcessFinished(new ProcessFinishedEvent(PID));
 
         verify(view).setStopButtonVisibility(PROCESS_ID, false);
     }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -45,5 +45,8 @@ public final class Constants {
 
     public static final String LINK_REL_GET_WORKSPACE_EVENTS_CHANNEL = "get workspace events channel";
 
+    public static final String WS_AGENT_PROCESS_NAME          = "CheWsAgent";
+
+
     private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/wsagent/WsAgentLauncherImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/wsagent/WsAgentLauncherImpl.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Map;
 
+import static org.eclipse.che.api.workspace.shared.Constants.WS_AGENT_PROCESS_NAME;
+
 /**
  * Starts ws agent in the machine and waits until ws agent sends notification about its start
  *
@@ -42,7 +44,6 @@ import java.util.Map;
 @Singleton
 public class WsAgentLauncherImpl implements WsAgentLauncher {
     public static final String WS_AGENT_PROCESS_START_COMMAND = "machine.ws_agent.run_command";
-    public static final String WS_AGENT_PROCESS_NAME          = "CheWsAgent";
 
     protected static final Logger LOG = LoggerFactory.getLogger(WsAgentLauncherImpl.class);
 
@@ -88,7 +89,9 @@ public class WsAgentLauncherImpl implements WsAgentLauncher {
                                                      devMachine.getId(),
                                                      new CommandImpl(WS_AGENT_PROCESS_NAME,
                                                                      wsAgentStartCommandLine,
-                                                                     "Arbitrary"),
+                                                                     WS_AGENT_PROCESS_NAME), //for server side type of command mean nothing
+                                                                                             //but we will use it as marker on
+                                                                                             //client side for track this command
                                                      getWsAgentProcessOutputChannel(devMachine.getWorkspaceId()));
             final long pingStartTimestamp = System.currentTimeMillis();
             LOG.debug("Starts pinging ws agent. Workspace ID:{}. Url:{}. Timestamp:{}",

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/wsagent/WsAgentLauncherImplTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/wsagent/WsAgentLauncherImplTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 
+import static org.eclipse.che.api.workspace.shared.Constants.WS_AGENT_PROCESS_NAME;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -104,9 +105,9 @@ public class WsAgentLauncherImplTest {
 
         verify(machineProcessManager).exec(eq(WORKSPACE_ID),
                                            eq(MACHINE_ID),
-                                           eq(new CommandImpl(WsAgentLauncherImpl.WS_AGENT_PROCESS_NAME,
-                                                       WS_AGENT_START_CMD_LINE,
-                                                       "Arbitrary")),
+                                           eq(new CommandImpl(WS_AGENT_PROCESS_NAME,
+                                                              WS_AGENT_START_CMD_LINE,
+                                                              WS_AGENT_PROCESS_NAME)),
                                            eq(WsAgentLauncherImpl.getWsAgentProcessOutputChannel(WORKSPACE_ID)));
 
     }


### PR DESCRIPTION
### What does this PR do?

Restore log of the running procces if refresh page (including ws-agent start log).
Rename class. 
Fix appearing terminal to the dev-machine in some cases
### What issues does this PR fix or reference?
#2325
### Previous behavior

see #2325 
### Minor change checklist
- [ ] Tests updated
- [ ] Tests passed

Signed-off-by: Vitaly Parfonov vparfonov@codenvy.com
