### PR TITLE
Add synthetic id to hashCode & equals methods

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -65,14 +66,14 @@ public class JpaFactoryDao implements FactoryDao {
         } catch (RuntimeException ex) {
             throw new ServerException(ex.getLocalizedMessage(), ex);
         }
-        return factory;
+        return new FactoryImpl(factory);
     }
 
     @Override
     public FactoryImpl update(FactoryImpl update) throws NotFoundException, ConflictException, ServerException {
         requireNonNull(update);
         try {
-            return doUpdate(update);
+            return new FactoryImpl(doUpdate(update));
         } catch (DuplicateKeyException ex) {
             throw new ConflictException(ex.getLocalizedMessage());
         } catch (RuntimeException ex) {
@@ -99,7 +100,7 @@ public class JpaFactoryDao implements FactoryDao {
             if (factory == null) {
                 throw new NotFoundException(format("Factory with id '%s' doesn't exist", id));
             }
-            return factory;
+            return new FactoryImpl(factory);
         } catch (RuntimeException ex) {
             throw new ServerException(ex.getLocalizedMessage(), ex);
         }
@@ -131,7 +132,10 @@ public class JpaFactoryDao implements FactoryDao {
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 typedQuery.setParameter(entry.getKey(), entry.getValue());
             }
-            return typedQuery.getResultList();
+            return typedQuery.getResultList()
+                             .stream()
+                             .map(FactoryImpl::new)
+                             .collect(Collectors.toList());
         } catch (RuntimeException ex) {
             throw new ServerException(ex.getLocalizedMessage(), ex);
         }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/ActionImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/ActionImpl.java
@@ -12,7 +12,6 @@ package org.eclipse.che.api.factory.server.model.impl;
 
 import org.eclipse.che.api.core.model.factory.Action;
 
-import javax.persistence.Basic;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -53,7 +52,9 @@ public class ActionImpl implements Action {
 
     public ActionImpl(String id, Map<String, String> properties) {
         this.id = id;
-        this.properties = properties;
+        if (properties != null) {
+            this.properties = new HashMap<>(properties);
+        }
     }
 
     public ActionImpl(Action action) {
@@ -83,25 +84,32 @@ public class ActionImpl implements Action {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof ActionImpl)) return false;
-        final ActionImpl other = (ActionImpl)obj;
-        return Objects.equals(id, other.getId())
-               && getProperties().equals(other.getProperties());
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ActionImpl)) {
+            return false;
+        }
+        final ActionImpl that = (ActionImpl)obj;
+        return Objects.equals(entityId, that.entityId)
+               && Objects.equals(id, that.id)
+               && getProperties().equals(that.getProperties());
     }
 
     @Override
     public int hashCode() {
-        int result = 7;
-        result = 31 * result + Objects.hashCode(id);
-        result = 31 * result + getProperties().hashCode();
-        return result;
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(entityId);
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + getProperties().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "ActionImpl{" +
-               "id='" + id + '\'' +
+               "entityId=" + entityId +
+               ", id='" + id + '\'' +
                ", properties=" + properties +
                '}';
     }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/ButtonImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/ButtonImpl.java
@@ -76,25 +76,32 @@ public class ButtonImpl implements Button {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof ButtonImpl)) return false;
-        final ButtonImpl other = (ButtonImpl)obj;
-        return Objects.equals(attributes, other.attributes)
-               && Objects.equals(type, other.type);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ButtonImpl)) {
+            return false;
+        }
+        final ButtonImpl that = (ButtonImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(attributes, that.attributes)
+               && Objects.equals(type, that.type);
     }
 
     @Override
     public int hashCode() {
-        int result = 7;
-        result = 31 * result + Objects.hashCode(attributes);
-        result = 31 * result + Objects.hashCode(type);
-        return result;
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(attributes);
+        hash = 31 * hash + Objects.hashCode(type);
+        return hash;
     }
 
     @Override
     public String toString() {
         return "ButtonImpl{" +
-               "attributes=" + attributes +
+               "id=" + id +
+               ", attributes=" + attributes +
                ", type=" + type +
                '}';
     }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/FactoryImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/FactoryImpl.java
