### PR TITLE
Allow modifying command attributes

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandImpl.java
@@ -16,8 +16,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.unmodifiableMap;
-
 /**
  * Model of the command.
  *
@@ -48,7 +46,7 @@ public class CommandImpl implements Command {
         this.name = name;
         this.commandLine = commandLine;
         this.type = type;
-        this.attributes = unmodifiableMap(attributes);
+        this.attributes = attributes;
     }
 
     /** Creates copy of the given {@link Command}. */
@@ -56,7 +54,7 @@ public class CommandImpl implements Command {
         this(command.getName(),
              command.getCommandLine(),
              command.getType(),
-             unmodifiableMap(command.getAttributes()));
+             command.getAttributes());
     }
 
     @Override
@@ -88,7 +86,7 @@ public class CommandImpl implements Command {
     }
 
     public void setAttributes(Map<String, String> attributes) {
-        this.attributes = unmodifiableMap(attributes);
+        this.attributes = attributes;
     }
 
     @Override


### PR DESCRIPTION
This PR removes using unmodifiable map from the command implementation (`org.eclipse.che.ide.api.command.CommandImpl`), which disallow user to add custom attributes to the command, e.g. preview url.

Related issue: https://github.com/eclipse/che/issues/2966

@vparfonov @azatsarynnyy review it, please.