### PR TITLE
Fix #2649 : Allow on Mac to use alt + 5 which is for example used to type {

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerExtension.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.ide.api.extension.Extension;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.KeyBuilder;
+import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.plugin.debugger.ide.actions.ChangeVariableValueAction;
 import org.eclipse.che.plugin.debugger.ide.actions.DebugAction;
 import org.eclipse.che.plugin.debugger.ide.actions.DeleteAllBreakpointsAction;
@@ -143,6 +144,11 @@ public class DebuggerExtension {
         keyBinding.getGlobal().addKey(new KeyBuilder().charCode(KeyCodeMap.F9).build(), RESUME_EXECUTION_ID);
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.F8).build(), EVALUATE_EXPRESSION_ID);
         keyBinding.getGlobal().addKey(new KeyBuilder().charCode(KeyCodeMap.F2).build(), CHANGE_VARIABLE_VALUE_ID);
-        keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode('5').build(), SHOW_HIDE_DEBUGGER_PANEL_ID);
+
+        if (UserAgent.isMac()) {
+            keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('5').build(), SHOW_HIDE_DEBUGGER_PANEL_ID);
+        } else {
+            keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode('5').build(), SHOW_HIDE_DEBUGGER_PANEL_ID);
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fix issue on Mac not allowing to enter {
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2649
### PR type
- [x] Minor change = no change to existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [x] Tests passed

Change-Id: I632415dfc97eaac87cdfc16649056fa198d4f033
Signed-off-by: Florent BENOIT fbenoit@codenvy.com
