### PR TITLE
Update Bitnami stacks to latest versions

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1446,39 +1446,36 @@
     "id": "bitnami-express",
     "creator": "Bitnami",
     "name": "Bitnami Express",
-    "description": "Default Express stack with Node.js 6.4.0, Express 4.14.0, MongoDB 3.2.7.",
+    "description": "Default Express stack with Node 7.0.0, Express 4.14.0, MongoDB 3.2.9.",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
-      "Node.JS",
-      "NPM",
       "Express"
     ],
     "components": [
       {
         "name": "Node.JS",
-        "version": "6.4.0"
-      },
-      {
-        "name": "NPM",
-        "version": "---"
+        "version": "7.0.0"
       },
       {
         "name": "Express",
         "version": "4.14.0"
       },
       {
-        "name": "MongoDB",
-        "version": "3.2.7"
+        "name": "Bower",
+        "version": "1.7.9"
       },
       {
-        "name": "Git",
+        "name": "NPM",
         "version": "---"
+      },
+      {
+        "name": "MongoDB",
+        "version": "3.2.9"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-express:che-4.14.0-r1"
+      "origin": "bitnami/che-express:che-4.14.0-r11"
     },
     "workspaceConfig": {
       "environments": {
@@ -1495,7 +1492,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-express:che-4.14.0-r1",
+            "location": "bitnami/che-express:che-4.14.0-r11",
             "type": "dockerimage"
           }
         }
@@ -1514,49 +1511,20 @@
     "id": "bitnami-swift",
     "creator": "Bitnami",
     "name": "Bitnami Swift",
-    "description": "Default Swift stack with Swift 3.0-PREVIEW-6",
+    "description": "Default Swift stack with Swift 3.0.1",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
       "Swift"
     ],
     "components": [
       {
         "name": "Swift",
-        "version": "3.0-PREVIEW-6"
-      },
-      {
-        "name": "JDK",
-        "version": "1.8.0_91"
-      },
-      {
-        "name": "Python",
-        "version": "2.7.12rc1"
-      },
-      {
-        "name": "CLANG",
-        "version": "---"
-      },
-      {
-        "name": "libxml2",
-        "version": "---"
-      },
-      {
-        "name": "libedit2",
-        "version": "---"
-      },
-      {
-        "name": "libicu52",
-        "version": "---"
-      },
-      {
-        "name": "Git",
-        "version": "---"
+        "version": "3.0.1"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-swift:che-3.0-PREVIEW-6-r2"
+      "origin": "bitnami/che-swift:che-3.0.1-RELEASE-r0"
     },
     "workspaceConfig": {
       "environments": {
@@ -1573,7 +1541,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-swift:che-3.0-PREVIEW-6-r2",
+            "location": "bitnami/che-swift:che-3.0.1-RELEASE-r0",
             "type": "dockerimage"
           }
         }
@@ -1592,14 +1560,10 @@
     "id": "bitnami-laravel",
     "creator": "Bitnami",
     "name": "Bitnami Laravel",
-    "description": "Default Laravel stack with PHP 7.0.10, Laravel 5.2.31, MariaDB 10.1.14.",
+    "description": "Default Laravel stack with PHP 7.0.10, Laravel 5.2.31, MariaDB 10.1.19.",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
-      "Node.JS",
-      "Laravel",
-      "PHP",
-      "MariaDB"
+      "Laravel"
     ],
     "components": [
       {
@@ -1613,19 +1577,11 @@
       {
         "name": "MariaDB",
         "version": "10.1.14"
-      },
-      {
-        "name": "Gulp",
-        "version": "---"
-      },
-      {
-        "name": "Git",
-        "version": "---"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-laravel:che-5.2.31-r5"
+      "origin": "bitnami/che-laravel:che-5.2.31-r9"
     },
     "workspaceConfig": {
       "environments": {
@@ -1642,7 +1598,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-laravel:che-5.2.31-r5",
+            "location": "bitnami/che-laravel:che-5.2.31-r8",
             "type": "dockerimage"
           }
         }
@@ -1664,16 +1620,9 @@
     "description": "Bitnami Rails stack with Ruby 2.3.1, Rails 5.0.0.1, MariaDB 10.1.14.",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
-      "BitnamiRails",
-      "MariaDB",
-      "Ruby"
+      "BitnamiRails"
     ],
     "components": [
-      {
-        "name": "MariaDb",
-        "version": "10.1.14"
-      },
       {
         "name": "Ruby",
         "version": "2.3.1"
@@ -1683,17 +1632,13 @@
         "version": "5.0.0.1"
       },
       {
-        "name": "MySQL Client",
-        "version": "10.1.13"
-      },
-      {
-        "name": "Git",
-        "version": "---"
+        "name": "MariaDB",
+        "version": "10.1.14"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-rails:che-5.0.0.1-r0"
+      "origin": "bitnami/che-rails:che-5.0.0.1-r3"
     },
     "workspaceConfig": {
       "environments": {
@@ -1710,7 +1655,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-rails:che-5.0.0.1-r0",
+            "location": "bitnami/che-rails:che-5.0.0.1-r3",
             "type": "dockerimage"
           }
         }
@@ -1729,18 +1674,15 @@
     "id": "bitnami-codeigniter",
     "creator": "Bitnami",
     "name": "Bitnami Codeigniter",
-    "description": "Default CodeIgniter stack with PHP 7.0.10, CodeIgniter 3.1.0, MariaDB 10.1.14.",
+    "description": "Default CodeIgniter stack with PHP 7.0.11, CodeIgniter 3.1.0, MariaDB 10.1.19.",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
-      "CodeIgniter",
-      "MariaDB",
-      "PHP"
+      "CodeIgniter"
     ],
     "components": [
       {
         "name": "PHP",
-        "version": "7.0.10"
+        "version": "7.0.11"
       },
       {
         "name": "Codeigniter",
@@ -1748,20 +1690,12 @@
       },
       {
         "name": "MariaDB",
-        "version": "10.1.14"
-      },
-      {
-        "name": "MySQL Client",
-        "version": "10.1.13"
-      },
-      {
-        "name": "Git",
-        "version": "---"
+        "version": "10.1.19"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-codeigniter:che-3.1.0-r2"
+      "origin": "bitnami/che-codeigniter:che-3.1.0-r9"
     },
     "workspaceConfig": {
       "environments": {
@@ -1778,7 +1712,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-codeigniter:che-3.1.0-r2",
+            "location": "bitnami/che-codeigniter:che-3.1.0-r9",
             "type": "dockerimage"
           }
         }
@@ -1797,18 +1731,15 @@
     "id": "bitnami-symfony",
     "creator": "Bitnami",
     "name": "Bitnami Symfony",
-    "description": "Default Symfony stack with PHP 7.0.10, Symfony 3.1.3, MariaDB 10.1.14.",
+    "description": "Default Symfony stack with PHP 7.0.11, Symfony 3.1.3, MariaDB 10.1.19.",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
-      "Symfony",
-      "PHP",
-      "MariaDB"
+      "Symfony"
     ],
     "components": [
       {
         "name": "PHP",
-        "version": "7.0.10"
+        "version": "7.0.11"
       },
       {
         "name": "Symfony",
@@ -1816,20 +1747,12 @@
       },
       {
         "name": "MariaDB",
-        "version": "10.1.14"
-      },
-      {
-        "name": "MySQL Client",
-        "version": "10.1.13"
-      },
-      {
-        "name": "Git",
-        "version": "---"
+        "version": "10.1.19"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-symfony:che-3.1.3-r0"
+      "origin": "bitnami/che-symfony:che-3.1.3-r6"
     },
     "workspaceConfig": {
       "environments": {
@@ -1846,7 +1769,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-symfony:che-3.1.3-r0",
+            "location": "bitnami/che-symfony:che-3.1.3-r6",
             "type": "dockerimage"
           }
         }
@@ -1865,13 +1788,10 @@
     "id": "bitnami-java-play",
     "creator": "Bitnami",
     "name": "Bitnami Play for Java",
-    "description": "Default Play stack with OpenJDK 1.8.0 and Play 2.55.",
+    "description": "Default Play stack with OpenJDK 1.8.0 and Play 1.3.10.",
     "scope": "advanced",
     "tags": [
-      "Ubuntu",
-      "Activator",
-      "Play",
-      "Java"
+      "Play"
     ],
     "components": [
       {
@@ -1883,21 +1803,13 @@
         "version": "2.55"
       },
       {
-        "name": "Node",
-        "version": "6.4.0"
-      },
-      {
         "name": "Activator",
         "version": "1.13.10"
-      },
-      {
-        "name": "Git",
-        "version": "---"
       }
     ],
     "source": {
       "type": "image",
-      "origin": "bitnami/che-java-play:che-2.55-r3"
+      "origin": "bitnami/che-java-play:che-1.3.10-r4"
     },
     "workspaceConfig": {
       "environments": {
@@ -1914,7 +1826,7 @@
             }
           },
           "recipe": {
-            "location": "bitnami/che-java-play:che-2.55-r3",
+            "location": "bitnami/che-java-play:che-1.3.10-r4",
             "type": "dockerimage"
           }
         }

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -994,7 +994,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1003,24 +1003,24 @@
       {
         "name": "1. Create and run project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && npm install express@4.13.4 && express -f . && cp -rn /bitnami/mongodb/conf ${current.project.path} && npm install mongodb@2.1.18 --save && npm install && counter=0; until nc -z localhost 27017; do counter=$((counter+1)); if [ $counter == 10 ]; then echo \"Error: Couldn't connect to MongoDB.\"; exit 1; fi; echo \"Trying to connect to MongoDB at localhost. Attempt $counter.\"; sleep 5; done; echo \"Connected to MongoDB database. Starting application server.\" && npm start",
+        "commandLine": "print-help && cd ${current.project.path} && npm install express@4.13.4 && express -f . && cp -rn /bitnami/mongodb/conf ${current.project.path} && npm install mongodb@2.1.18 --save && npm install && counter=0; until nc -z localhost 27017; do counter=$((counter+1)); if [ $counter == 10 ]; then echo \"Error: Couldn't connect to MongoDB.\"; exit 1; fi; echo \"Trying to connect to MongoDB at localhost. Attempt $counter.\"; sleep 5; done; echo \"Connected to MongoDB database. Starting application server.\" && npm start",
         "attributes": {
           "previewUrl": "http://${server.port.3000}"
         }
       },
       {
-        "name": "2. Run",
+        "name": "2. Stop",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && npm start",
-        "attributes": {
-          "previewUrl": "http://${server.port.3000}"
-        }
-      },
-      {
-        "name": "3. Stop",
-        "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && pkill -u bitnami node && echo \"Web server stopped.\"",
+        "commandLine": "print-help && cd ${current.project.path} && pkill -u bitnami node && echo \"Web server stopped.\"",
         "attributes": {}
+      },
+      {
+        "name": "3. Run",
+        "type": "custom",
+        "commandLine": "print-help && cd ${current.project.path} && npm start",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}"
+        }
       }
     ],
     "links": [],
