### PR TITLE
Add "Run/Debug PHP script" commands to the PHP and Zend stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -590,7 +590,7 @@
     "id": "php-default",
     "creator": "ide",
     "name": "PHP",
-    "description": "Default PHP Stack with PHP 5.5, most popular extensions and dockerimager.",
+    "description": "Default PHP Stack with PHP 5.6, most popular extensions and dockerimager.",
     "scope": "general",
     "tags": [
       "Ubuntu",
@@ -604,7 +604,7 @@
     "components": [
       {
         "name": "PHP",
-        "version": "5.5.9"
+        "version": "5.6.24"
       },
       {
         "name": "Apache",
@@ -651,6 +651,22 @@
       "defaultEnv": "default",
       "description": null,
       "commands": [
+        {
+          "name": "run php script",
+          "type": "custom",
+          "commandLine": "[ -z ${editor.current.file.path} ] && echo \"Open a PHP file in the editor before executing this command.\" || php ${editor.current.file.path}",
+          "attributes": {
+            "previewUrl": ""
+          }
+        },
+        {
+          "name": "debug php script",
+          "type": "custom",
+          "commandLine": "[ -z ${editor.current.file.path} ] && echo \"Open a PHP file in the editor before executing this command.\" || QUERY_STRING=\"start_debug=1&debug_host=localhost&debug_port=10137\" php ${editor.current.file.path}",
+          "attributes": {
+            "previewUrl": ""
+          }
+        },
         {
           "name": "start apache",
           "type": "custom",
@@ -1858,11 +1874,11 @@
     "components": [
       {
         "name": "PHP",
-        "version": "7.0.6"
+        "version": "7.0.11"
       },
       {
         "name": "Zend Server",
-        "version": "9.0.0"
+        "version": "9.0.1"
       },
       {
         "name": "Composer",
@@ -1897,6 +1913,22 @@
       "defaultEnv": "default",
       "description": null,
       "commands": [
+        {
+          "name": "run php script",
+          "type": "custom",
+          "commandLine": "[ -z ${editor.current.file.path} ] && echo \"Open a PHP file in the editor before executing this command.\" || php ${editor.current.file.path}",
+          "attributes": {
+            "previewUrl": ""
+          }
+        },
+        {
+          "name": "debug php script",
+          "type": "custom",
+          "commandLine": "[ -z ${editor.current.file.path} ] && echo \"Open a PHP file in the editor before executing this command.\" || QUERY_STRING=\"start_debug=1&debug_host=localhost&debug_port=10137\" php ${editor.current.file.path}",
+          "attributes": {
+            "previewUrl": ""
+          }
+        },
         {
           "name": "restart zend server",
           "type": "custom",


### PR DESCRIPTION
### What does this PR do?

Adds commands to the PHP and Zend stacks for running and debugging PHP scripts, a.k.a. CLI apps:
- "run php script" - executes the PHP script open in the current editor
- "debug php script" - executes the PHP script open in the current editor in debug mode, i.e. it defines the required `QUERY_STRING` env var, so a debug session is opened to the Zend Debugger engine.

Both commands have a check if there is a file currently opened in the editor. If this is not the case, a user friendly message is printed.

### What issues does this PR fix or reference?

This PR should be merge after merging the following two PRs:
- Zend Debugger for PHP #3202
- Install Zend Debugger in the default PHP stack https://github.com/eclipse/che-dockerfiles/pull/55

### Previous behavior
The user had to type these commands manually in the Terminal. While it is relatively easy for the "run php script" command, the `QUERY_STRING` env var is complex and requires copying the value from some doc page.

### New behavior
Easier running and debugging of PHP scripts by executing Che commands.

Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>