### PR TITLE
CHE-2618 Fix checkout with start point

### DIFF
--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
@@ -277,7 +277,7 @@ public class GitProjectImporter implements ProjectImporter {
         final CheckoutRequest request = dtoFactory.createDto(CheckoutRequest.class).withName(branchName);
         final boolean branchExist = git.branchList(dtoFactory.createDto(BranchListRequest.class).withListMode(LIST_ALL))
                                        .stream()
-                                       .anyMatch(branch -> branch.getName().equals(branchName));
+                                       .anyMatch(branch -> branch.getDisplayName().equals("origin/" + branchName));
         final GitCheckoutEvent checkout = dtoFactory.createDto(GitCheckoutEvent.class)
                                                     .withWorkspaceId(WorkspaceIdProvider.getWorkspaceId())
                                                     .withProjectName(projectName);

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/SourceStorageParametersValidator.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/SourceStorageParametersValidator.java
@@ -39,6 +39,7 @@ public class SourceStorageParametersValidator implements FactoryParameterValidat
                     }
                     break;
                 case "branch":
+                case "startPoint":
                 case "commitId":
                 case "keepDir":
                 case "fetch":


### PR DESCRIPTION
### What does this PR do?
- Fix usecase when specified branch already exists in remote repo (perform a simple checkount instead of checkout w/startpoint)
- Add "startPoint" as a valid parameter to SourceStorageParametersValidator
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2618
