### PR TITLE
CHE-2593: disable stack deletion if current user is not creator

### DIFF
--- a/dashboard/src/app/stacks/list-stacks/list-stacks.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/list-stacks.controller.ts
@@ -22,7 +22,7 @@ export class ListStacksController {
    * Default constructor that is using resource
    * @ngInject for Dependency injection
    */
-  constructor(cheStack, $log, $mdDialog, cheNotification, $rootScope, lodash, $q) {
+  constructor(cheStack, cheProfile, $log, $mdDialog, cheNotification, $rootScope, lodash, $q) {
     this.cheStack = cheStack;
     this.$log = $log;
     this.$mdDialog = $mdDialog;
@@ -40,7 +40,19 @@ export class ListStacksController {
     this.isNoSelected = true;
 
     this.stacks = [];
-    this.getStacks();
+
+    this.profile = cheProfile.getProfile();
+    if (this.profile.userId) {
+      this.userId = this.profile.userId;
+      this.getStacks();
+    } else {
+      this.profile.$promise.then(() => {
+        this.userId = this.profile.userId ? this.profile.userId : undefined;
+        this.getStacks();
+      }, () => {
+        this.userId = undefined;
+      });
+    }
   }
 
   /**

--- a/dashboard/src/app/stacks/list-stacks/list-stacks.html
+++ b/dashboard/src/app/stacks/list-stacks/list-stacks.html
@@ -66,7 +66,8 @@
               che-on-checkbox-click="listStacksController.updateSelectionState()"
               che-on-delete="listStacksController.deleteStack(stack)"
               che-on-duplicate="listStacksController.duplicateStack(stack)"
-              che-stack="stack"></stack-item>
+              stack="stack"
+              user-id="listStacksController.userId"></stack-item>
     </che-list>
     <div class="che-list-empty">
         <span ng-show="listStacksController.stacks.length > 0 && (listStacksController.stacks | filter:listStacksController.stackFilter).length === 0">

--- a/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.directive.ts
+++ b/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.directive.ts
@@ -28,7 +28,8 @@ export class StackItem {
 
     // scope values
     this.scope = {
-      stack: '=cheStack',
+      stack: '=stack',
+      userId: '=userId',
       isSelectable: '=cheSelectable',
       isSelect: '=?ngModel',
       onCheckboxClick: '&?cheOnCheckboxClick',

--- a/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.html
+++ b/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.html
@@ -19,9 +19,10 @@
          layout-align="start center"
          class="che-checkbox-area"
          ng-if="stackItemController.isSelectable === true">
-      <che-list-item-checked ng-model="stackItemController.isSelect"
-                             che-aria-label-checkbox="Stack {{stackItemController.stack.name}}"
-                             ng-click="stackItemController.onCheckboxClick()"></che-list-item-checked>
+      <che-list-item-checked ng-show="stackItemController.stack.creator === stackItemController.userId"
+        ng-model="stackItemController.isSelect"
+        che-aria-label-checkbox="Stack {{stackItemController.stack.name}}"
+        ng-click="stackItemController.onCheckboxClick()"></che-list-item-checked>
     </div>
     <div flex
          layout-xs="column" layout-gt-xs="row"
@@ -49,7 +50,8 @@
       <div flex-gt-xs="15">
         <span class="che-xs-header noselect" hide-gt-xs>Actions</span>
         <span class="che-list-actions">
-          <a tooltip="Delete Stack"  ng-click="stackItemController.onDelete(stackItemController.stack);">
+          <a tooltip="Delete Stack" ng-disabled="stackItemController.stack.creator !== stackItemController.userId"
+             ng-click="stackItemController.onDelete(stackItemController.stack);">
             <span class="fa fa-trash-o"></span>
           </a>
           <a tooltip="Duplicate stack" ng-click="stackItemController.onDuplicate(stackItemController.stack);">

--- a/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.styl
+++ b/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.styl
@@ -3,3 +3,7 @@
 
 stack-item:last-child .che-list-item
   border-bottom none
+
+stack-item .che-list-actions a[disabled]
+  pointer-events none
+  opacity 0.5


### PR DESCRIPTION
### What does this PR do?

The stack's delete button will be disabled if current user is not creator of the stack. Same with checkbox item - will be unavailable to select stack for bulk deletion.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2593

Signed-off-by: Ann Shumilova ashumilova@codenvy.com