@@ -135,6 +135,10 @@ public class FactoryImpl implements Factory {
              images);
     }
 
+    public FactoryImpl(FactoryImpl factory) {
+        this(factory, factory.images);
+    }
+
     @Override
     public String getId() {
         return id;

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/IdeImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/IdeImpl.java
@@ -102,27 +102,34 @@ public class IdeImpl implements Ide {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof IdeImpl)) return false;
-        final IdeImpl other = (IdeImpl)obj;
-        return Objects.equals(onAppLoaded, other.onAppLoaded)
-               && Objects.equals(onProjectsLoaded, other.onProjectsLoaded)
-               && Objects.equals(onAppClosed, other.onAppClosed);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof IdeImpl)) {
+            return false;
+        }
+        final IdeImpl that = (IdeImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(onAppLoaded, that.onAppLoaded)
+               && Objects.equals(onProjectsLoaded, that.onProjectsLoaded)
+               && Objects.equals(onAppClosed, that.onAppClosed);
     }
 
     @Override
     public int hashCode() {
-        int result = 7;
-        result = 31 * result + Objects.hashCode(onAppLoaded);
-        result = 31 * result + Objects.hashCode(onProjectsLoaded);
-        result = 31 * result + Objects.hashCode(onAppClosed);
-        return result;
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(onAppLoaded);
+        hash = 31 * hash + Objects.hashCode(onProjectsLoaded);
+        hash = 31 * hash + Objects.hashCode(onAppClosed);
+        return hash;
     }
 
     @Override
     public String toString() {
         return "IdeImpl{" +
-               "onAppLoaded=" + onAppLoaded +
+               "id=" + id +
+               ", onAppLoaded=" + onAppLoaded +
                ", onProjectsLoaded=" + onProjectsLoaded +
                ", onAppClosed=" + onAppClosed +
                '}';

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppClosedImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppClosedImpl.java
@@ -23,6 +23,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 import static javax.persistence.CascadeType.ALL;
@@ -75,21 +76,30 @@ public class OnAppClosedImpl implements OnAppClosed {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof OnAppClosedImpl)) return false;
-        final OnAppClosedImpl other = (OnAppClosedImpl)obj;
-        return getActions().equals(other.getActions());
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof OnAppClosedImpl)) {
+            return false;
+        }
+        final OnAppClosedImpl that = (OnAppClosedImpl)obj;
+        return Objects.equals(id, that.id)
+               && getActions().equals(that.getActions());
     }
 
     @Override
     public int hashCode() {
-        return getActions().hashCode();
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + getActions().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "OnAppClosedImpl{" +
-               "actions=" + actions +
+               "id=" + id +
+               ", actions=" + actions +
                '}';
     }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppLoadedImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppLoadedImpl.java
@@ -23,6 +23,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Data object for {@link OnAppLoaded}.
@@ -75,21 +76,30 @@ public class OnAppLoadedImpl implements OnAppLoaded {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof OnAppLoadedImpl)) return false;
-        final OnAppLoadedImpl other = (OnAppLoadedImpl)obj;
-        return getActions().equals(other.getActions());
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof OnAppLoadedImpl)) {
+            return false;
+        }
+        final OnAppLoadedImpl that = (OnAppLoadedImpl)obj;
+        return Objects.equals(id, that.id)
+               && getActions().equals(that.getActions());
     }
 
     @Override
     public int hashCode() {
-        return getActions().hashCode();
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + getActions().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "OnAppLoadedImpl{" +
-               "actions=" + actions +
+               "id=" + id +
+               ", actions=" + actions +
                '}';
     }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnProjectsLoadedImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnProjectsLoadedImpl.java
