### PR TITLE
CHE-2922: Fix Ctrl + S hotKey for Emacs. Add simple UI for incremental search.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -52,8 +52,6 @@ import org.eclipse.che.ide.actions.common.MaximizePartAction;
 import org.eclipse.che.ide.actions.common.MinimizePartAction;
 import org.eclipse.che.ide.actions.common.RestorePartAction;
 import org.eclipse.che.ide.actions.find.FindActionAction;
-import org.eclipse.che.ide.api.action.Action;
-import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.ide.api.action.IdeActions;
@@ -668,8 +666,6 @@ public class StandardComponentInitializer {
         editorTabContextMenu.add(splitHorizontallyAction);
         actionManager.registerAction(SPLIT_VERTICALLY, splitVerticallyAction);
         editorTabContextMenu.add(splitVerticallyAction);
-
-        actionManager.registerAction("noOpAction", new NoOpAction());
         actionManager.registerAction("signatureHelp", signatureHelpAction);
 
         DefaultActionGroup editorContextMenuGroup = new DefaultActionGroup(actionManager);
@@ -695,7 +691,6 @@ public class StandardComponentInitializer {
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.ARROW_LEFT).build(), "switchLeftTab");
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.ARROW_RIGHT).build(), "switchRightTab");
         keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('e').build(), "openRecentFiles");
-        keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('s').build(), "noOpAction");
         keyBinding.getGlobal().addKey(new KeyBuilder().charCode(KeyCodeMap.DELETE).build(), "deleteItem");
 
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode('N').build(), "newFile");
@@ -708,13 +703,6 @@ public class StandardComponentInitializer {
         } else {
             keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode('w').build(), "closeActiveEditor");
             keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('p').build(), "signatureHelp");
