### PR TITLE
Added suspend/resume calls for file status watcher during organize imports action

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
@@ -19,22 +19,22 @@ import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.texteditor.HandlesUndoRedo;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
+import org.eclipse.che.ide.api.editor.texteditor.UndoableEditor;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.Container;
 import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.VirtualFile;
-import org.eclipse.che.ide.api.editor.texteditor.HandlesUndoRedo;
-import org.eclipse.che.ide.api.editor.texteditor.UndoableEditor;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
 import org.eclipse.che.ide.ext.java.client.editor.JavaCodeAssistClient;
 import org.eclipse.che.ide.ext.java.client.resource.SourceFolderMarker;
 import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
 import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
-import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.util.loging.Log;
 
 import java.util.ArrayList;
@@ -54,11 +54,11 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  */
 @Singleton
 public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDelegate {
-    private final     OrganizeImportsView      view;
-    private final     JavaCodeAssistClient     javaCodeAssistClient;
-    private final     DtoFactory               dtoFactory;
-    private final     JavaLocalizationConstant locale;
-    private final     NotificationManager      notificationManager;
+    private final OrganizeImportsView      view;
+    private final JavaCodeAssistClient     javaCodeAssistClient;
+    private final DtoFactory               dtoFactory;
+    private final JavaLocalizationConstant locale;
+    private final NotificationManager      notificationManager;
     private final EventBus                 eventBus;
 
 
@@ -125,7 +125,8 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
                                 .catchError(new Operation<PromiseError>() {
                                     @Override
                                     public void apply(PromiseError arg) throws OperationException {
-                                        notificationManager.notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
+                                        notificationManager
+                                                .notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
                                         eventBus.fireEvent(newFileTrackingResumeEvent());
                                     }
                                 });
@@ -176,7 +177,8 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
                                 .catchError(new Operation<PromiseError>() {
                                     @Override
                                     public void apply(PromiseError arg) throws OperationException {
-                                        notificationManager.notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
+                                        notificationManager
+                                                .notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
                                     }
                                 });
         }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
@@ -124,8 +124,9 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
                                 .catchError(new Operation<PromiseError>() {
                                     @Override
                                     public void apply(PromiseError arg) throws OperationException {
-                                        notificationManager
-                                                .notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
+                                        String title = locale.failedToProcessOrganizeImports();
+                                        String message = arg.getMessage();
+                                        notificationManager.notify(title, message, FAIL, FLOAT_MODE);
                                         eventBus.fireEvent(newFileTrackingResumeEvent());
                                     }
                                 });
@@ -176,8 +177,9 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
                                 .catchError(new Operation<PromiseError>() {
                                     @Override
                                     public void apply(PromiseError arg) throws OperationException {
-                                        notificationManager
-                                                .notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
+                                        String title = locale.failedToProcessOrganizeImports();
+                                        String message = arg.getMessage();
+                                        notificationManager.notify(title, message, FAIL, FLOAT_MODE);
                                     }
                                 });
         }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.ext.java.client.organizeimports;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
@@ -41,6 +42,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingResumeEvent;
+import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingSuspendEvent;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 
@@ -51,11 +54,13 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  */
 @Singleton
 public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDelegate {
-    private final OrganizeImportsView      view;
-    private final JavaCodeAssistClient     javaCodeAssistClient;
-    private final DtoFactory               dtoFactory;
-    private final JavaLocalizationConstant locale;
-    private final NotificationManager      notificationManager;
+    private final     OrganizeImportsView      view;
+    private final     JavaCodeAssistClient     javaCodeAssistClient;
+    private final     DtoFactory               dtoFactory;
+    private final     JavaLocalizationConstant locale;
+    private final     NotificationManager      notificationManager;
+    private final EventBus                 eventBus;
+
 
     private int                     page;
     private List<ConflictImportDTO> choices;
@@ -69,9 +74,11 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
                                     JavaCodeAssistClient javaCodeAssistClient,
                                     DtoFactory dtoFactory,
                                     JavaLocalizationConstant locale,
-                                    NotificationManager notificationManager) {
+                                    NotificationManager notificationManager,
+                                    EventBus eventBus) {
         this.view = view;
         this.javaCodeAssistClient = javaCodeAssistClient;
+        this.eventBus = eventBus;
         this.view.setDelegate(this);
 
         this.dtoFactory = dtoFactory;
@@ -102,6 +109,7 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
 
             final String fqn = JavaUtil.resolveFQN((Container)srcFolder.get(), (Resource)file);
 
+            eventBus.fireEvent(newFileTrackingSuspendEvent());
             javaCodeAssistClient.organizeImports(project.get().getLocation().toString(), fqn)
                                 .then(new Operation<List<ConflictImportDTO>>() {
                                     @Override
@@ -111,12 +119,14 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
                                         } else {
                                             applyChanges(file);
                                         }
+                                        eventBus.fireEvent(newFileTrackingResumeEvent());
                                     }
                                 })
                                 .catchError(new Operation<PromiseError>() {
                                     @Override
                                     public void apply(PromiseError arg) throws OperationException {
                                         notificationManager.notify(locale.failedToProcessOrganizeImports(), arg.getMessage(), FAIL, FLOAT_MODE);
+                                        eventBus.fireEvent(newFileTrackingResumeEvent());
                                     }
                                 });
         }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenter.java
@@ -61,7 +61,6 @@ public class OrganizeImportsPresenter implements OrganizeImportsView.ActionDeleg
     private final NotificationManager      notificationManager;
     private final EventBus                 eventBus;
 
-
     private int                     page;
     private List<ConflictImportDTO> choices;
     private Map<Integer, String>    selected;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/organizeimports/OrganizeImportsPresenterTest.java
@@ -12,10 +12,13 @@ package org.eclipse.che.ide.ext.java.client.organizeimports;
 
 import com.google.common.base.Optional;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.editor.EditorInput;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.Container;
 import org.eclipse.che.ide.api.resources.File;
@@ -26,8 +29,6 @@ import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
 import org.eclipse.che.ide.ext.java.client.editor.JavaCodeAssistClient;
 import org.eclipse.che.ide.ext.java.client.resource.SourceFolderMarker;
 import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
-import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.resource.Path;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,9 +66,10 @@ public class OrganizeImportsPresenterTest {
     private JavaLocalizationConstant locale;
     @Mock
     private NotificationManager      notificationManager;
+    @Mock
+    private EventBus                 eventBus;
 
     private OrganizeImportsPresenter presenter;
-
     @Mock
     private File        file;
     @Mock
@@ -78,9 +80,9 @@ public class OrganizeImportsPresenterTest {
     private EditorInput editorInput;
     @Mock
     private TextEditor  editor;
+
     @Mock
     private Document    document;
-
     @Mock
     private Promise<List<ConflictImportDTO>> importsPromise;
     @Mock
@@ -121,7 +123,8 @@ public class OrganizeImportsPresenterTest {
                                                  javaCodeAssistClient,
                                                  dtoFactory,
                                                  locale,
-                                                 notificationManager);
+                                                 notificationManager,
+                                                 eventBus);
 
         prepareConflicts();
 


### PR DESCRIPTION
### What does this PR do?
Removes notification about external modification when we organize imports (internal modification) by suspending file status watchers for the time of organize imports operation is performed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/2745

### New behavior
On organize imports action calls appears no erroneous notification