### PR TITLE
Allow Che CLI to run in directory w/o write permissions

### DIFF
--- a/che.sh
+++ b/che.sh
@@ -203,8 +203,11 @@ docker_run() {
 docker_run_with_env_file() {
   debug $FUNCNAME
   get_list_of_che_system_environment_variables
-  docker_run --env-file=tmpgibberish "$@"
-  rm -rf $PWD/tmpgibberish > /dev/null
+  
+  # Silly issue - docker run --env-file does not accept path to file - must be in same dir
+  cd ~/.che
+  docker_run --env-file tmpgibberish "$@"
+  rm -rf ~/.che/tmpgibberish > /dev/null
 }
 
 docker_run_with_pseudo_tty() {
@@ -423,26 +426,27 @@ get_list_of_che_system_environment_variables() {
 
   # See: http://stackoverflow.com/questions/4128235/what-is-the-exact-meaning-of-ifs-n
   IFS=$'\n'
-  DOCKER_ENV=$(get_mount_path $PWD)/tmpgibberish
-  touch $DOCKER_ENV
+  DOCKER_ENV=~/.che/tmpgibberish
+  test -d ~/.che || mkdir -p ~/.che
+  touch ~/.che/tmpgibberish
   
   if has_default_profile; then
-    cat ~/.che/profiles/${CHE_PROFILE} >> $DOCKER_ENV
+    cat ~/.che/profiles/${CHE_PROFILE} >> ~/.che/tmpgibberish
   else
 
     # Grab these values to send to other utilities - they need to know the values  
-    echo "CHE_SERVER_CONTAINER_NAME=${CHE_SERVER_CONTAINER_NAME}" >> $DOCKER_ENV
-    echo "CHE_SERVER_IMAGE_NAME=${CHE_SERVER_IMAGE_NAME}" >> $DOCKER_ENV
-    echo "CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME}" >> $DOCKER_ENV
-    echo "CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME}" >> $DOCKER_ENV
-    echo "CHE_VERSION=${CHE_VERSION}" >> $DOCKER_ENV
-    echo "CHE_CLI_INFO=${CHE_CLI_INFO}" >> $DOCKER_ENV
-    echo "CHE_CLI_DEBUG=${CHE_CLI_DEBUG}" >> $DOCKER_ENV
+    echo "CHE_SERVER_CONTAINER_NAME=${CHE_SERVER_CONTAINER_NAME}" >> ~/.che/tmpgibberish
+    echo "CHE_SERVER_IMAGE_NAME=${CHE_SERVER_IMAGE_NAME}" >> ~/.che/tmpgibberish
+    echo "CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME}" >> ~/.che/tmpgibberish
+    echo "CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME}" >> ~/.che/tmpgibberish
+    echo "CHE_VERSION=${CHE_VERSION}" >> ~/.che/tmpgibberish
+    echo "CHE_CLI_INFO=${CHE_CLI_INFO}" >> ~/.che/tmpgibberish
+    echo "CHE_CLI_DEBUG=${CHE_CLI_DEBUG}" >> ~/.che/tmpgibberish
 
     CHE_VARIABLES=$(env | grep CHE_)
 
     if [ ! -z ${CHE_VARIABLES+x} ]; then
-      env | grep CHE_ >> $DOCKER_ENV
+      env | grep CHE_ >> ~/.che/tmpgibberish
     fi
 
     # Add in known proxy variables

--- a/che.sh
+++ b/che.sh
@@ -92,9 +92,10 @@ init_global_variables() {
   GLOBAL_GET_DOCKER_HOST_IP=$(get_docker_host_ip)
 
   if is_boot2docker && has_docker_for_windows_client; then
-  	if [[ ! "${CHE_DATA_FOLDER}" == *"${USERPROFILE}"* ]]; then
-      error_exit "Boot2docker for Windows - set CHE_DATA_FOLDER to subdir of ${USERPROFILE}. Exiting."
-      return 1
+  	if [[ "${CHE_DATA_FOLDER,,}" != *"${USERPROFILE,,}"* ]]; then
+  	  CHE_DATA_FOLDER=$(get_mount_path "${USERPROFILE}/.che/")
+      info "Boot2docker for Windows - CHE_DATA_FOLDER set to $CHE_DATA_FOLDER"
+      return
   	fi
   fi
 
@@ -440,6 +441,7 @@ get_list_of_che_system_environment_variables() {
     echo "CHE_VERSION=${CHE_VERSION}" >> ~/.che/tmpgibberish
     echo "CHE_CLI_INFO=${CHE_CLI_INFO}" >> ~/.che/tmpgibberish
     echo "CHE_CLI_DEBUG=${CHE_CLI_DEBUG}" >> ~/.che/tmpgibberish
+    echo "CHE_DATA_FOLDER=${CHE_DATA_FOLDER}" >> ~/.che/tmpgibberish
 
     CHE_VARIABLES=$(env | grep CHE_)
 
@@ -449,15 +451,15 @@ get_list_of_che_system_environment_variables() {
 
     # Add in known proxy variables
     if [ ! -z ${http_proxy+x} ]; then
-      echo "http_proxy=${http_proxy}" >> $DOCKER_ENV
+      echo "http_proxy=${http_proxy}" >> ~/.che/tmpgibberish
     fi
 
     if [ ! -z ${https_proxy+x} ]; then
-      echo "https_proxy=${https_proxy}" >> $DOCKER_ENV
+      echo "https_proxy=${https_proxy}" >> ~/.che/tmpgibberish
     fi
 
     if [ ! -z ${no_proxy+x} ]; then
-      echo "no_proxy=${no_proxy}" >> $DOCKER_ENV
+      echo "no_proxy=${no_proxy}" >> ~/.che/tmpgibberish
     fi
   fi
 }


### PR DESCRIPTION
### What does this PR do?

1: Updates the CLI to write its temporary file into ~/.che/tmpgibberish, which is always writable, instead of writing it into the current directory.  In order to do a docker run, temporarily changes the directory location to ~/.che/ to perform the execution.

2: Found reversion on the networking tests.  Seems that we reverted back to an old version of the tests.  So fixed that.

3: Added in check on boot2docker + windows - to override CHE_DATA_FOLDER to be %USERPROFILE%/.che, if CHE_DATA_FOLDER is not a subset of %USERPROFILE%.

There is no docs impact.
