### PR TITLE
Expose getCurrentBranch() method on git connection + rework gitvalueProviderFactory

### DIFF
--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitConnection.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitConnection.java
@@ -16,10 +16,10 @@ import org.eclipse.che.api.core.util.LineConsumerFactory;
 import org.eclipse.che.api.git.exception.GitException;
 import org.eclipse.che.api.git.shared.AddRequest;
 import org.eclipse.che.api.git.shared.Branch;
-import org.eclipse.che.api.git.shared.CheckoutRequest;
 import org.eclipse.che.api.git.shared.BranchCreateRequest;
 import org.eclipse.che.api.git.shared.BranchDeleteRequest;
 import org.eclipse.che.api.git.shared.BranchListRequest;
+import org.eclipse.che.api.git.shared.CheckoutRequest;
 import org.eclipse.che.api.git.shared.CloneRequest;
 import org.eclipse.che.api.git.shared.CommitRequest;
 import org.eclipse.che.api.git.shared.DiffRequest;
@@ -36,14 +36,14 @@ import org.eclipse.che.api.git.shared.PullRequest;
 import org.eclipse.che.api.git.shared.PullResponse;
 import org.eclipse.che.api.git.shared.PushRequest;
 import org.eclipse.che.api.git.shared.PushResponse;
+import org.eclipse.che.api.git.shared.RebaseRequest;
+import org.eclipse.che.api.git.shared.RebaseResponse;
 import org.eclipse.che.api.git.shared.Remote;
 import org.eclipse.che.api.git.shared.RemoteAddRequest;
 import org.eclipse.che.api.git.shared.RemoteListRequest;
 import org.eclipse.che.api.git.shared.RemoteReference;
 import org.eclipse.che.api.git.shared.RemoteUpdateRequest;
 import org.eclipse.che.api.git.shared.ResetRequest;
-import org.eclipse.che.api.git.shared.RebaseRequest;
-import org.eclipse.che.api.git.shared.RebaseResponse;
 import org.eclipse.che.api.git.shared.Revision;
 import org.eclipse.che.api.git.shared.RmRequest;
 import org.eclipse.che.api.git.shared.ShowFileContentRequest;
@@ -484,4 +484,14 @@ public interface GitConnection extends Closeable {
 
     /** Set publisher for git output, e.g. for sending git command output to the client side. */
     void setOutputLineConsumerFactory(LineConsumerFactory outputPublisherFactory);
+
+
+    /**
+     * Get the current branch on the current directory
+     *
+     * @return the name of the branch
+     * @throws GitException
+     *         if any exception occurs
+     */
+    String getBranchName() throws GitException;
 }

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitConnection.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitConnection.java
@@ -485,7 +485,6 @@ public interface GitConnection extends Closeable {
     /** Set publisher for git output, e.g. for sending git command output to the client side. */
     void setOutputLineConsumerFactory(LineConsumerFactory outputPublisherFactory);
 
-
     /**
      * Get the current branch on the current directory
      *
@@ -493,5 +492,5 @@ public interface GitConnection extends Closeable {
      * @throws GitException
      *         if any exception occurs
      */
-    String getBranchName() throws GitException;
+    String getCurrentBranch() throws GitException;
 }

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
@@ -15,7 +15,6 @@ import com.google.inject.Inject;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.git.shared.Remote;
 import org.eclipse.che.api.git.shared.RemoteListRequest;
-import org.eclipse.che.api.git.shared.StatusFormat;
 import org.eclipse.che.api.project.server.FolderEntry;
 import org.eclipse.che.api.project.server.type.ReadonlyValueProvider;
 import org.eclipse.che.api.project.server.type.ValueProvider;
