### PR TITLE
CHE-2915 Fix regexp in git importer page

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenter.java
@@ -29,23 +29,24 @@ import java.util.Map;
  */
 public class GitImporterPagePresenter extends AbstractWizardPage<MutableProjectConfig> implements GitImporterPageView.ActionDelegate {
 
+    private static final String HOST_PATTERN = "([A-Za-z0-9]+(\\.|\\-)?)*[A-Za-z0-9]+";
+    private static final String REPO_PATTERN = "([A-Za-z0-9]+(\\.|\\-|/)?)*[A-Za-z0-9]+/?$";
+
     // An alternative scp-like syntax: [user@]host.xz:path/to/repo.git/
-    private static final RegExp SCP_LIKE_SYNTAX = RegExp.compile("([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+:");
+    private static final RegExp SCP_LIKE_SYNTAX = RegExp.compile("^([A-Za-z0-9_\\.\\-]+@)?" + HOST_PATTERN + ":" + REPO_PATTERN);
     // the transport protocol
-    private static final RegExp PROTOCOL        = RegExp.compile("((http|https|git|ssh|ftp|ftps)://)");
-    // the address of the remote server between // and /
-    private static final RegExp HOST1           = RegExp.compile("//([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+/");
-    // the address of the remote server between @ and : or /
-    private static final RegExp HOST2           = RegExp.compile("@([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+[:/]");
-    // the repository name
-    private static final RegExp REPO_NAME       = RegExp.compile("/[A-Za-z0-9_.\\-]+$");
+    private static final RegExp PROTOCOL        = RegExp.compile("(http|https|git|ssh|ftp|ftps)://");
+    // the address of the remote server between // or @ and : or /
+    private static final RegExp HOST            = RegExp.compile("(//|@)" + HOST_PATTERN + "(/|:)");
+    // the repository path or name
+    private static final RegExp REPO            = RegExp.compile("/" + REPO_PATTERN);
     // start with white space
     private static final RegExp WHITE_SPACE     = RegExp.compile("^\\s");
 
     private GitLocalizationConstant locale;
     private GitImporterPageView     view;
 
-    private boolean                 ignoreChanges;
+    private boolean ignoreChanges;
 
     @Inject
     public GitImporterPagePresenter(GitImporterPageView view,
@@ -252,13 +253,13 @@ public class GitImporterPagePresenter extends AbstractWizardPage<MutableProjectC
             return false;
         }
 
-        if (!(HOST1.test(url) || HOST2.test(url))) {
+        if (!HOST.test(url)) {
             view.markURLInvalid();
             view.setURLErrorMessage(locale.importProjectMessageHostIncorrect());
             return false;
         }
 
-        if (!(REPO_NAME.test(url))) {
+        if (!REPO.test(url)) {
             view.markURLInvalid();
             view.setURLErrorMessage(locale.importProjectMessageNameRepoIncorrect());
             return false;

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenterTest.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/importer/page/GitImporterPagePresenterTest.java
@@ -106,6 +106,17 @@ public class GitImporterPagePresenterTest {
     }
 
     @Test
+    public void testUrlWithSlashAtTheEnd() {
+        // test for url with slash at the end of the path
+        String correctUrl = "git://hostname.com/path/to/repo.git/";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
     public void testUrlWithoutUsername() {
         String correctUrl = "git@hostname.com:projectName.git";
         when(view.getProjectName()).thenReturn("");
@@ -171,6 +182,72 @@ public class GitImporterPagePresenterTest {
     }
 
     @Test
+    public void testSshUriWithIpBetweenDoubleSlashAndSlash() {
+        //Check for type uri with ip address between // and /
+        String correctUrl = "ssh://127.0.0.1/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testSshUriWithLocalhostBetweenDoubleSlashAndSlash() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "ssh://localhost/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testSshUriWithIpBetweenAtAndSlash() {
+        //Check for type uri with ip address between @ and /
+        String correctUrl = "ssh://user@127.0.0.1/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testSshUriWithLocalhostBetweenAtAndSlash() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "ssh://user@localhost/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testUrlWithHostNameWithDotAndDash() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "git://host-name.com/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testUrlWithHostNameWithSeveralDotsAndDashes() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "git://ho-st.na-me.com/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
     public void projectUrlWithIncorrectProtocolEnteredTest() {
         String incorrectUrl = "htps://github.com/codenvy/ide.git";
         when(view.getProjectName()).thenReturn("");
@@ -179,6 +256,81 @@ public class GitImporterPagePresenterTest {
 
         verify(view).markURLInvalid();
         verify(view).setURLErrorMessage(eq(locale.importProjectMessageProtocolIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatStartsWithDotEnteredTest() {
+        String incorrectUrl = "https://.github.com/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatStartsWithDashEnteredTest() {
+        String incorrectUrl = "https://-github.com/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatEndsOnDotDashEnteredTest() {
+        String incorrectUrl = "https://github.com./codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatEndsOnDashDashEnteredTest() {
+        String incorrectUrl = "https://github.com-/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithEnteredHostNameWithDotAndDashTogetherTest() {
+        String incorrectUrl = "https://github.-com/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.projectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
 
         verify(source).setLocation(eq(incorrectUrl));
         verify(view).setProjectName(anyString());

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
@@ -53,16 +53,17 @@ import java.util.Map;
  */
 public class GithubImporterPagePresenter extends AbstractWizardPage<MutableProjectConfig> implements GithubImporterPageView.ActionDelegate {
 
+    private static final String HOST_PATTERN = "([A-Za-z0-9]+(\\.|\\-)?)*[A-Za-z0-9]+";
+    private static final String REPO_PATTERN = "([A-Za-z0-9]+(\\.|\\-|/)?)*[A-Za-z0-9]+/?$";
+
     // An alternative scp-like syntax: [user@]host.xz:path/to/repo.git/
-    private static final RegExp SCP_LIKE_SYNTAX = RegExp.compile("([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+:");
+    private static final RegExp SCP_LIKE_SYNTAX = RegExp.compile("^([A-Za-z0-9_\\.\\-]+@)?" + HOST_PATTERN + ":" + REPO_PATTERN);
     // the transport protocol
-    private static final RegExp PROTOCOL        = RegExp.compile("((http|https|git|ssh|ftp|ftps)://)");
-    // the address of the remote server between // and /
-    private static final RegExp HOST1           = RegExp.compile("//([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+/");
-    // the address of the remote server between @ and : or /
-    private static final RegExp HOST2           = RegExp.compile("@([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+[:/]");
-    // the repository name
-    private static final RegExp REPO_NAME       = RegExp.compile("/[A-Za-z0-9_.\\-]+$");
+    private static final RegExp PROTOCOL        = RegExp.compile("(http|https|git|ssh|ftp|ftps)://");
+    // the address of the remote server between // or @ and : or /
+    private static final RegExp HOST            = RegExp.compile("(//|@)" + HOST_PATTERN + "(/|:)");
+    // the repository path or name
+    private static final RegExp REPO            = RegExp.compile("/" + REPO_PATTERN);
     // start with white space
     private static final RegExp WHITE_SPACE     = RegExp.compile("^\\s");
 
@@ -466,13 +467,13 @@ public class GithubImporterPagePresenter extends AbstractWizardPage<MutableProje
             return false;
         }
 
-        if (!(HOST1.test(url) || HOST2.test(url))) {
+        if (!HOST.test(url)) {
             view.markURLInvalid();
             view.setURLErrorMessage(locale.importProjectMessageHostIncorrect());
             return false;
         }
 
-        if (!(REPO_NAME.test(url))) {
+        if (!REPO.test(url)) {
             view.markURLInvalid();
             view.setURLErrorMessage(locale.importProjectMessageNameRepoIncorrect());
             return false;

--- a/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
@@ -88,9 +88,9 @@ public class GithubImporterPagePresenterTest {
     private ArgumentCaptor<AsyncRequestCallback<Map<String, List<GitHubRepository>>>> asyncRequestCallbackRepoListCaptor;
 
     @Mock
-    private Wizard.UpdateDelegate           updateDelegate;
+    private Wizard.UpdateDelegate                     updateDelegate;
     @Mock
-    private DtoFactory                      dtoFactory;
+    private DtoFactory                                dtoFactory;
     @Mock
     private GithubImporterPageView                    view;
     @Mock
@@ -124,11 +124,11 @@ public class GithubImporterPagePresenterTest {
     @Mock
     private Response                                  response;
     @Mock
-    private OAuth2Authenticator             gitHubAuthenticator;
+    private OAuth2Authenticator                       gitHubAuthenticator;
     @Mock
-    private OAuth2AuthenticatorRegistry     gitHubAuthenticatorRegistry;
+    private OAuth2AuthenticatorRegistry               gitHubAuthenticatorRegistry;
     @Mock
-    private AppContext                      appContext;
+    private AppContext                                appContext;
 
     private GithubImporterPagePresenter presenter;
 
@@ -261,6 +261,17 @@ public class GithubImporterPagePresenterTest {
     }
 
     @Test
+    public void testUrlWithSlashAtTheEnd() {
+        // test for url with slash at the end of the path
+        String correctUrl = "git://hostname.com/path/to/repo.git/";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
     public void testUrlWithoutUsername() {
         String correctUrl = "git@hostname.com:projectName.git";
         when(view.getProjectName()).thenReturn("");
@@ -326,6 +337,72 @@ public class GithubImporterPagePresenterTest {
     }
 
     @Test
+    public void testSshUriWithIpBetweenDoubleSlashAndSlash() {
+        //Check for type uri with ip address between // and /
+        String correctUrl = "ssh://127.0.0.1/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testSshUriWithLocalhostBetweenDoubleSlashAndSlash() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "ssh://localhost/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testSshUriWithIpBetweenAtAndSlash() {
+        //Check for type uri with ip address between @ and /
+        String correctUrl = "ssh://user@127.0.0.1/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testSshUriWithLocalhostBetweenAtAndSlash() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "ssh://user@localhost/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testUrlWithHostNameWithDotAndDash() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "git://host-name.com/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
+    public void testUrlWithHostNameWithSeveralDotsAndDashes() {
+        //Check for type uri with localhost between // and /
+        String correctUrl = "git://ho-st.na-me.com/some/path";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(correctUrl);
+
+        verifyInvocationsForCorrectUrl(correctUrl);
+    }
+
+    @Test
     public void projectUrlWithIncorrectProtocolEnteredTest() {
         String correctUrl = "htps://github.com/codenvy/ide.git";
         when(view.getProjectName()).thenReturn("");
@@ -335,6 +412,81 @@ public class GithubImporterPagePresenterTest {
         verify(view).markURLInvalid();
         verify(view).setURLErrorMessage(eq(locale.importProjectMessageProtocolIncorrect()));
         verify(source).setLocation(eq(correctUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatStartsWithDotEnteredTest() {
+        String incorrectUrl = "https://.github.com/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatStartsWithDashEnteredTest() {
+        String incorrectUrl = "https://-github.com/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatEndsOnDotDashEnteredTest() {
+        String incorrectUrl = "https://github.com./codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithHostNameThatEndsOnDashDashEnteredTest() {
+        String incorrectUrl = "https://github.com-/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
+        verify(view).setProjectName(anyString());
+        verify(updateDelegate).updateControls();
+    }
+
+    @Test
+    public void projectUrlWithEnteredHostNameWithDotAndDashTogetherTest() {
+        String incorrectUrl = "https://github.-com/codenvy/ide.git";
+        when(view.getProjectName()).thenReturn("");
+
+        presenter.onProjectUrlChanged(incorrectUrl);
+
+        verify(view).markURLInvalid();
+        verify(view).setURLErrorMessage(eq(locale.importProjectMessageHostIncorrect()));
+
+        verify(source).setLocation(eq(incorrectUrl));
         verify(view).setProjectName(anyString());
         verify(updateDelegate).updateControls();
     }


### PR DESCRIPTION
### What does this PR do?
Fix regexp in git project import dialog to validate such git urls:
`http://localhost/gitrepo`
`http://56.4.44.44/gitrepo`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/2915

### Previous behavior
`http://localhost/gitrepo` and `http://56.4.44.44/gitrepo` git urls was marked as invalid.

@vparfonov @sleshchenko please review



