### PR TITLE
Changed comment section

### DIFF
--- a/dashboard/src/components/api/environment/compose-environment-manager.ts
+++ b/dashboard/src/components/api/environment/compose-environment-manager.ts
@@ -18,7 +18,7 @@ import {EnvironmentManager} from './environment-manager';
  * Format sample and specific description:
  * <code>
  *services:
- *  devmachine:
+ *  dev-machine:
  *    image: codenvy/ubuntu_jdk8
  *    depends_on:
  *      - anotherMachine


### PR DESCRIPTION
### What does this PR do?

Updates the comment section that describes the compose syntax to clarify that `dev-machine` is the correct name for the development machine.
### What issues does this PR fix or reference?

Only changes a comment, but clarifies things for users.
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

Change 'devmachine' to 'dev-machine' in compose format description to match the required name of the development machine.