@@ -24,6 +24,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
@@ -75,21 +76,30 @@ public class OnProjectsLoadedImpl implements OnProjectsLoaded {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof OnProjectsLoadedImpl)) return false;
-        final OnProjectsLoadedImpl other = (OnProjectsLoadedImpl)obj;
-        return getActions().equals(other.getActions());
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof OnProjectsLoadedImpl)) {
+            return false;
+        }
+        final OnProjectsLoadedImpl that = (OnProjectsLoadedImpl)obj;
+        return Objects.equals(id, that.id)
+               && getActions().equals(that.getActions());
     }
 
     @Override
     public int hashCode() {
-        return getActions().hashCode();
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + getActions().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "OnProjectsLoadedImpl{" +
-               "actions=" + actions +
+               "id=" + id +
+               ", actions=" + actions +
                '}';
     }
 }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -48,16 +48,20 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -95,8 +99,8 @@ public class FactoryDaoTest {
         for (int i = 0; i < ENTRY_COUNT; i++) {
             factories[i] = createFactory(i, users[i].getId());
         }
-        userTckRepository.createAll(asList(users));
-        factoryTckRepository.createAll(asList(factories));
+        userTckRepository.createAll(Arrays.asList(users));
+        factoryTckRepository.createAll(Stream.of(factories).map(FactoryImpl::new).collect(toList()));
     }
 
     @AfterMethod
