### PR TITLE
Small improvement in Zend stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1988,7 +1988,7 @@
         {
           "name": "restart zend server",
           "type": "custom",
-          "commandLine": "sudo sed -i 's#zray.zendserver_ui_url=.*#zray.zendserver_ui_url=http://${server.port.10081}/ZendServer#g' /usr/local/zend/etc/conf.d/zray.ini && sudo /usr/local/zend/bin/zendctl.sh restart",
+          "commandLine": "sudo sqlite3 /usr/local/zend/var/db/zsd.db \"UPDATE ZSD_DIRECTIVES SET DISK_VALUE='http://${server.port.10081}/ZendServer' WHERE NAME='zray.zendserver_ui_url'\" && sudo sed -i 's#zray.zendserver_ui_url=.*#zray.zendserver_ui_url=http://${server.port.10081}/ZendServer#g' /usr/local/zend/etc/conf.d/zray.ini && sudo /usr/local/zend/bin/zendctl.sh restart",
           "attributes": {
             "previewUrl": "http://${server.port.80}"
           }


### PR DESCRIPTION
### What does this PR do?

This is a small improvement in the Zend stack.

When running inside a Docker container, Zend Server needs an additional configuration before starting in order for Z-Ray to run properly. The `zray.zendserver_ui_url` needs to be configured with the current exposed port number of port 10081 (Zend Server Admin UI port). This PR improve this configuration step.
### What issues does this PR fix or reference?
- PHP support #2590 

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
