### PR TITLE
CHE-638: Trim added new git remote url

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/remote/add/AddRemoteRepositoryPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/remote/add/AddRemoteRepositoryPresenter.java
@@ -66,7 +66,7 @@ public class AddRemoteRepositoryPresenter implements AddRemoteRepositoryView.Act
     @Override
     public void onOkClicked() {
         final String name = view.getName();
-        final String url = view.getUrl();
+        final String url = view.getUrl().trim();
         final Project project = appContext.getRootProject();
 
         service.remoteAdd(appContext.getDevMachine(), project.getLocation(), name, url).then(new Operation<Void>() {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/remote/add/AddRemoteRepositoryPresenterTest.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/remote/add/AddRemoteRepositoryPresenterTest.java
@@ -12,11 +12,17 @@ package org.eclipse.che.ide.ext.git.client.remote.add;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.ext.git.client.BaseTest;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -74,5 +80,18 @@ public class AddRemoteRepositoryPresenterTest extends BaseTest {
         presenter.onValueChanged();
 
         verify(view).setEnableOkButton(eq(DISABLE_BUTTON));
+    }
+
+    @Test
+    public void testUrlWithLeadingAndTrailingSpaces() throws Exception {
+        when(appContext.getRootProject()).thenReturn(mock(Project.class));
+        when(voidPromise.then(any(Operation.class))).thenReturn(voidPromise);
+        when(voidPromise.catchError(any(Operation.class))).thenReturn(voidPromise);
+        when(service.remoteAdd(anyObject(), anyObject(), anyString(), anyString())).thenReturn(voidPromise);
+        when(view.getUrl()).thenReturn(" " + REMOTE_URI + " ");
+
+        presenter.onOkClicked();
+
+        verify(service).remoteAdd(anyObject(), anyObject(), anyString(), eq(REMOTE_URI));
     }
 }


### PR DESCRIPTION
### What does this PR do?
When adding a new git remote with URL that starts with spaces it will be wrongly displayed in the remotes list. Adding `trim()` to remote URL resolves this problem.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/638

### Previous behavior
![687474703a2f2f736e61672e67792f684d4962302e6a7067](https://cloud.githubusercontent.com/assets/7668752/20097842/24be7e7a-a5b9-11e6-914e-8986488e5d2c.jpg)

@vparfonov please review