### PR TITLE
Ability to set visibility state for machine plugin central toolbar items

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineExtension.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineExtension.java
@@ -53,6 +53,9 @@ import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPan
 import org.eclipse.che.ide.extension.machine.client.targets.EditTargetsAction;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.util.input.KeyCodeMap;
+import org.eclipse.che.ide.util.loging.Log;
+
+import javax.inject.Named;
 
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_CENTER_TOOLBAR;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_MAIN_MENU;
@@ -78,6 +81,16 @@ public class MachineExtension {
     public static final String GROUP_COMMANDS_LIST     = "CommandsListGroup";
     public static final String GROUP_MACHINES_DROPDOWN = "MachinesSelector";
     public static final String GROUP_MACHINES_LIST     = "MachinesListGroup";
+
+    /**
+     * Controls central toolbar action group visibility. Use for example next snippet:
+     * <code>
+     *     bindConstant().annotatedWith(Names.named("machine.extension.central.toolbar.visibility")).to(false);
+     * </code>
+     * to define a constant. If no constant defined than default value is used - <code>true</code>.
+     */
+    @Inject(optional = true)
+    @Named("machine.extension.central.toolbar.visibility") boolean centralToolbarVisible = true;
 
     @Inject
     public MachineExtension(final MachineResources machineResources,
@@ -187,15 +200,17 @@ public class MachineExtension {
         machineMenu.add(destroyMachineAction);
         machineMenu.add(createSnapshotAction);
 
-        // add actions on center part of toolbar
-        final DefaultActionGroup centerToolbarGroup = (DefaultActionGroup)actionManager.getAction(GROUP_CENTER_TOOLBAR);
-        final DefaultActionGroup machineToolbarGroup = new DefaultActionGroup(GROUP_MACHINE_TOOLBAR, false, actionManager);
-        actionManager.registerAction(GROUP_MACHINE_TOOLBAR, machineToolbarGroup);
-        centerToolbarGroup.add(machineToolbarGroup, FIRST);
-        machineToolbarGroup.add(selectCommandAction);
-        final DefaultActionGroup executeToolbarGroup = new DefaultActionGroup(actionManager);
-        executeToolbarGroup.add(executeSelectedCommandAction);
-        machineToolbarGroup.add(executeToolbarGroup);
+        if (centralToolbarVisible) {
+            // add actions on center part of toolbar
+            final DefaultActionGroup centerToolbarGroup = (DefaultActionGroup)actionManager.getAction(GROUP_CENTER_TOOLBAR);
+            final DefaultActionGroup machineToolbarGroup = new DefaultActionGroup(GROUP_MACHINE_TOOLBAR, false, actionManager);
+            actionManager.registerAction(GROUP_MACHINE_TOOLBAR, machineToolbarGroup);
+            centerToolbarGroup.add(machineToolbarGroup, FIRST);
+            machineToolbarGroup.add(selectCommandAction);
+            final DefaultActionGroup executeToolbarGroup = new DefaultActionGroup(actionManager);
+            executeToolbarGroup.add(executeSelectedCommandAction);
+            machineToolbarGroup.add(executeToolbarGroup);
+        }
 
         // add actions on right part of toolbar
         final DefaultActionGroup rightToolbarGroup = (DefaultActionGroup)actionManager.getAction(GROUP_RIGHT_TOOLBAR);


### PR DESCRIPTION
Added ability to define visibility for the central toolbar action group of machine plugin. It is defined by setting a constant named `machine.extension.central.toolbar.visibility`. For example setting next line in a `Gin` module

``` java
bindConstant().annotatedWith(Names.named("machine.extension.central.toolbar.visibility")).to(false);
```

will make machine plugin to not create an action group. 

Default visibility value is **`true`** so if no constant is defined than toolbar action groups are created and visible.

Related issue: https://github.com/codenvy/artik-ide/issues/158

_Note:_ on PR merge not to forget to merge this into master branch
