### PR TITLE
CHE-3058 - Update default che version

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -19,7 +19,7 @@ init_global_variables() {
   DEFAULT_CHE_TEST_IMAGE_NAME="codenvy/che-test"
   DEFAULT_CHE_DEV_IMAGE_NAME="codenvy/che-dev"
   DEFAULT_CHE_SERVER_CONTAINER_NAME="che-server"
-  DEFAULT_CHE_VERSION="latest"
+  DEFAULT_CHE_VERSION="nightly"
   DEFAULT_CHE_UTILITY_VERSION="nightly"
   DEFAULT_CHE_CLI_ACTION="help"
   DEFAULT_IS_INTERACTIVE="true"


### PR DESCRIPTION
### Motivation

Point che command line to tool to one of the existing dockerhub images.
Currently there are 2 different images that can be possible candidates for this:

- nightly
- 5.0.0-latest

As this change is going to master and other components like `DEFAULT_CHE_UTILITY_VERSION` already using `nightly` this would be the best choice for now.

Fix for issue #3058
