### PR TITLE
Calculate common path for several paths

### DIFF
--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/resource/Path.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/resource/Path.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.ide.resource;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
 
 import java.util.ArrayList;
@@ -20,6 +19,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.nullToEmpty;
 
 /**
  * Client side implementation for the resource path.
@@ -36,7 +36,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Vlad Zhukovskyi
  * @since 4.0.0-RC7
  */
-@Beta
 public final class Path {
 
     /**
@@ -1224,5 +1223,58 @@ public final class Path {
         }
 
         return list;
+    }
+
+    /**
+     * Calculated common path from the several paths given as array.
+     * <p>
+     * For example we have three paths:
+     * <ul>
+     * <li>{@code /a/b/c}</li>
+     * <li>{@code /a/b/d}</li>
+     * <li>{@code /a/b/d/e}</li>
+     * </ul>
+     * Common path will be {@code /a/b}
+     *
+     * @param paths
+     *         paths array
+     * @return common path of empty string if given array is empty
+     * @throws NullPointerException
+     *         in case if given {@code paths} array is null
+     * @since 5.0.0
+     */
+    public static Path commonPath(Path... paths) {
+        checkNotNull(paths);
+
+        Path commonPath = Path.ROOT;
+
+        if (paths.length == 0) {
+            return EMPTY;
+        }
+
+        for (int i = 0; i < paths.length; i++) {
+            final String currentSegment = paths[0].segment(i);
+
+            boolean segmentsMatched = true;
+
+            for (int j = 1; j < paths.length && segmentsMatched; j++) {
+                final Path comparedPath = paths[j];
+
+                if (comparedPath.segmentCount() < i) {
+                    segmentsMatched = false;
+                    break;
+                } else {
+                    segmentsMatched = nullToEmpty(comparedPath.segment(i)).equals(currentSegment);
+                }
+            }
+
+            if (segmentsMatched) {
+                commonPath = commonPath.append(currentSegment);
+            } else {
+                break;
+            }
+        }
+
+        return commonPath;
     }
 }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/resource/Path.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/resource/Path.java
@@ -1256,7 +1256,7 @@ public final class Path {
             return paths[0];
         }
 
-        for (int i = 0; i < paths.length; i++) {
+        for (int i = 0; i < paths[0].segmentCount(); i++) {
             final String currentSegment = paths[0].segment(i);
 
             boolean segmentsMatched = true;

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/resource/Path.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/resource/Path.java
@@ -1252,6 +1252,10 @@ public final class Path {
             return EMPTY;
         }
 
+        if (paths.length == 1) {
+            return paths[0];
+        }
+
         for (int i = 0; i < paths.length; i++) {
             final String currentSegment = paths[0].segment(i);
 

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
@@ -252,4 +252,20 @@ public class PathTest {
         assertFalse(path.equals(pathWithDevice));
         assertTrue(pathWithDevice.toString().equals("mnt:/foo"));
     }
+
+    @Test
+    public void testShouldReturnCommonPath() throws Exception {
+        final Path common = Path.valueOf("/foo");
+
+        final Path path1 = common.append("a/b");
+        final Path path2 = common.append("a/c");
+        final Path path3 = common.append("a/d");
+        final Path path4 = common.append("c/d/b");
+        final Path path5 = common.append("a/d/c");
+        final Path path6 = common.append("a/c/c");
+
+        final Path result = Path.commonPath(path1, path2, path3, path4, path5, path6);
+
+        assertEquals(result, common);
+    }
 }

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
@@ -268,4 +268,51 @@ public class PathTest {
 
         assertEquals(result, common);
     }
+
+    @Test
+    public void testShouldReturnRootPathAsCommon() throws Exception {
+        final Path path1 = Path.valueOf("/a");
+        final Path path2 = Path.valueOf("/b");
+        final Path path3 = Path.valueOf("/c");
+        final Path path4 = Path.valueOf("/d");
+        final Path path5 = Path.valueOf("/e");
+
+        final Path result = Path.commonPath(path1, path2, path3, path4, path5);
+
+        assertEquals(result, Path.ROOT);
+    }
+
+    @Test
+    public void testShouldReturnRootPathAsCommon2() throws Exception {
+        final Path path1 = Path.valueOf("/a");
+        final Path path2 = Path.valueOf("b");
+        final Path path3 = Path.valueOf("/c");
+        final Path path4 = Path.valueOf("d");
+        final Path path5 = Path.valueOf("/e");
+
+        final Path result = Path.commonPath(path1, path2, path3, path4, path5);
+
+        assertEquals(result, Path.ROOT);
+    }
+
+    @Test
+    public void testShouldReturnEmptyPathForEmptyInputArray() throws Exception {
+        final Path result = Path.commonPath();
+
+        assertEquals(result, Path.EMPTY);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testShouldThrowNPEOnNullArgument() throws Exception {
+        Path.commonPath(null);
+    }
+
+    @Test
+    public void testShouldReturnSamePathAsOneGivenAsArgument() throws Exception {
+        final Path path = Path.valueOf("/some/path");
+
+        final Path result = Path.commonPath(path);
+
+        assertEquals(result, path);
+    }
 }

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/resource/PathTest.java
@@ -315,4 +315,16 @@ public class PathTest {
 
         assertEquals(result, path);
     }
+
+    @Test
+    public void testShouldReturnCorrectCommonPathIfPathHasSegmentsMoreThanPathCount() throws Exception {
+        final Path common = Path.valueOf("/foo");
+
+        final Path path1 = common.append("a/b/c/d/e/f/g/h/i/j/k/l");
+        final Path path2 = common.append("b/c");
+
+        final Path result = Path.commonPath(path1, path2);
+
+        assertEquals(result, common);
+    }
 }


### PR DESCRIPTION
This PR adds a new utility method to calculate common path for more than one instance of `org.eclipse.che.ide.resource.Path`

For example we have several paths:
* `/a/b/c`
* `/a/d/b`
* `/a/a`
* `/a`

The result common path will be `/a`.

Related issue: none
Tests written: yes

The purpose of creating an additional utility method is to step by step refactor event firing mechanism from the client resource manager. To filter common path which has been updated and fire only one event instead of several.

@vparfonov @skabashnyuk review it, please.