### PR TITLE
CHE-2416: improve workspace-select-stack widget for UD

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.html
+++ b/dashboard/src/app/projects/create-project/create-project.html
@@ -70,8 +70,8 @@
               <div layout="column" layout-align="end end"
                    ng-show="createProjectCtrl.getCreationSteps()[createProjectCtrl.getCurrentProgressStep()].hasError">
                 <che-button-danger
-                  che-button-title="{{createProjectCtrl.isResourceProblem() ? 'Stop running workspaces' :  'Retry'}}"
-                  ng-click="createProjectCtrl.resetCreateProgress()"></che-button-danger>
+                        che-button-title="{{createProjectCtrl.isResourceProblem() ? 'Stop running workspaces' :  'Retry'}}"
+                        ng-click="createProjectCtrl.resetCreateProgress()"></che-button-danger>
                 <che-link class="create-project-download-logs-link"
                           ng-click="createProjectCtrl.downloadLogs()"
                           che-link-text="Problem? download logs"></che-link>
@@ -109,7 +109,7 @@
           <md-tab md-on-select="createProjectCtrl.setCurrentTab('github')">
             <md-tab-label>
               <md-icon md-font-icon="fa-github" class="fa che-tab-label-icon"></md-icon>
-              <span class="che-tab-label-title">Github</span>
+              <span class="che-tab-label-title">GitHub</span>
             </md-tab-label>
             <md-tab-body>
               <form name="createProjectGitHubForm">
@@ -220,7 +220,7 @@
       <md-radio-group ng-model="createProjectCtrl.templatesChoice">
         <md-radio-button value="templates-samples">Ready-to-run project samples</md-radio-button>
         <create-project-samples
-          ng-if="createProjectCtrl.templatesChoice === 'templates-samples'"></create-project-samples>
+                ng-if="createProjectCtrl.templatesChoice === 'templates-samples'"></create-project-samples>
         <md-radio-button ng-if="createProjectCtrl.enableWizardProject"
                          ng-click="createProjectCtrl.selectWizardProject()"
                          value="templates-wizard">Wizard-driven templates
@@ -278,7 +278,7 @@
                         ng-click="!createProjectCtrl.checkValidFormState() || createProjectCtrl.create()"
                         ng-disabled="!createProjectCtrl.checkValidFormState() || !createProjectCtrl.isReadyToCreate()"
                         class="projects-create-project-button"
-    ></che-button-primary>
+            ></che-button-primary>
 
     <div class="create-project-empty-space"></div>
 

--- a/dashboard/src/app/projects/create-project/create-project.styl
+++ b/dashboard/src/app/projects/create-project/create-project.styl
@@ -34,11 +34,11 @@ md-select.create-project-select
   margin-bottom 10px
   margin-right 24px
   background-color #fff
-  box-shadow 0 2px 6px 0 rgba(0,0,0,0.4)
+  box-shadow 0 2px 6px 0 rgba(0, 0, 0, 0.4)
 
 .create-project-header-button .che-button
   font-size 15px !important
-  box-shadow 0 0 0 0 rgba(0,0,0,0.26) !important
+  box-shadow 0 0 0 0 rgba(0, 0, 0, 0.26) !important
 
 .create-project-minimize-icon
   font-size 40px
@@ -61,6 +61,9 @@ md-select.create-project-select
 
 .projects-create-project
   padding 0 14px
+
+  md-tabs
+    min-height 185px
 
   .che-label-container-content .create-project-input
     margin -6px 0

--- a/dashboard/src/app/projects/create-project/github/create-project-github.html
+++ b/dashboard/src/app/projects/create-project/github/create-project-github.html
@@ -16,7 +16,7 @@
   We have a problem authenticating you with GitHub.
 </p>
 
-<div layout="column" layout-align="space-around center" ng-show="createProjectGithubCtrl.state == 'NO_REPO'">
+<div layout="column" layout-align="space-around flex-start" ng-show="createProjectGithubCtrl.state == 'NO_REPO'">
   <div class="github-create-project-github-warningempty">Your GitHub repositories will appear here</div>
   <div>GitHub repositories can easily be imported in {{createProjectGithubCtrl.productName}}</div>
   <che-button-default class="github-create-project-github-button"
@@ -32,7 +32,7 @@
 </div>
 
 <div ng-if="createProjectGithubCtrl.state == 'LOADED'">
