### PR TITLE
CHE-2308. Use own size of part when part stack size is too small for the content of the part

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/AbstractPartPresenter.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/AbstractPartPresenter.java
@@ -141,7 +141,7 @@ public abstract class AbstractPartPresenter implements PartPresenter {
     /** {@inheritDoc} */
     @Override
     public int getSize() {
-        return 285;
+        return DEFAULT_PART_SIZE;
     }
 
     /** {@inheritDoc} */
@@ -155,5 +155,4 @@ public abstract class AbstractPartPresenter implements PartPresenter {
     public SVGResource getTitleImage() {
         return null;
     }
-
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartPresenter.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartPresenter.java
@@ -35,6 +35,12 @@ public interface PartPresenter extends Presenter {
     /** The property id for <code>getSelection</code>. */
     int SELECTION_PROPERTY = 0x002;
 
+    /** The default size for the part. */
+    final int DEFAULT_PART_SIZE = 260;
+
+    /** The minimum allowable size for the part. */
+    final int MIN_PART_SIZE = 100;
+
     /** Store part state before changing perspective. */
     void storeState();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/PartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/PartStackPresenter.java
@@ -483,7 +483,7 @@ public class PartStackPresenter implements Presenter, PartStackView.ActionDelega
         }
 
         if (activePart != null) {
-            updateWorkBenchPartSize();
+            updateWorkBenchPartSize(); //we need to update the workbench part size depending on the size of the active part
         }
     }
 
@@ -533,6 +533,11 @@ public class PartStackPresenter implements Presenter, PartStackView.ActionDelega
         }
     }
 
+    /**
+     * Each part has own size. This method checks whether the given size is redefined by user.
+     *
+     * @return {@code true} when the given size does not match to any own part size of the part stack
+     */
     private boolean isSizeOverridden(double size) {
         if (size < MIN_PART_SIZE) {
             return false;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -58,14 +58,11 @@ import org.eclipse.che.ide.ui.smartTree.event.ExpandNodeEvent;
 import org.eclipse.che.ide.ui.smartTree.event.PostLoadEvent;
 import org.eclipse.che.ide.ui.smartTree.event.SelectionChangedEvent;
 import org.eclipse.che.ide.ui.smartTree.event.SelectionChangedEvent.SelectionChangedHandler;
-import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.providers.DynaObject;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.validation.constraints.NotNull;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -101,8 +98,6 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
 
     private UpdateTask updateTask = new UpdateTask();
     private Set<Path> expandQueue = new HashSet<>();
-
-    private static final int PART_SIZE = 500;
 
     private boolean hiddenFilesAreShown;
 
@@ -387,12 +382,6 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
     @Override
     public String getTitleToolTip() {
         return locale.projectExplorerPartTooltip();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public int getSize() {
-        return PART_SIZE;
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkBenchPartControllerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkBenchPartControllerImpl.java
@@ -75,10 +75,7 @@ public class WorkBenchPartControllerImpl implements WorkBenchPartController {
         if (!hidden) {
             splitLayoutPanel.setWidgetHidden(widget, false);
         }
-
-        splitLayoutPanel.setWidgetSize(widget, hidden ? 0 : getSize());
-        splitLayoutPanel.animate(DURATION);
-
+        setSize(hidden ? 0 : getSize());
     }
 
     @Override
@@ -90,5 +87,4 @@ public class WorkBenchPartControllerImpl implements WorkBenchPartController {
     public void setMinSize(int minSize) {
         splitLayoutPanel.setWidgetMinSize(widget, minSize);
     }
-
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
@@ -442,7 +442,7 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
     /** {@inheritDoc} */
     @Override
     public int getSize() {
-        return 450;
+        return 550;
     }
 
     protected enum DiffWith {


### PR DESCRIPTION
### What does this PR do?

We use default size for all part stacks now.
After applying my changes we will have next behavior:
 - for example you open Git History first, it uses 550 width. You open Pull Request panel while Git History was still displayed, it uses 550 width too.
 - you open Git History first, it uses 550 width. You close Git History and then open Pull Request panel while nothing was displayed on the right part, it uses default size (260) width.
- you open Pull Request first, it uses 260 width. You open Git History while Pull Request was still displaying on the right, it uses 550 width.
- you open Pull Request first, it uses 260 width. You close Pull Request and then open Git History panel while nothing was displayed on the right part, it uses 550 width.

This behavior will be apply for all part stacks. 
We use default size (260) for all parts except Git history part (it will be 550). 
### What issues does this PR fix or reference?
#2308

![history_pullreq_menu](https://cloud.githubusercontent.com/assets/5676062/22112439/987f96c4-de6b-11e6-9246-de018da3c12c.gif)

Signed-off-by: Roman Nikitenko rnikitenko@codenvy.com
