### PR TITLE
CHE-2848: Removing "skip-validate-sources" from "fast" maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -863,7 +863,6 @@
                 <gwt.compiler.localWorkers>2 -T 1C</gwt.compiler.localWorkers>
                 <license.skip>true</license.skip>
                 <mdep.analyze.skip>true</mdep.analyze.skip>
-                <skip-validate-sources>true</skip-validate-sources>
                 <skipTests>true</skipTests>
             </properties>
         </profile>


### PR DESCRIPTION
### What does this PR do?

Removes "skip-validate-sources" from "fast" maven profile
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2848

Signed-off-by: Ilya Buziuk ibuziuk@redhat.com
