### PR TITLE
Define tests phase for dashboard and skip condition

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -70,10 +70,6 @@
                                 <exec dir="${basedir}" executable="bower" failonerror="true">
                                     <arg value="install" />
                                 </exec>
-                                <!-- Run unit tests -->
-                                <exec dir="${basedir}" executable="gulp" failonerror="true">
-                                    <arg value="test" />
-                                </exec>
                                 <!-- Build the application -->
                                 <exec dir="${basedir}" executable="gulp" failonerror="true">
                                     <arg value="build" />
@@ -83,6 +79,21 @@
                                     <replacetoken><![CDATA[<base href="/">]]></replacetoken>
                                     <replacevalue><![CDATA[<base href="/dashboard/">]]></replacevalue>
                                 </replace>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compilation</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target unless="skipTests">
+                                <!-- Run unit tests -->
+                                <exec dir="${basedir}" executable="gulp" failonerror="true">
+                                    <arg value="test" />
+                                </exec>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### What does this PR do?

Provides definition of the test phase for Che dashboard.
We used to have tests in compile phase and they were not skippped by
`mvn clean install -DskipTests`
but now this case will work.


Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>