### PR TITLE
Add build args support in compose files (CHE-2661)

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -402,7 +402,8 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                             .withAuthConfigs(dockerCredentials.getCredentials())
                             .withDoForcePull(doForcePullOnBuild)
                             .withMemoryLimit(service.getMemLimit())
-                            .withMemorySwapLimit(-1);
+                            .withMemorySwapLimit(-1)
+                            .withBuildArgs(service.getBuild().getArgs());
 
             docker.buildImage(buildImageParams, progressMonitor);
         } catch (IOException e) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentEngine.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentEngine.java
@@ -902,9 +902,11 @@ public class CheEnvironmentEngine {
                 if (machineSource.getContent() != null) {
                     serviceWithCorrectSource.setBuild(new CheServiceBuildContextImpl(null,
                                                                                      null,
-                                                                                     machineSource.getContent()));
+                                                                                     machineSource.getContent(),
+                                                                                     null));
                 } else {
                     serviceWithCorrectSource.setBuild(new CheServiceBuildContextImpl(machineSource.getLocation(),
+                                                                                     null,
                                                                                      null,
                                                                                      null));
                 }
@@ -1137,6 +1139,7 @@ public class CheEnvironmentEngine {
                         "Please use dockerfile location instead");
             } else {
                 service.setBuild(new CheServiceBuildContextImpl(machineConfig.getSource().getLocation(),
+                                                                null,
                                                                 null,
                                                                 null));
             }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/EnvironmentParser.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/EnvironmentParser.java
