### PR TITLE
Add SNAPSHOTTING status tracking and remove obvious notifications

### DIFF
--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -137,8 +137,8 @@ export class NavbarRecentWorkspacesController {
    */
   getDropdownItems(workspaceId) {
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId),
-      disabled = workspace && (workspace.status === 'STARTING' || workspace.status === 'STOPPING'),
-      visibleScope = (workspace && (workspace.status === 'RUNNING' || workspace.status === 'STOPPING')) ? 'RUNNING' : 'STOPPED';
+      disabled = workspace && (workspace.status === 'STARTING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING'),
+      visibleScope = (workspace && (workspace.status === 'RUNNING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING')) ? 'RUNNING' : 'STOPPED';
 
     if (!this.dropdownItems[workspaceId]) {
       this.dropdownItems[workspaceId] = [];

--- a/dashboard/src/app/stacks/stack-details/stack.controller.ts
+++ b/dashboard/src/app/stacks/stack-details/stack.controller.ts
@@ -225,7 +225,6 @@ export class StackController {
    */
   createStack(): void {
     this.cheStack.createStack(this.stackContent).then((stack) => {
-      this.cheNotification.showInfo('Stack is successfully created.');
       this.stack = stack;
       this.isLoading = false;
       this.cheStack.fetchStacks();

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
@@ -18,7 +18,7 @@
         tooltip="Run workspace"></span>
   <span class="fa fa-stop"
         data-ng-click="workspaceStatusController.stopWorkspace()"
-        ng-show="(workspaceStatusController.workspace.status === 'RUNNING' || workspaceStatusController.workspace.status === 'STOPPING')"
+        ng-show="(workspaceStatusController.workspace.status === 'RUNNING' || workspaceStatusController.workspace.status === 'STOPPING' || workspaceStatusController.workspace.status === 'SNAPSHOTTING')"
         ng-class="{'disabled' : workspaceStatusController.workspace.status !== 'RUNNING'}"
         tooltip="Stop workspace"></span>
 </div>

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -366,9 +366,6 @@ export class WorkspaceDetailsController {
       // update list of workspaces
       // for new workspace to show in recent workspaces
       this.updateRecentWorkspace(workspaceData.id);
-
-      let infoMessage = 'Workspace ' + workspaceData.config.name + ' successfully created.';
-      this.cheNotification.showInfo(infoMessage);
       this.cheWorkspace.fetchWorkspaces().then(() => {
         this.$location.path('/workspace/' + workspaceData.namespace + '/' +  workspaceData.config.name);
       });

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -73,11 +73,11 @@
               <div layout="row" class="workspace-details-action-buttons">
                 <div>
                   <che-button-default ng-disabled="(workspaceDetailsController.isCreationFlow || workspaceDetailsController.getWorkspaceStatus() === 'STARTING')"
-                                      ng-show="(workspaceDetailsController.getWorkspaceStatus() !== 'RUNNING' && workspaceDetailsController.getWorkspaceStatus() !== 'STOPPING')"
+                                      ng-show="(workspaceDetailsController.getWorkspaceStatus() !== 'RUNNING' && workspaceDetailsController.getWorkspaceStatus() !== 'STOPPING' && workspaceDetailsController.getWorkspaceStatus() !== 'SNAPSHOTTING')"
                                       che-button-title="Run" name="runButton"
                                       ng-click="workspaceDetailsController.runWorkspace()"></che-button-default>
-                  <che-button-default ng-disabled="(workspaceDetailsController.isCreationFlow || workspaceDetailsController.getWorkspaceStatus() === 'STOPPING')"
-                                      ng-show="(workspaceDetailsController.getWorkspaceStatus() === 'RUNNING' || workspaceDetailsController.getWorkspaceStatus() === 'STOPPING')"
+                  <che-button-default ng-disabled="(workspaceDetailsController.isCreationFlow || workspaceDetailsController.getWorkspaceStatus() === 'STOPPING' || workspaceDetailsController.getWorkspaceStatus() === 'SNAPSHOTTING')"
+                                      ng-show="(workspaceDetailsController.getWorkspaceStatus() === 'RUNNING' || workspaceDetailsController.getWorkspaceStatus() === 'STOPPING' || workspaceDetailsController.getWorkspaceStatus() === 'SNAPSHOTTING')"
                                       che-button-title="Stop" name="stopButton"
                                       ng-click="workspaceDetailsController.stopWorkspace()"></che-button-default>
                 </div>

--- a/dashboard/src/app/workspaces/workspace-status/workspace-status-indicator.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-status/workspace-status-indicator.directive.ts
@@ -53,7 +53,7 @@ export class WorkspaceStatusIndicator {
       '<div class="spinner"><div class="rect1"></div><div class="rect2"></div><div class="rect3"></div></div>' +
       '</span>' +
       '<span ng-switch-when="ERROR" class="fa fa-circle workspace-status-error"></span>' +
-      '<span ng-switch-when="SNAPSHOT_CREATING" class="fa fa-circle workspace-status-snapshot"></span>' +
+      '<span ng-switch-when="SNAPSHOTTING" class="fa fa-circle workspace-status-snapshot"></span>' +
       '<span ng-switch-default class="fa ' + (emptyCircleOnStopped ? 'fa-circle-o' : 'fa-circle') + ' workspace-status-default"></span>' +
       '</span>';
   }

--- a/dashboard/src/components/api/che-workspace.factory.ts
+++ b/dashboard/src/components/api/che-workspace.factory.ts
@@ -27,7 +27,7 @@ export class CheWorkspace {
    * @ngInject for Dependency injection
    */
   constructor ($resource, $q, cheWebsocket, lodash, cheEnvironmentRegistry, $log) {
-    this.workspaceStatuses = ['RUNNING', 'STOPPED', 'PAUSED', 'STARTING', 'STOPPING', 'ERROR', 'SNAPSHOT_CREATING'];
+    this.workspaceStatuses = ['RUNNING', 'STOPPED', 'PAUSED', 'STARTING', 'STOPPING', 'ERROR'];
 
     // keep resource
     this.$resource = $resource;
@@ -480,6 +480,8 @@ export class CheWorkspace {
         //Filter workspace events, which really indicate the status change:
         if (this.workspaceStatuses.indexOf(message.eventType) >= 0) {
           this.getWorkspaceById(workspaceId).status = message.eventType;
+        } else if (message.eventType === 'SNAPSHOT_CREATING') {
+          this.getWorkspaceById(workspaceId).status = 'SNAPSHOTTING';
         } else if (message.eventType === 'SNAPSHOT_CREATED') {
           //Snapshot can be created for RUNNING workspace only. As far as snapshot creation is only the events, not the state,
           //we introduced SNAPSHOT_CREATING status to be handled by UI, though it is fake one, and end of it is indicated by SNAPSHOT_CREATED.


### PR DESCRIPTION
### What does this PR do?

Adds tracking the workspace SNAPSHOTTING status introduced in https://github.com/eclipse/che/issues/2683.

Removes notifications on stack and workspace creation.
### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2763
https://github.com/eclipse/che/issues/2622
https://github.com/eclipse/che/issues/2627
