### PR TITLE
Remove duplicated dependency

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>gwt-elemental</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-user</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>


### PR DESCRIPTION
Remove duplicated dependency to prevent warnings at build phase.
