### PR TITLE
Add some files generated by m2e to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 target/
 bin/
 test-output/
+maven-eclipse.xml
+Maven_Ant_Builder.launch
 
 # Idea #
 ##################

--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,13 @@
 ###################
 
 .classpath
+.launch
 .project
 .settings/
 target/
 bin/
 test-output/
 maven-eclipse.xml
-Maven_Ant_Builder.launch
 
 # Idea #
 ##################

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Eclipse  #
 ###################
 
+*.launch
 .classpath
-.launch
 .project
 .settings/
 target/


### PR DESCRIPTION
### What does this PR do?

I have quite some `maven-eclipse.xml` and `Maven_Ant_Builder.launch` files listed as unstaged changes. These files are generated by the m2e Eclipse plugin and are not supposed to be committed to the Git repo.

This PR adds `maven-eclipse.xml` and `Maven_Ant_Builder.launch` to `.gitignore`.
### PR type
- [x] Minor change = no change to existing features or docs

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
