### PR TITLE
Build che server Docker image with CentOS base image

### DIFF
--- a/.cccp.yml
+++ b/.cccp.yml
@@ -1,0 +1,7 @@
+# This is file is needed to include the project in the CentOS Container
+# Pipeline main index. It can be used to set the image name (using job-id), set
+# the test script and/or build script and whether to perform or skip the
+# user-defined tests. More information on cccp.yml file can be found on:
+# https://github.com/CentOS/container-index#the-cccpyml-file
+
+job-id: che-server

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,53 @@
+# Copyright (c) 2012-2016 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Dharmit Shah  - Initial implementation
+#   Mario Loriedo - Improvements
+#
+# To build it, run in the repository root:
+#  `docker build -t registry.centos.org/eclipse/che-server -f Dockerfile.centos .`
+#
+# To run it:
+#  docker run --net=host \
+#             --name che \
+#             -v /var/run/docker.sock:/var/run/docker.sock \
+#             -v /home/user/che/lib:/home/user/che/lib-copy \
+#             -v /home/user/che/workspaces:/home/user/che/workspaces \
+#             -v /home/user/che/storage:/home/user/che/storage \
+#             registry.centos.org/eclipse/che-server
+#           
+FROM registry.centos.org/centos/centos:latest
+
+ENV LANG=C.UTF-8 \
+    JAVA_HOME=/usr/lib/jvm/jre-1.8.0 \
+    PATH=${PATH}:${JAVA_HOME}/bin \
+    CHE_HOME=/home/user/che \
+    DOCKER_VERSION=1.6.0 \
+    DOCKER_BUCKET=get.docker.com
+
+RUN yum -y update && \
+    yum -y install openssl java sudo && \
+    curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
+    chmod +x /usr/bin/docker && \
+    yum -y remove openssl && \
+    yum clean all
+RUN useradd user -d /home/user -s /bin/bash -u 1000 -G root && \
+    groupadd docker -g 101 && \
+    usermod -aG ftp,users,docker user && \
+    echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers && \
+    rm -rf /tmp/* /var/cache/yum
+
+EXPOSE 8000 8080
+
+USER user
+
+ADD assembly/assembly-main/target/eclipse-che-*/eclipse-che-* /home/user/che/
+
+ENTRYPOINT [ "/home/user/che/bin/che.sh", "-c" ]
+
+CMD [ "run" ]


### PR DESCRIPTION
### What does this PR do?

Build Che Server Docker image on CentOS using [CentOS Community Container Pipeline](https://github.com/CentOS/container-pipeline-service/).
### What issues does this PR fix or reference?
### New behavior

Che Server image can now be built on top of CentOS base image. 
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [ ] Tests passed
### Major change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Documentation provided (include here or link to docs)
- [ ] Tests provided / updated
- [ ] Tests passed

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
