### PR TITLE
Add testing stack for Langage Server agents

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -962,6 +962,56 @@
     }
   },
   {
+    "id": "debianlsp",
+    "creator": "ide",
+    "name": "Debian LSP",
+    "description": "Simple stack with Debian (Jessie) to test LSP",
+    "scope": "advanced",
+    "tags": [
+      "Debian",
+      "LSP"
+    ],
+    "components": [
+      {
+        "name": "Debian",
+        "version": "Jessie"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "codenvy/debian_jre"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", 
+                "org.eclipse.che.ws-agent", 
+                "org.eclipse.che.ssh",
+                "org.eclipse.che.ls.csharp",
+                "org.eclipse.che.ls.json",
+                "org.eclipse.che.ls.php"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "codenvy/debian_jre",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null
+    }
+  },
+  {
     "id": "java-centos",
     "creator": "ide",
     "name": "Java CentOS",


### PR DESCRIPTION
### What does this PR do?

This PR add a testing stack where the LS Agents are embed. This way, it ease the ability to test those LS until the UI is implemented in the Dashboard
### What issues does this PR fix or reference?
#1281
### Previous behavior

To test LS Agent, developers had to create a new stack and add the LS Agents. 
### New behavior

A default sample stack is available to test LS Agents.
### PR type
- [x] Minor change = no change to existing features or docs

Signed-Off-by: Stevan Le Meur stevan.lemeur@gmail.com
