### PR TITLE
Provide full project configuration to CreateProjectHandler

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -27,7 +27,6 @@ import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.importer.ProjectImportOutputWSLineConsumer;
 import org.eclipse.che.api.project.server.importer.ProjectImporter;
 import org.eclipse.che.api.project.server.importer.ProjectImporterRegistry;
-import org.eclipse.che.api.project.server.type.AttributeValue;
 import org.eclipse.che.api.project.server.type.BaseProjectType;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
@@ -45,6 +44,7 @@ import org.eclipse.che.api.vfs.impl.file.event.LoEvent;
 import org.eclipse.che.api.vfs.impl.file.event.detectors.ProjectTreeChangesDetector;
 import org.eclipse.che.api.vfs.search.Searcher;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
+import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -240,19 +240,11 @@ public final class ProjectManager {
             final CreateProjectHandler generator = handlers.getCreateProjectHandler(projectConfig.getType());
 
             if (generator != null) {
-                Map<String, AttributeValue> valueMap = new HashMap<>();
-                Map<String, List<String>> attributes = projectConfig.getAttributes();
-
-                if (attributes != null) {
-                    for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
-                        valueMap.put(entry.getKey(), new AttributeValue(entry.getValue()));
-                    }
-                }
-
+                ProjectConfigImpl configCopy = new ProjectConfigImpl(projectConfig);
                 if (options == null) {
                     options = new HashMap<>();
                 }
-                generator.onCreateProject(projectFolder, valueMap, options);
+                generator.onCreateProject(projectFolder, configCopy, options);
             }
 
             final RegisteredProject project;

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/handlers/CreateProjectHandler.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/handlers/CreateProjectHandler.java
@@ -13,9 +13,12 @@ package org.eclipse.che.api.project.server.handlers;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.project.ProjectConfig;
 import org.eclipse.che.api.project.server.FolderEntry;
 import org.eclipse.che.api.project.server.type.AttributeValue;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -23,7 +26,37 @@ import java.util.Map;
  */
 public interface CreateProjectHandler extends ProjectHandler {
 
+    /**
+     * Called when a new project associated with the primary type equal to {@link #getProjectType()} is about to be
+     * created.
+     * 
+     * <p>
+     * NOTE: Until {@link #onCreateProject(FolderEntry, Map, Map)} is removed, this method delegates to it by default.
+     * 
+     * @param baseFolder
+     *            The base folder of the project.
+     * @param projectConfig
+     *            The initial project configuration. This is a safe copy.
+     * @param options
+     *            Options passed from the client for the handler.
+     * @throws ForbiddenException
+     * @throws ConflictException
+     * @throws ServerException
+     */
+    default void onCreateProject(FolderEntry baseFolder, ProjectConfig projectConfig, Map<String, String> options)
+            throws ForbiddenException, ConflictException, ServerException {
+        Map<String, List<String>> configAtts = projectConfig.getAttributes();
+        Map<String, AttributeValue> atts = new HashMap<>(configAtts.size(), 1f);
+        configAtts.forEach((k, v) -> atts.put(k, new AttributeValue(v)));
+        onCreateProject(baseFolder, atts, options);
+    }
+
+    /**
+     * @deprecated Use {@link #onCreateProject(FolderEntry, ProjectConfig, Map)} instead.
+     */
+    @Deprecated
     void onCreateProject(FolderEntry baseFolder,
                          Map<String, AttributeValue> attributes,
                          Map <String, String> options) throws ForbiddenException, ConflictException, ServerException;
+
 }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/handlers/CreateBaseProjectTypeHandlerTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/handlers/CreateBaseProjectTypeHandlerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.project.server.handlers;
 
 import org.eclipse.che.api.project.server.FolderEntry;
+import org.eclipse.che.api.project.server.type.AttributeValue;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -21,6 +22,8 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.util.Map;
+
 /**
  *  @author Vitalii Parfonov
  */
@@ -30,7 +33,7 @@ public class CreateBaseProjectTypeHandlerTest {
     public void testCreateProject() throws Exception {
         FolderEntry folderEntry = mock(FolderEntry.class);
         CreateBaseProjectTypeHandler createBaseProjectTypeHandler = new CreateBaseProjectTypeHandler();
-        createBaseProjectTypeHandler.onCreateProject(folderEntry, null, null);
+        createBaseProjectTypeHandler.onCreateProject(folderEntry, (Map<String,AttributeValue>)null, null);
         verify(folderEntry).createFile(anyString(), any(byte[].class));
     }
 }


### PR DESCRIPTION
### What does this PR do?

Allow project creation handlers in extensions to obtains more information about the project that is bing created.
### What issues does this PR fix or reference?

Some CreateProjectHandlers can benefit a lot more if they obtain full project configuration, most importantly:
1.  Access more information, e.g. mix-in types and source details.
2. Integration more easily with other code that works with project configurations.
### Previous behavior

Only `Map<String,AttributeValue>` is passed to `CreateProjectHandler`.
### New behavior

A safe, full copy of `ProjectConfig` is passed to `CreateProjectHandler`.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
