### PR TITLE
Fix BeforeWorkspaceRemovedEvent publishing

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceEntityListener.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceEntityListener.java
@@ -33,7 +33,7 @@ public class WorkspaceEntityListener {
     @PreRemove
     private void preRemove(WorkspaceImpl workspace) {
         final BeforeWorkspaceRemovedEvent event = new BeforeWorkspaceRemovedEvent(workspace);
-        eventService.publish(new BeforeWorkspaceRemovedEvent(workspace));
+        eventService.publish(event);
         if (event.getContext().isFailed()) {
             throw new CascadeRemovalException(event.getContext().getCause());
         }


### PR DESCRIPTION
### What does this PR do?
Used same instance of BeforeWorkspaceRemovedEvent for spread up exception that occurs during removal of dependent entities.

### Previous behavior
On client the error message was not clear.

@skabashnyuk, @evoevodin please take a look.