### PR TITLE
Add ability to auto select first node when tree becomes visible and it has at least one node

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/Tree.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/Tree.java
@@ -1031,8 +1031,9 @@ public class Tree extends FocusWidget implements HasBeforeExpandNodeHandlers,
                 @Override
                 public void onExecute() {
                     int count = getVisibleRowCount();
+                    List<Node> rootItems = getRootNodes();
+
                     if (count > 0) {
-                        List<Node> rootItems = getRootNodes();
                         List<Node> visible = getAllChildNodes(rootItems, true);
                         int[] vr = getVisibleRows(visible, count);
 
@@ -1053,6 +1054,10 @@ public class Tree extends FocusWidget implements HasBeforeExpandNodeHandlers,
                                 refresh(visible.get(i));
                             }
                         }
+                    }
+
+                    if (selectionModel.getSelectedNodes().isEmpty() && autoSelect && !rootItems.isEmpty()) {
+                        selectionModel.select(rootItems.get(0), false);
                     }
                 }
             };


### PR DESCRIPTION
If tree renders on the UI it may already have nodes and if tree is configured to use auto selection we should select first root node at update state. Update method calls after widget become visible on the UI.

@ashumilova review it, please.

Partly-related issue: https://github.com/eclipse/che/issues/2795