### PR TITLE
[cli] add all CHE_ properties to che.env file at first

### DIFF
--- a/dockerfiles/init/modules/che/templates/che.env.erb
+++ b/dockerfiles/init/modules/che/templates/che.env.erb
@@ -1,3 +1,11 @@
+# Include all custom CHE_* properties that user may has defined in its che.env file
+<% ENV.each do |k,v| -%>
+<% if k.include? "CHE_" then  -%>
+<%= k + '=' + v %>
+<% end -%>
+<% end -%>
+
+
 CHE_IP=<%= scope.lookupvar('che::che_ip') %>
 CHE_PORT=<%= scope.lookupvar('che::che_port') %>
 CHE_LOGS_DIR=/logs


### PR DESCRIPTION
### What does this PR do?
add all CHE_ properties to che.env file at first

### New behavior
It allow to override any che.properties property

like
CHE_WORKSPACE_AUTO__SNAPSHOT=false

(override che.workspace.auto_snapshot of che.properties)
Change-Id: Ia7a48355d81dc1ba7b4b86726038637ef3e44e68
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>