### PR TITLE
CHE-1756 Add ability to download workspace starting outputs from IDE loader

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/dialogs/DialogFactory.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/dialogs/DialogFactory.java
@@ -207,6 +207,40 @@ public interface DialogFactory {
                                   @Nullable CancelCallback cancelCallback);
 
     /**
+     * Create an input dialog with the specified initial value.
+     * <p/>
+     * The {@code initialValue} may be pre-selected. Selection begins
+     * at the specified {@code selectionStartIndex} and extends to the
+     * character at index {@code selectionLength}.
+     *
+     * @param title
+     *         the window title
+     * @param label
+     *         the label of the input field
+     * @param initialValue
+     *         the value used to initialize the input
+     * @param selectionStartIndex
+     *         the beginning index of the {@code initialValue} to select, inclusive
+     * @param selectionLength
+     *         the number of characters of the {@code initialValue} to be selected
+     * @param okButtonLabel
+     *         label for OK button
+     * @param inputCallback
+     *         the callback used on OK
+     * @param cancelCallback
+     *         the callback used on cancel
+     * @return an {@link InputDialog} instance
+     */
+    InputDialog createInputDialog(@NotNull @Assisted("title") String title,
+                                  @NotNull @Assisted("label") String label,
+                                  @NotNull @Assisted("initialValue") String initialValue,
+                                  @NotNull @Assisted("selectionStartIndex") Integer selectionStartIndex,
+                                  @NotNull @Assisted("selectionLength") Integer selectionLength,
+                                  @NotNull @Assisted("okButtonLabel") String okButtonLabel,
+                                  @Nullable InputCallback inputCallback,
+                                  @Nullable CancelCallback cancelCallback);
+
+    /**
      * Create a choice dialog with only text as content.
      * Use empty string for button label to hide button.
      *

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/outputconsole/OutputConsole.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/outputconsole/OutputConsole.java
@@ -40,17 +40,21 @@ public interface OutputConsole extends Presenter {
     void close();
 
     /**
-     * Listener for new output in the console.
+     * Action Delegate interface.
      */
