### PR TITLE
CHE-781: use 1Gb RAM for db machine and remove ssh agent from it

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -39,14 +39,14 @@
             },
             "db": {
               "agents": [
-                "org.eclipse.che.terminal", "org.eclipse.che.ssh"
+                "org.eclipse.che.terminal"
               ],
               "servers": {},
               "attributes" : {}
             }
           },
           "recipe": {
-            "content": "services:\n db:\n  image: codenvy/mysql\n  environment:\n   MYSQL_DATABASE: petclinic\n   MYSQL_USER: petclinic\n   MYSQL_PASSWORD: password\n  mem_limit: 2147483648\n dev-machine:\n  image: codenvy/ubuntu_jdk8\n  mem_limit: 2147483648\n  links:\n    - db",
+            "content": "services:\n db:\n  image: codenvy/mysql\n  environment:\n   MYSQL_DATABASE: petclinic\n   MYSQL_USER: petclinic\n   MYSQL_PASSWORD: password\n  mem_limit: 1073741824\n dev-machine:\n  image: codenvy/ubuntu_jdk8\n  mem_limit: 2147483648\n  links:\n    - db",
             "contentType": "application/x-yaml",
             "type": "compose"
           }


### PR DESCRIPTION
### What does this PR do?

Reduces allocated RAM for db machine in Java+MySQL stack and removes unused ssh agent.
### What issues does this PR fix or reference?

https://github.com/codenvy/codenvy/issues/781

Signed-off-by: Ann Shumilova ashumilova@codenvy.com
