### PR TITLE
Move oauth implementation to ide app

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/auth/OAuthServiceClientImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/auth/OAuthServiceClientImpl.java
@@ -8,9 +8,10 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.api.auth;
+package org.eclipse.che.ide.auth;
 
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.eclipse.che.ide.api.auth.OAuthServiceClient;
 import org.eclipse.che.ide.rest.AsyncRequestCallback;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.RestContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
@@ -28,7 +28,7 @@ import org.eclipse.che.ide.actions.find.FindActionViewImpl;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.auth.OAuthServiceClient;
-import org.eclipse.che.ide.api.auth.OAuthServiceClientImpl;
+import org.eclipse.che.ide.auth.OAuthServiceClientImpl;
 import org.eclipse.che.ide.api.component.Component;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
 import org.eclipse.che.ide.api.data.tree.NodeInterceptor;


### PR DESCRIPTION
Reorganize internal API. Move implementation `org.eclipse.che.ide.auth.OAuthServiceClientImpl` from `code-ide-api` to `core-ide-app`, because it isn't a part of exposed API.

@vparfonov review it, plz.
