### PR TITLE
CHE-2874 Let users configure the 'Z' flag when mouting a volume

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -133,6 +133,11 @@ che.docker.privilege=false
 # Limits the number of processes that can be forked inside a cgroup. Set -1 for unlimited.
 # Since 4.3 kernel.
 che.docker.pids_limit=-1
+# Adds options when mounting the /projects volume.
+che.docker.volumes_projects_options=Z
+
+# Adds options when mounting the /mnt/che/terminal, /mnt/che/ws-agent.tar.gz, /mnt/che/conf volume
+che.docker.volumes_agent_options=ro,Z
 
 # If the browser clients that are accessing Che are remote AND the configuration of Docker is an
 # internal IP address or using Unix sockets, then remote browser clients will not be able to connect

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/TerminalVolumeProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/TerminalVolumeProvider.java
@@ -34,13 +34,17 @@ import java.nio.file.Paths;
 @Singleton
 public class TerminalVolumeProvider implements Provider<String> {
 
-    private static final String CONTAINER_TARGET = ":/mnt/che/terminal:ro,Z";
+    private static final String CONTAINER_TARGET = ":/mnt/che/terminal";
     private static final String TERMINAL         = "terminal";
     private static final Logger LOG              = LoggerFactory.getLogger(TerminalVolumeProvider.class);
 
     @Inject
     @Named("che.workspace.terminal_linux_amd64")
     private String terminalArchivePath;
+
+    @Inject
+    @Named("che.docker.volumes_agent_options")
+    private String volumeOptions;
 
     @Override
     public String get() {
@@ -49,13 +53,18 @@ public class TerminalVolumeProvider implements Provider<String> {
                 final Path cheHome = WindowsHostUtils.ensureCheHomeExist();
                 final Path terminalPath = cheHome.resolve(TERMINAL);
                 IoUtil.copy(Paths.get(terminalArchivePath).toFile(), terminalPath.toFile(), null, true);
-                return terminalPath.toString() + CONTAINER_TARGET;
+                return getTargetOptions(terminalPath.toString());
             } catch (IOException e) {
                 LOG.warn(e.getMessage());
                 throw new RuntimeException(e);
             }
         } else {
-            return terminalArchivePath + CONTAINER_TARGET;
+            return getTargetOptions(terminalArchivePath);
         }
     }
+
+    private String getTargetOptions(final String path) {
+        return path + CONTAINER_TARGET + ":" + volumeOptions;
+    }
+
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/WsAgentVolumeProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/provider/WsAgentVolumeProvider.java
@@ -37,7 +37,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 @Singleton
 public class WsAgentVolumeProvider implements Provider<String> {
 
-    private static final String CONTAINER_TARGET = ":/mnt/che/ws-agent.tar.gz:ro,Z";
+    private static final String CONTAINER_TARGET = ":/mnt/che/ws-agent.tar.gz";
     private static final String WS_AGENT         = "ws-agent.tar.gz";
 
     private static final Logger LOG = LoggerFactory.getLogger(WsAgentVolumeProvider.class);
@@ -46,19 +46,28 @@ public class WsAgentVolumeProvider implements Provider<String> {
     @Named("che.workspace.agent.dev")
     private String wsAgentArchivePath;
 
+    @Inject
+    @Named("che.docker.volumes_agent_options")
+    private String volumeOptions;
+
     @Override
     public String get() {
+
         if (SystemInfo.isWindows()) {
             try {
                 final Path cheHome = WindowsHostUtils.ensureCheHomeExist();
                 final Path path = Files.copy(Paths.get(wsAgentArchivePath), cheHome.resolve(WS_AGENT), REPLACE_EXISTING);
-                return path.toString() + CONTAINER_TARGET;
+                return getTargetOptions(path.toString());
             } catch (IOException e) {
                 LOG.warn(e.getMessage());
                 throw new RuntimeException(e);
             }
         } else {
-            return wsAgentArchivePath + CONTAINER_TARGET;
+            return getTargetOptions(wsAgentArchivePath);
         }
+    }
+
+    private String getTargetOptions(final String path) {
+        return path + CONTAINER_TARGET + ":" + volumeOptions;
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalCheInfrastructureProvisioner.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalCheInfrastructureProvisioner.java
@@ -35,16 +35,19 @@ public class LocalCheInfrastructureProvisioner extends DefaultInfrastructureProv
     private final WorkspaceFolderPathProvider workspaceFolderPathProvider;
     private final WindowsPathEscaper          pathEscaper;
     private final String                      projectFolderPath;
+	private final String                      volumesOptions;
 
     @Inject
     public LocalCheInfrastructureProvisioner(AgentConfigApplier agentConfigApplier,
                                              WorkspaceFolderPathProvider workspaceFolderPathProvider,
                                              WindowsPathEscaper pathEscaper,
-                                             @Named("che.workspace.projects.storage") String projectFolderPath) {
+                                             @Named("che.workspace.projects.storage") String projectFolderPath,
+                                             @Named("che.docker.volumes_agent_options") String volumeOptions) {
         super(agentConfigApplier);
         this.workspaceFolderPathProvider = workspaceFolderPathProvider;
         this.pathEscaper = pathEscaper;
         this.projectFolderPath = projectFolderPath;
+        this.volumesOptions = volumeOptions;
     }
 
     @Override
@@ -66,9 +69,9 @@ public class LocalCheInfrastructureProvisioner extends DefaultInfrastructureProv
         // add bind-mount volume for projects in a workspace
         String projectFolderVolume;
         try {
-            projectFolderVolume = format("%s:%s:Z",
+            projectFolderVolume = format("%s:%s:%s",
                                          workspaceFolderPathProvider.getPath(internalEnv.getWorkspaceId()),
-                                         projectFolderPath);
+                                         projectFolderPath, volumesOptions);
         } catch (IOException e) {
             throw new EnvironmentException("Error occurred on resolving path to files of workspace " +
                                            internalEnv.getWorkspaceId());


### PR DESCRIPTION
### What does this PR do?

It adds the following two properties:

che.machine.docker.volumes.projects.options (Z by default)

that is used when che mounts the /projects volume

che.machine.docker.volumes.workspace.options (ro,Z by default)

used when mounting the following volumes:

/mnt/che/terminal
/mnt/che/ws-agent.tar.gz
/mnt/che/conf

Notice:
che-launcher also uses the Z option. I haven't changed it.
### What issues does this PR fix or reference?
#2874

Signed-off-by: Snjezana Peco snjezana.peco@redhat.com
