### PR TITLE
Publish StackPersistedEvent after stack is persisted

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/StackPersistedEvent.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/StackPersistedEvent.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.event;
+
+import org.eclipse.che.api.core.notification.EventOrigin;
+import org.eclipse.che.api.workspace.shared.stack.Stack;
+
+/**
+ * Published after stack instance is persisted.
+ *
+ * @author Yevhenii Voevodin
+ */
+@EventOrigin("stack")
+public class StackPersistedEvent {
+
+    private final Stack stack;
+
+    public StackPersistedEvent(Stack stack) {
+        this.stack = stack;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackLoader.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackLoader.java
@@ -21,6 +21,7 @@ import com.google.inject.name.Named;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.spi.StackDao;
 import org.eclipse.che.api.workspace.server.stack.image.StackIcon;
@@ -58,7 +59,8 @@ public class StackLoader {
     @SuppressWarnings("unused")
     public StackLoader(@Named("che.stacks.default") String stacksPath,
                        @Named("che.stacks.images.storage") String stackIconFolder,
-                       StackDao stackDao) {
+                       StackDao stackDao,
+                       EntityListenerInjectionManagerInitializer installer) {
         this.stackJsonPath = Paths.get(stacksPath);
         this.stackIconFolderPath = Paths.get(stackIconFolder);
         this.stackDao = stackDao;

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
@@ -69,7 +69,7 @@ public class StackLoaderTest {
         URL url = Resources.getResource("stacks.json");
         URL urlFolder = Thread.currentThread().getContextClassLoader().getResource("stack_img");
 
-        stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao);
+        stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao, null);
 
         stackLoader.start();
         verify(stackDao, times(5)).update(any());
@@ -83,7 +83,7 @@ public class StackLoaderTest {
 
         doThrow(new NotFoundException("Stack is already exist")).when(stackDao).update(any());
 
-        stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao);
+        stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao, null);
 
         stackLoader.start();
         verify(stackDao, times(5)).update(any());
@@ -97,7 +97,7 @@ public class StackLoaderTest {
 
         doThrow(new ServerException("Internal server error")).when(stackDao).update(any());
 
-        stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao);
+        stackLoader = new StackLoader(url.getPath(), urlFolder.getPath(), stackDao, null);
 
         stackLoader.start();
         verify(stackDao, times(5)).update(any());


### PR DESCRIPTION
### What does this PR do?

Adds a new `StackPersitedEvent` which is published after stack is persisted. 
Declares `StackLoader` to be initialized after `EntityListenerInjectionManagerInitializer` is initalized
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [x] Tests provided / updated
- [x] Tests passed

@skabashnyuk please review
