### PR TITLE
CODENVY-1007: add erb extension support as ruby template

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
@@ -114,6 +114,7 @@ public class ExtensionFileTypeIdentifier implements FileTypeIdentifier {
         this.mappings.put("py", makeList("text/x-python"));
         this.mappings.put("pyx", makeList("text/x-cython"));
         this.mappings.put("rb", makeList("text/x-ruby"));
+        this.mappings.put("erb", makeList("text/html"));//templates with embedded ruby
         this.mappings.put("gemspec", makeList("text/x-ruby"));
         this.mappings.put("go", makeList("text/x-go"));
         this.mappings.put("rs", makeList("text/x-rustsrc"));


### PR DESCRIPTION
### What does this PR do?

Adds erb extension to track .html.erb files as html templates.

### What issues does this PR fix or reference?

https://github.com/codenvy/codenvy/issues/1007

Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>