### PR TITLE
Changed che.sh. CHE_PRODUCT_NAME=ECLIPSE_CHE removing the space

### DIFF
--- a/che.sh
+++ b/che.sh
@@ -53,7 +53,7 @@ check_docker() {
 
 init_global_variables() {
   # Name used in INFO statements
-  DEFAULT_CHE_PRODUCT_NAME="ECLIPSE CHE"
+  DEFAULT_CHE_PRODUCT_NAME="ECLIPSE_CHE"
 
   # Name used in CLI statements
   DEFAULT_CHE_MINI_PRODUCT_NAME="che"


### PR DESCRIPTION
### What does this PR do?

Remove space in CHE_PRODUCT_NAME
### What issues does this PR fix or reference?

[2561](https://github.com/eclipse/che/issues/2561)
### PR type
- [x] Minor change = no change to existing features or docs