-  <div layout="row" layout-align="space-around center">
+  <div layout="row" layout-align="space-around flex-start">
 
     <div layout="row" flex="45" class="github-create-project-search-component">
       <md-icon flex-gt-sm="5" md-font-icon="fa fa-search"></md-icon>
@@ -49,10 +49,10 @@
   </div>
   <che-list class="github-create-project-repositories-list">
     <che-list-item
-      ng-repeat="gitHubRepository in createProjectGithubCtrl.gitHubRepositories | githubFilterRepositories:createProjectGithubCtrl.organizationName:createProjectGithubCtrl.repositoryName | orderBy:'name'"
-      ng-click="createProjectGithubCtrl.selectRepository(gitHubRepository)" flex-gt-sm="100" flex="33"
-      ng-class="{'github-create-project-active' : gitHubRepository == createProjectGithubCtrl.selectedRepository}">
-      <div layout-gt-sm="row" flex="100" layout-align="start center" class="project-list-row">
+            ng-repeat="gitHubRepository in createProjectGithubCtrl.gitHubRepositories | githubFilterRepositories:createProjectGithubCtrl.organizationName:createProjectGithubCtrl.repositoryName | orderBy:'name'"
+            ng-click="createProjectGithubCtrl.selectRepository(gitHubRepository)" flex-gt-sm="100" flex="33"
+            ng-class="{'github-create-project-active' : gitHubRepository == createProjectGithubCtrl.selectedRepository}">
+      <div layout-gt-sm="row" flex="100" layout-align="start flex-start" class="project-list-row">
         <div class="github-create-project-icons" flex-gt-sm="5">
           <span ng-if="!gitHubRepository.fork" class="github-create-project-icon fa fa-folder"></span>
           <span ng-if="gitHubRepository.fork" class="github-create-project-icon fa fa-code-fork" title="forked"></span>

--- a/dashboard/src/app/projects/create-project/github/create-project-github.styl
+++ b/dashboard/src/app/projects/create-project/github/create-project-github.styl
@@ -2,7 +2,7 @@
   margin-left 5px
 
 .github-create-project
-  cursor:pointer
+  cursor pointer
 
 .create-project-github-panel
   margin 15px
@@ -17,10 +17,9 @@
   background-image none
   border 1px solid #e5e5e5
   border-radius 0
-  -webkit-box-shadow inset 0 1px 1px rgba(0,0,0,.075)
-  -webkit-transition border-color ease-in-out .15s,box-shadow ease-in-out .15s
-  transition border-color ease-in-out .15s,box-shadow ease-in-out .15s
-
+  -webkit-box-shadow inset 0 1px 1px rgba(0, 0, 0, .075)
+  -webkit-transition border-color ease-in-out .15s, box-shadow ease-in-out .15s
+  transition border-color ease-in-out .15s, box-shadow ease-in-out .15s
 
 .github-create-project-repository-name
   font-size 16px
@@ -56,7 +55,9 @@
   margin-bottom 27px
 
 .github-create-project-github-button
- margin-top 10px
+  margin-top 10px
+  button
+    margin-left 0
 
 .github-create-project-github-warningempty
   margin-bottom 10px

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.directive.js
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.directive.js
@@ -20,7 +20,7 @@
  * `<ready-to-go-stacks></ready-to-go-stacks>` for creating new projects from ready to go stacks.
  *
  * @usage
- *   <ready-to-go-stacks class="projects-create-project-tab" layout="row" layout-wrap></ready-to-go-stacks>
+ *   <ready-to-go-stacks></ready-to-go-stacks>
  *
  * @author Florent Benoit
  */
