### PR TITLE
Simplify Tomcat che.sh bootsrap script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ FROM alpine:3.4
 ENV LANG=C.UTF-8 \
     JAVA_HOME=/usr/lib/jvm/default-jvm/jre \
     PATH=${PATH}:${JAVA_HOME}/bin \
-    CHE_HOME=/home/user/che \
     DOCKER_VERSION=1.6.0 \
-    DOCKER_BUCKET=get.docker.com
+    DOCKER_BUCKET=get.docker.com \
+    CHE_IN_CONTAINER=true
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     apk upgrade --update && \
@@ -46,13 +46,6 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/reposit
     rm -rf /tmp/* /var/cache/apk/*
 
 EXPOSE 8000 8080
-
 USER user
-
 ADD assembly/assembly-main/target/eclipse-che-*/eclipse-che-* /home/user/che/
-
-ENV CHE_HOME /home/user/che
-
-ENTRYPOINT [ "/home/user/che/bin/che.sh", "-c" ]
-
-CMD [ "run" ]
+ENTRYPOINT ["/home/user/che/bin/docker.sh"]

--- a/assembly/assembly-main/src/assembly/assembly.xml
+++ b/assembly/assembly-main/src/assembly/assembly.xml
@@ -193,6 +193,12 @@
     </fileSets>
       <files>
         <file>
+            <source>${project.basedir}/src/assembly/bin/docker.sh</source>
+            <outputDirectory>bin</outputDirectory>
+            <destName>docker.sh</destName>
+            <fileMode>755</fileMode>
+        </file>
+        <file>
             <source>${project.basedir}/src/assembly/bin/che.sh</source>
             <outputDirectory>bin</outputDirectory>
             <destName>che.sh</destName>

--- a/assembly/assembly-main/src/assembly/bin/che.sh
+++ b/assembly/assembly-main/src/assembly/bin/che.sh
@@ -10,251 +10,181 @@
 #   Codenvy, S.A. - initial API and implementation
 #
 
-# See: https://sipb.mit.edu/doc/safe-shell/
 set -e
 set +o posix
 
