### PR TITLE
Zend stack and project sample

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/images/type-zend.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/images/type-zend.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="512"
+   width="512"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="type-zend.svg">
+  <title
+     id="title3009">Zend logo</title>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="1163"
+     id="namedview26"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="518.0125"
+     inkscape:cy="208.81077"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8" />
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata6">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Zend logo</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-348.15625,140.18036)"
+     id="g8">
+    <path
+       d="m 860.15625,-125.89886 -314.5099,414.63741 243.5604,0 c 39.24003,0 70.94901,-32.08985 70.94901,-71.2562 l 0,-343.38121 z m -441.05099,68.491962 c -39.20317,0 -70.94901,32.053008 -70.94901,71.256207 l 0,343.688831 314.5099,-414.945038 -243.5604,0 z"
+       id="path10"
+       inkscape:connector-curvature="0"
+       style="fill:#000100;fill-opacity:1;fill-rule:nonzero" />
+  </g>
+</svg>

--- a/ide/che-core-ide-stacks/src/main/resources/images/type-zend.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/images/type-zend.svg
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!--
 
+    Copyright (c) 2016 Rogue Wave Software, Inc. All rights reserved.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1933,7 +1933,7 @@
     "id": "zend",
     "creator": "ide",
     "name": "Zend",
-    "description": "Zend Server with PHP 7, Z-Ray, Composer, Git, etc.",
+    "description": "Zend stack with PHP 7, Zend Server 9 and Z-Ray.",
     "scope": "advanced",
     "tags": [
       "PHP",

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1928,5 +1928,92 @@
       "name": "type-bitnami.svg",
       "mediaType": "image/svg+xml"
     }
+  },
+  {
+    "id": "zend",
+    "creator": "ide",
+    "name": "Zend",
+    "description": "Zend Server with PHP 7, Z-Ray, Composer, Git, etc.",
+    "scope": "advanced",
+    "tags": [
+      "PHP",
+      "Zend",
+      "Z-Ray",
+      "Composer",
+      "Ubuntu",
+      "Git"
+    ],
+    "components": [
+      {
+        "name": "PHP",
+        "version": "7.0.6"
+      },
+      {
+        "name": "Zend Server",
+        "version": "9.0.0"
+      },
+      {
+        "name": "Composer",
+        "version": "---"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "kaloyanraev/che-zendserver"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "kaloyanraev/che-zendserver",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": [  
+        {
+          "name": "restart zend server",
+          "type": "custom",
+          "commandLine": "sudo sed -i 's#zray.zendserver_ui_url=.*#zray.zendserver_ui_url=http://${server.port.10081}/ZendServer#g' /usr/local/zend/etc/conf.d/zray.ini && sudo /usr/local/zend/bin/zendctl.sh restart",
+          "attributes": {
+            "previewUrl": "http://${server.port.80}"
+          }
+        },
+        {
+          "name": "stop zend server",
+          "type": "custom",
+          "commandLine": "sudo /usr/local/zend/bin/zendctl.sh stop",
+          "attributes": {
+            "previewUrl": ""
+          }
+        },
+        {
+          "name": "show admin password",
+          "type": "custom",
+          "commandLine": "echo \"Zend Server admin password is `sudo cat /root/zend-password`\"",
+          "attributes": {
+            "previewUrl": "http://${server.port.10081}"
+          }
+        }
+      ]
+    },
+    "stackIcon": {
+      "name": "type-zend.svg",
+      "mediaType": "image/svg+xml"
+    }
   }
 ]

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -1260,5 +1260,56 @@
     "tags": [
       "Play"
     ]
+  },
+  {
+    "name": "astro-splash",
+    "displayName": "astro-splash",
+    "path": "/astro-splash",
+    "description": "An app that uses the Astronomy Picture of the Day API provided by NASA and the Zend Expressive framework.",
+    "projectType": "php",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/kaloyan-raev/AstroSplash.git",
+      "parameters": {}
+    },
+    "commands": [
+      {
+        "name": "configure",
+        "type": "custom",
+        "commandLine": "chmod 777 ${current.project.path}/data; echo -e \"<VirtualHost *:80>\n    DocumentRoot ${current.project.path}/public\n    SetEnv APPLICATION_ENV 'development'\n    <Directory ${current.project.path}/public>\n        DirectoryIndex index.php\n        AllowOverride All\n        Require all granted\n    </Directory>\n</VirtualHost>\" | sudo tee /etc/apache2/sites-available/000-default.conf; composer --working-dir=${current.project.path} install && cp /usr/local/zend/etc/php.ini /tmp/update-php.ini && grep -q 'extension=pcntl.so' /tmp/update-php.ini || echo -e \"\nextension=pcntl.so\" | sudo tee -a /tmp/update-php.ini && php -c /tmp/update-php.ini ${current.project.path}/bin/update.php && rm /tmp/update-php.ini",
+        "attributes": {
+          "previewUrl": ""
+        }
+      },
+      {
+        "name": "update images",
+        "type": "custom",
+        "commandLine": "cp /usr/local/zend/etc/php.ini /tmp/update-php.ini && grep -q 'extension=pcntl.so' /tmp/update-php.ini || echo -e \"\nextension=pcntl.so\" | sudo tee -a /tmp/update-php.ini && php -c /tmp/update-php.ini ${current.project.path}/bin/update.php && rm /tmp/update-php.ini",
+        "attributes": {
+          "previewUrl": ""
+        }
+      },
+      {
+        "name": "clean doctrine cache",
+        "type": "custom",
+        "commandLine": "sudo rm -rf ${current.project.path}/data/doctrine-cache",
+        "attributes": {
+          "previewUrl": ""
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Zend"
+    ]
   }
 ]


### PR DESCRIPTION
### What does this PR do?

Adds a stack with [Zend Server](http://www.zend.com/en/products/zend_server), based on the [official docker image](https://hub.docker.com/r/_/php-zendserver/). Zend Server is a professional and certified PHP distribution. The docker image includes a free trial Developer license.

Also adds a project sample of the [Astro Splash](https://github.com/kaloyan-raev/AstroSplash) application, which is a demo app based on the [Zend Expressive](https://zendframework.github.io/zend-expressive/) framework.

After creating a workspace with these stack and template the user must:
1. Execute the `configure` command.
2. Execute the `restart zend server` command.
3. Click on the preview link generated by the `restart zend server` command.
### What issues does this PR fix or reference?
- PHP support #2590
### New behavior
- New stack with Zend Server.
- New project sample: Astro Splash demo app, based on Zend Expressive.
### PR type
- [x] Minor change = no change to existing features or docs

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
