### PR TITLE
Correct processing reload depth when there is not any resource exists

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -923,7 +923,7 @@ public final class ResourceManager {
             public Promise<Resource[]> apply(List<ProjectConfigDto> updatedConfiguration) throws FunctionException {
                 cachedConfigs = updatedConfiguration.toArray(new ProjectConfigDto[updatedConfiguration.size()]);
 
-                int maxDepth = 0;
+                int maxDepth = 1;
 
                 final Optional<Resource[]> descendants = store.getAll(container.getLocation());
 


### PR DESCRIPTION
Correct processing reload depth when container is trying to synchronize, when there is no any resource in the workspace root. Depth in this case should be 1 by default.

Related issue: https://github.com/eclipse/che/issues/2876

@vparfonov @skabashnyuk review it, please.