### PR TITLE
CHE-2369: add a mechanism which checks state of the ws agent

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -89,6 +89,9 @@ public class WsMasterModule extends AbstractModule {
                 new org.eclipse.che.api.machine.server.model.impl.ServerConfImpl(Constants.WSAGENT_DEBUG_REFERENCE, "4403/tcp", "http",
                                                                                  null));
 
+        bind(org.eclipse.che.api.agent.server.WsAgentHealthChecker.class)
+                .to(org.eclipse.che.api.agent.server.WsAgentHealthCheckerImpl.class);
+
         bind(org.eclipse.che.api.machine.server.recipe.RecipeLoader.class);
         Multibinder.newSetBinder(binder(), String.class, Names.named("predefined.recipe.path"))
                    .addBinding()

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
@@ -17,8 +17,9 @@ import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
-import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
+import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
+import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
 
 import java.util.List;
 
@@ -282,5 +283,15 @@ public interface WorkspaceServiceClient {
      * @see WorkspaceService#createSnapshot(String)
      */
     Promise<Void> createSnapshot(String workspaceId);
+
+    /**
+     * Gets state of the workspace agent.
+     *
+     * @param workspaceId
+     *         workspace ID
+     * @return a promise that will resolve when the snapshot has been created, or rejects with an error
+     * @see WorkspaceService#checkAgentHealth(String)
+     */
+    Promise<WsAgentHealthStateDto> getWsAgentState(String workspaceId);
 
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClientImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
+import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
@@ -380,5 +381,12 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
                                    .send(newCallback(callback));
             }
         });
+    }
+
+    @Override
+    public Promise<WsAgentHealthStateDto> getWsAgentState(String workspaceId) {
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + '/' + workspaceId + "/check")
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .send(dtoUnmarshallerFactory.newUnmarshaller(WsAgentHealthStateDto.class));
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/ProjectTypeComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/ProjectTypeComponent.java
@@ -14,13 +14,13 @@ import com.google.gwt.core.client.Callback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.eclipse.che.ide.api.project.ProjectTypeServiceClient;
 import org.eclipse.che.api.project.shared.dto.ProjectTypeDto;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
