### PR TITLE
add terminal and ssh agents into creating dev-machine object

### DIFF
--- a/dashboard/src/components/api/che-workspace.factory.js
+++ b/dashboard/src/components/api/che-workspace.factory.js
@@ -259,7 +259,7 @@ export class CheWorkspace {
       defaultEnvironment = {
         'name': config.defaultEnv,
         'recipe': null,
-        'machines': {'dev-machine': {'attributes': {'memoryLimitBytes': ram}, 'agents': ['org.eclipse.che.ws-agent']}}
+        'machines': {'dev-machine': {'attributes': {'memoryLimitBytes': ram}, 'agents': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh']}}
       };
 
       config.environments[config.defaultEnv] = defaultEnvironment;
@@ -291,7 +291,7 @@ export class CheWorkspace {
         'attributes': {'memoryLimitBytes': ram},
         'type': 'docker',
         'source': source,
-        'agents': ['org.eclipse.che.ws-agent']
+        'agents': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh']
       };
       defaultEnvironment.machines[devMachine.name] = devMachine;
     } else {


### PR DESCRIPTION
### What does this PR do?

Add terminal and ssh agents into creating dev-machine object during create workspace flow from custom stack.
### What issues does this PR fix or reference?

They add  terminal and ssh agents.  So, we can have a terminal and ssh connection for run commands in IDE with custom stacks.

Signed-off-by: Oleksii Orel oorel@codenvy.com
