### PR TITLE
Fix search text in PHP, HTML and other files

### DIFF
--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("Duplicates")
 public class FSLuceneSearcherTest {
     private static final String[] TEST_CONTENT = {
             "Apollo set several major human spaceflight milestones",
@@ -163,6 +164,18 @@ public class FSLuceneSearcherTest {
         assertTrue(paths.isEmpty());
         paths = searcher.search(new QueryExpression().setText("should")).getFilePaths();
         assertTrue(paths.isEmpty());
+    }
+
+
+    @Test
+    public void searchesByWordFragment() throws Exception {
+        VirtualFileSystem virtualFileSystem = virtualFileSystem();
+        VirtualFile folder = virtualFileSystem.getRoot().createFolder("folder");
+        folder.createFile("xxx.txt", TEST_CONTENT[0]);
+        searcher.init(virtualFileSystem);
+
+        List<String> paths = searcher.search(new QueryExpression().setText("stone")).getFilePaths();
+        assertEquals(newArrayList("/folder/xxx.txt"), paths);
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
1. Fix filtering by MimeType for now MimeTypeFilter skip only binary  like: image/*, video/* and etc
2. Add ability set search Whole world option
### What issues does this PR fix or reference?
#2816 

Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>