### PR TITLE
Fix #2471: Send json/schemaAssociations notification

### DIFF
--- a/plugins/plugin-json/che-plugin-json-server/pom.xml
+++ b/plugins/plugin-json/che-plugin-json-server/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>io.typefox.lsapi</groupId>
+            <artifactId>io.typefox.lsapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.typefox.lsapi</groupId>
             <artifactId>io.typefox.lsapi.services</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/languageserver/JsonLanguageServer.java
+++ b/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/languageserver/JsonLanguageServer.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.json.languageserver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.che.api.languageserver.registry.ServerInitializerObserver;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+
+import io.typefox.lsapi.ServerCapabilities;
+import io.typefox.lsapi.services.LanguageServer;
+import io.typefox.lsapi.services.json.JsonBasedLanguageServer;
+
+/**
+ * Implements the specifics related to the JSON language server.
+ * 
+ * After the Initialize Request the client must send a 'json/schemaAssociations'
+ * notification in order to associate JSON schemas to popular JSON files. This
+ * automatically enables code completion, validation, hover, etc. capabilities
+ * for these files without the need of adding a "$schema" key.
+ * 
+ * @author Kaloyan Raev
+ */
+public class JsonLanguageServer extends JsonBasedLanguageServer implements ServerInitializerObserver {
+
+    private final static String JSON_SCHEMA_ASSOCIATIONS = "json/schemaAssociations";
+
+    @Override
+    public void onServerInitialized(LanguageServer server, ServerCapabilities capabilities,
+            LanguageDescription languageDescription, String projectPath) {
+        registerSchemaAssociations();
+    }
+
+    private void registerSchemaAssociations() {
+        Map<String, String[]> associations = new HashMap<>();
+        associations.put("/*.schema.json", new String[] { "http://json-schema.org/draft-04/schema#" });
+        associations.put("/bower.json", new String[] { "http://json.schemastore.org/bower" });
+        associations.put("/.bower.json", new String[] { "http://json.schemastore.org/bower" });
+        associations.put("/.bowerrc", new String[] { "http://json.schemastore.org/bowerrc" });
+        associations.put("/composer.json", new String[] { "https://getcomposer.org/schema.json" });
+        associations.put("/package.json", new String[] { "http://json.schemastore.org/package" });
+        associations.put("/jsconfig.json", new String[] { "http://json.schemastore.org/jsconfig" });
+        associations.put("/tsconfig.json", new String[] { "http://json.schemastore.org/tsconfig" });
+
+        sendNotification(JSON_SCHEMA_ASSOCIATIONS, associations);
+    }
+
+}

--- a/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/languageserver/JsonLanguageServerLauncher.java
+++ b/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/languageserver/JsonLanguageServerLauncher.java
@@ -64,7 +64,7 @@ public class JsonLanguageServerLauncher extends LanguageServerLauncherTemplate {
     }
 
     protected JsonBasedLanguageServer connectToLanguageServer(Process languageServerProcess) {
-        JsonBasedLanguageServer languageServer = new JsonBasedLanguageServer();
+        JsonBasedLanguageServer languageServer = new JsonLanguageServer();
         languageServer.connect(languageServerProcess.getInputStream(), languageServerProcess.getOutputStream());
         return languageServer;
     }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImpl.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImpl.java
@@ -139,6 +139,10 @@ public class ServerInitializerImpl implements ServerInitializer {
         server.getTextDocumentService().onPublishDiagnostics(publishDiagnosticsParamsMessenger::onEvent);
         server.getWindowService().onLogMessage(messageParams -> LOG.error(messageParams.getType() + " " + messageParams.getMessage()));
         server.onTelemetryEvent(o -> LOG.error(o.toString()));
+        
+        if (server instanceof ServerInitializerObserver) {
+            addObserver((ServerInitializerObserver) server);
+        }
     }
 
     protected InitializeParamsImpl prepareInitializeParams(String projectPath) {


### PR DESCRIPTION
### What does this PR do?

The VS Code's JSON language server expects a `json/schemaAssociations`
notification to associate JSON files to JSON schemas. This activates
capabilities like code completion, validation and hover without the need
to add a `$schema` key.

This change implements an extension of the JsonBasedLanguageServer that
registers as ServerInitializerObserver and sends the
`json/schemaAssociations` notification on the `onServerInitialized`
event.
### What issues does this PR fix or reference?
#2471, #1287
### Previous behavior

Code completion, validation and hover capabilities in the JSON editor were enabled only after manually adding a `$schema` key.
### New behavior

The JSON editor automatically associates JSON schema for popular JSON files like `package.json`, `bower.json`, `composer.json`, `tsconfig.json`, etc. Code completion, validation, hover and other capabilities work out of the box.
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
