### PR TITLE
Resolve project type after adding all commands

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.controller.ts
+++ b/dashboard/src/app/projects/create-project/create-project.controller.ts
@@ -522,7 +522,7 @@ export class CreateProjectController {
       });
 
       // now, resolve the project
-      deferredImportPromise.then(() => {
+      deferredAddCommandPromise.then(() => {
         this.resolveProjectType(workspaceId, projectName, projectData, deferredResolve);
       });
       promise = this.$q.all([deferredImportPromise, deferredAddCommandPromise, deferredResolvePromise]);


### PR DESCRIPTION
### What does this PR do?

This fix ensures that, during project creation, the project type is resolved after all commands from the project template are added to the workspace. This avoids the race condition that causes bug #2680.
### What issues does this PR fix or reference?

Fixes #2680: Sometimes, commands are not added correctly on workspace creation from stack

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