-        }
-    }
-
-    /** Action that does nothing. It's just for disabling (catching) browser's hot key. */
-    private class NoOpAction extends Action {
-        @Override
-        public void actionPerformed(ActionEvent e) {
         }
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/KeyBindingManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/KeyBindingManager.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.keybinding;
 import elemental.dom.Element;
 import elemental.events.Event;
 import elemental.events.EventListener;
+import elemental.events.KeyboardEvent;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.AreaElement;
@@ -86,6 +87,7 @@ public class KeyBindingManager implements KeyBindingAgent {
 
                 //handle event in active scheme
                 int digest = CharCodeWithModifiers.computeKeyDigest(signalEvent);
+                preventDefaultBrowserAction((KeyboardEvent)event, digest);
 
                 List<String> actionIds = activeScheme.getActionIds(digest);
 
@@ -106,6 +108,13 @@ public class KeyBindingManager implements KeyBindingAgent {
         } else {
             //webkit fires keydown events
             documentElement.addEventListener(Event.KEYDOWN, downListener, true);
+        }
+    }
+
+    private void preventDefaultBrowserAction(KeyboardEvent keyboardEvent, int digest) {
+        //prevent browser default action on Ctrl + S
+        if (digest == 65651) {
+            keyboardEvent.preventDefault();
         }
     }
 

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorExtension.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorExtension.java
@@ -163,6 +163,7 @@ public class OrionEditorExtension {
     private void defineDefaultTheme() {
         // The codenvy theme uses both an orion css file and a CssResource
         orionResource.editorStyle().ensureInjected();
+        orionResource.getIncrementalFindStyle().ensureInjected();
         OrionTextThemeOverlay.setDefaultTheme("orionCodenvy", "orion-codenvy-theme.css");
     }
 

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionResource.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionResource.java
@@ -22,4 +22,12 @@ public interface OrionResource extends ClientBundle {
 
     @Source({"orion-codenvy-theme.css", "org/eclipse/che/ide/api/ui/style.css"})
     CssResource editorStyle();
+
+    @Source({"incremental-find-container.css", "org/eclipse/che/ide/api/ui/style.css"})
+    IncrementalFindResources getIncrementalFindStyle();
+
+    interface IncrementalFindResources extends CssResource {
+        String incrementalFindContainer();
+        String incrementalFindError();
+    }
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/incremental/find/IncrementalFindReportStatusObserver.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/incremental/find/IncrementalFindReportStatusObserver.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.incremental.find;
+
+import elemental.dom.Text;
+import elemental.html.DivElement;
+
+import com.google.gwt.dom.client.Element;
+import com.google.inject.Inject;
+
+import org.eclipse.che.ide.api.editor.texteditor.EditorWidget;
+import org.eclipse.che.ide.editor.orion.client.OrionEditorWidget;
+import org.eclipse.che.ide.editor.orion.client.OrionResource;
+import org.eclipse.che.ide.status.message.StatusMessage;
+import org.eclipse.che.ide.status.message.StatusMessageObserver;
+import org.eclipse.che.ide.util.dom.Elements;
+
+import static org.eclipse.che.ide.util.StringUtils.isNullOrEmpty;
+
+/**
+ * IncrementalFindReportStatusObserver listens editor status messages and filter messages
+ * which contains information about incremental find state. It creates simple UI
+ * for user notification about incremental find operation progress.
+ * Note: incremental find can be straight or reverse.
+ *
+ * @author Alexander Andrienko
+ */
+public class IncrementalFindReportStatusObserver implements StatusMessageObserver {
+
+    private final OrionResource orionResource;
+
+    private EditorWidget editorWidget;
+    private DivElement   findDiv;
+
+    @Inject
+    public IncrementalFindReportStatusObserver(OrionResource orionResource) {
+        this.orionResource = orionResource;
+    }
+
+    /**
+     * Sets editor widget which contains text source to incremental search.
+     *
+     * @param editorWidget
+     *         editor widget with content to search.
+     */
+    public void setEditorWidget(OrionEditorWidget editorWidget) {
+        this.editorWidget = editorWidget;
+    }
+
+    /**
+     *
+     * Checks if {@code statusMessage} is incremental find message.
+     * In case if this is true than create or update simple UI to display
+     * message content, otherwise skip this message.
+     *
+     * @param statusMessage
+     *         editor status message.
+     */
+    @Override
+    public void update(StatusMessage statusMessage) {
+        String message = statusMessage.getMessage();
+        boolean isIncrementalFindMessage = message.startsWith("Incremental find:") | message.startsWith("Reverse Incremental find:");
+        if (!message.isEmpty() && !isIncrementalFindMessage) {
+            return;
+        }
+
+        Element editorElem = editorWidget.asWidget().getElement();
+
+        Element findDiv = createFindDiv(message);
+        setStyle(message, findDiv);
+        editorElem.appendChild(findDiv);
+
+        if (isNullOrEmpty(message) && findDiv != null) {
+            editorElem.removeChild(findDiv);
+            this.findDiv = null;
+        }
+    }
+
+    private Element createFindDiv(String message) {
+        if (findDiv == null) {
+            findDiv = Elements.createDivElement();
+            Text messageNode = Elements.createTextNode(message);
+            findDiv.appendChild(messageNode);
+        }
+
+        findDiv.getFirstChild().setTextContent(message);
+        return (Element)findDiv;
+    }
+
+    private void setStyle(String message, Element element) {
+        if (message.endsWith("(not found)")) {
+            element.addClassName(orionResource.getIncrementalFindStyle().incrementalFindContainer());
+            element.addClassName(orionResource.getIncrementalFindStyle().incrementalFindError());
+        } else {
+            element.setClassName(orionResource.getIncrementalFindStyle().incrementalFindContainer());
+        }
+    }
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/inject/OrionEditorGinModule.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/inject/OrionEditorGinModule.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.editor.orion.client.ContentAssistWidgetFactory;
 import org.eclipse.che.ide.editor.orion.client.OrionEditorBuilder;
 import org.eclipse.che.ide.editor.orion.client.OrionEditorWidget;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionCodeEditWidgetOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionEditorOptionsOverlay;
 import org.eclipse.che.ide.requirejs.ModuleHolder;
 
 @ExtensionGinModule
@@ -37,6 +38,7 @@ public class OrionEditorGinModule extends AbstractGinModule {
         install(new GinFactoryModuleBuilder().build(new TypeLiteral<EditorWidgetFactory<OrionEditorWidget>>() {}));
 
         bind(OrionCodeEditWidgetOverlay.class).toProvider(OrionCodeEditWidgetProvider.class);
+        bind(OrionEditorOptionsOverlay.class).toProvider(OrionEditorOptionsOverlayProvider.class);
 
         install(new GinFactoryModuleBuilder().build(ContentAssistWidgetFactory.class));
 

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/inject/OrionEditorOptionsOverlayProvider.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/inject/OrionEditorOptionsOverlayProvider.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.inject;
+
+import org.eclipse.che.ide.editor.orion.client.jso.OrionEditorOptionsOverlay;
+
+import com.google.inject.Provider;
+
+/**
+ * @author Alexander Andrienko
+ */
+public class OrionEditorOptionsOverlayProvider implements Provider<OrionEditorOptionsOverlay> {
+    @Override
+    public OrionEditorOptionsOverlay get() {
+        return OrionEditorOptionsOverlay.createObject().cast();
+    }
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionEditorOptionsOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionEditorOptionsOverlay.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Overlay for Orion editor options.
+ *
+ * @author Alexander Andrienko
+ */
+public class OrionEditorOptionsOverlay extends JavaScriptObject {
+
+    protected OrionEditorOptionsOverlay() {
+    }
+
+    /**
+     * Returns status reporter function.
+     * This function handles editor status messages.
+     */
+    public final native JavaScriptObject getStatusReporter() /*-{
+        return this.statusReporter;
+    }-*/;
+
+    /**
+     * Set status reporter function.
+     *
+     * @param statusReporter
+     *         status reporter function.
+     */
+    public final native void setStatusReporter(JavaScriptObject statusReporter) /*-{
+        this.statusReporter = statusReporter;
+    }-*/;
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/StatusMessageReporterOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/StatusMessageReporterOverlay.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+import org.eclipse.che.ide.status.message.StatusMessageReporter;
+
+/**
+ * Overlay for status message reporter function
+ * which sends messages about editor status.
+ *
+ * @author Alexander Andrienko
+ */
+public class StatusMessageReporterOverlay extends JavaScriptObject {
+
+    protected StatusMessageReporterOverlay() {
+    }
+
+    /**
+     * Create StatusMessageReporterOverlay for delegation status message
+     * reporting to class {@link StatusMessageReporter}.
+     *
+     * @param messageReporter
+     *         delegate to report message status of the editor.
+     */
+    public static final native StatusMessageReporterOverlay create(StatusMessageReporter messageReporter) /*-{
+        return function (message, type, isAccessible) {
+            messageReporter.@org.eclipse.che.ide.status.message.StatusMessageReporter::notifyObservers(*)(message, type, isAccessible)
+        };
+    }-*/;
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/status/message/StatusMessage.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/status/message/StatusMessage.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.status.message;
+
+import java.util.Objects;
+
+/**
+ * The message to show about Orion editor status.
+ *
+ * @author Alexander Andrienko
+ */
+public class StatusMessage {
+
+    private String  message;
+    private String  type;
+    private boolean isAccessible;
+
+    public StatusMessage(String message, String type, boolean isAccessible) {
+        this.message = message;
+        this.type = type;
+        this.isAccessible = isAccessible;
+    }
+
+    /**
+     * Returns the message to show.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Returns the message type. Either normal or "progress" or "error".
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * If returns <code>true</code>, a screen reader will read this message.
+     */
+    public boolean isAccessible() {
+        return isAccessible;
+    }
+
+    @Override
+    public String toString() {
+        return "StatusMessage{" +
+               "message='" + message + '\'' +
+               ", type='" + type + '\'' +
+               ", isAccessible=" + isAccessible +
+               '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StatusMessage)) {
+            return false;
+        }
+        StatusMessage that = (StatusMessage)obj;
+
+        return Objects.equals(message, that.message) &&
+               Objects.equals(type, that.type) &&
+               isAccessible == that.isAccessible;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + message.hashCode();
+        hash = 31 * hash + type.hashCode();
+        hash = 31 * hash + (isAccessible ? 1 : 0);
+        return hash;
+    }
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/status/message/StatusMessageObserver.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/status/message/StatusMessageObserver.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.status.message;
+
+/**
+ * Observer to update object which is
+ * interested in {@link StatusMessage} report.
+ *
+ * @author Alexander Andrienko
+ */
+public interface StatusMessageObserver {
+    /**
+     * Update interested object by new editor status message.
+     *
+     * @param message
+     *         message about editor status.
+     */
+    void update(StatusMessage message);
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/status/message/StatusMessageReporter.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/status/message/StatusMessageReporter.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.status.message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reporter to notify all interested objects about Orion
+ * editor status message.
+ *
+ * @author Alexander Andrienko
+ */
+public class StatusMessageReporter {
+
+    private List<StatusMessageObserver> observers = new ArrayList<>();
+
+    /**
+     * Register {@code observer}.
+     *
+     * @param observer
+     *         object to notify about new editor status message.
+     */
+    public void registerObserver(StatusMessageObserver observer) {
+        observers.add(observer);
+    }
+
+    /**
+     * Notify all observers about new editor status message.
+     *
+     * @param message
+     *         message about editor status.
+     * @param type
+     *         message type
+     * @param isAccessible
+     *         specified for orion attribute, describes screen
+     *         reader ability to read new status message.
+     */
+    public void notifyObservers(String message, String type, boolean isAccessible) {
+        for (StatusMessageObserver observer : observers) {
+            observer.update(new StatusMessage(message, type, isAccessible));
+        }
+    }
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/incremental-find-container.css
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/incremental-find-container.css
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+.incrementalFindContainer {
+    min-width: 194px;
+    padding: 4px 3px;
+    height: 20px;
+    background-color: panelBackgroundColor;
+    right: 40px;
+    z-index: 150;
+    position: absolute;
+    border: 1px solid black;
+    box-shadow: 0 1px 0 0 #3c3c3c;
+    border-radius: 3px;
+}
+
+.incrementalFindError {
+    color: errorColor;
+}


### PR DESCRIPTION
### What does this PR do?
Fix Ctrl + S hotKey for Emacs. Add simple UI for incremental search. This UI used for straight incremental find "Ctrl + S" and for revers incremental find "Ctrl + R" on the EMACS keybinding.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/2992

### Previous behavior
Ctrl + S hotkey combination doesn't work.  And reverse incremental find (Ctrl + R) has no UI for displaying user typing.

### New behavior
Ctrl + S and Strl + R works by EMACS keybinding and user typing displays on the simple special UI.
@vparfonov @azatsarynnyy  @slemeur @tolusha review please.
![incrementalfind](https://cloud.githubusercontent.com/assets/6873095/20835238/242d345a-b8a2-11e6-97f6-792164e352cc.png)
![incrementalfind2](https://cloud.githubusercontent.com/assets/6873095/20835292/6ccf6df4-b8a2-11e6-99c4-ce06c03e538c.png)



