### PR TITLE
Fix failed test after PR#3005

### DIFF
--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/perspectives/general/AbstractPerspectivePersistenceTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/perspectives/general/AbstractPerspectivePersistenceTest.java
@@ -39,9 +39,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -166,6 +172,16 @@ public class AbstractPerspectivePersistenceTest {
         JsonObject partStack = Json.createObject();
         parts.put("INFORMATION", partStack);
         partStack.put("HIDDEN", true);
+
+        //PartStackPresenter should not be empty otherwise setHidden() will call twice
+        final List<PartPresenter> partPresenters = new ArrayList<>();
+        partPresenters.add(mock(PartPresenter.class));
+        when(partStackPresenter.getParts()).thenAnswer(new Answer<List<? extends PartPresenter>>() {
+            public List<? extends PartPresenter> answer(InvocationOnMock invocation) throws Throwable {
+                return partPresenters;
+            }
+
+        });
 
         perspective.loadState(state);
         verify(workBenchController).setHidden(true);


### PR DESCRIPTION
### What does this PR do?

Fix failed tests after #3005 
Looks like test became fail after adding this code:

https://github.com/eclipse/che/blob/master/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/perspectives/general/AbstractPerspective.java#L300-L302

Got this error:

```
shouldRestoreHiddenPartStackState on shouldRestoreHiddenPartStackState(org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspectivePersistenceTest)(org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspectivePersistenceTest)  Time elapsed: 0.017 sec  <<< FAILURE!
org.mockito.exceptions.verification.TooManyActualInvocations:
workBenchController.setHidden(true);
Wanted 1 time:
-> at org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspectivePersistenceTest.shouldRestoreHiddenPartStackState(AbstractPerspectivePersistenceTest.java:171)
But was 2 times. Undesired invocation:
-> at org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspective.restorePartController(AbstractPerspective.java:383)

        at org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspectivePersistenceTest.shouldRestoreHiddenPartStackState(AbstractPerspectivePersistenceTest.java:171)


Results :

Failed tests:
  AbstractPerspectivePersistenceTest.shouldRestoreHiddenPartStackState:171
workBenchController.setHidden(true);
Wanted 1 time:
-> at org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspectivePersistenceTest.shouldRestoreHiddenPartStackState(AbstractPerspectivePersistenceTest.java:171)
But was 2 times. Undesired invocation:
-> at org.eclipse.che.ide.workspace.perspectives.general.AbstractPerspective.restorePartController(AbstractPerspective.java:383)

```

@evidolob please check my commit is my fixing correct?  

Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>