-    interface ConsoleOutputListener {
+    interface ActionDelegate {
 
+        /** Is called when new is printed */
         void onConsoleOutput(OutputConsole console);
+
+        /** Is called when user asked to download output */
+        void onDownloadOutput(OutputConsole console);
 
     }
 
     /**
-     * Adds an output listener.
+     * Sets action delegate.
      */
-    void addOutputListener(ConsoleOutputListener listener);
+    void addActionDelegate(ActionDelegate actionDelegate);
 
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
@@ -788,7 +788,7 @@ public class DarkTheme implements Theme {
 
     @Override
     public String consolesToolbarButtonColor() {
-        return "#aaaaaa";
+        return "#808080";
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspaceNotification.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspaceNotification.java
@@ -88,8 +88,7 @@ public class StartWorkspaceNotification {
                 Widget widget = uiBinder.createAndBindUi(StartWorkspaceNotification.this);
 
                 if (snapshots.isEmpty()) {
-                    restore.setValue(false);
-                    restore.setEnabled(false);
+                    restore.setVisible(false);
                 }
 
                 loader.show(LoaderPresenter.Phase.WORKSPACE_STOPPED, widget);

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/FontAwesome.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/FontAwesome.java
@@ -43,6 +43,11 @@ public class FontAwesome {
     public static final String DOT_CIRCLE = "<i class=\"fa fa-dot-circle-o\"></i>";
 
     /**
+     * http://fortawesome.github.io/Font-Awesome/icon/download/
+     */
+    public static final String DOWNLOAD = "<i class=\"fa fa-download\"></i>";
+
+    /**
      * http://fortawesome.github.io/Font-Awesome/icon/expand/
      */
     public static final String EXPAND = "<i class=\"fa fa-expand\"></i>";

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenter.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenter.java
@@ -74,6 +74,30 @@ public class InputDialogPresenter implements InputDialog, InputDialogView.Action
         this.localizationConstant = localizationConstant;
     }
 
+    @AssistedInject
+    public InputDialogPresenter(final @NotNull InputDialogView view,
+                                final @NotNull @Assisted("title") String title,
+                                final @NotNull @Assisted("label") String label,
+                                final @NotNull @Assisted("initialValue") String initialValue,
+                                final @NotNull @Assisted("selectionStartIndex") Integer selectionStartIndex,
+                                final @NotNull @Assisted("selectionLength") Integer selectionLength,
+                                final @NotNull @Assisted("okButtonLabel") String okButtonLabel,
+                                final @Nullable @Assisted InputCallback inputCallback,
+                                final @Nullable @Assisted CancelCallback cancelCallback,
+                                final UILocalizationConstant localizationConstant) {
+        this.view = view;
+        this.view.setContent(label);
+        this.view.setTitle(title);
+        this.view.setValue(initialValue);
+        this.view.setSelectionStartIndex(selectionStartIndex);
+        this.view.setSelectionLength(selectionLength);
+        this.view.setOkButtonLabel(okButtonLabel);
+        this.inputCallback = inputCallback;
+        this.cancelCallback = cancelCallback;
+        this.view.setDelegate(this);
+        this.localizationConstant = localizationConstant;
+    }
+
     @Override
     public void cancelled() {
         view.closeDialog();

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogView.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogView.java
@@ -36,6 +36,9 @@ public interface InputDialogView {
     /** Sets the window title. */
     void setTitle(String title);
 
+    /** Sets new label for Ok button */
+    void setOkButtonLabel(String label);
+
     /** Returns the input value. */
     String getValue();
 
@@ -62,7 +65,7 @@ public interface InputDialogView {
     boolean isCancelButtonInFocus();
 
     /** The interface for the action delegate. */
-    public interface ActionDelegate {
+    interface ActionDelegate {
 
         /** Defines what's done when the user clicks cancel. */
         void cancelled();
@@ -76,4 +79,5 @@ public interface InputDialogView {
         /** Performs any actions appropriate in response to the user having clicked the Enter key. */
         void onEnterClicked();
     }
+
 }

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogViewImpl.java
@@ -105,6 +105,11 @@ public class InputDialogViewImpl extends Window implements InputDialogView {
     }
 
     @Override
+    public void setOkButtonLabel(String label) {
+        footer.getOkButton().setText(label);
+    }
+
+    @Override
     public String getValue() {
         return value.getValue();
     }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/DownloadWorkspaceOutputEvent.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/DownloadWorkspaceOutputEvent.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ui.loaders;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Fire this event to download logs of the current workspace.
+ *
+ * @author Vitaliy Guliy
+ */
+public class DownloadWorkspaceOutputEvent extends GwtEvent<DownloadWorkspaceOutputEvent.Handler> {
+
+    public interface Handler extends EventHandler {
+
+        void onDownloadWorkspaceOutput(DownloadWorkspaceOutputEvent event);
+
+    }
+
+    public static final Type<Handler> TYPE = new Type<>();
+
+    @Override
+    public Type<Handler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(Handler handler) {
+        handler.onDownloadWorkspaceOutput(this);
+    }
+
+}

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/LoaderPresenter.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/LoaderPresenter.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.ui.loaders;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Map;
  * @author Vitaliy Guliy
  */
 @Singleton
-public class LoaderPresenter {
+public class LoaderPresenter implements PopupLoader.ActionDelegate {
 
     public enum Phase {
         STARTING_WORKSPACE_RUNTIME,
@@ -36,14 +37,17 @@ public class LoaderPresenter {
 
     private PopupLoaderFactory      popupLoaderFactory;
     private PopupLoaderMessages     locale;
+    private EventBus                eventBus;
 
     private Map<Phase, PopupLoader> popups = new HashMap<>();
 
     @Inject
     public LoaderPresenter(PopupLoaderFactory popupLoaderFactory,
-                           PopupLoaderMessages locale) {
+                           PopupLoaderMessages locale,
+                           EventBus eventBus) {
         this.popupLoaderFactory = popupLoaderFactory;
         this.locale = locale;
+        this.eventBus = eventBus;
     }
 
     /**
@@ -78,6 +82,7 @@ public class LoaderPresenter {
         switch (phase) {
             case STARTING_WORKSPACE_RUNTIME:
                 loader = popupLoaderFactory.getPopup(locale.startingWorkspaceRuntime(), locale.startingWorkspaceRuntimeDescription());
+                loader.showDownloadButton();
                 break;
             case STARTING_WORKSPACE_AGENT:
                 loader = popupLoaderFactory.getPopup(locale.startingWorkspaceAgent(), locale.startingWorkspaceAgentDescription());
@@ -96,6 +101,7 @@ public class LoaderPresenter {
                 break;
         }
 
+        loader.setDelegate(this);
         popups.put(phase, loader);
         return loader;
     }
@@ -128,6 +134,11 @@ public class LoaderPresenter {
             popups.remove(phase);
             popup.setError();
         }
+    }
+
+    @Override
+    public void onDownloadLogs() {
+        eventBus.fireEvent(new DownloadWorkspaceOutputEvent());
     }
 
 }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoader.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoader.java
@@ -27,4 +27,23 @@ public interface PopupLoader {
      */
     void setError();
 
+    /**
+     * Shows a button to download logs.
+     */
+    void showDownloadButton();
+
+    /**
+     * Sets an action delegate to handle user actions.
+     *
+     * @param actionDelegate
+     *          action delegate
+     */
+    void setDelegate(ActionDelegate actionDelegate);
+
+    interface ActionDelegate {
+
+        void onDownloadLogs();
+
+    }
+
 }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.java
@@ -10,11 +10,14 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ui.loaders;
 
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Hyperlink;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -53,6 +56,11 @@ public class PopupLoaderImpl extends Composite implements PopupLoader {
     @UiField
     FlowPanel customWidget;
 
+    @UiField
+    Hyperlink downloadOutputs;
+
+    private ActionDelegate actionDelegate;
+
     @AssistedInject
     public PopupLoaderImpl(LoaderPopupImplUiBinder uiBinder,
                            @NotNull @Assisted("title") String title,
@@ -83,6 +91,7 @@ public class PopupLoaderImpl extends Composite implements PopupLoader {
         this(uiBinder, title, description);
 
         if (widget != null) {
+            customWidget.clear();
             customWidget.setVisible(true);
             customWidget.add(widget);
             playTimer.cancel();
@@ -113,6 +122,24 @@ public class PopupLoaderImpl extends Composite implements PopupLoader {
 
         // Reset title
         titleLabel.setText(title);
+    }
+
+    @Override
+    public void showDownloadButton() {
+        customWidget.setVisible(true);
+        downloadOutputs.setVisible(true);
+    }
+
+    @Override
+    public void setDelegate(ActionDelegate actionDelegate) {
+        this.actionDelegate = actionDelegate;
+    }
+
+    @UiHandler("downloadOutputs")
+    void downloadLogsClicked(ClickEvent e) {
+        if (actionDelegate != null) {
+            actionDelegate.onDownloadLogs();
+        }
     }
 
     private Timer playTimer = new Timer() {

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.ui.xml
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.ui.xml
@@ -14,6 +14,8 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:g="urn:import:com.google.gwt.user.client.ui">
 
+    <ui:with field='messages' type='org.eclipse.che.ide.ui.loaders.PopupLoaderMessages'/>
+
     <ui:style>
 
         @eval popupLoaderBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.popupLoaderBackgroundColor();
@@ -66,12 +68,25 @@
             overflow: hidden;
         }
 
+        .hyperlink {
+            position: absolute;
+            top: 25px;
+            left: 15px;
+        }
+
+        .hyperlink a {
+            font-size: 11px;
+            color: #94b6d4;
+        }
+
     </ui:style>
 
     <g:FlowPanel styleName="{style.main}">
         <g:Label ui:field="titleLabel" addStyleNames="{style.title}" />
         <g:Label ui:field="descriptionLabel" addStyleNames="{style.description}" />
-        <g:FlowPanel ui:field="customWidget" styleName="{style.customWidget}" visible="false"></g:FlowPanel>
+        <g:FlowPanel ui:field="customWidget" styleName="{style.customWidget}" visible="false">
+            <g:Hyperlink ui:field="downloadOutputs" styleName="{style.hyperlink}" visible="false" text="{messages.downloadOutputs}" ></g:Hyperlink>
+        </g:FlowPanel>
     </g:FlowPanel>
 
 </ui:UiBinder>

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderMessages.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderMessages.java
@@ -55,4 +55,7 @@ public interface PopupLoaderMessages extends Messages {
     @Key("workspaceStopped.description")
     String workspaceStoppedDescription();
 
+    @Key("downloadOutputs")
+    String downloadOutputs();
+
 }

--- a/ide/commons-gwt/src/main/resources/org/eclipse/che/ide/ui/loaders/PopupLoaderMessages.properties
+++ b/ide/commons-gwt/src/main/resources/org/eclipse/che/ide/ui/loaders/PopupLoaderMessages.properties
@@ -21,3 +21,4 @@ snapshottingWorkspace.title = Snapshotting the workspace
 snapshottingWorkspace.description = Creating a snapshot of the current workspace
 workspaceStopped.title = Workspace is not running
 workspaceStopped.description =
+downloadOutputs = Download outputs

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/outputconsole/GitOutputConsolePresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/outputconsole/GitOutputConsolePresenter.java
@@ -31,11 +31,12 @@ import java.util.List;
  */
 
 public class GitOutputConsolePresenter implements GitOutputPartView.ActionDelegate, GitOutputConsole {
-    private final GitOutputPartView view;
-    private final GitResources      resources;
-    private final String            title;
 
-    private final List<ConsoleOutputListener> outputListeners = new ArrayList<>();
+    private final GitOutputPartView     view;
+    private final GitResources          resources;
+    private final String                title;
+
+    private final List<ActionDelegate>  actionDelegates = new ArrayList<>();
 
     /** Construct empty Part */
     @Inject
@@ -77,8 +78,8 @@ public class GitOutputConsolePresenter implements GitOutputPartView.ActionDelega
         }
         view.scrollBottom();
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
     }
 
@@ -87,8 +88,8 @@ public class GitOutputConsolePresenter implements GitOutputPartView.ActionDelega
         view.print(text, color);
         view.scrollBottom();
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
     }
 
@@ -134,12 +135,12 @@ public class GitOutputConsolePresenter implements GitOutputPartView.ActionDelega
 
     @Override
     public void close() {
-        outputListeners.clear();
+        actionDelegates.clear();
     }
 
     @Override
-    public void addOutputListener(ConsoleOutputListener listener) {
-        outputListeners.add(listener);
+    public void addActionDelegate(ActionDelegate actionDelegate) {
+        actionDelegates.add(actionDelegate);
     }
 
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.java
@@ -22,6 +22,12 @@ public interface MachineLocalizationConstant extends Messages {
     @Key("button.cancel")
     String cancelButton();
 
+    @Key("button.download")
+    String downloadButton();
+
+    @Key("downloadOutputs")
+    String downloadOutputs();
+
     @Key("main.menu.machine")
     String mainMenuMachine();
 

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/CommandOutputConsolePresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/CommandOutputConsolePresenter.java
@@ -76,7 +76,7 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
     /** Follow output when printing text */
     private boolean followOutput = true;
 
-    private List<ConsoleOutputListener> outputListenes = new ArrayList<>();
+    private final List<ActionDelegate> actionDelegates = new ArrayList<>();
 
     @Inject
     public CommandOutputConsolePresenter(final OutputConsoleView view,
@@ -146,8 +146,8 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
             protected void onMessageReceived(String result) {
                 view.print(result, result.endsWith("\r"));
 
-                for (ConsoleOutputListener listener : outputListenes) {
-                    listener.onConsoleOutput(CommandOutputConsolePresenter.this);
+                for (ActionDelegate actionDelegate : actionDelegates) {
+                    actionDelegate.onConsoleOutput(CommandOutputConsolePresenter.this);
                 }
             }
 
@@ -260,12 +260,12 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
 
     @Override
     public void close() {
-        outputListenes.clear();
+        actionDelegates.clear();
     }
 
     @Override
-    public void addOutputListener(ConsoleOutputListener listener) {
-        outputListenes.add(listener);
+    public void addActionDelegate(ActionDelegate actionDelegate) {
+        actionDelegates.add(actionDelegate);
     }
 
     @Override
@@ -295,6 +295,13 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
     }
 
     @Override
+    public void downloadOutputsButtonClicked() {
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onDownloadOutput(this);
+        }
+    }
+
+    @Override
     public void wrapTextButtonClicked() {
         wrapText = !wrapText;
         view.wrapText(wrapText);
@@ -313,6 +320,16 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
     public void onOutputScrolled(boolean bottomReached) {
         followOutput = bottomReached;
         view.toggleScrollToEndButton(bottomReached);
+    }
+
+    /**
+     * Returns the console text.
+     *
+     * @return
+     *          console text
+     */
+    public String getText() {
+        return view.getText();
     }
 
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/DefaultOutputConsole.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/DefaultOutputConsole.java
@@ -32,7 +32,7 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
     private final MachineResources              resources;
     private       String                        title;
 
-    private final List<ConsoleOutputListener>   outputListeners;
+    private final List<ActionDelegate>          actionDelegates = new ArrayList<>();
 
     private boolean                             wrapText;
 
@@ -46,7 +46,6 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
         this.view = view;
         this.title = title;
         this.resources = resources;
-        outputListeners = new ArrayList<>();
 
         view.setDelegate(this);
 
@@ -65,8 +64,8 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
     public void printText(String text) {
         view.print(text, text.endsWith("\r"));
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
     }
 
@@ -81,9 +80,19 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
     public void printText(String text, String color) {
         view.print(text, text.endsWith("\r"), color);
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
+    }
+
+    /**
+     * Returns the console text.
+     *
+     * @return
+     *          console text
+     */
+    public String getText() {
+        return view.getText();
     }
 
     /** {@inheritDoc} */
@@ -116,12 +125,12 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
 
     @Override
     public void close() {
-        outputListeners.clear();
+        actionDelegates.clear();
     }
 
     @Override
-    public void addOutputListener(ConsoleOutputListener listener) {
-        outputListeners.add(listener);
+    public void addActionDelegate(ActionDelegate actionDelegate) {
+        actionDelegates.add(actionDelegate);
     }
 
     @Override
@@ -135,6 +144,13 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
     @Override
     public void clearOutputsButtonClicked() {
         view.clearConsole();
+    }
+
+    @Override
+    public void downloadOutputsButtonClicked() {
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onDownloadOutput(this);
+        }
     }
 
     @Override

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleView.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleView.java
@@ -60,6 +60,14 @@ public interface OutputConsoleView extends View<OutputConsoleView.ActionDelegate
     void print(String text, boolean carriageReturn, String color);
 
     /**
+     * Returns the console text.
+     *
+     * @return
+     *         console text
+     */
+    String getText();
+
+    /**
      * Hides command title and command label.
      */
     void hideCommand();
@@ -138,6 +146,9 @@ public interface OutputConsoleView extends View<OutputConsoleView.ActionDelegate
 
         /** Handle click on `Clear console` button. */
         void clearOutputsButtonClicked();
+
+        /** Handle click on `Download outputs` button. */
+        void downloadOutputsButtonClicked();
 
         /** Handle click on `Wrap text` button. */
         void wrapTextButtonClicked();

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleViewImpl.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleViewImpl.java
@@ -13,7 +13,9 @@ package org.eclipse.che.ide.extension.machine.client.outputspanel.console;
 import com.google.common.base.Strings;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Node;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.dom.client.PreElement;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -36,6 +38,7 @@ import com.google.inject.Inject;
 
 import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
 import org.eclipse.che.ide.extension.machine.client.MachineResources;
+import org.eclipse.che.ide.ui.FontAwesome;
 import org.eclipse.che.ide.ui.Tooltip;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -103,6 +106,9 @@ public class OutputConsoleViewImpl extends Composite implements OutputConsoleVie
     FlowPanel clearOutputsButton;
 
     @UiField
+    FlowPanel downloadOutputsButton;
+
+    @UiField
     FlowPanel wrapTextButton;
 
     @UiField
@@ -125,6 +131,7 @@ public class OutputConsoleViewImpl extends Composite implements OutputConsoleVie
         reRunProcessButton.add(new SVGImage(resources.reRunIcon()));
         stopProcessButton.add(new SVGImage(resources.stopIcon()));
         clearOutputsButton.add(new SVGImage(resources.clearOutputsIcon()));
+        downloadOutputsButton.getElement().setInnerHTML(FontAwesome.DOWNLOAD);
 
         wrapTextButton.add(new SVGImage(resources.lineWrapIcon()));
         scrollToBottomButton.add(new SVGImage(resources.scrollToBottomIcon()));
@@ -154,6 +161,15 @@ public class OutputConsoleViewImpl extends Composite implements OutputConsoleVie
             public void onClick(ClickEvent event) {
                 if (!clearOutputsButton.getElement().hasAttribute("disabled") && delegate != null) {
                     delegate.clearOutputsButtonClicked();
+                }
+            }
+        }, ClickEvent.getType());
+
+        downloadOutputsButton.addDomHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                if (delegate != null) {
+                    delegate.downloadOutputsButtonClicked();
                 }
             }
         }, ClickEvent.getType());
@@ -335,6 +351,20 @@ public class OutputConsoleViewImpl extends Composite implements OutputConsoleVie
         consoleLines.getElement().appendChild(pre);
 
         followOutput();
+    }
+
+    @Override
+    public String getText() {
+        String text = "";
+        NodeList<Node> nodes = consoleLines.getElement().getChildNodes();
+
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.getItem(i);
+            Element element = node.cast();
+            text += element.getInnerText() + "\r\n";
+        }
+
+        return text;
     }
 
     @Override

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleViewImpl.ui.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleViewImpl.ui.xml
@@ -195,6 +195,7 @@
                 <g:FlowPanel ui:field="reRunProcessButton" styleName="{style.toolbarButton}" />
                 <g:FlowPanel ui:field="stopProcessButton" styleName="{style.toolbarButton}" />
                 <g:FlowPanel ui:field="clearOutputsButton" styleName="{style.toolbarButton}" />
+                <g:FlowPanel ui:field="downloadOutputsButton" styleName="{style.toolbarButton}" />
                 <g:FlowPanel ui:field="wrapTextButton" styleName="{style.toolbarButton}" addStyleNames="{style.wrapTextButton}" />
                 <g:FlowPanel ui:field="scrollToBottomButton" styleName="{style.toolbarButton}" addStyleNames="{style.scrollToEndButton}" />
             </g:FlowPanel>

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.properties
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.properties
@@ -11,6 +11,9 @@
 
 ##### Buttons #####
 button.cancel = Cancel
+button.download = Download
+
+downloadOutputs = Download outputs
 
 ##### Actions #####
 main.menu.machine = Machine

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
@@ -188,7 +188,7 @@ public class ProcessesPanelPresenterTest {
 
         MachineStateEvent machineStateEvent = mock(MachineStateEvent.class);
         when(machineStateEvent.getMachine()).thenReturn(machine);
-        verify(eventBus, times(6)).addHandler(anyObject(), machineStateHandlerCaptor.capture());
+        verify(eventBus, times(7)).addHandler(anyObject(), machineStateHandlerCaptor.capture());
         MachineStateEvent.Handler machineStateHandler = machineStateHandlerCaptor.getAllValues().get(0);
         machineStateHandler.onMachineCreating(machineStateEvent);
 

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/common/SubversionOutputConsolePresenter.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/common/SubversionOutputConsolePresenter.java
@@ -34,7 +34,7 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
     private final SubversionOutputConsoleView  view;
     private final String                       title;
 
-    private final List<ConsoleOutputListener> outputListeners = new ArrayList<>();
+    private final List<ActionDelegate>         actionDelegates = new ArrayList<>();
 
     @Inject
     public SubversionOutputConsolePresenter(final SubversionExtensionLocalizationConstants constants,
@@ -67,8 +67,8 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
         }
         view.scrollBottom();
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
     }
 
@@ -84,8 +84,8 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
         view.print(text, color);
         view.scrollBottom();
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
     }
 
@@ -99,8 +99,8 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
     public void printCommand(@NotNull String text) {
         view.printPredefinedStyle(text, "font-weight: bold; font-style: italic;");
 
-        for (ConsoleOutputListener outputListener : outputListeners) {
-            outputListener.onConsoleOutput(this);
+        for (ActionDelegate actionDelegate : actionDelegates) {
+            actionDelegate.onConsoleOutput(this);
         }
     }
 
@@ -130,7 +130,9 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
     }
 
     @Override
-    public String getTitle() { return title; }
+    public String getTitle() {
+        return title;
+    }
 
     /**
      * Returns the title SVG image resource of this console.
@@ -155,7 +157,6 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
      */
     @Override
     public void stop() {
-
     }
 
     /**
@@ -163,16 +164,12 @@ public class SubversionOutputConsolePresenter implements SubversionOutputConsole
      */
     @Override
     public void close() {
-        outputListeners.clear();
+        actionDelegates.clear();
     }
 
-    /**
-     * Adds an output listener.
-     *
-     * @param listener
-     */
     @Override
-    public void addOutputListener(ConsoleOutputListener listener) {
-        outputListeners.add(listener);
+    public void addActionDelegate(ActionDelegate actionDelegate) {
+        actionDelegates.add(actionDelegate);
     }
+
 }


### PR DESCRIPTION
Adds the "Download outputs" hyperlink to the loader.
Adds "Download" button to output consoles.

https://github.com/eclipse/che/issues/1756
