### PR TITLE
INFRA-14: Limits number of pids

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -130,6 +130,10 @@ che.docker.always_pull_image=true
 # to be able to launch their own runtimes which are embedded Docker containers.
 che.docker.privilege=false
 
+# Limits the number of processes that can be forked inside a cgroup. Set -1 for unlimited.
+# Since 4.3 kernel.
+che.docker.pids_limit=200
+
 # If the browser clients that are accessing Che are remote AND the configuration of Docker is an
 # internal IP address or using Unix sockets, then remote browser clients will not be able to connect
 # to the workspace. Set the Docker configuration so that Docker containers have an external IP

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -132,7 +132,7 @@ che.docker.privilege=false
 
 # Limits the number of processes that can be forked inside a cgroup. Set -1 for unlimited.
 # Since 4.3 kernel.
-che.docker.pids_limit=200
+che.docker.pids_limit=-1
 
 # If the browser clients that are accessing Che are remote AND the configuration of Docker is an
 # internal IP address or using Unix sockets, then remote browser clients will not be able to connect

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/HostConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/HostConfig.java
@@ -44,6 +44,7 @@ public class HostConfig {
 
     private Map<String, PortBinding[]> portBindings     = new HashMap<>();
     private int                        memorySwappiness = -1;
+    private int                        pidsLimit        = -1;
 
     public String[] getBinds() {
         return binds;
@@ -85,6 +86,10 @@ public class HostConfig {
         this.publishAllPorts = publishAllPorts;
     }
 
+    public void setPidsLimit(int pidsLimit) {
+        this.pidsLimit = pidsLimit;
+    }
+
     public HostConfig withBinds(String... binds) {
         this.binds = binds;
         return this;
@@ -107,6 +112,11 @@ public class HostConfig {
 
     public HostConfig withPublishAllPorts(boolean publishAllPorts) {
         this.publishAllPorts = publishAllPorts;
+        return this;
+    }
+
+    public HostConfig withPidsLimit(int pidsLimit) {
+        this.pidsLimit = pidsLimit;
         return this;
     }
 
@@ -255,6 +265,10 @@ public class HostConfig {
 
     public long getMemory() {
         return memory;
+    }
+
+    public long getPidsLimit() {
+        return pidsLimit;
     }
 
     public void setMemory(long memory) {
@@ -422,6 +436,7 @@ public class HostConfig {
                ", cpuShares=" + cpuShares +
                ", cpusetCpus='" + cpusetCpus + '\'' +
                ", pidMode='" + pidMode + '\'' +
+               ", pidsLimit='" + pidsLimit + '\'' +
                ", readonlyRootfs=" + readonlyRootfs +
                ", ulimits=" + Arrays.toString(ulimits) +
                ", portBindings=" + portBindings +

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -209,8 +209,7 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
             md.put("hostConfig.restartPolicy", String.valueOf(hostConfig.getRestartPolicy()));
             md.put("hostConfig.ulimits", Arrays.toString(hostConfig.getUlimits()));
             md.put("hostConfig.volumesFrom", Arrays.toString(hostConfig.getVolumesFrom()));
-            md.put("hostConfig.memory", Long.toString(hostConfig.getMemory()));
-            md.put("hostConfig.memorySwap", Long.toString(hostConfig.getMemorySwap()));
+            md.put("hostConfig.pidsLimit", Long.toString(hostConfig.getPidsLimit()));
         }
 
         return md;

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -113,6 +113,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
     private final DockerInstanceStopDetector                    dockerInstanceStopDetector;
     private final boolean                                       doForcePullOnBuild;
     private final boolean                                       privilegeMode;
+    private final int                                           pidsLimit;
     private final DockerMachineFactory                          dockerMachineFactory;
     private final List<String>                                  devMachinePortsToExpose;
     private final List<String>                                  commonMachinePortsToExpose;
@@ -140,6 +141,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                                @Nullable @Named("che.workspace.hosts") String allMachinesExtraHosts,
                                @Named("che.docker.always_pull_image") boolean doForcePullOnBuild,
                                @Named("che.docker.privilege") boolean privilegeMode,
+                               @Named("che.docker.pids_limit") int pidsLimit,
                                @Named("machine.docker.dev_machine.machine_env") Set<String> devMachineEnvVariables,
                                @Named("machine.docker.machine_env") Set<String> allMachinesEnvVariables,
                                @Named("che.docker.registry_for_snapshots") boolean snapshotUseRegistry,
@@ -166,6 +168,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
         this.memorySwapMultiplier = memorySwapMultiplier == -1 ? -1 : memorySwapMultiplier + 1;
         this.networkDriver = networkDriver;
         this.windowsPathEscaper = windowsPathEscaper;
+        this.pidsLimit = pidsLimit;
 
         allMachinesSystemVolumes = removeEmptyAndNullValues(allMachinesSystemVolumes);
         devMachineSystemVolumes = removeEmptyAndNullValues(devMachineSystemVolumes);
@@ -490,6 +493,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                   .withMemorySwap(machineMemorySwap)
                   .withMemory(service.getMemLimit())
                   .withPrivileged(privilegeMode)
+                  .withPidsLimit(pidsLimit)
                   .withNetworkMode(networkName)
                   .withLinks(toArrayIfNotNull(service.getLinks()))
                   .withPortBindings(service.getPorts()

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
@@ -296,6 +296,19 @@ public class MachineProviderImplTest {
         assertTrue(argumentCaptor.getValue().getContainerConfig().getHostConfig().isPrivileged());
     }
 
+    @Test
+    public void shouldCreateContainerWithPidsLimit() throws Exception {
+        provider = spy(new MachineProviderBuilder().setPidsLimit(512)
+                                                   .build());
+
+        createInstanceFromRecipe();
+
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue().getContainerConfig().getHostConfig().getPidsLimit(), 512);
+    }
+
+
     @Test(expectedExceptions = ServerException.class)
     public void shouldRemoveContainerInCaseFailedStartContainer() throws Exception {
         doThrow(IOException.class).when(dockerConnector).startContainer(StartContainerParams.create(CONTAINER_ID));
@@ -1118,6 +1131,7 @@ public class MachineProviderImplTest {
         private String           extraHosts;
         private boolean          doForcePullOnBuild;
         private boolean          privilegedMode;
+        private int              pidsLimit;
         private Set<String>      devMachineEnvVars;
         private Set<String>      allMachineEnvVars;
         private boolean          snapshotUseRegistry;
@@ -1137,6 +1151,7 @@ public class MachineProviderImplTest {
             allMachineVolumes = emptySet();
             extraHosts = null;
             memorySwapMultiplier = MEMORY_SWAP_MULTIPLIER;
+            pidsLimit = -1;
         }
 
         public MachineProviderBuilder setDevMachineEnvVars(Set<String> devMachineEnvVars) {
@@ -1156,6 +1171,11 @@ public class MachineProviderImplTest {
 
         public MachineProviderBuilder setPrivilegedMode(boolean privilegedMode) {
             this.privilegedMode = privilegedMode;
+            return this;
+        }
+
+        public MachineProviderBuilder setPidsLimit(int pidsLimit) {
+            this.pidsLimit = pidsLimit;
             return this;
         }
 
@@ -1202,6 +1222,7 @@ public class MachineProviderImplTest {
                                            extraHosts,
                                            doForcePullOnBuild,
                                            privilegedMode,
+                                           pidsLimit,
                                            devMachineEnvVars,
                                            allMachineEnvVars,
                                            snapshotUseRegistry,


### PR DESCRIPTION
### What does this PR do?
Limits the number of processes that can be forked inside a cgroup. Set -1 for unlimited.
Works on nodes where kernel version is equal or greater than 4.3

### What issues does this PR fix or reference?
https://github.com/codenvy/infrastructure/issues/14

### Previous behavior
Docker sets limits by itself. By default it is 512.

### New behavior
Admin might set its own limits.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

Some docs 
https://blog.docker.com/2016/02/docker-engine-1-10-security/
https://docs.docker.com/engine/reference/commandline/run/
