### PR TITLE
Rework Tck tests to use TckListener instead of TckModuleFactory

### DIFF
--- a/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/JpaCleaner.java
+++ b/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/JpaCleaner.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.commons.test.tck;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManagerFactory;
+
+/**
+ * This class is designed to close {@link EntityManagerFactory}
+ * on finish of tck test with jpa implementation.
+ *
+ * <p/>
+ * Examples of usage:<br>
+ * <code>bind(TckResourcesCleaner.class).to(JpaCleaner.class)</code><br>
+ * <code>bind(TckResourcesCleaner.class).annotatedWith(Names.named(MyTckTest.class.getName())).to(JpaCleaner.class);</code>
+ *
+ * @author Sergii Leschenko
+ */
+public class JpaCleaner implements TckResourcesCleaner {
+    @Inject
+    private EntityManagerFactory entityManagerFactory;
+
+    @Override
+    public void clean() {
+        entityManagerFactory.close();
+    }
+}

--- a/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/TckModule.java
+++ b/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/TckModule.java
@@ -13,7 +13,6 @@ package org.eclipse.che.commons.test.tck;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 
-import org.testng.IModuleFactory;
 import org.testng.ITestContext;
 
 import java.util.ServiceLoader;
@@ -26,20 +25,18 @@ import java.util.ServiceLoader;
  * and for injecting them later. So each module which is TCK module must
  * provide the implementations list(as described by {@code ServiceLoader} mechanism)
  * in the file named <i>org.eclipse.che.commons.test.tck.TckModule</i> usually under
- * <i>test/resources/META-INF/services</i> directory, then the {@link TckModuleFactory}
+ * <i>test/resources/META-INF/services</i> directory, then the {@link TckListener}
  * will recognise and load it.
  *
  * @author Yevhenii Voevodin
