### PR TITLE
fix workspace-edit-mode-overlay z-index

### DIFF
--- a/dashboard/src/app/workspaces/workspace-edit-mode/workspace-edit-mode-overlay.styl
+++ b/dashboard/src/app/workspaces/workspace-edit-mode/workspace-edit-mode-overlay.styl
@@ -3,7 +3,6 @@
   bottom 0
   left 0
   right 0
-  z-index 100
   background-color lighten($mouse-gray-color, 10%)
   height 50px
   border-top 1px solid $very-light-grey-color


### PR DESCRIPTION
### What does this PR do?
fixes z-indes of workspace-edit-mode-overlay 

### Previous behavior
![before](https://cloud.githubusercontent.com/assets/16220722/20625311/360b7c0e-b31b-11e6-914f-3628643d8e7a.png)


### New behavior
![after](https://cloud.githubusercontent.com/assets/16220722/20625314/3a62183a-b31b-11e6-842f-e62be9e62ec9.png)

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>