### PR TITLE
CHE-3218: improves the documentation popup for LSP code completion

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -13,9 +13,10 @@ package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
 import io.typefox.lsapi.ServerCapabilities;
 
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.eclipse.che.api.languageserver.shared.lsapi.CompletionItemDTO;
@@ -36,6 +37,8 @@ import org.eclipse.che.plugin.languageserver.ide.filters.Match;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 
 import java.util.List;
+
+import static org.eclipse.che.ide.api.theme.Style.theme;
 
 /**
  * @author Anatolii Bazko
@@ -99,12 +102,15 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
             documentation = "No documentation found.";
         }
 
-        Label label = new Label(documentation);
-        label.setWordWrap(true);
-        label.getElement().getStyle().setFontSize(13, Style.Unit.PX);
-        label.getElement().getStyle().setMarginLeft(4, Style.Unit.PX);
-        label.setSize("100%", "100%");
-        return label;
+        HTML widget = new HTML(documentation);
+        widget.setWordWrap(true);
+        widget.getElement().getStyle().setColor(theme.completionPopupItemTextColor());
+        widget.getElement().getStyle().setFontSize(13, Style.Unit.PX);
+        widget.getElement().getStyle().setMarginLeft(4, Style.Unit.PX);
+        widget.getElement().getStyle().setOverflow(Overflow.AUTO);
+        widget.getElement().getStyle().setProperty("userSelect", "text");
+        widget.setHeight("100%");
+        return widget;
     }
 
     @Override

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -126,7 +126,9 @@ public class ContentAssistWidget implements EventListener {
                     final EventTarget target = mouseEvent.getTarget();
                     if (target instanceof Element) {
                         final Element elementTarget = (Element)target;
-                        if (elementTarget.equals(docPopup.getElement()) && docPopup.isVisible()) {
+                        if (docPopup.isVisible() && 
+                            (elementTarget.equals(docPopup.getElement()) || 
+                             elementTarget.getParentElement().equals(docPopup.getElement()))) {
                             return;
                         }
 
@@ -219,16 +221,11 @@ public class ContentAssistWidget implements EventListener {
                         if (info != null) {
                             docPopup.clear();
                             docPopup.add(info);
-
-                            if (docPopup.isAttached()) {
-                                return;
-                            }
-
-                            docPopup.getElement().getStyle()
-                                    .setLeft(popupElement.getOffsetLeft() + popupElement.getOffsetWidth() + 3, Style.Unit.PX);
-                            docPopup.getElement().getStyle().setTop(popupElement.getOffsetTop(), Style.Unit.PX);
-                            RootPanel.get().add(docPopup);
                             docPopup.getElement().getStyle().setOpacity(1);
+
+                            if (!docPopup.isAttached()) {
+                                RootPanel.get().add(docPopup);
+                            }
                         } else {
                             docPopup.getElement().getStyle().setOpacity(0);
                         }
@@ -412,7 +409,6 @@ public class ContentAssistWidget implements EventListener {
         selectedElement = element;
         selectedElement.setAttribute("selected", "true");
 
-        docPopup.clear();
         showDocTimer.cancel();
         showDocTimer.schedule(docPopup.isAttached() ? 100 : 1500);
 
@@ -521,7 +517,7 @@ public class ContentAssistWidget implements EventListener {
             this.popupElement.getStyle().setProperty("maxWidth", viewportWidth + caretLocation.getX() + "px");
         }
 
-        /* Don't attach handlers twice. Visible popup must already their attached. */
+        /* Don't attach handlers twice. Visible popup must already have their attached. */
         if (!visible) {
             addPopupEventListeners();
         }
@@ -530,16 +526,11 @@ public class ContentAssistWidget implements EventListener {
         visible = true;
         focused = false;
 
-        if (docPopup.isAttached()) {
-            docPopup.getElement().getStyle().setOpacity(0);
-            new Timer() {
-                @Override
-                public void run() {
-                    docPopup.removeFromParent();
-                    showDocTimer.schedule(1500);
-                }
-            }.schedule(250);
-        }
+        /* Update documentation popup position */
+        docPopup.getElement().getStyle()
+                .setLeft(popupElement.getOffsetLeft() + popupElement.getOffsetWidth() + 3, Style.Unit.PX);
+        docPopup.getElement().getStyle()
+                .setTop(popupElement.getOffsetTop(), Style.Unit.PX);
 
         /* Select first row. */
         selectFirst();


### PR DESCRIPTION
### What does this PR do?

Improves the documentation popup for LSP code completion.

### What issues does this PR fix or reference?

Fixes #3218

### Previous behavior

![image](https://cloud.githubusercontent.com/assets/468091/20769681/99eb2010-b74b-11e6-9b48-3d5d0df9f62a.png)

### New behavior

- Scrollbars when necessary
- HTML tags are rendered
- Possible to select and copy some text from the documentation
- No flickering while typing

![image](https://cloud.githubusercontent.com/assets/468091/20789347/ad73b5f4-b7bc-11e6-9b26-89b36ac3787a.png)

Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>