### PR TITLE
Update stacks.json to Refer to Eclipse Dockerhub Repository

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -24,7 +24,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_jdk8"
+      "origin": "eclipse/ubuntu_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -46,7 +46,7 @@
             }
           },
           "recipe": {
-            "content": "services:\n db:\n  image: codenvy/mysql\n  environment:\n   MYSQL_DATABASE: petclinic\n   MYSQL_USER: petclinic\n   MYSQL_PASSWORD: password\n  mem_limit: 1073741824\n dev-machine:\n  image: codenvy/ubuntu_jdk8\n  mem_limit: 2147483648\n  depends_on:\n    - db",
+            "content": "services:\n db:\n  image: eclipse/mysql\n  environment:\n   MYSQL_DATABASE: petclinic\n   MYSQL_USER: petclinic\n   MYSQL_PASSWORD: password\n  mem_limit: 1073741824\n dev-machine:\n  image: eclipse/ubuntu_jdk8\n  mem_limit: 2147483648\n  depends_on:\n    - db",
             "contentType": "application/x-yaml",
             "type": "compose"
           }
@@ -99,7 +99,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_jdk8"
+      "origin": "eclipse/ubuntu_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -116,7 +116,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_jdk8",
+            "location": "eclipse/ubuntu_jdk8",
             "type": "dockerimage"
           }
         }
@@ -152,7 +152,7 @@
     "components": [],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_jdk8"
+      "origin": "eclipse/ubuntu_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -169,7 +169,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_jdk8",
+            "location": "eclipse/ubuntu_jdk8",
             "type": "dockerimage"
           }
         }
@@ -210,7 +210,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_android"
+      "origin": "eclipse/ubuntu_android"
     },
     "workspaceConfig": {
       "environments": {
@@ -227,7 +227,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_android",
+            "location": "eclipse/ubuntu_android",
             "type": "dockerimage"
           }
         }
@@ -277,7 +277,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/cpp_gcc"
+      "origin": "eclipse/cpp_gcc"
     },
     "workspaceConfig": {
       "environments": {
@@ -294,7 +294,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/cpp_gcc",
+            "location": "eclipse/cpp_gcc",
             "type": "dockerimage"
           }
         }
@@ -338,7 +338,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/dotnet_core"
+      "origin": "eclipse/dotnet_core"
     },
     "workspaceConfig": {
       "environments": {
@@ -355,7 +355,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/dotnet_core",
+            "location": "eclipse/dotnet_core",
             "type": "dockerimage"
           }
         }
@@ -409,7 +409,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_go"
+      "origin": "eclipse/ubuntu_go"
     },
     "workspaceConfig": {
       "environments": {
@@ -426,7 +426,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_go",
+            "location": "eclipse/ubuntu_go",
             "type": "dockerimage"
           }
         }
@@ -478,7 +478,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/hadoop-dev"
+      "origin": "eclipse/hadoop-dev"
     },
     "workspaceConfig": {
       "environments": {
@@ -495,7 +495,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/hadoop-dev",
+            "location": "eclipse/hadoop-dev",
             "type": "dockerimage"
           }
         }
@@ -555,7 +555,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/node"
+      "origin": "eclipse/node"
     },
     "workspaceConfig": {
       "environments": {
@@ -572,7 +572,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/node",
+            "location": "eclipse/node",
             "type": "dockerimage"
           }
         }
@@ -625,7 +625,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/php"
+      "origin": "eclipse/php"
     },
     "workspaceConfig": {
       "environments": {
@@ -642,7 +642,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/php",
+            "location": "eclipse/php",
             "type": "dockerimage"
           }
         }
@@ -706,7 +706,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_python:latest"
+      "origin": "eclipse/ubuntu_python:latest"
     },
     "workspaceConfig": {
       "environments": {
@@ -723,7 +723,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_python:latest",
+            "location": "eclipse/ubuntu_python:latest",
             "type": "dockerimage"
           }
         }
@@ -776,7 +776,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_rails"
+      "origin": "eclipse/ubuntu_rails"
     },
     "workspaceConfig": {
       "environments": {
@@ -793,7 +793,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_rails",
+            "location": "eclipse/ubuntu_rails",
             "type": "dockerimage"
           }
         }
@@ -842,7 +842,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/debian_jre"
+      "origin": "eclipse/debian_jre"
     },
     "workspaceConfig": {
       "environments": {
@@ -859,7 +859,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/debian_jre",
+            "location": "eclipse/debian_jre",
             "type": "dockerimage"
           }
         }
@@ -887,7 +887,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/debian_jre"
+      "origin": "eclipse/debian_jre"
     },
     "workspaceConfig": {
       "environments": {
@@ -909,7 +909,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/debian_jre",
+            "location": "eclipse/debian_jre",
             "type": "dockerimage"
           }
         }
@@ -953,7 +953,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/centos_jdk8"
+      "origin": "eclipse/centos_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -970,7 +970,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/centos_jdk8",
+            "location": "eclipse/centos_jdk8",
             "type": "dockerimage"
           }
         }
@@ -1025,7 +1025,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/debian_jdk8"
+      "origin": "eclipse/debian_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -1042,7 +1042,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/debian_jdk8",
+            "location": "eclipse/debian_jdk8",
             "type": "dockerimage"
           }
         }
@@ -1100,7 +1100,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/php:gae"
+      "origin": "eclipse/php:gae"
     },
     "workspaceConfig": {
       "environments": {
@@ -1117,7 +1117,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/php:gae",
+            "location": "eclipse/php:gae",
             "type": "dockerimage"
           }
         }
@@ -1165,7 +1165,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_python:2.7"
+      "origin": "eclipse/ubuntu_python:2.7"
     },
     "workspaceConfig": {
       "environments": {
@@ -1182,7 +1182,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_python:2.7",
+            "location": "eclipse/ubuntu_python:2.7",
             "type": "dockerimage"
           }
         }
@@ -1227,7 +1227,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_python:gae_python2.7"
+      "origin": "eclipse/ubuntu_python:gae_python2.7"
     },
     "workspaceConfig": {
       "environments": {
@@ -1244,7 +1244,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_python:gae_python2.7",
+            "location": "eclipse/ubuntu_python:gae_python2.7",
             "type": "dockerimage"
           }
         }
@@ -1308,7 +1308,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/selenium"
+      "origin": "eclipse/selenium"
     },
     "workspaceConfig": {
       "environments": {
@@ -1325,7 +1325,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/selenium",
+            "location": "eclipse/selenium",
             "type": "dockerimage"
           }
         }
@@ -1428,7 +1428,7 @@
             }
           },
           "recipe": {
-            "location": "codenvy/ubuntu_jre",
+            "location": "eclipse/ubuntu_jre",
             "type": "dockerimage"
           }
         }
@@ -1439,7 +1439,7 @@
     },
     "source": {
       "type": "image",
-      "origin": "codenvy/ubuntu_jre"
+      "origin": "eclipse/ubuntu_jre"
     }
   },
   {


### PR DESCRIPTION
### What does this PR do?
Che docker image references to codenvy repository is changed to associated eclipse repository.

### What issues does this PR fix or reference?
Che dockerfiles should be located under the eclipse foundation Docker repository.