@@ -59,7 +58,7 @@ public class GitValueProviderFactory implements ValueProviderFactory {
                         case VCS_PROVIDER_NAME:
                             return Collections.singletonList("git");
                         case GIT_CURRENT_BRANCH_NAME:
-                            return Collections.singletonList(gitConnection.status(StatusFormat.LONG).getBranchName());
+                            return Collections.singletonList(gitConnection.getBranchName());
                         case GIT_REPOSITORY_REMOTES:
                             return gitConnection.remoteList(newDto(RemoteListRequest.class))
                                                 .stream()

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
@@ -58,7 +58,7 @@ public class GitValueProviderFactory implements ValueProviderFactory {
                         case VCS_PROVIDER_NAME:
                             return Collections.singletonList("git");
                         case GIT_CURRENT_BRANCH_NAME:
-                            return Collections.singletonList(gitConnection.getBranchName());
+                            return Collections.singletonList(gitConnection.getCurrentBranch());
                         case GIT_REPOSITORY_REMOTES:
                             return gitConnection.remoteList(newDto(RemoteListRequest.class))
                                                 .stream()

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -1522,6 +1522,18 @@ class JGitConnection implements GitConnection {
         this.lineConsumerFactory = lineConsumerFactory;
     }
 
+    /**
+     * Get the current branch on the current directory
+     *
+     * @return the name of the branch
+     * @throws GitException
+     *         if any exception occurs
+     */
+    @Override
+    public String getBranchName() throws GitException {
+        return this.getCurrentBranch();
+    }
+
     private Git getGit() {
         if (git != null) {
             return git;

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -1522,17 +1522,6 @@ class JGitConnection implements GitConnection {
         this.lineConsumerFactory = lineConsumerFactory;
     }
 
-    /**
-     * Get the current branch on the current directory
-     *
-     * @return the name of the branch
-     * @throws GitException
-     *         if any exception occurs
-     */
-    @Override
-    public String getBranchName() throws GitException {
-        return this.getCurrentBranch();
-    }
 
     private Git getGit() {
         if (git != null) {
@@ -1727,7 +1716,14 @@ class JGitConnection implements GitConnection {
         return repository;
     }
 
-    private String getCurrentBranch() throws GitException {
+    /**
+     * Get the current branch on the current directory
+     *
+     * @return the name of the branch
+     * @throws GitException
+     *         if any exception occurs
+     */
+    public String getCurrentBranch() throws GitException {
         try {
             return Repository.shortenRefName(repository.exactRef(Constants.HEAD).getLeaf().getName());
         } catch (IOException exception) {

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -154,13 +154,13 @@ public class JGitConnectionTest {
      * @throws Exception if it fails
      */
     @Test
-    public void checkBranchName() throws Exception {
+    public void checkCurrentBranch() throws Exception {
         String branchTest = "helloWorld";
         Ref ref = Mockito.mock(Ref.class);
         when(repository.exactRef(Constants.HEAD)).thenReturn(ref);
         when(ref.getLeaf()).thenReturn(ref);
         when(ref.getName()).thenReturn(branchTest);
-        String branchName = jGitConnection.getBranchName();
+        String branchName = jGitConnection.getCurrentBranch();
 
         assertEquals(branchTest, branchName);
     }

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -26,7 +26,6 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -156,7 +155,7 @@ public class JGitConnectionTest {
     @Test
     public void checkCurrentBranch() throws Exception {
         String branchTest = "helloWorld";
-        Ref ref = Mockito.mock(Ref.class);
+        Ref ref = mock(Ref.class);
         when(repository.exactRef(Constants.HEAD)).thenReturn(ref);
         when(ref.getLeaf()).thenReturn(ref);
         when(ref.getName()).thenReturn(branchTest);

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -17,6 +17,8 @@ import org.eclipse.che.api.git.shared.GitRequest;
 import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.TransportHttp;
@@ -24,6 +26,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -144,5 +147,21 @@ public class JGitConnectionTest {
 
         //then
         verifyZeroInteractions(transportHttp);
+    }
+
+    /**
+     * Check branch using current repository reference is returned
+     * @throws Exception if it fails
+     */
+    @Test
+    public void checkBranchName() throws Exception {
+        String branchTest = "helloWorld";
+        Ref ref = Mockito.mock(Ref.class);
+        when(repository.exactRef(Constants.HEAD)).thenReturn(ref);
+        when(ref.getLeaf()).thenReturn(ref);
+        when(ref.getName()).thenReturn(branchTest);
+        String branchName = jGitConnection.getBranchName();
+
+        assertEquals(branchTest, branchName);
     }
 }


### PR DESCRIPTION
### What does this PR do?

It brings new method to update gitValueProviderFactory 
it will avoid to use status object requiring a lot of I/O
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2567
### New behavior

Faster way to grab current branch name
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [x] Tests provided / updated
- [x] Tests passed

Change-Id: If88da1e1b63a252f0226f1a586f3a67d7295e6c3
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
