### PR TITLE
CHE-3181: Fix appearing 'Restore project structure' loader.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerStateComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerStateComponent.java
@@ -91,12 +91,10 @@ public class ProjectExplorerStateComponent implements StateComponent {
             projectExplorer.showHiddenFiles(state.getBoolean(SHOW_HIDDEN_FILES));
         }
 
-        JsonArray paths;
+        JsonArray paths = state.hasKey(PATH_PARAM_ID) ? state.getArray(PATH_PARAM_ID) : Json.createArray();
 
-        if (state.hasKey(PATH_PARAM_ID)) {
-            paths = state.getArray(PATH_PARAM_ID);
-        } else {
-            paths = Json.createArray();
+        if (paths.length() == 0) {
+            return;
         }
 
         Promise<Node> revealPromise = null;


### PR DESCRIPTION
### What does this PR do?
Doesn't show 'Restore project structure' loader if workspace hasn't projects.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3181

Please review @vparfonov @azatsarynnyy 

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>