### PR TITLE
CLI: Add new command - ws - for listing & logs of workspaces

### DIFF
--- a/che.sh
+++ b/che.sh
@@ -20,6 +20,9 @@ init_logging() {
   DEFAULT_CHE_CLI_VERSION="latest"
   CHE_CLI_VERSION=${CHE_CLI_VERSION:-${DEFAULT_CHE_CLI_VERSION}}
 
+  DEFAULT_CHE_PRODUCT_NAME="ECLIPSE CHE"
+  CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
+
   # Name used in CLI statements
   DEFAULT_CHE_MINI_PRODUCT_NAME="che"
   CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
@@ -45,7 +48,16 @@ warning() {
 
 info() {
   if is_info; then
-    printf  "${GREEN}INFO:${NC} %s\n" "${1}"
+    if [ -z ${2+x} ]; then 
+      PRINT_COMMAND=""
+      PRINT_STATEMENT=$1
+    else
+      PRINT_COMMAND="($CHE_MINI_PRODUCT_NAME $1):"
+      PRINT_STATEMENT=$2
+    fi
+    printf  "${GREEN}INFO:${NC} %s %s\n" \
+              "${PRINT_COMMAND}" \
+              "${PRINT_STATEMENT}"
   fi
 }
 
@@ -112,7 +124,7 @@ check_docker() {
 }
 
 curl () {
-  docker run --rm appropriate/curl "$@"
+  docker run --rm --net=host appropriate/curl "$@"
 }
 
 update_che_cli() {


### PR DESCRIPTION
### What does this PR do?

1: Adds in functionality to let users list all workspaces and then display the logs of a running workspace.

2: Provides some limited discovery - if no running workspaces, returns an error. If 1 running workspace, will automatically display the logs for that.  If 2+ workspaces, lists the workspaces and their ws-id asking user to pick which one they want.

```
che ws list                            List all workspaces
che ws logs [<ws-id>]                  Get the agent logs for a workspace
```

3: Fixes a bug in the --networking command where the use of the new curl command requires --net=host to operate properly. This bug was previously unreported, but was discovered in testing the info changes.

4:  Adds in logic so that INFO: command either prints out no pre-info (such as what we need for certain long-output command) or prints out `(che <command-name>):` as a prefix.

5: Simplifies all error: messages to remove any product name from it.
### PR type
- [x] Minor change = no change to existing features or docs
