### PR TITLE
CHE-2816. Correctly applying exclude filters at indexing files

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchPresenter.java
@@ -118,7 +118,7 @@ public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegat
         String[] items = escapedText.trim().split("\\s+");
         int numberItem = items.length;
         if (numberItem == 1) {
-            return items[0] + '*';
+            return items[0];
         }
 
         String lastItem = items[numberItem - 1];
@@ -127,7 +127,6 @@ public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegat
         sb.append(escapedText.substring(0, escapedText.lastIndexOf(lastItem)));
         sb.append("\" " + AND_OPERATOR + " ");
         sb.append(lastItem);
-        sb.append('*');
         return sb.toString();
     }
 

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/MediaTypeFilter.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/MediaTypeFilter.java
@@ -25,8 +25,11 @@ import java.util.Set;
 
 /**
  * Filter based on media type of the file.
+ * The filter includes in result files with media type different from the specified types in the set {@link MediaTypeFilter#mediaTypes}
+ * Note: if media type can not be detected a file will be include in result as well.
  *
  * @author Valeriy Svydenko
+ * @author Roman Nikitenko
  */
 public class MediaTypeFilter implements VirtualFileFilter {
     private final Set<MediaType> mediaTypes;
@@ -40,9 +43,9 @@ public class MediaTypeFilter implements VirtualFileFilter {
         try (InputStream content = file.getContent()) {
             TikaConfig tikaConfig = new TikaConfig();
             MediaType mimeType = tikaConfig.getDetector().detect(content, new Metadata());
-            return mediaTypes.contains(mimeType);
+            return !mediaTypes.contains(mimeType);
         } catch (TikaException | ForbiddenException | ServerException | IOException e) {
-            return false;
+            return true;
         }
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/AbstractLuceneSearcherProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/AbstractLuceneSearcherProvider.java
@@ -30,16 +30,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.collect.Lists.newArrayList;
 
 public abstract class AbstractLuceneSearcherProvider implements SearcherProvider {
-    protected final VirtualFileFilter fileIndexFilter;
+    protected final VirtualFileFilter excludeFileIndexFilters;
     protected final AtomicReference<Searcher> searcherReference = new AtomicReference<>();
     private final ExecutorService executor;
 
     /**
-     * @param fileIndexFilters
+     * @param excludeFileIndexFilters
      *         set filter for files that should not be indexed
      */
-    protected AbstractLuceneSearcherProvider(Set<VirtualFileFilter> fileIndexFilters) {
-        this.fileIndexFilter = mergeFileIndexFilters(fileIndexFilters);
+    protected AbstractLuceneSearcherProvider(Set<VirtualFileFilter> excludeFileIndexFilters) {
+        this.excludeFileIndexFilters = mergeFileIndexFilters(excludeFileIndexFilters);
         executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
                                                              .setDaemon(true)
                                                              .setNameFormat("LuceneSearcherInitThread")
@@ -53,7 +53,7 @@ public abstract class AbstractLuceneSearcherProvider implements SearcherProvider
         } else {
             final List<VirtualFileFilter> myFilters = newArrayList(new MediaTypeFilter());
             myFilters.addAll(fileIndexFilters);
-            filter = VirtualFileFilters.createAndFilter(myFilters);
+            filter = VirtualFileFilters.createOrFilter(myFilters);
         }
         return filter;
     }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherProvider.java
@@ -45,6 +45,6 @@ public class FSLuceneSearcherProvider extends AbstractLuceneSearcherProvider {
 
     @Override
     protected LuceneSearcher createLuceneSearcher(CloseCallback closeCallback) {
-        return new FSLuceneSearcher(indexRootDirectory, fileIndexFilter, closeCallback);
+        return new FSLuceneSearcher(indexRootDirectory, excludeFileIndexFilters, closeCallback);
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java
@@ -71,7 +71,7 @@ public abstract class LuceneSearcher implements Searcher {
 
     private static final int RESULT_LIMIT = 1000;
 
-    private final List<VirtualFileFilter>                      indexFilters;
+    private final List<VirtualFileFilter>                      excludeFileIndexFilters;
     private final AbstractLuceneSearcherProvider.CloseCallback closeCallback;
 
     private IndexWriter     luceneIndexWriter;
@@ -88,24 +88,24 @@ public abstract class LuceneSearcher implements Searcher {
     }
 
     /**
-     * @param indexFilter
+     * @param excludeFileIndexFilter
      *         common filter for files that should not be indexed. If complex excluding rules needed then few filters might be combined
      *         with {@link VirtualFileFilters#createAndFilter} or {@link VirtualFileFilters#createOrFilter} methods
      */
-    protected LuceneSearcher(VirtualFileFilter indexFilter, AbstractLuceneSearcherProvider.CloseCallback closeCallback) {
+    protected LuceneSearcher(VirtualFileFilter excludeFileIndexFilter, AbstractLuceneSearcherProvider.CloseCallback closeCallback) {
         this.closeCallback = closeCallback;
-        indexFilters = new CopyOnWriteArrayList<>();
-        indexFilters.add(indexFilter);
+        excludeFileIndexFilters = new CopyOnWriteArrayList<>();
+        excludeFileIndexFilters.add(excludeFileIndexFilter);
     }
 
     @Override
     public boolean addIndexFilter(VirtualFileFilter indexFilter) {
-        return indexFilters.add(indexFilter);
+        return excludeFileIndexFilters.add(indexFilter);
     }
 
     @Override
     public boolean removeIndexFilter(VirtualFileFilter indexFilter) {
-        return indexFilters.remove(indexFilter);
+        return excludeFileIndexFilters.remove(indexFilter);
     }
 
     protected Analyzer makeAnalyzer() {
@@ -389,8 +389,8 @@ public abstract class LuceneSearcher implements Searcher {
     }
 
     private boolean shouldIndexContent(VirtualFile virtualFile) {
-        for (VirtualFileFilter indexFilter : indexFilters) {
-            if (!indexFilter.accept(virtualFile)) {
+        for (VirtualFileFilter indexFilter : excludeFileIndexFilters) {
+            if (indexFilter.accept(virtualFile)) {
                 return false;
             }
         }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/MemoryLuceneSearcherProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/MemoryLuceneSearcherProvider.java
@@ -19,15 +19,15 @@ import java.util.Set;
 @Singleton
 public class MemoryLuceneSearcherProvider extends AbstractLuceneSearcherProvider {
     /**
-     * @param fileIndexFilters
+     * @param excludeFileIndexFilters
      *         set filter for files that should not be indexed
      */
-    public MemoryLuceneSearcherProvider(@Named("vfs.index_filter") Set<VirtualFileFilter> fileIndexFilters) {
-        super(fileIndexFilters);
+    public MemoryLuceneSearcherProvider(@Named("vfs.index_filter") Set<VirtualFileFilter> excludeFileIndexFilters) {
+        super(excludeFileIndexFilters);
     }
 
     @Override
     protected LuceneSearcher createLuceneSearcher(CloseCallback closeCallback) {
-        return new MemoryLuceneSearcher(fileIndexFilter, closeCallback);
+        return new MemoryLuceneSearcher(excludeFileIndexFilters, closeCallback);
     }
 }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/MediaTypeFilterTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/MediaTypeFilterTest.java
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith;
 import java.io.ByteArrayInputStream;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,11 +33,11 @@ public class MediaTypeFilterTest {
     @DataProvider
     public static Object[][] testData() throws Exception {
         return new Object[][]{
-                {virtualFileWithContent("to be or not to be".getBytes()), true},
-                {virtualFileWithContent("<html><head></head></html>".getBytes()), true},
-                {virtualFileWithContent("<a><b/></a>".getBytes()), true},
-                {virtualFileWithContent("public class SomeClass {}".getBytes()), true},
-                {virtualFileWithContent(new byte[10]), false}
+                {virtualFileWithContent("to be or not to be".getBytes()), false},
+                {virtualFileWithContent("<html><head></head></html>".getBytes()), false},
+                {virtualFileWithContent("<a><b/></a>".getBytes()), false},
+                {virtualFileWithContent("public class SomeClass {}".getBytes()), false},
+                {virtualFileWithContent(new byte[10]), true}
         };
     }
 

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherTest.java
@@ -60,7 +60,7 @@ public class FSLuceneSearcherTest {
         assertTrue(indexDirectory.mkdir());
 
         filter = mock(VirtualFileFilter.class);
-        when(filter.accept(any(VirtualFile.class))).thenReturn(true);
+        when(filter.accept(any(VirtualFile.class))).thenReturn(false);
 
         closeCallback = mock(AbstractLuceneSearcherProvider.CloseCallback.class);
         searcher = new FSLuceneSearcher(indexDirectory, filter, closeCallback);
@@ -232,7 +232,7 @@ public class FSLuceneSearcherTest {
         folder.createFile("yyy.txt", TEST_CONTENT[2]);
         folder.createFile("zzz.txt", TEST_CONTENT[2]);
 
-        when(filter.accept(withName("yyy.txt"))).thenReturn(false);
+        when(filter.accept(withName("yyy.txt"))).thenReturn(true);
         searcher.init(virtualFileSystem);
 
         List<String> paths = searcher.search(new QueryExpression().setText("be")).getFilePaths();

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/MemoryLuceneSearcherTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/MemoryLuceneSearcherTest.java
@@ -52,7 +52,7 @@ public class MemoryLuceneSearcherTest {
     @Before
     public void setUp() throws Exception {
         filter = mock(VirtualFileFilter.class);
-        when(filter.accept(any(VirtualFile.class))).thenReturn(true);
+        when(filter.accept(any(VirtualFile.class))).thenReturn(false);
         closeCallback = mock(AbstractLuceneSearcherProvider.CloseCallback.class);
         searcher = new MemoryLuceneSearcher(filter, closeCallback);
     }
@@ -222,7 +222,7 @@ public class MemoryLuceneSearcherTest {
         folder.createFile("yyy.txt", TEST_CONTENT[2]);
         folder.createFile("zzz.txt", TEST_CONTENT[2]);
 
-        when(filter.accept(withName("yyy.txt"))).thenReturn(false);
+        when(filter.accept(withName("yyy.txt"))).thenReturn(true);
         searcher.init(virtualFileSystem);
 
         List<String> paths = searcher.search(new QueryExpression().setText("be")).getFilePaths();


### PR DESCRIPTION
### What does this PR do?
- avoid to duplicate '*' for searching request
- correctly applying exclude filters at indexing files

Current behavior: we need to have exclude filters here https://github.com/eclipse/che/blob/master/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java#L95 
and we have some filters for files that should NOT be indexed. But  org.eclipse.che.api.vfs.search.MediaTypeFilter  includes in result files that SHOULD  be indexed. 
New behavior: the media type filter will include in result files with media type that should NOT be indexed.
### What issues does this PR fix or reference?
#2816

Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com