@@ -171,7 +171,8 @@ public class EnvironmentParser {
             CheServiceBuildContextImpl buildContext = null;
             if (service.getBuild() != null) {
                 buildContext = new CheServiceBuildContextImpl().withContext(service.getBuild().getContext())
-                                                               .withDockerfilePath(service.getBuild().getDockerfile());
+                                                               .withDockerfilePath(service.getBuild().getDockerfile())
+                                                               .withArgs(service.getBuild().getArgs());
             }
 
             CheServiceImpl cheService = new CheServiceImpl().withBuild(buildContext)

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/compose/BuildContextImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/compose/BuildContextImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.environment.server.compose;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -18,19 +20,22 @@ import java.util.Objects;
  * @author Alexander Garagatyi
  */
 public class BuildContextImpl {
-    private String context;
-    private String dockerfile;
+    private String              context;
+    private String              dockerfile;
+    private Map<String, String> args;
 
     public BuildContextImpl() {}
 
-    public BuildContextImpl(String context, String dockerfile) {
+    public BuildContextImpl(String context, String dockerfile, Map<String,String> args) {
         this.context = context;
         this.dockerfile = dockerfile;
+        if (args != null) {
+          this.args = new HashMap<>(args);
+        }
     }
 
     public BuildContextImpl(BuildContextImpl buildContext) {
-        this.context = buildContext.getContext();
-        this.dockerfile = buildContext.getDockerfile();
+        this(buildContext.getContext(),buildContext.getDockerfile(), buildContext.getArgs());
     }
 
     /**
@@ -69,25 +74,46 @@ public class BuildContextImpl {
         return this;
     }
 
+    /**
+     * Args for Dockerfile build.
+     */
+    public Map<String,String> getArgs() {
+        if (args == null) {
+            args = new HashMap<>();
+        }
+        return args;
+    }
+
+    public void setArgs(Map<String,String> args) {
+        this.args = args;
+    }
+
+    public BuildContextImpl withArgs(Map<String,String> args) {
+        this.args = args;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof BuildContextImpl)) return false;
         BuildContextImpl that = (BuildContextImpl)o;
         return Objects.equals(context, that.context) &&
-               Objects.equals(dockerfile, that.dockerfile);
+               Objects.equals(dockerfile, that.dockerfile) &&
+               Objects.equals(args, that.args);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(context, dockerfile);
+        return Objects.hash(context, dockerfile, args);
     }
 
     @Override
     public String toString() {
         return "BuildContextImpl{" +
                "context='" + context + '\'' +
-               ", dockerfile='" + dockerfile + '\'' +
+                ", dockerfile='" + dockerfile + '\'' +
+                ", args='" + args + '\'' +
                '}';
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/model/CheServiceBuildContextImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/model/CheServiceBuildContextImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.environment.server.model;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -18,24 +20,30 @@ import java.util.Objects;
  * @author Alexander Garagatyi
  */
 public class CheServiceBuildContextImpl {
-    private String context;
-    private String dockerfilePath;
-    private String dockerfileContent;
+    private String             context;
+    private String             dockerfilePath;
+    private String             dockerfileContent;
+    private Map<String,String> args;
 
     public CheServiceBuildContextImpl() {}
 
     public CheServiceBuildContextImpl(String context,
                                       String dockerfilePath,
-                                      String dockerfileContent) {
+                                      String dockerfileContent,
+                                      Map<String,String> args) {
         this.context = context;
         this.dockerfilePath = dockerfilePath;
         this.dockerfileContent = dockerfileContent;
+        if (args != null) {
+            this.args = new HashMap<>(args);
+        }
     }
 
     public CheServiceBuildContextImpl(CheServiceBuildContextImpl buildContext) {
-        this.context = buildContext.getContext();
-        this.dockerfilePath = buildContext.getDockerfilePath();
-        this.dockerfileContent = buildContext.getDockerfileContent();
+        this(buildContext.getContext(),
+             buildContext.getDockerfilePath(),
+             buildContext.getDockerfileContent(),
+             buildContext.getArgs());
     }
 
     /**
@@ -93,6 +101,25 @@ public class CheServiceBuildContextImpl {
         return this;
     }
 
+    /**
+     * Args for Dockerfile build.
+     */
+    public Map<String,String> getArgs() {
+        if (args == null) {
+            args = new HashMap<>();
+        }
+        return args;
+    }
+
+    public void setArgs(Map<String,String> args) {
+        this.args = args;
+    }
+
+    public CheServiceBuildContextImpl withArgs(Map<String,String> args) {
+        this.args = args;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -100,12 +127,13 @@ public class CheServiceBuildContextImpl {
         CheServiceBuildContextImpl that = (CheServiceBuildContextImpl)o;
         return Objects.equals(context, that.context) &&
                Objects.equals(dockerfilePath, that.dockerfilePath) &&
-               Objects.equals(dockerfileContent, that.dockerfileContent);
+               Objects.equals(dockerfileContent, that.dockerfileContent) &&
+               Objects.equals(args, that.args);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(context, dockerfilePath, dockerfileContent);
+        return Objects.hash(context, dockerfilePath, dockerfileContent, args);
     }
 
     @Override
@@ -114,6 +142,7 @@ public class CheServiceBuildContextImpl {
                "context='" + context + '\'' +
                ", dockerfilePath='" + dockerfilePath + '\'' +
                ", dockerfileContent='" + dockerfileContent + '\'' +
+               ", args='" + args + '\'' +
                '}';
     }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/CheEnvironmentValidatorTest.java
@@ -342,28 +342,31 @@ public class CheEnvironmentValidatorTest {
         serviceEntry = getAnyService(env);
         service = serviceEntry.getValue();
         service.setImage(null);
-        service.setBuild(new CheServiceBuildContextImpl(null, "dockerfile", null));
+        service.setBuild(new CheServiceBuildContextImpl(null, "dockerfile", null, null));
         data.add(asList(env, format("Field 'image' or 'build.context' is required in machine '%s' in environment 'env'", serviceEntry.getKey())));
 
         env = createServicesEnv();
         serviceEntry = getAnyService(env);
         service = serviceEntry.getValue();
         service.setImage("");
-        service.setBuild(new CheServiceBuildContextImpl("", "dockerfile", null));
+        service.setBuild(new CheServiceBuildContextImpl("", "dockerfile", null, null));
         data.add(asList(env, format("Field 'image' or 'build.context' is required in machine '%s' in environment 'env'", serviceEntry.getKey())));
 
         env = createServicesEnv();
         serviceEntry = getAnyService(env);
         service = serviceEntry.getValue();
         service.setImage("");
-        service.setBuild(new CheServiceBuildContextImpl(null, null, null));
+        service.setBuild(new CheServiceBuildContextImpl(null, null, null, null));
         data.add(asList(env, format("Field 'image' or 'build.context' is required in machine '%s' in environment 'env'", serviceEntry.getKey())));
 
         env = createServicesEnv();
         serviceEntry = getAnyService(env);
         service = serviceEntry.getValue();
         service.setImage("");
-        service.setBuild(new CheServiceBuildContextImpl("some url", null, "some content"));
+        service.setBuild(new CheServiceBuildContextImpl("some url",
+                                                        null,
+                                                        "some content",
+                                                        new HashMap<String, String>() {{put("argkey","argvalue");}}));
         data.add(asList(env, format("Machine '%s' in environment 'env' contains mutually exclusive dockerfile content and build context.",
                                     serviceEntry.getKey())));
 
@@ -600,6 +603,7 @@ public class CheEnvironmentValidatorTest {
         CheServicesEnvironmentImpl cheServicesEnvironment = new CheServicesEnvironmentImpl();
         cheServicesEnvironment.setVersion("2");
         Map<String, CheServiceImpl> services = new HashMap<>();
+        Map<String, String> buildArgs =  new HashMap<String, String>() {{put("argkey","argvalue");}};
         cheServicesEnvironment.setServices(services);
 
         services.put("dev-machine", createCheService("_dev",
@@ -613,7 +617,7 @@ public class CheEnvironmentValidatorTest {
                                                   null,
                                                   emptyList(),
                                                   null);
-        service.setBuild(new CheServiceBuildContextImpl("context", "file", null));
+        service.setBuild(new CheServiceBuildContextImpl("context", "file", null, buildArgs));
 
         services.put("machine2", service);
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/EnvironmentParserTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/EnvironmentParserTest.java
@@ -772,7 +772,7 @@ public class EnvironmentParserTest {
     }
 
     private static EnvironmentImpl createCompose1MachineEnvConfig() {
-        HashMap<String, ExtendedMachineImpl> machines = new HashMap<>();
+        Map<String, ExtendedMachineImpl> machines = new HashMap<>();
         machines.put(DEFAULT_MACHINE_NAME, new ExtendedMachineImpl(emptyList(),
                                                          emptyMap(),
                                                          emptyMap()));
@@ -798,7 +798,7 @@ public class EnvironmentParserTest {
                                                                 List<String> expectedExpose,
                                                                 Map<String, String> expectedLabels) {
         CheServiceBuildContextImpl build =
-                dockerfile == null ? null : new CheServiceBuildContextImpl(null, null, dockerfile);
+                dockerfile == null ? null : new CheServiceBuildContextImpl(null, null, dockerfile, null);
         CheServicesEnvironmentImpl environment = new CheServicesEnvironmentImpl();
         environment.getServices()
                    .put(DEFAULT_MACHINE_NAME, new CheServiceImpl().withImage(image)
@@ -853,7 +853,8 @@ public class EnvironmentParserTest {
         BuildContextImpl buildContext = null;
         if (service.getBuild() != null) {
             buildContext = new BuildContextImpl().withContext(service.getBuild().getContext())
-                                                 .withDockerfile(service.getBuild().getDockerfilePath());
+                                                 .withDockerfile(service.getBuild().getDockerfilePath())
+                                                 .withArgs(service.getBuild().getArgs());
         }
 
         return new ComposeServiceImpl().withBuild(buildContext)
@@ -889,7 +890,8 @@ public class EnvironmentParserTest {
         CheServiceBuildContextImpl buildContext = null;
         if (service.getBuild() != null) {
             buildContext = new CheServiceBuildContextImpl().withContext(service.getBuild().getContext())
-                                                           .withDockerfilePath(service.getBuild().getDockerfile());
+                                                           .withDockerfilePath(service.getBuild().getDockerfile())
+                                                           .withArgs(service.getBuild().getArgs());
         }
 
         return new CheServiceImpl().withBuild(buildContext)
@@ -911,7 +913,11 @@ public class EnvironmentParserTest {
 
     private static CheServiceImpl createCheService(boolean isImageBased) {
         return new CheServiceImpl()
-                .withBuild(isImageBased ? null : new CheServiceBuildContextImpl("some url", "some path", null))
+                .withBuild(isImageBased ? null : new CheServiceBuildContextImpl("some url",
+                                                                                "some path",
+                                                                                null,
+                                                                                new HashMap<String, String>()
+                                                                                {{put("argkey","argvalue");}}))
                 .withCommand(asList("some", "command"))
                 .withContainerName("con name")
                 .withDependsOn(asList("depends1", "depends2"))

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/compose/BuildContextTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/environment/server/compose/BuildContextTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.environment.server.compose;
+
+import org.eclipse.che.api.core.ServerException;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * @author Mario Loriedo
+ */
+public class BuildContextTest {
+
+    ComposeFileParser parser = new ComposeFileParser();
+
+    @Test
+    public void shouldParseBuildArgsWhenProvided() throws ServerException {
+        // given
+        String recipeContent = "services:\n" +
+                " dev-machine:\n" +
+                "  build:\n" +
+                "   context: .\n" +
+                "   args:\n" +
+                "    buildno: 1\n" +
+                "    password: secret\n";
+        String recipeContentType = "application/x-yaml";
+
+        Map<String,String> expected = new HashMap<String, String>() {
+            {
+                put("buildno","1");
+                put("password","secret");
+            }
+        };
+
+        // when
+        ComposeEnvironmentImpl composeEnvironment = parser.parse(recipeContent, recipeContentType);
+
+
+        // then
+        assertEquals(composeEnvironment.getServices().get("dev-machine").getBuild().getArgs(), expected);
+    }
+
+    @Test
+    public void shouldNotParseBuildArgsWhenNotProvided() throws ServerException {
+        // given
+        String recipeContent = "services:\n" +
+                " dev-machine:\n" +
+                "  build:\n" +
+                "   context: .\n";
+        String recipeContentType = "application/x-yaml";
+
+        // when
+        ComposeEnvironmentImpl composeEnvironment = parser.parse(recipeContent, recipeContentType);
+
+        // then
+        assertEquals(Collections.emptyMap(), composeEnvironment.getServices().get("dev-machine").getBuild().getArgs());
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?

Add support for build args in compose files:

``` yaml
services:
 dev-machine:
  build:
   context: .
   args:
    buildno: 1
    password: secret
```
### What issues does this PR fix or reference?
#2661

Signed-off-by: Mario Loriedo mloriedo@redhat.com
