### PR TITLE
Adding 'fast' profile for building Che faster by skipping unit tests,…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -849,4 +849,18 @@
             <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
         </pluginRepository>
     </pluginRepositories>
+    <profiles>
+        <!-- Profile for building Che faster by skipping unit tests, license checks and other enforcement features -->
+        <profile>
+            <id>fast</id>
+            <properties>
+                <findbugs.skip>true</findbugs.skip>
+                <gwt.compiler.localWorkers>2 -T 1C</gwt.compiler.localWorkers>
+                <license.skip>true</license.skip>
+                <mdep.analyze.skip>true</mdep.analyze.skip>
+                <skip-validate-sources>true</skip-validate-sources>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### What does this PR do?

'fast' profile for building Che faster by skipping unit tests, license checks and other enforcement features
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2594
### New behavior

"mvn clean verify -Pfast" will allow to build che with the following  system properties enabled:

```
    -DskipTests=true
    -Dfindbugs.skip=true
    -Dskip-validate-sources
    -Dmdep.analyze.skip=true
    -Dlicense.skip=true
    -Dgwt.compiler.localWorkers=2 -T 1C
```
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Tests provided / updated
- [x] Tests passed
### Major change checklist
- [ ] New API required?
- [ ] API updated
- [ ] Documentation provided (include here or link to docs)
- [ ] Tests provided / updated
- [ ] Tests passed

Signed-off-by: Ilya Buziuk ibuziuk@redhat.com
