### PR TITLE
Fix git config test failure

### DIFF
--- a/wsagent/che-core-api-git/src/test/java/org/eclipse/che/git/impl/ConfigTest.java
+++ b/wsagent/che-core-api-git/src/test/java/org/eclipse/che/git/impl/ConfigTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertEquals;
  */
 public class ConfigTest {
 
-    private static final String PROPERTY_NAME         = "difftool.prompt";
+    private static final String PROPERTY_NAME         = "test.prop";
     private static final String INVALID_PROPERTY_NAME = "someInvalidProperty";
     private static final String PROPERTY_VALUE        = "testValue";
 


### PR DESCRIPTION
### What does this PR do?

Changes property used for testing git config implementation to an unused one instead of `difftool.prompt`.
### What issues does this PR fix or reference?

Fixes issue with running tests in `che-core-git-impl-jgit` when `difftool.prompt` option is set globally.
### Previous behavior

JGit pulls the global config file when creating a repository. While running tests, if `difftool.prompt` is set in the global `.gitconfig` file, this will causes tests to fail while building `Che Core :: Git Impl JGit`.
### New behavior

Changes `ConfigTest.java` to use nonsense property `test.prop`, so that there is no conflict.

Signed-off-by: Angel Misevski amisevsk@redhat.com
