### PR TITLE
Remove returning of optional by getNextPageRef and getPreviousPageRef methods

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/Page.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/Page.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.core;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -143,26 +142,24 @@ public class Page<ITEM_T> {
     }
 
     /**
-     * Returns an {@link Optional} describing reference to the next page,
-     * or the empty {@code Optional} when this page is the first one.
+     * Returns a reference to the next page.
+     *
+     * <p>Note: This method was designed to be used in couple with {@link #hasNextPage()}.
+     * Returns reference to the next page even when {@link #hasNextPage()} returns false.
      */
-    public Optional<PageRef> getNextPageRef() {
-        if (!hasNextPage()) {
-            return Optional.empty();
-        }
-        return Optional.of(new PageRef(itemsBefore + pageSize, pageSize));
+    public PageRef getNextPageRef() {
+        return new PageRef(itemsBefore + pageSize, pageSize);
     }
 
     /**
-     * Returns an {@link Optional} describing reference to the previous page,
-     * or the empty {@code Optional} when this page is the last one.
+     * Returns a reference to the previous page.
+     *
+     * <p>Note: This method was designed to be used in couple with {@link #hasPreviousPage()}.
+     * Returns reference to the first page when {@link #hasPreviousPage()} returns false.
      */
-    public Optional<PageRef> getPreviousPageRef() {
-        if (!hasPreviousPage()) {
-            return Optional.empty();
-        }
+    public PageRef getPreviousPageRef() {
         final long skipItems = itemsBefore <= pageSize ? 0 : itemsBefore - pageSize;
-        return Optional.of(new PageRef(skipItems, pageSize));
+        return new PageRef(skipItems, pageSize);
     }
 
     /** Returns the reference to the last page. */

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/PagingUtil.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/PagingUtil.java
@@ -62,10 +62,10 @@ public final class PagingUtil {
         pageRefs.add(Pair.of("first", page.getFirstPageRef()));
         pageRefs.add(Pair.of("last", page.getLastPageRef()));
         if (page.hasPreviousPage()) {
-            pageRefs.add(Pair.of("prev", page.getPreviousPageRef().get()));
+            pageRefs.add(Pair.of("prev", page.getPreviousPageRef()));
         }
         if (page.hasNextPage()) {
-            pageRefs.add(Pair.of("next", page.getNextPageRef().get()));
+            pageRefs.add(Pair.of("next", page.getNextPageRef()));
         }
         final UriBuilder ub = UriBuilder.fromUri(uri);
         return pageRefs.stream()

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/PageTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/PageTest.java
@@ -87,10 +87,8 @@ public class PageTest {
         assertEquals(page.getNumber(), -1, "page number");
 
         assertFalse(page.hasPreviousPage(), "has previous page");
-        assertFalse(page.getPreviousPageRef().isPresent(), "has previous page ref");
 
         assertFalse(page.hasNextPage(), "page has next page");
-        assertFalse(page.getNextPageRef().isPresent(), "page has next page ref");
 
         assertEquals(page.getItems(), asList("item3", "item4", "item5"));
         assertEquals(page.getItems(i -> i.substring(4)), asList("3", "4", "5"));
@@ -128,14 +126,12 @@ public class PageTest {
         assertEquals(page.getNumber(), 2, "page number");
 
         assertTrue(page.hasPreviousPage(), "has previous page");
-        assertTrue(page.getPreviousPageRef().isPresent(), "has previous page ref");
-        final Page.PageRef prevRef = page.getPreviousPageRef().get();
+        final Page.PageRef prevRef = page.getPreviousPageRef();
         assertEquals(prevRef.getItemsBefore(), 0, "items before prev page");
         assertEquals(prevRef.getPageSize(), 3, "prev page size");
 
         assertTrue(page.hasNextPage(), "page has next page");
-        assertTrue(page.getNextPageRef().isPresent(), "page has next page ref");
-        final Page.PageRef nextRef = page.getNextPageRef().get();
+        final Page.PageRef nextRef = page.getNextPageRef();
         assertEquals(nextRef.getItemsBefore(), 6, "items before next page");
         assertEquals(nextRef.getPageSize(), 3, "next page size");
 
@@ -172,11 +168,9 @@ public class PageTest {
         assertEquals(page.getNumber(), 1, "page number");
 
         assertFalse(page.hasPreviousPage(), "has previous page");
-        assertFalse(page.getPreviousPageRef().isPresent(), "page has previous page ref");
 
         assertTrue(page.hasNextPage(), "page has next page");
-        assertTrue(page.getNextPageRef().isPresent(), "page has next page ref");
-        final Page.PageRef nextRef = page.getNextPageRef().get();
+        final Page.PageRef nextRef = page.getNextPageRef();
         assertEquals(nextRef.getPageSize(), 5, "next page size");
         assertEquals(nextRef.getItemsBefore(), 5, "next page skip items");
 
@@ -211,13 +205,11 @@ public class PageTest {
         assertEquals(page.getNumber(), 3, "page number");
 
         assertTrue(page.hasPreviousPage(), "has previous page");
-        assertTrue(page.getPreviousPageRef().isPresent(), "page has previous page ref");
-        final Page.PageRef prevRef = page.getPreviousPageRef().get();
+        final Page.PageRef prevRef = page.getPreviousPageRef();
         assertEquals(prevRef.getPageSize(), 3, "prev page size");
         assertEquals(prevRef.getItemsBefore(), 3, "prev page skip items");
 
         assertFalse(page.hasNextPage(), "has next page");
-        assertFalse(page.getNextPageRef().isPresent(), "page has next page ref");
 
         assertEquals(page.getItems(), asList("item7", "item8"));
     }
@@ -243,10 +235,8 @@ public class PageTest {
         assertEquals(page.getNumber(), 1, "page number");
 
         assertFalse(page.hasPreviousPage(), "has previous page");
-        assertFalse(page.getPreviousPageRef().isPresent(), "page has previous page ref");
 
         assertFalse(page.hasNextPage(), "page has next page");
-        assertFalse(page.getNextPageRef().isPresent(), "page has next page ref");
 
         assertEquals(page.getItems(), singleton("item1"));
     }


### PR DESCRIPTION
### What does this PR do?

Page object has hasNextPage and hasPreviousPage methods and returns optional instead of PageRef objects. So we can get next and previous pages references by

```
Page currentPage = ...;
if (currentPage.hasNextPage()) {
    PageRef nextPageRef = currentPage.getNextPageRef().get();
    // we can use page ref here
}
```

or by 

```
Page currentPage = ...;
Optional nextPageRefOpt = currentPage.getNextPageRef();
if (nextPageRefOpt.isPresent()) {
    PageRef nextPageRef = nextPageRefOpt.get();
    // we can use page ref here
}
```

But the most useful is following variant

```
Page currentPage = ...;
if (currentPage.hasNextPage()) {
    PageRef nextPageRef = currentPage.getNextPageRef();
    // we can use page ref here
}
```

So this pull request removes returning of optional by getNextPageRef and getPreviousPageRef methods to avoid double checking of next and previous page availability and usage of redundant optional variable
