### PR TITLE
Enable to find the container deployed by Kubernetes.

### DIFF
--- a/assembly/assembly-main/src/assembly/bin/docker.sh
+++ b/assembly/assembly-main/src/assembly/bin/docker.sh
@@ -157,7 +157,12 @@ get_che_server_container_id() {
   # Returning `hostname` doesn't work when running Che on OpenShift/Kubernetes.
   # In these cases `hostname` correspond to the pod ID that is different from
   # the container ID
-  hostname
+
+  if [[ -z "${KUBERNETES_SERVICE_HOST+x}" ]]; then
+    hostname
+  else
+    docker ps | grep -v POD | grep $HOSTNAME | awk '{print $NF}'
+  fi
 }
 
 get_docker_host_ip() {


### PR DESCRIPTION
### What does this PR do?

On vanilla Docker, the container-ID and the hostname in the container will be same.
Kubernetes (a.k.a k8s) names container-ID in Docker as specified naming rules.
So the hostname and the container-ID are not same.
This patch enables get container-ID deployed by K8s.

### What issues does this PR fix or reference?

None.

### Previous behavior

Just returns the result of `hostname`

### New behavior

In case KUBERNETES_SERVICE_HOST has the value, find container-id that have hostname and `POD`.
KUBERNETES_SERVICE_HOST is always defined by the K8s runtime.