@@ -111,7 +115,7 @@ public class FactoryDaoTest {
         factory.getCreator().setUserId(factories[0].getCreator().getUserId());
         factoryDao.create(factory);
 
-        assertEquals(factoryDao.getById(factory.getId()), factory);
+        assertEquals(factoryDao.getById(factory.getId()), new FactoryImpl(factory));
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -364,8 +368,6 @@ public class FactoryDaoTest {
         wCfg.setCommands(commands);
         wCfg.setProjects(projects);
         wCfg.setEnvironments(environments);
-
-        wCfg.getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
 
         return wCfg;
     }

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/CommandImpl.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/CommandImpl.java
@@ -117,30 +117,33 @@ public class CommandImpl implements Command {
         if (!(obj instanceof CommandImpl)) {
             return false;
         }
-        final CommandImpl command = (CommandImpl)obj;
-        return Objects.equals(name, command.name) &&
-               Objects.equals(commandLine, command.commandLine) &&
-               Objects.equals(type, command.type) &&
-               Objects.equals(getAttributes(), command.getAttributes());
+        final CommandImpl that = (CommandImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(name, that.name)
+               && Objects.equals(commandLine, that.commandLine)
+               && Objects.equals(type, that.type)
+               && getAttributes().equals(that.getAttributes());
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
         hash = 31 * hash + Objects.hashCode(name);
         hash = 31 * hash + Objects.hashCode(commandLine);
         hash = 31 * hash + Objects.hashCode(type);
-        hash = 31 * hash + Objects.hashCode(getAttributes());
+        hash = 31 * hash + getAttributes().hashCode();
         return hash;
     }
 
     @Override
     public String toString() {
         return "CommandImpl{" +
-               "name='" + name + '\'' +
+               "id=" + id +
+               ", name='" + name + '\'' +
                ", commandLine='" + commandLine + '\'' +
                ", type='" + type + '\'' +
-               ", attributes=" + getAttributes() +
+               ", attributes=" + attributes +
                '}';
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaStackDao.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaStackDao.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +70,7 @@ public class JpaStackDao implements StackDao {
             if (stack == null) {
                 throw new NotFoundException(format("Stack with id '%s' doesn't exist", id));
             }
-            return stack;
+            return new StackImpl(stack);
         } catch (RuntimeException x) {
             throw new ServerException(x.getLocalizedMessage(), x);
         }
@@ -89,7 +90,7 @@ public class JpaStackDao implements StackDao {
     public StackImpl update(StackImpl update) throws NotFoundException, ServerException, ConflictException {
         requireNonNull(update, "Required non-null update");
         try {
-            return doUpdate(update);
+            return new StackImpl(doUpdate(update));
         } catch (DuplicateKeyException x) {
             throw new ConflictException(format("Stack with name '%s' already exists", update.getName()));
         } catch (RuntimeException x) {
@@ -115,7 +116,10 @@ public class JpaStackDao implements StackDao {
         try {
             return query.setMaxResults(maxItems)
                         .setFirstResult(skipCount)
-                        .getResultList();
+                        .getResultList()
+                        .stream()
+                        .map(StackImpl::new)
+                        .collect(Collectors.toList());
         } catch (RuntimeException x) {
             throw new ServerException(x.getLocalizedMessage(), x);
         }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
@@ -25,6 +25,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -89,6 +90,9 @@ public class EnvironmentImpl implements Environment {
 
     @Override
     public Map<String, ExtendedMachineImpl> getMachines() {
+        if (machines == null) {
+            machines = new HashMap<>();
+        }
         return machines;
     }
 
@@ -97,23 +101,33 @@ public class EnvironmentImpl implements Environment {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof EnvironmentImpl)) return false;
-        EnvironmentImpl that = (EnvironmentImpl)o;
-        return Objects.equals(recipe, that.recipe) &&
-               Objects.equals(machines, that.machines);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof EnvironmentImpl)) {
+            return false;
+        }
+        final EnvironmentImpl that = (EnvironmentImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(recipe, that.recipe)
+               && getMachines().equals(that.getMachines());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(recipe, machines);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(recipe);
+        hash = 31 * hash + getMachines().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "EnvironmentImpl{" +
-               "recipe=" + recipe +
+               "id=" + id +
+               ", recipe=" + recipe +
                ", machines=" + machines +
                '}';
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ExtendedMachineImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ExtendedMachineImpl.java
@@ -87,6 +87,9 @@ public class ExtendedMachineImpl implements ExtendedMachine {
 
     @Override
     public List<String> getAgents() {
+        if (agents == null) {
+            agents = new ArrayList<>();
+        }
         return agents;
     }
 
@@ -118,6 +121,9 @@ public class ExtendedMachineImpl implements ExtendedMachine {
 
     @Override
     public Map<String, String> getAttributes() {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
         return attributes;
     }
 
@@ -131,26 +137,37 @@ public class ExtendedMachineImpl implements ExtendedMachine {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ExtendedMachineImpl)) return false;
-        ExtendedMachineImpl that = (ExtendedMachineImpl)o;
-        return Objects.equals(agents, that.agents) &&
-               Objects.equals(servers, that.servers) &&
-               Objects.equals(attributes, that.attributes);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ExtendedMachineImpl)) {
+            return false;
+        }
+        final ExtendedMachineImpl that = (ExtendedMachineImpl)obj;
+        return Objects.equals(id, that.id)
+               && getAgents().equals(that.getAgents())
+               && getAttributes().equals(that.getAttributes())
+               && getServers().equals(that.getServers());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(agents, servers, attributes);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + getAgents().hashCode();
+        hash = 31 * hash + getAttributes().hashCode();
+        hash = 31 * hash + getServers().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "ExtendedMachineImpl{" +
-               "agents=" + agents +
-               ", servers=" + servers +
+               "id=" + id +
+               ", agents=" + agents +
                ", attributes=" + attributes +
+               ", servers=" + servers +
                '}';
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -175,42 +175,49 @@ public class ProjectConfigImpl implements ProjectConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ProjectConfigImpl)) return false;
-        final ProjectConfigImpl other = (ProjectConfigImpl)o;
-        return Objects.equals(name, other.name)
-               && Objects.equals(path, other.path)
-               && Objects.equals(description, other.description)
-               && Objects.equals(type, other.type)
-               && getMixins().equals(other.getMixins())
-               && getAttributes().equals(other.getAttributes())
-               && Objects.equals(source, other.getSource());
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ProjectConfigImpl)) {
+            return false;
+        }
+        final ProjectConfigImpl that = (ProjectConfigImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(path, that.path)
+               && Objects.equals(name, that.name)
+               && Objects.equals(type, that.type)
+               && Objects.equals(description, that.description)
+               && Objects.equals(source, that.source)
+               && getMixins().equals(that.getMixins())
+               && getAttributes().equals(that.getAttributes());
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = hash * 31 + Objects.hashCode(name);
-        hash = hash * 31 + Objects.hashCode(path);
-        hash = hash * 31 + Objects.hashCode(description);
-        hash = hash * 31 + Objects.hashCode(type);
-        hash = hash * 31 + getMixins().hashCode();
-        hash = hash * 31 + getAttributes().hashCode();
-        hash = hash * 31 + Objects.hashCode(source);
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(path);
+        hash = 31 * hash + Objects.hashCode(name);
+        hash = 31 * hash + Objects.hashCode(type);
+        hash = 31 * hash + Objects.hashCode(description);
+        hash = 31 * hash + Objects.hashCode(source);
+        hash = 31 * hash + getMixins().hashCode();
+        hash = 31 * hash + getAttributes().hashCode();
         return hash;
     }
 
     @Override
     public String toString() {
         return "ProjectConfigImpl{" +
-               "name='" + name + '\'' +
+               "id=" + id +
                ", path='" + path + '\'' +
-               ", description='" + description + '\'' +
+               ", name='" + name + '\'' +
                ", type='" + type + '\'' +
+               ", description='" + description + '\'' +
+               ", source=" + source +
                ", mixins=" + mixins +
                ", attributes=" + attributes +
-               ", source=" + source +
                '}';
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConf2Impl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConf2Impl.java
@@ -102,24 +102,35 @@ public class ServerConf2Impl implements ServerConf2 {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ServerConf2Impl)) return false;
-        ServerConf2Impl that = (ServerConf2Impl)o;
-        return Objects.equals(port, that.port) &&
-               Objects.equals(protocol, that.protocol) &&
-               Objects.equals(properties, that.properties);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ServerConf2Impl)) {
+            return false;
+        }
+        final ServerConf2Impl that = (ServerConf2Impl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(port, that.port)
+               && Objects.equals(protocol, that.protocol)
+               && getProperties().equals(that.getProperties());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(port, protocol, properties);
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(port);
+        hash = 31 * hash + Objects.hashCode(protocol);
+        hash = 31 * hash + getProperties().hashCode();
+        return hash;
     }
 
     @Override
     public String toString() {
         return "ServerConf2Impl{" +
-               "port='" + port + '\'' +
+               "id=" + id +
+               ", port='" + port + '\'' +
                ", protocol='" + protocol + '\'' +
                ", properties=" + properties +
                '}';

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/SourceStorageImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/SourceStorageImpl.java
@@ -94,28 +94,35 @@ public class SourceStorageImpl implements SourceStorage {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SourceStorageImpl)) return false;
-        final SourceStorageImpl other = (SourceStorageImpl)o;
-        return Objects.equals(type, other.type) &&
-               Objects.equals(location, other.location) &&
-               getParameters().equals(other.getParameters());
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SourceStorageImpl)) {
+            return false;
+        }
+        final SourceStorageImpl that = (SourceStorageImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(type, that.type)
+               && Objects.equals(location, that.location)
+               && getParameters().equals(that.getParameters());
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = hash * 31 + Objects.hashCode(type);
-        hash = hash * 31 + Objects.hashCode(location);
-        hash = hash * 31 + getParameters().hashCode();
+        hash = 31 * hash + Objects.hashCode(id);
+        hash = 31 * hash + Objects.hashCode(type);
+        hash = 31 * hash + Objects.hashCode(location);
+        hash = 31 * hash + getParameters().hashCode();
         return hash;
     }
 
     @Override
     public String toString() {
         return "SourceStorageImpl{" +
-               "type='" + type + '\'' +
+               "id=" + id +
+               ", type='" + type + '\'' +
                ", location='" + location + '\'' +
                ", parameters=" + parameters +
                '}';

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceConfigImpl.java
@@ -26,8 +26,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
-import javax.persistence.PrePersist;
-import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -184,26 +182,32 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof WorkspaceConfigImpl)) return false;
-        final WorkspaceConfigImpl other = (WorkspaceConfigImpl)obj;
-        return Objects.equals(name, other.name)
-               && Objects.equals(defaultEnv, other.defaultEnv)
-               && getCommands().equals(other.getCommands())
-               && getEnvironments().equals(other.getEnvironments())
-               && getProjects().equals(other.getProjects())
-               && Objects.equals(description, other.description);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof WorkspaceConfigImpl)) {
+            return false;
+        }
+        final WorkspaceConfigImpl that = (WorkspaceConfigImpl)obj;
+        return Objects.equals(id, that.id)
+               && Objects.equals(name, that.name)
+               && Objects.equals(description, that.description)
+               && Objects.equals(defaultEnv, that.defaultEnv)
+               && getCommands().equals(that.getCommands())
+               && getProjects().equals(that.getProjects())
+               && getEnvironments().equals(that.getEnvironments());
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
+        hash = 31 * hash + Objects.hashCode(id);
         hash = 31 * hash + Objects.hashCode(name);
