### PR TITLE
CHE-2300: fix usage of dockerfile as a source of machine in case of secured API

### DIFF
--- a/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/impl/AgentSorter.java
+++ b/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/impl/AgentSorter.java
@@ -18,6 +18,7 @@ import org.eclipse.che.api.agent.server.exception.AgentException;
 import org.eclipse.che.api.agent.server.model.impl.AgentKeyImpl;
 import org.eclipse.che.api.agent.shared.model.Agent;
 import org.eclipse.che.api.agent.shared.model.AgentKey;
+import org.eclipse.che.commons.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -54,13 +55,15 @@ public class AgentSorter {
      * @throws AgentException
      *      if circular dependency found or agent creation failed or other unexpected error
      */
-    public List<AgentKey> sort(List<String> agentKeys) throws AgentException {
+    public List<AgentKey> sort(@Nullable List<String> agentKeys) throws AgentException {
         List<AgentKey> sorted = new ArrayList<>();
         Set<String> pending = new HashSet<>();
 
         if (agentKeys != null) {
             for (String agentKey : agentKeys) {
-                doSort(agentKeys, AgentKeyImpl.parse(agentKey), sorted, pending);
+                if (agentKey != null) {
+                    doSort(agentKeys, AgentKeyImpl.parse(agentKey), sorted, pending);
+                }
             }
         }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/AgentConfigApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/AgentConfigApplier.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.agent.shared.model.Agent;
 import org.eclipse.che.api.agent.shared.model.AgentKey;
 import org.eclipse.che.api.core.model.workspace.compose.ComposeService;
 import org.eclipse.che.api.environment.server.compose.model.ComposeServiceImpl;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +77,7 @@ public class AgentConfigApplier {
      *
      * @throws AgentException
      */
-    public void modify(ComposeServiceImpl composeService, List<String> agentKeys) throws AgentException {
+    public void modify(ComposeServiceImpl composeService, @Nullable List<String> agentKeys) throws AgentException {
         for (AgentKey agentKey : sorter.sort(agentKeys)) {
             Agent agent = agentRegistry.getAgent(agentKey);
             addEnv(composeService, agent.getProperties());

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentEngine.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentEngine.java
@@ -547,13 +547,10 @@ public class CheEnvironmentEngine {
     private void applyAgents(@Nullable ExtendedMachine extendedMachine,
                              ComposeServiceImpl composeService) throws ServerException {
         if (extendedMachine != null) {
-            List<String> agents = extendedMachine.getAgents();
-            if (agents != null) {
-                try {
-                    agentConfigApplier.modify(composeService, agents);
-                } catch (AgentException e) {
-                    throw new ServerException("Can't apply agent config", e);
-                }
+            try {
+                agentConfigApplier.modify(composeService, extendedMachine.getAgents());
+            } catch (AgentException e) {
+                throw new ServerException("Can't apply agent config", e);
             }
         }
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentValidator.java
@@ -136,14 +136,13 @@ public class CheEnvironmentValidator {
         List<String> devMachines = env.getMachines()
                                       .entrySet()
                                       .stream()
-                                      .filter(entry -> entry.getValue()
-                                                            .getAgents()
-                                                            .contains("org.eclipse.che.ws-agent"))
+                                      .filter(entry -> entry.getValue().getAgents() != null &&
+                                                       entry.getValue().getAgents().contains("org.eclipse.che.ws-agent"))
                                       .map(Map.Entry::getKey)
                                       .collect(toList());
 
         checkArgument(devMachines.size() == 1,
-                      "Environment '%s' should contain exactly 1 machine with org.eclipse.che.ws-agent, but contains '%s'. " +
+                      "Environment '%s' should contain exactly 1 machine with agent 'org.eclipse.che.ws-agent', but contains '%s'. " +
                       "All machines with this agent: %s",
                       envName, devMachines.size(), Joiner.on(", ").join(devMachines));
 
@@ -274,6 +273,14 @@ public class CheEnvironmentValidator {
                                              "Machine '%s' in environment '%s' contains server conf '%s' with invalid protocol '%s'",
                                              machineName, envName, serverName, server.getProtocol());
                            });
+        }
+
+        if (extendedMachine.getAgents() != null) {
+            for (String agent : extendedMachine.getAgents()) {
+                checkArgument(!isNullOrEmpty(agent),
+                              "Machine '%s' in environment '%s' contains invalid agent '%s'",
+                              machineName, envName, agent);
+            }
         }
 
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -407,8 +407,9 @@ public class WorkspaceRuntimes {
             }
         }
 
-        Instance instance = environmentEngine.startMachine(workspaceId, machineConfig);
-        launchAgents(instance, Collections.singletonList("org.eclipse.che.terminal"));
+        List<String> agents = Collections.singletonList("org.eclipse.che.terminal");
+        Instance instance = environmentEngine.startMachine(workspaceId, machineConfig, agents);
+        launchAgents(instance, agents);
 
         try (StripedLocks.WriteLock lock = stripedLocks.acquireWriteLock(workspaceId)) {
             WorkspaceState workspaceState = workspaces.get(workspaceId);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentEngineTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentEngineTest.java
@@ -116,7 +116,9 @@ public class CheEnvironmentEngineTest {
                                               environmentParser,
                                               new ComposeServicesStartStrategy(),
                                               composeProvider,
-                                              agentConfigApplier));
+                                              agentConfigApplier,
+                                              "",
+                                              recipeDownloader));
 
         when(machineInstanceProviders.getProvider("docker")).thenReturn(instanceProvider);
         when(instanceProvider.getRecipeTypes()).thenReturn(Collections.singleton("dockerfile"));

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentEngineTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentEngineTest.java
@@ -61,6 +61,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.Matchers.any;
@@ -75,8 +76,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -84,6 +87,9 @@ import static org.testng.Assert.assertTrue;
  */
 @Listeners(MockitoTestNGListener.class)
 public class CheEnvironmentEngineTest {
+    private static final int    DEFAULT_MACHINE_MEM_LIMIT_MB = 256;
+    private static final String API_ENDPOINT                 = "http://eclipse.che:8080/api";
+
     @Mock
     MessageConsumer<MachineLogMessage> messageConsumer;
     @Mock
@@ -111,13 +117,13 @@ public class CheEnvironmentEngineTest {
         engine = spy(new CheEnvironmentEngine(snapshotDao,
                                               machineInstanceProviders,
                                               "/tmp",
-                                              256,
+                                              DEFAULT_MACHINE_MEM_LIMIT_MB,
                                               eventService,
                                               environmentParser,
                                               new ComposeServicesStartStrategy(),
                                               composeProvider,
                                               agentConfigApplier,
-                                              "",
+                                              API_ENDPOINT,
                                               recipeDownloader));
 
         when(machineInstanceProviders.getProvider("docker")).thenReturn(instanceProvider);
@@ -225,6 +231,353 @@ public class CheEnvironmentEngineTest {
 
         // then
         assertEquals(machines, expectedMachines);
+    }
+
+    @Test
+    public void shouldSetDefaultRamToMachinesWithoutRamOnEnvironmentStart() throws Exception {
+        // given
+        EnvironmentImpl env = createEnv();
+        String machineName = "machineWithoutRam";
+        String additionalServiceComposeFilePart = "\n  " + machineName + ":\n    image: codenvy/ubuntu_jdk8";
+        env.getRecipe().setContent(env.getRecipe().getContent() + additionalServiceComposeFilePart);
+
+        // when
+        startEnv(env);
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertEquals((long)actualService.getMemLimit(), DEFAULT_MACHINE_MEM_LIMIT_MB * 1024L * 1024L);
+    }
+
+    @Test
+    public void shouldUseConfiguredInServiceRamInsteadOfSetDefaultOnEnvironmentStart() throws Exception {
+        // given
+        EnvironmentImpl env = createEnv();
+        String machineName = "machineWithoutRam";
+        String additionalServiceComposeFilePart = "\n  " + machineName + ":\n    image: codenvy/ubuntu_jdk8\n    mem_limit: 42943433";
+        env.getRecipe().setContent(env.getRecipe().getContent() + additionalServiceComposeFilePart);
+
+        // when
+        startEnv(env);
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertEquals((long)actualService.getMemLimit(), 42943433L);
+    }
+
+    @Test
+    public void shouldSetDockerfileContentInsteadOfUrlIfUrlPointsToCheApiOnEnvironmentStart() throws Exception {
+        // given
+        EnvironmentImpl env = createEnv();
+        String machineName = "machineWithDockerfileFromApi";
+        String additionalServiceComposeFilePart = "\n  " + machineName + ":\n    build:\n      context: " + API_ENDPOINT + "/recipe/12345";
+        env.getRecipe().setContent(env.getRecipe().getContent() + additionalServiceComposeFilePart);
+        String dockerfileContent = "this is dockerfile content";
+        when(recipeDownloader.getRecipe(anyString())).thenReturn(dockerfileContent);
+
+        // when
+        startEnv(env);
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertNull(actualService.getBuild().getContext());
+        assertEquals(actualService.getBuild().getDockerfile(), dockerfileContent);
+    }
+
+    @Test
+    public void shouldNotSetDockerfileContentInsteadOfUrlIfUrlDoesNotPointToCheApiOnEnvironmentStart() throws Exception {
+        // given
+        EnvironmentImpl env = createEnv();
+        String machineName = "machineWithDockerfileNotFromApi";
+        String contextUrl = "http://another-server.com/recipe/12345";
+        String additionalServiceComposeFilePart = "\n  " + machineName + ":\n    build:\n      context: " + contextUrl;
+        env.getRecipe().setContent(env.getRecipe().getContent() + additionalServiceComposeFilePart);
+
+        // when
+        startEnv(env);
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertNull(actualService.getBuild().getDockerfile());
+        assertEquals(actualService.getBuild().getContext(), contextUrl);
+    }
+
+    @Test
+    public void shouldApplyAgentsOnEnvironmentStart() throws Exception {
+        EnvironmentImpl env = createEnv();
+        String machineName = "extraMachine";
+        String additionalServiceComposeFilePart = "\n  " + machineName + ":\n    image: codenvy/ubuntu_jdk8";
+        env.getRecipe().setContent(env.getRecipe().getContent() + additionalServiceComposeFilePart);
+
+        // when
+        startEnv(env);
+
+        // then
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             any(ComposeServiceImpl.class),
+                                             any(LineConsumer.class));
+        for (ExtendedMachineImpl extendedMachine : env.getMachines().values()) {
+            verify(agentConfigApplier).modify(any(ComposeServiceImpl.class), eq(extendedMachine.getAgents()));
+        }
+        verifyNoMoreInteractions(agentConfigApplier);
+    }
+
+    @Test
+    public void shouldSetDefaultRamToMachineWithoutRamOnMachineStart() throws Exception {
+        // given
+        List<Instance> instances = startEnv();
+        String workspaceId = instances.get(0).getWorkspaceId();
+
+        when(engine.generateMachineId()).thenReturn("newMachineId");
+        Instance newMachine = mock(Instance.class);
+        when(newMachine.getId()).thenReturn("newMachineId");
+        when(newMachine.getWorkspaceId()).thenReturn(workspaceId);
+        when(composeProvider.startService(anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyBoolean(),
+                                          anyString(),
+                                          any(ComposeServiceImpl.class),
+                                          any(LineConsumer.class)))
+                .thenReturn(newMachine);
+
+        MachineConfigImpl config = createConfig(false);
+        String machineName = "extraMachine";
+        config.setName(machineName);
+        config.setLimits(null);
+
+        // when
+        engine.startMachine(workspaceId, config, emptyList());
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertEquals((long)actualService.getMemLimit(), DEFAULT_MACHINE_MEM_LIMIT_MB * 1024L * 1024L);
+    }
+
+    @Test
+    public void shouldUseConfiguredInMachineRamInsteadOfSetDefaultOnMachineStart() throws Exception {
+        // given
+        List<Instance> instances = startEnv();
+        String workspaceId = instances.get(0).getWorkspaceId();
+
+        when(engine.generateMachineId()).thenReturn("newMachineId");
+        Instance newMachine = mock(Instance.class);
+        when(newMachine.getId()).thenReturn("newMachineId");
+        when(newMachine.getWorkspaceId()).thenReturn(workspaceId);
+        when(composeProvider.startService(anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyBoolean(),
+                                          anyString(),
+                                          any(ComposeServiceImpl.class),
+                                          any(LineConsumer.class)))
+                .thenReturn(newMachine);
+
+        MachineConfigImpl config = createConfig(false);
+        String machineName = "extraMachine";
+        config.setName(machineName);
+        config.setLimits(new MachineLimitsImpl(4096));
+
+        // when
+        engine.startMachine(workspaceId, config, emptyList());
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertEquals((long)actualService.getMemLimit(), 4096L * 1024L * 1024L);
+    }
+
+    @Test
+    public void shouldSetDockerfileContentInsteadOfUrlIfUrlPointsToCheApiOnMachineStart() throws Exception {
+        // given
+        List<Instance> instances = startEnv();
+        String workspaceId = instances.get(0).getWorkspaceId();
+
+        when(engine.generateMachineId()).thenReturn("newMachineId");
+        Instance newMachine = mock(Instance.class);
+        when(newMachine.getId()).thenReturn("newMachineId");
+        when(newMachine.getWorkspaceId()).thenReturn(workspaceId);
+        when(composeProvider.startService(anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyBoolean(),
+                                          anyString(),
+                                          any(ComposeServiceImpl.class),
+                                          any(LineConsumer.class)))
+                .thenReturn(newMachine);
+
+        MachineConfigImpl config = createConfig(false);
+        String machineName = "extraMachine";
+        config.setName(machineName);
+        config.setSource(new MachineSourceImpl("docker").setLocation(API_ENDPOINT + "/recipe/12345"));
+        String dockerfileContent = "this is dockerfile content";
+        when(recipeDownloader.getRecipe(anyString())).thenReturn("this is dockerfile content");
+
+        // when
+        engine.startMachine(workspaceId, config, emptyList());
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertNull(actualService.getBuild().getContext());
+        assertEquals(actualService.getBuild().getDockerfile(), dockerfileContent);
+    }
+
+    @Test
+    public void shouldNotSetDockerfileContentInsteadOfUrlIfUrlDoesNotPointToCheApiOnMachineStart() throws Exception {
+        // given
+        List<Instance> instances = startEnv();
+        String workspaceId = instances.get(0).getWorkspaceId();
+
+        when(engine.generateMachineId()).thenReturn("newMachineId");
+        Instance newMachine = mock(Instance.class);
+        when(newMachine.getId()).thenReturn("newMachineId");
+        when(newMachine.getWorkspaceId()).thenReturn(workspaceId);
+        when(composeProvider.startService(anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyBoolean(),
+                                          anyString(),
+                                          any(ComposeServiceImpl.class),
+                                          any(LineConsumer.class)))
+                .thenReturn(newMachine);
+
+        MachineConfigImpl config = createConfig(false);
+        String machineName = "extraMachine";
+        config.setName(machineName);
+        String contextUrl = "http://another-server.com/recipe/12345";
+        config.setSource(new MachineSourceImpl("docker").setLocation(contextUrl));
+
+        // when
+        engine.startMachine(workspaceId, config, emptyList());
+
+        // then
+        ArgumentCaptor<ComposeServiceImpl> captor = ArgumentCaptor.forClass(ComposeServiceImpl.class);
+        verify(composeProvider).startService(anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             anyString(),
+                                             eq(machineName),
+                                             eq(false),
+                                             anyString(),
+                                             captor.capture(),
+                                             any(LineConsumer.class));
+        ComposeServiceImpl actualService = captor.getValue();
+        assertNull(actualService.getBuild().getDockerfile());
+        assertEquals(actualService.getBuild().getContext(), contextUrl);
+    }
+
+    @Test
+    public void shouldApplyAgentsOnDockerMachineStart() throws Exception {
+        // given
+        List<Instance> instances = startEnv();
+        String workspaceId = instances.get(0).getWorkspaceId();
+
+        when(engine.generateMachineId()).thenReturn("newMachineId");
+        Instance newMachine = mock(Instance.class);
+        when(newMachine.getId()).thenReturn("newMachineId");
+        when(newMachine.getWorkspaceId()).thenReturn(workspaceId);
+        when(composeProvider.startService(anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyString(),
+                                          anyBoolean(),
+                                          anyString(),
+                                          any(ComposeServiceImpl.class),
+                                          any(LineConsumer.class)))
+                .thenReturn(newMachine);
+
+        MachineConfigImpl config = createConfig(false);
+        List<String> agents = asList("agent1", "agent2");
+
+        // when
+        engine.startMachine(workspaceId, config, agents);
+
+        // then
+        verify(agentConfigApplier).modify(any(ComposeServiceImpl.class), eq(agents));
     }
 
     @Test
@@ -339,7 +692,7 @@ public class CheEnvironmentEngineTest {
         MachineConfigImpl config = createConfig(false);
 
         // when
-        Instance actualInstance = engine.startMachine(workspaceId, config);
+        Instance actualInstance = engine.startMachine(workspaceId, config, emptyList());
 
         // then
         assertEquals(actualInstance, newMachine);
@@ -375,7 +728,7 @@ public class CheEnvironmentEngineTest {
 
 
         // when
-        Instance actualInstance = engine.startMachine(workspaceId, config);
+        Instance actualInstance = engine.startMachine(workspaceId, config, emptyList());
 
         // then
         assertEquals(actualInstance, newMachine);
@@ -390,7 +743,7 @@ public class CheEnvironmentEngineTest {
         MachineConfigImpl config = createConfig(false);
 
         // when
-        engine.startMachine("wsIdOfNotRunningEnv", config);
+        engine.startMachine("wsIdOfNotRunningEnv", config, emptyList());
     }
 
     @Test(expectedExceptions = ConflictException.class,
@@ -404,7 +757,7 @@ public class CheEnvironmentEngineTest {
         config.setName(instance.getConfig().getName());
 
         // when
-        engine.startMachine(instance.getWorkspaceId(), config);
+        engine.startMachine(instance.getWorkspaceId(), config, emptyList());
     }
 
     @Test
@@ -417,7 +770,7 @@ public class CheEnvironmentEngineTest {
         when(engine.generateMachineId()).thenReturn("newMachineId");
 
         // when
-        engine.startMachine(instance.getWorkspaceId(), config);
+        engine.startMachine(instance.getWorkspaceId(), config, emptyList());
 
         // then
         verify(eventService).publish(newDto(MachineStatusEvent.class)
@@ -559,6 +912,10 @@ public class CheEnvironmentEngineTest {
 
     private List<Instance> startEnv() throws Exception {
         EnvironmentImpl env = createEnv();
+        return startEnv(env);
+    }
+
+    private List<Instance> startEnv(EnvironmentImpl env) throws Exception {
         String envName = "env-1";
         String workspaceId = "wsId";
         when(composeProvider.startService(anyString(),
@@ -644,6 +1001,11 @@ public class CheEnvironmentEngineTest {
             machineSource = new MachineSourceImpl("dockerfile").setLocation(service.getBuild().getContext());
         } else if (service.getImage() != null) {
             machineSource = new MachineSourceImpl("image").setLocation(service.getImage());
+        } else if (service.getBuild() != null &&
+                   service.getBuild().getContext() == null &&
+                   service.getBuild().getDockerfile() != null) {
+
+            machineSource = new MachineSourceImpl("dockerfile").setContent(service.getBuild().getDockerfile());
         } else {
             throw new IllegalArgumentException("Build context or image should contain non empty value");
         }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentValidatorTest.java
@@ -199,9 +199,22 @@ public class CheEnvironmentValidatorTest {
 
         env = createEnv();
         env.getMachines().entrySet().forEach(entry -> entry.getValue().getAgents().add("org.eclipse.che.ws-agent"));
-        data.add(asList(env, "Environment 'env' should contain exactly 1 machine with org.eclipse.che.ws-agent, but contains '" +
+        data.add(asList(env, "Environment 'env' should contain exactly 1 machine with agent 'org.eclipse.che.ws-agent', but contains '" +
                              env.getMachines().size() + "'. " + "All machines with this agent: " +
                              Joiner.on(", ").join(env.getMachines().keySet())));
+
+        env = createEnv();
+        env.getMachines().entrySet().forEach(entry -> entry.getValue().setAgents(null));
+        data.add(asList(env,
+                        "Environment 'env' should contain exactly 1 machine with agent 'org.eclipse.che.ws-agent', but contains '0'. All machines with this agent: "));
+
+        env = createEnv();
+        env.getMachines().entrySet().forEach(entry -> entry.getValue().getAgents().add(null));
+        data.add(asList(env, "Machine 'machine2' in environment 'env' contains invalid agent 'null'"));
+
+        env = createEnv();
+        env.getMachines().entrySet().forEach(entry -> entry.getValue().getAgents().add(""));
+        data.add(asList(env, "Machine 'machine2' in environment 'env' contains invalid agent ''"));
 
         env = createEnv();
         machineEntry = env.getMachines().entrySet().iterator().next();

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -57,6 +57,7 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -94,7 +95,11 @@ public class WorkspaceRuntimesTest {
 
     @BeforeMethod
     public void setUp(Method method) throws Exception {
-        runtimes = spy(new WorkspaceRuntimes(eventService, environmentEngine, agentSorter, launcherFactory, agentRegistry));
+        runtimes = spy(new WorkspaceRuntimes(eventService,
+                                             environmentEngine,
+                                             agentSorter,
+                                             launcherFactory,
+                                             agentRegistry));
 
         List<Instance> machines = asList(createMachine(true), createMachine(false));
         when(environmentEngine.start(anyString(),
@@ -395,7 +400,7 @@ public class WorkspaceRuntimesTest {
                        false);
         MachineConfigImpl config = createConfig(false);
         Instance instance = mock(Instance.class);
-        when(environmentEngine.startMachine(anyString(), any(MachineConfig.class))).thenReturn(instance);
+        when(environmentEngine.startMachine(anyString(), any(MachineConfig.class), any())).thenReturn(instance);
         when(instance.getConfig()).thenReturn(config);
 
         // when
@@ -403,7 +408,30 @@ public class WorkspaceRuntimesTest {
 
         // then
         assertEquals(actual, instance);
-        verify(environmentEngine).startMachine(workspace.getId(), config);
+        verify(environmentEngine).startMachine(workspace.getId(), config, any());
+    }
+
+    @Test
+    public void shouldAddTerminalAgentOnMachineStart() throws Exception {
+        // when
+        WorkspaceImpl workspace = createWorkspace();
+        runtimes.start(workspace,
+                       workspace.getConfig().getDefaultEnv(),
+                       false);
+        MachineConfigImpl config = createConfig(false);
+        Instance instance = mock(Instance.class);
+        when(environmentEngine.startMachine(anyString(), any(MachineConfig.class), any())).thenReturn(instance);
+        when(instance.getConfig()).thenReturn(config);
+
+        // when
+        Instance actual = runtimes.startMachine(workspace.getId(), config);
+
+        // then
+        assertEquals(actual, instance);
+        verify(environmentEngine).startMachine(eq(workspace.getId()),
+                                               eq(config),
+                                               eq(singletonList("org.eclipse.che.terminal")));
+        verify(runtimes).launchAgents(instance, singletonList("org.eclipse.che.terminal"));
     }
 
     @Test(expectedExceptions = ConflictException.class,
@@ -416,7 +444,7 @@ public class WorkspaceRuntimesTest {
         runtimes.startMachine("someWsID", config);
 
         // then
-        verify(environmentEngine, never()).startMachine(anyString(), any(MachineConfig.class));
+        verify(environmentEngine, never()).startMachine(anyString(), any(MachineConfig.class), any());
     }
 
     @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -408,7 +408,7 @@ public class WorkspaceRuntimesTest {
 
         // then
         assertEquals(actual, instance);
-        verify(environmentEngine).startMachine(workspace.getId(), config, any());
+        verify(environmentEngine).startMachine(eq(workspace.getId()), eq(config), any());
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Fixes usage of URL to dockerfile as a source/context of machine if URL points to API of Che.
Also adds some fixes and tests of agents usage.
### What issues does this PR fix or reference?

Fixes #2300 
Fixes #2426 
### Previous behavior

We sent url to dockerfile to the docker daemon. When API of Che is secured docker daemon was not able to download it.
### New behavior

We workaround that by downloading dockerfile if it is hosted by URL matching API endpoint of Che. Then we send tar context to docker daemon.
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist
- [x] Tests provided / updated
- [x] Tests passed
