### PR TITLE
Remove redundant CHE_HOME env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ FROM alpine:3.4
 ENV LANG=C.UTF-8 \
     JAVA_HOME=/usr/lib/jvm/default-jvm/jre \
     PATH=${PATH}:${JAVA_HOME}/bin \
-    CHE_HOME=/home/user/che \
     DOCKER_VERSION=1.6.0 \
     DOCKER_BUCKET=get.docker.com
 


### PR DESCRIPTION
### What does this PR do?

It removes a redundant CHE_HOME in the Dockerfile
### What issues does this PR fix or reference?

n/a (not reported)
### New behavior

Remove redundant CHE_HOME environment variable
