### PR TITLE
Apply non-strict rules for PT appliance on project import to avoid wo…

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -264,6 +264,17 @@ public final class ProjectManager {
                 throw e;
             }
 
+            // unlike imported it is not appropriate for newly created project to have problems
+            if(!project.getProblems().isEmpty()) {
+
+                // rollback project folder
+                projectFolder.getVirtualFile().delete();
+                // remove project entry
+                projectRegistry.removeProjects(projectConfig.getPath());
+                throw new ServerException("Problems occured: " + project.getProblemsStr());
+            }
+
+
             workspaceProjectsHolder.sync(projectRegistry);
 
             projectRegistry.fireInitHandlers(project);
@@ -308,7 +319,17 @@ public final class ProjectManager {
             throw new NotFoundException(String.format("Folder '%s' doesn't exist.", path));
         }
 
+        ProjectConfig oldConfig = projectRegistry.getProject(path);
+
         final RegisteredProject project = projectRegistry.putProject(newConfig, baseFolder, true, false);
+
+        // unlike imported it is not appropriate for updated project to have problems
+        if(!project.getProblems().isEmpty()) {
+
+            // rollback project folder
+            projectRegistry.putProject(oldConfig, baseFolder, false, false);
+            throw new ServerException("Problems occured: " + project.getProblemsStr());
+        }
 
         workspaceProjectsHolder.sync(projectRegistry);
 
@@ -320,6 +341,23 @@ public final class ProjectManager {
         return project;
     }
 
+    /**
+     *
+     * Import source code as a Basic type of Project
+     *
+     * @param path where to import
+     * @param sourceStorage where sources live
+     * @param rewrite whether rewrite or not (throw exception othervise) if such a project exists
+     *
+     * @return Project
+     *
+     * @throws ServerException
+     * @throws IOException
+     * @throws ForbiddenException
+     * @throws UnauthorizedException
+     * @throws ConflictException
+     * @throws NotFoundException
+     */
     public RegisteredProject importProject(String path, SourceStorage sourceStorage, boolean rewrite) throws ServerException,
                                                                                                              IOException,
                                                                                                              ForbiddenException,
@@ -379,12 +417,23 @@ public final class ProjectManager {
         }
     }
 
