### PR TITLE
Setup wildcard mime-type in content-type header if null body occurred

### DIFF
--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/rest/AsyncRequestFactory.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/rest/AsyncRequestFactory.java
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package org.eclipse.che.ide.rest;
 
+import com.google.common.base.Preconditions;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.che.ide.MimeType;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.dto.JsonSerializable;
 
 import java.util.List;
 
@@ -23,6 +25,7 @@ import java.util.List;
  * Provides implementations of {@link AsyncRequest} instances.
  *
  * @author Artem Zatsarynnyi
+ * @author Vlad Zhukovskyi
  */
 @Singleton
 public class AsyncRequestFactory {
@@ -64,8 +67,7 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoData
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code
-     *         null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface. May be {@code null}.
      * @return new {@link AsyncRequest} instance to send POST request
      */
     public AsyncRequest createPostRequest(String url, Object dtoData) {
@@ -78,8 +80,7 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoData
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code
-     *         null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface. May be {@code null}.
      * @return new {@link AsyncRequest} instance to send PUT request
      */
     public AsyncRequest createPutRequest(String url, Object dtoData) {
@@ -92,8 +93,8 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoArray
-     *         the array of DTO to send as body of the request. Must contain objects that implement {@link
-     *         org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code null}.
+     *         the array of DTO to send as body of the request. Must contain objects that implement {@link JsonSerializable} interface.
+     *         May be {@code null}.
      * @return new {@link AsyncRequest} instance to send POST request
      */
     public AsyncRequest createPostRequest(String url, List<Object> dtoArray) {
@@ -106,8 +107,7 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoData
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code
-     *         null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface. May be {@code null}.
      * @param async
      *         if <b>true</b> - request will be sent in asynchronous mode
      * @return new {@link AsyncRequest} instance to send POST request
@@ -122,8 +122,7 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoData
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code
-     *         null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface. May be {@code null}.
      * @param async
      *         if <b>true</b> - request will be sent in asynchronous mode
      * @return new {@link AsyncRequest} instance to send POST request
@@ -132,15 +131,14 @@ public class AsyncRequestFactory {
         return createRequest(RequestBuilder.PUT, url, dtoData, async);
     }
 
-
     /**
      * Creates new POST request to the specified {@code url} with the provided {@code data}.
      *
      * @param url
      *         request URL
      * @param dtoArray
-     *         the array of DTO to send as body of the request. Must contain objects that implement {@link
-     *         org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code null}.
+     *         the array of DTO to send as body of the request. Must contain objects that implement {@link JsonSerializable} interface.
+     *         May be {@code null}.
      * @param async
      *         if <b>true</b> - request will be sent in asynchronous mode
      * @return new {@link AsyncRequest} instance to send POST request
@@ -157,11 +155,15 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoBody
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code
-     *         null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface. May be {@code null}.
      * @param async
      *         if <b>true</b> - request will be sent in asynchronous mode
      * @return new {@link AsyncRequest} instance to send POST request
+     * @throws NullPointerException
+     *         in case if request {@code method} is {@code null}, reason includes:
+     *         <ul>
+     *         <li>Request method should not be a null</li>
+     *         </ul>
      */
     public AsyncRequest createRequest(RequestBuilder.Method method, String url, Object dtoBody, boolean async) {
         return doCreateRequest(method, url, dtoBody, async);
@@ -175,11 +177,15 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoBody
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface. May be {@code
-     *         null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface. May be {@code null}.
      * @param async
      *         if <b>true</b> - request will be sent in asynchronous mode
      * @return new {@link AsyncRequest} instance to send POST request
+     * @throws NullPointerException
+     *         in case if request {@code method} is {@code null}, reason includes:
+     *         <ul>
+     *         <li>Request method should not be a null</li>
+     *         </ul>
      */
     public AsyncRequest createRequest(RequestBuilder.Method method, String url, List<Object> dtoBody, boolean async) {
         return doCreateRequest(method, url, dtoBody, async);
@@ -193,27 +199,45 @@ public class AsyncRequestFactory {
      * @param url
      *         request URL
      * @param dtoBody
-     *         the DTO to send as body of the request. Must implement {@link org.eclipse.che.ide.dto.JsonSerializable} interface or contain
-     *         objects that implement it. May be {@code null}.
+     *         the DTO to send as body of the request. Must implement {@link JsonSerializable} interface or contain objects that
+     *         implement it. May be {@code null}.
      * @param async
      *         if <b>true</b> - request will be sent in asynchronous mode
      * @return new {@link AsyncRequest} instance to send POST request
+     * @throws NullPointerException
+     *         in case if request {@code method} is {@code null}, reason includes:
+     *         <ul>
+     *         <li>Request method should not be a null</li>
+     *         </ul>
      */
     protected AsyncRequest doCreateRequest(RequestBuilder.Method method, String url, Object dtoBody, boolean async) {
+        Preconditions.checkNotNull(method, "Request method should not be a null");
+
         AsyncRequest asyncRequest = new AsyncRequest(method, url, async);
         if (dtoBody != null) {
             if (dtoBody instanceof List) {
                 asyncRequest.data(dtoFactory.toJson((List)dtoBody));
             } else if (dtoBody instanceof String) {
-                asyncRequest.data((String) dtoBody);
+                asyncRequest.data((String)dtoBody);
             } else {
                 asyncRequest.data(dtoFactory.toJson(dtoBody));
             }
             asyncRequest.header(HTTPHeader.CONTENT_TYPE, DTO_CONTENT_TYPE);
+        } else if (method.equals(RequestBuilder.POST) || method.equals(RequestBuilder.PUT)) {
+
+            /*
+               Here we need to setup wildcard mime type in content-type header, because CORS filter
+               responses with 403 error in case if user makes POST/PUT request with null body and without
+               content-type header. Setting content-type header with wildcard mime type solves this problem.
+
+               Note, this issue need to be investigated, because the problem may be occurred as a bug in
+               CORS filter.
+             */
+
+            asyncRequest.header(HTTPHeader.CONTENT_TYPE, MimeType.WILDCARD);
         }
         return asyncRequest;
     }
-
 
     /**
      * Creates new GET request to the specified {@code url}.


### PR DESCRIPTION
This commit fix the problem when user try to send POST/PUT request with null body and without content-type header. In this case CORS filter responses with 403 Forbidden error. Adding wildcard mime-type into the content-type header fix this problem.

Discovered during: https://github.com/codenvy/plugin-openshift/issues/36

@vparfonov @ashumilova review it please.
