### PR TITLE
Performance improvements and other fixes in code completion

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CodeAssistProcessor.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CodeAssistProcessor.java
@@ -25,17 +25,22 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 public interface CodeAssistProcessor {
 
     /**
-     * Returns a list of completion proposals based on the
-     * specified location within the document that corresponds
-     * to the current cursor position within the text view.
+     * Returns a list of completion proposals based on the specified location
+     * within the document that corresponds to the current cursor position
+     * within the text view.
      *
      * @param editor
-     *         the editor whose document is used to compute the proposals
+     *            the editor whose document is used to compute the proposals
      * @param offset
-     *         an offset within the document for which completions should be computed
-     * @return an array of completion proposals or <code>null</code> if no proposals are possible
+     *            an offset within the document for which completions should be
+     *            computed
+     * @param triggered
+     *            if triggered by the content assist key binding
+     * 
+     * @return an array of completion proposals or <code>null</code> if no
+     *         proposals are possible
      */
-    void computeCompletionProposals(TextEditor editor, int offset, CodeAssistCallback callback);
+    void computeCompletionProposals(TextEditor editor, int offset, boolean triggered, CodeAssistCallback callback);
 
     /**
      * Returns the reason why this content assist processor

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CodeAssistant.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CodeAssistant.java
@@ -50,8 +50,9 @@ public interface CodeAssistant {
      * appropriate content assist processor to invoke.
      * 
      * @param offset a document offset
+     * @param triggered if triggered by the content assist key binding
      * @param callback the callback to use once completions are ready
      */
-    void computeCompletionProposals(int offset, CodeAssistCallback callback);
+    void computeCompletionProposals(int offset, boolean triggered, CodeAssistCallback callback);
 
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CodeAssistantImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CodeAssistantImpl.java
@@ -52,12 +52,12 @@ public class CodeAssistantImpl implements CodeAssistant {
     }
 
     @Override
-    public void computeCompletionProposals(final int offset, final CodeAssistCallback callback) {
+    public void computeCompletionProposals(final int offset, final boolean triggered, final CodeAssistCallback callback) {
         this.lastErrorMessage = "processing";
 
         final CodeAssistProcessor processor = getProcessor(offset);
         if (processor != null) {
-            processor.computeCompletionProposals(textEditor, offset, callback);
+            processor.computeCompletionProposals(textEditor, offset, triggered, callback);
             this.lastErrorMessage = processor.getErrorMessage();
             if (this.lastErrorMessage != null) {
                 notificationManager.notify("", lastErrorMessage, FAIL, EMERGE_MODE);
@@ -66,7 +66,7 @@ public class CodeAssistantImpl implements CodeAssistant {
         } else {
             final CodeAssistProcessor fallbackProcessor = getFallbackProcessor();
             if (fallbackProcessor != null) {
-                fallbackProcessor.computeCompletionProposals(textEditor, offset, callback);
+                fallbackProcessor.computeCompletionProposals(textEditor, offset, triggered, callback);
                 this.lastErrorMessage = fallbackProcessor.getErrorMessage();
                 if (this.lastErrorMessage != null) {
                     this.textEditor.showMessage(this.lastErrorMessage);

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CompletionProposal.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/CompletionProposal.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.editor.codeassist;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.eclipse.che.ide.api.icon.Icon;
@@ -28,10 +29,10 @@ public interface CompletionProposal {
     /**
      * Returns optional additional information about the proposal. The additional information will be presented to assist the user
      * in deciding if the selected proposal is the desired choice.
-     *
-     * @return the additional information or <code>null</code>
+     * 
+     * @param callback a callback to return a widget with additional information
      */
-    Widget getAdditionalProposalInfo();
+    void getAdditionalProposalInfo(AsyncCallback<Widget> callback);
 
     /**
      * Returns the string to be displayed in the list of completion proposals.

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/DefaultChainedCodeAssistProcessor.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/codeassist/DefaultChainedCodeAssistProcessor.java
@@ -36,13 +36,13 @@ public abstract class DefaultChainedCodeAssistProcessor implements CodeAssistPro
     }
 
     @Override
-    public void computeCompletionProposals(final TextEditor textEditor, final int offset, final CodeAssistCallback callback) {
+    public void computeCompletionProposals(final TextEditor textEditor, final int offset, final boolean triggered, final CodeAssistCallback callback) {
         if (!this.codeAssistProcessors.isEmpty()) {
             final List<CompletionProposal> proposalList = new ArrayList<>();
             final List<CodeAssistProcessor> expected = new ArrayList<>();
             for (final CodeAssistProcessor processor : this.codeAssistProcessors) {
                 expected.add(processor);
-                processor.computeCompletionProposals(textEditor, offset, new CodeAssistCallback() {
+                processor.computeCompletionProposals(textEditor, offset, triggered, new CodeAssistCallback() {
                     @Override
                     public void proposalComputed(final List<CompletionProposal> processorProposals) {
                         expected.remove(processor);

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorInit.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorInit.java
@@ -191,7 +191,7 @@ public class TextEditorInit<T extends EditorWidget> {
             final KeyBindingAction action = new KeyBindingAction() {
                 @Override
                 public boolean action() {
-                    showCompletion(codeAssistant);
+                    showCompletion(codeAssistant, true);
                     return true;
                 }
             };
@@ -202,7 +202,7 @@ public class TextEditorInit<T extends EditorWidget> {
             documentHandle.getDocEventBus().addHandler(CompletionRequestEvent.TYPE, new CompletionRequestHandler() {
                 @Override
                 public void onCompletionRequest(final CompletionRequestEvent event) {
-                    showCompletion(codeAssistant);
+                    showCompletion(codeAssistant, false);
                 }
             });
         } else {
@@ -234,8 +234,9 @@ public class TextEditorInit<T extends EditorWidget> {
      * Show the available completions.
      *
      * @param codeAssistant the code assistant
+     * @param triggered if triggered by the content assist key binding
      */
-    private void showCompletion(final CodeAssistant codeAssistant) {
+    private void showCompletion(final CodeAssistant codeAssistant, final boolean triggered) {
         final int cursor = textEditor.getCursorOffset();
         if (cursor < 0) {
             return;
@@ -248,7 +249,7 @@ public class TextEditorInit<T extends EditorWidget> {
                     // cursor must be computed here again so it's original value is not baked in
                     // the SMI instance closure - important for completion update when typing
                     final int cursor = textEditor.getCursorOffset();
-                    codeAssistant.computeCompletionProposals(cursor, new CodeAssistCallback() {
+                    codeAssistant.computeCompletionProposals(cursor, triggered, new CodeAssistCallback() {
                         @Override
                         public void proposalComputed(final List<CompletionProposal> proposals) {
                             callback.onCompletionReady(proposals);

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/ActionCompletionProposal.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/ActionCompletionProposal.java
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ext.java.client.editor;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
+import org.eclipse.che.ide.api.editor.codeassist.CompletionProposal;
 import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.ide.ext.java.client.action.ProposalAction;
-import org.eclipse.che.ide.api.editor.codeassist.CompletionProposal;
 import org.eclipse.che.ide.util.loging.Log;
 
 /**
@@ -35,8 +36,8 @@ public class ActionCompletionProposal implements CompletionProposal {
     }
 
     @Override
-    public Widget getAdditionalProposalInfo() {
-        return null;
+    public void getAdditionalProposalInfo(AsyncCallback<Widget> callback) {
+        callback.onSuccess(null);
     }
 
     @Override

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCodeAssistProcessor.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCodeAssistProcessor.java
@@ -155,7 +155,9 @@ public class JavaCodeAssistProcessor implements CodeAssistProcessor {
     }
 
     @Override
-    public void computeCompletionProposals(final TextEditor textEditor, final int offset,
+    public void computeCompletionProposals(final TextEditor textEditor,
+                                           final int offset,
+                                           final boolean triggered,
                                            final CodeAssistCallback callback) {
         if (errorMessage != null) {
             return;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCompletionProposal.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCompletionProposal.java
@@ -79,14 +79,14 @@ public class JavaCompletionProposal implements CompletionProposal, CompletionPro
 
     /** {@inheritDoc} */
     @Override
-    public Widget getAdditionalProposalInfo() {
+    public void getAdditionalProposalInfo(AsyncCallback<Widget> callback) {
         Frame frame = new Frame();
         frame.setSize("100%", "100%");
         frame.getElement().getStyle().setBorderStyle(Style.BorderStyle.NONE);
         frame.getElement().setAttribute("sandbox", ""); // empty value, not null
         frame.getElement().getStyle().setProperty("resize", "both");
         frame.setUrl(client.getProposalDocUrl(id, sessionId));
-        return frame;
+        callback.onSuccess(frame);
     }
 
     /** {@inheritDoc} */

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -121,6 +121,15 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
@@ -68,7 +68,7 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
     }
 
     @Override
-    public void computeCompletionProposals(TextEditor editor, final int offset, final CodeAssistCallback callback) {
+    public void computeCompletionProposals(TextEditor editor, final int offset, final boolean triggered, final CodeAssistCallback callback) {
         this.lastErrorMessage = null;
 
         TextDocumentPositionParamsDTO documentPosition = dtoBuildHelper.createTDPP(editor.getDocument(), offset);
@@ -76,7 +76,7 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
         String currentLine = editor.getDocument().getLineContent(documentPosition.getPosition().getLine());
         final String currentWord = getCurrentWord(currentLine, documentPosition.getPosition().getCharacter());
 
-        if (latestCompletionResult.isGoodFor(documentId, offset, currentWord)) {
+        if (!triggered && latestCompletionResult.isGoodFor(documentId, offset, currentWord)) {
             // no need to send new completion request
             computeProposals(currentWord, offset - latestCompletionResult.getOffset(), callback);
         } else {

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
 import org.eclipse.che.api.languageserver.shared.lsapi.CompletionItemDTO;
+import org.eclipse.che.api.languageserver.shared.lsapi.CompletionListDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.TextDocumentIdentifierDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.TextDocumentPositionParamsDTO;
 import org.eclipse.che.api.promises.client.Operation;
@@ -48,6 +49,7 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
     private final TextDocumentServiceClient documentServiceClient;
     private final FuzzyMatches fuzzyMatches;
     private String lastErrorMessage;
+    private final LatestCompletionResult    latestCompletionResult;
 
     @Inject
     public LanguageServerCodeAssistProcessor(TextDocumentServiceClient documentServiceClient,
@@ -62,40 +64,35 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
         this.imageProvider = imageProvider;
         this.serverCapabilities = serverCapabilities;
         this.fuzzyMatches = fuzzyMatches;
+        this.latestCompletionResult = new LatestCompletionResult();
     }
 
     @Override
-    public void computeCompletionProposals(TextEditor editor, int offset, final CodeAssistCallback callback) {
+    public void computeCompletionProposals(TextEditor editor, final int offset, final CodeAssistCallback callback) {
+        this.lastErrorMessage = null;
+
         TextDocumentPositionParamsDTO documentPosition = dtoBuildHelper.createTDPP(editor.getDocument(), offset);
         final TextDocumentIdentifierDTO documentId = documentPosition.getTextDocument();
         String currentLine = editor.getDocument().getLineContent(documentPosition.getPosition().getLine());
-        final String currentIdentifier = getCurrentIdentifier(currentLine, documentPosition.getPosition().getCharacter());
-        this.lastErrorMessage = null;
-        documentServiceClient.completion(documentPosition).then(new Operation<List<CompletionItemDTO>>() {
+        final String currentWord = getCurrentWord(currentLine, documentPosition.getPosition().getCharacter());
 
-            @Override
-            public void apply(List<CompletionItemDTO> items) throws OperationException {
-                List<CompletionProposal> proposals = newArrayList();
-                for (CompletionItemDTO item : items) {
-                    List<Match> highlights = filter(currentIdentifier, item);
-                    if (highlights != null ) {
-                        proposals.add(new CompletionItemBasedCompletionProposal(item,
-                                                                                documentServiceClient,
-                                                                                documentId,
-                                                                                resources,
-                                                                                imageProvider.getIcon(item.getKind()),
-                                                                                serverCapabilities,
-                                                                                highlights));
-                    }
+        if (latestCompletionResult.isGoodFor(documentId, offset, currentWord)) {
+            // no need to send new completion request
+            computeProposals(currentWord, callback);
+        } else {
+            documentServiceClient.completion(documentPosition).then(new Operation<CompletionListDTO>() {
+                @Override
+                public void apply(CompletionListDTO list) throws OperationException {
+                    latestCompletionResult.update(documentId, offset, currentWord, list);
+                    computeProposals(currentWord, callback);
                 }
-                callback.proposalComputed(proposals);
-            }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError error) throws OperationException {
-                lastErrorMessage = error.getMessage();
-            }
-        });
+            }).catchError(new Operation<PromiseError>() {
+                @Override
+                public void apply(PromiseError error) throws OperationException {
+                    lastErrorMessage = error.getMessage();
+                }
+            });
+        }
     }
 
     @Override
@@ -103,15 +100,15 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
         return lastErrorMessage;
     }
 
-    private String getCurrentIdentifier(String text, int offset) {
+    private String getCurrentWord(String text, int offset) {
         int i = offset - 1;
-        while (i >= 0 && isIdentifierChar(text.charAt(i))) {
+        while (i >= 0 && isWordChar(text.charAt(i))) {
             i--;
         }
         return text.substring(i + 1, offset);
     }
-    
-    private boolean isIdentifierChar(char c) {
+
+    private boolean isWordChar(char c) {
         return c >= 'a' && c <= 'z' ||
             c >= 'A' && c <= 'Z' ||
             c >= '0' && c <= '9' ||
@@ -120,11 +117,11 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
             c == '_' ||
             c == '-';
     }
-    
+
     private List<Match> filter(String word, CompletionItemDTO item) {
         return filter(word, item.getLabel(), item.getFilterText());
     }
-    
+
     private List<Match> filter(String word, String label, String filterText) {
         if (filterText == null || filterText.isEmpty()) {
             filterText = label;
@@ -139,6 +136,22 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
         }
         
         return null;
+    }
+
+    private void computeProposals(String currentWord, CodeAssistCallback callback) {
+        List<CompletionProposal> proposals = newArrayList();
+        for (CompletionItemDTO item : latestCompletionResult.getCompletionList().getItems()) {
+            List<Match> highlights = filter(currentWord, item);
+            if (highlights != null) {
+                proposals.add(new CompletionItemBasedCompletionProposal(item, 
+                                                                        documentServiceClient,
+                                                                        latestCompletionResult.getDocumentId(),
+                                                                        resources, 
+                                                                        imageProvider.getIcon(item.getKind()), 
+                                                                        serverCapabilities, highlights));
+            }
+        }
+        callback.proposalComputed(proposals);
     }
 
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Rogue Wave Software, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Rogue Wave Software, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
+
+import org.eclipse.che.api.languageserver.shared.lsapi.CompletionListDTO;
+import org.eclipse.che.api.languageserver.shared.lsapi.TextDocumentIdentifierDTO;
+
+/**
+ * Contains the latest completion result retrieved from the completion service.
+ * 
+ * @author Kaloyan Raev
+ */
+public class LatestCompletionResult {
+
+    private TextDocumentIdentifierDTO documentId;
+    private int                       offset;
+    private String                    word;
+    private CompletionListDTO         completionList;
+
+    /**
+     * Returns the identifier of document used to compute the latest completion
+     * result.
+     * 
+     * @return the document identifier
+     */
+    public TextDocumentIdentifierDTO getDocumentId() {
+        return this.documentId;
+    }
+
+    /**
+     * Returns the offset position in document used to compute the latest
+     * completion result.
+     * 
+     * @return the offset
+     */
+    public int getOffset() {
+        return this.offset;
+    }
+
+    /**
+     * Returns the word at the cursor at the time of computing the latest
+     * completion result.
+     * 
+     * @return the word
+     */
+    public String getWord() {
+        return this.word;
+    }
+
+    /**
+     * Returns the latest completion list DTO object.
+     * 
+     * @return the completion list
+     */
+    public CompletionListDTO getCompletionList() {
+        return this.completionList;
+    }
+
+    /**
+     * Checks if the completion result is still good for the given document
+     * position.
+     * 
+     * <p>
+     * The following checks are executed:
+     * <ol>
+     * <li>A completion result has been retrieved at least once.</li>
+     * <li>The latest completion result is "complete", i.e. the
+     * <code>isIncomplete</code> property is <code>false</code>.
+     * <li>The given document id is the same as in the latest completion
+     * result.</li>
+     * <li>The given offset is greater than the one in the latest completion
+     * result.</li>
+     * <li>The given word starts with the one in the latest completion
+     * result.</li>
+     * </ol>
+     * Only if all checks are satisfied then the latest completion result can be
+     * reused for the given document position.
+     * </p>
+     * 
+     * @param documentId
+     *            a text document identifier
+     * @param offset
+     *            an offset position in the document
+     * @param word
+     *            the word at the current position in the document
+     * 
+     * @return <code>true</code> if the completion result can still be used for
+     *         the given document position, <code>false</code> otherwise.
+     */
+    public boolean isGoodFor(TextDocumentIdentifierDTO documentId, int offset, String word) {
+        return completionList != null &&
+               !completionList.isIncomplete() &&
+               this.documentId.getUri().equals(documentId.getUri()) &&
+               offset > this.offset && 
+               word.startsWith(this.word);
+    }
+
+    /**
+     * Updates the latest completion result.
+     * 
+     * @param documentId
+     *            a text document identifier
+     * @param offset
+     *            an offset position in the document
+     * @param word
+     *            the word at the current position in the document
+     * @param completionList
+     *            a completion list
+     */
+    public void update(TextDocumentIdentifierDTO documentId, int offset, String word,
+            CompletionListDTO completionList) {
+        this.documentId = documentId;
+        this.offset = offset;
+        this.word = word;
+        this.completionList = completionList;
+    }
+
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java
@@ -76,10 +76,11 @@ public class LatestCompletionResult {
      * <code>isIncomplete</code> property is <code>false</code>.
      * <li>The given document id is the same as in the latest completion
      * result.</li>
-     * <li>The given offset is greater than the one in the latest completion
-     * result.</li>
      * <li>The given word starts with the one in the latest completion
      * result.</li>
+     * <li>The difference between the given offset and the one in the latest
+     * completion result matches the respective difference between the
+     * words.</li>
      * </ol>
      * Only if all checks are satisfied then the latest completion result can be
      * reused for the given document position.
@@ -99,8 +100,8 @@ public class LatestCompletionResult {
         return completionList != null &&
                !completionList.isIncomplete() &&
                this.documentId.getUri().equals(documentId.getUri()) &&
-               offset > this.offset && 
-               word.startsWith(this.word);
+               word.startsWith(this.word) && 
+               offset - this.offset == word.length() - this.word.length();
     }
 
     /**

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.che.api.languageserver.shared.lsapi.CompletionItemDTO;
+import org.eclipse.che.api.languageserver.shared.lsapi.CompletionListDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DidChangeTextDocumentParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DidCloseTextDocumentParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DidOpenTextDocumentParamsDTO;
@@ -95,10 +96,9 @@ public class TextDocumentServiceClient {
      * @param position
      * @return
      */
-    public Promise<List<CompletionItemDTO>> completion(TextDocumentPositionParamsDTO position) {
+    public Promise<CompletionListDTO> completion(TextDocumentPositionParamsDTO position) {
         String requestUrl = appContext.getDevMachine().getWsAgentBaseUrl() + "/languageserver/textDocument/completion";
-        Unmarshallable<List<CompletionItemDTO>> unmarshaller = unmarshallerFactory
-                .newListUnmarshaller(CompletionItemDTO.class);
+        Unmarshallable<CompletionListDTO> unmarshaller = unmarshallerFactory.newUnmarshaller(CompletionListDTO.class);
         return asyncRequestFactory.createPostRequest(requestUrl, null).header(ACCEPT, APPLICATION_JSON)
                                   .header(CONTENT_TYPE, APPLICATION_JSON).data(((JsonSerializable)position).toJson()).send(unmarshaller);
     }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -18,6 +18,7 @@ import elemental.events.EventListener;
 import elemental.events.EventTarget;
 import elemental.events.KeyboardEvent;
 import elemental.events.MouseEvent;
+import elemental.html.HTMLCollection;
 import elemental.html.SpanElement;
 import elemental.html.Window;
 
@@ -31,18 +32,18 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 
+import org.eclipse.che.ide.api.editor.codeassist.Completion;
+import org.eclipse.che.ide.api.editor.codeassist.CompletionProposal;
+import org.eclipse.che.ide.api.editor.codeassist.CompletionProposalExtension;
+import org.eclipse.che.ide.api.editor.events.CompletionRequestEvent;
+import org.eclipse.che.ide.api.editor.text.LinearRange;
 import org.eclipse.che.ide.api.editor.texteditor.HandlesUndoRedo;
 import org.eclipse.che.ide.api.editor.texteditor.UndoableEditor;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionKeyModeOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionModelChangedEventOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionPixelPositionOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewOverlay;
-import org.eclipse.che.ide.api.editor.codeassist.Completion;
-import org.eclipse.che.ide.api.editor.codeassist.CompletionProposal;
-import org.eclipse.che.ide.api.editor.codeassist.CompletionProposalExtension;
-import org.eclipse.che.ide.api.editor.events.CompletionRequestEvent;
 import org.eclipse.che.ide.ui.popup.PopupResources;
-import org.eclipse.che.ide.api.editor.text.LinearRange;
 import org.eclipse.che.ide.util.dom.Elements;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -53,6 +54,7 @@ import static elemental.css.CSSStyleDeclaration.Unit.PX;
 /**
  * @author Evgen Vidolob
  * @author Vitaliy Guliy
+ * @author Kaloyan Raev
  */
 public class ContentAssistWidget implements EventListener {
     /**
@@ -60,6 +62,7 @@ public class ContentAssistWidget implements EventListener {
      */
     private static final String CUSTOM_EVT_TYPE_VALIDATE = "itemvalidate";
     private static final String DOCUMENTATION            = "documentation";
+    private static final int    DOM_ITEMS_SIZE           = 50;
 
     private final PopupResources popupResources;
 
@@ -77,6 +80,7 @@ public class ContentAssistWidget implements EventListener {
     private final EventListener popupListener;
 
     private boolean visible = false;
+    private boolean focused = false;
     private boolean insert  = true;
 
     /**
@@ -86,6 +90,8 @@ public class ContentAssistWidget implements EventListener {
     private FlowPanel docPopup;
 
     private OrionTextViewOverlay.EventHandler<OrionModelChangedEventOverlay> handler;
+
+    private List<CompletionProposal> proposals;
 
     @AssistedInject
     public ContentAssistWidget(final PopupResources popupResources,
@@ -149,8 +155,8 @@ public class ContentAssistWidget implements EventListener {
         }
     };
 
-    public void validateItem(boolean replace) {
-        this.insert = replace;
+    public void validateItem(boolean insert) {
+        this.insert = insert;
         selectedElement.dispatchEvent(createValidateEvent(CUSTOM_EVT_TYPE_VALIDATE));
     }
 
@@ -163,12 +169,14 @@ public class ContentAssistWidget implements EventListener {
     }-*/;
 
     /**
-     * Appends new proposal item to the popup
+     * Creates a new proposal item.
      *
      * @param proposal
      */
-    private void addProposalPopupItem(final CompletionProposal proposal) {
+    private Element createProposalPopupItem(int index) {
+        final CompletionProposal proposal = proposals.get(index);
         final Element element = Elements.createLiElement(popupResources.popupStyle().item());
+        element.setId(Integer.toString(index));
 
         final Element icon = Elements.createDivElement(popupResources.popupStyle().icon());
         if (proposal.getIcon() != null && proposal.getIcon().getSVGImage() != null) {
@@ -183,9 +191,6 @@ public class ContentAssistWidget implements EventListener {
         element.appendChild(label);
 
         element.setTabIndex(1);
-
-        // add item to the popup
-        listElement.appendChild(element);
 
         final EventListener validateListener = new EventListener() {
             @Override
@@ -212,9 +217,10 @@ public class ContentAssistWidget implements EventListener {
         element.addEventListener(Event.CLICK, new EventListener() {
             @Override
             public void handleEvent(Event event) {
-                selectElement(element);
+                select(element);
             }
         }, false);
+        element.addEventListener(Event.FOCUS, this, false);
 
         element.addEventListener(DOCUMENTATION, new EventListener() {
             @Override
@@ -237,6 +243,8 @@ public class ContentAssistWidget implements EventListener {
                 }
             }
         }, false);
+
+        return element;
     }
 
     private void addPopupEventListeners() {
@@ -280,7 +288,7 @@ public class ContentAssistWidget implements EventListener {
         textEditor.getTextView().setAction("cheContentAssistNextPage", new Action() {
             @Override
             public boolean onAction() {
-                selectNext(listElement.getParentElement().getOffsetHeight() / listElement.getFirstElementChild().getOffsetHeight() - 1);
+                selectNextPage();
                 return true;
             }
         });
@@ -288,7 +296,7 @@ public class ContentAssistWidget implements EventListener {
         textEditor.getTextView().setAction("cheContentAssistPreviousPage", new Action() {
             @Override
             public boolean onAction() {
-                selectPrevious(listElement.getParentElement().getOffsetHeight() / listElement.getFirstElementChild().getOffsetHeight() - 1);
+                selectPreviousPage();
                 return true;
             }
         });
@@ -296,7 +304,7 @@ public class ContentAssistWidget implements EventListener {
         textEditor.getTextView().setAction("cheContentAssistEnd", new Action() {
             @Override
             public boolean onAction() {
-                selectElement(listElement.getLastElementChild());
+                selectLast();
                 return true;
             }
         });
@@ -304,7 +312,7 @@ public class ContentAssistWidget implements EventListener {
         textEditor.getTextView().setAction("cheContentAssistHome", new Action() {
             @Override
             public boolean onAction() {
-                selectElement(listElement.getFirstElementChild());
+                selectFirst();
                 return true;
             }
         });
@@ -319,6 +327,7 @@ public class ContentAssistWidget implements EventListener {
 
         textEditor.getTextView().addEventListener("ModelChanging", handler);
         listElement.addEventListener(Event.KEYDOWN, this, false);
+        popupBodyElement.addEventListener(Event.SCROLL, this, false);
     }
 
     private void removePopupEventListeners() {
@@ -329,72 +338,84 @@ public class ContentAssistWidget implements EventListener {
         // remove the keyboard listener
         listElement.removeEventListener(Event.KEYDOWN, this, false);
 
+        // remove the scroll listener
+        popupBodyElement.removeEventListener(Event.SCROLL, this, false);
+
         // remove the mouse listener
         Elements.getDocument().removeEventListener(Event.MOUSEDOWN, this.popupListener);
     }
 
+    private void selectFirst() {
+        scrollTo(0);
+        updateIfNecessary();
+        select(getFirstItemInDOM());
+    }
+
+    private void selectLast() {
+        scrollTo(getTotalItems() - 1);
+        updateIfNecessary();
+        select(getLastItemInDOM());
+    }
+
+    private void select(int index) {
+        select(getItem(index));
+    }
+
     private void selectPrevious() {
         Element previousElement = selectedElement.getPreviousElementSibling();
-        if (previousElement != null) {
-            selectElement(previousElement);
+        if (previousElement != null && previousElement == getExtraTopRow() && getExtraTopRow().isHidden()) {
+            selectLast();
         } else {
-            selectElement(listElement.getLastElementChild());
+            selectOffset(-1);
         }
     }
 
-    private void selectPrevious(int offset) {
-        Element element = selectedElement;
-
-        for (int i = 0; i < offset; i++) {
-            Element previousElement = element.getPreviousElementSibling();
-            if (previousElement == null) {
-                break;
-            }
-            element = previousElement;
-        }
-
-        selectElement(element);
+    private void selectPreviousPage() {
+        int offset = getItemsPerPage() - 1;
+        selectOffset(-offset);
     }
 
     private void selectNext() {
         Element nextElement = selectedElement.getNextElementSibling();
-        if (nextElement != null) {
-            selectElement(nextElement);
+        if (nextElement != null && nextElement == getExtraBottomRow() && getExtraBottomRow().isHidden()) {
+            selectFirst();
         } else {
-            selectElement(listElement.getFirstElementChild());
+            selectOffset(1);
         }
     }
 
-    private void selectNext(int offset) {
-        Element element = selectedElement;
-
-        for (int i = 0; i < offset; i++) {
-            Element nextElement = element.getNextElementSibling();
-            if (nextElement == null) {
-                break;
-            }
-            element = nextElement;
-        }
-
-        selectElement(element);
+    private void selectNextPage() {
+        int offset = getItemsPerPage() - 1;
+        selectOffset(offset);
     }
 
-    private void selectElement(Element element) {
+    private void selectOffset(int offset) {
+        int index = getItemId(selectedElement) + offset;
+        index = Math.max(index, 0);
+        index = Math.min(index, getTotalItems() - 1);
+
+        if (!isItemInDOM(index)) {
+            scrollTo(index);
+            update();
+        }
+
+        select(index);
+    }
+
+    private void select(Element element) {
+        if (element == selectedElement) {
+            return;
+        }
+
         if (selectedElement != null) {
             selectedElement.removeAttribute("selected");
         }
-
-        if (docPopup.isAttached()) {
-            if (element != selectedElement) {
-                element.dispatchEvent(createValidateEvent(DOCUMENTATION));
-            }
-        } else {
-            showDocTimer.cancel();
-            showDocTimer.schedule(1500);
-        }
-
         selectedElement = element;
         selectedElement.setAttribute("selected", "true");
+
+        docPopup.clear();
+        showDocTimer.cancel();
+        showDocTimer.schedule(docPopup.isAttached() ? 100 : 1500);
 
         if (selectedElement.getOffsetTop() < this.popupBodyElement.getScrollTop()) {
             selectedElement.scrollIntoView(true);
@@ -420,6 +441,8 @@ public class ContentAssistWidget implements EventListener {
      *         proposals to display
      */
     public void show(final List<CompletionProposal> proposals) {
+        this.proposals = proposals;
+
         OrionTextViewOverlay textView = textEditor.getTextView();
         OrionPixelPositionOverlay caretLocation = textView.getLocationAtOffset(textView.getCaretOffset());
         caretLocation.setY(caretLocation.getY() + textView.getLineHeight());
@@ -429,14 +452,14 @@ public class ContentAssistWidget implements EventListener {
         listElement.setInnerHTML("");
 
         /* Display an empty popup when it is nothing to show. */
-        if (proposals == null || proposals.isEmpty()) {
+        if (getTotalItems() == 0) {
             final Element emptyElement = Elements.createLiElement(popupResources.popupStyle().item());
             emptyElement.setTextContent("No proposals");
             listElement.appendChild(emptyElement);
             return;
         }
 
-        if (proposals.size() == 1) {
+        if (getTotalItems() == 1) {
             CompletionProposal.CompletionCallback callback = new CompletionProposal.CompletionCallback() {
                 @Override
                 public void onCompletion(Completion completion) {
@@ -450,11 +473,6 @@ public class ContentAssistWidget implements EventListener {
             return;
         }
 
-        /* Add new popup items. */
-        for (CompletionProposal proposal : proposals) {
-            addProposalPopupItem(proposal);
-        }
-
         /* Reset popup dimensions and show. */
         popupElement.getStyle().setLeft(caretLocation.getX(), PX);
         popupElement.getStyle().setTop(caretLocation.getY(), PX);
@@ -462,6 +480,17 @@ public class ContentAssistWidget implements EventListener {
         popupElement.getStyle().setHeight("200px");
         popupElement.getStyle().setOpacity(0);
         Elements.getDocument().getBody().appendChild(this.popupElement);
+
+        /* Add the top extra row. */
+        setExtraRowHeight(appendExtraRow(), 0);
+
+        /* Add the popup items. */
+        for (int i = 0; i < Math.min(DOM_ITEMS_SIZE, getTotalItems()); i++) {
+            listElement.appendChild(createProposalPopupItem(i));
+        }
+
+        /* Add the bottom extra row. */
+        setExtraRowHeight(appendExtraRow(), Math.max(0, getTotalItems() - DOM_ITEMS_SIZE));
 
         Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
             @Override
@@ -515,6 +544,7 @@ public class ContentAssistWidget implements EventListener {
 
         /* Indicates the codeassist is visible. */
         visible = true;
+        focused = false;
 
         if (docPopup.isAttached()) {
             docPopup.getElement().getStyle().setOpacity(0);
@@ -528,13 +558,15 @@ public class ContentAssistWidget implements EventListener {
         }
 
         /* Select first row. */
-        selectElement(listElement.getFirstElementChild());
+        selectFirst();
     }
 
     /**
      * Hides the popup and displaying javadoc.
      */
     public void hide() {
+        textEditor.setFocus();
+
         if (docPopup.isAttached()) {
             docPopup.getElement().getStyle().setOpacity(0);
             new Timer() {
@@ -565,7 +597,7 @@ public class ContentAssistWidget implements EventListener {
 
     @Override
     public void handleEvent(Event evt) {
-        if (evt instanceof KeyboardEvent) {
+        if (Event.KEYDOWN.equalsIgnoreCase(evt.getType())) {
             final KeyboardEvent keyEvent = (KeyboardEvent)evt;
             switch (keyEvent.getKeyCode()) {
                 case KeyCodes.KEY_ESCAPE:
@@ -588,21 +620,21 @@ public class ContentAssistWidget implements EventListener {
                     break;
 
                 case KeyCodes.KEY_PAGEUP:
-                    selectPrevious(listElement.getParentElement().getOffsetHeight() / listElement.getFirstElementChild().getOffsetHeight() - 1);
+                    selectPreviousPage();
                     evt.preventDefault();
                     break;
 
                 case KeyCodes.KEY_PAGEDOWN:
-                    selectNext(listElement.getParentElement().getOffsetHeight() / listElement.getFirstElementChild().getOffsetHeight() - 1);
+                    selectNextPage();
                     evt.preventDefault();
                     break;
 
                 case KeyCodes.KEY_HOME:
-                    selectElement(listElement.getFirstElementChild());
+                    selectFirst();
                     break;
 
                 case KeyCodes.KEY_END:
-                    selectElement(listElement.getLastElementChild());
+                    selectLast();
                     break;
 
                 case KeyCodes.KEY_ENTER:
@@ -617,6 +649,56 @@ public class ContentAssistWidget implements EventListener {
                     validateItem(false);
                     break;
             }
+        } else if (Event.SCROLL.equalsIgnoreCase(evt.getType())) {
+            updateIfNecessary();
+        } else if (Event.FOCUS.equalsIgnoreCase(evt.getType())) {
+            focused = true;
+        }
+    }
+
+    private void updateIfNecessary() {
+        int scrollTop = popupBodyElement.getScrollTop();
+        int extraTopHeight = getExtraTopRow().getClientHeight();
+
+        if (scrollTop < extraTopHeight) {
+            // the scroll bar is above the buffered area
+            update();
+        } else if (scrollTop + popupBodyElement.getClientHeight() > extraTopHeight + getItemHeight() * DOM_ITEMS_SIZE) {
+            // the scroll bar is below the buffered area
+            update();
+        }
+    }
+
+    private void update() {
+        int topVisibleItem = popupBodyElement.getScrollTop() / getItemHeight();
+        int topDOMItem = Math.max(0, topVisibleItem - (DOM_ITEMS_SIZE - getItemsPerPage()) / 2);
+        int bottomDOMItem = Math.min(getTotalItems() - 1, topDOMItem + DOM_ITEMS_SIZE - 1);
+        if (bottomDOMItem == getTotalItems() - 1) {
+            topDOMItem = Math.max(0, bottomDOMItem - DOM_ITEMS_SIZE + 1);
+        }
+
+        // resize the extra top row
+        setExtraRowHeight(getExtraTopRow(), topDOMItem);
+
+        // replace the DOM items with new content based on the scroll position
+        HTMLCollection nodes = listElement.getChildren();
+        for (int i = 0; i <= (bottomDOMItem - topDOMItem); i++) {
+            Element newNode = createProposalPopupItem(topDOMItem + i);
+            listElement.replaceChild(newNode, nodes.item(i + 1));
+
+            // check if the item is the selected
+            if (newNode.getId().equals(selectedElement.getId())) {
+                selectedElement = newNode;
+                selectedElement.setAttribute("selected", "true");
+            }
+        }
+
+        // resize the extra bottom row
+        setExtraRowHeight(getExtraBottomRow(), getTotalItems() - (bottomDOMItem + 1));
+
+        // ensure the keyboard focus is in the visible area
+        if (focused) {
+            getItem(topDOMItem + (bottomDOMItem - topDOMItem) / 2).focus();
         }
     }
 
@@ -656,6 +738,72 @@ public class ContentAssistWidget implements EventListener {
                 undoRedo.endCompoundChange();
             }
         }
+    }
+
+    private Element getExtraTopRow() {
+        return (listElement == null) ? null : listElement.getFirstElementChild();
+    }
+
+    private Element getExtraBottomRow() {
+        return (listElement == null) ? null : listElement.getLastElementChild();
+    }
+
+    private Element getFirstItemInDOM() {
+        Element extraTopRow = getExtraTopRow();
+        return (extraTopRow == null) ? null : extraTopRow.getNextElementSibling();
+    }
+
+    private Element getLastItemInDOM() {
+        Element extraBottomRow = getExtraBottomRow();
+        return (extraBottomRow == null) ? null : extraBottomRow.getPreviousElementSibling();
+    }
+
+    private int getItemId(Element item) {
+        return Integer.parseInt(item.getId());
+    }
+
+    private Element getItem(int index) {
+        return (Element) listElement.getChildren().namedItem(Integer.toString(index));
+    }
+
+    private int getItemHeight() {
+        Element item = getFirstItemInDOM();
+        return (item == null) ? 0 : item.getClientHeight();
+    }
+
+    private Element appendExtraRow() {
+        Element extraRow = Elements.createLiElement();
+        listElement.appendChild(extraRow);
+        return extraRow;
+    }
+
+    private void setExtraRowHeight(Element extraRow, int items) {
+        int height = items * getItemHeight();
+        extraRow.getStyle().setHeight(height + "px");
+        extraRow.setHidden(height <= 0);
+    }
+
+    private int getItemsPerPage() {
+        return (int) Math.ceil((double) popupBodyElement.getClientHeight() / getItemHeight());
+    }
+
+    private int getTotalItems() {
+        return (proposals == null) ? 0 : proposals.size();
+    }
+
+    private boolean isItemInDOM(int index) {
+        return index >= getItemId(getFirstItemInDOM()) && index <= getItemId(getLastItemInDOM());
+    }
+
+    private void scrollTo(int index) {
+        int currentScrollTop = popupBodyElement.getScrollTop();
+        int newScrollTop = index * getItemHeight();
+        if (currentScrollTop < newScrollTop) {
+            // the scrolling direction is from top to bottom, so show the item
+            // at the bottom of the widget
+            newScrollTop -= popupBodyElement.getClientHeight();
+        }
+        popupBodyElement.setScrollTop(newScrollTop);
     }
 
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -195,20 +195,7 @@ public class ContentAssistWidget implements EventListener {
         final EventListener validateListener = new EventListener() {
             @Override
             public void handleEvent(final Event evt) {
-                CompletionProposal.CompletionCallback callback = new CompletionProposal.CompletionCallback() {
-                    @Override
-                    public void onCompletion(final Completion completion) {
-                        applyCompletion(completion);
-                    }
-                };
-
-                if (proposal instanceof CompletionProposalExtension) {
-                    ((CompletionProposalExtension)proposal).getCompletion(insert, callback);
-                } else {
-                    proposal.getCompletion(callback);
-                }
-
-                hide();
+                applyProposal(proposal);
             }
         };
 
@@ -459,17 +446,9 @@ public class ContentAssistWidget implements EventListener {
             return;
         }
 
+        /* Automatically apply the completion proposal if it only one. */
         if (getTotalItems() == 1) {
-            CompletionProposal.CompletionCallback callback = new CompletionProposal.CompletionCallback() {
-                @Override
-                public void onCompletion(Completion completion) {
-                    applyCompletion(completion);
-                }
-            };
-
-            CompletionProposal proposal = proposals.get(0);
-            proposal.getCompletion(callback);
-
+            applyProposal(proposals.get(0));
             return;
         }
 
@@ -715,6 +694,23 @@ public class ContentAssistWidget implements EventListener {
         if (visible && selectedElement != null) {
             selectedElement.dispatchEvent(createValidateEvent(DOCUMENTATION));
         }
+    }
+
+    private void applyProposal(CompletionProposal proposal) {
+        CompletionProposal.CompletionCallback callback = new CompletionProposal.CompletionCallback() {
+            @Override
+            public void onCompletion(Completion completion) {
+                applyCompletion(completion);
+            }
+        };
+
+        if (proposal instanceof CompletionProposalExtension) {
+            ((CompletionProposalExtension) proposal).getCompletion(insert, callback);
+        } else {
+            proposal.getCompletion(callback);
+        }
+
+        hide();
     }
 
     private void applyCompletion(Completion completion) {

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -457,7 +457,7 @@ public class ContentAssistWidget implements EventListener {
         popupElement.getStyle().setTop(caretLocation.getY(), PX);
         popupElement.getStyle().setWidth("400px");
         popupElement.getStyle().setHeight("200px");
-        popupElement.getStyle().setOpacity(0);
+        popupElement.getStyle().setOpacity(1);
         Elements.getDocument().getBody().appendChild(this.popupElement);
 
         /* Add the top extra row. */
@@ -470,13 +470,6 @@ public class ContentAssistWidget implements EventListener {
 
         /* Add the bottom extra row. */
         setExtraRowHeight(appendExtraRow(), Math.max(0, getTotalItems() - DOM_ITEMS_SIZE));
-
-        Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
-            @Override
-            public void execute() {
-                popupElement.getStyle().setOpacity(1);
-            }
-        });
 
         /* Correct popup position (wants to be refactored) */
         final Window window = Elements.getWindow();

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -26,6 +26,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -212,22 +213,33 @@ public class ContentAssistWidget implements EventListener {
         element.addEventListener(DOCUMENTATION, new EventListener() {
             @Override
             public void handleEvent(Event event) {
-                Widget info = proposal.getAdditionalProposalInfo();
+                proposal.getAdditionalProposalInfo(new AsyncCallback<Widget>() {
+                    @Override
+                    public void onSuccess(Widget info) {
+                        if (info != null) {
+                            docPopup.clear();
+                            docPopup.add(info);
 
-                if (info != null) {
-                    docPopup.clear();
-                    docPopup.add(info);
+                            if (docPopup.isAttached()) {
+                                return;
+                            }
 
-                    if (docPopup.isAttached()) {
-                        return;
+                            docPopup.getElement().getStyle()
+                                    .setLeft(popupElement.getOffsetLeft() + popupElement.getOffsetWidth() + 3, Style.Unit.PX);
+                            docPopup.getElement().getStyle().setTop(popupElement.getOffsetTop(), Style.Unit.PX);
+                            RootPanel.get().add(docPopup);
+                            docPopup.getElement().getStyle().setOpacity(1);
+                        } else {
+                            docPopup.getElement().getStyle().setOpacity(0);
+                        }
                     }
-
-                    docPopup.getElement().getStyle()
-                            .setLeft(popupElement.getOffsetLeft() + popupElement.getOffsetWidth() + 3, Style.Unit.PX);
-                    docPopup.getElement().getStyle().setTop(popupElement.getOffsetTop(), Style.Unit.PX);
-                    RootPanel.get().add(docPopup);
-                    docPopup.getElement().getStyle().setOpacity(1);
-                }
+                    
+                    @Override
+                    public void onFailure(Throwable e) {
+                        Log.error(getClass(), e);
+                        docPopup.getElement().getStyle().setOpacity(0);
+                    }
+                });
             }
         }, false);
 

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorInit.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorInit.java
@@ -193,7 +193,7 @@ public class OrionEditorInit {
             final KeyBindingAction action = new KeyBindingAction() {
                 @Override
                 public boolean action() {
-                    showCompletion(codeAssistant);
+                    showCompletion(codeAssistant, true);
                     return true;
                 }
             };
@@ -204,7 +204,7 @@ public class OrionEditorInit {
             documentHandle.getDocEventBus().addHandler(CompletionRequestEvent.TYPE, new CompletionRequestHandler() {
                 @Override
                 public void onCompletionRequest(final CompletionRequestEvent event) {
-                    showCompletion(codeAssistant);
+                    showCompletion(codeAssistant, false);
                 }
             });
         } else {
@@ -236,8 +236,9 @@ public class OrionEditorInit {
      * Show the available completions.
      *
      * @param codeAssistant the code assistant
+     * @param triggered if triggered by the content assist key binding
      */
-    private void showCompletion(final CodeAssistant codeAssistant) {
+    private void showCompletion(final CodeAssistant codeAssistant, final boolean triggered) {
         final int cursor = textEditor.getCursorOffset();
         if (cursor < 0) {
             return;
@@ -250,7 +251,7 @@ public class OrionEditorInit {
                     // cursor must be computed here again so it's original value is not baked in
                     // the SMI instance closure - important for completion update when typing
                     final int cursor = textEditor.getCursorOffset();
-                    codeAssistant.computeCompletionProposals(cursor, new CodeAssistCallback() {
+                    codeAssistant.computeCompletionProposals(cursor, triggered, new CodeAssistCallback() {
                         @Override
                         public void proposalComputed(final List<CompletionProposal> proposals) {
                             callback.onCompletionReady(proposals);

--- a/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/editor/JsonExampleCodeAssistProcessor.java
+++ b/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/editor/JsonExampleCodeAssistProcessor.java
@@ -47,7 +47,7 @@ public class JsonExampleCodeAssistProcessor implements CodeAssistProcessor {
     }
 
     @Override
-    public void computeCompletionProposals(final TextEditor editor, final int offset, final CodeAssistCallback callback) {
+    public void computeCompletionProposals(final TextEditor editor, final int offset, final boolean triggered, final CodeAssistCallback callback) {
         final List<CompletionProposal> proposals = new ArrayList<>();
 
         proposals.addAll(Arrays.asList(

--- a/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/editor/SimpleCompletionProposal.java
+++ b/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/editor/SimpleCompletionProposal.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.jsonexample.ide.editor;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.eclipse.che.ide.api.editor.codeassist.CompletionProposal;
@@ -35,8 +36,8 @@ public class SimpleCompletionProposal implements CompletionProposal {
     }
 
     @Override
-    public Widget getAdditionalProposalInfo() {
-        return null;
+    public void getAdditionalProposalInfo(AsyncCallback<Widget> callback) {
+        callback.onSuccess(null);
     }
 
     @Override

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/lsapi/CompletionListDTO.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/lsapi/CompletionListDTO.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Rogue Wave Software, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Rogue Wave Software, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.languageserver.shared.lsapi;
+
+import io.typefox.lsapi.CompletionList;
+
+import org.eclipse.che.dto.shared.DTO;
+
+import java.util.List;
+
+/**
+ * Represents a collection of completion items to be presented in the editor.
+ * 
+ * @author Kaloyan Raev
+ */
+@DTO
+public interface CompletionListDTO extends CompletionList {
+
+    /**
+     * This list it not complete. Further typing should result in recomputing
+     * this list.
+     */
+    void setIncomplete(boolean incomplete);
+
+    /**
+     * The completion items. Overridden to return the DTO type.
+     */
+    List<CompletionItemDTO> getItems();
+
+    /**
+     * The completion items.
+     */
+    void setItems(List<CompletionItemDTO> items);
+
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.languageserver.service;
 
 import io.typefox.lsapi.CompletionItem;
+import io.typefox.lsapi.CompletionList;
 import io.typefox.lsapi.Hover;
 import io.typefox.lsapi.Location;
 import io.typefox.lsapi.SignatureHelp;
@@ -79,17 +80,17 @@ public class TextDocumentService {
     @Path("completion")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public List<? extends CompletionItem> completion(TextDocumentPositionParamsDTO textDocumentPositionParams) throws InterruptedException,
-                                                                                                                      ExecutionException,
-                                                                                                                      LanguageServerException {
+    public CompletionList completion(TextDocumentPositionParamsDTO textDocumentPositionParams) throws InterruptedException,
+                                                                                                      ExecutionException,
+                                                                                                      LanguageServerException {
         textDocumentPositionParams.getTextDocument().setUri(prefixURI(textDocumentPositionParams.getTextDocument().getUri()));
         textDocumentPositionParams.setUri(prefixURI(textDocumentPositionParams.getUri()));
         LanguageServer server = getServer(textDocumentPositionParams.getTextDocument().getUri());
         if (server == null) {
-            return emptyList();
+            return null;
         }
         return server.getTextDocumentService()
-                     .completion(textDocumentPositionParams).get().getItems();
+                     .completion(textDocumentPositionParams).get();
     }
 
     @POST

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
@@ -162,7 +162,7 @@ public class TextDocumentService {
     public CompletionItem resolveCompletionItem(CompletionItemDTO unresolved) throws InterruptedException,
                                                                                      ExecutionException,
                                                                                      LanguageServerException {
-        LanguageServer server = getServer(unresolved.getTextDocumentIdentifier().getUri());
+        LanguageServer server = getServer(prefixURI(unresolved.getTextDocumentIdentifier().getUri()));
         if (server != null) {
             return server.getTextDocumentService().resolveCompletionItem(unresolved).get();
         } else {


### PR DESCRIPTION
### What does this PR do?

This PR contains performance improvements for the code completion discussed in #2815.

__Issue 1__. Avoid overloading the DOM tree when creating the content assist widget.

Instead of adding a ```<li>``` element to the DOM tree for each proposal item, now there are no more than 50 elements added for displaying the available proposals. The ```scroll``` event is handled to update this fixed number of elements.

An "extra top row" and an "extra bottom row" are introduced to simulate a full list of items in the browser. These extra rows are empty and their height is adjusted as necessary to place the list's scrollbar in the correct scroll position and with the correct height. These extra rows are never visible to users.

An "id" attribute with the index number is added to the ```<li>``` elements. It is necessary for the key navigation from the currently selected element. As the selected element may go out the buffered range when scrolling, the index in the "id" attribute is used to determine the newly selected element on key navigation (up, down, pageup, pagedown).

Additional care is taken to keep the keyboard focus adequate. This is necessary because the currently focused ```<li>``` element may go out of range when scrolling, and the browser will move the focus to another element in the DOM tree, outside of the ContentAssistWidget.

__Issue 2__. respect the `CompletionList.isIncomplete` flag.

The latest completion result is stored in the `LatestCompletionResult` object. If the result is "complete", i.e. the `isIncomplete` flag is `false`, then the latest completion result is checked if it is still good for the current document position. In such case no new completion request is sent and the latest completion result is reused after filtering.

A completion request is always sent if the user hits Ctrl+Space, regardless if there is a good latest completion result for the same position.

__Other fixes__

- Fixed flickering of the content assist widget between keystrokes
- The content assist widget sometimes did not disappear when automatically applying the single completion result
- Fixed retrieval of completion item's documentation when a Completion Resolve request is necessary

### What issues does this PR fix or reference?

Fixes #2815: Performance issues with code completion

### Previous behavior

The initial invocation of code completion took several seconds, especially when the the list of completion proposals is long. Subsequent key stroke may also cause noticeable UI freeze.

### New behavior

Smoother experience with code completion. Faster initial response, no freeze on further typing.

Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>