+        hash = 31 * hash + Objects.hashCode(description);
         hash = 31 * hash + Objects.hashCode(defaultEnv);
         hash = 31 * hash + getCommands().hashCode();
-        hash = 31 * hash + getEnvironments().hashCode();
         hash = 31 * hash + getProjects().hashCode();
-        hash = 31 * hash + Objects.hashCode(description);
+        hash = 31 * hash + getEnvironments().hashCode();
         return hash;
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -152,6 +152,10 @@ public class WorkspaceImpl implements Workspace {
              workspace.getStatus());
     }
 
+    public WorkspaceImpl(WorkspaceImpl workspace) {
+        this(workspace, workspace.account);
+    }
+
     @Override
     public String getId() {
         return id;

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/StackDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/StackDaoTest.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
 import org.eclipse.che.api.workspace.server.event.StackPersistedEvent;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackSourceImpl;
@@ -35,8 +36,10 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.workspace.server.spi.tck.WorkspaceDaoTest.createWorkspaceConfig;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -71,7 +74,7 @@ public class StackDaoTest {
         for (int i = 0; i < STACKS_SIZE; i++) {
             stacks[i] = createStack("stack-" + i, "name-" + i);
         }
-        stackRepo.createAll(asList(stacks));
+        stackRepo.createAll(Stream.of(stacks).map(StackImpl::new).collect(toList()));
     }
 
     @AfterMethod
@@ -102,7 +105,7 @@ public class StackDaoTest {
 
         stackDao.create(stack);
 
-        assertEquals(stackDao.getById(stack.getId()), stack);
+        assertEquals(stackDao.getById(stack.getId()), new StackImpl(stack));
     }
 
     @Test(expectedExceptions = ConflictException.class)

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -38,14 +38,17 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -96,15 +99,15 @@ public class WorkspaceDaoTest {
             // 2 workspaces share 1 namespace
             workspaces[i] = createWorkspace("workspace-" + i, accounts[i / 2], "name-" + i);
         }
-        accountRepo.createAll(asList(accounts));
-        workspaceRepo.createAll(asList(workspaces));
+        accountRepo.createAll(Arrays.asList(accounts));
+        workspaceRepo.createAll(Stream.of(workspaces).map(WorkspaceImpl::new).collect(toList()));
     }
 
     @Test
     public void shouldGetWorkspaceById() throws Exception {
         final WorkspaceImpl workspace = workspaces[0];
 
-        assertEquals(workspaceDao.get(workspace.getId()), workspace);
+        assertEquals(workspaceDao.get(workspace.getId()), new WorkspaceImpl(workspace));
     }
 
     @Test(expectedExceptions = NotFoundException.class)
