### PR TITLE
Enable 'keepVcs' property when importing with sparse checkout

### DIFF
--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
@@ -193,9 +193,9 @@ public class GitProjectImporter implements ProjectImporter {
                 if (branchMerge != null) {
                     git.getConfig().set("branch." + (branch == null ? "master" : branch) + ".merge", branchMerge);
                 }
-                if (!keepVcs) {
-                    cleanGit(git.getWorkingDir());
-                }
+            }
+            if (!keepVcs) {
+                cleanGit(git.getWorkingDir());
             }
         } catch (URISyntaxException e) {
             throw new ServerException(


### PR DESCRIPTION
### What does this PR do?

Removes git directory and related files when importing a project with sparse checkout and keepVcs property is set to `false`.
### Previous behavior

Git directory and related files were present, even if `keepVcs` property was set to `false` on importing a project with sparse checkout.

@skabashnyuk please review
