### PR TITLE
Fix links for websockets

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineServiceLinksInjector.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineServiceLinksInjector.java
@@ -97,7 +97,6 @@ public class MachineServiceLinksInjector {
         final Link workspaceChannelLink = createLink("GET",
                                                      serviceContext.getBaseUriBuilder()
                                                                    .path("ws")
-                                                                   .path(machine.getWorkspaceId())
                                                                    .scheme("https".equals(getProcessesUri.getScheme()) ? "wss" : "ws")
                                                                    .build()
                                                                    .toString(),

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceLinksInjector.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceLinksInjector.java
@@ -122,7 +122,6 @@ public class WorkspaceServiceLinksInjector {
         final Link workspaceChannelLink = createLink("GET",
                                                      serviceContext.getBaseUriBuilder()
                                                                    .path("ws")
-                                                                   .path(workspace.getId())
                                                                    .scheme("https".equals(ideUri.getScheme()) ? "wss" : "ws")
                                                                    .build()
                                                                    .toString(),


### PR DESCRIPTION
### What does this PR do?

I've discovered using 'che dir' that links were not updated when workspace id has been removed for websocket connections

With this fix workspace id is no longer in links
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/1787

### Previous behavior
links are not correct

### New behavior
Fix links that are no longer valid since https://github.com/eclipse/che/pull/2907

Change-Id: I4103f7f2a316361ddc9dfd26c7b47e2096f99855
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>