### PR TITLE
Provide Maven plugin for generating TypeScript DTO objects based on Java DTO

### DIFF
--- a/core/che-core-typescript-dto-maven-plugin/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-core-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>5.0.0-M2-SNAPSHOT</version>
+    </parent>
+    <groupId>org.eclipse.che.core</groupId>
+    <artifactId>che-core-typescript-dto-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Che Core :: API :: TypeScript DTO maven plugin</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-dto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.plexus</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jsr250-api</artifactId>
+                    <groupId>javax.annotation</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto;
+
+import org.eclipse.che.dto.shared.DelegateTo;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper class
+ *
+ * @author Florent Benoit
+ */
+public class DTOHelper {
+
+    /**
+     * Utility class.
+     */
+    private DTOHelper() {
+
+    }
+
+    /**
+     * Check is specified method is DTO getter.
+     */
+    public static boolean isDtoGetter(Method method) {
+        if (method.isAnnotationPresent(DelegateTo.class)) {
+            return false;
+        }
+
+        if (method.getParameterTypes().length > 0) {
+            return false;
+        }
+
+        String methodName = method.getName();
+
+        return methodName.startsWith("get") ||
+               (methodName.startsWith("is") && ((method.getReturnType() == Boolean.class || method.getReturnType() == boolean.class)));
+
+    }
+
+
+    /**
+     * Check is specified method is DTO setter.
+     */
+    public static boolean isDtoSetter(Method method) {
+        if (method.isAnnotationPresent(DelegateTo.class)) {
+            return false;
+        }
+        String methodName = method.getName();
+        return methodName.startsWith("set") && method.getParameterTypes().length == 1;
+    }
+
+    /**
+     * Check is specified method is DTO with.
+     */
+    public static boolean isDtoWith(Method method) {
+        if (method.isAnnotationPresent(DelegateTo.class)) {
+            return false;
+        }
+        String methodName = method.getName();
+        return methodName.startsWith("with") && method.getParameterTypes().length == 1;
+    }
+
+    /**
+     * Compute field name from the stringified string type
+     */
+    public static String getFieldName(String type) {
+        char[] c = type.toCharArray();
+        c[0] = Character.toLowerCase(c[0]);
+        return new String(c);
+    }
+
+    /**
+     * Extract field name from the getter method
+     */
+    public static String getGetterFieldName(Method method) {
+        String methodName = method.getName();
+        if (methodName.startsWith("get")) {
+            return getFieldName(methodName.substring(3));
+        } else if (methodName.startsWith("is")) {
+            return getFieldName(methodName.substring(2));
+        }
+        throw new IllegalArgumentException("Invalid getter method" + method.getName());
+    }
+
+    /**
+     * Extract field name from the setter method
+     */
+    public static String getSetterFieldName(Method method) {
+        String methodName = method.getName();
+        if (methodName.startsWith("set")) {
+            return getFieldName(methodName.substring(3));
+        }
+        throw new IllegalArgumentException("Invalid setter method" + method.getName());
+    }
+
+    /**
+     * Extract field name from the with method
+     */
+    public static String getWithFieldName(Method method) {
+        String methodName = method.getName();
+        if (methodName.startsWith("with")) {
+            return getFieldName(methodName.substring(4));
+        }
+        throw new IllegalArgumentException("Invalid with method" + method.getName());
+    }
+
+    /**
+     * Convert Java type to TypeScript type
+     */
+    public static String convertType(Type type) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType)type;
+            Type rawType = parameterizedType.getRawType();
+            return convertParametrizedType(type, parameterizedType, rawType);
+        } else if (String.class.equals(type) || (type instanceof Class && ((Class)type).isEnum())) {
+            // Maybe find a better enum type for typescript
+            return "string";
+        } else if (Integer.class.equals(type) || Integer.TYPE.equals(type) || Long.class.equals(type) || Long.TYPE.equals(type)) {
+            return "number";
+        } else if (Boolean.class.equals(type)) {
+            return "boolean";
+        }
+
+        return type.getTypeName();
+    }
+
+    /**
+     * Handle convert of a parametrized Java type to TypeScript type
+     */
+    public static String convertParametrizedType(Type type, ParameterizedType parameterizedType, Type rawType) {
+
+        if (List.class.equals(rawType)) {
+            return "Array<" + convertType(parameterizedType.getActualTypeArguments()[0]) + ">";
+        } else if (Map.class.equals(rawType)) {
+            return "Map<" + convertType(parameterizedType.getActualTypeArguments()[0]) + "," +
+                   convertType(parameterizedType.getActualTypeArguments()[1]) + ">";
+        } else {
+            throw new IllegalArgumentException("Invalid type" + type);
+        }
+    }
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojo.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojo.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Mojo for generating TypeScript DTO interface + implementation for handling JSON data.
+ * @author Florent Benoit
+ */
+@Mojo(name = "build",
+      defaultPhase = LifecyclePhase.PACKAGE,
+      requiresProject = true,
+      requiresDependencyCollection = ResolutionScope.RUNTIME)
+public class TypeScriptDTOGeneratorMojo extends AbstractMojo {
+
+    /**
+     * Project providing artifact id, version and dependencies.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
+
+    /**
+     * build directory used to write the intermediate bom file.
+     */
+    @Parameter(defaultValue = "${project.build.directory}")
+    private File targetDirectory;
+
+    @Component
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * Path to the generated typescript file
+     */
+    private File typescriptFile;
+
+    /**
+     * Use of classpath instead of classloader
+     */
+    private boolean useClassPath;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        getLog().info("Generating TypeScript DTO");
+
+        TypeScriptDtoGenerator typeScriptDtoGenerator = new TypeScriptDtoGenerator();
+
+        typeScriptDtoGenerator.setUseClassPath(useClassPath);
+
+        // define output path for the file to write with typescript definition
+        String output = typeScriptDtoGenerator.execute();
+
+        this.typescriptFile = new File(targetDirectory, project.getArtifactId() + ".ts");
+        File parentDir = this.typescriptFile.getParentFile();
+        if (!parentDir.exists() && !parentDir.mkdirs()) {
+            throw new MojoExecutionException("Unable to create a directory for writing DTO typescript file '" + parentDir + "'.");
+        }
+
+        try (Writer fileWriter = Files.newBufferedWriter(this.typescriptFile.toPath(), StandardCharsets.UTF_8)) {
+            fileWriter.write(output);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Cannot write DTO typescript file");
+        }
+
+        // attach this typescript file as maven artifact
+        projectHelper.attachArtifact(project, "ts", typescriptFile);
+    }
+
+    /**
+     * Gets the TypeScript generated file
+     * @return the generated file TypeScript link
+     */
+    public File getTypescriptFile() {
+        return typescriptFile;
+    }
+
+    /**
+     * Allow to configure generator to use classpath instead of classloader
+     * @param useClassPath true if want to use classpath loading
+     */
+    public void setUseClassPath(boolean useClassPath) {
+        this.useClassPath = useClassPath;
+    }
+
+
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDtoGenerator.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDtoGenerator.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto;
+
+import com.google.common.io.Resources;
+
+import org.eclipse.che.dto.shared.DTO;
+import org.eclipse.che.plugin.typescript.dto.model.DtoModel;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ConfigurationBuilder;
+import org.stringtemplate.v4.ST;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.reflections.util.ClasspathHelper.forClassLoader;
+import static org.reflections.util.ClasspathHelper.forJavaClassPath;
+
+/**
+ * Write all DTOs found in classpath into a specific file. It will contains both DTO interface and DTO implementation.
+ * It will generate TypeScript code
+ * @author Florent Benoit
+ */
+public class TypeScriptDtoGenerator {
+
+    /**
+     * Name of the template
+     */
+    public static final String TEMPLATE_NAME = "/".concat(TypeScriptDtoGenerator.class.getPackage().getName().replace(".", "/")).concat("/typescript.template");
+
+    /**
+     * String template instance used
+     */
+    private ST st;
+
+    /**
+     * Model of DTOs that will be provided to the String Template
+     */
+    private List<DtoModel> dtoModels;
+
+
+    /**
+     * Use of classpath
+     */
+    private boolean useClassPath;
+
+    /**
+     * Setup a new generator
+     */
+    public TypeScriptDtoGenerator() {
+        this.dtoModels = new ArrayList<>();
+    }
+
+    public static void main(String[] args) {
+        new TypeScriptDtoGenerator().execute();
+    }
+
+
+    /**
+     * Init stuff is responsible to grab all DTOs found in classpath (classloader) and setup model for String Template
+     */
+    protected void init() {
+
+        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().setScanners(new SubTypesScanner(), new TypeAnnotationsScanner());
+        if (useClassPath) {
+            configurationBuilder.setUrls(forJavaClassPath());
+        } else {
+            configurationBuilder.setUrls(forClassLoader());
+        }
+
+        // keep only DTO interfaces
+        Reflections reflections = new Reflections(configurationBuilder);
+        List<Class<?>> annotatedWithDtos = new ArrayList<>(reflections.getTypesAnnotatedWith(DTO.class));
+        List<Class<?>> interfacesDtos = annotatedWithDtos.stream()
+                                                         .filter(clazz -> clazz.isInterface())
+                                                         .collect(Collectors.toList());
+        interfacesDtos.stream().forEach(this::analyze);
+
+    }
+
+    /**
+     * Analyze a DTO interface by registering the associate model.
+     * @param dto the DTO to analyze
+     */
+    protected void analyze(Class<?> dto) {
+        // for each dto class, store some data about it
+        this.dtoModels.add(new DtoModel(dto));
+    }
+
+    /**
+     * Execute this generator.
+     */
+    public String execute() {
+        init();
+        ST template = getTemplate();
+        template.add("dtos", this.dtoModels);
+        String output = template.render();
+        return output;
+    }
+
+    /**
+     * Get the template for typescript
+     * @return the String Template
+     */
+    protected ST getTemplate() {
+        if (st == null) {
+            URL url = Resources.getResource(TypeScriptDtoGenerator.class, TEMPLATE_NAME);
+            try {
+                st = new ST(Resources.toString(url, UTF_8));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Unable to read template", e);
+            }
+        }
+        return st;
+    }
+
+
+    public void setUseClassPath(boolean useClassPath) {
+        this.useClassPath = useClassPath;
+    }
+}
+

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoModel.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto.model;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.convertType;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.getGetterFieldName;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.getSetterFieldName;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.getWithFieldName;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.isDtoGetter;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.isDtoSetter;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.isDtoWith;
+
+/***
+ * Model of the DTO
+ * It includes attributes/fields and methods.
+ *
+ * @author Florent Benoit
+ */
+public class DtoModel {
+
+    /**
+     * DTO instance (interface).
+     */
+    private Class dto;
+
+    /**
+     * Model of methods for this interface.
+     */
+    private List<MethodModel> methods;
+
+    /**
+     * Map of all attributes found when scanning methods
+     */
+    private Map<String, Type> fieldAttributes = new HashMap<>();
+
+    /**
+     * Model for the attributes of this interface (for generating implementation)
+     */
+    private List<FieldAttributeModel> fieldAttributeModels;
+
+    /**
+     * Build a new model for the given DTO class by scanning it.
+     *
+     * @param dto
+     *         the interface with {@link org.eclipse.che.dto.shared.DTO} annotation
+     */
+    public DtoModel(Class dto) {
+        this.dto = dto;
+        this.methods = new ArrayList<>();
+        this.fieldAttributeModels = new ArrayList<>();
+        analyze();
+    }
+
+    /**
+     * Scan all getter/setter/with methods that are not inherited
+     */
+    protected void analyze() {
+        Arrays.asList(this.dto.getMethods()).stream()
+              .filter(method -> !method.isBridge() && (isDtoGetter(method) || isDtoSetter(method) || isDtoWith(method)))
+              .forEach(method -> {
+                  MethodModel methodModel = new MethodModel(method);
+                  methods.add(methodModel);
+                  if (isDtoGetter(method)) {
+                      analyzeDtoGetterMethod(method, methodModel);
+                  } else if (isDtoSetter(method)) {
+                      analyzeDtoSetterMethod(method, methodModel);
+                  } else if (isDtoWith(method)) {
+                      analyzeDtoWithMethod(method, methodModel);
+                  }
+              });
+
+        // now convert map into list
+        fieldAttributes.entrySet().stream().forEach(field -> fieldAttributeModels.add(new FieldAttributeModel(field.getKey(), field.getValue())));
+
+    }
+
+    /**
+     * Populate model from given reflect getter method
+     * @param method the method to analyze
+     * @param methodModel the model to update
+     */
+    protected void analyzeDtoGetterMethod(Method method, MethodModel methodModel) {
+        methodModel.setGetter(true);
+        Type fieldType = method.getGenericReturnType();
+        String fieldName = getGetterFieldName(method);
+        fieldAttributes.put(fieldName, fieldType);
+        methodModel.setFieldName(fieldName);
+        methodModel.setFieldType(convertType(fieldType));
+    }
+
+    /**
+     * Populate model from given reflect setter method
+     * @param method the method to analyze
+     * @param methodModel the model to update
+     */
+    protected void analyzeDtoSetterMethod(Method method, MethodModel methodModel) {
+        methodModel.setSetter(true);
+        // add the parameter
+        Type fieldType = method.getGenericParameterTypes()[0];
+        String fieldName = getSetterFieldName(method);
+        fieldAttributes.put(fieldName, fieldType);
+        methodModel.setFieldName(fieldName);
+        methodModel.setFieldType(convertType(fieldType));
+
+    }
+
+    /**
+     * Populate model from given reflect with method
+     * @param method the method to analyze
+     * @param methodModel the model to update
+     */
+    protected void analyzeDtoWithMethod(Method method, MethodModel methodModel) {
+        methodModel.setWith(true);
+        // add the parameter
+        Type fieldType = method.getGenericParameterTypes()[0];
+        String fieldName = getWithFieldName(method);
+        fieldAttributes.put(fieldName, fieldType);
+        methodModel.setFieldName(fieldName);
+        methodModel.setFieldType(convertType(fieldType));
+    }
+
+        /**
+         * @return model of attributes
+         */
+    public List<FieldAttributeModel> getFieldAttributeModels() {
+        return fieldAttributeModels;
+    }
+
+    /**
+     * Gets the package name of this interface
+     *
+     * @return the package name of this interface
+     */
+    public String getPackageName() {
+        return this.dto.getPackage().getName();
+    }
+
+    /**
+     * Gets the short (simple) name of the interface. Like HelloWorld if FQN class is foo.bar.HelloWorld
+     *
+     * @return the name of the interface
+     */
+    public String getSimpleName() {
+        return this.dto.getSimpleName();
+    }
+
+    /**
+     * Gets the FQN of this interface like foo.bar.HelloWorld
+     *
+     * @return the FQN name of this DTO interface
+     */
+    public String getName() {
+        return this.dto.getName();
+    }
+
+    /**
+     * Provides the model for every methods of the DTO that are getter/setter/with methods
+     *
+     * @return the list
+     */
+    public List<MethodModel> getMethods() {
+        return this.methods;
+    }
+
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/FieldAttributeModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/FieldAttributeModel.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto.model;
+
+import com.google.gson.internal.Primitives;
+
+import org.eclipse.che.dto.shared.DTO;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.convertType;
+
+/**
+ * A field model will used for providing class generation of a DTO
+ *
+ * @author Florent Benoit
+ */
+public class FieldAttributeModel {
+
+    /**
+     * Typescript value of the type of the field
+     */
+    private final String typeName;
+
+    /**
+     * For Map, List object, need to initialize field first. Like new Field<>()
+     */
+    private boolean needInitialize;
+
+    /**
+     * Name of the field
+     */
+    private String fieldName;
+
+    /**
+     * Java Type of the object (used internally)
+     */
+    private Type type;
+
+    /**
+     * This field type is a List of objects ?
+     */
+    private boolean isList;
+
+    /**
+     * This field type is a simple primitive
+     */
+    private boolean isPrimitive;
+
+    /**
+     * This field type is a map
+     */
+    private boolean isMap;
+
+    /**
+     * This list type is in fact a list of DTOs
+     */
+    private boolean isListOfDto;
+
+    /**
+     * The type is a DTO or a list of DTO and then this value is the name of the DTO implementation
+     */
+    private String dtoImpl;
+
+    /**
+     * type is a DTO object.
+     */
+    private boolean isDto;
+
+
+    /**
+     * Build a new field model based on the name and Java type
+     *
+     * @param fieldName
+     *         the name of the field
+     * @param type
+     *         the Java raw type that will allow further analyzes
+     */
+    public FieldAttributeModel(String fieldName, Type type) {
+        this.fieldName = fieldName;
+        this.type = type;
+        this.typeName = convertType(type);
+
+        if (typeName.startsWith("Array<") || typeName.startsWith("Map<")) {
+            this.needInitialize = true;
+        }
+
+        if (this.type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType)this.type;
+            Type rawType = parameterizedType.getRawType();
+            analyzeParametrizedType(parameterizedType, rawType);
+        } else if (Primitives.isPrimitive(this.type) || Primitives.isWrapperType(this.type) || String.class.equals(this.type)) {
+            this.isPrimitive = true;
+        } else if (this.type instanceof Class && ((Class)this.type).isAnnotationPresent(DTO.class)) {
+            this.isDto = true;
+            dtoImpl = this.type.getTypeName() + "Impl";
+        }
+
+    }
+
+    /**
+     * Analyze a complex parametrized type attribute (which can be a list or map for example)
+     * @param parameterizedType
+     * @param rawType
+     */
+    protected void analyzeParametrizedType(ParameterizedType parameterizedType, Type rawType) {
+        if (List.class.equals(rawType)) {
+            this.isList = true;
+            if (parameterizedType.getActualTypeArguments()[0] instanceof Class &&
+                ((Class)parameterizedType.getActualTypeArguments()[0]).isAnnotationPresent(DTO.class)) {
+                isListOfDto = true;
+                dtoImpl = convertType(parameterizedType.getActualTypeArguments()[0]) + "Impl";
+            }
+        } else if (Map.class.equals(rawType)) {
+            isMap = true;
+        }
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public boolean isList() {
+        return isList;
+    }
+
+    public boolean isPrimitive() {
+        return isPrimitive;
+    }
+
+    public boolean isMap() {
+        return isMap;
+    }
+
+    public boolean isListOfDto() {
+        return isListOfDto;
+    }
+
+    public String getDtoImpl() {
+        return dtoImpl;
+    }
+
+    public boolean isDto() {
+        return isDto;
+    }
+
+    public boolean isNeedInitialize() {
+        return needInitialize;
+    }
+
+    public String getName() {
+        return this.fieldName;
+    }
+
+    public String getSimpleType() {
+        return this.typeName;
+    }
+
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/MethodModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/MethodModel.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto.model;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.convertType;
+
+/**
+ * Defines the model of the method
+ *
+ * @author Florent Benoit
+ */
+public class MethodModel {
+
+    /**
+     * Reflect object used internally.
+     */
+    private Method method;
+
+    /**
+     * Typescript return value of the method
+     */
+    private String returnType;
+
+    /**
+     * List of parameters for this method
+     */
+    private List<ParameterMethodModel> parameters;
+
+    /**
+     * This method is a DTO getter method
+     */
+    private boolean isGetter;
+
+    /**
+     * This method is a DTO setter method
+     */
+    private boolean isSetter;
+
+    /**
+     * This method is a DTO with method
+     */
+    private boolean isWith;
+
+    /**
+     * Name of the field associated to this method (field to return for a getter, field to store for setter/with)
+     */
+    private String fieldName;
+
+    /**
+     * Type of the field associated to this method.
+     */
+    private String fieldType;
+
+
+    /**
+     * Build a new model around the DTO method.
+     *
+     * @param method
+     */
+    public MethodModel(Method method) {
+        this.method = method;
+        this.parameters = new ArrayList<>();
+        analyze();
+    }
+
+    /**
+     * Loop on all parameters and initialize return value as well
+     */
+    protected void analyze() {
+        IntStream.range(0, method.getGenericParameterTypes().length).forEach(i ->
+            parameters.add(new ParameterMethodModel("arg" + i, convertType(method.getGenericParameterTypes()[i])))
+        );
+
+        // add return type
+        this.returnType = convertType(method.getGenericReturnType());
+    }
+
+
+    public boolean isGetter() {
+        return isGetter;
+    }
+
+    public void setGetter(boolean getter) {
+        isGetter = getter;
+    }
+
+    public boolean isSetter() {
+        return isSetter;
+    }
+
+    public void setSetter(boolean setter) {
+        isSetter = setter;
+    }
+
+    public boolean isWith() {
+        return isWith;
+    }
+
+    public void setWith(boolean with) {
+        isWith = with;
+    }
+
+
+    public String getName() {
+        return this.method.getName();
+    }
+
+    public List<ParameterMethodModel> getParameters() {
+        return this.parameters;
+    }
+
+    public String getReturnType() {
+        return this.returnType;
+    }
+
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldType(String fieldType) {
+        this.fieldType = fieldType;
+    }
+
+    public String getFieldType() {
+        return fieldType;
+    }
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/ParameterMethodModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/ParameterMethodModel.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto.model;
+
+/**
+ * Defines the model link to parameter of a method
+ *
+ * @author Florent Benoit
+ */
+public class ParameterMethodModel {
+
+    /**
+     * Name of the parameter.
+     */
+    private String parameterName;
+
+    /**
+     * Type of the parameter. (Type is in TypeScript format)
+     */
+    private String parameterType;
+
+    /**
+     * Create a new instance of parameter model with specified name and type
+     *
+     * @param parameterName
+     *         the name of the parameter like foo
+     * @param parameterType
+     *         the type of the parameter (like foo.bar.MyDTO or primitive value like string)
+     */
+    public ParameterMethodModel(String parameterName, String parameterType) {
+        this.parameterName = parameterName;
+        this.parameterType = parameterType;
+    }
+
+    /**
+     * Getter for the name
+     *
+     * @return the name of the parameter
+     */
+    public String getName() {
+        return this.parameterName;
+    }
+
+    /**
+     * Getter for the type
+     *
+     * @return the type of the parameter
+     */
+    public String getType() {
+        return this.parameterType;
+    }
+
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.template
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.template
@@ -1,0 +1,93 @@
+// File has been generated automatically by Eclipse Che TypeScript DTO generator
+
+<dtos: { dto |
+
+<! Write TypeScript DTO interface first !>
+
+<! BEGIN declare dto module !>
+export module <dto.packageName> {
+
+  <! BEGIN declare interface !>
+  export interface <dto.simpleName> {
+  <dto.methods : {method |
+    <method.name>(<method.parameters :{parameter | <if(!first(parameter))>,<endif><parameter.name>}>): <method.returnType>;
+  }>
+  \} <! END declare interface !>
+\} <! END declare dto module !>
+
+
+<! Now write TypeScript DTO implementation with suffix Impl !>
+<! BEGIN declare dto module !>
+export module <dto.packageName> {
+
+  <! BEGIN declare class !>
+  export class <dto.simpleName>Impl implements <dto.name> {
+
+    <! BEGIN declare fields !>
+    <dto.fieldAttributeModels:{ field |
+    <field.name> : <field.simpleType>;
+    }>
+    <! add custom field for storing the JSON object !>
+    __jsonObject : any;
+
+    <! BEGIN constructor !>
+    constructor(__jsonObject?: any) {
+      this.__jsonObject = __jsonObject;
+      <dto.fieldAttributeModels:{ field |
+      <if(field.needInitialize)>
+      this.<field.name> = new <field.simpleType>();
+      <endif>
+      if (__jsonObject.<field.name>) {
+        <! handle list object !>
+        <if(field.list)>
+          __jsonObject.<field.name>.forEach((item) => {
+          <if(field.listOfDto)>
+          this.<field.name>.push(new <field.dtoImpl>(item));
+          <else>
+          this.<field.name>.push(item);
+          <endif>
+          \});
+        <endif>
+        <! handle map object !>
+        <if(field.map)>
+        let tmp : Array\<any> = Object.keys(__jsonObject.<field.name>);
+        tmp.forEach((key) => {
+          this.<field.name>.set(key, __jsonObject.<field.name>[key]);
+         \});
+        <endif>
+        <if(field.primitive)>
+        this.<field.name> = __jsonObject.<field.name>;
+        <endif>
+        <if(field.dto)>
+        this.<field.name> = new <field.dtoImp>(__jsonObject.<field.name>);
+        <endif>
+      \}
+      }>
+    \} <! END constructor !>
+
+    <! BEGIN write methods !>
+    <dto.methods : {method |
+    <! Generate Getter code !>
+    <if(method.getter)>
+    <method.name>() : <method.returnType> {
+      return this.<method.fieldName>;
+    \}
+    <endif>
+    <! Generate setter code !>
+    <if(method.setter)>
+    <method.name>(<method.fieldName> : <method.fieldType>) : void {
+      this.<method.fieldName> = this.<method.fieldName>;
+    \}
+    <endif>
+    <! Generate with code !>
+    <if(method.with)>
+    <method.name>(<method.fieldName> : <method.fieldType>) : <method.returnType> {
+      this.<method.fieldName> = this.<method.fieldName>;
+      return this;
+    \}
+    <endif>
+  }> <! END write methods !>
+  \} <! END declare interface !>
+\} <! END declare dto module !>
+
+}>

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyCustomDTO.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyCustomDTO.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * @author Florent Benoit
+ */
+@DTO
+public interface MyCustomDTO {
+
+    String getName();
+    void setName(String name);
+    MyCustomDTO withName(String name);
+
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoTest.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto;
+
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.plugin.testing.resources.TestResources;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.nio.file.Files;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Florent Benoit
+ */
+public class TypeScriptDTOGeneratorMojoTest {
+
+    /**
+     * Rule to manage the mojo (inject, get variables from mojo)
+     */
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    /**
+     * Resources of each test mapped on the name of the method
+     */
+    @Rule
+    public TestResources resources = new TestResources();
+
+
+    /**
+     * Helper method used to inject data in mojo
+     * @param mojo the mojo
+     * @param baseDir root dir on which we extract files
+     * @throws IllegalAccessException if unable to set variables
+     */
+    protected void configure(TypeScriptDTOGeneratorMojo mojo, File baseDir) throws Exception {
+        this.rule.setVariableValueToObject(mojo, "targetDirectory", this.resources.getBasedir(""));
+        this.rule.setVariableValueToObject(mojo, "useClassPath", true);
+    }
+
+    /**
+     * Check that the TypeScript definition is generated and that WorkspaceDTO is generated (dependency is part of the test)
+     */
+    @Test
+    public void testCheckTypeScriptGenerated() throws Exception {
+
+        File projectCopy = this.resources.getBasedir("project");
+        File pom = new File(projectCopy, "pom.xml");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+
+        TypeScriptDTOGeneratorMojo mojo = (TypeScriptDTOGeneratorMojo) this.rule.lookupMojo("build", pom);
+        configure(mojo, projectCopy);
+        mojo.execute();
+
+        File typeScriptFile = mojo.getTypescriptFile();
+        // Check file has been generated
+        Assert.assertTrue(typeScriptFile.exists());
+
+        // Now check there is "org.eclipse.che.plugin.typescript.dto.MyCustomDTO" inside
+        boolean foundMyCustomDTO = false;
+        try (BufferedReader reader = Files.newBufferedReader(typeScriptFile.toPath(), UTF_8)) {
+            String line = reader.readLine();
+            while (line != null && !foundMyCustomDTO) {
+                if (line.contains("MyCustomDTO")) {
+                    foundMyCustomDTO = true;
+                }
+                line = reader.readLine();
+            }
+        }
+
+        Assert.assertTrue("The MyCustomDTO has not been generated in the typescript definition file.", foundMyCustomDTO);
+
+    }
+
+
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/stub/TypeScriptDTOGeneratorMojoProjectStub.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/stub/TypeScriptDTOGeneratorMojoProjectStub.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.typescript.dto.stub;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Florent Benoit
+ */
+public class TypeScriptDTOGeneratorMojoProjectStub extends MavenProjectStub {
+
+
+    /** {@inheritDoc} */
+    @Override
+    public File getBasedir() {
+        return new File(super.getBasedir() + "/src/test/projects/project");
+    }
+
+
+    /**
+     * Default constructor
+     */
+    public TypeScriptDTOGeneratorMojoProjectStub() {
+        MavenXpp3Reader pomReader = new MavenXpp3Reader();
+        Model model;
+        try {
+            model = pomReader.read(ReaderFactory.newXmlReader(new File(getBasedir(), "pom.xml")));
+            setModel(model);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        setGroupId(model.getGroupId());
+        setArtifactId(model.getArtifactId());
+        setVersion(model.getVersion());
+        setName(model.getName());
+        setUrl(model.getUrl());
+        setPackaging(model.getPackaging());
+
+        Build build = new Build();
+        build.setFinalName(model.getArtifactId());
+        build.setDirectory(getBasedir() + "/target");
+        build.setSourceDirectory(getBasedir() + "/src/main/java");
+        build.setOutputDirectory(getBasedir() + "/target/classes");
+        build.setTestSourceDirectory(getBasedir() + "/src/test/java");
+        build.setTestOutputDirectory(getBasedir() + "/target/test-classes");
+        setBuild(build);
+
+        List compileSourceRoots = new ArrayList();
+        compileSourceRoots.add(getBasedir() + "/src/main/java");
+        setCompileSourceRoots(compileSourceRoots);
+
+        List testCompileSourceRoots = new ArrayList();
+        testCompileSourceRoots.add(getBasedir() + "/src/test/java");
+        setTestCompileSourceRoots(testCompileSourceRoots);
+    }
+
+    /**
+     * Use of mockito artifact
+     */
+    @Override
+    public Artifact getArtifact() {
+        Artifact artifact = Mockito.mock(Artifact.class);
+        when(artifact.getArtifactId()).thenReturn(getModel().getArtifactId());
+        when(artifact.getGroupId()).thenReturn(getModel().getGroupId());
+        when(artifact.getVersion()).thenReturn(getModel().getVersion());
+        when(artifact.getVersionRange()).thenReturn(VersionRange.createFromVersion(getModel().getVersion()));
+        return artifact;
+    }
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/test/projects/project/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/projects/project/pom.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.che.test</groupId>
+    <artifactId>my-typescript-test-moddule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test of Eclipse Che TypeScript plugin</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-typescript-dto-maven-plugin</artifactId>
+                <configuration>
+                    <project implementation="org.eclipse.che.plugin.typescript.dto.stub.TypeScriptDTOGeneratorMojoProjectStub"/>
+                </configuration>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,7 @@
         <module>commons</module>
         <module>che-core-api-dto</module>
         <module>che-core-api-dto-maven-plugin</module>
+        <module>che-core-typescript-dto-maven-plugin</module>
         <module>che-core-api-core</module>
         <module>che-core-api-model</module>
         <module>che-core-api-jdbc</module>


### PR DESCRIPTION
### What does this PR do?

It allow javascript clients (like Dashboard and Chefile) of REST API of Eclipse Che to use a Typed variables by using TypeScript definition and implementation

Generation is based on string template library https://github.com/eclipse/che-dependencies/pull/17

input : <dependendy set of maven DTO modules>
ouput : dto.ts file including DTO definition and an implementation for building objects around JSON content

usage example

```
            ...
            <plugin>
                <groupId>org.eclipse.che.core</groupId>
                <artifactId>che-core-typescript-dto-maven-plugin</artifactId>
                <executions>
                    <execution>
                        <goals>
                            <goal>build</goal>
                        </goals>
                    </execution>
                </executions>
                <dependencies>
                    <dependency>
                        <groupId>org.eclipse.che.core</groupId>
                        <artifactId>che-core-api-workspace-shared</artifactId>
                    </dependency>
                </dependencies>
                <configuration>
                    <inherited>false</inherited>
                </configuration>
            </plugin>
            ...
```
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [x] Tests provided / updated
- [x] Tests passed

Change-Id: I5eb2e2a958ffb99fc63dc6ff606a528ad105d7e0
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