- * @see TckModuleFactory
+ * @see TckListener
  */
 public abstract class TckModule extends AbstractModule {
 
     /**
      * It is guaranteed that this field is always present and
-     * can be reused by implementation, the value is equal to the
-     * {@link IModuleFactory#createModule(ITestContext, Class)} first
-     * parameter and will be set by {@link TckModuleFactory} immediately after module
-     * implementation is loaded by {@link ServiceLoader}.
+     * can be reused by implementation, it will be set by {@link TckListener} immediately
+     * after module implementation is loaded by {@link ServiceLoader}.
      */
     private ITestContext testContext;
 
@@ -50,7 +47,7 @@ public abstract class TckModule extends AbstractModule {
 
     /**
      * Sets the context of currently executing test suite.
-     * This method designed to be used by {@link TckModuleFactory} for setting
+     * This method designed to be used by {@link TckListener} for setting
      * the context before installing modules.
      */
     void setTestContext(ITestContext testContext) {

--- a/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/TckResourcesCleaner.java
+++ b/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/tck/TckResourcesCleaner.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.commons.test.tck;
+
+/**
+ * This class is designed to clean up resources after tck test.
+ *
+ * <p>Implementation should be defined in {@link TckModule}.
+ * It can be defined common for all tests or test specific by using @Named annotation.
+ * Cleaning of resources is invoked after finish of all tests methods from one test suite
+ * that should contains one and only one tck test class.
+ *
+ * <p>The usage example:
+ * <pre>
+ * class MyTckModule extends TckModule {
+ *     public void configure() {
+ *         bind(TckResourcesCleaner.class).to(...);
+ *         bind(TckResourcesCleaner.class).annotatedWith(Names.named(SomeTest.class.getName())).to(...);
+ *     }
+ * }
+ * </pre>
+ *
+ * @author Sergii Leschenko
+ * @see TckListener
+ */
+public interface TckResourcesCleaner {
+    /**
+     * Clean up resources.
+     *
+     * <p>Note: it is invoked after finish of all methods from one test suite.
+     */
+    void clean();
+}

--- a/core/commons/che-core-commons-test/src/test/java/org/eclipse/che/commons/test/tck/DBServerListener.java
+++ b/core/commons/che-core-commons-test/src/test/java/org/eclipse/che/commons/test/tck/DBServerListener.java
@@ -11,8 +11,6 @@
 package org.eclipse.che.commons.test.tck;
 
 import org.testng.ITestContext;
-import org.testng.ITestListener;
-import org.testng.ITestResult;
 
 /**
  * Listener representing fake db server url injection for testing "attributes sharing"

--- a/core/commons/che-core-commons-test/src/test/java/org/eclipse/che/commons/test/tck/TckComponentsTest.java
+++ b/core/commons/che-core-commons-test/src/test/java/org/eclipse/che/commons/test/tck/TckComponentsTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.commons.test.tck;
 
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -24,7 +24,7 @@ import static org.testng.Assert.assertNotNull;
  *
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 public class TckComponentsTest {
 
     @Inject

--- a/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/tck/AccountDaoTest.java
+++ b/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/tck/AccountDaoTest.java
@@ -14,12 +14,12 @@ import org.eclipse.che.account.spi.AccountDao;
 import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertEquals;
  *
  * @author Sergii Leschenko
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = AccountDaoTest.SUITE_NAME)
 public class AccountDaoTest {
     public static final String SUITE_NAME = "AccountDaoTck";

--- a/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/tck/jpa/AccountJpaTckModule.java
+++ b/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/tck/jpa/AccountJpaTckModule.java
@@ -18,7 +18,9 @@ import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.account.spi.jpa.JpaAccountDao;
 import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
 import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
+import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 
@@ -31,6 +33,8 @@ public class AccountJpaTckModule extends TckModule {
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
         bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
+        bind(TckResourcesCleaner.class).to(JpaCleaner.class);
+
         bind(new TypeLiteral<TckRepository<AccountImpl>>() {}).toInstance(new JpaTckRepository<>(AccountImpl.class));
 
         bind(AccountDao.class).to(JpaAccountDao.class);

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/jpa/JpaTckModule.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/jpa/JpaTckModule.java
@@ -24,7 +24,9 @@ import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
+import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.security.PasswordEncryptor;
@@ -40,6 +42,7 @@ public class JpaTckModule extends TckModule {
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
         bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
+        bind(TckResourcesCleaner.class).to(JpaCleaner.class);
 
         bind(new TypeLiteral<TckRepository<UserImpl>>() {}).toInstance(new JpaTckRepository<>(UserImpl.class));
         bind(new TypeLiteral<TckRepository<FactoryImpl>>() {}).toInstance(new JpaTckRepository<>(FactoryImpl.class));
@@ -51,5 +54,6 @@ public class JpaTckModule extends TckModule {
         bind(FactoryDao.class).to(JpaFactoryDao.class);
 
         bind(PasswordEncryptor.class).to(SHA512PasswordEncryptor.class).in(Singleton.class);
+
     }
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -39,11 +39,11 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConf2Impl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.commons.lang.Pair;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -65,7 +65,7 @@ import static org.testng.Assert.assertEquals;
  *
  * @author Anton Korneta
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = FactoryDaoTest.SUITE_NAME)
 public class FactoryDaoTest {
 

--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/jpa/JpaTckModule.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/jpa/JpaTckModule.java
@@ -19,7 +19,9 @@ import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;
 import org.eclipse.che.api.machine.server.spi.RecipeDao;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
+import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 
@@ -32,7 +34,7 @@ public class JpaTckModule extends TckModule {
     protected void configure() {
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
-
+        bind(TckResourcesCleaner.class).to(JpaCleaner.class);
         bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
 
         bind(new TypeLiteral<TckRepository<RecipeImpl>>() {}).toInstance(new JpaTckRepository<>(RecipeImpl.class));

--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/spi/tck/RecipeDaoTest.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/spi/tck/RecipeDaoTest.java
@@ -18,11 +18,11 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;
 import org.eclipse.che.api.machine.server.spi.RecipeDao;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -40,7 +39,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @author Anton Korneta
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = RecipeDaoTest.SUITE_NAME)
 public class RecipeDaoTest {
 

--- a/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/spi/tck/SnapshotDaoTest.java
+++ b/wsmaster/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/spi/tck/SnapshotDaoTest.java
@@ -18,13 +18,13 @@ import org.eclipse.che.api.machine.server.exception.SnapshotException;
 import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.util.HashSet;
@@ -40,7 +40,7 @@ import static org.testng.Assert.fail;
  *
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = SnapshotDaoTest.SUITE_NAME)
 public class SnapshotDaoTest {
 

--- a/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/jpa/SshTckModule.java
+++ b/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/jpa/SshTckModule.java
@@ -18,7 +18,9 @@ import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.api.ssh.server.spi.SshDao;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 
@@ -37,5 +39,6 @@ public class SshTckModule extends TckModule {
         bind(JpaInitializer.class).asEagerSingleton();
         bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
         bind(org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler.class);
+        bind(TckResourcesCleaner.class).to(JpaCleaner.class);
     }
 }

--- a/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/spi/tck/SshDaoTest.java
+++ b/wsmaster/che-core-api-ssh/src/test/java/org/eclipse/che/api/ssh/server/spi/tck/SshDaoTest.java
@@ -16,12 +16,12 @@ import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.api.ssh.server.spi.SshDao;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -41,10 +41,11 @@ import static org.testng.Assert.fail;
  * @author Mihail Kuznyetsov.
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = SshDaoTest.SUITE_NAME)
 public class SshDaoTest {
-    public static final String SUITE_NAME   = "SshDaoTck";
+    public static final String SUITE_NAME = "SshDaoTck";
+
     private static final int COUNT_OF_PAIRS = 6;
     private static final int COUNT_OF_USERS = 3;
 
@@ -73,8 +74,8 @@ public class SshDaoTest {
         pairs = new SshPairImpl[COUNT_OF_PAIRS];
 
         for (int i = 0; i < COUNT_OF_PAIRS; i++) {
-            pairs[i] = new SshPairImpl("owner" + i/3, // 3 each pairs share the same owner
-                                       "service" + i/2, // each 2 pairs share the same service
+            pairs[i] = new SshPairImpl("owner" + i / 3, // 3 each pairs share the same owner
+                                       "service" + i / 2, // each 2 pairs share the same service
                                        "name" + i,
                                        NameGenerator.generate("publicKey-", 20),
                                        NameGenerator.generate("privateKey-", 20));
@@ -107,8 +108,9 @@ public class SshDaoTest {
     public void shouldThrowNpeOnCreateIfSshPairIsNull() throws Exception {
         sshDao.create(null);
     }
+
     @Test
-    public void shouldGetSshPairByNameOwnerAndService() throws Exception{
+    public void shouldGetSshPairByNameOwnerAndService() throws Exception {
         SshPairImpl sshPair = pairs[0];
 
         sshDao.get(sshPair.getOwner(), sshPair.getService(), sshPair.getName());
@@ -122,22 +124,22 @@ public class SshDaoTest {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNpeOnGetSshPairWhenOwnerIsNull() throws Exception{
+    public void shouldThrowNpeOnGetSshPairWhenOwnerIsNull() throws Exception {
         sshDao.get(null, "service", "name");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNpeOnGetSshPairWhenServiceIsNull() throws Exception{
+    public void shouldThrowNpeOnGetSshPairWhenServiceIsNull() throws Exception {
         sshDao.get("owner", null, "name");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNpeOnGetSshPairWhenNameIsNull() throws Exception{
+    public void shouldThrowNpeOnGetSshPairWhenNameIsNull() throws Exception {
         sshDao.get("owner", "service", null);
     }
 
     @Test
-    public void shouldGetSshPairListByNameAndService() throws Exception{
+    public void shouldGetSshPairListByNameAndService() throws Exception {
         SshPairImpl sshPair1 = pairs[0];
         SshPairImpl sshPair2 = pairs[1];
         assertEquals(sshPair1.getOwner(), sshPair2.getOwner(), "Owner must be the same");
@@ -153,12 +155,12 @@ public class SshDaoTest {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNpeOnGetSshPairsListWhenOwnerIsNull() throws Exception{
+    public void shouldThrowNpeOnGetSshPairsListWhenOwnerIsNull() throws Exception {
         sshDao.get(null, "service");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowNpeOnGetSshPairsListWhenServiceIsNull() throws Exception{
+    public void shouldThrowNpeOnGetSshPairsListWhenServiceIsNull() throws Exception {
         sshDao.get("owner", null);
     }
 

--- a/wsmaster/che-core-api-user/pom.xml
+++ b/wsmaster/che-core-api-user/pom.xml
@@ -73,10 +73,6 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-test</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -118,6 +114,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/JpaTckModule.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/jpa/JpaTckModule.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.user.server.jpa;
 
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 import com.google.inject.persist.jpa.JpaPersistModule;
 
 import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
@@ -21,13 +22,19 @@ import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.PreferenceDao;
 import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
+import org.eclipse.che.api.user.server.spi.tck.PreferenceDaoTest;
+import org.eclipse.che.api.user.server.spi.tck.ProfileDaoTest;
+import org.eclipse.che.api.user.server.spi.tck.UserDaoTest;
 import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.security.PasswordEncryptor;
 import org.eclipse.che.security.SHA512PasswordEncryptor;
 
+import javax.inject.Named;
 import java.util.Map;
 
 /**
@@ -40,6 +47,7 @@ public class JpaTckModule extends TckModule {
         install(new JpaPersistModule("main"));
         bind(JpaInitializer.class).asEagerSingleton();
         bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
+        bind(TckResourcesCleaner.class).to(JpaCleaner.class);
 
         bind(new TypeLiteral<TckRepository<UserImpl>>() {}).to(UserJpaTckRepository.class);
         bind(new TypeLiteral<TckRepository<ProfileImpl>>() {}).toInstance(new JpaTckRepository<>(ProfileImpl.class));

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/model/impl/DataObjectsTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/model/impl/DataObjectsTest.java
@@ -124,7 +124,7 @@ public class DataObjectsTest {
         assertFalse(copy.getAttributes().containsKey("new-attribute"));
     }
 
-    @Test(dataProvider = "singleObjectProvider")
+    @Test(dataProvider = "reflexivenessProvider")
     @SuppressWarnings("all")
     public void testReflexiveness(Object obj) throws Exception {
         assertTrue(obj.equals(obj));
@@ -148,7 +148,7 @@ public class DataObjectsTest {
         assertTrue(object1.equals(object2));
     }
 
-    @Test(dataProvider = "singleObjectProvider")
+    @Test(dataProvider = "reflexivenessProvider")
     @SuppressWarnings("all")
     public void testNotEqualityToNull(Object object) throws Exception {
         assertFalse(object.equals(null));

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/PreferenceDaoTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/PreferenceDaoTest.java
@@ -15,11 +15,11 @@ import com.google.common.collect.ImmutableMap;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.PreferenceDao;
 import org.eclipse.che.commons.lang.Pair;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -39,7 +39,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @author Anton Korneta
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = PreferenceDaoTest.SUITE_NAME)
 public class PreferenceDaoTest {
 

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/ProfileDaoTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/ProfileDaoTest.java
@@ -19,12 +19,12 @@ import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertEquals;
  *
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = ProfileDaoTest.SUITE_NAME)
 public class ProfileDaoTest {
 
@@ -56,7 +56,7 @@ public class ProfileDaoTest {
     @Inject
     private TckRepository<ProfileImpl> profileTckRepository;
     @Inject
-    private TckRepository<UserImpl> userTckRepository;
+    private TckRepository<UserImpl>    userTckRepository;
 
     @BeforeMethod
     private void setUp() throws TckRepositoryException {

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/UserDaoTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/spi/tck/UserDaoTest.java
@@ -18,12 +18,12 @@ import org.eclipse.che.api.user.server.Constants;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.UserDao;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -42,7 +42,7 @@ import static org.testng.AssertJUnit.assertTrue;
  *
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = UserDaoTest.SUITE_NAME)
 public class UserDaoTest {
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
@@ -20,7 +20,9 @@ import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.spi.StackDao;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 
@@ -35,6 +37,7 @@ public class WorkspaceTckModule extends TckModule {
         bind(JpaInitializer.class).asEagerSingleton();
         bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
         bind(org.eclipse.che.api.core.h2.jdbc.jpa.eclipselink.H2ExceptionHandler.class);
+        bind(TckResourcesCleaner.class).to(JpaCleaner.class);
 
         bind(new TypeLiteral<TckRepository<AccountImpl>>() {}).toInstance(new JpaTckRepository<>(AccountImpl.class));
         bind(new TypeLiteral<TckRepository<WorkspaceImpl>>() {}).toInstance(new JpaTckRepository<>(WorkspaceImpl.class));

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/StackDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/StackDaoTest.java
@@ -24,12 +24,12 @@ import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackSourceImpl;
 import org.eclipse.che.api.workspace.server.spi.StackDao;
 import org.eclipse.che.api.workspace.server.stack.image.StackIcon;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
@@ -46,7 +46,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = StackDaoTest.SUITE_NAME)
 public class StackDaoTest {
 
@@ -228,7 +228,7 @@ public class StackDaoTest {
 
     @Test
     public void shouldPublishStackPersistedEventAfterStackIsPersisted() throws Exception {
-        final boolean[] isNotified = new boolean[] { false };
+        final boolean[] isNotified = new boolean[] {false};
         eventService.subscribe(event -> isNotified[0] = true, StackPersistedEvent.class);
 
         stackDao.create(createStack("test", "test"));
@@ -244,19 +244,19 @@ public class StackDaoTest {
 
     private static StackImpl createStack(String id, String name) {
         final StackImpl stack = StackImpl.builder()
-                                     .setId(id)
-                                     .setName(name)
-                                     .setCreator("user123")
-                                     .setDescription(id + "-description")
-                                     .setScope(id + "-scope")
-                                     .setTags(asList(id + "-tag1", id + "-tag2"))
-                                     .setComponents(asList(new StackComponentImpl(id + "-component1", id + "-component1-version"),
-                                                           new StackComponentImpl(id + "-component2", id + "-component2-version")))
-                                     .setSource(new StackSourceImpl(id + "-type", id + "-origin"))
-                                     .setStackIcon(new StackIcon(id + "-icon",
-                                                                 id + "-media-type",
-                                                                 "0x1234567890abcdef".getBytes()))
-                                     .build();
+                                         .setId(id)
+                                         .setName(name)
+                                         .setCreator("user123")
+                                         .setDescription(id + "-description")
+                                         .setScope(id + "-scope")
+                                         .setTags(asList(id + "-tag1", id + "-tag2"))
+                                         .setComponents(asList(new StackComponentImpl(id + "-component1", id + "-component1-version"),
+                                                               new StackComponentImpl(id + "-component2", id + "-component2-version")))
+                                         .setSource(new StackSourceImpl(id + "-type", id + "-origin"))
+                                         .setStackIcon(new StackIcon(id + "-icon",
+                                                                     id + "-media-type",
+                                                                     "0x1234567890abcdef".getBytes()))
+                                         .build();
         final WorkspaceConfigImpl config = createWorkspaceConfig("test");
         stack.setWorkspaceConfig(config);
         return stack;

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -28,12 +28,12 @@ import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
-import org.eclipse.che.commons.test.tck.TckModuleFactory;
+import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Guice;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
@@ -54,7 +54,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @author Yevhenii Voevodin
  */
-@Guice(moduleFactory = TckModuleFactory.class)
+@Listeners(TckListener.class)
 @Test(suiteName = WorkspaceDaoTest.SUITE_NAME)
 public class WorkspaceDaoTest {
 
@@ -188,7 +188,7 @@ public class WorkspaceDaoTest {
 
     @Test
     public void shouldPublicRemoveWorkspaceEventAfterRemoveWorkspace() throws Exception {
-        final boolean[] isNotified = new boolean[] { false };
+        final boolean[] isNotified = new boolean[] {false};
         eventService.subscribe(event -> isNotified[0] = true, WorkspaceRemovedEvent.class);
 
         workspaceDao.remove(workspaces[0].getId());


### PR DESCRIPTION
### What does this PR do?
Rework Tck tests to use TckListener instead of TckModuleFactory

### What issues does this PR fix or reference?
-

### Previous behavior
Earlier there was not ability to close entity manager factory on finish of tck test. So it could broke tests when there were one or more tests (non tck) that used EntityManagerFactory and some tck test that did not close entity manager factory.
Also there were issues with child injectors which guice uses.

### New behavior
There is ability to close entity manager after tck testing. And TckListener creates new injector for each tck test that solves problem with child injector.