### PR TITLE
Fix NPE in ServerImpl constructor

### DIFF
--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/ServerImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/ServerImpl.java
@@ -34,7 +34,9 @@ public class ServerImpl implements Server {
         this.protocol = protocol;
         this.address = address;
         this.url = url;
-        this.properties = new ServerPropertiesImpl(properties);
+        if (properties != null) {
+            this.properties = new ServerPropertiesImpl(properties);
+        }
     }
 
     public ServerImpl(Server server) {


### PR DESCRIPTION
Fixes NPE by making new instance of `properties` only when passed one is not null.

@sleshchenko, @akorneta review please
