### PR TITLE
Use eager fetch type for workspace entities

### DIFF
--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/CommandImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/CommandImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.core.model.machine.Command;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MapKeyColumn;
@@ -43,7 +44,7 @@ public class CommandImpl implements Command {
     @Column(nullable = false)
     private String type;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @MapKeyColumn(name = "name")
     @Column(name = "value", columnDefinition = "TEXT")
     private Map<String, String> attributes;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.core.model.workspace.ExtendedMachine;
 import javax.persistence.CascadeType;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -40,7 +41,7 @@ public class EnvironmentImpl implements Environment {
     @Embedded
     private EnvironmentRecipeImpl recipe;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn
     private Map<String, ExtendedMachineImpl> machines;
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ExtendedMachineImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ExtendedMachineImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.core.model.workspace.ServerConf2;
 import javax.persistence.CascadeType;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -37,13 +38,13 @@ public class ExtendedMachineImpl implements ExtendedMachine {
     @GeneratedValue
     private Long id;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private List<String> agents;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private Map<String, String> attributes;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn
     private Map<String, ServerConf2Impl> servers;
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -19,6 +19,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -63,10 +64,10 @@ public class ProjectConfigImpl implements ProjectConfig {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private SourceStorageImpl source;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private List<String> mixins;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn
     @MapKey(name = "name")
     private Map<String, Attribute> dbAttributes;
@@ -230,7 +231,7 @@ public class ProjectConfigImpl implements ProjectConfig {
         @Basic
         private String name;
 
-        @ElementCollection
+        @ElementCollection(fetch = FetchType.EAGER)
         private List<String> values;
 
         public Attribute() {}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConf2Impl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConf2Impl.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.core.model.workspace.ServerConf2;
 import javax.persistence.Basic;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.util.HashMap;
@@ -37,7 +38,7 @@ public class ServerConf2Impl implements ServerConf2 {
     @Basic
     private String protocol;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private Map<String, String> properties;
 
     public ServerConf2Impl() {}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/SourceStorageImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/SourceStorageImpl.java
@@ -16,6 +16,7 @@ import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.util.HashMap;
@@ -40,7 +41,7 @@ public class SourceStorageImpl implements SourceStorage {
     @Column(columnDefinition = "TEXT")
     private String location;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private Map<String, String> parameters;
 
     public SourceStorageImpl() {}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceConfigImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.che.commons.annotation.Nullable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -62,15 +63,15 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
     @Column(nullable = false)
     private String defaultEnv;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn
     private List<CommandImpl> commands;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn
     private List<ProjectConfigImpl> projects;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn
     private Map<String, EnvironmentImpl> environments;
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -84,7 +84,7 @@ public class WorkspaceImpl implements Workspace {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private WorkspaceConfigImpl config;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private Map<String, String> attributes;
 
     @Basic


### PR DESCRIPTION
### What does this PR do?

Uses `FetchType.EAGER` for `Workspace` and `WorkspaceConfig` relationships.
Check out [this](https://bugs.eclipse.org/bugs/show_bug.cgi?id=399528) EclipseLink bug.
The problem described in the [issue](https://github.com/codenvy/codenvy/issues/899#issuecomment-251652029) appears when several threads access the same indirect connection in unlucky timing, which causes `org.eclipse.persistence.exceptions.ConcurrencyException`.
### What issues does this PR fix or reference?

Fixes the problem described by [this issue](https://github.com/codenvy/codenvy/issues/899#issuecomment-251652029)
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [x] Tests passed

@skabashnyuk, @akorneta please review
