### PR TITLE
Fix default PHP content

### DIFF
--- a/plugins/plugin-php/che-plugin-php-lang-server/src/main/resources/files/default_php_content
+++ b/plugins/plugin-php/che-plugin-php-lang-server/src/main/resources/files/default_php_content
@@ -1,5 +1,3 @@
-// Hello World program
-
 <?php
-  echo "Hello World!";
-?>
+
+echo "Hello World!\n";


### PR DESCRIPTION
### What does this PR do?

The default PHP content introduced with #2710 has several issues:
- Any text outside the scope of the `<?php` tag is printed directly in the STDOUT. Thus `// Hello World program` is not really a comment and will be printed.
- Usage of the close `?>` tag at the end of flie is highly discouraged in general. Explanation [here](http://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag).
- There should be no indentation after the `<?php` open tag.
- It is a good convention to have an empty line between the `<?php` open tag and the first line of actual code.

This PR fixes the above issues.

The output of the file can be easily tested by executing the following command in the Terminal:

``` bash
$ php <project-name>/hello.php
```
### PR type
- [x] Minor change = no change to existing features or docs

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
