### PR TITLE
Fixes #2728: Respect user settings when sending formatting options to LS

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerEditorConfiguration.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerEditorConfiguration.java
@@ -56,7 +56,6 @@ public class LanguageServerEditorConfiguration extends DefaultTextEditorConfigur
         if (serverCapabilities.isDocumentFormattingProvider() || serverCapabilities.isDocumentRangeFormattingProvider() ||
             serverCapabilities.getDocumentOnTypeFormattingProvider() != null) {
             this.formatter = formatterFactory.create(serverCapabilities);
-            formatter.setTabWidth(getTabWidth());
         }
         this.serverCapabilities = serverCapabilities;
         this.annotationModel = annotationModelFactory.get(docPositionMapProvider.get());

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -180,7 +180,7 @@ public class LanguageServerFormatter implements ContentFormatter {
         options.setTabSize(Integer.parseInt(getEditorProperty(EditorProperties.TAB_SIZE)));
         return options;
     }
-    
+
     private String getEditorProperty(EditorProperties property) {
         return editorPropertiesManager.getEditorProperties().get(property.toString()).toString();
     }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -38,6 +38,8 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.editor.texteditor.UndoableEditor;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.editor.preferences.editorproperties.EditorProperties;
+import org.eclipse.che.ide.editor.preferences.editorproperties.EditorPropertiesManager;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 
@@ -53,22 +55,20 @@ public class LanguageServerFormatter implements ContentFormatter {
     private final DtoFactory                dtoFactory;
     private final NotificationManager       manager;
     private final ServerCapabilities        capabilities;
-    private       int                       tabWidth;
+    private final EditorPropertiesManager   editorPropertiesManager;
     private       TextEditor                editor;
 
     @Inject
     public LanguageServerFormatter(TextDocumentServiceClient client,
                                    DtoFactory dtoFactory,
                                    NotificationManager manager,
-                                   @Assisted ServerCapabilities capabilities) {
+                                   @Assisted ServerCapabilities capabilities,
+                                   EditorPropertiesManager editorPropertiesManager) {
         this.client = client;
         this.dtoFactory = dtoFactory;
         this.manager = manager;
         this.capabilities = capabilities;
-    }
-
-    public void setTabWidth(int tabWidth) {
-        this.tabWidth = tabWidth;
+        this.editorPropertiesManager = editorPropertiesManager;
     }
 
     @Override
@@ -176,9 +176,13 @@ public class LanguageServerFormatter implements ContentFormatter {
 
     private FormattingOptionsDTO getFormattingOptions() {
         FormattingOptionsDTO options = dtoFactory.createDto(FormattingOptionsDTO.class);
-        options.setInsertSpaces(true);
-        options.setTabSize(tabWidth);
+        options.setInsertSpaces(Boolean.parseBoolean(getEditorProperty(EditorProperties.EXPAND_TAB)));
+        options.setTabSize(Integer.parseInt(getEditorProperty(EditorProperties.TAB_SIZE)));
         return options;
+    }
+    
+    private String getEditorProperty(EditorProperties property) {
+        return editorPropertiesManager.getEditorProperties().get(property.toString()).toString();
     }
 
     private void formatRange(TextRange selectedRange, Document document) {


### PR DESCRIPTION
### What does this PR do?

Replaces the hard coded formatting options sent to language servers with those configured in user preferences.
### What issues does this PR fix or reference?

Language Server formatting options are hardcoded #2728
### Previous behavior

Documents are formatted with hardcoded "tab size" and "insert spaces" (if editor uses a language server, e.g. JSON editor)
### New behavior

Documents are formatted with the "tab size" and "insert spaces" from the user preferences.
### PR type
- [x] Minor change = no change to existing features or docs

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
