### PR TITLE
Fix failing Closure Compiling in case GWT JavaScript compiler output style set to DETAILED mode

### DIFF
--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/command/MavenCommandModel.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/command/MavenCommandModel.java
@@ -22,9 +22,10 @@ class MavenCommandModel {
     private String workingDirectory;
     private String arguments;
 
-    MavenCommandModel(String workingDirectory, String arguments) {
+    // Note that Closure Compiler doesn't allow to use 'arguments' as a name of a method argument.
+    MavenCommandModel(String workingDirectory, String args) {
         this.workingDirectory = workingDirectory;
-        this.arguments = arguments;
+        this.arguments = args;
     }
 
     /** Crates {@link MavenCommandModel} instance from the given command line. */
@@ -58,9 +59,12 @@ class MavenCommandModel {
         return arguments;
     }
 
-    /** Set command arguments, e.g. {@code [options] [<goal(s)>] [<phase(s)>]}. */
-    void setArguments(String arguments) {
-        this.arguments = arguments;
+    /**
+     * Set command arguments, e.g. {@code [options] [<goal(s)>] [<phase(s)>]}.
+     * <p>Note that Closure Compiler doesn't allow to use 'arguments' as a name of a method argument.
+     */
+    void setArguments(String args) {
+        this.arguments = args;
     }
 
     String toCommandLine() {

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/command/MavenCommandPageView.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/command/MavenCommandPageView.java
@@ -32,7 +32,7 @@ public interface MavenCommandPageView extends View<MavenCommandPageView.ActionDe
     String getArguments();
 
     /** Sets value of the 'Arguments' field. */
-    void setArguments(String arguments);
+    void setArguments(String args);
 
     /** Action handler for the view actions/controls. */
     interface ActionDelegate {

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/command/MavenCommandPageViewImpl.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/command/MavenCommandPageViewImpl.java
@@ -76,9 +76,10 @@ public class MavenCommandPageViewImpl implements MavenCommandPageView {
         return arguments.getValue();
     }
 
+    // Note that Closure Compiler doesn't allow to use 'arguments' as a name of a method argument.
     @Override
-    public void setArguments(String arguments) {
-        this.arguments.setValue(arguments);
+    public void setArguments(String args) {
+        this.arguments.setValue(args);
     }
 
     @UiHandler({"workingDirectory"})


### PR DESCRIPTION
### What does this PR do?

Fix failing Closure Compiling in case GWT JavaScript compiler output style set to DETAILED mode.
### What issues does this PR fix or reference?

When I enable Closure Compiler and set GWT JavaScript compiler output style to DETAILED mode
by providing the following configuration of gwt-maven-plugin:

```
<configuration>
    <modules>
        <module>org.eclipse.che.ide.IDE</module>
    </modules>
    <style>DETAILED</style>
    <enableClosureCompiler>true</enableClosureCompiler>
</configuration>
```

I get the following compilation error:

```
[INFO]    Compiling 4 permutations
[INFO]       Compiling permutation 0...
[ERROR] error optimizing:JSC_VAR_ARGUMENTS_SHADOWED_ERROR. Shadowing "arguments" is not allowed at org/eclipse/che/plugin/maven/client/command/MavenCommandModel.java line 25 : 0
[INFO]       [ERROR] Unexpected internal compiler error
[INFO] java.lang.RuntimeException: Shadowing "arguments" is not allowed
[INFO]  at com.google.gwt.dev.js.ClosureJsRunner.compile(ClosureJsRunner.java:207)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler$PermutationCompiler.generateJavaScriptCode(JavaToJavaScriptCompiler.java:524)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler$PermutationCompiler.compilePermutation(JavaToJavaScriptCompiler.java:347)
[INFO]  at com.google.gwt.dev.jjs.MonolithicJavaToJavaScriptCompiler.compilePermutation(MonolithicJavaToJavaScriptCompiler.java:296)
[INFO]  at com.google.gwt.dev.jjs.UnifiedAst.compilePermutation(UnifiedAst.java:143)
[INFO]  at com.google.gwt.dev.CompilePerms.compile(CompilePerms.java:197)
[INFO]  at com.google.gwt.dev.ThreadedPermutationWorkerFactory$ThreadedPermutationWorker.compile(ThreadedPermutationWorkerFactory.java:50)
[INFO]  at com.google.gwt.dev.PermutationWorkerFactory$Manager$WorkerThread.run(PermutationWorkerFactory.java:74)
[INFO]  at java.lang.Thread.run(Thread.java:745)
[INFO]       [ERROR] Unrecoverable exception, shutting down
[INFO] com.google.gwt.core.ext.UnableToCompleteException: (see previous log entries)
[INFO]  at com.google.gwt.dev.javac.CompilationProblemReporter.logAndTranslateException(CompilationProblemReporter.java:112)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler$PermutationCompiler.compilePermutation(JavaToJavaScriptCompiler.java:363)
[INFO]  at com.google.gwt.dev.jjs.MonolithicJavaToJavaScriptCompiler.compilePermutation(MonolithicJavaToJavaScriptCompiler.java:296)
[INFO]  at com.google.gwt.dev.jjs.UnifiedAst.compilePermutation(UnifiedAst.java:143)
[INFO]  at com.google.gwt.dev.CompilePerms.compile(CompilePerms.java:197)
[INFO]  at com.google.gwt.dev.ThreadedPermutationWorkerFactory$ThreadedPermutationWorker.compile(ThreadedPermutationWorkerFactory.java:50)
[INFO]  at com.google.gwt.dev.PermutationWorkerFactory$Manager$WorkerThread.run(PermutationWorkerFactory.java:74)
[INFO]  at java.lang.Thread.run(Thread.java:745)
[INFO]       [ERROR] Not all permutation were compiled , completed (0/4)
```

It means that using '**arguments**' as a name of a method parameter is forbidden by Google Closure Compiler because, it seems, that it's reserved for internal using here:
https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/SyntacticScopeCreator.java#L38

Thank to @gazarenkov for reporting this problem :bowing_man:
@vparfonov please review this PR
