### PR TITLE
#2729 do not send file operation messages if LS doesn't exist

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
@@ -32,7 +32,9 @@ import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorProv
 import org.eclipse.che.plugin.languageserver.ide.hover.HoverProvider;
 import org.eclipse.che.plugin.languageserver.ide.service.LanguageServerRegistryServiceClient;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -49,8 +51,10 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
     private final EditorRegistry                      editorRegistry;
     private final OrionContentTypeRegistrant          contentTypeRegistrant;
     private final OrionHoverRegistrant                orionHoverRegistrant;
-    private final LanguageServerEditorProvider editorProvider;
-    private final HoverProvider hoverProvider;
+    private final LanguageServerEditorProvider        editorProvider;
+    private final HoverProvider                       hoverProvider;
+
+    private final Set<String> lsExtensions = new HashSet<>();
 
     @Inject
     public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry,
@@ -85,6 +89,7 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
                             final FileType fileType = new FileType(resources.file(), ext);
                             fileTypeRegistry.registerFileType(fileType);
                             editorRegistry.registerDefaultEditor(fileType, editorProvider);
+                            lsExtensions.add(ext);
                         }
                         List<String> mimeTypes = lang.getMimeTypes();
                         if (mimeTypes.isEmpty()) {
@@ -118,5 +123,9 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
                 callback.onFailure(new Exception(arg.getMessage(), arg.getCause()));
             }
         });
+    }
+
+    public boolean hasLSForExtension(String ext) {
+        return lsExtensions.contains(ext);
     }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/che/plugin/languageserver/LanguageServer.gwt.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/che/plugin/languageserver/LanguageServer.gwt.xml
@@ -25,6 +25,7 @@
     <inherits name="io.typefox.lsapi.LsApi"/>
     <inherits name="org.eclipse.che.ide.editor.orion.OrionEditor"/>
     <inherits name="org.eclipse.che.api.promises.Promises"/>
+    <inherits name="org.eclipse.che.api.languageserver.LanguageServer"/>
 
     <source path="ide"/>
 </module>


### PR DESCRIPTION
### What does this PR do?

Do not send file operation messages (open, save, close) to LS if LS for such file doesn't exist.
### What issues does this PR fix or reference?
#2729
### Previous behavior

Send file operation messages to LS for every opened file