@@ -30,8 +30,8 @@ export class ReadyToGoStacks {
    * Default constructor that is using resource
    * @ngInject for Dependency injection
    */
-  constructor () {
-    this.restrict='E';
+  constructor() {
+    this.restrict = 'E';
     this.templateUrl = 'app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.html';
 
     this.controller = 'ReadyToGoStacksController';
@@ -39,11 +39,7 @@ export class ReadyToGoStacks {
     this.bindToController = true;
 
     // scope values
-    this.scope = {
-      stack: '=cheStack',
-      onChange: '&cheOnChange'
-    };
-
+    this.scope = {};
   }
 
 }

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
@@ -10,24 +10,26 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<ng-form name="workspaceInformationForm">
-
+<div layout="column" flex>
   <div class="stack-label-info">Create a new workspace with a ready-to-go stack.</div>
-  <div layout="column" flex>
-    <div layout="row" layout-wrap>
-      <md-card layout="column" class="che-simple-selector"
-               ng-repeat="stack in readyToGoStacksCtrl.generalStacks | orderBy:[readyToGoStacksCtrl.getPrivilegedSortPosition, 'name']"
-               ng-init="readyToGoStacksCtrl.initValue($first, stack)"
-               ng-click="readyToGoStacksCtrl.select(stack)"
-               ng-class="{'che-simple-selector-active' : '{{stack.name}}' === readyToGoStacksCtrl.stack.name}">
-        <div layout="row">
-          <div class="selector-icon" ng-class="{'chefont cheico-type-blank' : !stack.iconSrc}">
-            <img ng-if="stack.iconSrc" ng-src="{{stack.iconSrc}}"/>
-          </div>
-          <div flex="70" class="title">{{stack.name}}</div>
-        </div>
-        <div class="description">{{readyToGoStacksCtrl.tagsToString(stack.tags)}}</div>
-      </md-card>
-    </div>
+  <div layout="row" flex="100">
+    <che-stack-library-filter layout="row" flex
+                              ng-model="readyToGoStacksCtrl.allStackTags">
+    </che-stack-library-filter>
   </div>
-</ng-form>
+  <div layout="row" layout-wrap>
+    <md-card layout="column" class="che-simple-selector"
+             ng-repeat="stack in filteredStacks = (readyToGoStacksCtrl.generalStacks | stackSelectedStackFilter:readyToGoStacksCtrl.filteredStackIds) | orderBy:[readyToGoStacksCtrl.getPrivilegedSortPosition, 'name']"
+             ng-init="$first && readyToGoStacksCtrl.setStackSelectionById(stack.id)"
+             ng-click="readyToGoStacksCtrl.setStackSelectionById(stack.id)"
+             ng-class="{'che-simple-selector-active' : '{{stack.id}}' === readyToGoStacksCtrl.selectedStackId}">
+      <div layout="row">
+        <div class="selector-icon" ng-class="{'chefont cheico-type-blank' : !readyToGoStacksCtrl.stackIconsMap.has(stack.id)}">
+          <img ng-src="{{readyToGoStacksCtrl.stackIconsMap.get(stack.id)}}"/>
+        </div>
+        <div flex="70" class="title">{{stack.name}}</div>
+      </div>
+      <div class="description">{{readyToGoStacksCtrl.tagsToString(stack.tags)}}</div>
+    </md-card>
+  </div>
+</div>

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.styl
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/ready-to-go-stacks/ready-to-go-stacks.styl
@@ -76,6 +76,9 @@ $che-simple-selector-color = $label-info-color
   height 24px
   padding-bottom 1px
 
+  .cheico-type-blank > img
+    display none
+
 .che-simple-selector .title
   font-size 12px
   line-height 22px

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library-selected-stack.filter.js
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library-selected-stack.filter.js
@@ -18,14 +18,14 @@
 export class CreateProjectStackLibrarySelectedStackFilter {
 
   constructor(register) {
-    register.app.filter( 'stackSelectedStackFilter' , function () {
+    register.app.filter('stackSelectedStackFilter', () => {
       return function (templates, idFilter) {
         if (!templates) {
           return [];
         }
 
         if (!idFilter || !idFilter.length) {
-          return [];
+          return templates;
         }
 
         var filtered = [];

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library.controller.js
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library.controller.js
@@ -32,8 +32,6 @@ export class CreateProjectStackLibraryController {
     this.allStackTags = [];
     this.filteredStackIds = [];
 
-    this.onChoice();
-
     this.stacks = cheStack.getStacks();
     if (this.stacks.length) {
       this.updateData();
@@ -56,7 +54,6 @@ export class CreateProjectStackLibraryController {
       if (!tags) {
         tags = [];
       }
-
       this.stacks.forEach((stack) => {
         let matches = 0,
           stackTags = stack.tags.map(tag => tag.toLowerCase());
@@ -83,20 +80,13 @@ export class CreateProjectStackLibraryController {
 
   /**
    * Select stack by Id
+   * @param stackId
    */
   setStackSelectionById(stackId) {
     this.selectedStackId = stackId;
-    this.onChoice();
-  }
-
-  /**
-   * Callback when item has been select
-   */
-  onChoice() {
-    if (!this.selectedStackId) {
-      return;
+    if (this.selectedStackId) {
+      this.$scope.$emit('event:selectStackId', this.selectedStackId);
     }
-    this.$scope.$emit('event:selectStackId', this.selectedStackId);
   }
 
   /**
@@ -112,7 +102,8 @@ export class CreateProjectStackLibraryController {
 
   /**
    * Provides tooltip data from a stack
-   * @param stack the data to analyze
+   * @param stack - the data to analyze
+   * @returns String
    */
   getTooltip(stack) {
     // get components and add data from the components

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library.html
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library.html
@@ -1,4 +1,4 @@
-<div layout="column" flex class="create-project-stack-library">
+<div layout="column" flex>
   <div class="stack-label-info">Select from our library of stacks.</div>
   <div layout="row" flex="100">
     <che-stack-library-filter layout="row" flex
@@ -6,23 +6,21 @@
     </che-stack-library-filter>
   </div>
   <div layout="row" flex layout-align="start start">
-    <md-radio-group ng-model="createProjectStackLibraryCtrl.createChoice" ng-change="createProjectStackLibraryCtrl.onChoice()">
-      <div layout="row">
-        <div layout="column" flex="auto">
+    <div layout="row">
+      <div layout="column" flex="auto">
 
-          <div layout="row" layout-wrap>
-            <che-stack-library-selecter
-              ng-repeat="stack in filteredStacks = (createProjectStackLibraryCtrl.stacks | stackSelectedStackFilter:createProjectStackLibraryCtrl.filteredStackIds) | orderBy:'name'"
-              ng-init="$first && createProjectStackLibraryCtrl.setStackSelectionById(stack.id)"
-              che-is-select="stack.id === createProjectStackLibraryCtrl.selectedStackId"
-              che-is-active="true"
-              che-title="{{stack.name}}"
-              che-text="{{stack.description}}"
-              che-extra-text="{{createProjectStackLibraryCtrl.getTooltip(stack)}}"
-              che-stack-id="{{stack.id}}"/>
-          </div>
+        <div layout="row" layout-wrap>
+          <che-stack-library-selecter
+                  ng-repeat="stack in filteredStacks = (createProjectStackLibraryCtrl.stacks | stackSelectedStackFilter:createProjectStackLibraryCtrl.filteredStackIds) | orderBy:'name'"
+                  ng-init="$first && createProjectStackLibraryCtrl.setStackSelectionById(stack.id)"
+                  che-is-select="stack.id === createProjectStackLibraryCtrl.selectedStackId"
+                  che-is-active="true"
+                  che-title="{{stack.name}}"
+                  che-text="{{stack.description}}"
+                  che-extra-text="{{createProjectStackLibraryCtrl.getTooltip(stack)}}"
+                  che-stack-id="{{stack.id}}"/>
         </div>
       </div>
-    </md-radio-group>
+    </div>
   </div>
 </div>

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library.styl
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/create-project-stack-library.styl
@@ -1,7 +1,0 @@
-.create-project-stack-library md-radio-button
-  margin-left 0px
-  margin-top 0px
-  margin-right 20px
-
-.create-project-stack-library-nostack
-  padding-left 30px

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/stack-library-filter/che-stack-library-filter.styl
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/stack-library/stack-library-filter/che-stack-library-filter.styl
@@ -1,5 +1,5 @@
 .stack-library-filter
-  padding-bottom 20px
+  padding-bottom 10px
 
   .md-chip-input-container
     margin 0 !important
@@ -14,7 +14,7 @@
 .stack-library-filter
   .md-chips
     padding 0 0 2px 0
-    margin-right 0px
+    margin-right 0
 
     .md-chip:last-of-type
       margin-right 16px
@@ -127,7 +127,7 @@
 .stack-library-filter-description
   font-size 12px
   color $disabled-color
-  line-height 12px
+  line-height 20px
 
 .stack-library-filter-description-bold
   font-weight bold

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/workspace-select-stack.controller.js
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/workspace-select-stack.controller.js
@@ -28,8 +28,12 @@ export class WorkspaceSelectStackController {
     this.lodash = lodash;
 
     this.stacks = cheStack.getStacks();
-    if (!this.stacks.length) {
-      cheStack.fetchStacks();
+    if (this.stacks.length) {
+      this.$scope.$emit('create-project-stacks:initialized');
+    } else {
+      cheStack.fetchStacks().then(() => {
+        this.$scope.$emit('create-project-stacks:initialized');
+      });
     }
 
     $scope.$on('event:selectStackId', (event, data) => {
@@ -38,10 +42,12 @@ export class WorkspaceSelectStackController {
         return stack.id === data;
       });
       if (findStack) {
-        this.stackLibraryUser = findStack;
-        if (this.tabName === 'stack-library') {
-          this.onStackSelect(findStack);
+        if (this.tabName === 'ready-to-go') {
+          this.readyToGoStack = findStack;
+        } else if (this.tabName === 'stack-library') {
+          this.stackLibraryUser = findStack;
         }
+        this.onStackSelect(findStack);
       }
     });
   }
@@ -58,20 +64,19 @@ export class WorkspaceSelectStackController {
 
     if (tabName === 'ready-to-go') {
       this.onStackSelect(this.readyToGoStack);
+      return;
     } else if (tabName === 'stack-library') {
       this.onStackSelect(this.stackLibraryUser);
-    } else {
-      this.onStackSelect(null);
+      return;
     }
+    this.onStackSelect(null);
   }
 
   /**
    * Callback when stack has been select
+   * @param stack
    */
   onStackSelect(stack) {
-    if (!stack && this.tabName !== 'custom-stack') {
-      return;
-    }
     this.stack = stack;
     this.$timeout(() => {
       this.onStackChange();

--- a/dashboard/src/app/workspaces/create-workspace/select-stack/workspace-select-stack.html
+++ b/dashboard/src/app/workspaces/create-workspace/select-stack/workspace-select-stack.html
@@ -6,12 +6,7 @@
         <span class="che-tab-label-title">Ready-to-go Stacks</span>
       </md-tab-label>
       <md-tab-body>
-        <ready-to-go-stacks class="projects-create-project-tab"
-                            layout="row"
-                            layout-wrap
-                            che-stack="workspaceSelectStackCtrl.readyToGoStack"
-                            che-on-change="workspaceSelectStackCtrl.onStackSelect(workspaceSelectStackCtrl.readyToGoStack)">
-        </ready-to-go-stacks>
+        <ready-to-go-stacks></ready-to-go-stacks>
       </md-tab-body>
     </md-tab>
     <md-tab md-on-select="workspaceSelectStackCtrl.setStackTab('stack-library')">

--- a/dashboard/src/components/widget/tab/che-tab.styl
+++ b/dashboard/src/components/widget/tab/che-tab.styl
@@ -1,4 +1,3 @@
-
 /* There are two kinds of elements here:
    md-tab-item Those are the items you see in the tab header
    md-dummy-tab Those are used for pagination size calculations so need to have the same layout as md-tab-item
@@ -10,11 +9,18 @@ md-tabs md-tabs-canvas.md-center-tabs
   & md-tab-item.md-tab,
   & md-dummy-tab.md-tab
     min-width max-content /* at least as wide as the content */
-    flex-basis 0          /* all tab headers should have same width _when possible_ */
+    flex-basis 0 /* all tab headers should have same width _when possible_ */
     /* same as angular-md layout="row" layout-align="center center" */
     flex-direction row
     justify-content center
     align-items center
+
+md-tabs md-tab-content
+  transition-property none
+  transform none
+
+md-tabs md-tab-content.md-active-remove-active
+  visibility hidden
 
 md-tab-item.md-tab, md-dummy-tab.md-tab
   & .che-tab-label-icon
@@ -44,7 +50,9 @@ md-tab-content
 /* selected tab color changes */
 md-tabs-canvas md-tab-item.md-tab.md-active,
 md-tabs-canvas md-tab-item.md-tab.md-active md-icon.che-tab-label-icon::before
-  color $primary-color !important /* either !important or preprend md-tabs.md-maincontent-theme-theme  to selector */
+  color $primary-color !important
+
+/* either !important or preprend md-tabs.md-maincontent-theme-theme  to selector */
 
 md-tabs md-tab-item:not(.md-active)
   border-bottom 1px solid $disabled-color


### PR DESCRIPTION
### What does this PR do?

Fix spelling tab name for GitHub. Change link for custom stack documentation. Remove animation during different tabs selection. Add filter to ready-to-go-stacks widget.
### What issues does this PR fix or reference?
#2416

Signed-off-by: Oleksii Orel oorel@codenvy.com
![selection_003](https://cloud.githubusercontent.com/assets/6310786/18469585/6a564f50-79b1-11e6-98f9-99bd59f89833.png)