@@ -1045,7 +1045,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1054,13 +1054,13 @@
       {
         "name": "1. Create project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && mkdir ${current.project.path}/app_template && cd ${current.project.path}/app_template && swift-package init --type executable && swift build && echo \"Project built successfully.\"",
+        "commandLine": "print-help && mkdir ${current.project.path}/app_template && cd ${current.project.path}/app_template && swift-package init --type executable 2>&1 | grep -v \"no version information available\"; swift build 2>&1 | grep -v \"no version information available\"; echo \"Project built successfully.\"",
         "attributes": {}
       },
       {
         "name": "2. Run",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path}/app_template && swift build && ./.build/debug/app_template",
+        "commandLine": "print-help && cd ${current.project.path}/app_template && swift build 2>&1 | grep -v \"no version information available\"; ./.build/debug/app_template",
         "attributes": {}
       }
     ],
@@ -1086,7 +1086,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1095,24 +1095,24 @@
       {
         "name": "1. Create and run project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami start mariadb && cp -a /tmp/laravel-sample/. ${current.project.path} && cd ${current.project.path} && composer update && php artisan migrate && php artisan serve --host=0.0.0.0 --port=3000",
+        "commandLine": "print-help && sudo HOME=/root /opt/bitnami/nami/bin/nami start mariadb && cp -a /tmp/laravel-sample/. ${current.project.path} && cd ${current.project.path} && composer update && php artisan migrate && php artisan serve --host=0.0.0.0 --port=3000",
         "attributes": {
           "previewUrl": "http://${server.port.3000}/"
         }
       },
       {
-        "name": "2. Run",
+        "name": "2. Stop",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && php artisan serve --host=0.0.0.0 --port=3000",
-        "attributes": {
-          "previewUrl": "http://${server.port.3000}/"
-        }
-      },
-      {
-        "name": "3. Stop",
-        "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && pkill -u bitnami php && echo \"Web server stopped.\"",
+        "commandLine": "print-help && cd ${current.project.path} && pkill -u bitnami php && echo \"Web server stopped.\"",
         "attributes": {}
+      },
+      {
+        "name": "3. Run",
+        "type": "custom",
+        "commandLine": "print-help && cd ${current.project.path} && php artisan serve --host=0.0.0.0 --port=3000",
+        "attributes": {
+          "previewUrl": "http://${server.port.3000}/"
+        }
       }
     ],
     "links": [],