-# Run the finish function if exit signal initiated
-trap exit SIGHUP SIGINT SIGTERM
+check_docker() {
+  if ! has_docker; then
+    error "Docker not found. Get it at https://docs.docker.com/engine/installation/."
+    return 1;
+  fi
+
+  if ! docker ps > /dev/null 2>&1; then
+    output=$(docker ps)
+    error "Docker not installed properly: \n${output}"
+    echo "Check: Does /var/run/docker.sock have r/w permissions?"
+    echo "Check: Does your Docker client & version match?"
+    DOCKER_PERMS=$(stat -c %A /var/run/docker.sock)
+    DOCKER_SERVER_VERSION=$(docker version --format '{{.Server.Version}}') 
+    DOCKER_CLIENT_VERSION=$(docker version --format '{{.Client.Version}}')
+    echo "Docker /var/run/docker.sock Permissions: $DOCKER_PERMS"
+    echo "Docker Server: $DOCKER_SERVER_VERSION"
+    echo "Docker Client: $DOCKER_CLIENT_VERSION"
+    return 1;
+  fi
+}
+
+has_docker() {
+  hash docker 2>/dev/null && return 0 || return 1
+}
+
+determine_os () {
+  case "${OSTYPE}" in
+     linux*|freebsd*)
+       HOST="linux" 
+     ;;
+     darwin*)
+       HOST="mac" 
+     ;;
+     cygwin|msys|win32)
+       HOST="windows" 
+     ;;
+     *)
+       # unknown option
+       error "We could not detect your operating system. Che is unlikely to work properly."
+       return 1
+     ;;
+  esac
+}
 
 init_global_variables () {
-
-  # Short circuit
-  JUMP_TO_END=false
-
   # For coloring console output
   BLUE='\033[1;34m'
   GREEN='\033[0;32m'
   NC='\033[0m'
 
-  ### Define various error and usage messages
   USAGE="
 Usage:
-  che [OPTIONS] [COMMAND]
-     -v,        --vmware                Use the docker-machine VMware driver (instead of VirtualBox)
-     -m:name,   --machine:name          For Win & Mac, sets the docker-machine VM name; default=che
-     -a:driver, --machine-driver:driver For Win & Mac, specifies the docker-machine driver to use; default=vbox
-     -p:port,   --port:port             Port that Che server will use for HTTP requests; default=8080
-     -l:level,  --logs_level:level      Logging level. Possible values are the logback logging levels; default=INFO
-     -r:ip,     --remote:ip             If Che clients are not localhost, set to IP address of Che server
-     -h,        --help                  Show this help
-     -d,        --debug                 Use debug mode (prints command line options + app server debug)
+  che [COMMAND]
+     start                              Starts server with output in the background
+     stop                               Stops ${CHE_MINI_PRODUCT_NAME} server
+     run                                Starts server with output in the foreground
 
-  Options when running Che natively:
-     -b,        --blocking-entropy      Security: https://wiki.apache.org/tomcat/HowTo/FasterStartUp
-     -g,        --registry              Launch Docker registry as a container (used for ws snapshots)
-     -s:client, --skip:client           Do not print browser client connection information
-     -s:java,   --skip:java             Do not enforce Java version checks
-     -s:uid,    --skip:uid              Do not enforce UID=1000 for Docker
+Variables:
+    CHE_SERVER_ACTION                   Another way to set the [COMMAND] to [run | start | stop]
+    CHE_PORT                            The port the Che server will listen on
+    CHE_IP                              The IP address of the host - must be set if remote clients connecting
+    CHE_LOCAL_CONF_DIR                  If set, will load che.properties from folder
+    CHE_BLOCKING_ENTROPY                Starts Tomcat with blocking entropy: -Djava.security.egd=file:/dev/./urandom
+    CHE_IN_CONTAINER                    Set to true if this server is running inside of a Docker container
+    CHE_LAUNCH_DOCKER_REGISTRY          If true, uses Docker registry to save ws snapshots instead of disk
+    CHE_REGISTRY_HOST                   Hostname of Docker registry to launch, otherwise 'localhost'
+    CHE_LOG_LEVEL                       [INFO | DEBUG] Sets the output level of Tomcat messages
+    CHE_DEBUG_SERVER                    If true, activates Tomcat's JPDA debugging mode
+    CHE_SKIP_JAVA_VERSION_CHECK         If true, skips the pre-flight check for a valid JAVA_HOME
+    CHE_HOME                            Where the Che assembly resides - self-determining if not set
+"
 
-  Options to launch Che in a Docker container:
-     -i,        --image                 (Deprecated) Launches Che within a Docker container using latest image
-     -i:tag,    --image:tag             (Deprecated) Launches Che within a Docker container using specific version
+  # Use blocking entropy -- needed for some servers
+  DEFAULT_CHE_BLOCKING_ENTROPY=false
+  CHE_BLOCKING_ENTROPY=${CHE_BLOCKING_ENTROPY:-${DEFAULT_CHE_BLOCKING_ENTROPY}}
 
-  Commands:
-     run                                (Default) Starts Che server with logging in current console
-     start                              Starts Che server in new console
-     stop                               Stops Che server
+  DEFAULT_CHE_SERVER_ACTION=run
+  CHE_SERVER_ACTION=${CHE_SERVER_ACTION:-${DEFAULT_CHE_SERVER_ACTION}}
 
-Docs: http://eclipse.org/che/getting-started.
+  DEFAULT_CHE_IN_CONTAINER=false
+  CHE_IN_CONTAINER=${CHE_IN_CONTAINER:-${DEFAULT_CHE_IN_CONTAINER}}
 
-If you are running Che as a server on a VM for multiple users, review the additional networking
-configuration that control how clients, Che and workspaces initiate connections. See:
-https://eclipse-che.readme.io/docs/networking."
+  DEFAULT_CHE_LAUNCH_DOCKER_REGISTRY=false
+  CHE_LAUNCH_DOCKER_REGISTRY=${CHE_LAUNCH_DOCKER_REGISTRY:-${DEFAULT_CHE_LAUNCH_DOCKER_REGISTRY}}
 
-  # Command line parameters
-  USE_BLOCKING_ENTROPY=false
-  USE_DOCKER=false
-  USE_VMWARE=false
-  CHE_DOCKER_TAG=latest
-  CHE_PORT=8080
-  CHE_LOGS_LEVEL=INFO
-  CHE_IP=
-  USE_HELP=false
-  CHE_SERVER_ACTION=run
-  COPY_LIB=false
-  VM=${CHE_DOCKER_MACHINE_NAME:-che}
-  MACHINE_DRIVER=virtualbox
-  USE_DEBUG=false
-  SKIP_PRINT_CLIENT=false
-  SKIP_DOCKER_UID=false
-  SKIP_JAVA_VERSION=false
-  LAUNCH_REGISTRY=false
+  # Must be exported as this will be needed by Tomcat's JVM
+  DEFAULT_CHE_REGISTRY_HOST=localhost
+  export CHE_REGISTRY_HOST=${CHE_REGISTRY_HOST:-${DEFAULT_CHE_REGISTRY_HOST}}
 
-  # Sets value of operating system
-  WIN=false
-  MAC=false
-  LINUX=false
+  DEFAULT_CHE_PORT=8080
+  CHE_PORT=${CHE_PORT:-${DEFAULT_CHE_PORT}}
+
+  DEFAULT_CHE_IP=
+  CHE_IP=${CHE_IP:-${DEFAULT_CHE_IP}}
+
+  DEFAULT_CHE_LOG_LEVEL=INFO
+  CHE_LOG_LEVEL=${CHE_LOG_LEVEL:-${DEFAULT_CHE_LOG_LEVEL}}
+
+  DEFAULT_CHE_DEBUG_SERVER=false
+  CHE_DEBUG_SERVER=${CHE_DEBUG_SERVER:-${DEFAULT_CHE_DEBUG_SERVER}}
+
+  DEFAULT_CHE_SKIP_JAVA_VERSION_CHECK=false
+  CHE_SKIP_JAVA_VERSION_CHECK=${CHE_SKIP_JAVA_VERSION_CHECK:-${DEFAULT_CHE_SKIP_JAVA_VERSION_CHECK}}
+
+  DEFAULT_CHE_HOME=$(get_default_che_home)
+  export CHE_HOME=${CHE_HOME:-${DEFAULT_CHE_HOME}}
+
+  DEFAULT_CHE_DATA=$(get_default_che_data)
+  export CHE_DATA=${CHE_DATA:-${DEFAULT_CHE_DATA}}
+}
+
+get_default_che_home () {
+  # The base directory of Che
+  if [ -z "${CHE_HOME}" ]; then
+    if [ "${HOST}" == "windows" ]; then
+      # che-497: Determine windows short directory name in bash
+      echo `(cd "$( dirname "${BASH_SOURCE[0]}" )" && \
+                      cmd //C 'FOR %i in (..) do @echo %~Si')`
+    else
+      echo "$(dirname "$(cd "$(dirname "${0}")" && pwd -P)")"
+    fi
+  else
+    echo "/home/user/che"
+  fi
+}
+
+get_default_che_data () {
+  # The base directory of Che
+  if [ -z "${CHE_DATA}" ]; then
+    echo "/data"
+  fi
+}
+
+parse_command_line () {
+  if [ $# -gt 1 ]; then
+    error "'--<name>' parameters are deprecated - use CHE_ variables instead."
+    usage
+    return 1
+  fi
+
+  case $1 in
+    start|stop|run)
+      CHE_SERVER_ACTION=$1
+    ;;
+    -h|--help)
+      usage
+      return 1
+    ;;
+    *)
+      # unknown option
+      usage
+      return 1
+    ;;
+  esac
+}
+
+error () {
+  echo
+  echo "!!!"
+  echo -e "!!! ${1}"
+  echo "!!!"
+  return 0
 }
 
 usage () {
   echo "${USAGE}"
 }
 
