### PR TITLE
Issue 1793: Language Server Protocol: ShowMessage Notification feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ config/
 *.log
 *.sql
 *.sqlite
+npm-debug.log.*
 
 # OS generated files #
 ######################

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/ShowMessageProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/ShowMessageProcessor.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.languageserver.ide.editor;
+
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
+
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.notification.StatusNotification;
+import org.eclipse.che.ide.util.loging.Log;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import io.typefox.lsapi.MessageParams;
+
+/**
+ * A processor for incoming <code>window/showMessage</code> notifications sent
+ * by a language server.
+ * 
+ * @author xcoulon
+ */
+@Singleton
+public class ShowMessageProcessor {
+
+	private final NotificationManager notificationManager;
+
+	@Inject
+	public ShowMessageProcessor(final NotificationManager notificationManager) {
+		this.notificationManager = notificationManager;
+	}
+
+	public void processNotification(final MessageParams messageParams) {
+		Log.debug(getClass(), "Received a 'ShowMessage' message: " + messageParams.getMessage());
+		switch(messageParams.getType()) {
+		case Error:
+			this.notificationManager.notify(messageParams.getMessage(), StatusNotification.Status.FAIL, FLOAT_MODE);
+			break;
+		case Warning:
+			this.notificationManager.notify(messageParams.getMessage(), StatusNotification.Status.WARNING, FLOAT_MODE);
+			break;
+		case Info:
+		case Log:
+		default:
+			this.notificationManager.notify(messageParams.getMessage(), StatusNotification.Status.SUCCESS, FLOAT_MODE);
+			break;
+		}
+	}
+
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.languageserver.shared.lsapi.HoverDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.LocationDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.PublishDiagnosticsParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.ReferenceParamsDTO;
+import org.eclipse.che.api.languageserver.shared.lsapi.ShowMessageRequestParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.SignatureHelpDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.SymbolInformationDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.TextDocumentPositionParamsDTO;
@@ -48,6 +49,7 @@ import org.eclipse.che.ide.websocket.MessageBus;
 import org.eclipse.che.ide.websocket.WebSocketException;
 import org.eclipse.che.ide.websocket.rest.SubscriptionHandler;
 import org.eclipse.che.plugin.languageserver.ide.editor.PublishDiagnosticsProcessor;
+import org.eclipse.che.plugin.languageserver.ide.editor.ShowMessageProcessor;
 
 import java.util.List;
 
@@ -67,6 +69,7 @@ public class TextDocumentServiceClient {
     private final AppContext                  appContext;
     private final NotificationManager         notificationManager;
     private final PublishDiagnosticsProcessor publishDiagnosticsProcessor;
+    private final ShowMessageProcessor        showMessageProcessor;
 
     @Inject
     public TextDocumentServiceClient(
@@ -75,7 +78,8 @@ public class TextDocumentServiceClient {
             final AppContext appContext,
             final AsyncRequestFactory asyncRequestFactory,
             final WsAgentStateController wsAgentStateController,
-            final PublishDiagnosticsProcessor publishDiagnosticsProcessor) {
+            final PublishDiagnosticsProcessor publishDiagnosticsProcessor,
+            final ShowMessageProcessor showMessageProcessor) {
         this.unmarshallerFactory = unmarshallerFactory;
         this.notificationManager = notificationManager;
         this.appContext = appContext;
@@ -83,10 +87,12 @@ public class TextDocumentServiceClient {
         this.publishDiagnosticsProcessor = publishDiagnosticsProcessor;
         wsAgentStateController.getMessageBus().then(new Operation<MessageBus>() {
             @Override
-            public void apply(MessageBus arg) throws OperationException {
-                subscribeToPublishDiagnostics(arg);
+            public void apply(MessageBus messageBus) throws OperationException {
+                subscribeToPublishDiagnostics(messageBus);
+                subscribeToShowMessages(messageBus);
             }
         });
+        this.showMessageProcessor = showMessageProcessor;
     }
 
     /**
@@ -310,4 +316,28 @@ public class TextDocumentServiceClient {
         }
     }
 
+    /**
+     * Subscribes to websocket for 'window/showMessage' notifications. 
+     */
+    private void subscribeToShowMessages(final MessageBus messageBus) {
+        final org.eclipse.che.ide.websocket.rest.Unmarshallable<ShowMessageRequestParamsDTO> unmarshaller =
+                unmarshallerFactory.newWSUnmarshaller(ShowMessageRequestParamsDTO.class);
+        try {
+            messageBus.subscribe("languageserver/window/showMessage",
+                                 new SubscriptionHandler<ShowMessageRequestParamsDTO>(unmarshaller) {
+                                     @Override
+                                     protected void onMessageReceived(ShowMessageRequestParamsDTO showMessageRequestParamsDTO) {
+                                         showMessageProcessor.processNotification(showMessageRequestParamsDTO);
+                                     }
+
+                                     @Override
+                                     protected void onErrorReceived(Throwable exception) {
+                                         notificationManager.notify(exception.getMessage(), StatusNotification.Status.FAIL,
+                                                                    StatusNotification.DisplayMode.NOT_EMERGE_MODE);
+                                     }
+                                 });
+        } catch (WebSocketException exception) {
+            Log.error(getClass(), exception);
+        }
+    }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
@@ -20,7 +20,6 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.rest.Unmarshallable;
-
 import java.util.List;
 
 import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
@@ -35,11 +34,13 @@ public class WorkspaceServiceClient {
     private final DtoUnmarshallerFactory unmarshallerFactory;
     private final AppContext appContext;
     private final AsyncRequestFactory asyncRequestFactory;
-
+    
+    
     @Inject
     public WorkspaceServiceClient(final DtoUnmarshallerFactory unmarshallerFactory,
                                   final AppContext appContext,
-                                  final AsyncRequestFactory asyncRequestFactory) {
+                                  final AsyncRequestFactory asyncRequestFactory
+                                  ) {
         this.unmarshallerFactory = unmarshallerFactory;
         this.appContext = appContext;
         this.asyncRequestFactory = asyncRequestFactory;
@@ -59,4 +60,5 @@ public class WorkspaceServiceClient {
                                   .header(CONTENT_TYPE, APPLICATION_JSON)
                                   .send(unmarshaller);
     }
+    
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
@@ -10,18 +10,19 @@
  *******************************************************************************/
 package org.eclipse.che.api.languageserver;
 
-import com.google.inject.AbstractModule;
-
-import org.eclipse.che.api.languageserver.messager.PublishDiagnosticsParamsMessenger;
-import org.eclipse.che.api.languageserver.registry.ServerInitializer;
-import org.eclipse.che.api.languageserver.service.LanguageRegistryService;
-import org.eclipse.che.api.languageserver.service.TextDocumentService;
-import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.api.languageserver.messager.InitializeEventMessenger;
+import org.eclipse.che.api.languageserver.messager.PublishDiagnosticsParamsMessenger;
+import org.eclipse.che.api.languageserver.messager.ShowMessageMessenger;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistryImpl;
+import org.eclipse.che.api.languageserver.registry.ServerInitializer;
 import org.eclipse.che.api.languageserver.registry.ServerInitializerImpl;
+import org.eclipse.che.api.languageserver.service.LanguageRegistryService;
+import org.eclipse.che.api.languageserver.service.TextDocumentService;
 import org.eclipse.che.api.languageserver.service.WorkspaceService;
+import org.eclipse.che.inject.DynaModule;
+
+import com.google.inject.AbstractModule;
 
 @DynaModule
 public class LanguageServerModule extends AbstractModule {
@@ -30,11 +31,11 @@ public class LanguageServerModule extends AbstractModule {
     protected void configure() {
         bind(LanguageServerRegistry.class).to(LanguageServerRegistryImpl.class);
         bind(ServerInitializer.class).to(ServerInitializerImpl.class);
-
         bind(LanguageRegistryService.class);
         bind(TextDocumentService.class);
         bind(WorkspaceService.class);
         bind(PublishDiagnosticsParamsMessenger.class);
+        bind(ShowMessageMessenger.class);
         bind(InitializeEventMessenger.class);
     }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/messager/ShowMessageMessenger.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/messager/ShowMessageMessenger.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.languageserver.messager;
+
+import java.io.IOException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.websocket.EncodeException;
+
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.everrest.websockets.WSConnectionContext;
+import org.everrest.websockets.message.ChannelBroadcastMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+import io.typefox.lsapi.MessageParams;
+
+/**
+ * {@link EventSubscriber} for incoming <code>window/showMessage</code> notifications.
+ * @author xcoulon
+ */
+@Singleton
+public class ShowMessageMessenger implements EventSubscriber<MessageParams> {
+	
+    private final static Logger LOG = LoggerFactory.getLogger(ShowMessageMessenger.class);
+
+    private final EventService eventService;
+
+    @Inject
+    public ShowMessageMessenger(EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    public void onEvent(final MessageParams event) {
+        try {
+            final ChannelBroadcastMessage bm = new ChannelBroadcastMessage();
+            bm.setChannel("languageserver/window/showMessage");
+            bm.setBody(new Gson().toJson(event));
+            WSConnectionContext.sendMessage(bm);
+        } catch (EncodeException | IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    @PostConstruct
+    public void subscribe() {
+        eventService.subscribe(this);
+    }
+
+    @PreDestroy
+    public void unsubscribe() {
+        eventService.unsubscribe(this);
+    }
+}

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImplTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImplTest.java
@@ -17,6 +17,7 @@ import io.typefox.lsapi.services.LanguageServer;
 
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
 import org.eclipse.che.api.languageserver.messager.PublishDiagnosticsParamsMessenger;
+import org.eclipse.che.api.languageserver.messager.ShowMessageMessenger;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -47,6 +48,8 @@ public class ServerInitializerImplTest {
     @Mock
     private PublishDiagnosticsParamsMessenger   publishDiagnosticsParamsMessenger;
     @Mock
+    private ShowMessageMessenger          showMessageParamsMessenger;
+    @Mock
     private LanguageDescription                 languageDescription;
     @Mock
     private LanguageServerLauncher              launcher;
@@ -59,7 +62,7 @@ public class ServerInitializerImplTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        initializer = spy(new ServerInitializerImpl(publishDiagnosticsParamsMessenger));
+        initializer = spy(new ServerInitializerImpl(publishDiagnosticsParamsMessenger, showMessageParamsMessenger));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Added a ShowMessageProcessor and a ShowMessageMessager classes to process
incoming `window/showMessage` notification and display a notification
in `float` mode in the UI if the message type is `error` or `warning`, in
the events panel otherwise. Note that the notification type for `error`
messages is incorrectly set to `Log` because of a bug in the typefox
dependency: `io.typefox.lsapi.MessageType#Log` has the value `1` instead of
`4`.

This issue depends on https://github.com/eclipse/che/pull/3113
(Add a 'warning' state for the notifications)

To test the pull request, please follow the instructions on
https://github.com/eclipse/che/pull/3123 to run the 'test-lang' server.
Once in the workspace, create a project, add a `foo.test` file (the
Language Server support for the 'test-lang' will be activated), then
type the following line

> window/showMessage:error: a message

and wait for the editor to save the changes. This will trigger a
`window/showMessage` notification from the 'test-lang' server in the Che UI.

### What issues does this PR fix or reference?
Issue #1793

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>