+    /**
+     * Estimates if the folder can be treated as a project of particular type
+     *
+     * @param path to the folder
+     * @param projectTypeId project type to estimate
+     *
+     * @return resolution object
+     * @throws ServerException
+     * @throws NotFoundException
+     * @throws ValueStorageException
+     */
     public ProjectTypeResolution estimateProject(String path, String projectTypeId) throws ServerException,
                                                                                            NotFoundException,
                                                                                            ValueStorageException {
         final ProjectTypeDef projectType = projectTypeRegistry.getProjectType(projectTypeId);
         if (projectType == null) {
-            throw new NotFoundException("Project Type " + projectTypeId + " not found.");
+            throw new NotFoundException("Project Type to estimate needed.");
         }
 
         final FolderEntry baseFolder = asFolder(path);
@@ -396,7 +445,16 @@ public final class ProjectManager {
         return projectType.resolveSources(baseFolder);
     }
 
-    // ProjectSuggestion
+    /**
+     * Estimates to which project types the folder can be converted to
+     *
+     * @param path to the folder
+     * @param transientOnly whether it can be estimated to the transient types of Project only
+     *
+     * @return list of resolutions
+     * @throws ServerException
+     * @throws NotFoundException
+     */
     public List<ProjectTypeResolution> resolveSources(String path, boolean transientOnly) throws ServerException, NotFoundException {
         final List<ProjectTypeResolution> resolutions = new ArrayList<>();
 
@@ -443,6 +501,20 @@ public final class ProjectManager {
         workspaceProjectsHolder.sync(projectRegistry);
     }
 
+    /**
+     * Copies item to new path with
+     *
+     * @param itemPath path to item to copy
+     * @param newParentPath path where the item should be copied to
+     * @param newName new item name
+     * @param overwrite whether existed (if any) item should be overwritten
+     *
+     * @return new item
+     * @throws ServerException
+     * @throws NotFoundException
+     * @throws ConflictException
+     * @throws ForbiddenException
+     */
     public VirtualFileEntry copyTo(String itemPath, String newParentPath, String newName, boolean overwrite) throws ServerException,
                                                                                                                     NotFoundException,
                                                                                                                     ConflictException,
@@ -478,6 +550,20 @@ public final class ProjectManager {
         return copy;
     }
 
+    /**
+     * Moves item to the new path
+     *
+     * @param itemPath path to the item
+     * @param newParentPath path of new parent
+     * @param newName new item's name
+     * @param overwrite whether existed (if any) item should be overwritten
+     *
+     * @return new item
+     * @throws ServerException
+     * @throws NotFoundException
+     * @throws ConflictException
+     * @throws ForbiddenException
+     */
     public VirtualFileEntry moveTo(String itemPath, String newParentPath, String newName, boolean overwrite) throws ServerException,
                                                                                                                     NotFoundException,
                                                                                                                     ConflictException,

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectRegistry.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectRegistry.java
@@ -16,13 +16,10 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.project.ProjectConfig;
 import org.eclipse.che.api.core.notification.EventService;
-import org.eclipse.che.api.project.server.RegisteredProject.Problem;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.handlers.ProjectInitHandler;
 import org.eclipse.che.api.project.server.type.BaseProjectType;
-import org.eclipse.che.api.project.server.type.ProjectTypeConstraintException;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
-import org.eclipse.che.api.project.server.type.ValueStorageException;
 import org.eclipse.che.api.vfs.Path;
 import org.eclipse.che.api.vfs.VirtualFile;
 import org.eclipse.che.api.vfs.VirtualFileSystem;
@@ -76,7 +73,6 @@ public class ProjectRegistry {
 
     @PostConstruct
     public void initProjects() throws ConflictException, NotFoundException, ServerException, ForbiddenException {
-        //final Workspace workspace = workspaceHolder.getWorkspace();
 
         List<? extends ProjectConfig> projectConfigs = workspaceHolder.getProjects();
 
@@ -85,19 +81,9 @@ public class ProjectRegistry {
             final String path = projectConfig.getPath();
             final VirtualFile vf = vfs.getRoot().getChild(Path.of(path));
             final FolderEntry projectFolder = ((vf == null) ? null : new FolderEntry(vf, this));
-            // need that to make "problematic" project and not break the workspace
-            try {
-                putProject(projectConfig, projectFolder, false, false);
-            } catch (ProjectTypeConstraintException e) {
-                //in case bad config
-                projects.put(path, new RegisteredProject(projectFolder, false, false, projectTypeRegistry, new Problem(12, e.getMessage())));
-            } catch (NotFoundException e) {
-                //in case project type not found
-                projects.put(path, new RegisteredProject(projectFolder, false, false, projectTypeRegistry, new Problem(13, e.getMessage())));
-            } catch (ValueStorageException e) {
-                //in case can't calculate Attributes
-                projects.put(path, new RegisteredProject(projectFolder, false, false, projectTypeRegistry, new Problem(14, e.getMessage())));
-            }
+
+            putProject(projectConfig, projectFolder, false, false);
+
         }
 
         initUnconfiguredFolders();

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectTypes.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectTypes.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.project.server;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.project.type.Attribute;
+import org.eclipse.che.api.project.server.RegisteredProject.Problem;
 import org.eclipse.che.api.project.server.type.ProjectTypeConstraintException;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
@@ -20,8 +21,10 @@ import org.eclipse.che.api.project.server.type.ValueStorageException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author gazarenkov
@@ -30,15 +33,16 @@ public class ProjectTypes {
 
     private final String                      projectPath;
     private final ProjectTypeRegistry         projectTypeRegistry;
-    private final ProjectTypeDef              primary;
+    private ProjectTypeDef                    primary;
     private final Map<String, ProjectTypeDef> mixins;
     private final Map<String, ProjectTypeDef> all;
     private final Map<String, Attribute>      attributeDefs;
 
-    public ProjectTypes(String projectPath,
+    ProjectTypes(String projectPath,
                         String type,
                         List<String> mixinTypes,
-                        ProjectTypeRegistry projectTypeRegistry) throws ProjectTypeConstraintException, NotFoundException {
+                        ProjectTypeRegistry projectTypeRegistry,
+                        List<Problem>      problems) throws ProjectTypeConstraintException, NotFoundException {
         mixins = new HashMap<>();
         all = new HashMap<>();
         attributeDefs = new HashMap<>();
@@ -46,16 +50,28 @@ public class ProjectTypes {
         this.projectTypeRegistry = projectTypeRegistry;
         this.projectPath = projectPath;
 
+        ProjectTypeDef tmpPrimary;
         if (type == null) {
-            throw new ProjectTypeConstraintException("No primary type defined for " + projectPath);
+
+            problems.add(new Problem(12, "No primary type defined for " + projectPath + " Base Project Type assigned."));
+            tmpPrimary = ProjectTypeRegistry.BASE_TYPE;
+
+        } else {
+
+            try {
+                tmpPrimary = projectTypeRegistry.getProjectType(type);
+            } catch (NotFoundException e) {
+                problems.add(new Problem(12, "Primary type " + type + " defined for " + projectPath + " is not registered. Base Project Type assigned."));
+                tmpPrimary = ProjectTypeRegistry.BASE_TYPE;
+            }
+
+            if (!tmpPrimary.isPrimaryable()) {
+                problems.add(new Problem(12, "Project type " + tmpPrimary.getId() + " is not allowable to be primary type. Base Project Type assigned."));
+                tmpPrimary = ProjectTypeRegistry.BASE_TYPE;
+            }
         }
 
-        primary = projectTypeRegistry.getProjectType(type);
-
-        if (!primary.isPrimaryable()) {
-            throw new ProjectTypeConstraintException("Project type " + primary.getId() + " is not allowable to be primary type");
-        }
-
+        this.primary = tmpPrimary;
         all.put(primary.getId(), primary);
 
         List<String> mixinsFromConfig = mixinTypes;
@@ -73,10 +89,19 @@ public class ProjectTypes {
                 continue;
             }
 
-            final ProjectTypeDef mixin = projectTypeRegistry.getProjectType(mixinFromConfig);
-            if (!mixin.isMixable()) {
-                throw new ProjectTypeConstraintException("Project type " + mixin + " is not allowable to be mixin. It not mixable");
+            final ProjectTypeDef mixin;
+            try {
+                mixin = projectTypeRegistry.getProjectType(mixinFromConfig);
+            } catch (NotFoundException e) {
+                problems.add(new Problem(12, "Project type " + mixinFromConfig + " is not registered. Skipped."));
+                continue;
             }
+
+            if (!mixin.isMixable()) {
+                problems.add(new Problem(12, "Project type " + mixin + " is not allowable to be mixin. It not mixable. Skipped."));
+                continue;
+            }
+
             if (!mixin.isPersisted()) {
                 continue;
             }
@@ -84,11 +109,12 @@ public class ProjectTypes {
             // detect duplicated attributes
             for (Attribute attr : mixin.getAttributes()) {
                 if (attributeDefs.containsKey(attr.getName())) {
-                    throw new ProjectTypeConstraintException(
-                            "Attribute name conflict. Duplicated attributes detected " + projectPath +
-                            " Attribute " + attr.getName() + " declared in " + mixin.getId() + " already declared in " +
-                            attributeDefs.get(attr.getName()).getProjectType()
-                    );
+
+                    problems.add(new Problem(13, "Attribute name conflict. Duplicated attributes detected " + projectPath +
+                                                 " Attribute " + attr.getName() + " declared in " + mixin.getId() + " already declared in " +
+                                                 attributeDefs.get(attr.getName()).getProjectType()+" Skipped."));
+                    continue;
+
                 }
 
                 attributeDefs.put(attr.getName(), attr);
@@ -114,6 +140,50 @@ public class ProjectTypes {
 
     public Map<String, ProjectTypeDef> getAll() {
         return all;
+    }
+
+    /**
+     * Reset project types and atrributes after initialization
+     * in case when some attributes are not valid
+     * (for instance required attributes are not initialized)
+     *
+     * @param attributesToDel - invalid attributes
+     */
+    void reset(Set<Attribute> attributesToDel) {
+
+        Set<String> ptsToDel = new HashSet<>();
+        for(Attribute attr : attributesToDel) {
+
+            ptsToDel.add(attr.getProjectType());
+        }
+
+        Set <String>attrNamesToDel = new HashSet<>();
+        for(String pt : ptsToDel) {
+
+            ProjectTypeDef typeDef = all.get(pt);
+            for(Attribute attrDef: typeDef.getAttributes()) {
+                attrNamesToDel.add(attrDef.getName());
+            }
+        }
+
+        // remove project types
+        for(String typeId : ptsToDel) {
+
+            this.all.remove(typeId);
+            if(this.primary.getId().equals(typeId)) {
+                this.primary = ProjectTypeRegistry.BASE_TYPE;
+                this.all.put(ProjectTypeRegistry.BASE_TYPE.getId(), ProjectTypeRegistry.BASE_TYPE);
+            } else {
+                mixins.remove(typeId);
+            }
+        }
+
+        // remove attributes
+        for(String attr : attrNamesToDel) {
+            this.attributeDefs.remove(attr);
+        }
+
+
     }
 
     void addTransient(FolderEntry projectFolder) throws ServerException,

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectTypes.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectTypes.java
@@ -52,12 +52,9 @@ public class ProjectTypes {
 
         ProjectTypeDef tmpPrimary;
         if (type == null) {
-
             problems.add(new Problem(12, "No primary type defined for " + projectPath + " Base Project Type assigned."));
             tmpPrimary = ProjectTypeRegistry.BASE_TYPE;
-
         } else {
-
             try {
                 tmpPrimary = projectTypeRegistry.getProjectType(type);
             } catch (NotFoundException e) {
@@ -114,9 +111,7 @@ public class ProjectTypes {
                                                  " Attribute " + attr.getName() + " declared in " + mixin.getId() + " already declared in " +
                                                  attributeDefs.get(attr.getName()).getProjectType()+" Skipped."));
                     continue;
-
                 }
-
                 attributeDefs.put(attr.getName(), attr);
             }
 
@@ -153,13 +148,11 @@ public class ProjectTypes {
 
         Set<String> ptsToDel = new HashSet<>();
         for(Attribute attr : attributesToDel) {
-
             ptsToDel.add(attr.getProjectType());
         }
 
         Set <String>attrNamesToDel = new HashSet<>();
         for(String pt : ptsToDel) {
-
             ProjectTypeDef typeDef = all.get(pt);
             for(Attribute attrDef: typeDef.getAttributes()) {
                 attrNamesToDel.add(attrDef.getName());
@@ -168,7 +161,6 @@ public class ProjectTypes {
 
         // remove project types
         for(String typeId : ptsToDel) {
-
             this.all.remove(typeId);
             if(this.primary.getId().equals(typeId)) {
                 this.primary = ProjectTypeRegistry.BASE_TYPE;
@@ -182,8 +174,6 @@ public class ProjectTypes {
         for(String attr : attrNamesToDel) {
             this.attributeDefs.remove(attr);
         }
-
-
     }
 
     void addTransient(FolderEntry projectFolder) throws ServerException,

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/RegisteredProject.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/RegisteredProject.java
@@ -75,7 +75,6 @@ public class RegisteredProject implements ProjectConfig {
         problems = new ArrayList<>();
         attributes = new HashMap<>();
 
-
         Path path;
         if (folder != null) {
             path = folder.getPath();
@@ -86,7 +85,7 @@ public class RegisteredProject implements ProjectConfig {
         }
 
         this.folder = folder;
-        this.config = (config == null) ? new NewProjectConfig(/*folder.getPath()*/ path) : config;
+        this.config = (config == null) ? new NewProjectConfig(path) : config;
         this.updated = updated;
         this.detected = detected;
 
@@ -239,13 +238,12 @@ public class RegisteredProject implements ProjectConfig {
      * @return list of Problems as a String
      */
     public String getProblemsStr() {
-        String problemsStr = "";
-        int i = 1;
+        StringBuilder builder = new StringBuilder();
+        int i = 0;
         for( RegisteredProject.Problem prb : problems ) {
-            problemsStr += "["+i+"] : " + prb.message + "\n";
-            i++;
+            builder.append("[").append(i++).append("] : ").append(prb.message).append("\n");
         }
-        return problemsStr;
+        return builder.toString();
     }
 
     /**

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/RegisteredProject.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/RegisteredProject.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.project.server;
 
-import com.google.common.collect.ImmutableList;
-
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.project.ProjectConfig;
@@ -19,18 +17,20 @@ import org.eclipse.che.api.core.model.project.SourceStorage;
 import org.eclipse.che.api.core.model.project.type.Attribute;
 import org.eclipse.che.api.core.model.project.type.Value;
 import org.eclipse.che.api.project.server.type.AttributeValue;
-import org.eclipse.che.api.project.server.type.BaseProjectType;
 import org.eclipse.che.api.project.server.type.ProjectTypeConstraintException;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
 import org.eclipse.che.api.project.server.type.ValueProvider;
 import org.eclipse.che.api.project.server.type.ValueStorageException;
 import org.eclipse.che.api.project.server.type.Variable;
+import org.eclipse.che.api.vfs.Path;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -75,8 +75,18 @@ public class RegisteredProject implements ProjectConfig {
         problems = new ArrayList<>();
         attributes = new HashMap<>();
 
+
+        Path path;
+        if (folder != null) {
+            path = folder.getPath();
+        } else if (config != null) {
+            path = Path.of(config.getPath());
+        } else {
+            throw new ServerException("Invalid Project Configuration. Path undefined.");
+        }
+
         this.folder = folder;
-        this.config = (config == null) ? new NewProjectConfig(folder.getPath()) : config;
+        this.config = (config == null) ? new NewProjectConfig(/*folder.getPath()*/ path) : config;
         this.updated = updated;
         this.detected = detected;
 
@@ -89,45 +99,13 @@ public class RegisteredProject implements ProjectConfig {
         }
 
         // 1. init project types
-        this.types = new ProjectTypes(this.config.getPath(), this.config.getType(), this.config.getMixins(), projectTypeRegistry);
+        this.types = new ProjectTypes(this.config.getPath(), this.config.getType(), this.config.getMixins(), projectTypeRegistry, problems);
 
         // 2. init transient (implicit, like git) project types.
         types.addTransient(folder);
 
         // 3. initialize attributes
         initAttributes();
-    }
-
-
-    /**
-     * Either root folder in this case Project not configure well.
-     * Use it if can't initialize project correct, project type will be BLANK
-     *
-     * @param folder
-     *         root local folder or null
-     * @param updated
-     *         if this object was updated, i.e. no more synchronized with workspace master
-     * @param detected
-     *         if this project was detected, initialized when "parent" project initialized
-     * @param problem
-     *         project problem
-     */
-    RegisteredProject(FolderEntry folder,
-                      boolean updated,
-                      boolean detected,
-                      ProjectTypeRegistry projectTypeRegistry,
-                      Problem problem) throws NotFoundException,
-                                                                      ProjectTypeConstraintException,
-                                                                      ServerException,
-                                                                      ValueStorageException {
-        attributes = new HashMap<>();
-
-        this.folder = folder;
-        this.config = new NewProjectConfig(folder.getPath());
-        this.updated = updated;
-        this.detected = detected;
-        types = new ProjectTypes(folder.getPath().toString(), BaseProjectType.ID, null, projectTypeRegistry);
-        problems = ImmutableList.of(problem);
     }
 
 
@@ -140,6 +118,9 @@ public class RegisteredProject implements ProjectConfig {
      * @throws NotFoundException
      */
     private void initAttributes() throws ValueStorageException, ProjectTypeConstraintException, ServerException, NotFoundException {
+
+        Set<Attribute> invalidAttributes = new HashSet<>();
+
         // we take only defined attributes, others ignored
         for (Map.Entry<String, Attribute> entry : types.getAttributeDefs().entrySet()) {
             final Attribute definition = entry.getValue();
@@ -174,7 +155,9 @@ public class RegisteredProject implements ProjectConfig {
                 }
 
                 if (value.isEmpty() && variable.isRequired()) {
-                    throw new ProjectTypeConstraintException("Value for required attribute is not initialized " + variable.getId());
+                    this.problems.add(new Problem(13, "Value for required attribute is not initialized " + variable.getId()));
+                    invalidAttributes.add(variable);
+                    //throw new ProjectTypeConstraintException("Value for required attribute is not initialized " + variable.getId());
                 }
 
                 if (!value.isEmpty()) {
@@ -182,6 +165,9 @@ public class RegisteredProject implements ProjectConfig {
                 }
             }
         }
+
+        types.reset(invalidAttributes);
+
     }
 
     /**
@@ -247,6 +233,19 @@ public class RegisteredProject implements ProjectConfig {
      */
     public List<Problem> getProblems() {
         return problems;
+    }
+
+    /**
+     * @return list of Problems as a String
+     */
+    public String getProblemsStr() {
+        String problemsStr = "";
+        int i = 1;
+        for( RegisteredProject.Problem prb : problems ) {
+            problemsStr += "["+i+"] : " + prb.message + "\n";
+            i++;
+        }
+        return problemsStr;
     }
 
     /**

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/WorkspaceHolder.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/WorkspaceHolder.java
@@ -36,7 +36,7 @@ public class WorkspaceHolder extends WorkspaceProjectsSyncer {
 
     private String apiEndpoint;
 
-    private final String workspaceId;
+    private String workspaceId;
 
     private HttpJsonRequestFactory httpJsonRequestFactory;
 
@@ -61,12 +61,10 @@ public class WorkspaceHolder extends WorkspaceProjectsSyncer {
     }
 
 
-
-
     @Override
     public List<? extends ProjectConfig> getProjects() throws ServerException {
 
-        return  workspaceDto(workspaceId).getConfig().getProjects();
+        return workspaceDto(workspaceId).getConfig().getProjects();
     }
 
     @Override
@@ -108,7 +106,7 @@ public class WorkspaceHolder extends WorkspaceProjectsSyncer {
         final String href = UriBuilder.fromUri(apiEndpoint)
                                       .path(WorkspaceService.class)
                                       .path(WorkspaceService.class, "updateProject")
-                                      .build(new String[] {workspaceId, project.getPath()}, false).toString();
+                                      .build(new String[]{workspaceId, project.getPath()}, false).toString();
         try {
             httpJsonRequestFactory.fromUrl(href).usePutMethod().setBody(asDto(project)).request();
         } catch (IOException | ApiException e) {
@@ -120,10 +118,10 @@ public class WorkspaceHolder extends WorkspaceProjectsSyncer {
 
     protected void removeProject(ProjectConfig project) throws ServerException {
 
-         final String href = UriBuilder.fromUri(apiEndpoint)
+        final String href = UriBuilder.fromUri(apiEndpoint)
                                       .path(WorkspaceService.class)
                                       .path(WorkspaceService.class, "deleteProject")
-                                      .build(new String[] {workspaceId, project.getPath()}, false).toString();
+                                      .build(new String[]{workspaceId, project.getPath()}, false).toString();
         try {
             httpJsonRequestFactory.fromUrl(href).useDeleteMethod().request();
         } catch (IOException | ApiException e) {
@@ -137,6 +135,7 @@ public class WorkspaceHolder extends WorkspaceProjectsSyncer {
      * @throws ServerException
      */
     private WorkspaceDto workspaceDto(String wsId) throws ServerException {
+
         final String href = UriBuilder.fromUri(apiEndpoint)
                                       .path(WorkspaceService.class).path(WorkspaceService.class, "getByKey")
                                       .build(wsId).toString();

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerReadTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerReadTest.java
@@ -116,9 +116,12 @@ public class ProjectManagerReadTest extends WsAgentTestBase {
 
         assertEquals(6, projectRegistry.getProjects().size());
         assertEquals(1, projectRegistry.getProject("/foo").getProblems().size());
-        assertEquals(13, projectRegistry.getProject("/foo").getProblems().get(0).code);
-        assertEquals(1, projectRegistry.getProject("/bar").getProblems().size());
-        assertEquals(12, projectRegistry.getProject("/bar").getProblems().get(0).code);
+        assertEquals(12, projectRegistry.getProject("/foo").getProblems().get(0).code);
+
+        //Value for required attribute is not initialized pt3:pt2-var2
+        //Value for required attribute is not initialized pt3:pt2-provided1
+        assertEquals(2, projectRegistry.getProject("/bar").getProblems().size());
+        assertEquals(13, projectRegistry.getProject("/bar").getProblems().get(0).code);
     }
 
 

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerWriteTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerWriteTest.java
@@ -22,7 +22,6 @@ import org.eclipse.che.api.core.util.ValueHolder;
 import org.eclipse.che.api.project.server.importer.ProjectImporter;
 import org.eclipse.che.api.project.server.type.AttributeValue;
 import org.eclipse.che.api.project.server.type.BaseProjectType;
-import org.eclipse.che.api.project.server.type.ProjectTypeConstraintException;
 import org.eclipse.che.api.project.server.type.Variable;
 import org.eclipse.che.api.vfs.Path;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
@@ -106,7 +105,7 @@ public class ProjectManagerWriteTest extends WsAgentTestBase {
         try {
             pm.createProject(pc, null);
             fail("ProjectTypeConstraintException should be thrown : pt-var2 attribute is mandatory");
-        } catch (ProjectTypeConstraintException e) {
+        } catch (ServerException e) {
             //
         }
 
@@ -138,14 +137,14 @@ public class ProjectManagerWriteTest extends WsAgentTestBase {
     public void testFailCreateProjectWithNoRequiredGenerator() throws Exception {
 
         // SPECS:
-        // If there are no respective CreateProjectHandler ProjectTypeConstraintException will be thrown
+        // If there are no respective CreateProjectHandler ServerException will be thrown
 
         ProjectConfig pc = new NewProjectConfig("/testFailCreateProjectWithNoRequiredGenerator", "pt4", null, "name", "descr", null, null);
 
         try {
             pm.createProject(pc, null);
             fail("ProjectTypeConstraintException: Value for required attribute is not initialized pt4:pt4-provided1");
-        } catch (ProjectTypeConstraintException e) {
+        } catch (ServerException e) {
         }
 
 
@@ -186,7 +185,7 @@ public class ProjectManagerWriteTest extends WsAgentTestBase {
         try {
             pm.createProject(pc, null);
             fail("NotFoundException: Project Type not found: invalid");
-        } catch (NotFoundException e) {
+        } catch (ServerException e) {
         }
 
         assertNull(projectRegistry.getProject("/testInvalidPTProjectCreateFailed"));
@@ -202,7 +201,7 @@ public class ProjectManagerWriteTest extends WsAgentTestBase {
         try {
             pm.createProject(pc, null);
             fail("NotFoundException: Project Type not found: invalid");
-        } catch (NotFoundException e) {
+        } catch (ServerException e) {
         }
 
 
@@ -223,7 +222,7 @@ public class ProjectManagerWriteTest extends WsAgentTestBase {
         try {
             pm.createProject(pc, null);
             fail("ProjectTypeConstraintException: Attribute name conflict. Duplicated attributes detected /testConflictAttributesProjectCreateFailed Attribute pt2-const1 declared in m2 already declared in pt2");
-        } catch (ProjectTypeConstraintException e) {
+        } catch (ServerException e) {
         }
 
         //assertNull(projectRegistry.folder("/testConflictAttributesProjectCreateFailed"));
@@ -317,7 +316,7 @@ public class ProjectManagerWriteTest extends WsAgentTestBase {
         try {
             pm.updateProject(pc);
             fail("ProjectTypeConstraintException: Value for required attribute is not initialized pt3:pt2-provided1 ");
-        } catch (ProjectTypeConstraintException e) {
+        } catch (ServerException e) {
         }
 
 

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -82,6 +82,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -411,7 +412,7 @@ public class ProjectServiceTest {
                     throws ForbiddenException, ConflictException, ServerException {
                 baseFolder.createFolder("a");
                 baseFolder.createFolder("b");
-                baseFolder.createFile("test.txt", "test".getBytes());
+                baseFolder.createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
             }
 
             @Override
@@ -448,7 +449,7 @@ public class ProjectServiceTest {
                                                       "http://localhost:8080/api/project",
                                                       "http://localhost:8080/api",
                                                       headers,
-                                                      DtoFactory.getInstance().toJson(newProjectConfig).getBytes(),
+                                                      DtoFactory.getInstance().toJson(newProjectConfig).getBytes(Charset.defaultCharset()),
                                                       null);
 
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -511,7 +512,7 @@ public class ProjectServiceTest {
                                                       "http://localhost:8080/api/project/testUpdateProject",
                                                       "http://localhost:8080/api",
                                                       headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(),
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()),
                                                       null);
 
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -553,7 +554,7 @@ public class ProjectServiceTest {
                                                       "http://localhost:8080/api/project/not_project",
                                                       "http://localhost:8080/api",
                                                       headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(),
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()),
                                                       null);
 
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -579,7 +580,7 @@ public class ProjectServiceTest {
                                                       "http://localhost:8080/api/project/my_project_invalid",
                                                       "http://localhost:8080/api",
                                                       headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(),
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()),
                                                       null);
         assertEquals(response.getStatus(), 404);
     }
@@ -611,9 +612,6 @@ public class ProjectServiceTest {
                 return (List <String>)singletonList("checked");
             }
 
-//            @Override
-//            public void setValues(String attributeName, List<String> value) {
-//            }
         };
 
         ProjectTypeDef pt = new ProjectTypeDef("testEstimateProjectPT", "my testEstimateProject type", true, false) {
@@ -713,7 +711,7 @@ public class ProjectServiceTest {
         ZipOutputStream zipOut = new ZipOutputStream(bout);
         zipOut.putNextEntry(new ZipEntry("folder1/"));
         zipOut.putNextEntry(new ZipEntry("folder1/file1.txt"));
-        zipOut.write("to be or not to be".getBytes());
+        zipOut.write("to be or not to be".getBytes(Charset.defaultCharset()));
         zipOut.close();
         final InputStream zip = new ByteArrayInputStream(bout.toByteArray());
         final String importType = "_123_";
@@ -736,7 +734,7 @@ public class ProjectServiceTest {
                       "            \"type\": \"%s\"\n" +
                       "}";
 
-        byte[] b = String.format(json, importType).getBytes();
+        byte[] b = String.format(json, importType).getBytes(Charset.defaultCharset());
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/import/new_project",
                                                       "http://localhost:8080/api", headers, b, null);
@@ -801,7 +799,7 @@ public class ProjectServiceTest {
                                                       "http://localhost:8080/api/project/file/my_project?name=test.txt",
                                                       "http://localhost:8080/api",
                                                       null,
-                                                      myContent.getBytes(),
+                                                      myContent.getBytes(Charset.defaultCharset()),
                                                       null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         ItemReference fileItem = (ItemReference)response.getEntity();
@@ -823,7 +821,7 @@ public class ProjectServiceTest {
     @Test
     public void testGetFileContent() throws Exception {
         String myContent = "to be or not to be";
-        pm.getProject("my_project").getBaseFolder().createFile("test.txt", myContent.getBytes());
+        pm.getProject("my_project").getBaseFolder().createFile("test.txt", myContent.getBytes(Charset.defaultCharset()));
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/file/my_project/test.txt",
@@ -836,10 +834,10 @@ public class ProjectServiceTest {
     @Test
     public void testUpdateFileContent() throws Exception {
         String myContent = "<test>hello</test>";
-        pm.getProject("my_project").getBaseFolder().createFile("test.xml", "to be or not to be".getBytes());
+        pm.getProject("my_project").getBaseFolder().createFile("test.xml", "to be or not to be".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(PUT,
                                                       "http://localhost:8080/api/project/file/my_project/test.xml",
-                                                      "http://localhost:8080/api", null, myContent.getBytes(), null);
+                                                      "http://localhost:8080/api", null, myContent.getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         VirtualFileEntry file = pm.getProject("my_project").getBaseFolder().getChild("test.xml");
         Assert.assertTrue(file.isFile());
@@ -894,7 +892,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testDeleteFile() throws Exception {
-        pm.getProject("my_project").getBaseFolder().createFile("test.txt", "to be or not to be".getBytes());
+        pm.getProject("my_project").getBaseFolder().createFile("test.txt", "to be or not to be".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(DELETE,
                                                       "http://localhost:8080/api/project/my_project/test.txt",
                                                       "http://localhost:8080/api", null, null, null);
@@ -993,7 +991,7 @@ public class ProjectServiceTest {
     public void testCopyFile() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b/test.txt?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1008,7 +1006,7 @@ public class ProjectServiceTest {
     public void testCopyFileWithRename() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put(CONTENT_TYPE, singletonList(APPLICATION_JSON));
@@ -1020,7 +1018,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b/test.txt?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create("http://localhost:8080/api/project/file/my_project/a/b/c/copyOfTest.txt"));
@@ -1041,8 +1039,8 @@ public class ProjectServiceTest {
         String originContent = "to be or not no be";
         String overwrittenContent = "that is the question";
 
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes());
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwrittenContent.getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(Charset.defaultCharset()));
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwrittenContent.getBytes(Charset.defaultCharset()));
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put(CONTENT_TYPE, singletonList(APPLICATION_JSON));
@@ -1054,7 +1052,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b/" + originFileName + "?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create("http://localhost:8080/api/project/file/my_project/a/b/c/" + destinationFileName));
@@ -1083,7 +1081,7 @@ public class ProjectServiceTest {
     public void testCopyFolder() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1098,7 +1096,7 @@ public class ProjectServiceTest {
     public void testCopyFolderWithRename() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
 
         // new name for folder
         final String renamedFolder = "renamedFolder";
@@ -1113,7 +1111,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1138,8 +1136,8 @@ public class ProjectServiceTest {
         // new name for folder
         final String renamedFolder = "renamedFolder";
 
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes());
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwrittenContent.getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(Charset.defaultCharset()));
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwrittenContent.getBytes(Charset.defaultCharset()));
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put(CONTENT_TYPE, singletonList(APPLICATION_JSON));
@@ -1151,7 +1149,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1166,7 +1164,7 @@ public class ProjectServiceTest {
     public void testMoveFile() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/move/my_project/a/b/test.txt?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1181,7 +1179,7 @@ public class ProjectServiceTest {
     public void testMoveFileWithRename() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
 
         // name for file after move
         final String destinationName = "copyOfTestForMove.txt";
@@ -1196,7 +1194,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/move/my_project/a/b/test.txt?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1209,7 +1207,7 @@ public class ProjectServiceTest {
     public void testRenameFile() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
 
         // name for file after move
         final String destinationName = "copyOfTestForMove.txt";
@@ -1224,7 +1222,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/move/my_project/a/b/test.txt",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1246,8 +1244,8 @@ public class ProjectServiceTest {
         String originContent = "to be or not no be";
         String overwrittenContent = "that is the question";
 
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes());
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwrittenContent.getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(Charset.defaultCharset()));
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwrittenContent.getBytes(Charset.defaultCharset()));
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put(CONTENT_TYPE, singletonList(APPLICATION_JSON));
@@ -1260,7 +1258,7 @@ public class ProjectServiceTest {
                                                       "http://localhost:8080/api/project/move/my_project/a/b/" + originFileName +
                                                       "?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create("http://localhost:8080/api/project/file/my_project/a/b/c/" + destinationFileName));
@@ -1288,7 +1286,7 @@ public class ProjectServiceTest {
     public void testMoveFolder() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/move/my_project/a/b/c?to=/my_project/a",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1304,7 +1302,7 @@ public class ProjectServiceTest {
     public void testMoveFolderWithRename() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
 
         // new name for folder
         final String renamedFolder = "renamedFolder";
@@ -1319,7 +1317,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1331,7 +1329,7 @@ public class ProjectServiceTest {
     public void testRenameFolder() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("a/b");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(Charset.defaultCharset()));
 
         // new name for folder
         final String renamedFolder = "renamedFolder";
@@ -1346,7 +1344,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/move/my_project/a/b",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1370,8 +1368,8 @@ public class ProjectServiceTest {
         // new name for folder
         final String renamedFolder = "renamedFolder";
 
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes());
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes());
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(Charset.defaultCharset()));
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(Charset.defaultCharset()));
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put(CONTENT_TYPE, singletonList(APPLICATION_JSON));
@@ -1383,7 +1381,7 @@ public class ProjectServiceTest {
         ContainerResponse response = launcher.service(POST,
                                                       "http://localhost:8080/api/project/copy/my_project/a/b?to=/my_project/a/b/c",
                                                       "http://localhost:8080/api", headers,
-                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+                                                      DtoFactory.getInstance().toJson(descriptor).getBytes(Charset.defaultCharset()), null);
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         assertEquals(response.getHttpHeaders().getFirst("Location"),
                      URI.create(
@@ -1400,7 +1398,7 @@ public class ProjectServiceTest {
         ZipOutputStream zipOut = new ZipOutputStream(bout);
         zipOut.putNextEntry(new ZipEntry("folder1/"));
         zipOut.putNextEntry(new ZipEntry("folder1/file1.txt"));
-        zipOut.write("to be or not to be".getBytes());
+        zipOut.write("to be or not to be".getBytes(Charset.defaultCharset()));
         zipOut.close();
         byte[] zip = bout.toByteArray();
         Map<String, List<String>> headers = new HashMap<>();
@@ -1424,7 +1422,7 @@ public class ProjectServiceTest {
         zipOut.putNextEntry(new ZipEntry("folder1/"));
         zipOut.putNextEntry(new ZipEntry("folder1/folder2/"));
         zipOut.putNextEntry(new ZipEntry("folder1/folder2/file1.txt"));
-        zipOut.write("to be or not to be".getBytes());
+        zipOut.write("to be or not to be".getBytes(Charset.defaultCharset()));
         zipOut.close();
         byte[] zip = bout.toByteArray();
         Map<String, List<String>> headers = new HashMap<>();
@@ -1443,7 +1441,7 @@ public class ProjectServiceTest {
     @Test
     public void testExportZip() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes());
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/export/my_project",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1457,7 +1455,7 @@ public class ProjectServiceTest {
         RegisteredProject myProject = pm.getProject("my_project");
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b");
-        a.createFile("test.txt", "test".getBytes());
+        a.createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/children/my_project/a",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1476,7 +1474,7 @@ public class ProjectServiceTest {
         RegisteredProject myProject = pm.getProject("my_project");
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b");
-        a.createFile("test.txt", "test".getBytes());
+        a.createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/item/my_project/a/b",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1497,7 +1495,7 @@ public class ProjectServiceTest {
     @Test
     public void testGetItemWithoutParentProject() throws Exception {
         FolderEntry a = pm.getProjectsRoot().createFolder("a");
-        a.createFile("test.txt", "test".getBytes());
+        a.createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/item/a/test.txt",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1521,7 +1519,7 @@ public class ProjectServiceTest {
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
         a.createFolder("x/y");
-        a.createFile("test.txt", "test".getBytes());
+        a.createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/tree/my_project/a",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1550,7 +1548,7 @@ public class ProjectServiceTest {
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
         a.createFolder("x/y");
-        a.createFile("test.txt", "test".getBytes());
+        a.createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/tree/my_project/a?depth=2",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1583,7 +1581,7 @@ public class ProjectServiceTest {
         RegisteredProject myProject = pm.getProject("my_project");
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
-        a.createFolder("x").createFile("test.txt", "test".getBytes());
+        a.createFolder("x").createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/tree/my_project/a?depth=100&includeFiles=true",
                                                       "http://localhost:8080/api", null, null, null);
@@ -1653,9 +1651,9 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByName() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes());
-        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes());
-        myProject.getBaseFolder().createFolder("c").createFile("exclude", "test".getBytes());
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("c").createFile("exclude", "test".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/search/my_project?name=test.txt",
@@ -1675,9 +1673,9 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByText() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes());
-        myProject.getBaseFolder().createFolder("x/y").createFile("__test.txt", "searchhit".getBytes());
-        myProject.getBaseFolder().createFolder("c").createFile("_test", "searchhit".getBytes());
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("x/y").createFile("__test.txt", "searchhit".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("c").createFile("_test", "searchhit".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/search/my_project?text=searchhit",
@@ -1701,9 +1699,9 @@ public class ProjectServiceTest {
                                "to" + URL_ENCODED_SPACE +
                                "be" + URL_ENCODED_QUOTES;
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "Pay attention! To be or to be that is the question".getBytes());
-        myProject.getBaseFolder().createFolder("c").createFile("_test", "Pay attention! To be or to not be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "Pay attention! To be or to be that is the question".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("c").createFile("_test", "Pay attention! To be or to not be that is the question".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response =
                 launcher.service(GET, "http://localhost:8080/api/project/search/my_project" + queryToSearch,
@@ -1725,11 +1723,11 @@ public class ProjectServiceTest {
                                "the" + URL_ENCODED_QUOTES + URL_ENCODED_SPACE + AND_OPERATOR + URL_ENCODED_SPACE +
                                "question" + URL_ENCODED_ASTERISK;
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes(Charset.defaultCharset()));
         myProject.getBaseFolder().createFolder("a/b")
-                 .createFile("containsSearchTextAlso.txt", "Pay attention! To be or not to be that is the questionS".getBytes());
+                 .createFile("containsSearchTextAlso.txt", "Pay attention! To be or not to be that is the questionS".getBytes(Charset.defaultCharset()));
         myProject.getBaseFolder().createFolder("c")
-                 .createFile("notContainsSearchText", "Pay attention! To be or to not be that is the questEon".getBytes());
+                 .createFile("notContainsSearchText", "Pay attention! To be or to not be that is the questEon".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response =
                 launcher.service(GET,"http://localhost:8080/api/project/search/my_project" + queryToSearch,
@@ -1750,11 +1748,11 @@ public class ProjectServiceTest {
         String queryToSearch = "?text=" +
                                "question" + URL_ENCODED_ASTERISK;
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes(Charset.defaultCharset()));
         myProject.getBaseFolder().createFolder("a/b")
-                 .createFile("containsSearchTextAlso.txt", "Pay attention! To be or not to be that is the questionS".getBytes());
+                 .createFile("containsSearchTextAlso.txt", "Pay attention! To be or not to be that is the questionS".getBytes(Charset.defaultCharset()));
         myProject.getBaseFolder().createFolder("c")
-                 .createFile("notContainsSearchText", "Pay attention! To be or to not be that is the questEon".getBytes());
+                 .createFile("notContainsSearchText", "Pay attention! To be or to not be that is the questEon".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response =
                 launcher.service(GET, "http://localhost:8080/api/project/search/my_project" + queryToSearch,
@@ -1776,10 +1774,10 @@ public class ProjectServiceTest {
                                "question" + URL_ENCODED_SPACE + NOT_OPERATOR + URL_ENCODED_SPACE + URL_ENCODED_QUOTES +
                                "attention!" + URL_ENCODED_QUOTES;
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes());
+        myProject.getBaseFolder().createFolder("x/y").createFile("containsSearchText.txt", "To be or not to be that is the question".getBytes(Charset.defaultCharset()));
         myProject.getBaseFolder().createFolder("b")
-                 .createFile("notContainsSearchText", "Pay attention! To be or not to be that is the question".getBytes());
-        myProject.getBaseFolder().createFolder("c").createFile("alsoNotContainsSearchText", "To be or to not be that is the ...".getBytes());
+                 .createFile("notContainsSearchText", "Pay attention! To be or not to be that is the question".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("c").createFile("alsoNotContainsSearchText", "To be or to not be that is the ...".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response =
                 launcher.service(GET, "http://localhost:8080/api/project/search/my_project" + queryToSearch,
@@ -1808,7 +1806,7 @@ public class ProjectServiceTest {
                                URL_ENCODED_BACKSLASH + ':' + "projectName=test";
         RegisteredProject myProject = pm.getProject("my_project");
         myProject.getBaseFolder().createFolder("x/y")
-                 .createFile("test.txt", "http://localhost:8080/ide/dev6?action=createProject:projectName=test".getBytes());
+                 .createFile("test.txt", "http://localhost:8080/ide/dev6?action=createProject:projectName=test".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response = launcher.service(GET, "http://localhost:8080/api/project/search/my_project" + queryToSearch,
                                                       "http://localhost:8080/api", null, null, null);
@@ -1824,9 +1822,9 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByNameAndText() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "test".getBytes());
-        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes());
-        myProject.getBaseFolder().createFolder("c").createFile("test", "test".getBytes());
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("c").createFile("test", "test".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/search/my_project?text=test&name=test.txt",
@@ -1848,9 +1846,9 @@ public class ProjectServiceTest {
     @Test
     public void testSearchFromWSRoot() throws Exception {
         RegisteredProject myProject = pm.getProject("my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test", "test".getBytes());
-        myProject.getBaseFolder().createFolder("x/y").createFile("test", "test".getBytes());
-        myProject.getBaseFolder().createFolder("c").createFile("test.txt", "test".getBytes());
+        myProject.getBaseFolder().createFolder("a/b").createFile("test", "test".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("x/y").createFile("test", "test".getBytes(Charset.defaultCharset()));
+        myProject.getBaseFolder().createFolder("c").createFile("test.txt", "test".getBytes(Charset.defaultCharset()));
 
         ContainerResponse response = launcher.service(GET,
                                                       "http://localhost:8080/api/project/search/?text=test&name=test.txt",


### PR DESCRIPTION
@vparfonov @azatsarynnyy  please review. 
### What does this PR do?

Improves solving the PT related problems with importing Project. Such as: 
- The System (Che or Codenvy) does not contain Project Types described in serialized Project configuration. 
-  There are non-conformance between PT descriptions so serialized Project configuration  does not contain required (as for PTs registered in the System) Attributes
### What issues does this PR fix or reference?

none
### Previous behavior

Initially import of such data broke Workspace creation.
After it was some improved so ANY problem caused adding Problem record (only one) with description replacing primary PT with Blank, removing all the mixins and attributes.
### New behavior

In a case of problematic import:
- Added as many Problem record as needed (all the problems are covered)
- In a case of problem with primary PT replaces it with Blank and removes only Attributes belonged to initial PT
- In a case of problem with mixin PT removes only it and removes only Attributes belonged to initial mixin PT

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

…rkspace failing
