### PR TITLE
Dto streaming

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CheJsonProvider.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CheJsonProvider.java
@@ -37,6 +37,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -80,8 +81,8 @@ public class CheJsonProvider<T> implements MessageBodyReader<T>, MessageBodyWrit
         // Add Cache-Control before start write body.
         httpHeaders.putSingle(HttpHeaders.CACHE_CONTROL, "public, no-cache, no-store, no-transform");
         if (t instanceof JsonSerializable) {
-            try (Writer w = new OutputStreamWriter(entityStream, Charset.forName("UTF-8"))) {
-                w.write(((JsonSerializable)t).toJson());
+            try (Writer w = new OutputStreamWriter(entityStream, StandardCharsets.UTF_8)) {
+                ((JsonSerializable)t).toJson(w);
             }
         } else {
             delegate.writeTo(t, type, genericType, annotations, mediaType, httpHeaders, entityStream);

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Abstract base class for the source generating template for a single DTO. */
 abstract class DtoImpl {
@@ -174,6 +175,16 @@ abstract class DtoImpl {
             addSuperGetters(dto, getters);
         }
         return new ArrayList<>(getters.values());
+    }
+
+    protected Set<String> getSuperGetterNames(Class<?> dto) {
+        final Map<String, Method> getters = new HashMap<>();
+        Class<?> superDto = getSuperDtoInterface(dto);
+        if (superDto != null) {
+            addDtoGetters(superDto, getters);
+            addSuperGetters(superDto, getters);
+        }
+        return getters.keySet();
     }
 
     /**

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
@@ -177,6 +177,9 @@ abstract class DtoImpl {
         return new ArrayList<>(getters.values());
     }
 
+    /**
+     * Get the names of all the getters in the super DTO interface and upper ancestors.
+     */
     protected Set<String> getSuperGetterNames(Class<?> dto) {
         final Map<String, Method> getters = new HashMap<>();
         Class<?> superDto = getSuperDtoInterface(dto);

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoTemplate.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoTemplate.java
@@ -229,7 +229,7 @@ public class DtoTemplate {
         }
         builder.append(" {\n\n");
         if ("server".equals(implType)) {
-            builder.append("  private static final Gson gson = new GsonBuilder().disableHtmlEscaping().create();\n\n");
+            builder.append("  private static final Gson gson = org.eclipse.che.dto.server.DtoFactory.getInstance().getGson();\n\n");
             builder.append("  @Override\n" +
                            "  public void accept(org.eclipse.che.dto.server.DtoFactory dtoFactory) {\n");
             for (DtoImpl dto : getDtoInterfaces()) {

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonArrayImpl.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonArrayImpl.java
@@ -15,6 +15,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 
+import java.io.Writer;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -152,6 +153,11 @@ public class JsonArrayImpl<T> implements JsonArray<T> {
     @Override
     public String toJson() {
         return gson.toJson(this);
+    }
+
+    @Override
+    public void toJson(Writer w) {
+        gson.toJson(this, w);
     }
 
     @Override

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonSerializable.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonSerializable.java
@@ -14,6 +14,7 @@
 package org.eclipse.che.dto.server;
 
 import java.io.Serializable;
+import java.io.Writer;
 
 import com.google.gson.JsonElement;
 
@@ -22,6 +23,9 @@ public interface JsonSerializable extends Serializable {
 
     /** Serializes DTO to JSON format. */
     String toJson();
+
+    /** Serialize the DTO to JSON text through the given Writer. */
+    void toJson(Writer w);
 
     /** Serializes DTO to JSON object. */
     JsonElement toJsonElement();

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonStringMapImpl.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonStringMapImpl.java
@@ -15,6 +15,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 
+import java.io.Writer;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -99,6 +100,11 @@ public class JsonStringMapImpl<T> implements JsonStringMap<T> {
     @Override
     public String toJson() {
         return gson.toJson(this);
+    }
+
+    @Override
+    public void toJson(Writer w) {
+        gson.toJson(this, w);
     }
 
     @Override

--- a/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/DTOHierarchy.java
+++ b/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/DTOHierarchy.java
@@ -46,5 +46,18 @@ public final class DTOHierarchy {
         void setParentField(String parentField);
 
         ChildDto withParentField(String parentField);
+
+        ChildDto getShadowedField();
+
+        void setShadowedField(ChildDto v);
     }
+
+    @DTO
+    public interface GrandchildDto extends ChildDto {
+
+        GrandchildDto getShadowedField();
+
+        void setShadowedField(GrandchildDto v);
+    }
+
 }


### PR DESCRIPTION
### What does this PR do?

Eliminates the redundant creation of full in-memory JSON tress and then strings when reading DTOs from requests or writing them to responses. Applies to general consumption of `DtoFactory` as well, not JAX-RS services only.

### What issues does this PR fix or reference?

* Performance.
Current method always constructs a full replica of the DTO objects as an in-memory `JsonElement` tree, and then asks Gson to dump the tree as a full string. There are two issues here:
  * Gson can generate the JSON in a stream-based method based on `JsonWriter` which eliminates the need for any intermediate trees. Actually no JSON elements are created at all here.
  * The whole method of generating/parsing full JSON texts is not needed, the JAX-RS `CheJsonProvider` passes stream `Reader` and response `Writer` that can used directly by Gson, eliminating even the need of an intermediate full JSON texts.
* Maintainability.
A large part of the generated DTO implementation code is there to replicate the DTO data in `JsonElement` trees, bit by bit. The code section in the generator that takes care of generating this java code in the tool is the most complicated area in the already hard to maintain generator. Gson can do this automatically and more efficiently (previous point).

### Previous behavior
* Full JSON trees built when converting DTOs to JSONs.
* Full JSON text is created before parsing DTOs from JAX-RS requests and (vise versa for responses).

### New behavior
* JSON trees eliminated by using Gson to generate the DTOs objects directly.
* Full JSON texts eliminated by using request `Reader`s and response `Writer`s directly in `DtoFactory`.
* Smaller files generated for DTO implementations: workspace API reduced by 30%, machine API by 29%

#### Changelog
Removes redundant in-memory JSON trees for faster DTO parsing performance.

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>
