### PR TITLE
ARTIK-187: hide an error message if text in the input dialog is empty

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/zip/ZipImporterPagePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/zip/ZipImporterPagePresenter.java
@@ -24,6 +24,8 @@ import org.eclipse.che.ide.util.NameUtils;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 /**
  * @author Roman Nikitenko
  */
@@ -156,6 +158,11 @@ public class ZipImporterPagePresenter extends AbstractWizardPage<MutableProjectC
      * @return <code>true</code> if url is correct
      */
     private boolean isUrlCorrect(@NotNull String url) {
+        if(isNullOrEmpty(url)) {
+            view.showUrlError("");
+            return false;
+        }
+
         if (!END_URL.test(url)) {
             view.showUrlError(locale.importProjectMessageUrlInvalid());
             return false;

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projectimport/zip/ZipImporterPagePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projectimport/zip/ZipImporterPagePresenterTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.when;
 public class ZipImporterPagePresenterTest {
 
     private static final String SKIP_FIRST_LEVEL_PARAM_NAME = "skipFirstLevel";
+    private static final String CORRECT_URL = "https://host.com/some/path/angularjs.zip";
+    private static final String INCORRECT_URL = " https://host.com/some/path/angularjs.zip";
 
     @Mock
     private ZipImporterPageView                       view;
@@ -84,11 +86,10 @@ public class ZipImporterPagePresenterTest {
 
     @Test
     public void incorrectProjectUrlEnteredTest() {
-        String incorrectUrl = "https//host.com/some/path/angularjs.zip";
         when(view.getProjectName()).thenReturn("");
         when(view.getProjectName()).thenReturn("angularjs");
 
-        presenter.projectUrlChanged(incorrectUrl);
+        presenter.projectUrlChanged(INCORRECT_URL);
 
         verify(view).showUrlError(anyString());
         verify(delegate).updateControls();
@@ -108,10 +109,9 @@ public class ZipImporterPagePresenterTest {
 
     @Test
     public void projectUrlStartWithWhiteSpaceEnteredTest() {
-        String incorrectUrl = " https://host.com/some/path/angularjs.zip";
         when(view.getProjectName()).thenReturn("name");
 
-        presenter.projectUrlChanged(incorrectUrl);
+        presenter.projectUrlChanged(INCORRECT_URL);
 
         verify(view).showUrlError(eq(locale.importProjectMessageStartWithWhiteSpace()));
         verify(delegate).updateControls();
@@ -119,10 +119,9 @@ public class ZipImporterPagePresenterTest {
 
     @Test
     public void correctProjectUrlEnteredTest() {
-        String correctUrl = "https://host.com/some/path/angularjs.zip";
         when(view.getProjectName()).thenReturn("", "angularjs");
 
-        presenter.projectUrlChanged(correctUrl);
+        presenter.projectUrlChanged(CORRECT_URL);
 
         verify(view, never()).showUrlError(anyString());
         verify(view).hideNameError();
@@ -176,6 +175,16 @@ public class ZipImporterPagePresenterTest {
         String description = "description";
         presenter.projectDescriptionChanged(description);
 
+        verify(delegate).updateControls();
+    }
+
+    @Test
+    public void pageShouldNotBeReadyIfUrlIsEmpty() throws Exception {
+        when(view.getProjectName()).thenReturn("name");
+
+        presenter.projectUrlChanged("");
+
+        verify(view).showUrlError(eq(""));
         verify(delegate).updateControls();
     }
 }

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenter.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenter.java
@@ -10,16 +10,17 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ui.dialogs.input;
 
-import org.eclipse.che.ide.api.dialogs.InputDialog;
-import org.eclipse.che.ide.api.dialogs.InputValidator;
-import org.eclipse.che.ide.ui.UILocalizationConstant;
-import org.eclipse.che.ide.api.dialogs.CancelCallback;
-import org.eclipse.che.ide.api.dialogs.InputCallback;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 
-import javax.validation.constraints.NotNull;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.ide.api.dialogs.CancelCallback;
+import org.eclipse.che.ide.api.dialogs.InputCallback;
+import org.eclipse.che.ide.api.dialogs.InputDialog;
+import org.eclipse.che.ide.api.dialogs.InputValidator;
+import org.eclipse.che.ide.ui.UILocalizationConstant;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * {@link InputDialog} implementation.
@@ -151,7 +152,7 @@ public class InputDialogPresenter implements InputDialog, InputDialogView.Action
     private boolean isInputValid() {
         String currentValue = view.getValue();
         if (currentValue.trim().isEmpty()) {
-            view.showErrorHint(localizationConstant.validationErrorMessage());
+            view.showErrorHint("");
             return false;
         }
 

--- a/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenterTest.java
+++ b/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenterTest.java
@@ -103,7 +103,7 @@ public class InputDialogPresenterTest extends BaseTest {
 
         presenter.inputValueChanged();
 
-        verify(view).showErrorHint(anyString());
+        verify(view).showErrorHint(eq(""));
         verify(view, never()).hideErrorHint();
         verify(view, never()).setValue(anyString());
     }


### PR DESCRIPTION
### What does this PR do?
Hides unnecessary error message in input dialog.

### What issues does this PR fix or reference?
https://github.com/codenvy/artik-ide/issues/187
https://github.com/codenvy/artik-ide/issues/186

### Previous behavior
When input dialog opens, error message was shown. 

@vparfonov please take a look