-error_exit () {
-  echo
-  echo "!!!"
-  echo -e "!!! ${1}"
-  echo "!!!"
-  echo 
-  JUMP_TO_END=true
-}
-
-parse_command_line () {
-
-  for command_line_option in "$@"
-  do
-  case ${command_line_option} in
-    -b|--blocking-entropy)
-      USE_BLOCKING_ENTROPY=true
-    ;;
-    -c|--copy-lib)
-      COPY_LIB=true
-    ;;
-    -i|--image)
-      USE_DOCKER=true
-    ;;
-    -g|--registry)
-      LAUNCH_REGISTRY=true
-    ;;
-    -i:*|--image:*)
-      USE_DOCKER=true
-      if [ "${command_line_option#*:}" != "" ]; then
-        CHE_DOCKER_TAG="${command_line_option#*:}"
-      fi
-    ;;
-    -p:*|--port:*)
-      if [ "${command_line_option#*:}" != "" ]; then
-        CHE_PORT="${command_line_option#*:}"
-      fi
-    ;;
-    -r:*|--remote:*)
-      if [ "${command_line_option#*:}" != "" ]; then
-        CHE_IP="${command_line_option#*:}"
-      fi
-    ;;
-    -m:*|--machine:*)
-      if [ "${command_line_option#*:}" != "" ]; then
-        VM="${command_line_option#*:}"
-      fi
-    ;;
-    -l:*|--log_level:*)
-      if [ "${command_line_option#*:}" != "" ]; then
-        CHE_LOGS_LEVEL="${command_line_option#*:}"
-      fi
-    ;;
-    -a:*|--machine-driver:*)
-      if [ "${command_line_option#*:}" != "" ]; then
-        case "${command_line_option#*:}" in
-          vbox)
-            MACHINE_DRIVER=virtualbox
-          ;;
-          fusion)
-            MACHINE_DRIVER=fusion
-          ;;
-          *)
-          # unsupported driver
-          error_exit "Only vbox and fusion docker-machine drivers are supported."
-          ;;
-        esac
-      fi
-    ;;
-    -s:*|--skip:*)
-      if [ "${command_line_option#*:}" != "" ]; then
-        case "${command_line_option#*:}" in
-          client)
-            SKIP_PRINT_CLIENT=true
-          ;;
-          uid)
-            SKIP_DOCKER_UID=true
-          ;;
-          java)
-            SKIP_JAVA_VERSION=true
-          ;;
-        esac
-      fi
-    ;;
-    -h|--help)
-      USE_HELP=true
-      usage
-      return
-    ;;
-    -d|--debug)
-      USE_DEBUG=true
-      CHE_LOGS_LEVEL=DEBUG
-    ;;
-    start|stop|run)
-      CHE_SERVER_ACTION=${command_line_option}
-    ;;
-    *)
-      # unknown option
-      error_exit "You passed an unknown command line option."
-    ;;
-  esac
-
-  done
-
-  if ${USE_DEBUG}; then
-    echo "USE_BLOCKING_ENTROPY: ${USE_BLOCKING_ENTROPY}"
-    echo "USE_DOCKER: ${USE_DOCKER}"
-    echo "CHE_DOCKER_TAG: ${CHE_DOCKER_TAG}"
-    echo "CHE_PORT: ${CHE_PORT}"
-    echo "CHE_IP: \"${CHE_IP}\""
-    echo "LOGGING_LEVEL: ${CHE_LOGS_LEVEL}"
-    echo "CHE_DOCKER_MACHINE: ${VM}"
-    echo "COPY_LIB: ${COPY_LIB}"
-    echo "MACHINE_DRIVER: ${MACHINE_DRIVER}"
-    echo "LAUNCH_REGISTRY: ${LAUNCH_REGISTRY}"
-    echo "SKIP_PRINT_CLIENT: ${SKIP_PRINT_CLIENT}"
-    echo "SKIP_DOCKER_UID: ${SKIP_DOCKER_UID}"
-    echo "SKIP_JAVA_VERSION: ${SKIP_JAVA_VERSION}"
-    echo "USE_HELP: ${USE_HELP}"
-    echo "CHE_SERVER_ACTION: ${CHE_SERVER_ACTION}"
-    echo "USE_DEBUG: ${USE_DEBUG}"
-  fi
-}
-
-determine_os () {
-  # Set OS.  Mac & Windows require VirtualBox and docker-machine.
-
-  if [[ "${OSTYPE}" == "linux"* ]]; then
-    # Linux
-    LINUX=true
-  elif [[ "${OSTYPE}" == "darwin"* ]]; then
-    # Mac OSX
-    MAC=true
-  elif [[ "${OSTYPE}" == "cygwin" ]]; then
-    # POSIX compatibility layer and Linux environment emulation for Windows
-    WIN=true
-  elif [[ "${OSTYPE}" == "msys" ]]; then
-    # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
-    WIN=true
-  elif [[ "${OSTYPE}" == "win32" ]]; then
-    # I'm not sure this can happen.
-    WIN=true
-  elif [[ "${OSTYPE}" == "freebsd"* ]]; then
-    # FreeBSD
-    LINUX=true
-  else
-    error_exit "We could not detect your operating system. Che is unlikely to work properly."
-  fi
-
-}
-
 set_environment_variables () {
-  ### Set the value of derived environment variables.
-  ### Use values set by user, unless they are broken, then fix them
-  # The base directory of Che
-  if [ -z "${CHE_HOME}" ]; then
-    if [ "${WIN}" == "true" ]; then
-      # che-497: Determine windows short directory name in bash
-      export CHE_HOME=`(cd "$( dirname "${BASH_SOURCE[0]}" )" && cmd //C 'FOR %i in (..) do @echo %~Si')`
-    else
-      export CHE_HOME="$(dirname "$(cd "$(dirname "${0}")" && pwd -P)")"
-    fi
-  fi
+  ### Set value of derived environment variables.
 
-  # The environment variable is used by Che to set its IP address
+  # CHE_DOCKER_MACHINE_HOST is used internally by Che to set its IP address
   if [[ -n "${CHE_IP}" ]]; then
     export CHE_DOCKER_MACHINE_HOST="${CHE_IP}"
   fi
@@ -269,11 +199,12 @@ set_environment_variables () {
     JAVA_HOME=$(echo /"${JAVA_HOME}" | sed  's|\\|/|g' | sed 's|:||g')
   fi
 
+  # Convert Che environment variables to POSIX format.
   if [[ "${CHE_HOME}" == *":"* ]]; then
     CHE_HOME=$(echo /"${CHE_HOME}" | sed  's|\\|/|g' | sed 's|:||g')
   fi
 
-  if [[ "${CHE_HOME}" =~ \ |\' ]] && [[ "${WIN}" == "true" ]]; then
+  if [[ "${CHE_HOME}" =~ \ |\' ]] && [[ "${HOST}" == "windows" ]]; then
     echo "!!!"
     echo "!!! Ohhhhh boy."
     echo "!!! You are on Windows and installed Che into a directory that contains a space."
@@ -286,321 +217,98 @@ set_environment_variables () {
     echo "!!! You can fix this issue by installing Che into a directory without spaces in the name."
     echo "!!! Isn't Windows fun?  Long live William Shatner."
     echo "!!!"
-    JUMP_TO_END=true
+    return 1
   fi
 
-  # Che configuration directory - where .properties files can be placed by user
+  # Che configuration directory - where che.properties lives
   if [ -z "${CHE_LOCAL_CONF_DIR}" ]; then
     export CHE_LOCAL_CONF_DIR="${CHE_HOME}/conf/"
   fi
 
   # Sets the location of the application server and its executables
-  export CATALINA_HOME="${CHE_HOME}"/tomcat
+  # Internal property - should generally not be overridden
+  export CATALINA_HOME="${CHE_HOME}/tomcat"
 
   # Convert windows path name to POSIX
-  if [[ "${CATALINA_HOME}" == *":"* ]]
-  then
+  if [[ "${CATALINA_HOME}" == *":"* ]]; then
     CATALINA_HOME=$(echo /"${CATALINA_HOME}" | sed  's|\\|/|g' | sed 's|:||g')
   fi
 
-  export CATALINA_BASE="${CHE_HOME}"/tomcat
-  export ASSEMBLY_BIN_DIR="${CATALINA_HOME}"/bin
-  export CHE_LOGS_LEVEL="${CHE_LOGS_LEVEL}"
-
-  # Global logs directory
-  if [ -z "${CHE_LOGS_DIR}" ]; then
-    export CHE_LOGS_DIR="${CATALINA_HOME}/logs/"
-  fi
-
+  # Internal properties - should generally not be overridden
+  export CATALINA_BASE="${CHE_HOME}/tomcat"
+  export ASSEMBLY_BIN_DIR="${CATALINA_HOME}/bin"
+  export CHE_LOGS_LEVEL="${CHE_LOG_LEVEL}"
+  export CHE_LOGS_DIR="${CATALINA_HOME}/logs/"
 }
 
 get_docker_ready () {
-
-  if [ "${WIN}" == "true" ]; then
-    export DOCKER=${DOCKER_TOOLBOX_INSTALL_PATH}\\docker.exe
-  elif [ "${MAC}" == "true" ]; then
-    export DOCKER=/usr/local/bin/docker
-  elif [ "${LINUX}" == "true" ]; then
-    export DOCKER=/usr/bin/docker
-  fi
-
-  # Test to ensure user is in Docker group with appropriate permissions
-  if [ "${LINUX}" == "true" ]; then
-
-    LINUX_USER=$(whoami)
-    LINUX_GROUPS=$(groups "${LINUX_USER}")
-    LINUX_UID=$(id -u "${LINUX_USER}")
-
-    if [[ "${SKIP_DOCKER_UID}" == "false" ]] ; then
-      if echo "${LINUX_GROUPS}" | grep "docker" &>/dev/null; then
-
-        if [[ "${LINUX_UID}" != "1000" ]] ; then
-          error_exit "This Linux user was launched with a UID != 1000. `
-                     `Che must run under UID 1000. See https://eclipse-che.readme.io/docs/usage#section-cannot-create-projects"
-        fi
-
-      else
-        error_exit "This Linux user is not in 'docker' group. `
-                   `See https://docs.docker.com/engine/installation/ubuntulinux/#create-a-docker-group"
-      fi
-    fi
-
-  fi
-
-  # Docker should be available, either in a VM or natively.
-  # Test to see if docker binary is installed
-  if [ ! -f "${DOCKER}" ]; then
-    error_exit "Could not find Docker client. `
-               `Expected at Windows: %DOCKER_TOOLBOX_INSTALL_PATH%\\docker.exe, `
-               `Mac: /usr/local/bin/docker, `
-               `Linux: /usr/bin/docker."
-    return
-  fi
-
-  # Test to see that docker command works
-  "${DOCKER}" &> /dev/null || DOCKER_EXISTS=$? || true
-
-  if [ "${DOCKER_EXISTS}" == "1" ]; then
-    error_exit "We found the 'docker' binary, but running 'docker' failed. Is a docker symlink broken?"
-    return
-  fi
-
-  # Test to verify that docker can reach the VM
-  "${DOCKER}" ps &> /dev/null || DOCKER_VM_REACHABLE=$? || true
-
-  if [ "${DOCKER_VM_REACHABLE}" == "1" ]; then
-    
-    # If this is Mac or Windows and we get a failure, assume Docker is not installed.
-    # Use Docker Machine to launch a VM where we can use Docker
-    if [ "${WIN}" == "true" ] || [ "${MAC}" == "true" ]; then
-      launch_docker_vm
-    else
-
-      # CHE-1202: Improve error messages in case of docker ps failure
-      # Verify that /var/run/docker.sock has read / write permissions
-      PERMS=$(stat -c %A /var/run/docker.sock)
-      OWNER_READ=$(cut -c2 <(echo $PERMS))
-      OWNER_WRITE=$(cut -c3 <(echo $PERMS))
-      GROUP_READ=$(cut -c5 <(echo $PERMS))
-      GROUP_WRITE=$(cut -c6 <(echo $PERMS))
-      OTHER_READ=$(cut -c8 <(echo $PERMS))
-      OTHER_WRITE=$(cut -c9 <(echo $PERMS))
-
-      if [[ "$OWNER_READ" != "r" || "$OWNER_WRITE" != "w" || `
-           `"$GROUP_READ" != "r" || "$GROUP_WRITE" != "w" || `
-           `"$OTHER_READ" != "r" || "$OTHER_WRITE" != "w" ]]; then
-        error_exit "Running 'docker' succeeded, but 'docker ps' failed. \n`
-                   `The file /var/run/docker.sock does not have appropriate permissions. \n`
-                   `OWNER READ:  ${OWNER_READ} \n`
-                   `OWNER WRITE: ${OWNER_WRITE} \n`
-                   `GROUP READ:  ${GROUP_READ} \n`
-                   `GROUP WRITE: ${GROUP_WRITE} \n`
-                   `OTHER READ:  ${OTHER_READ} \n`
-                   `OTHER WRITE: ${OTHER_WRITE} \n`
-                   `Run 'sudo chmod 666 /var/run/docker.sock' to give the right permissions."
-        return
-      fi
-
-      # CHE-1202: Improve error messages in case of docker ps failure
-      # Verify that docker client and server versions match
-      DOCKER_SERVER_VERSION=$(docker version --format '{{.Server.Version}}')
-      DOCKER_CLIENT_VERSION=$(docker version --format '{{.Client.Version}}')
-
-      if [[ "$DOCKER_SERVER_VERSION" != "$DOCKER_CLIENT_VERSION" ]]; then
-        error_exit "Running 'docker' succeeded, but 'docker ps' failed. \n`
-                   `The docker client version does not match the docker server version. \n`
-                   `DOCKER SERVER: ${DOCKER_SERVER_VERSION} \n`
-                   `DOCKER CLIENT: ${DOCKER_CLIENT_VERSION} \n`
-                   `This can occur if you are running Che as a container itself. \n`
-                   `The Che container has an internal docker client that uses your host's docker server. \n` 
-                   `Consider updating docker engine to have the versions match."
-        return
-      fi
-      
-      error_exit "Running 'docker' succeeded, but 'docker ps' failed. \n`
-                 `/var/run/docker.sock is ok and your docker client and server have matching versions. \n`
-                 `Run 'docker ps' and inspect the output for additional clues."
-      return
+  if [ "${HOST}" == "windows" ]; then
+    if [ -z ${DOCKER_HOST+x} ]; then
+      export DOCKER_HOST=tcp://localhost:2375
     fi
   fi
-
-  # Hidden parameter
-  # Only used if running Che server inside a Docker container.
-  # Copies Che libraries to a temporary directory which is mounted by the container to be reachable by external host.
-  # Files must be copied otherwise host will overwrite them to blank.
-  if [ "${COPY_LIB}" == "true" ]; then
-    sudo chown -R user:user ${CHE_HOME}
-    rm -rf ${CHE_HOME}/lib-copy/*
-    mkdir -p ${CHE_HOME}/lib-copy
-    cp -rf ${CHE_HOME}/lib/* ${CHE_HOME}/lib-copy
-
-    export JAVA_OPTS="${JAVA_OPTS} -Dche.docker.network=bridge"
-  fi 
 }
 
-launch_docker_vm () {
-  # Create absolute file names for docker and docker-machine
-  # DOCKER_TOOLBOX_INSTALL_PATH set globally by Docker Toolbox installer
-  if [ "${WIN}" == "true" ]; then
-    if [ ! -z "${DOCKER_TOOLBOX_INSTALL_PATH}" ]; then
-      export DOCKER_MACHINE=${DOCKER_TOOLBOX_INSTALL_PATH}\\docker-machine.exe
-    else
-      error_exit "DOCKER_TOOLBOX_INSTALL_PATH environment variable not set. Add it or rerun Docker Toolbox installation."
-      return
-    fi
-  else 
-    export DOCKER_MACHINE=/usr/local/bin/docker-machine
-  fi
-
-  # Path to run VMware on the command line - used for creating VMs
-  # TODO: add support for VMware Workstation
-  if [ "${MAC}" == "true" ] && [ "${MACHINE_DRIVER}" == "fusion" ]; then
-    VMRUN="/Applications/VMware Fusion.app/Contents/Library/vmrun"
-    echo "$VMRUN"
-    VM_CHECK_CMD="$("$VMRUN" list \| grep $VM)"
-    DOCKER_MACHINE_DRIVER=vmwarefusion
-    if [ ! -f "$VMRUN" ]; then
-      error_exit "Could not find vmrun. Expected vmrun in $VMRUN. Check VMware Fusion installation."
-      return
-    fi
+docker_exec() {
+  if [ "${HOST}" == "windows" ]; then
+    MSYS_NO_PATHCONV=1 docker.exe "$@"
   else
-    if [ ! -z "${VBOX_MSI_INSTALL_PATH}" ]; then
-      # Convert this directory to its short form name on Windows
-      if [ "${WIN}" == "true" ]; then
-        export VBOX_MSI_INSTALL_PATH=`(cd "${VBOX_MSI_INSTALL_PATH}" && cmd //C 'FOR %i in (.) do @echo %~Si')`\\
-    fi
-      VBOXMANAGE="${VBOX_MSI_INSTALL_PATH}"VBoxManage.exe
-    else
-      VBOXMANAGE=/usr/local/bin/VBoxManage
-    fi
-    VM_CHECK_CMD="${VBOXMANAGE} showvminfo ${VM}"
-    DOCKER_MACHINE_DRIVER=virtualbox
-    DOCKER_MACHINE_DRIVER_OPTIONS='--virtualbox-host-dns-resolver --virtualbox-memory 2048 --virtualbox-cpu-count 2'
-    if [ ! -f "${VBOXMANAGE}" ]; then
-      error_exit "Could not find VirtualBox. Win: VBOX_MSI_INSTALL_PATH env variable not set. `
-                 `Add it or rerun Docker Toolbox installation. Mac: Expected Virtual Box at /usr/local/bin/VBoxManage."
-    return
-    fi
+    "$(which docker)" "$@"
   fi
-
-  if [ ! -f "${DOCKER_MACHINE}" ]; then
-    error_exit "Could not find docker-machine executable. Win: DOCKER_TOOLBOX_INSTALL_PATH env variable not set. `
-               `Mac: Expected docker-machine at /usr/local/bin/docker-machine."
-    return
-  fi
-
-  # Test to see if the VM we need is already running
-  # Added || true to not fail due to set -e
-  ${VM_CHECK_CMD} &> /dev/null || VM_EXISTS_CODE=$? || true
-  if [ "${VM_EXISTS_CODE}" == "1" ]; then
-    echo -e "Could not find an existing docker machine named ${GREEN}${VM}${NC}."
-    echo -e "Creating docker machine named ${GREEN}${VM}${NC}... Be patient, this takes a couple minutes the first time."
-    "${DOCKER_MACHINE}" rm -f ${VM} &> /dev/null || true
-    rm -rf ~/.docker/machine/machines/${VM}
-    "${DOCKER_MACHINE}" create -d $DOCKER_MACHINE_DRIVER $DOCKER_MACHINE_DRIVER_OPTIONS ${VM} &> /dev/null || true
-
-    # Seems that sometimes you have to regenerate certs even when creating new machine on windows
-    echo -e "Successfully started docker machine named ${GREEN}${VM}${NC}..."
-  else
-    echo -e "Docker machine named ${GREEN}${VM}${NC} already exists..."
-  fi
-
-  VM_STATUS=$("${DOCKER_MACHINE}" status ${VM} 2>&1)
-
-  if [ "${VM_STATUS}" != "Running" ]; then
-    echo -e "Docker machine named ${GREEN}${VM}${NC} is not running."
-    echo -e "Starting docker machine named ${GREEN}${VM}${NC}..."
-    "${DOCKER_MACHINE}" start ${VM} || true
-    yes | "${DOCKER_MACHINE}" regenerate-certs ${VM} &> /dev/null  || true
-  fi
-
-  echo -e "Setting environment variables for machine ${GREEN}${VM}${NC}..."
-  eval "$("${DOCKER_MACHINE}" env --shell=bash ${VM})"
-
-  echo -e "${BLUE}Docker${NC} is configured to use docker-machine named `
-          `${GREEN}${VM}${NC} with IP ${GREEN}$("${DOCKER_MACHINE}" ip ${VM})${NC}..."
 }
 
-# Added || true to not fail due to set -e
-# We set -o pipefail to cause failures in pipe processing, but not needed for this functional
-strip_url () {
-  # extract the protocol
-  proto="`echo ${1} | grep '://' | sed -e's,^\(.*://\).*,\1,g'`" || true
-
-  # remove the protocol
-  url=`echo ${1} | sed -e s,${proto},,g` || true
-
-  # extract the user and password (if any)
-  userpass=`echo ${url} | grep @ | cut -d@ -f1` || true
-  pass=`echo ${userpass} | grep : | cut -d: -f2` || true
-
-
-  if [ -n "${pass}" ]; then
-      user=`echo ${userpass} | grep : | cut -d: -f1` || true
-  else
-      user=${userpass}
+start_che_server () {
+  if ${CHE_LAUNCH_DOCKER_REGISTRY} ; then
+    # Export the value of host here
+    launch_docker_registry
   fi
 
-  # extract the host and remove the port
-  hostport=`echo ${url} | sed -e s,${userpass}@,,g | cut -d/ -f1` || true
-  port=`echo ${hostport} | grep : | cut -d: -f2` || true
-  if [ -n "${port}" ]; then
-      host=`echo ${hostport} | grep : | cut -d: -f1` || true
-  else
-      host=${hostport}
-  fi
-
-  # extract the path (if any)
-  path="`echo ${url} | grep / | cut -d/ -f2-`" || true
+  #########################################
+  # Launch Che natively as a tomcat server
+  call_catalina
 }
 
-print_client_connect () {
-  HOST_PRINT_VALUE=${host}
-  echo "
-############## HOW TO CONNECT YOUR CHE CLIENT ###############
-After Che server has booted, you can connect your clients by:
-1. Open browser to http://${HOST_PRINT_VALUE}:${CHE_PORT}, or:
-2. Open native chromium app.
-#############################################################
-"
+stop_che_server () {
+  echo -e "Stopping Che server running on localhost:${CHE_PORT}"
+  call_catalina >/dev/null 2>&1
+  return 1;
 }
 
 call_catalina () {
-
   # Test to see that Che application server is where we expect it to be
   if [ ! -d "${ASSEMBLY_BIN_DIR}" ]; then
-    error_exit "Could not find Che's application server."
-    return
+    error "Could not find Che's application server."
+    return 1;
   fi
 
   if [ -z "${JAVA_HOME}" ]; then
-    error_exit "JAVA_HOME is not set. Please set to directory of JVM or JRE."
-    return
+    error "JAVA_HOME is not set. Please set to directory of JVM or JRE."
+    return 1;
   fi
 
   # Test to see that Java is installed and working
   "${JAVA_HOME}"/bin/java &>/dev/null || JAVA_EXIT=$? || true
   if [ "${JAVA_EXIT}" != "1" ]; then
-    error_exit "We could not find a working Java JVM. 'java' command fails."
-    return
+    error "We could not find a working Java JVM. 'java' command fails."
+    return 1;
   fi
 
-  if [[ "${SKIP_JAVA_VERSION}" == false ]]; then
+  if [[ "${CHE_SKIP_JAVA_VERSION_CHECK}" == false ]]; then
     # Che requires Java version 1.8 or higher.
     JAVA_VERSION=$("${JAVA_HOME}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
     if [  -z "${JAVA_VERSION}" ]; then
-      error_exit "Failure running JAVA_HOME/bin/java -version. We received ${JAVA_VERSION}."
-      return
+      error "Failure running JAVA_HOME/bin/java -version. We received ${JAVA_VERSION}."
+      return 1;
     fi
 
     if [[ "${JAVA_VERSION}" < "1.8" ]]; then
-      error_exit "Che requires Java version 1.8 or higher. We found ${JAVA_VERSION}."
-      return
+      error "Che requires Java version 1.8 or higher. We found ${JAVA_VERSION}."
+      return 1;
     fi
   fi
 
   ### Initialize default JVM arguments to run che
-  if [[ "${USE_BLOCKING_ENTROPY}" == true ]]; then
+  if [[ "${CHE_BLOCKING_ENTROPY}" == true ]]; then
     [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m"
   else
     [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m -Djava.security.egd=file:/dev/./urandom"
@@ -612,41 +320,30 @@ call_catalina () {
   export SERVER_PORT=${CHE_PORT}
 
   # Launch the Che application server, passing in command line parameters
-  if [[ "${USE_DEBUG}" == true ]]; then
+  if [[ "${CHE_DEBUG_SERVER}" == true ]]; then
     "${ASSEMBLY_BIN_DIR}"/catalina.sh jpda ${CHE_SERVER_ACTION}
   else
     "${ASSEMBLY_BIN_DIR}"/catalina.sh ${CHE_SERVER_ACTION}
   fi
 }
 
-stop_che_server () {
-
-  echo -e "Stopping Che server running on localhost:${CHE_PORT}"
-  call_catalina >/dev/null 2>&1
-  return
-
-}
-
 kill_and_launch_docker_registry () {
-  echo -e "A Docker container named ${GREEN}registry${NC} does not exist or duplicate conflict was discovered."
-  echo -e "Launching a new Docker container named ${GREEN}registry${NC} from image ${GREEN}registry:2${NC}."
-  "${DOCKER}" rm -f registry &> /dev/null || true
-  "${DOCKER}" run -d -p 5000:5000 --restart=always --name registry registry:2
-  echo
+  echo -e "Launching Docker container named ${GREEN}registry${NC} from image ${GREEN}registry:2${NC}."
+  docker_exec rm -f registry &> /dev/null || true
+  docker_exec run -d -p 5000:5000 --restart=always --name registry registry:2
 }
 
 launch_docker_registry () {
-
     echo "Launching a Docker registry for workspace snapshots."
     CREATE_NEW_CONTAINER=false
 
     # Check to see if the registry docker was not properly shut down
-    "${DOCKER}" inspect registry &> /dev/null || DOCKER_INSPECT_EXIT=$? || true
+    docker_exec inspect registry &> /dev/null || DOCKER_INSPECT_EXIT=$? || true
     if [ "${DOCKER_INSPECT_EXIT}" != "1" ]; then
 
       # Existing container running registry is found.  Let's start it.
       echo -e "Found a registry container named ${GREEN}registry${NC}. Attempting restart."
-      "${DOCKER}" start registry &>/dev/null || DOCKER_EXIT=$? || true
+      docker_exec start registry &>/dev/null || DOCKER_EXIT=$? || true
 
       # Existing container found, but could not start it properly.
       if [ "${DOCKER_EXIT}" == "1" ]; then
@@ -663,77 +360,25 @@ launch_docker_registry () {
     fi
 
     if ${CREATE_NEW_CONTAINER} ; then
-
       # Container in bad state or not found, kill and launch new container.
       kill_and_launch_docker_registry
-
     fi
 }
 
-launch_che_server () {
-
-  if [[ -n "${DOCKER_HOST}" ]]; then
-    strip_url ${DOCKER_HOST}
-  else
-    host=localhost
-  fi
-
-  if ! ${SKIP_PRINT_CLIENT}; then
-    print_client_connect
-  fi
-
-  if ${LAUNCH_REGISTRY} ; then
-    # Export the value of host here
-    # Will be used on Che properties to set the location of registry
-    export CHE_REGISTRY_HOST="${host}"
-    launch_docker_registry
-
-  else
-    export CHE_REGISTRY_HOST="localhost"
-  fi
-
-  #########################################
-  # Launch Che natively as a tomcat server
-  call_catalina
-}
-
-init_global_variables
-parse_command_line "$@"
-determine_os
-
-if [ "${USE_DOCKER}" == "true" ]; then
-  error_exit "The '--image' option has been deprecated. Please use Che's 'docker run' syntax to run Che in a container."
-fi 
-
-if [ "${USE_HELP}" == "false" ] && [ "${JUMP_TO_END}" == "false" ]; then
-
+execute_che () { 
+  check_docker
+  determine_os
+  init_global_variables
+  parse_command_line "$@"
   set_environment_variables
+  get_docker_ready
 
-  if ${WIN} && [ "${JUMP_TO_END}" == "false" ]; then
-    # Prep windows
-    # Check to see if %userprofile%\AppData\Local\che exists.
-    # Create directory if it doesn't exist
-    echo
-    echo "#############################################################"
-    echo "On Windows, Che projects can only reside in %userprofile% due"
-    echo "to limitations of Docker. On this computer, %userprofile% is "
-    echo -e "${GREEN}${USERPROFILE}${NC}"
-    echo "#############################################################"
-    echo
-
+  if [ "${CHE_SERVER_ACTION}" == "stop" ]; then
+    stop_che_server
+  else
+    start_che_server
   fi
+}
 
-  ### Variables are all set.  Get Docker ready
-  if [ "${JUMP_TO_END}" == "false" ]; then
-    get_docker_ready
-  fi
-
-  ### Launch or shut down Che server
-  if [ "${JUMP_TO_END}" == "false" ]; then
-    if [ "${CHE_SERVER_ACTION}" == "stop" ]; then
-      stop_che_server
-    else
-      launch_che_server
-    fi
-  fi
-fi
+# Run the finish function if exit signal initiated
+execute_che "$@"

--- a/assembly/assembly-main/src/assembly/bin/docker.sh
+++ b/assembly/assembly-main/src/assembly/bin/docker.sh
@@ -1,0 +1,237 @@
+#!/bin/sh
+#
+# Copyright (c) 2012-2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
+# This file is a specialized launcher to be used as an entrypoint for the Che Dockerfile.
+# This script has logic to detect and configure Che if it is running inside of a container.
+pid=0
+
+check_docker() {
+  if [ ! -S /var/run/docker.sock ]; then
+    echo "Docker socket (/var/run/docker.sock) hasn't been mounted. Verify your \"docker run\" syntax."
+    return 1;
+  fi
+
+  if ! docker ps > /dev/null 2>&1; then
+    output=$(docker ps)
+    error_exit "Error when running \"docker ps\": ${output}"
+  fi
+}
+
+init() {
+  # Set variables that use docker as utilities to avoid over container execution
+  ETH0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth0 2> /dev/null" | \
+                                                            grep "inet addr:" | \
+                                                            cut -d: -f2 | \
+                                                            cut -d" " -f1)
+
+  ETH1_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig eth1 2> /dev/null" | \
+                                                            grep "inet addr:" | \
+                                                            cut -d: -f2 | \
+                                                            cut -d" " -f1) 
+
+  DOCKER0_ADDRESS=$(docker run --rm --net host alpine /bin/sh -c "ifconfig docker0 2> /dev/null" | \
+                                                              grep "inet addr:" | \
+                                                              cut -d: -f2 | \
+                                                              cut -d" " -f1)
+
+  ### Any variables with export is a value that native Tomcat che.sh startup script requires
+
+  ### Set these values for any che server running in a container
+  DOCKER_HOST_IP=$(get_docker_host_ip)
+  export CHE_IP=${CHE_IP:-${DOCKER_HOST_IP}}
+  export CHE_IN_CONTAINER="true"
+  export CHE_SKIP_JAVA_VERSION_CHECK="true"
+
+  ### Are we using the included assembly or did user provide their own?
+  DEFAULT_CHE_HOME="/home/user/che"
+  export CHE_HOME=${CHE_ASSEMBLY:-${DEFAULT_CHE_HOME}}
+
+  if [ ! -f $CHE_HOME/bin/che.sh ]; then
+    echo "!!!"
+    echo "!!! Error: Could not find $CHE_HOME/bin/che.sh."
+    echo "!!! Error: Did you use CHE_ASSEMBLY with a typo?"
+    echo "!!!"
+    exit 1
+  fi
+
+  ### We need to discover the host mount provided by the user for `/data`
+  DEFAULT_CHE_DATA="/data"
+  export CHE_DATA=${CHE_DATA:-${DEFAULT_CHE_DATA}}
+  CHE_DATA_HOST=$(get_che_data_from_host)
+
+  ### Are we going to use the embedded che.properties or one provided by user?`
+  ### CHE_LOCAL_CONF_DIR is internal Che variable that sets where to load
+  DEFAULT_CHE_CONF_DIR="${CHE_DATA}/conf"
+  export CHE_LOCAL_CONF_DIR=${CHE_LOCAL_CONF_DIR:-${DEFAULT_CHE_CONF_DIR}}
+
+  if [ ! -f "${CHE_LOCAL_CONF_DIR}/che.properties" ]; then
+    echo "Did not discover che.properties file. Copying properties template to ${CHE_DATA_HOST}/conf."
+    mkdir -p /data/conf
+    cp -rf "${CHE_HOME}/conf/che.properties" /data/conf/che.properties
+  fi
+
+  # Update the provided che.properties with the location of the /data mounts
+  sed -i "/che.workspace.storage/c\che.workspace.storage=${CHE_DATA_HOST}/workspaces" $CHE_LOCAL_CONF_DIR/che.properties
+  sed -i "/che.conf.storage/c\che.conf.storage=/data/storage" $CHE_LOCAL_CONF_DIR/che.properties
+  sed -i "/machine.server.ext.archive/c\machine.server.ext.archive=${CHE_DATA_HOST}/lib/ws-agent.tar.gz" $CHE_LOCAL_CONF_DIR/che.properties
+  sed -i "/machine.server.terminal.path_to_archive.linux_amd64/c\machine.server.terminal.path_to_archive.linux_amd64=${CHE_DATA_HOST}/lib/linux_amd64/terminal" $CHE_LOCAL_CONF_DIR/che.properties
+  sed -i "/machine.server.terminal.path_to_archive.linux_arm7/c\machine.server.terminal.path_to_archive.linux_arm7=${CHE_DATA_HOST}/lib/linux_arm7/terminal" $CHE_LOCAL_CONF_DIR/che.properties
+
+  ### If this container is inside of a VM like boot2docker, then additional internal mods required
+  DEFAULT_CHE_IN_VM=$(is_in_vm)
+  export CHE_IN_VM=${CHE_IN_VM:-${DEFAULT_CHE_IN_VM}}
+
+  if [ "$CHE_IN_VM" = "true" ]; then
+    # CHE_DOCKER_MACHINE_HOST_EXTERNAL must be set if you are in a VM. 
+    HOSTNAME=$(get_docker_external_hostname)
+    if has_external_hostname; then
+      # Internal property used by Che to set hostname.
+      # See: LocalDockerInstanceRuntimeInfo.java#L9
+      export CHE_DOCKER_MACHINE_HOST_EXTERNAL=${HOSTNAME}
+    fi
+    ### Necessary to allow the container to write projects to the folder
+    export CHE_WORKSPACE_STORAGE="${CHE_DATA_HOST}/workspaces"
+    export CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false
+  fi
+
+  # Ensure that the user "user" has permissions for CHE_HOME and CHE_DATA
+  sudo chown -R user:user ${CHE_HOME}
+  sudo chown -R user:user ${CHE_DATA}
+
+  # Move files from /lib to /lib-copy.  This puts files onto the host.
+  rm -rf ${CHE_DATA}/lib/*
+  mkdir -p ${CHE_DATA}/lib
+  cp -rf ${CHE_HOME}/lib/* ${CHE_DATA}/lib
+
+  # A che property, which names the Docker network used for che + ws to communicate
+  export JAVA_OPTS="${JAVA_OPTS} -Dche.docker.network=bridge"
+}
+
+get_che_data_from_host() {
+  CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id)
+  echo $(docker inspect --format='{{(index .Volumes "/data")}}' $CHE_SERVER_CONTAINER_ID)
+}
+
+get_che_server_container_id() {
+  hostname
+}
+
+get_docker_host_ip() {
+  case $(get_docker_install_type) in
+   boot2docker)
+     echo $ETH1_ADDRESS
+   ;;
+   native)
+     echo $DOCKER0_ADDRESS
+   ;;
+   *)
+     echo $ETH0_ADDRESS
+   ;;
+  esac
+}
+
+get_docker_install_type() {
+  if is_boot2docker; then
+    echo "boot2docker"
+  elif is_docker_for_windows; then
+    echo "docker4windows"
+  elif is_docker_for_mac; then
+    echo "docker4mac"
+  else
+    echo "native"
+  fi
+}
+
+is_boot2docker() {
+  if uname -r | grep -q 'boot2docker'; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_docker_for_windows() {
+  if uname -r | grep -q 'moby' && has_docker_for_windows_ip; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+has_docker_for_windows_ip() {
+  if [ "${ETH0_ADDRESS}" = "10.0.75.2" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_docker_for_mac() {
+  if uname -r | grep -q 'moby' && ! has_docker_for_windows_ip; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_in_vm() {
+  if is_docker_for_mac || is_docker_for_windows || is_boot2docker; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+get_docker_external_hostname() {
+  if is_docker_for_mac || is_docker_for_windows; then
+    echo "localhost"
+  else
+    echo ""
+  fi
+}
+
+has_external_hostname() {
+  if [ "${HOSTNAME}" = "" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+# SITTERM / SIGINT
+responsible_shutdown() {
+  echo ""
+  echo "Received SIGTERM"
+  "${CHE_HOME}"/bin/che.sh stop
+}
+
+# setup handlers
+# on callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
+trap 'responsible_shutdown' SIGHUP SIGTERM SIGINT
+
+check_docker
+init
+
+# run application
+"${CHE_HOME}"/bin/che.sh run &
+PID=$!
+
+# See: http://veithen.github.io/2014/11/16/sigterm-propagation.html
+wait $PID
+wait $PID
+EXIT_STATUS=$?
+
+# wait forever
+while true
+do
+  tail -f /dev/null & wait ${!}
+done


### PR DESCRIPTION
### What does this PR do?

Contains a rewrite for the native Tomcat scripts for starting and stopping Che to incorporate a number of improvements requested by users, and to remove a number of Docker-launch capabilities that are no longer needed as we provide `che-server` and `che-launcher` containers, which are more commonly used.

The improvements targeted for this pull request:
- [x] Get rid of all `--<command>` command line options and replace them with environment variables.
- [x] Move any bootstrap code that is specific to a container into che-server container.
- [x] Improve the che-server container to handle container-specific logic, such as che-lib.
- [x] Simplify the che-server container to only require a single `/data` mount folder.
- [x] Make improvements to che-launcher container to adapt to these improvements. Located in [che-dockerfiles](https://github.com/eclipse/che-dockerfiles/pull/29).
- [x] Support SIGTERM and SIGINT signals, so that `docker stop che` handled proper shutdown.

In order to deliver on this capability, we now have the Dockerfile entrypoint be `start.sh` which is then responsible for calling /home/user/che/bin/che.sh with the right command. We launch the command in the background which is necessary for JVM programs to receive a SIGTERM.  This will also allow us to intercept the `CHE_ASSEMBLY` and handle the logic there along with some nice checking of the path to see if the path is valid for usage.

As part of this change, we are now only supporting a single volume mount of `/data`. Everything that is user configurable and / or needs to be saved in between multiple runs is now saved in this directory and volume mounted.   In the basic tests - the following worked. We do an inspection in the che-server container to find the host volume that is mounted to `/data`. We then take that value and update the default che.properties to replace five fields with this location.  

```
docker run -p 8080:8080 --name che --rm -v /var/run/docker.sock:/var/run/docker.sock -v /C/tmp:/data codenvy/che-server:nightly

# Fields modified in che.properties by the startup script to write in the proper /data location:
che.workspace.storage=${CHE_DATA_HOST}/workspaces
che.conf.storage=/data/storage
machine.server.ext.archive=${CHE_DATA_HOST}/lib/ws-agent.tar.gz
machine.server.terminal.path_to_archive.linux_amd64=${CHE_DATA_HOST}/lib/linux_amd64/terminal
machine.server.terminal.path_to_archive.linux_arm7=${CHE_DATA_HOST}/lib/linux_arm7/terminal
# where CHE_DATA_HOST is derived as the volume mount of /data inside the container
```

Shadow documentation: 
https://eclipse-che.readme.io/v5.0/docs/usage-docker-server-1
### Build

This image is not yet hosted on Docker Hub. You need to build it locally.

```
git clone http://github.com/eclipse/che
cd che
git checkout che-startup-tcomat
cd assembly/assembly-main
mvn clean install
cd ../..
docker build -t codenvy/che-server:nightly .
```
### What issues does this PR fix or reference?
#2754 (open) - che.sh not checking for /var/run/docker.sock, & do DOCKER_HOST checks.
#2755 (open) - Usability improvements to che-server execution
#2771 - mapping
### Previous behavior

The existing native script has a mix of environment variables and command line options which are not consistently applied. Also, the current bootstrap script will attempt to launch Docker using docker-machine if it is not present. This is no longer required as the only users of the Tomcat bootstrap script are those that understand how to configure Docker properly.
### New behavior

*1. Have the trap shut down che
*2. Remove -v, -m, -a options.
*3. Remove launch_docker_vm from che.sh?
*4. Remove print_client_connect method
*5. Convert all parameters to inherit from env variables & CHE_ values
*6. Add check for any parameters with nice output for codenvy/che-server run <params>
*7. -p:port ==> CHE_PORT
*8. -l:level ==> CHE_LOG_LEVEL (check CLI version)
*9. Show help if no parameters
*9. -r:ip ==> CHE_IP environment variable
*10. Check che-launcher for how debug is handled
*11. Add CHE_BLOCKING_ENTROPY
*12. Add CHE_LAUNCH_DOCKER_REGISTRY
*13. Add CHE_SKIP_JAVA_VERSION_CHECK
*14. Add CHE_SKIP_DOCKER_UID_ENFORCEMENT
*15. Remove USE_DOCKER, add check into early compatibility check
*16. Remove CHE_DOCKER_TAG
*17. Move help to better section - it's in the core body now
*18. Formalize CHE_SERVER_ACTION
*19. Add CHE_IN_CONTAINER=true to replace COPY_LIB
*20. Remove unnecessary Windows command output
*22. Auto detect if the container is in a VM and set necessary properties including
CHE_DOCKER_MACHINE_HOST_EXTERNAL=${HOSTNAME}
CHE_WORKSPACE_STORAGE="${CHE_DATA_HOST}/workspaces"
CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false
- 23. Rename CHE_LOCAL_BINARY to just simply CHE_ASSEMBLY
- 24. Refactor certain che-launcher commands to make use of CHE_HOST value instead of --remote property.
