### PR TITLE
CHE-2477 Move Git and Subversion menus to the left

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitExtension.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitExtension.java
@@ -40,8 +40,8 @@ import org.eclipse.che.ide.ext.git.client.action.ShowMergeAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowRemoteAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowStatusAction;
 
-import static org.eclipse.che.ide.api.action.IdeActions.GROUP_HELP;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_MAIN_MENU;
+import static org.eclipse.che.ide.api.action.IdeActions.GROUP_PROFILE;
 import static org.eclipse.che.ide.api.constraints.Anchor.BEFORE;
 
 /**
@@ -89,7 +89,7 @@ public class GitExtension {
 
         DefaultActionGroup git = new DefaultActionGroup(GIT_GROUP_MAIN_MENU, true, actionManager);
         actionManager.registerAction("git", git);
-        mainMenu.add(git, new Constraints(BEFORE, GROUP_HELP));
+        mainMenu.add(git, new Constraints(BEFORE, GROUP_PROFILE));
 
         DefaultActionGroup commandGroup = new DefaultActionGroup(COMMAND_GROUP_MAIN_MENU, false, actionManager);
         actionManager.registerAction("gitCommandGroup", commandGroup);

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/SubversionExtension.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/SubversionExtension.java
@@ -80,7 +80,6 @@ public class SubversionExtension {
                                final SubversionExtensionResources resources) {
         SVN_GROUP_MAIN_MENU = constants.subversionLabel();
 
-        final Constraints beforeWindow = new Constraints(Anchor.BEFORE, IdeActions.GROUP_HELP);
         final DefaultActionGroup addCommandGroup = new DefaultActionGroup(ADD_COMMAND_GROUP, false, actionManager);
         final DefaultActionGroup mainMenu = (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_MAIN_MENU);
         final DefaultActionGroup fileCommandGroup = new DefaultActionGroup(FILE_COMMAND_GROUP, false, actionManager);
@@ -98,7 +97,7 @@ public class SubversionExtension {
 
         // Register action groups
         actionManager.registerAction(SVN_GROUP_MAIN_MENU, svnMenu);
-        mainMenu.add(svnMenu, beforeWindow);
+        mainMenu.add(svnMenu, new Constraints(Anchor.BEFORE, IdeActions.GROUP_PROFILE));
 
         actionManager.registerAction(REMOTE_COMMAND_GROUP, remoteCommandGroup);
         svnMenu.add(remoteCommandGroup);


### PR DESCRIPTION
Moves menu items according to the issue.

https://github.com/eclipse/che/issues/2447

Signed-off-by: Vitaliy Guliy vguliy@codenvy.com