+import org.eclipse.che.ide.api.project.ProjectTypeServiceClient;
 import org.eclipse.che.ide.api.project.type.ProjectTypeRegistry;
 
 import java.util.List;

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/WsAgentHealthStateDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/WsAgentHealthStateDto.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.shared.dto;
+
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Describes status of the ws agent.
+ *
+ * @author Vitalii Parfonov
+ * @author Valeriy Svydenko
+ */
+@DTO
+public interface WsAgentHealthStateDto {
+
+    void setWorkspaceStatus(WorkspaceStatus status);
+
+    WsAgentHealthStateDto withWorkspaceStatus(WorkspaceStatus status);
+
+    /**
+     * Returns the status of the current workspace instance.
+     * <p>
+     * <p>All the workspaces which are stopped have runtime
+     * are considered {@link WorkspaceStatus#STOPPED}.
+     */
+    WorkspaceStatus getWorkspaceStatus();
+
+    void setCode(int code);
+
+    /** Returns HTTP status code, see {@code javax.ws.rs.core.Response.Status} */
+    int getCode();
+
+    WsAgentHealthStateDto withCode(int code);
+
+    void setReason(String reason);
+
+    /** Returns reason of the state. */
+    String getReason();
+
+    WsAgentHealthStateDto withReason(String reason);
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentHealthChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentHealthChecker.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
+
+/**
+ * Describes a mechanism for checking ws agent's state.
+ * It needs when Workspace Agent (WS Agent) stops to respond and projects disappear from the project tree,
+ * and the page shows 'Cannot get project types' error.
+ * It may happens for example, when OOM happens in a WS Agent and kernel kills WS Agent process.
+ * Problem here that we can't detect properly OOM error but we can check if WS Agent is alive for user.
+ * <p>
+ * If client (IDE) lost WebSocket connection to the WS Agent - in this case IDE will request some other service in our infrastructure to
+ * check WS Agent state, here we have two ways:
+ * <p>
+ * 1/ WS Agent was shutdown by OS. If it not available for this service too, a user should be notified that the workspace is broken
+ * probably because of OOM (it will be just suggest because we not sure about reason).
+ * <p>
+ * 2/ WS Agent is working well and is accessible for our infrastructure, in this case user has networking problem. It can be not
+ * well configured proxy server or other problems which are not related to our responsibility.
+ *
+ * @author Vitalii Parfonov
+ */
+public interface WsAgentHealthChecker {
+
+    /**
+     * Verifies if ws agent is alive.
+     *
+     * @param machine
+     *         machine instance
+     * @return state of the ws agent
+     * @throws ServerException
+     *         if internal server error occurred
+     */
+    WsAgentHealthStateDto check(Machine machine) throws ServerException;
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentHealthCheckerImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentHealthCheckerImpl.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server;
+
+import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.rest.HttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonResponse;
+import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Map;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
+/**
+ * Mechanism for checking workspace agent's state.
+ *
+ * @author Vitalii Parfonov
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class WsAgentHealthCheckerImpl implements WsAgentHealthChecker {
+    protected static final Logger LOG = LoggerFactory.getLogger(WsAgentHealthCheckerImpl.class);
+
+    private final WsAgentPingRequestFactory wsAgentPingRequestFactory;
+
+    @Inject
+    public WsAgentHealthCheckerImpl(WsAgentPingRequestFactory wsAgentPingRequestFactory) {
+        this.wsAgentPingRequestFactory = wsAgentPingRequestFactory;
+    }
+
+    @Override
+    public WsAgentHealthStateDto check(Machine machine) throws ServerException {
+        Server wsAgent = getWsAgent(machine);
+        final WsAgentHealthStateDto agentHealthStateDto = newDto(WsAgentHealthStateDto.class);
+        if (wsAgent == null) {
+            return agentHealthStateDto.withCode(NOT_FOUND.getStatusCode())
+                                      .withReason("Workspace Agent not available");
+        }
+        try {
+            final HttpJsonRequest pingRequest = createPingRequest(machine);
+            final HttpJsonResponse response = pingRequest.request();
+            return agentHealthStateDto.withCode(response.getResponseCode());
+        } catch (ApiException | IOException e) {
+            return agentHealthStateDto.withCode(SERVICE_UNAVAILABLE.getStatusCode())
+                                      .withReason(e.getMessage());
+        }
+    }
+
+    protected HttpJsonRequest createPingRequest(Machine machine) throws ServerException {
+        return wsAgentPingRequestFactory.createRequest(machine);
+    }
+
+    private Server getWsAgent(Machine machine) {
+        final Map<String, ? extends Server> servers = machine.getRuntime().getServers();
+        for (Server server : servers.values()) {
+            if (WSAGENT_REFERENCE.equals(server.getRef())) {
+                return server;
+            }
+        }
+        return null;
+    }
+
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactory.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.rest.HttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.api.machine.shared.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.ws.rs.HttpMethod;
+import java.util.Map;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Creates a request for pinging Workspace Agent.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class WsAgentPingRequestFactory {
+    protected static final Logger LOG = LoggerFactory.getLogger(WsAgentPingRequestFactory.class);
+
+    private static final String WS_AGENT_SERVER_NOT_FOUND_ERROR     = "Workspace agent server not found in dev machine.";
+    private static final String WS_AGENT_URL_IS_NULL_OR_EMPTY_ERROR = "URL of Workspace Agent is null or empty.";
+
+    private final HttpJsonRequestFactory httpJsonRequestFactory;
+    private final int                    wsAgentPingConnectionTimeoutMs;
+
+    @Inject
+    public WsAgentPingRequestFactory(HttpJsonRequestFactory httpJsonRequestFactory,
+                                     @Named("machine.ws_agent.ping_conn_timeout_ms") int wsAgentPingConnectionTimeoutMs) {
+        this.httpJsonRequestFactory = httpJsonRequestFactory;
+        this.wsAgentPingConnectionTimeoutMs = wsAgentPingConnectionTimeoutMs;
+    }
+
+    /**
+     * Creates request which can check if workspace agent is pinging.
+     *
+     * @param machine
+     *         machine instance
+     * @return instance of {@link HttpJsonRequest}
+     * @throws ServerException
+     *         if internal server error occurred
+     */
+    public HttpJsonRequest createRequest(Machine machine) throws ServerException {
+        Map<String, ? extends Server> servers = machine.getRuntime().getServers();
+        Server wsAgentServer = servers.get(Constants.WS_AGENT_PORT);
+        if (wsAgentServer == null) {
+            LOG.error("{} WorkspaceId: {}, DevMachine Id: {}, found servers: {}",
+                      WS_AGENT_SERVER_NOT_FOUND_ERROR, machine.getWorkspaceId(), machine.getId(), servers);
+            throw new ServerException(WS_AGENT_SERVER_NOT_FOUND_ERROR);
+        }
+        String wsAgentPingUrl = wsAgentServer.getProperties().getInternalUrl();
+        if (isNullOrEmpty(wsAgentPingUrl)) {
+            LOG.error(WS_AGENT_URL_IS_NULL_OR_EMPTY_ERROR);
+            throw new ServerException(WS_AGENT_URL_IS_NULL_OR_EMPTY_ERROR);
+        }
+        // since everrest mapped on the slash in case of it absence
+        // we will always obtain not found response
+        if (!wsAgentPingUrl.endsWith("/")) {
+            wsAgentPingUrl = wsAgentPingUrl.concat("/");
+        }
+        return httpJsonRequestFactory.fromUrl(wsAgentPingUrl)
+                                     .setMethod(HttpMethod.GET)
+                                     .setTimeout(wsAgentPingConnectionTimeoutMs);
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/WsAgentHealthCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/WsAgentHealthCheckerTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server;
+
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.rest.HttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonResponse;
+import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
+import static org.eclipse.che.api.machine.shared.Constants.WS_AGENT_PORT;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Valeriy Svydenko
+ */
+@Listeners(value = {MockitoTestNGListener.class})
+public class WsAgentHealthCheckerTest {
+    private final static String WS_AGENT_SERVER_URL                 = "ws_agent";
+
+    @Mock
+    private WsAgentPingRequestFactory wsAgentPingRequestFactory;
+    @Mock
+    private Machine                devMachine;
+    @Mock
+    private MachineRuntimeInfo     machineRuntimeInfo;
+    @Mock
+    private Server                 server;
+    @Mock
+    private HttpJsonRequest        httpJsonRequest;
+    @Mock
+    private HttpJsonResponse       httpJsonResponse;
+
+    private Map<String, Server> servers = new HashMap<>(1);
+
+    private WsAgentHealthCheckerImpl checker;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        servers.put(WSAGENT_REFERENCE, server);
+        servers.put(WS_AGENT_PORT, server);
+
+        when(server.getRef()).thenReturn(WSAGENT_REFERENCE);
+        when(server.getUrl()).thenReturn(WS_AGENT_SERVER_URL);
+        when(wsAgentPingRequestFactory.createRequest(devMachine)).thenReturn(httpJsonRequest);
+
+        checker = new WsAgentHealthCheckerImpl(wsAgentPingRequestFactory);
+
+        when(httpJsonRequest.setMethod(any())).thenReturn(httpJsonRequest);
+        when(httpJsonRequest.setTimeout(anyInt())).thenReturn(httpJsonRequest);
+        when(httpJsonRequest.request()).thenReturn(httpJsonResponse);
+
+        when(httpJsonResponse.getResponseCode()).thenReturn(200);
+        when(httpJsonResponse.asString()).thenReturn("response");
+
+        when(devMachine.getRuntime()).thenReturn(machineRuntimeInfo);
+        doReturn(servers).when(machineRuntimeInfo).getServers();
+    }
+
+    @Test
+    public void stateShouldBeReturnedWithStatusNotFoundIfWorkspaceAgentIsNotExist() throws Exception {
+        when(machineRuntimeInfo.getServers()).thenReturn(emptyMap());
+
+        WsAgentHealthStateDto result = checker.check(devMachine);
+
+        assertEquals(NOT_FOUND.getStatusCode(), result.getCode());
+    }
+
+    @Test
+    public void returnStateWithNotFoundCode() throws Exception {
+        doReturn(emptyMap()).when(machineRuntimeInfo).getServers();
+
+        final WsAgentHealthStateDto check = checker.check(devMachine);
+        assertEquals(NOT_FOUND.getStatusCode(), check.getCode());
+        assertEquals("Workspace Agent not available", check.getReason());
+    }
+
+    @Test
+    public void pingRequestToWsAgentShouldBeSent() throws Exception {
+        final WsAgentHealthStateDto result = checker.check(devMachine);
+
+        verify(httpJsonRequest).request();
+
+        assertEquals(200, result.getCode());
+    }
+
+    @Test
+    public void returnResultWithUnavailableStateIfDoNotGetResponseFromWsAgent() throws Exception {
+        doThrow(IOException.class).when(httpJsonRequest).request();
+        final WsAgentHealthStateDto result = checker.check(devMachine);
+
+        verify(httpJsonRequest).request();
+
+        assertEquals(SERVICE_UNAVAILABLE.getStatusCode(), result.getCode());
+    }
+
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactoryTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.machine.MachineRuntimeInfo;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.core.model.machine.ServerProperties;
+import org.eclipse.che.api.core.rest.HttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.HttpMethod;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.eclipse.che.api.machine.shared.Constants.WS_AGENT_PORT;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Listeners(value = {MockitoTestNGListener.class})
+public class WsAgentPingRequestFactoryTest {
+    private final static int    WS_AGENT_PING_CONNECTION_TIMEOUT_MS = 20;
+    private final static String WS_AGENT_URL_IS_NOT_VALID           = "URL of Workspace Agent is null or empty.";
+    private static final String WS_AGENT_SERVER_NOT_FOUND_ERROR     = "Workspace agent server not found in dev machine.";
+    private final static String WS_AGENT_SERVER_URL                 = "ws_agent";
+
+    @Mock
+    private HttpJsonRequestFactory httpJsonRequestFactory;
+    @Mock
+    private HttpJsonRequest        httpJsonRequest;
+    @Mock
+    private Machine                devMachine;
+    @Mock
+    private Server                 server;
+    @Mock
+    private MachineRuntimeInfo     machineRuntimeInfo;
+    @Mock
+    private ServerProperties       serverProperties;
+
+    private Map<String, Server> servers = new HashMap<>(1);
+
+    private WsAgentPingRequestFactory factory;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        factory = new WsAgentPingRequestFactory(httpJsonRequestFactory, WS_AGENT_PING_CONNECTION_TIMEOUT_MS);
+
+        servers.put(WS_AGENT_SERVER_URL, server);
+        servers.put(WS_AGENT_PORT, server);
+
+        when(httpJsonRequestFactory.fromUrl(anyString())).thenReturn(httpJsonRequest);
+        when(httpJsonRequest.setMethod(HttpMethod.GET)).thenReturn(httpJsonRequest);
+        when(server.getProperties()).thenReturn(serverProperties);
+        when(serverProperties.getInternalUrl()).thenReturn(WS_AGENT_SERVER_URL);
+        when(devMachine.getRuntime()).thenReturn(machineRuntimeInfo);
+        doReturn(servers).when(machineRuntimeInfo).getServers();
+    }
+
+
+    @Test(expectedExceptions = ServerException.class, expectedExceptionsMessageRegExp = WS_AGENT_SERVER_NOT_FOUND_ERROR)
+    public void throwsServerExceptionWhenWsAgentIsNull() throws Exception {
+        servers.clear();
+
+        factory.createRequest(devMachine);
+    }
+
+    @Test(expectedExceptions = ServerException.class, expectedExceptionsMessageRegExp = WS_AGENT_URL_IS_NOT_VALID)
+    public void throwsServerExceptionWhenWsServerUrlIsNull() throws Exception {
+        when(serverProperties.getInternalUrl()).thenReturn(null);
+
+        factory.createRequest(devMachine);
+    }
+
+    @Test(expectedExceptions = ServerException.class, expectedExceptionsMessageRegExp = WS_AGENT_URL_IS_NOT_VALID)
+    public void throwsServerExceptionWhenWsServerUrlIsEmpty() throws Exception {
+        when(serverProperties.getInternalUrl()).thenReturn("");
+
+        factory.createRequest(devMachine);
+    }
+
+    @Test
+    public void pingRequestShouldBeCreated() throws Exception {
+        factory.createRequest(devMachine);
+
+        verify(httpJsonRequestFactory).fromUrl(WS_AGENT_SERVER_URL + '/');
+        verify(httpJsonRequest).setMethod(javax.ws.rs.HttpMethod.GET);
+        verify(httpJsonRequest).setTimeout(WS_AGENT_PING_CONNECTION_TIMEOUT_MS);
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -17,6 +17,7 @@ import com.jayway.restassured.response.Response;
 
 import org.eclipse.che.account.shared.model.Account;
 import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.agent.server.WsAgentHealthChecker;
 import org.eclipse.che.api.core.model.machine.MachineStatus;
 import org.eclipse.che.api.core.model.project.ProjectConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
@@ -48,6 +49,7 @@ import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.SourceStorageDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
+import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -134,13 +136,16 @@ public class WorkspaceServiceTest {
     private MachineProcessManager machineProcessManager;
     @Mock
     private WorkspaceValidator    validator;
+    @Mock
+    private WsAgentHealthChecker  wsAgentHealthChecker;
 
-    private WorkspaceService      service;
+    private WorkspaceService service;
 
     @BeforeMethod
     public void setup() {
         service = new WorkspaceService(wsManager,
                                        validator,
+                                       wsAgentHealthChecker,
                                        new WorkspaceServiceLinksInjector(new MachineServiceLinksInjector()));
     }
 
@@ -358,7 +363,7 @@ public class WorkspaceServiceTest {
     @Test
     public void shouldStartWorkspace() throws Exception {
         final WorkspaceImpl workspace = createWorkspace(createConfigDto());
-        when(wsManager.startWorkspace(any(),  any(), any())).thenReturn(workspace);
+        when(wsManager.startWorkspace(any(), any(), any())).thenReturn(workspace);
         when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
 
         final Response response = given().auth()
@@ -834,6 +839,46 @@ public class WorkspaceServiceTest {
     }
 
     @Test
+    public void stateOfWsAgentShouldBeChecked() throws Exception {
+        final WorkspaceImpl workspace = createWorkspace(createConfigDto());
+        workspace.setStatus(RUNNING);
+
+        WsAgentHealthStateDto wsAgentState = newDto(WsAgentHealthStateDto.class);
+        WorkspaceRuntimeImpl runtime = mock(WorkspaceRuntimeImpl.class);
+        MachineImpl machine = mock(MachineImpl.class);
+        when(runtime.getDevMachine()).thenReturn(machine);
+        when(wsAgentHealthChecker.check(machine)).thenReturn(wsAgentState);
+
+        workspace.setRuntime(runtime);
+
+        when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
+
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .when()
+                                         .get(SECURE_PATH + "/workspace/" + workspace.getId() + "/check");
+
+        verify(wsAgentHealthChecker).check(machine);
+        assertEquals(RUNNING, wsAgentState.getWorkspaceStatus());
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    public void stateOfWsAgentShouldNotBeCheckedIfWsIsNotRunning() throws Exception {
+        final WorkspaceImpl workspace = createWorkspace(createConfigDto());
+        workspace.setStatus(STARTING);
+        when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
+
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .when()
+                                         .get(SECURE_PATH + "/workspace/" + workspace.getId() + "/check");
+
+        verify(wsAgentHealthChecker, never()).check(any());
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
     public void shouldReturnEmptyListIfNotSnapshotsFound() throws Exception {
         // given
         String workspaceId = "testWsId1";
@@ -908,7 +953,7 @@ public class WorkspaceServiceTest {
         final WorkspaceConfigImpl config = WorkspaceConfigImpl.builder()
                                                               .setName("dev-workspace")
                                                               .setDefaultEnv("dev-env")
-                                                              .setEnvironments(singletonMap("dev-env",new EnvironmentImpl(createEnvDto())))
+                                                              .setEnvironments(singletonMap("dev-env", new EnvironmentImpl(createEnvDto())))
                                                               .setCommands(singletonList(createCommandDto()))
                                                               .setProjects(singletonList(createProjectDto()))
                                                               .build();


### PR DESCRIPTION
### What does this PR do?

Adds a service which periodically pings ws agent and notify a user when something is happened.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2369
### Previous behavior

When ws agent stops responding a user don't get any response about this and don't know what is happened.
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [x] Tests provided / updated
- [x] Tests passed

@vparfonov please take a look
