### PR TITLE
Add missing dependencies to build all sample plugins

### DIFF
--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -95,7 +95,7 @@
                         <configuration>
                             <target>
                                 <loadfile property="stack.che-in-che" srcFile="${project.basedir}/src/assembly/stack/che-in-che.json" />
-                                <unzip src="${org.eclipse.che.core:che-core-ide-stacks:jar}" dest="${project.build.directory}/stacks" />
+                                <unzip dest="${project.build.directory}/stacks" src="${org.eclipse.che.core:che-core-ide-stacks:jar}" />
                                 <replaceregexp file="${project.build.directory}/stacks/stacks.json" flags="m">
                                     <regexp pattern="^]$" />
                                     <substitution expression=", ${stack.che-in-che} ]" />

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.sample</groupId>
+                <artifactId>che-sample-plugin-embedjs-ide</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.sample</groupId>
                 <artifactId>che-sample-plugin-filetype-ide</artifactId>
                 <version>${che.version}</version>
             </dependency>
@@ -805,6 +810,26 @@
             <dependency>
                 <groupId>org.eclipse.che.sample</groupId>
                 <artifactId>che-sample-plugin-json-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.sample</groupId>
+                <artifactId>che-sample-plugin-nativeaccess-ide</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.sample</groupId>
+                <artifactId>che-sample-plugin-parts-ide</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.sample</groupId>
+                <artifactId>che-sample-plugin-serverservice-ide</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.sample</groupId>
+                <artifactId>che-sample-plugin-serverservice-server</artifactId>
                 <version>${che.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### What does this PR do?

PR add some missing dependencies in order to build all sample plugins
### Previous behavior

Not all plugin samples were not present in the build of che

Signed-off-by: Stevan Le Meur stevan.lemeur@gmail.com
