### PR TITLE
Contribute PatternFly starter template

### DIFF
--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -543,6 +543,52 @@
       "Node.JS"
     ]
   },
+  {                                                                                                                     
+    "name": "angular-patternfly-starter",                                                                               
+    "displayName": "angular-patternfly-starter",                                                                        
+    "path": "/angular-patternfly-starter",                                                                              
+    "description": "Angular PatternFly Starter project.",                                                               
+    "projectType": "node-js",                                                                                           
+    "mixins": [],                                                                                                       
+    "attributes": {                                                                                                     
+      "language": [                                                                                                     
+        "javascript"                                                                                                    
+      ]                                                                                                                 
+    },                                                                                                                  
+    "modules": [],                                                                                                      
+    "problems": [],                                                                                                     
+    "source": {                                                                                                         
+      "type": "git",                                                                                                    
+      "location": "https://github.com/patternfly/angular-patternfly-demo-app.git",                                            
+      "parameters": {}                                                                                                  
+    },                                                                                                                  
+    "commands": [                                                                                                       
+      {                                                                                                                 
+        "name": "install dependencies",                                                                                 
+        "type": "custom",                                                                                               
+        "commandLine": "cd ${current.project.path} && npm install --no-bin-links && bower install",                     
+        "attributes": {                                                                                                 
+          "previewUrl": ""                                                                                              
+        }                                                                                                               
+      },                                                                                                                
+      {                                                                                                                 
+        "name": "run",                                                                                                  
+        "type": "custom",                                                                                               
+        "commandLine": "cd ${current.project.path} && grunt server",                                                    
+        "attributes": {                                                                                                 
+          "previewUrl": "http://${server.port.8003}"                                                                    
+        }                                                                                                               
+      }                                                                                                                 
+    ],                                                                                                                  
+    "links": [],                                                                                                        
+    "category": "Samples",                                                                                              
+    "tags": [                                                                                                           
+      "nodejs",                                                                                                         
+      "patternfly",                                                                                                     
+      "javascript",                                                                                                     
+      "Node.JS"                                                                                                         
+    ]                                                                                                                   
+  },
   {
     "name": "web-java-spring",
     "displayName": "web-java-spring",

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -547,7 +547,7 @@
     "name": "angular-patternfly-starter",                                                                               
     "displayName": "angular-patternfly-starter",                                                                        
     "path": "/angular-patternfly-starter",                                                                              
-    "description": "Angular PatternFly Starter project.",                                                               
+    "description": "Angular PatternFly Starter Project.",                                                               
     "projectType": "node-js",                                                                                           
     "mixins": [],                                                                                                       
     "attributes": {                                                                                                     


### PR DESCRIPTION
### Add PatternFly Angular template for the Node.JS stack.

### What issues does this PR fix or reference? None

### New behavior
Adds a PatternFly starter template for the Node.JS stack.  This uses on Angular 1 and makes use of PatternFly styles (www.patternfly.org) and bootstrap themes for building enterprise web applications.