### PR TITLE
Adding Node.js info to the 'Requirements' section of the README.MD

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,8 +5,13 @@ Che Dashboard
 ==============
 
 #Requirements
+- Node.js `v4.x.x` (`v5.x.x` / `v6.x.x` are currently not supported)
+- npm
+- Bower
+- gulp
 
-This  version is using bower and gulp as tools.
+Installation instructions for Node.js and npm can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). Bower and gulp are CLI utilities which are installed via npm:
+
 ```sh
 $ npm install --global bower gulp
 ```


### PR DESCRIPTION
### What does this PR do?

Adds info about required version of Node.js for building the dashboard component. I do believe it would be great to update the documentation in order to avoid subtle issues after building against Node.js v6 like  
https://github.com/eclipse/che/issues/1700
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/1700
### New behavior

Only documentation update
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [x] Tests passed

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

Signed-off-by: Ilya Buziuk ibuziuk@redhat.com
