### PR TITLE
Replace deprecated junit.framework.Assert with org.junit.Assert

### DIFF
--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
@@ -14,12 +14,12 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link Path}.


### PR DESCRIPTION
Replace deprecated junit.framework.Assert with org.junit.Assert

@skabashnyuk review it, please.
