### PR TITLE
Syntax coloration to machine outputs

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>gwt-elemental</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>


### PR DESCRIPTION
Adds syntax coloration to machine outputs when workspace is starting

Related issue: https://github.com/eclipse/che/issues/1755

![](https://api.monosnap.com/rpc/file/download?id=ce4KljUXhyh0xXRN27n3eaaQwNPV0f)

@vparfonov @ashumilova review it, plz.
