### PR TITLE
CODENVY-804 : Use of userManager to get the userId (when injecting ssh keys)

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-server/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-user</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/MachineModule.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/MachineModule.java
@@ -19,6 +19,8 @@ import org.eclipse.che.inject.DynaModule;
 
 @DynaModule
 public class MachineModule extends AbstractModule {
+
+    @Override
     protected void configure() {
         bind(KeysInjector.class).asEagerSingleton();
         bind(WorkspaceSshKeys.class).asEagerSingleton();

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjector.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjector.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.ext.machine.server.ssh;
 
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.environment.server.CheEnvironmentEngine;
@@ -19,6 +20,7 @@ import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.shared.dto.event.MachineStatusEvent;
 import org.eclipse.che.api.ssh.server.SshManager;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.Exec;
 import org.eclipse.che.plugin.docker.client.LogMessage;
@@ -47,6 +49,7 @@ public class KeysInjector {
     private final EventService         eventService;
     private final DockerConnector      docker;
     private final SshManager           sshManager;
+    private final UserManager          userManager;
     // TODO replace with WorkspaceManager
     private final CheEnvironmentEngine environmentEngine;
 
@@ -54,11 +57,13 @@ public class KeysInjector {
     public KeysInjector(EventService eventService,
                         DockerConnector docker,
                         SshManager sshManager,
-                        CheEnvironmentEngine environmentEngine) {
+                        CheEnvironmentEngine environmentEngine,
+                        UserManager userManager) {
         this.eventService = eventService;
         this.docker = docker;
         this.sshManager = sshManager;
         this.environmentEngine = environmentEngine;
+        this.userManager = userManager;
     }
 
     @PostConstruct
@@ -77,8 +82,19 @@ public class KeysInjector {
                     }
 
                     try {
+                        // get userid
+                        final String userId;
+                        try {
+                            final User user = userManager.getByName(machine.getOwner());
+                            userId = user.getId();
+                        } catch (NotFoundException e) {
+                            LOG.error("User with name {} associated to machine not found", machine.getOwner());
+                            return;
+                        }
+
+
                         // get machine keypairs
-                        List<SshPairImpl> sshPairs = sshManager.getPairs(machine.getOwner(), "machine");
+                        List<SshPairImpl> sshPairs = sshManager.getPairs(userId, "machine");
                         final List<String> publicMachineKeys = sshPairs.stream()
                                                              .filter(sshPair -> sshPair.getPublicKey() != null)
                                                              .map(SshPairImpl::getPublicKey)
@@ -87,7 +103,7 @@ public class KeysInjector {
                         // get workspace keypair (if any)
                         SshPairImpl sshWorkspacePair = null;
                         try {
-                            sshWorkspacePair = sshManager.getPair(machine.getOwner(), "workspace", event.getWorkspaceId());
+                            sshWorkspacePair = sshManager.getPair(userId, "workspace", event.getWorkspaceId());
                         } catch (NotFoundException e) {
                             LOG.debug("No ssh key associated to the workspace", e);
                         }


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/804

### Previous behavior
No ssh keys are injected (machine or workspace keys)

### New behavior
SSH keys are injected as expected

In Eclipse Che, Owner of a machine or namespace of a workspace is the same than the user-id

ssh service is using user-id while username is given so there is never a match

It fixes it by asking userManager the userId.

Change-Id: I30a20a52ffc3149a8f732edeb8ab86db827c9d91
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>