### PR TITLE
Add property machine.docker.local_node_host.external

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -124,6 +124,11 @@ machine.docker.privilege_mode=false
 # address and provide this host or IP address here.
 machine.docker.local_node_host=NULL
 
+# If the browser cannot access directly to the IP of the Docker host (e.g. when docker host is behind a NAT or
+# with Docker for Mac) we can set this external address to let the browser access Docker containers.
+# wsmaster will still use machine.docker.local_node_host to access Docker containers containers.
+machine.docker.local_node_host.external=NULL
+
 # Allows to use registry for machine snapshots, you should set this property to {true},
 # otherwise workspace snapshots would be saved locally.
 machine.docker.snapshot_use_registry=false

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/Server.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/Server.java
@@ -25,7 +25,13 @@ public interface Server {
     String getRef();
 
     /**
-     * Address of the server in form <b>host:port</b>
+     * External address of the server in form <b>hostname:port</b>.
+     * <p>
+     * This address is used by the browser to communicate with the server.
+     * <b>hostname</b> can be configured using property machine.docker.local_node_host.external
+     * or environment variable CHE_DOCKER_MACHINE_HOST_EXTERNAL.
+     * <b>port</b> is the external port and cannot be configured.
+     * If not explicitly configured that address is set using {@link ServerProperties#getInternalAddress()}
      */
     String getAddress();
 
@@ -36,14 +42,15 @@ public interface Server {
     String getProtocol();
 
     /**
-     * Path to access the server.
-     */
-    @Nullable
-    String getPath();
-
-    /**
-     * Url of the server, e.g. http://localhost:8080
+     * Url of the server, e.g.&nbsp;http://localhost:8080
      */
     @Nullable
     String getUrl();
+
+
+    /**
+     * Non mandatory properties of the server.
+     */
+    @Nullable
+    ServerProperties getProperties();
 }

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/ServerProperties.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/ServerProperties.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.model.machine;
+
+import org.eclipse.che.commons.annotation.Nullable;
+
+/**
+ * Not mandatory properties of a {@link Server}
+ *
+ * @author Mario Loriedo
+ */
+public interface ServerProperties {
+
+    /**
+     * Path to access the server.
+     */
+    @Nullable
+    String getPath();
+
+    /**
+     * Internal address of the server in form <b>host:port</b>.
+     * <p>
+     * Used by wsmaster to communicate with the server
+     */
+    @Nullable
+    String getInternalAddress();
+
+
+    /**
+     * Internal Url of the server, e.g.&nbsp;http://localhost:8080.
+     * <p>
+     * Used by wsmaster to comunicate with the server
+     */
+    @Nullable
+    String getInternalUrl();
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachineServer.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachineServer.java
@@ -11,29 +11,32 @@
 package org.eclipse.che.ide.api.machine;
 
 import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.model.machine.ServerProperties;
 import org.eclipse.che.api.machine.shared.dto.ServerDto;
+
+import java.util.Objects;
 
 /**
  * Describe development machine server instance.
- * {@link Server}
  *
+ * @link Server
  * @author Vitalii Parfonov
  */
 public class DevMachineServer implements Server {
 
 
-        private final String path;
-        private final String address;
-        private final String protocol;
-        private final String ref;
-        private final String url;
+    private final String address;
+    private final String protocol;
+    private final String ref;
+    private final String url;
+    private final ServerProperties properties;
 
         public DevMachineServer(Server dto) {
-            path = dto.getPath();
             address = dto.getAddress();
             protocol = dto.getProtocol();
             ref = dto.getRef();
             url = dto.getUrl();
+            properties = dto.getProperties();
         }
 
 
@@ -53,12 +56,45 @@ public class DevMachineServer implements Server {
         }
 
         @Override
-        public String getPath() {
-            return path;
-        }
-
-        @Override
         public String getUrl() {
             return url;
         }
-}
+
+        @Override
+        public ServerProperties getProperties() { return properties; };
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DevMachineServer)) return false;
+            final DevMachineServer other = (DevMachineServer) o;
+            return Objects.equals(ref, other.ref) &&
+                           Objects.equals(protocol, other.protocol) &&
+                           Objects.equals(address, other.address) &&
+                           Objects.equals(url, other.url) &&
+                           Objects.equals(properties, other.properties);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = hash * 31 + Objects.hashCode(ref);
+            hash = hash * 31 + Objects.hashCode(protocol);
+            hash = hash * 31 + Objects.hashCode(address);
+            hash = hash * 31 + Objects.hashCode(url);
+            hash = hash * 31 + Objects.hashCode(properties);
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "DevMachineServer{" +
+                           "ref='" + ref + '\'' +
+                           ", protocol='" + protocol + '\'' +
+                           ", address='" + address + '\'' +
+                           ", url='" + url + '\'' +
+                           ", properties='" + properties + '\'' +
+                           '}';
+        }
+
+    }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachineServerProperties.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachineServerProperties.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.machine;
+
+import org.eclipse.che.api.core.model.machine.ServerProperties;
+
+import java.util.Objects;
+
+/**
+ * Describe development machine server instance.
+ *
+ * @link ServerProperties
+ * @author Mario Loriedo
+ */
+public class DevMachineServerProperties implements ServerProperties {
+
+    private final String path;
+    private final String internalAddress;
+    private final String internalUrl;
+
+    public DevMachineServerProperties(ServerProperties properties) {
+        path = properties.getPath();
+        internalAddress = properties.getInternalAddress();
+        internalUrl = properties.getInternalUrl();
+    }
+
+    @Override
+    public String getInternalAddress() {
+        return internalAddress;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getInternalUrl() {
+        return internalUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DevMachineServerProperties)) return false;
+        final DevMachineServerProperties other = (DevMachineServerProperties)o;
+
+        return Objects.equals(path, other.path) &&
+                       Objects.equals(internalAddress, other.internalAddress) &&
+                       Objects.equals(internalUrl, other.internalUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = hash * 31 + Objects.hashCode(path);
+        hash = hash * 31 + Objects.hashCode(internalAddress);
+        hash = hash * 31 + Objects.hashCode(internalUrl);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "DevMachineServerProperties{" +
+                       "path='" + path + '\'' +
+                       ", internalAddress='" + internalAddress + '\'' +
+                       ", internalUrl='" + internalUrl + '\'' +
+                       '}';
+    }
+
+}

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -145,6 +145,7 @@ public class DockerInstance extends AbstractInstance {
             try {
                 final ContainerInfo containerInfo = docker.inspectContainer(container);
                 machineRuntime = new MachineRuntimeInfoImpl(dockerMachineFactory.createMetadata(containerInfo,
+                                                                                                null,
                                                                                                 node.getHost(),
                                                                                                 getConfig()));
             } catch (IOException e) {

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -17,6 +17,8 @@ import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
 import org.eclipse.che.api.core.model.machine.ServerConf;
 import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.ContainerState;
@@ -83,17 +85,21 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
     protected static final String SERVER_CONF_LABEL_PATH_SUFFIX     = ":path";
 
     private final ContainerInfo               info;
-    private final String                      containerHost;
+    private final String                      containerExternalHostname;
+    private final String                      containerInternalHostname;
     private final Map<String, ServerConfImpl> serversConf;
 
     @Inject
     public DockerInstanceRuntimeInfo(@Assisted ContainerInfo containerInfo,
-                                     @Assisted String containerHost,
+                                     @Assisted("externalhost") @Nullable String containerExternalHostname,
+                                     @Assisted("internalhost") String containerInternalHostname,
                                      @Assisted MachineConfig machineConfig,
                                      @Named("machine.docker.dev_machine.machine_servers") Set<ServerConf> devMachineSystemServers,
                                      @Named("machine.docker.machine_servers") Set<ServerConf> allMachinesSystemServers) {
         this.info = containerInfo;
-        this.containerHost = containerHost;
+        this.containerExternalHostname = containerExternalHostname == null ?
+                                                    containerInternalHostname : containerExternalHostname;
+        this.containerInternalHostname = containerInternalHostname;
         Stream<ServerConf> confStream = Stream.concat(machineConfig.getServers().stream(), allMachinesSystemServers.stream());
         if (machineConfig.isDev()) {
             confStream = Stream.concat(confStream, devMachineSystemServers.stream());
@@ -244,7 +250,8 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
         }
         return addDefaultReferenceForServersWithoutReference(
                 addRefAndUrlToServers(
-                        getServersWithFilledPorts(containerHost,
+                        getServersWithFilledPorts(containerExternalHostname,
+                                                  containerInternalHostname,
                                                   ports),
                         labels));
     }
@@ -264,33 +271,44 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
     protected Map<String, ServerImpl> addRefAndUrlToServers(final Map<String, ServerImpl> servers, final Map<String, String> labels) {
         final Map<String, ServerConfImpl> serversConfFromLabels = getServersConfFromLabels(servers.keySet(), labels);
         for (Map.Entry<String, ServerImpl> serverEntry : servers.entrySet()) {
+            ServerPropertiesImpl serverProperties = new ServerPropertiesImpl(serverEntry.getValue().getProperties());
             ServerConf serverConf = serversConf.getOrDefault(serverEntry.getKey(), serversConfFromLabels.get(serverEntry.getKey()));
             if (serverConf != null) {
                 if (serverConf.getRef() != null) {
                     serverEntry.getValue().setRef(serverConf.getRef());
                 }
                 if (serverConf.getPath() != null) {
-                    serverEntry.getValue().setPath(serverConf.getPath());
+                    serverProperties.setPath(serverConf.getPath());
                 }
                 if (serverConf.getProtocol() != null) {
                     serverEntry.getValue().setProtocol(serverConf.getProtocol());
 
-                    String url = serverConf.getProtocol() + "://" + serverEntry.getValue().getAddress();
+                    String externalUrl = serverConf.getProtocol() + "://" + serverEntry.getValue().getAddress();
                     if (!isNullOrEmpty(serverConf.getPath())) {
                         if (serverConf.getPath().charAt(0) != '/') {
-                            url = url + '/';
+                            externalUrl = externalUrl + '/';
                         }
-                        url = url + serverConf.getPath();
+                        externalUrl = externalUrl + serverConf.getPath();
                     }
-                    serverEntry.getValue().setUrl(url);
+                    serverEntry.getValue().setUrl(externalUrl);
+
+                    String internalUrl = serverConf.getProtocol() + "://" + serverProperties.getInternalAddress();
+                    if (serverConf.getPath() != null) {
+                        if (serverConf.getPath().charAt(0) != '/') {
+                            internalUrl = internalUrl + '/';
+                        }
+                        internalUrl = internalUrl + serverConf.getPath();
+                    }
+                    serverProperties.setInternalUrl(internalUrl);
                 }
+                serverEntry.getValue().setProperties(serverProperties);
             }
         }
 
         return servers;
     }
 
-    protected Map<String, ServerImpl> getServersWithFilledPorts(final String host, final Map<String, List<PortBinding>> exposedPorts) {
+    protected Map<String, ServerImpl> getServersWithFilledPorts(final String externalHostame, final String internalHostname, final Map<String, List<PortBinding>> exposedPorts) {
         final HashMap<String, ServerImpl> servers = new LinkedHashMap<>();
 
         for (Map.Entry<String, List<PortBinding>> portEntry : exposedPorts.entrySet()) {
@@ -300,9 +318,9 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
             String externalPort = portEntry.getValue().get(0).getHostPort();
             servers.put(portProtocol, new ServerImpl(null,
                                                      null,
-                                                     host + ":" + externalPort,
+                                                     externalHostame + ":" + externalPort,
                                                      null,
-                                                     null));
+                                                     new ServerPropertiesImpl(null, internalHostname + ":" + externalPort, null)));
         }
 
         return servers;

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineFactory.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineFactory.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.server.spi.InstanceProcess;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.machine.node.DockerNode;
 
@@ -80,10 +81,12 @@ public interface DockerMachineFactory {
      * Creates {@link DockerInstanceRuntimeInfo} instance using assisted injection
      *
      * @param containerInfo description of docker container
-     * @param containerHost host where docker container is placed
+     * @param containerExternalHostname docker host external hostname (used by the browser)
+     * @param containerInternalHostname docker host internal hostname (used by the wsmaster)
      * @param machineConfig config of machine
      */
     DockerInstanceRuntimeInfo createMetadata(@Assisted ContainerInfo containerInfo,
-                                             @Assisted String containerHost,
+                                             @Assisted("externalhost") @Nullable String containerExternalHostname,
+                                             @Assisted("internalhost") String containerInternalHostname,
                                              @Assisted MachineConfig machineConfig);
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerInstanceRuntimeInfo.java
@@ -20,38 +20,86 @@ import org.eclipse.che.plugin.docker.machine.DockerInstanceRuntimeInfo;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.List;
 import java.util.Set;
 
 /**
- * Gets predefined docker containers host for machine servers instead of evaluating it from docker configuration
+ * Gets predefined docker containers host (internal and external addresses) for machine servers instead of evaluating it
+ * from docker configuration. External address is needed when clients (UD, IDE, etc...) can't ping machine servers
+ * directly (e.g. when running on Docker for Mac or behind a NAT). If the external address is not provided it defaults
+ * to the internal one.
  *
  * <p>Value of host can be retrieved from property ${code machine.docker.local_node_host} or
  * from environment variable {@code CHE_DOCKER_MACHINE_HOST}.<br>
- * Environment variable has lower priority.
+ * <p>Value of external hostname can be retrieved from property ${code machine.docker.local_node_host.external} or
+ * from environment variable {@code CHE_DOCKER_MACHINE_HOST_EXTERNAL}.<br>
+ * Environment variables have higher priority.
  *
  * @author Alexander Garagatyi
  * @see org.eclipse.che.api.core.model.machine.ServerConf
  */
 public class LocalDockerInstanceRuntimeInfo extends DockerInstanceRuntimeInfo {
     /**
-     * Env variable that shows host (or IP) where docker machines are deployed
+     * Env variable that provides host (or IP) of the Docker host.
+     * This value is used by wsmaster to communicate with servers running inside containers.
      */
-    public static final String CHE_DOCKER_MACHINE_HOST = "CHE_DOCKER_MACHINE_HOST";
+    public static final String CHE_DOCKER_MACHINE_HOST_INTERNAL = "CHE_DOCKER_MACHINE_HOST";
+
+    /**
+     * Env variable that provides the external host (or IP) of the Docker host.
+     * The value is used by UD, IDE and other clients to communicate with the servers running inside containers.
+     */
+    public static final String CHE_DOCKER_MACHINE_HOST_EXTERNAL = "CHE_DOCKER_MACHINE_HOST_EXTERNAL";
 
     @Inject
     public LocalDockerInstanceRuntimeInfo(@Assisted ContainerInfo containerInfo,
-                                          @Assisted String containerHost,
+                                          @Assisted("externalhost") @Nullable String containerExternalHostname,
+                                          @Assisted("internalhost") String containerInternalHostname,
                                           @Assisted MachineConfig machineConfig,
-                                          @Nullable @Named("machine.docker.local_node_host") String dockerNodeHost,
+                                          @Nullable @Named("machine.docker.local_node_host") String dockerNodeInternalHostname,
+                                          @Nullable @Named("machine.docker.local_node_host.external") String dockerNodeExternalHostname,
                                           @Named("machine.docker.dev_machine.machine_servers") Set<ServerConf> devMachineServers,
                                           @Named("machine.docker.machine_servers") Set<ServerConf> allMachinesServers) {
+
+
         super(containerInfo,
-              dockerNodeHost != null ? dockerNodeHost : (System.getenv(CHE_DOCKER_MACHINE_HOST) != null ?
-                                                         System.getenv(CHE_DOCKER_MACHINE_HOST) :
-                                                         containerHost),
+              externalHostnameWithPrecedence(dockerNodeExternalHostname,
+                                           containerExternalHostname,
+                                           dockerNodeInternalHostname,
+                                           containerInternalHostname),
+              internalHostnameWithPrecedence(dockerNodeInternalHostname,
+                                           containerInternalHostname),
               machineConfig,
               devMachineServers,
               allMachinesServers);
+    }
+
+    private static String externalHostnameWithPrecedence(String externalHostnameProperty,
+                                                              String externalHostnameAssisted,
+                                                              String internalHostnameProperty,
+                                                              String internalHostnameAssisted) {
+
+        String externalHostnameEnvVar = System.getenv(CHE_DOCKER_MACHINE_HOST_EXTERNAL);
+        if (externalHostnameEnvVar != null) {
+            return externalHostnameEnvVar;
+        } else if (externalHostnameProperty != null) {
+            return externalHostnameProperty;
+        } else if (externalHostnameAssisted != null) {
+            return externalHostnameAssisted;
+        } else {
+            return internalHostnameWithPrecedence(internalHostnameProperty,internalHostnameAssisted);
+        }
+    }
+
+    private static String internalHostnameWithPrecedence(String internalHostnameProperty,
+                                                              String internalHostnameAssisted) {
+
+        String internalHostNameEnvVariable = System.getenv(CHE_DOCKER_MACHINE_HOST_INTERNAL);
+        if (internalHostNameEnvVariable != null) {
+            return internalHostNameEnvVariable;
+        } else if (internalHostnameProperty != null) {
+            return internalHostnameProperty;
+        } else {
+            return internalHostnameAssisted;
+        }
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfoTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfoTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.machine.ServerConf;
 import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
@@ -43,8 +44,9 @@ import static org.testng.Assert.assertEquals;
 
 @Listeners(MockitoTestNGListener.class)
 public class DockerInstanceRuntimeInfoTest {
-    private static final String CONTAINER_HOST  = "container-host.com";
-    private static final String DEFAULT_ADDRESS = "192.168.1.1";
+    private static final String CONTAINER_HOST           = "container-host.com";
+    private static final String CONTAINER_HOST_EXTERNAL  = "container-host-ext.com";
+    private static final String DEFAULT_ADDRESS          = "192.168.1.1";
 
     @Mock
     private ContainerInfo   containerInfo;
@@ -60,6 +62,7 @@ public class DockerInstanceRuntimeInfoTest {
     @BeforeMethod
     public void setUp() {
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     Collections.emptySet(),
@@ -162,17 +165,17 @@ public class DockerInstanceRuntimeInfoTest {
                                                        null,
                                                        CONTAINER_HOST + ":32100",
                                                        null,
-                                                       null));
+                                                       new ServerPropertiesImpl(null, CONTAINER_HOST + ":32100", null)));
         expectedServers.put("100100/udp", new ServerImpl("Server-100100-udp",
                                                          null,
                                                          CONTAINER_HOST + ":32101",
                                                          null,
-                                                         null));
+                                                         new ServerPropertiesImpl(null, CONTAINER_HOST + ":32101", null)));
         expectedServers.put("8080/udp", new ServerImpl("Server-8080-udp",
                                                        null,
                                                        CONTAINER_HOST + ":32102",
                                                        null,
-                                                       null));
+                                                       new ServerPropertiesImpl(null, CONTAINER_HOST + ":32102", null)));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -201,6 +204,7 @@ public class DockerInstanceRuntimeInfoTest {
         serversConfigs.add(new ServerConfImpl("myserv2", "100100/udp", "dhcp", "/some"));
         serversConfigs.add(new ServerConfImpl(null, "8000/tcp", "tcp", "/path"));
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     Collections.emptySet(),
@@ -209,23 +213,31 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("8080/tcp", new ServerImpl("myserv1",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       null,
-                                                       "http://" + CONTAINER_HOST + ":32100"));
+                                                       "http://" + CONTAINER_HOST + ":32100",
+                                                        new ServerPropertiesImpl(null,
+                                                                CONTAINER_HOST + ":32100",
+                                                                "http://" + CONTAINER_HOST + ":32100")));
         expectedServers.put("100100/udp", new ServerImpl("myserv2",
                                                          "dhcp",
                                                          CONTAINER_HOST + ":32101",
-                                                         "/some",
-                                                         "dhcp://" + CONTAINER_HOST + ":32101/some"));
+                                                         "dhcp://" + CONTAINER_HOST + ":32101/some",
+                                                         new ServerPropertiesImpl("/some",
+                                                                 CONTAINER_HOST + ":32101",
+                                                                 "dhcp://" + CONTAINER_HOST + ":32101/some")));
         expectedServers.put("8080/udp", new ServerImpl("myserv1-tftp",
                                                        "tftp",
                                                        CONTAINER_HOST + ":32102",
-                                                       "/some/path",
-                                                       "tftp://" + CONTAINER_HOST + ":32102/some/path"));
+                                                       "tftp://" + CONTAINER_HOST + ":32102/some/path",
+                                                        new ServerPropertiesImpl("/some/path",
+                                                                 CONTAINER_HOST + ":32102",
+                                                                 "tftp://" + CONTAINER_HOST + ":32102/some/path")));
         expectedServers.put("8000/tcp", new ServerImpl("Server-8000-tcp",
                                                        "tcp",
                                                        CONTAINER_HOST + ":32103",
-                                                       "/path",
-                                                       "tcp://" + CONTAINER_HOST + ":32103/path"));
+                                                       "tcp://" + CONTAINER_HOST + ":32103/path",
+                                                       new ServerPropertiesImpl("/path",
+                                                                 CONTAINER_HOST + ":32103",
+                                                                 "tcp://" + CONTAINER_HOST + ":32103/path")));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -248,6 +260,7 @@ public class DockerInstanceRuntimeInfoTest {
         serversConfigs.add(new ServerConfImpl("myserv1", "8080", "http", "/some"));
         serversConfigs.add(new ServerConfImpl("myserv1-tftp", "8080/udp", "tftp", "path"));
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     Collections.emptySet(),
@@ -256,13 +269,17 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("8080/tcp", new ServerImpl("myserv1",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       "/some",
-                                                       "http://" + CONTAINER_HOST + ":32100/some"));
+                                                       "http://" + CONTAINER_HOST + ":32100/some",
+                                                       new ServerPropertiesImpl("/some",
+                                                               CONTAINER_HOST + ":32100",
+                                                               "http://" + CONTAINER_HOST + ":32100/some")));
         expectedServers.put("8080/udp", new ServerImpl("myserv1-tftp",
                                                        "tftp",
                                                        CONTAINER_HOST + ":32102",
-                                                       "path",
-                                                       "tftp://" + CONTAINER_HOST + ":32102/path"));
+                                                       "tftp://" + CONTAINER_HOST + ":32102/path",
+                                                       new ServerPropertiesImpl("path",
+                                                               CONTAINER_HOST + ":32102",
+                                                               "tftp://" + CONTAINER_HOST + ":32102/path")));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -275,6 +292,7 @@ public class DockerInstanceRuntimeInfoTest {
     public void shouldAddRefUrlPathToServerFromLabels() throws Exception {
         // given
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     Collections.emptySet(),
@@ -304,23 +322,31 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("8080/tcp", new ServerImpl("myserv1",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       "/some/path",
-                                                       "http://" + CONTAINER_HOST + ":32100/some/path"));
+                                                       "http://" + CONTAINER_HOST + ":32100/some/path",
+                                                       new ServerPropertiesImpl("/some/path",
+                                                                 CONTAINER_HOST + ":32100",
+                                                                 "http://" + CONTAINER_HOST + ":32100/some/path")));
         expectedServers.put("100100/udp", new ServerImpl("myserv2",
                                                          "dhcp",
                                                          CONTAINER_HOST + ":32101",
-                                                         "some/path",
-                                                         "dhcp://" + CONTAINER_HOST + ":32101/some/path"));
+                                                         "dhcp://" + CONTAINER_HOST + ":32101/some/path",
+                                                         new ServerPropertiesImpl("some/path",
+                                                                 CONTAINER_HOST + ":32101",
+                                                                 "dhcp://" + CONTAINER_HOST + ":32101/some/path")));
         expectedServers.put("8080/udp", new ServerImpl("myserv1-tftp",
                                                        "tftp",
                                                        CONTAINER_HOST + ":32102",
-                                                       null,
-                                                       "tftp://" + CONTAINER_HOST + ":32102"));
+                                                       "tftp://" + CONTAINER_HOST + ":32102",
+                                                       new ServerPropertiesImpl(null,
+                                                               CONTAINER_HOST + ":32102",
+                                                               "tftp://" + CONTAINER_HOST + ":32102")));
         expectedServers.put("8000/tcp", new ServerImpl("Server-8000-tcp",
                                                        "tcp",
                                                        CONTAINER_HOST + ":32103",
-                                                       null,
-                                                       "tcp://" + CONTAINER_HOST + ":32103"));
+                                                       "tcp://" + CONTAINER_HOST + ":32103",
+                                                       new ServerPropertiesImpl(null,
+                                                               CONTAINER_HOST + ":32103",
+                                                               "tcp://" + CONTAINER_HOST + ":32103")));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -333,6 +359,7 @@ public class DockerInstanceRuntimeInfoTest {
     public void shouldAllowToUsePortFromDockerLabelsWithoutTransportProtocol() throws Exception {
         // given
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     Collections.emptySet(),
@@ -357,18 +384,24 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("8080/tcp", new ServerImpl("myserv1",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       null,
-                                                       "http://" + CONTAINER_HOST + ":32100"));
+                                                       "http://" + CONTAINER_HOST + ":32100",
+                                                       new ServerPropertiesImpl(null,
+                                                               CONTAINER_HOST + ":32100",
+                                                               "http://" + CONTAINER_HOST + ":32100")));
         expectedServers.put("8080/udp", new ServerImpl("myserv1-tftp",
                                                        "tftp",
                                                        CONTAINER_HOST + ":32102",
-                                                       null,
-                                                       "tftp://" + CONTAINER_HOST + ":32102"));
+                                                       "tftp://" + CONTAINER_HOST + ":32102",
+                                                       new ServerPropertiesImpl(null,
+                                                               CONTAINER_HOST + ":32102",
+                                                               "tftp://" + CONTAINER_HOST + ":32102")));
         expectedServers.put("8000/tcp", new ServerImpl("myserv2",
                                                        "tcp",
                                                        CONTAINER_HOST + ":32103",
-                                                       null,
-                                                       "tcp://" + CONTAINER_HOST + ":32103"));
+                                                       "tcp://" + CONTAINER_HOST + ":32103",
+                                                       new ServerPropertiesImpl(null,
+                                                               CONTAINER_HOST + ":32103",
+                                                               "tcp://" + CONTAINER_HOST + ":32103")));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -402,6 +435,7 @@ public class DockerInstanceRuntimeInfoTest {
         serversConfigs.add(new ServerConfImpl("myserv1conf", "8080/tcp", "http", null));
         serversConfigs.add(new ServerConfImpl(null, "8080/udp", null, "some/path"));
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     Collections.emptySet(),
@@ -410,18 +444,22 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("8080/tcp", new ServerImpl("myserv1conf",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       null,
-                                                       "http://" + CONTAINER_HOST + ":32100"));
+                                                       "http://" + CONTAINER_HOST + ":32100",
+                                                       new ServerPropertiesImpl(null,
+                                                               CONTAINER_HOST + ":32100",
+                                                               "http://" + CONTAINER_HOST + ":32100")));
         expectedServers.put("100100/udp", new ServerImpl("myserv2label",
                                                          "dhcp",
                                                          CONTAINER_HOST + ":32101",
-                                                         "/path",
-                                                         "dhcp://" + CONTAINER_HOST + ":32101/path"));
+                                                         "dhcp://" + CONTAINER_HOST + ":32101/path",
+                                                         new ServerPropertiesImpl("/path",
+                                                                CONTAINER_HOST + ":32101",
+                                                                "dhcp://" + CONTAINER_HOST + ":32101/path")));
         expectedServers.put("8080/udp", new ServerImpl("Server-8080-udp",
                                                        null,
                                                        CONTAINER_HOST + ":32102",
-                                                       "some/path",
-                                                       null));
+                                                       null,
+                                                       new ServerPropertiesImpl("some/path", CONTAINER_HOST + ":32102", null)));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -452,6 +490,7 @@ public class DockerInstanceRuntimeInfoTest {
         devSystemServersConfigs.add(new ServerConfImpl("devSysServer1-tcp", "4305/tcp", "http", null));
         when(machineConfig.isDev()).thenReturn(false);
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     devSystemServersConfigs,
@@ -460,23 +499,29 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("4301/tcp", new ServerImpl("sysServer1-tcp",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       "/some/path",
-                                                       "http://" + CONTAINER_HOST + ":32100/some/path"));
+                                                       "http://" + CONTAINER_HOST + ":32100/some/path",
+                                                       new ServerPropertiesImpl("/some/path",
+                                                                   CONTAINER_HOST + ":32100",
+                                                                   "http://" + CONTAINER_HOST + ":32100/some/path")));
         expectedServers.put("4302/udp", new ServerImpl("sysServer2-udp",
                                                        "dhcp",
                                                        CONTAINER_HOST + ":32101",
-                                                       null,
-                                                       "dhcp://" + CONTAINER_HOST + ":32101"));
+                                                       "dhcp://" + CONTAINER_HOST + ":32101",
+                                                       new ServerPropertiesImpl(null,
+                                                                    CONTAINER_HOST + ":32101",
+                                                                    "dhcp://" + CONTAINER_HOST + ":32101")));
         expectedServers.put("4301/udp", new ServerImpl("sysServer1-udp",
                                                        null,
                                                        CONTAINER_HOST + ":32102",
-                                                       "some/path",
-                                                       null));
+                                                       null,
+                                                       new ServerPropertiesImpl("some/path",
+                                                                   CONTAINER_HOST + ":32102",
+                                                                   null)));
         expectedServers.put("4305/tcp", new ServerImpl("Server-4305-tcp",
                                                        null,
                                                        CONTAINER_HOST + ":32103",
                                                        null,
-                                                       null));
+                                                       new ServerPropertiesImpl(null, CONTAINER_HOST + ":32103", null)));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();
@@ -506,6 +551,7 @@ public class DockerInstanceRuntimeInfoTest {
         devSystemServersConfigs.add(new ServerConfImpl("devSysServer1-udp", "4305/udp", null, "some/path4"));
         when(machineConfig.isDev()).thenReturn(true);
         runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                    null,
                                                     CONTAINER_HOST,
                                                     machineConfig,
                                                     devSystemServersConfigs,
@@ -514,23 +560,117 @@ public class DockerInstanceRuntimeInfoTest {
         expectedServers.put("4301/tcp", new ServerImpl("sysServer1-tcp",
                                                        "http",
                                                        CONTAINER_HOST + ":32100",
-                                                       "/some/path1",
-                                                       "http://" + CONTAINER_HOST + ":32100/some/path1"));
+                                                       "http://" + CONTAINER_HOST + ":32100/some/path1",
+                                                       new ServerPropertiesImpl("/some/path1",
+                                                           CONTAINER_HOST + ":32100",
+                                                           "http://" + CONTAINER_HOST + ":32100/some/path1")));
         expectedServers.put("4302/udp", new ServerImpl("sysServer2-udp",
                                                        "dhcp",
                                                        CONTAINER_HOST + ":32101",
-                                                       "some/path2",
-                                                       "dhcp://" + CONTAINER_HOST + ":32101/some/path2"));
+                                                       "dhcp://" + CONTAINER_HOST + ":32101/some/path2",
+                                                       new ServerPropertiesImpl("some/path2",
+                                                           CONTAINER_HOST + ":32101",
+                                                           "dhcp://" + CONTAINER_HOST + ":32101/some/path2")));
         expectedServers.put("4305/tcp", new ServerImpl("devSysServer1-tcp",
                                                        "http",
                                                        CONTAINER_HOST + ":32102",
-                                                       "/some/path3",
-                                                       "http://" + CONTAINER_HOST + ":32102/some/path3"));
+                                                       "http://" + CONTAINER_HOST + ":32102/some/path3",
+                                                       new ServerPropertiesImpl("/some/path3",
+                                                           CONTAINER_HOST + ":32102",
+                                                           "http://" + CONTAINER_HOST + ":32102/some/path3")));
         expectedServers.put("4305/udp", new ServerImpl("devSysServer1-udp",
                                                        null,
                                                        CONTAINER_HOST + ":32103",
-                                                       "some/path4",
-                                                       null));
+                                                       null,
+                                                       new ServerPropertiesImpl("some/path4",
+                                                           CONTAINER_HOST + ":32103",
+                                                           null)));
+
+        // when
+        final Map<String, ServerImpl> servers = runtimeInfo.getServers();
+
+        // then
+        assertEquals(servers, expectedServers);
+    }
+
+    @Test
+    public void shouldSetExternalAddressAsInternalAddressIfContainerExternalHostnameIsNull() throws Exception {
+        // given
+        Map<String, List<PortBinding>> ports = new HashMap<>();
+        when(networkSettings.getPorts()).thenReturn(ports);
+        ports.put("4301/tcp", Collections.singletonList(new PortBinding().withHostIp(DEFAULT_ADDRESS)
+                                                                .withHostPort("32100")));
+        ports.put("4305/udp", Collections.singletonList(new PortBinding().withHostIp(DEFAULT_ADDRESS)
+                                                                .withHostPort("32103")));
+        Set<ServerConf> commonSystemServersConfigs = new HashSet<>();
+        commonSystemServersConfigs.add(new ServerConfImpl("sysServer1-tcp", "4301/tcp", "http", "/some/path1"));
+        Set<ServerConf> devSystemServersConfigs = new HashSet<>();
+        devSystemServersConfigs.add(new ServerConfImpl("devSysServer1-udp", "4305/udp", null, "some/path4"));
+        when(machineConfig.isDev()).thenReturn(true);
+        runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                           null,
+                                                           CONTAINER_HOST,
+                                                           machineConfig,
+                                                           devSystemServersConfigs,
+                                                           commonSystemServersConfigs);
+        final HashMap<String, ServerImpl> expectedServers = new HashMap<>();
+        expectedServers.put("4301/tcp", new ServerImpl("sysServer1-tcp",
+                                                              "http",
+                                                              CONTAINER_HOST + ":32100",
+                                                              "http://" + CONTAINER_HOST + ":32100/some/path1",
+                                                              new ServerPropertiesImpl("/some/path1",
+                                                                                              CONTAINER_HOST + ":32100",
+                                                                                              "http://" + CONTAINER_HOST + ":32100/some/path1")));
+        expectedServers.put("4305/udp", new ServerImpl("devSysServer1-udp",
+                                                              null,
+                                                              CONTAINER_HOST + ":32103",
+                                                              null,
+                                                              new ServerPropertiesImpl("some/path4",
+                                                                                              CONTAINER_HOST + ":32103",
+                                                                                              null)));
+
+        // when
+        final Map<String, ServerImpl> servers = runtimeInfo.getServers();
+
+        // then
+        assertEquals(servers, expectedServers);
+    }
+
+    @Test
+    public void shouldSetExternalAddressDistinctFromInternalWhenExternalHostnameIsNotNull() throws Exception {
+        // given
+        Map<String, List<PortBinding>> ports = new HashMap<>();
+        when(networkSettings.getPorts()).thenReturn(ports);
+        ports.put("4301/tcp", Collections.singletonList(new PortBinding().withHostIp(DEFAULT_ADDRESS)
+                                                                .withHostPort("32100")));
+        ports.put("4305/udp", Collections.singletonList(new PortBinding().withHostIp(DEFAULT_ADDRESS)
+                                                                .withHostPort("32103")));
+        Set<ServerConf> commonSystemServersConfigs = new HashSet<>();
+        commonSystemServersConfigs.add(new ServerConfImpl("sysServer1-tcp", "4301/tcp", "http", "/some/path1"));
+        Set<ServerConf> devSystemServersConfigs = new HashSet<>();
+        devSystemServersConfigs.add(new ServerConfImpl("devSysServer1-udp", "4305/udp", null, "some/path4"));
+        when(machineConfig.isDev()).thenReturn(true);
+        runtimeInfo = new DockerInstanceRuntimeInfo(containerInfo,
+                                                           CONTAINER_HOST_EXTERNAL,
+                                                           CONTAINER_HOST,
+                                                           machineConfig,
+                                                           devSystemServersConfigs,
+                                                           commonSystemServersConfigs);
+        final HashMap<String, ServerImpl> expectedServers = new HashMap<>();
+        expectedServers.put("4301/tcp", new ServerImpl("sysServer1-tcp",
+                                                              "http",
+                                                              CONTAINER_HOST_EXTERNAL + ":32100",
+                                                              "http://" + CONTAINER_HOST_EXTERNAL + ":32100/some/path1",
+                                                              new ServerPropertiesImpl("/some/path1",
+                                                                                              CONTAINER_HOST + ":32100",
+                                                                                              "http://" + CONTAINER_HOST + ":32100/some/path1")));
+        expectedServers.put("4305/udp", new ServerImpl("devSysServer1-udp",
+                                                              null,
+                                                              CONTAINER_HOST_EXTERNAL + ":32103",
+                                                              null,
+                                                              new ServerPropertiesImpl("some/path4",
+                                                                                              CONTAINER_HOST + ":32103",
+                                                                                              null)));
 
         // when
         final Map<String, ServerImpl> servers = runtimeInfo.getServers();

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/server/Server.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/server/Server.java
@@ -16,6 +16,7 @@ import com.google.inject.assistedinject.Assisted;
 import org.eclipse.che.api.machine.shared.dto.ServerDto;
 
 import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 /**
  * The class which describes entity which store information of current server.
@@ -24,19 +25,17 @@ import javax.validation.constraints.NotNull;
  */
 public class Server implements org.eclipse.che.api.core.model.machine.Server {
 
-    private final String    port;
     private final ServerDto descriptor;
+    private final String    port;
 
     @Inject
     public Server(@Assisted String port, @Assisted ServerDto descriptor) {
-        this.port = port;
+        this.port       = port;
         this.descriptor = descriptor;
     }
 
     @NotNull
-    public String getPort() {
-        return port;
-    }
+    public String getPort() { return port; }
 
     @NotNull
     @Override
@@ -61,7 +60,32 @@ public class Server implements org.eclipse.che.api.core.model.machine.Server {
     }
 
     @Override
-    public String getPath() {
-        return descriptor.getPath();
+    public ServerProperties getProperties() {
+        return new ServerProperties(descriptor.getProperties());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Server)) return false;
+        Server other = (Server) o;
+        return Objects.equals(descriptor, other.descriptor) &&
+                       Objects.equals(port, other.port);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = hash * 31 + Objects.hashCode(descriptor);
+        hash = hash * 31 + Objects.hashCode(port);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "Server{" +
+                       "descriptor=" + descriptor +
+                       ", port='" + port + '\'' +
+                       '}';
     }
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/server/ServerProperties.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/server/ServerProperties.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.extension.machine.client.perspective.widgets.machine.appliance.server;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+import org.eclipse.che.api.machine.shared.dto.ServerPropertiesDto;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+/**
+ * ServeProperties class stores non mandatory properties of the current server.
+ *
+ * @author Mario Loriedo
+ */
+public class ServerProperties implements org.eclipse.che.api.core.model.machine.ServerProperties {
+
+    private final ServerPropertiesDto descriptor;
+
+    @Inject
+    public ServerProperties(@Assisted ServerPropertiesDto descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    @Override
+    public String getPath() {
+        return descriptor.getPath();
+    }
+
+    @Override
+    public String getInternalAddress() { return descriptor.getInternalAddress(); }
+
+    @Override
+    public String getInternalUrl() {
+        return descriptor.getInternalUrl();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ServerProperties)) return false;
+        final ServerProperties other = (ServerProperties) o;
+        return Objects.equals(descriptor, other.descriptor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(descriptor.getPath());
+    }
+
+    @Override
+    public String toString() {
+        return "ServerProperties{" +
+                       "descriptor=" + descriptor +
+                       '}';
+    }
+}

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/server/ServerTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/perspective/widgets/machine/appliance/server/ServerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.ide.extension.machine.client.perspective.widgets.machine.appliance.server;
 
 import org.eclipse.che.api.machine.shared.dto.ServerDto;
+import org.eclipse.che.api.machine.shared.dto.ServerPropertiesDto;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,9 @@ public class ServerTest {
 
     @Mock
     private ServerDto descriptor;
+
+    @Mock
+    private ServerPropertiesDto descriptor2;
 
     private Server server;
 
@@ -55,15 +59,6 @@ public class ServerTest {
     }
 
     @Test
-    public void pathShouldBeReturned() {
-        when(descriptor.getPath()).thenReturn(SOME_TEXT);
-
-        assertThat(server.getPath(), equalTo(SOME_TEXT));
-
-        verify(descriptor).getPath();
-    }
-
-    @Test
     public void urlShouldBeReturned() {
         when(descriptor.getUrl()).thenReturn(SOME_TEXT);
 
@@ -79,6 +74,39 @@ public class ServerTest {
         assertThat(server.getRef(), equalTo(SOME_TEXT));
 
         verify(descriptor).getRef();
+    }
+
+    @Test
+    public void pathShouldBeReturned() {
+        when(descriptor.getProperties()).thenReturn(descriptor2);
+        when(descriptor2.getPath()).thenReturn(SOME_TEXT);
+
+        assertThat(server.getProperties().getPath(), equalTo(SOME_TEXT));
+
+        verify(descriptor).getProperties();
+        verify(descriptor2).getPath();
+    }
+
+    @Test
+    public void internalAddressShouldBeReturned() {
+        when(descriptor.getProperties()).thenReturn(descriptor2);
+        when(descriptor2.getInternalAddress()).thenReturn(SOME_TEXT);
+
+        assertThat(server.getProperties().getInternalAddress(), equalTo(SOME_TEXT));
+
+        verify(descriptor).getProperties();
+        verify(descriptor2).getInternalAddress();
+    }
+
+    @Test
+    public void internalUrlShouldBeReturned() {
+        when(descriptor.getProperties()).thenReturn(descriptor2);
+        when(descriptor2.getInternalUrl()).thenReturn(SOME_TEXT);
+
+        assertThat(server.getProperties().getInternalUrl(), equalTo(SOME_TEXT));
+
+        verify(descriptor).getProperties();
+        verify(descriptor2).getInternalUrl();
     }
 
 }

--- a/plugins/plugin-ssh-machine/src/main/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstance.java
+++ b/plugins/plugin-ssh-machine/src/main/java/org/eclipse/che/plugin/machine/ssh/SshMachineInstance.java
@@ -200,8 +200,8 @@ public class SshMachineInstance extends AbstractInstance {
         return new ServerImpl(serverConf.getRef(),
                               serverConf.getProtocol(),
                               serverUri.getHost() + ":" + serverUri.getPort(),
-                              serverUri.getPath(),
-                              serverConf.getProtocol() != null ? serverUri.toString() : null);
+                              serverConf.getProtocol() != null ? serverUri.toString() : null,
+                              null);
     }
 
 }

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/ServerDto.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/ServerDto.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.machine.shared.dto;
 
 import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.model.machine.ServerProperties;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -26,13 +27,6 @@ public interface ServerDto extends Server {
     void setProtocol(String protocol);
 
     ServerDto withProtocol(String protocol);
-
-    @Override
-    String getPath();
-
-    void setPath(String path);
-
-    ServerDto withPath(String path);
 
     @Override
     String getAddress();
@@ -54,4 +48,11 @@ public interface ServerDto extends Server {
     void setRef(String ref);
 
     ServerDto withRef(String ref);
+
+    @Override
+    ServerPropertiesDto getProperties();
+
+    void setProperties(ServerPropertiesDto properties);
+
+    ServerDto withProperties(ServerPropertiesDto properties);
 }

--- a/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/ServerPropertiesDto.java
+++ b/wsmaster/che-core-api-machine-shared/src/main/java/org/eclipse/che/api/machine/shared/dto/ServerPropertiesDto.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.shared.dto;
+
+import org.eclipse.che.api.core.model.machine.ServerProperties;
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Describes how to access servers properties
+ *
+ * @author Mario Loriedo
+ */
+@DTO
+public interface ServerPropertiesDto extends ServerProperties {
+    @Override
+    String getPath();
+
+    void setPath(String path);
+
+    ServerPropertiesDto withPath(String path);
+
+    @Override
+    String getInternalAddress();
+
+    void setInternalAddress(String internalAddress);
+
+    ServerPropertiesDto withInternalAddress(String internalAddress);
+
+    @Override
+    String getInternalUrl();
+
+    void setInternalUrl(String internalUrl);
+
+    ServerPropertiesDto withInternalUrl(String internalUrl);
+}

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/DtoConverter.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/DtoConverter.java
@@ -10,23 +10,25 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.server;
 
-import org.eclipse.che.api.core.model.machine.MachineLimits;
 import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.MachineLimits;
 import org.eclipse.che.api.core.model.machine.MachineProcess;
 import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
 import org.eclipse.che.api.core.model.machine.MachineSource;
 import org.eclipse.che.api.core.model.machine.Server;
 import org.eclipse.che.api.core.model.machine.ServerConf;
+import org.eclipse.che.api.core.model.machine.ServerProperties;
 import org.eclipse.che.api.core.model.machine.Snapshot;
-import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
+import org.eclipse.che.api.machine.shared.dto.MachineLimitsDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
 import org.eclipse.che.api.machine.shared.dto.MachineRuntimeInfoDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
 import org.eclipse.che.api.machine.shared.dto.ServerConfDto;
 import org.eclipse.che.api.machine.shared.dto.ServerDto;
+import org.eclipse.che.api.machine.shared.dto.ServerPropertiesDto;
 import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 
 import java.util.Map;
@@ -106,10 +108,19 @@ public final class DtoConverter {
      */
     public static ServerDto asDto(Server server) {
         return newDto(ServerDto.class).withAddress(server.getAddress())
-                                      .withRef(server.getRef())
-                                      .withProtocol(server.getProtocol())
-                                      .withPath(server.getPath())
-                                      .withUrl(server.getUrl());
+                       .withRef(server.getRef())
+                       .withProtocol(server.getProtocol())
+                       .withUrl(server.getUrl())
+                       .withProperties(asDto(server.getProperties()));
+    }
+
+    /**
+     * Converts {@link ServerProperties} to {@link ServerPropertiesDto}.
+     */
+    public static ServerPropertiesDto asDto(ServerProperties serverProperties) {
+        return newDto(ServerPropertiesDto.class).withPath(serverProperties.getPath())
+                       .withInternalAddress(serverProperties.getInternalAddress())
+                       .withInternalUrl(serverProperties.getInternalUrl());
     }
 
     /**

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/ServerImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/ServerImpl.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.machine.server.model.impl;
 
 import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.model.machine.ServerProperties;
 
 import java.util.Objects;
 
@@ -22,22 +23,22 @@ import java.util.Objects;
  */
 public class ServerImpl implements Server {
 
-    private String ref;
-    private String address;
-    private String url;
-    private String protocol;
-    private String path;
+    private String               ref;
+    private String               protocol;
+    private String               address;
+    private String               url;
+    private ServerPropertiesImpl properties;
 
-    public ServerImpl(String ref, String protocol, String address, String path, String url) {
+    public ServerImpl(String ref, String protocol, String address, String url, ServerProperties properties) {
         this.ref = ref;
+        this.protocol = protocol;
         this.address = address;
         this.url = url;
-        this.protocol = protocol;
-        this.path = path;
+        this.properties = new ServerPropertiesImpl(properties);
     }
 
     public ServerImpl(Server server) {
-        this(server.getRef(), server.getProtocol(), server.getAddress(), server.getPath(), server.getUrl());
+        this(server.getRef(), server.getProtocol(), server.getAddress(), server.getUrl(), server.getProperties());
     }
 
     @Override
@@ -77,12 +78,12 @@ public class ServerImpl implements Server {
     }
 
     @Override
-    public String getPath() {
-        return path;
+    public ServerProperties getProperties() {
+        return properties;
     }
 
-    public void setPath(String path) {
-        this.path = path;
+    public void setProperties(ServerPropertiesImpl properties) {
+        this.properties = properties;
     }
 
     @Override
@@ -93,8 +94,8 @@ public class ServerImpl implements Server {
         return Objects.equals(ref, other.ref) &&
                Objects.equals(protocol, other.protocol) &&
                Objects.equals(address, other.address) &&
-               Objects.equals(path, other.path) &&
-               Objects.equals(url, other.url);
+               Objects.equals(url, other.url) &&
+               Objects.equals(properties, other.properties);
     }
 
     @Override
@@ -103,8 +104,8 @@ public class ServerImpl implements Server {
         hash = hash * 31 + Objects.hashCode(ref);
         hash = hash * 31 + Objects.hashCode(protocol);
         hash = hash * 31 + Objects.hashCode(address);
-        hash = hash * 31 + Objects.hashCode(path);
         hash = hash * 31 + Objects.hashCode(url);
+        hash = hash * 31 + Objects.hashCode(properties);
         return hash;
     }
 
@@ -114,8 +115,8 @@ public class ServerImpl implements Server {
                "ref='" + ref + '\'' +
                ", protocol='" + protocol + '\'' +
                ", address='" + address + '\'' +
-               ", path='" + path + '\'' +
                ", url='" + url + '\'' +
+               ", properties='" + properties + '\'' +
                '}';
     }
 }

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/ServerPropertiesImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/ServerPropertiesImpl.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server.model.impl;
+
+import org.eclipse.che.api.core.model.machine.ServerProperties;
+
+import java.util.Objects;
+
+/**
+ * Data object for {@link ServerProperties}.
+ *
+ * @author Mario Loriedo
+ */
+public class ServerPropertiesImpl implements ServerProperties {
+
+    private String               path;
+    private String               internalAddress;
+    private String               internalUrl;
+
+    public ServerPropertiesImpl(String path, String internalAddress, String internalUrl) {
+        this.internalAddress = internalAddress;
+        this.internalUrl = internalUrl;
+        this.path = path;
+    }
+
+    public ServerPropertiesImpl(ServerProperties properties) {
+        this(properties.getPath(), properties.getInternalAddress(), properties.getInternalUrl());
+    }
+
+
+    @Override
+    public String getPath() { return path; }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public String getInternalAddress() { return internalAddress; }
+
+    public void setInternalAddress(String internalAddress) {
+        this.internalAddress = internalAddress;
+    }
+
+    @Override
+    public String getInternalUrl() {
+        return internalUrl;
+    }
+
+    public void setInternalUrl(String internalUrl) {
+        this.internalUrl = internalUrl;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ServerPropertiesImpl)) return false;
+        final ServerPropertiesImpl other = (ServerPropertiesImpl)o;
+
+        return Objects.equals(path, other.path) &&
+               Objects.equals(internalAddress, other.internalAddress) &&
+               Objects.equals(internalUrl, other.internalUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = hash * 31 + Objects.hashCode(path);
+        hash = hash * 31 + Objects.hashCode(internalAddress);
+        hash = hash * 31 + Objects.hashCode(internalUrl);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "ServerImpl{" +
+                       "path='" + path + '\'' +
+                       ", internalAddress='" + internalAddress + '\'' +
+                       ", internalUrl='" + internalUrl + '\'' +
+                       '}';
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/launcher/WsAgentLauncherImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/launcher/WsAgentLauncherImpl.java
@@ -150,7 +150,7 @@ public class WsAgentLauncherImpl implements AgentLauncher {
                       WS_AGENT_SERVER_NOT_FOUND_ERROR, machine.getWorkspaceId(), machine.getId(), servers);
             throw new ServerException(WS_AGENT_SERVER_NOT_FOUND_ERROR);
         }
-        String wsAgentPingUrl = wsAgentServer.getUrl();
+        String wsAgentPingUrl = wsAgentServer.getProperties().getInternalUrl();
         // since everrest mapped on the slash in case of it absence
         // we will always obtain not found response
         if (!wsAgentPingUrl.endsWith("/")) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -33,6 +33,7 @@ import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
 import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
@@ -748,11 +749,16 @@ public class WorkspaceServiceTest {
                                               MachineStatus.RUNNING,
                                               new MachineRuntimeInfoImpl(emptyMap(),
                                                                          emptyMap(),
-                                                                         singletonMap("8080/https", new ServerImpl("wsagent",
-                                                                                                                   "8080",
-                                                                                                                   "https",
-                                                                                                                   "path1",
-                                                                                                                   "url")))));
+                                                                         singletonMap("8080/https",
+                                                                                      new ServerImpl(
+                                                                                              "wsagent",
+                                                                                              "https",
+                                                                                              "address",
+                                                                                              "url",
+                                                                                              new ServerPropertiesImpl(
+                                                                                                  "path",
+                                                                                                  "internaladdress",
+                                                                                                  "internalurl"))))));
         runtime.getMachines().add(runtime.getDevMachine());
         workspace.setStatus(RUNNING);
         workspace.setRuntime(runtime);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/launcher/WsAgentLauncherImplTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/launcher/WsAgentLauncherImplTest.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.machine.Command;
 import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.model.machine.ServerProperties;
 import org.eclipse.che.api.core.rest.HttpJsonRequest;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonResponse;
@@ -24,6 +25,7 @@ import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.shared.Constants;
 import org.eclipse.che.commons.test.mockito.answer.SelfReturningAnswer;
@@ -51,20 +53,25 @@ import static org.mockito.Mockito.when;
 
 @Listeners(MockitoTestNGListener.class)
 public class WsAgentLauncherImplTest {
-    private static final String     MACHINE_ID                    = "machineId";
-    private static final String     WORKSPACE_ID                  = "testWorkspaceId";
-    private static final String     WS_AGENT_PORT                 = Constants.WS_AGENT_PORT;
-    private static final long       WS_AGENT_MAX_START_TIME_MS    = 1000;
-    private static final long       WS_AGENT_PING_DELAY_MS        = 1;
-    private static final int        WS_AGENT_PING_CONN_TIMEOUT_MS = 1;
-    private static final String     WS_AGENT_SERVER_LOCATION      = "ws-agent.com:456789/";
-    private static final String     WS_AGENT_SERVER_URL           = "http://" + WS_AGENT_SERVER_LOCATION;
-    private static final ServerImpl SERVER                        = new ServerImpl("ref",
-                                                                                   "http",
+    private static final String               MACHINE_ID                    = "machineId";
+    private static final String               WORKSPACE_ID                  = "testWorkspaceId";
+    private static final String               WS_AGENT_PORT                 = Constants.WS_AGENT_PORT;
+    private static final long                 WS_AGENT_MAX_START_TIME_MS    = 1000;
+    private static final long                 WS_AGENT_PING_DELAY_MS        = 1;
+    private static final int                  WS_AGENT_PING_CONN_TIMEOUT_MS = 1;
+    private static final String               WS_AGENT_SERVER_LOCATION      = "ws-agent.com:456789/";
+    private static final String               WS_AGENT_SERVER_URL           = "http://" + WS_AGENT_SERVER_LOCATION;
+    private static final String               WS_AGENT_SERVER_LOCATION_EXT  = "ws-agent-ext.com:456789/";
+    private static final String               WS_AGENT_SERVER_URL_EXT       = "http://" + WS_AGENT_SERVER_LOCATION;
+    private static final ServerPropertiesImpl SERVER_PROPERTIES             = new ServerPropertiesImpl(null,
                                                                                    WS_AGENT_SERVER_LOCATION,
-                                                                                   null,
                                                                                    WS_AGENT_SERVER_URL);
-    private static final String     WS_AGENT_TIMED_OUT_MESSAGE    = "timeout error message";
+    private static final ServerImpl           SERVER                        = new ServerImpl("ref",
+                                                                                   "http",
+                                                                                   WS_AGENT_SERVER_LOCATION_EXT,
+                                                                                   WS_AGENT_SERVER_URL_EXT,
+                                                                                   SERVER_PROPERTIES);
+    private static final String               WS_AGENT_TIMED_OUT_MESSAGE    = "timeout error message";
 
     @Mock
     private MachineProcessManager  machineProcessManager;


### PR DESCRIPTION
### What does this PR do?

Introduce a new property, `machine.docker.local_node_host.external` (along with the environment variable `CHE_DOCKER_MACHINE_HOST_EXTERNAL`), that allow to configure the external URL browsers need to use to connect with containers that are not directly pingable. This happens for example with Docker for Mac.

``` properties
machine.docker.local_node_host.external=localhost
```

When this property is set the browser will use it to connect to the containers. Note that the wsmaster won't use that value to connect to the containers.

If this property is not set Che behaves as before.

This PR introduce a change to the API: [Server class](https://github.com/eclipse/che/blob/master/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/Server.java) has a couple of new attributes: `internalUrl` and `internalAddress`. On the other there no particular change is needed client side and all clients will benefit of this change.

``` json
"servers": {
      "4401/tcp": {
                "url": "http://localhost:32906/wsagent/ext", 
                "internalUrl": "http://192.168.65.2:32906/wsagent/ext", 
                "address": "localhost:32906",
                "internalAddress": "192.168.65.2:32906",
                "path": "/wsagent/ext",
                "protocol": "http",
                "ref": "wsagent"
     }
}
```

This PR takes into account some feedbacks from PR #2004:
- There are no changes on client side
- Works on configurations where the wsagent and docker containers are on different hosts

I will not close PR #2004. I want to continue the work to integrate Traefik in the che-launcher there. But containous/traefik#444 should be fixed first.   
### What issues does this PR fix or reference?
#1644
### Previous behavior

Running Che on Docker for Mac required some networking hacking
### New behavior

Remove the need for the networking hack when running Che on Docker for Mac and make running Che as simple as `docker run -v /var/run/docker.sock:/var/run/docker.sock codenvy/che-launcher start` on all platforms.
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [x] API updated
- [x] Tests updated
- [x] Tests passed
