### PR TITLE
Make ProjectManager a non-final class

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -74,7 +74,7 @@ import static java.lang.String.format;
  * @author gazarenkov
  */
 @Singleton
-public final class ProjectManager {
+public class ProjectManager {
     private static final Logger LOG = LoggerFactory.getLogger(ProjectManager.class);
 
     private final VirtualFileSystem              vfs;


### PR DESCRIPTION
### What does this PR do?

Make ``ProjectManager`` a non-final class.

### What issues does this PR fix or reference?

Allow mocking and extending ``ProjectManager`` more easily - ``final`` classes are very limited when mocking them and they cannot be extended for injecting modified behavior.
