### PR TITLE
CHE-2979: fix display machines name in RAM widget

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.html
+++ b/dashboard/src/app/projects/create-project/create-project.html
@@ -198,7 +198,7 @@
               <div>
                 <div data-ng-repeat="machine in createProjectCtrl.getStackMachines(environmentValue)">
                   <div class="workspace-machine" ng-if="machine.attributes && machine.attributes.memoryLimitBytes">
-                    <span ng-if="$first !== $last">MACHINE: {{machineKey}}</span>
+                    <span ng-if="createProjectCtrl.getStackMachines(environmentValue).length > 1">Machine: {{machine.name}}</span>
                     <che-workspace-ram-allocation-slider
                             ng-model="machine.attributes.memoryLimitBytes"></che-workspace-ram-allocation-slider>
                   </div>


### PR DESCRIPTION
### What does this PR do?

Fixes machine's displayed name in RAM allocation widget on workspace+project creation flow.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/2979

Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>