@@ -142,7 +145,7 @@ public class WorkspaceDaoTest {
     public void shouldGetWorkspaceByNameAndNamespace() throws Exception {
         final WorkspaceImpl workspace = workspaces[0];
 
-        assertEquals(workspaceDao.get(workspace.getConfig().getName(), workspace.getNamespace()), workspace);
+        assertEquals(workspaceDao.get(workspace.getConfig().getName(), workspace.getNamespace()), new WorkspaceImpl(workspace));
     }
 
     @Test(expectedExceptions = NotFoundException.class)
@@ -484,8 +487,6 @@ public class WorkspaceDaoTest {
         wCfg.setCommands(commands);
         wCfg.setProjects(projects);
         wCfg.setEnvironments(new HashMap<>(environments));
-
-        wCfg.getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
 
         return wCfg;
     }

--- a/wsmaster/integration-tests/cascade-removal/pom.xml
+++ b/wsmaster/integration-tests/cascade-removal/pom.xml
@@ -58,6 +58,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-agent</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
             <scope>test</scope>
         </dependency>
@@ -68,7 +73,17 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh-shared</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -79,6 +94,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace-shared</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
@@ -10,14 +10,22 @@
  *******************************************************************************/
 package org.eclipse.che.core.db.jpa;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.eclipse.che.account.shared.model.Account;
+import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentRecipeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ExtendedMachineImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConf2Impl;
+import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackComponentImpl;
@@ -29,6 +37,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
 /**
  * Defines method for creating tests object instances.
@@ -61,9 +71,49 @@ public final class TestObjectsFactory {
         return new WorkspaceConfigImpl(id + "_name",
                                        id + "description",
                                        "default-env",
-                                       null,
-                                       null,
-                                       null);
+                                       asList(new CommandImpl(id + "cmd1", "mvn clean install", "maven"),
+                                              new CommandImpl(id + "cmd2", "mvn clean install", "maven")),
+                                       asList(createProjectConfig(id + "-project1"),
+                                              createProjectConfig(id + "-project2")),
+                                       ImmutableMap.of(id + "env1", createEnv(),
+                                                       id + "env2", createEnv()));
+    }
+
+    public static ProjectConfigImpl createProjectConfig(String name) {
+        final ProjectConfigImpl project = new ProjectConfigImpl();
+        project.setDescription(name + "-description");
+        project.setName(name);
+        project.setPath("/" + name);
+        project.setType(name + "type");
+        project.setSource(new SourceStorageImpl("source-type",
+                                                "source-location",
+                                                ImmutableMap.of("param1", "value",
+                                                                "param2", "value")));
+        project.setMixins(asList("mixin1", "mixin2"));
+        project.getAttributes().put("attribute1", singletonList("value1"));
+        project.getAttributes().put("attribute2", singletonList("value2"));
+        project.getAttributes().put("attribute3", singletonList("value3"));
+        return project;
+    }
+
+    public static EnvironmentImpl createEnv() {
+        final EnvironmentRecipeImpl newRecipe = new EnvironmentRecipeImpl();
+        newRecipe.setLocation("new-location");
+        newRecipe.setType("new-type");
+        newRecipe.setContentType("new-content-type");
+        newRecipe.setContent("new-content");
+
+        final ExtendedMachineImpl newMachine = new ExtendedMachineImpl();
+        final ServerConf2Impl serverConf1 = new ServerConf2Impl("2265", "http", ImmutableMap.of("prop1", "val"));
+        final ServerConf2Impl serverConf2 = new ServerConf2Impl("2266", "ftp", ImmutableMap.of("prop1", "val"));
+        newMachine.setServers(ImmutableMap.of("ref1", serverConf1, "ref2", serverConf2));
+        newMachine.setAgents(ImmutableList.of("agent5", "agent4"));
+        newMachine.setAttributes(singletonMap("att1", "val"));
+
+        final EnvironmentImpl newEnv = new EnvironmentImpl();
+        newEnv.setMachines(ImmutableMap.of("new-machine", newMachine));
+        newEnv.setRecipe(newRecipe);
+        return newEnv;
     }
 
     public static WorkspaceImpl createWorkspace(String id, Account account) {

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -87,6 +87,16 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-machine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh</artifactId>
             <scope>test</scope>
         </dependency>
@@ -94,6 +104,11 @@
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh</artifactId>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh-shared</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -110,6 +125,11 @@
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace</artifactId>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace-shared</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
+++ b/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
@@ -37,6 +37,7 @@ import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
 import org.eclipse.che.api.workspace.server.jpa.JpaStackDao;
 import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao;
+import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.spi.StackDao;
@@ -140,8 +141,8 @@ public class PostgreSqlTckModule extends TckModule {
         // workspace
         bind(WorkspaceDao.class).to(JpaWorkspaceDao.class);
         bind(StackDao.class).to(JpaStackDao.class);
-        bind(new TypeLiteral<TckRepository<WorkspaceImpl>>() {}).toInstance(new JpaTckRepository<>(WorkspaceImpl.class));
-        bind(new TypeLiteral<TckRepository<StackImpl>>() {}).toInstance(new JpaTckRepository<>(StackImpl.class));
+        bind(new TypeLiteral<TckRepository<WorkspaceImpl>>() {}).toInstance(new WorkspaceRepository());
+        bind(new TypeLiteral<TckRepository<StackImpl>>() {}).toInstance(new StackRepository());
     }
 
     private static void waitConnectionIsEstablished(String dbUrl, String dbUser, String dbPassword) {
@@ -227,6 +228,30 @@ public class PostgreSqlTckModule extends TckModule {
                                                                                    w.getNamespace(),
                                                                                    "simple")))
                                     .collect(Collectors.toList()));
+        }
+    }
+
+    private static class WorkspaceRepository extends JpaTckRepository<WorkspaceImpl> {
+        public WorkspaceRepository() { super(WorkspaceImpl.class); }
+
+        @Override
+        public void createAll(Collection<? extends WorkspaceImpl> entities) throws TckRepositoryException {
+            for (WorkspaceImpl entity : entities) {
+                entity.getConfig().getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
+            }
+            super.createAll(entities);
+        }
+    }
+
+    private static class StackRepository extends JpaTckRepository<StackImpl> {
+        public StackRepository() { super(StackImpl.class); }
+
+        @Override
+        public void createAll(Collection<? extends StackImpl> entities) throws TckRepositoryException {
+            for (StackImpl stack : entities) {
+                stack.getWorkspaceConfig().getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
+            }
+            super.createAll(entities);
         }
     }
 }


### PR DESCRIPTION
When the entity like `Workspace` contains some internal object which are unique only in the entity context it may happen that cascade removal of such entities doesn't work properly.

#### The problem:
Such entities as `WorkspaceConfig`, `Command`, `Environment`, `ProjectConfig` are unique in the certain workspace context and can be identified with their name + dependency primary key, but name is an updatable attribute which means that it is bad candidate for primary key. That's why for such kind of objects we generate their own synthetic identifier like this:

```java
@Id
@GeneratedValue
private Long id;
```
This approach allows us to save those object along with owning objects.
As the identifier is a certain DB related attribute we don't include it to the equals and hashcode methods.
But when we remove several entities in a single transaction EclipseLink builds dependency graph to perform removal in the right order, so project config entities are removed before the workspace config(dependency owner) and the graph is stored in the current session hashmap, where key is entity and values are the set of depending on the key entities. 
So if object `A1` is removed in the same transaction with object `A2` and those objects contain the same values for all the fields instead of id then, dependency graph will be like this:
```
A1 -> [ depends_on_A1]
A2 -> [ depends_on_A1, depends_on_A2 ]
```
because of the same hashcode & equals behaviour for A1 and A2.

The same happens with project source storages and project configs, as blank project & project samples refer to the source storage with the same fields.
And deletion fails with an error like this:
```
org.eclipse.che.api.core.ServerException: Exception [EclipseLink-6004] (Eclipse Persistence Services - 2.6.2.v20151217-774c696): org.eclipse.persistence.exceptions.QueryException
Exception Description: The object [ProjectConfigImpl{name='workspace1-project2', path='/workspace1-project2', description='workspace1-project2-description', type='workspace1-project2type', mixins=[mixin1, mixin2], attributes={attribute1=[value1], attribute3=[value3], attribute2=[value2]}, source=SourceStorageImpl{type='source-type', location='source-location', parameters={param2=value, param1=value}}}], of class [class org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl], with identity hashcode (System.identityHashCode()) [945,150,386], 
is not from this UnitOfWork object space, but the parent session's.  The object was never registered in this UnitOfWork, 
but read from the parent session and related to an object registered in the UnitOfWork.  Ensure that you are correctly
registering your objects.  If you are still having problems, you can use the UnitOfWork.validateObjectSpace() method to 
help debug where the error occurred.  For more information, see the manual or FAQ.
``` 

#### The solution:

The simplest solution will be to add synthetically generated identifier into the hashcode & equals methods which i basically did and return object without database specific information from data access layer, it may be easily achieved by usage of model based copy constructors.
So for the object `Workspace workspace1` which contains all the database specific information the object `Workspace workspace2 = new WorkspaceImpl(workspace1)` won't contain such information.

### What issues does this PR fix or reference?
#2993 

### Previous behavior
Sometimes cascade deletion fails.

### New behavior
Cascade deletion works just fine.

@skabashnyuk, @akorneta, @sleshchenko please review the changes