@@ -1137,7 +1137,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1146,7 +1146,7 @@
       {
         "name": "1. Create and run project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami start mariadb && cd ${current.project.path} && mv README.md README-CHE.md && rails new . --skip-bundle --database mysql && sed -Ei 's/\\s*#\\s*gem(.*)therubyracer/gem\\1therubyracer/' Gemfile && bundle install && bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0 -p 3000",
+        "commandLine": "print-help && sudo HOME=/root /opt/bitnami/nami/bin/nami start mariadb && cd ${current.project.path} && mv README.md README-CHE.md && rails new . --skip-bundle --database mysql && sed -Ei 's/\\s*#\\s*gem(.*)therubyracer/gem\\1therubyracer/' Gemfile && bundle install && bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0 -p 3000",
         "attributes": {
           "previewUrl": "http://${server.port.3000}/"
         }
@@ -1154,7 +1154,7 @@
       {
         "name": "2. Run",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && bundle exec rails server -b 0.0.0.0 -p 3000",
+        "commandLine": "print-help && cd ${current.project.path} && bundle exec rails server -b 0.0.0.0 -p 3000",
         "attributes": {
           "previewUrl": "http://${server.port.3000}/"
         }
@@ -1170,7 +1170,7 @@
     "name": "codeigniter",
     "displayName": "codeigniter",
     "path": "/codeigniter",
-    "description": "A simple application created by Codeigniter. Execute the '1. Create and run project' command to create the sample project.",
+    "description": "A simple application created by CodeIgniter. Execute the '1. Create and run project' command to create the sample project.",
     "projectType": "php",
     "mixins": [],
     "attributes": {
@@ -1182,7 +1182,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1191,7 +1191,7 @@
       {
         "name": "1. Create and run project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami execute codeigniter createProject --force codeigniter | grep -v undefined && php -S 0.0.0.0:8000 -t ${current.project.path}",
+        "commandLine": "print-help && sudo HOME=/root /opt/bitnami/nami/bin/nami execute codeigniter createProject --force $(basename ${current.project.path}) | grep -v undefined && php -S 0.0.0.0:8000 -t ${current.project.path}",
         "attributes": {
            "previewUrl": "http://${server.port.8000}/"
         }
@@ -1199,7 +1199,7 @@
       {
         "name": "2. Run",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && php -S 0.0.0.0:8000 -t ${current.project.path}",
+        "commandLine": "print-help && php -S 0.0.0.0:8000 -t ${current.project.path}",
         "attributes": {
            "previewUrl": "http://${server.port.8000}/"
         }
@@ -1227,7 +1227,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1236,7 +1236,7 @@
       {
         "name": "1. Create and run project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root nami execute symfony createProject --force symfony | grep -v undefined && ln -fs ${current.project.path}/web/app.php ${current.project.path}/web/index.php && php -S 0.0.0.0:8000 -t ${current.project.path}/web",
+        "commandLine": "print-help && sudo HOME=/root nami execute symfony createProject --force $(basename ${current.project.path}) | grep -v undefined && ln -fs ${current.project.path}/web/app.php ${current.project.path}/web/index.php && php -S 0.0.0.0:8000 -t ${current.project.path}/web",
         "attributes": {
            "previewUrl": "http://${server.port.8000}/"
         }
@@ -1244,7 +1244,7 @@
       {
         "name": "2. Run",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && php -S 0.0.0.0:8000 -t ${current.project.path}/web",
+        "commandLine": "print-help && php -S 0.0.0.0:8000 -t ${current.project.path}/web",
         "attributes": {
            "previewUrl": "http://${server.port.8000}/"
         }
@@ -1272,7 +1272,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample",
+      "location": "https://github.com/bitnami/bitnami-docker-che-blank-sample.git",
       "parameters": {
         "keepVcs": "false"
       }
@@ -1281,24 +1281,24 @@
       {
         "name": "1. Create and run project",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && sudo HOME=/root /opt/bitnami/nami/bin/nami execute activator createProject --force $(basename ${current.project.path}) play-java | grep -v undefined && cd ${current.project.path} && /opt/bitnami/activator/bin/activator -Dsbt.log.noformat=true -Doffline=true -Dhttp.host=0.0.0.0 -Dhttp.port=9000 ~run",
+        "commandLine": "print-help && sudo HOME=/root /opt/bitnami/nami/bin/nami execute activator createProject --force $(basename ${current.project.path}) play-java | grep -v undefined && cd ${current.project.path} && /opt/bitnami/activator/bin/activator -Dsbt.log.noformat=true -Doffline=true -Dhttp.host=0.0.0.0 -Dhttp.port=9000 ~run",
         "attributes": {
            "previewUrl": "http://${server.port.9000}/"
         }
       },
       {
-        "name": "2. Run",
+        "name": "2. Stop",
         "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && /opt/bitnami/activator/bin/activator -Doffline=true -Dhttp.host=0.0.0.0 -Dhttp.port=9000 -Dsbt.log.noformat=true ~run",
-        "attributes": {
-           "previewUrl": "http://${server.port.9000}/"
-        }
-      },
-      {
-        "name": "3. Stop",
-        "type": "custom",
-        "commandLine": "source /opt/bitnami/stacksmith-utils.sh && print_welcome_page && cd ${current.project.path} && pkill -u bitnami activator && echo \"Web server stopped.\"",
+        "commandLine": "print-help && cd ${current.project.path} && pkill -u bitnami -n java && echo \"Web server stopped.\"",
         "attributes": {}
+      },
+      {
+        "name": "3. Run",
+        "type": "custom",
+        "commandLine": "print-help && cd ${current.project.path} && /opt/bitnami/activator/bin/activator -Doffline=true -Dhttp.host=0.0.0.0 -Dhttp.port=9000 -Dsbt.log.noformat=true ~run",
+        "attributes": {
+           "previewUrl": "http://${server.port.9000}/"
+        }
       }
     ],
     "links": [],


### PR DESCRIPTION
### What does this PR do?

Updates the Bitnami Stacks to the latest version. The containers now use Bitnami's own "minideb" image as a base, which reduces the size of the containers in comparison with the previous version.

### What issues does this PR fix or reference?

It doesn't reference an issue.

### New behavior
Bitnami stacks updated to latest version.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
