### PR TITLE
CHE-642 When browser is resized, the content of the IDE terminal is missing partly

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/panel/SubPanelViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/panel/SubPanelViewImpl.java
@@ -19,6 +19,7 @@ import com.google.gwt.user.client.ui.DeckLayoutPanel;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.SplitLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -53,7 +54,8 @@ import static com.google.gwt.user.client.ui.DockLayoutPanel.Direction.CENTER;
  */
 public class SubPanelViewImpl extends Composite implements SubPanelView,
                                                            Menu.ActionDelegate,
-                                                           Tab.ActionDelegate {
+                                                           Tab.ActionDelegate,
+                                                           RequiresResize {
 
     private final TabItemFactory                    tabItemFactory;
     private final Menu                              menu;
@@ -133,6 +135,8 @@ public class SubPanelViewImpl extends Composite implements SubPanelView,
         splitLayoutPanel.remove(mainPanel);
         splitLayoutPanel.addSouth(subPanelView, height);
         splitLayoutPanel.add(mainPanel);
+
+        onResize();
     }
 
     @Override
@@ -144,6 +148,8 @@ public class SubPanelViewImpl extends Composite implements SubPanelView,
         splitLayoutPanel.remove(mainPanel);
         splitLayoutPanel.addEast(subPanelView, width);
         splitLayoutPanel.add(mainPanel);
+
+        onResize();
     }
 
     @Override
@@ -300,7 +306,7 @@ public class SubPanelViewImpl extends Composite implements SubPanelView,
     public void onMenuItemClosing(MenuItem menuItem) {
         Object data = menuItem.getData();
         if (data instanceof Tab) {
-            closeTab((Tab)data);
+            closeTab((Tab) data);
         }
     }
 
@@ -326,6 +332,16 @@ public class SubPanelViewImpl extends Composite implements SubPanelView,
         closeTab(tab);
     }
 
+    @Override
+    public void onResize() {
+        for (WidgetToShow widgetToShow : widgets2Tabs.keySet()) {
+            if (widgetToShow.getWidget() instanceof RequiresResize) {
+                ((RequiresResize)widgetToShow.getWidget()).onResize();
+            }
+        }
+    }
+
     interface SubPanelViewImplUiBinder extends UiBinder<Widget, SubPanelViewImpl> {
     }
+
 }

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
@@ -895,10 +895,6 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         download(fileName, getText(devMachine.getId()));
     }
 
-    private native void log(String msg) /*-{
-        console.log(msg);
-    }-*/;
-
     @Override
     public void onDownloadOutput(OutputConsole console) {
         String id = consoleCommands.get(console);


### PR DESCRIPTION
Updates the terminal dimensions when resizing split panels.

Run `stty size` in terminal to check.

https://github.com/eclipse/che/issues/642
