### PR TITLE
CHE-2278: Fixing appearing SSH button. Now it showing only after starting machine 

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
@@ -200,6 +200,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
 
     @Override
     public void onMachineRunning(MachineStateEvent event) {
+        updateMachineNode(event.getMachine());
     }
 
     @Override
@@ -597,6 +598,26 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         view.setProcessesData(rootNode);
 
         return machineNode;
+    }
+
+    /**
+     * Going to update machine state after changing it status to RUNNING
+     * TODO: need to review this fix in case done like fast fix for release 4.7.1 https://github.com/eclipse/che/issues/2278
+     * TODO: need fine better solution
+     * @param machine
+     */
+    private void updateMachineNode(Machine machine) {
+        ProcessTreeNode machineNode = machineNodes.get(machine.getId());
+        if (machineNode == null) {
+            return;
+        }
+        rootNodes.remove(machineNode);
+
+        machineNode = new ProcessTreeNode(MACHINE_NODE, rootNode, machine, null, new ArrayList<ProcessTreeNode>());
+        machineNode.setRunning(true);
+        machineNodes.put(machine.getId(), machineNode);
+        rootNodes.add(machineNode);
+        view.setProcessesData(rootNode);
     }
 
     /** Get the list of all available machines. */

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelViewImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelViewImpl.java
@@ -46,6 +46,7 @@ import org.eclipse.che.ide.ui.tree.SelectionModel;
 import org.eclipse.che.ide.ui.tree.Tree;
 import org.eclipse.che.ide.ui.tree.TreeNodeElement;
 import org.eclipse.che.ide.util.input.SignalEvent;
+import org.eclipse.che.ide.util.loging.Log;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import java.util.HashMap;
@@ -280,18 +281,23 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
         focusedSubPanel.addWidget(widgetToShow, !machineConsole, new SubPanel.WidgetRemovingListener() {
             @Override
             public void onWidgetRemoving(SubPanel.RemoveCallback removeCallback) {
-                final ProcessTreeNode treeNode = widget2TreeNodes.get(widgetToShow.getWidget());
+                try {
+                    final ProcessTreeNode treeNode = widget2TreeNodes.get(widgetToShow.getWidget());
 
-                switch (treeNode.getType()) {
-                    case COMMAND_NODE:
-                        delegate.onCommandTabClosing(treeNode, removeCallback);
-                        break;
-                    case TERMINAL_NODE:
-                        delegate.onTerminalTabClosing(treeNode);
-                        removeCallback.remove();
-                        break;
+                    switch (treeNode.getType()) {
+                        case COMMAND_NODE:
+                            delegate.onCommandTabClosing(treeNode, removeCallback);
+                            break;
+                        case TERMINAL_NODE:
+                            delegate.onTerminalTabClosing(treeNode);
+                            removeCallback.remove();
+                            break;
+                    }
+                } catch (Exception e) {
+                    Log.error(getClass(), e);
                 }
             }
+
         });
 
         processWidgets.put(processId, widgetToShow);


### PR DESCRIPTION
Fixing appearing SSH button. Now it showing only after starting machine.
Fix stop workspace behavior: close all related process panel
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2278
### Previous behavior

see https://github.com/eclipse/che/issues/2278
### New behavior

SSH button will be shown only after starting machine 

Signed-off-by: Vitaly Parfonov vparfonov@codenvy.com
