### PR TITLE
Che server should connect to ws-agent on internal URL (#2030)

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -143,7 +143,7 @@ che.docker.ip=NULL
 che.docker.ip.external=NULL
 
 # If true, then uses the internal address and port of workspace Docker containers (i.e. within the Docker
-# Docker network) instead of the address and port provided by the Docker daemon. May be necessary if the
+# Docker network) instead of the docker host address and the port provided by the Docker daemon. May be necessary if the
 # Che server is unable to contact workspace agents, but will prevent communication if the server and workspace
 # are not on the same network.
 che.docker.ip.use_internal_address=false

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -142,6 +142,12 @@ che.docker.ip=NULL
 # This is unusual, but happens for example in Docker for Mac when containers are in a VM.
 che.docker.ip.external=NULL
 
+# If true, then uses the internal address and port of workspace Docker containers (i.e. within the Docker
+# Docker network) instead of the address and port provided by the Docker daemon. May be necessary if the
+# Che server is unable to contact workspace agents, but will prevent communication if the server and workspace
+# are not on the same network.
+che.docker.ip.use_internal_address=false
+
 # Provides a Docker network where Che server is running.
 # Workspace containers created by Che will be added to this Docker network.
 # Communications between the Che server and container occur over this network.

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -310,7 +310,7 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
         return servers;
     }
 
-    protected Map<String, ServerImpl> getServersWithFilledPorts(final String externalHostame, final String internalHostname, final Map<String, List<PortBinding>> exposedPorts) {
+    protected Map<String, ServerImpl> getServersWithFilledPorts(final String externalHostname, final String internalHostname, final Map<String, List<PortBinding>> exposedPorts) {
         final HashMap<String, ServerImpl> servers = new LinkedHashMap<>();
 
         for (Map.Entry<String, List<PortBinding>> portEntry : exposedPorts.entrySet()) {
@@ -330,7 +330,7 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
 
             servers.put(portProtocol, new ServerImpl(null,
                                                      null,
-                                                     externalHostame + ":" + externalPort,
+                                                     externalHostname + ":" + externalPort,
                                                      null,
                                                      new ServerPropertiesImpl(null, internalHostnameAndPort, null)));
         }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -88,6 +88,7 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
     private final String                      containerExternalHostname;
     private final String                      containerInternalHostname;
     private final Map<String, ServerConfImpl> serversConf;
+    private final boolean                     useInternalAddress;
 
     @Inject
     public DockerInstanceRuntimeInfo(@Assisted ContainerInfo containerInfo,
@@ -95,7 +96,8 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
                                      @Assisted("internalhost") String containerInternalHostname,
                                      @Assisted MachineConfig machineConfig,
                                      @Named("machine.docker.dev_machine.machine_servers") Set<ServerConf> devMachineSystemServers,
-                                     @Named("machine.docker.machine_servers") Set<ServerConf> allMachinesSystemServers) {
+                                     @Named("machine.docker.machine_servers") Set<ServerConf> allMachinesSystemServers,
+                                     @Named("che.docker.ip.use_internal_address") boolean useInternalAddress) {
         this.info = containerInfo;
         this.containerExternalHostname = containerExternalHostname == null ? containerInternalHostname : containerExternalHostname;
         this.containerInternalHostname = containerInternalHostname;
@@ -108,6 +110,7 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
                                                                srvConf.getPort() :
                                                                srvConf.getPort() + "/tcp",
                                                     ServerConfImpl::new));
+        this.useInternalAddress = useInternalAddress;
     }
 
     @Override
@@ -315,11 +318,21 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
             String portProtocol = portEntry.getKey();
             // we are assigning ports automatically, so have 1 to 1 binding (at least per protocol)
             String externalPort = portEntry.getValue().get(0).getHostPort();
+
+            // If we are sending messages to the container directly, we don't want to use the mapped ports.
+            String internalHostnameAndPort;
+            if (useInternalAddress) {
+                String internalPort = portProtocol.split("/")[0];
+                internalHostnameAndPort = internalHostname + ":" + internalPort;
+            } else {
+                internalHostnameAndPort = internalHostname + ":" + externalPort;
+            }
+
             servers.put(portProtocol, new ServerImpl(null,
                                                      null,
                                                      externalHostame + ":" + externalPort,
                                                      null,
-                                                     new ServerPropertiesImpl(null, internalHostname + ":" + externalPort, null)));
+                                                     new ServerPropertiesImpl(null, internalHostnameAndPort, null)));
         }
 
         return servers;
@@ -355,4 +368,5 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
 
         return serversConf;
     }
+
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerInstanceRuntimeInfo.java
@@ -29,13 +29,10 @@ import java.util.Set;
  * directly (e.g. when running on Docker for Mac or behind a NAT). If the external address is not provided it defaults
  * to the internal one.
  *
- * <p>If environment variable {@code CHE_DOCKER_IP_USE__INTERNAL__ADDRESS} or
- * property {@code che.docker.ip.use_internal_address} is true, is true, the IP Address from
+ * <p>If property {@code che.docker.ip.use_internal_address} is true, is true, the IP Address from
  * {@link ContainerInfo}, if available, is used for internal address instead.<br>
- * <p>Value of host can be retrieved from property {@code che.docker.ip} or
- * from environment variable {@code CHE_DOCKER_IP}.<br>
- * <p>Value of external hostname can be retrieved from property {@code che.docker.ip.external} or
- * from environment variable {@code CHE_DOCKER_IP_EXTERNAL}.<br>
+ * <p>Value of host can be retrieved from property {@code che.docker.ip}. <br>
+ * <p>Value of external hostname can be retrieved from property {@code che.docker.ip.external}. <br>
  * Environment variables override properties.
  *
  * @author Alexander Garagatyi


### PR DESCRIPTION
### What does this PR do?

Enables che-server to use the internal address of wsagent containers when it is running
in docker through setting an environment variable. 

When `CHE_DOCKER_USE_INTERNAL_CONTAINER_ADDRESS` is set to "true", the
`ServerProperties` objects returned as part of `DockerInstanceRuntimeInfo#getServers()`
will use the internal address of the container as obtained from docker inspect. 

If the environment variable is not set, then behaviour is unchanged.

This is a WIP so comments / suggestions are greatly appreciated.
### What issues does this PR fix or reference?

Che server should connect to ws-agent on internal URL (#2030)
### Previous behavior

Value used for internal address could cause issues contacting wsagent if firewall interfered.
### New behavior

Che-server can now optionally communicate with wsagent directly.
### PR type
- [x] Minor change = no change to existing features or docs
- [ ] Major change = changes existing features or docs
### Minor change checklist
- [ ] New API required?
- [ ] API updated
- [x] Tests updated
- [x] Tests passed

Signed-off-by: Angel Misevski amisevsk@redhat.com
