### PR TITLE
CHE-3199: add cpu limits configuration

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -133,6 +133,30 @@ che.docker.privilege=false
 # Limits the number of processes that can be forked inside a cgroup. Set -1 for unlimited.
 # Since 4.3 kernel.
 che.docker.pids_limit=-1
+
+# Sets parent cgroup for cgroups of containers created by workspaces.
+# This allows an admin to set custom cgroup limitations to all containers of workspaces by configuring cgroups.
+# Example:
+# /my_group
+# my_another_group
+che.docker.parent_cgroup=NULL
+
+# Sets set of CPUs that can be used by each container of started workspace.
+# Example:
+# 0-3
+# 1,4
+che.docker.cpuset_cpus=NULL
+
+# Next 2 properties set limits on CPU consumption by containers of started workspaces.
+# Period sets amount of units per CPU core.
+# Quota sets amount of units available for container per whole CPU.
+# Max value of quota could be period * number of CPU cores in a system.
+# Example:
+# che.docker.cpu_period=5000
+# che.docker.cpu_quota=10000
+che.docker.cpu_period=0
+che.docker.cpu_quota=0
+
 # Adds options when mounting the /projects volume.
 che.docker.volumes_projects_options=Z
 
@@ -183,7 +207,6 @@ che.docker.tcp_connection_read_timeout_ms=600000
 # default is -1 which is unlimited swap. If set, value is multipled by machine memory set by user
 # to determine swap size. To disable swap set to 0.
 che.docker.swap=-1
-
 
 ### INTERNAL
 # Remove locations where internal message bus events should be propagated to.

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -200,6 +200,44 @@
 #     unlimited. Requires Docker running on a 4.3 Linux kernel.
 #CHE_DOCKER_PIDS__LIMIT=-1
 
+# CPU cores limit
+#     Configuration of CPU cores used for running docker containers in workspaces.
+#     Example:
+#         CODENVY_DOCKER_CPUSET__CPUS=0-3
+#         CODENVY_DOCKER_CPUSET__CPUS=0,2
+#     See more at https://docs.docker.com/engine/reference/run/#/cpuset-constraint
+#CHE_DOCKER_CPUSET__CPUS=NULL
+
+# CPU consumption limit
+#     Next 2 values set limits on CPU consumption by containers of started workspaces.
+#     Period sets amount of units per CPU core.
+#     Quota sets amount of units available for container per whole CPU.
+#     Max value of quota could be period * number of CPU cores in a system.
+#     Example:
+#         These values allows usage of 100% of 2 cores on 2+ cores system.
+#         Period declares that 100% is equal to 5000 units
+#         and container is allowed to use 2x more than 1 core.
+#         Although max consumption is explained in cores performance workload will be
+#         splitted between several cores.
+#         CODENVY_DOCKER_CPU__PERIOD=5000
+#         CODENVY_DOCKER_CPU__QUOTA=10000
+#         In this example limit is set to half of a CPU core.
+#         CODENVY_DOCKER_CPU__PERIOD=10000
+#         CODENVY_DOCKER_CPU__QUOTA=5000
+#    See more at https://docs.docker.com/engine/reference/run/#/cpu-period-constraint
+#                https://docs.docker.com/engine/reference/run/#/cpu-quota-constraint
+#CODENVY_DOCKER_CPU__PERIOD=0
+#CODENVY_DOCKER_CPU__QUOTA=0
+
+# Cgroup parent for containers
+#     Admin can configure cgroup with appropriate limits and set it with this variable as
+#     parent for all cgroups of containers created by workspaces. The value can start
+#     from slash which means it will be absolute or without slash for relative.
+#     Docker will create this cgroup if it is missing.
+#     Then admin can configure limits on this cgroup on all nodes in a system specific way.
+#     See more at https://docs.docker.com/engine/reference/run/#/specifying-custom-cgroups
+#CODENVY_DOCKER_PARENT_CGROUP=NULL
+
 # SELinux Options
 #     By default, your source code is mounted into a workspace into /projects folder.
 #     On SELinux and other OS, you may need to add additional mounting attributes.

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -200,25 +200,25 @@
 #     unlimited. Requires Docker running on a 4.3 Linux kernel.
 #CHE_DOCKER_PIDS__LIMIT=-1
 
-# CPU cores limit
-#     Configuration of CPU cores used for running docker containers in workspaces.
+# CPU Core Limits
+#     Limit the CPU cores used for running Che workspaces as containers.
 #     Example:
 #         CODENVY_DOCKER_CPUSET__CPUS=0-3
 #         CODENVY_DOCKER_CPUSET__CPUS=0,2
 #     See more at https://docs.docker.com/engine/reference/run/#/cpuset-constraint
 #CHE_DOCKER_CPUSET__CPUS=NULL
 
-# CPU consumption limit
-#     Next 2 values set limits on CPU consumption by containers of started workspaces.
-#     Period sets amount of units per CPU core.
-#     Quota sets amount of units available for container per whole CPU.
+# CPU Consumption Limit
+#     Limit the CPU utilitization given to containers powering workspaces started
+#     by Che. 'period' sets the amount of units for each CPU core. 'quota' sets the
+#     sets amount of units available per whole CPU.
 #     Max value of quota could be period * number of CPU cores in a system.
 #     Example:
 #         These values allows usage of 100% of 2 cores on 2+ cores system.
 #         Period declares that 100% is equal to 5000 units
 #         and container is allowed to use 2x more than 1 core.
 #         Although max consumption is explained in cores performance workload will be
-#         splitted between several cores.
+#         split between several cores.
 #         CODENVY_DOCKER_CPU__PERIOD=5000
 #         CODENVY_DOCKER_CPU__QUOTA=10000
 #         In this example limit is set to half of a CPU core.
@@ -229,12 +229,11 @@
 #CODENVY_DOCKER_CPU__PERIOD=0
 #CODENVY_DOCKER_CPU__QUOTA=0
 
-# Cgroup parent for containers
-#     Admin can configure cgroup with appropriate limits and set it with this variable as
-#     parent for all cgroups of containers created by workspaces. The value can start
-#     from slash which means it will be absolute or without slash for relative.
-#     Docker will create this cgroup if it is missing.
-#     Then admin can configure limits on this cgroup on all nodes in a system specific way.
+# CGroup Parent
+#     CGroups allow admins to to configure limits on nodes in a system in a specific
+#     way. The value can start with a slash which means it will be absolute or 
+#     without a slash for relative value. Docker will create this cgroup if it is missing.
+#     Admin can configure limits on this cgroup on all nodes in a system specific way.
 #     See more at https://docs.docker.com/engine/reference/run/#/specifying-custom-cgroups
 #CODENVY_DOCKER_PARENT_CGROUP=NULL
 

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -6,7 +6,7 @@
 # Parameters that affect the initial system operation.
 #
 
-# IP address, hostname, or DNS  
+# IP address, hostname, or DNS
 #     The IP address or DNS name of where the Che endpoint will service your users.
 #     If you are running this on a local system, we auto-detect this value as the IP
 #     address of your Docker daemon. On many systems, especially those from cloud hosters
@@ -15,14 +15,14 @@
 #CHE_HOST=localhost
 
 # Proxies
-#     Che's internal system services such as its internal JVMs need to 
-#     have system level properties applied so that they can reach the Internet. Che's 
-#     system uses the Internet to communicate with DockerHub for downloading images that 
+#     Che's internal system services such as its internal JVMs need to
+#     have system level properties applied so that they can reach the Internet. Che's
+#     system uses the Internet to communicate with DockerHub for downloading images that
 #     are used to run Che's systems. Note that you must configure proxy access in three
-#     locations. First, you enabled your system Docker daemon to use proxies. Second, you 
-#     configure proxies for Che's internal system services. Third, if you want your users 
+#     locations. First, you enabled your system Docker daemon to use proxies. Second, you
+#     configure proxies for Che's internal system services. Third, if you want your users
 #     to access the Internet, then you should also add proxy values for their workspaces.
-#    
+#
 #     Please be mindful of the proxy URL formatting. Proxies are unforgiving if you do not
 #     type the URL properly, including the protocol and whether they allow a trailing /.
 #CHE_HTTP_PROXY_FOR_CHE=http://myproxy.com:8001/
@@ -44,8 +44,8 @@
 
 
 # XMX
-#      Che's core server runs as a Tomcat application on top of a JVM. This sets the 
-#      JVM XMX settings that are loaded by the JVM when the Che container boots. 
+#      Che's core server runs as a Tomcat application on top of a JVM. This sets the
+#      JVM XMX settings that are loaded by the JVM when the Che container boots.
 #      It should be rare that you would need to change this.
 #CHE_SERVER_XMX=2048
 
@@ -56,22 +56,22 @@
 #
 # User workspaces have their own runtimes. Those runtimes are composed of 1..n containers.
 # We call each container a 'machine' as it is a dedicated runtime. One of the machines for
-# a workspace must be designated as the 'development' machine, which installs Che agents to 
+# a workspace must be designated as the 'development' machine, which installs Che agents to
 # provide additional services to the user. These parameters configure how Che manages user
-# machines and the agents that are deployed within them. 
+# machines and the agents that are deployed within them.
 #
 # Since workspaces have their own runtimes, they have separate proxies that do not inherit
 # from system proxies that you have configured for your Docker daemon.
 #
 # /etc/hosts
 #     This will add entries into the user's /etc/hosts file that is running within their
-#     workspace. You may need to configure this to give user's access to systems within 
+#     workspace. You may need to configure this to give user's access to systems within
 #     your network or access to the Internet.
 #CHE_MACHINE_EXTRA_HOSTS=NULL
 
 # Idle Timeout
 #     The system will suspend the workspace and snapshot it if the end user is idle for
-#     this length of time. Idleness is determined by the length of time that a user has 
+#     this length of time. Idleness is determined by the length of time that a user has
 #     not interacted with the workspace, meaning that one of our agents has not received
 #     instructions. Leaving a browser window open counts as idleness time.
 #CHE_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS=600000
@@ -81,10 +81,10 @@
 #CHE_MACHINE_DEFAULT_MEM_SIZE_MB=1024
 
 # Memory Swap
-#     Adjust machine swap memory by multiplication current machnine memory on provided 
-#     value. Default is 0 which means disabled swap, if set multiplier value equal to 0.5 
-#     machine swap will be configured with size that equal to half of current machine memory. 
-#     It should be rare that you would configure this. See Docker memory swap online 
+#     Adjust machine swap memory by multiplication current machnine memory on provided
+#     value. Default is 0 which means disabled swap, if set multiplier value equal to 0.5
+#     machine swap will be configured with size that equal to half of current machine memory.
+#     It should be rare that you would configure this. See Docker memory swap online
 #     for background.
 #CHE_MACHINE_DOCKER_MEMORY_SWAP_MULTIPLIER=0
 
@@ -96,16 +96,16 @@
 
 # Privilged Mode
 #     Set to `true` if you would like user workspaces to be started with Docker's
-#     privileged mode. Please be careful when setting this property. This allows 
-#     user workspaces to gain access to the underly host with root privileges. 
+#     privileged mode. Please be careful when setting this property. This allows
+#     user workspaces to gain access to the underly host with root privileges.
 #     However, privileged mode is needed if users want to launch their own Docker
 #     containers from within their Docker-powered workspace.
 #CHE_DOCKER_PRIVILEGE__MODE=false
 
 # Agent Start Timeout
 #     The length of time that a workspace will be allowed to boot before the system terminates the
-#     boot process. If the Che container cannot establish two way communications with the 
-#     agents within the workspace when it boots, then the workspace will not be started. 
+#     boot process. If the Che container cannot establish two way communications with the
+#     agents within the workspace when it boots, then the workspace will not be started.
 #CHE_MACHINE_WS_AGENT_MAX_START_TIME_MS=300000
 
 
@@ -119,7 +119,7 @@
 # workspaces establish connections to one another, and also how remote browser clients
 # should discover and connect to workspaces.
 #
-# Che goes through a progression algorithm to establish the protocol, IP address and 
+# Che goes through a progression algorithm to establish the protocol, IP address and
 # port to establish communications with it is booting or starting a workspace.
 #
 # Browser --> Che Server
@@ -140,7 +140,7 @@
 # Workspace Agent --> Che Server
 #    1. Default is http://che-host:${SERVER_PORT}/wsmaster/api, where che-host is IP of server.
 #    2. Else, use value of che.workspace.che_server_endpoint
-#    3. Else, if 'docker0' interface is unreachable, then che-host replaced with 
+#    3. Else, if 'docker0' interface is unreachable, then che-host replaced with
 #       172.17.42.1 or 192.168.99.1
 #    4. Else, print connection exception
 
@@ -151,10 +151,10 @@
 #####                                                                              #####
 #
 # IP Address
-#     The IP address of the Docker daemon that is running on your host. We do a 
-#     self-discovery to auto-set this. You can combine this with DOCKER_HOST to change 
-#     communications from socket to TCP. This value will be set to DOCKER_MACHINE_HOST 
-#     env variable for the Che Docker container when it boots - it's how we determine 
+#     The IP address of the Docker daemon that is running on your host. We do a
+#     self-discovery to auto-set this. You can combine this with DOCKER_HOST to change
+#     communications from socket to TCP. This value will be set to DOCKER_MACHINE_HOST
+#     env variable for the Che Docker container when it boots - it's how we determine
 #     what containers will boot.
 #CHE_DOCKER_IP=172.17.0.1
 
@@ -170,15 +170,15 @@
 
 # Docker Registry
 #     Docker is the default machine implementation within Che. Workspaces are powered
-#     by machines that are constructed when the workspace is started. The images used to 
+#     by machines that are constructed when the workspace is started. The images used to
 #     generate containers for the machines can come from DockerHub or a private
 #     Docker registry.
-#   
+#
 #     You can have an internal registry configured for Che to store images:
 #CHE_DOCKER_REGISTRY=${CHE_REGISTRY_HOST}:5000
-#  
+#
 #     You can configure 1..n private registries for Che to connect to when searching
-#     for Docker images to be used for your workspaces. 
+#     for Docker images to be used for your workspaces.
 #CHE_DOCKER_REGISTRY_AUTH_<insert-name>_URL=https://index.docker.io/v1/
 #CHE_DOCKER_REGISTRY_AUTH_<insert-name>_USERNAME=<username>
 #CHE_DOCKER_REGISTRY_AUTH_<insert-name>_URL=https://index.docker.io/v1/
@@ -191,20 +191,20 @@
 
 # Force Image Update
 #     If true, then Che always pulls an image from a registry even if it is cached
-#     If false, Docker only pulls the image if it does not exist locally. This can 
+#     If false, Docker only pulls the image if it does not exist locally. This can
 #     create situations where images are not current, but a forced pull is slower.
 #CHE_DOCKER_ALWAYS__PULL__IMAGE=true
 
 # Control User Processes
-#     Limits the number of processes that can be forked inside a cgroup. Set -1 for 
+#     Limits the number of processes that can be forked inside a cgroup. Set -1 for
 #     unlimited. Requires Docker running on a 4.3 Linux kernel.
 #CHE_DOCKER_PIDS__LIMIT=-1
 
 # CPU Core Limits
 #     Limit the CPU cores used for running Che workspaces as containers.
 #     Example:
-#         CODENVY_DOCKER_CPUSET__CPUS=0-3
-#         CODENVY_DOCKER_CPUSET__CPUS=0,2
+#         CHE_DOCKER_CPUSET__CPUS=0-3
+#         CHE_DOCKER_CPUSET__CPUS=0,2
 #     See more at https://docs.docker.com/engine/reference/run/#/cpuset-constraint
 #CHE_DOCKER_CPUSET__CPUS=NULL
 
@@ -219,23 +219,29 @@
 #         and container is allowed to use 2x more than 1 core.
 #         Although max consumption is explained in cores performance workload will be
 #         split between several cores.
-#         CODENVY_DOCKER_CPU__PERIOD=5000
-#         CODENVY_DOCKER_CPU__QUOTA=10000
+#         CHE_DOCKER_CPU__PERIOD=5000
+#         CHE_DOCKER_CPU__QUOTA=10000
 #         In this example limit is set to half of a CPU core.
-#         CODENVY_DOCKER_CPU__PERIOD=10000
-#         CODENVY_DOCKER_CPU__QUOTA=5000
+#         CHE_DOCKER_CPU__PERIOD=10000
+#         CHE_DOCKER_CPU__QUOTA=5000
 #    See more at https://docs.docker.com/engine/reference/run/#/cpu-period-constraint
 #                https://docs.docker.com/engine/reference/run/#/cpu-quota-constraint
-#CODENVY_DOCKER_CPU__PERIOD=0
-#CODENVY_DOCKER_CPU__QUOTA=0
+#CHE_DOCKER_CPU__PERIOD=0
+#CHE_DOCKER_CPU__QUOTA=0
 
 # CGroup Parent
 #     CGroups allow admins to to configure limits on nodes in a system in a specific
-#     way. The value can start with a slash which means it will be absolute or 
+#     way. The value can start with a slash which means it will be absolute or
 #     without a slash for relative value. Docker will create this cgroup if it is missing.
 #     Admin can configure limits on this cgroup on all nodes in a system specific way.
+#     Example:
+#         On Ubuntu 16.04 use CHE_DOCKER_PARENT__CGROUP=/my_group. Then let container
+#         create cgoup by running Che. Then edit
+#         /sys/fs/cgroup/<resource folder>/my_group/<resource file>
+#         For example to limit CPU cores to 0-1 put value "0-1" into file
+#         /sys/fs/cgroup/cpuset/my_group/cpuset.cpus
 #     See more at https://docs.docker.com/engine/reference/run/#/specifying-custom-cgroups
-#CODENVY_DOCKER_PARENT_CGROUP=NULL
+#CHE_DOCKER_PARENT__CGROUP=NULL
 
 # SELinux Options
 #     By default, your source code is mounted into a workspace into /projects folder.
@@ -261,7 +267,7 @@
 #####                                     OAUTH                                    #####
 #####                                                                              #####
 #
-# You can configure a 3rd party provider's oAuth, which will be used for your users when 
+# You can configure a 3rd party provider's oAuth, which will be used for your users when
 # they initiate Git actions from within Che.
 #
 # GitHub
@@ -277,9 +283,9 @@
 #####                                                                              #####
 #####                                      JMX                                     #####
 #####                                                                              #####
-# 
-# JMX provides a management interface point to within the Che container. JMX is not 
-# use by other containers such as haproxy or nginx. While Che is running, grab the 
+#
+# JMX provides a management interface point to within the Che container. JMX is not
+# use by other containers such as haproxy or nginx. While Che is running, grab the
 # IP address of the Che container and you can connect to its embedded JMX server.
 #
 #CHE_JMX_USERNAME=admin
@@ -293,9 +299,9 @@
 # Custom che.properties Property
 #     Che's server loads name=value properties in a .properties file. Those values can
 #     be seen by custom extensions that are packaged within a Che server. There are
-#     also Che properties that are rarely configured that are shown in documentation 
+#     also Che properties that are rarely configured that are shown in documentation
 #     that can be added with a custom format here. You can add as many as you would like.
-#    
+#
 #     Add a new property in the format of CHE_<PROPERTY_NAME>=value. If in your
 #     <PROPERTY_NAME> you have a single underscore '_', that will be replaced with a
 #     dot '.'. A double underscore '__' will be replaced with a single underscore '_'.
@@ -305,5 +311,5 @@
 #CHE_WORKSPACE_AUTO__SNAPSHOT=false
 
 # A complete list of internal properties used by Che are available in the default
-# properties file that is embedded in the server's runtime. You can view it in our 
+# properties file that is embedded in the server's runtime. You can view it in our
 # GitHub repository: https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
@@ -71,10 +71,18 @@ public class ContainerConfig {
         this.env = env;
     }
 
+    /**
+     * @deprecated Use {@link HostConfig#getCpuShares()}
+     */
+    @Deprecated
     public int getCpuShares() {
         return cpuShares;
     }
 
+    /**
+     * @deprecated Use {@link HostConfig#setCpuShares(int)}
+     */
+    @Deprecated
     public void setCpuShares(int cpuShares) {
         this.cpuShares = cpuShares;
     }
@@ -182,6 +190,10 @@ public class ContainerConfig {
         return this;
     }
 
+    /**
+     * @deprecated Use {@link HostConfig#withCpuShares(int)}
+     */
+    @Deprecated
     public ContainerConfig withCpuShares(int cpuShares) {
         this.cpuShares = cpuShares;
         return this;
@@ -268,14 +280,26 @@ public class ContainerConfig {
         return this;
     }
 
+    /**
+     * @deprecated Use {@link HostConfig#getCpusetCpus()}
+     */
+    @Deprecated
     public String getCpuset() {
         return cpuset;
     }
 
+    /**
+     * @deprecated Use {@link HostConfig#setCpusetCpus(String)}
+     */
+    @Deprecated
     public void setCpuset(String cpuset) {
         this.cpuset = cpuset;
     }
 
+    /**
+     * @deprecated Use {@link HostConfig#withCpusetCpus(String)}
+     */
+    @Deprecated
     public ContainerConfig withCpuset(String cpuset) {
         this.cpuset = cpuset;
         return this;

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/HostConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/HostConfig.java
@@ -41,6 +41,8 @@ public class HostConfig {
     private String         pidMode;
     private boolean        readonlyRootfs;
     private Ulimit[]       ulimits;
+    private Long           cpuQuota;
+    private Long           cpuPeriod;
 
     private Map<String, PortBinding[]> portBindings     = new HashMap<>();
     private int                        memorySwappiness = -1;
@@ -371,6 +373,32 @@ public class HostConfig {
         return this;
     }
 
+    public Long getCpuQuota() {
+        return cpuQuota;
+    }
+
+    public void setCpuQuota(Long cpuQuota) {
+        this.cpuQuota = cpuQuota;
+    }
+
+    public HostConfig withCpuQuota(Long cpuQuota) {
+        this.cpuQuota = cpuQuota;
+        return this;
+    }
+
+    public Long getCpuPeriod() {
+        return cpuPeriod;
+    }
+
+    public void setCpuPeriod(Long cpuPeriod) {
+        this.cpuPeriod = cpuPeriod;
+    }
+
+    public HostConfig withCpuPeriod(Long cpuPeriod) {
+        this.cpuPeriod = cpuPeriod;
+        return this;
+    }
+
     public String getPidMode() {
         return pidMode;
     }
@@ -441,6 +469,8 @@ public class HostConfig {
                ", ulimits=" + Arrays.toString(ulimits) +
                ", portBindings=" + portBindings +
                ", memorySwappiness=" + memorySwappiness +
+               ", cpuPeriod='" + cpuPeriod + '\'' +
+               ", cpuQuota='" + cpuQuota + '\'' +
                '}';
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
@@ -472,21 +472,21 @@ public class BuildImageParams {
         return "BuildImageParams{" +
                "repository='" + repository + '\'' +
                ", tag='" + tag + '\'' +
-               ", authConfigs=" + authConfigs +
-               ", doForcePull=" + doForcePull +
-               ", memoryLimit=" + memoryLimit +
-               ", memorySwapLimit=" + memorySwapLimit +
-               ", files=" + files +
+               ", authConfigs='" + authConfigs + '\'' +
+               ", doForcePull='" + doForcePull + '\'' +
+               ", memoryLimit='" + memoryLimit + '\'' +
+               ", memorySwapLimit='" + memorySwapLimit + '\'' +
+               ", files=" + files + '\'' +
                ", dockerfile='" + dockerfile + '\'' +
                ", remote='" + remote + '\'' +
-               ", quiet=" + quiet +
-               ", noCache=" + noCache +
-               ", removeIntermediateContainer=" + removeIntermediateContainer +
-               ", forceRemoveIntermediateContainers=" + forceRemoveIntermediateContainers +
-               ", cpusetCpus=" + cpusetCpus +
-               ", cpuPeriod=" + cpuPeriod +
-               ", cpuQuota=" + cpuQuota +
-               ", buildArgs=" + buildArgs +
+               ", quiet='" + quiet + '\'' +
+               ", noCache='" + noCache + '\'' +
+               ", removeIntermediateContainer='" + removeIntermediateContainer + '\'' +
+               ", forceRemoveIntermediateContainers='" + forceRemoveIntermediateContainers + '\'' +
+               ", cpusetCpus='" + cpusetCpus + '\'' +
+               ", cpuPeriod='" + cpuPeriod + '\'' +
+               ", cpuQuota='" + cpuQuota + '\'' +
+               ", buildArgs='" + buildArgs + '\'' +
                '}';
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/params/BuildImageParams.java
@@ -46,6 +46,9 @@ public class BuildImageParams {
     private Boolean             removeIntermediateContainer;
     private Boolean             forceRemoveIntermediateContainers;
     private Map<String, String> buildArgs;
+    private String              cpusetCpus;
+    private Long                cpuPeriod;
+    private Long                cpuQuota;
 
     /**
      * Creates arguments holder with required parameters.
@@ -315,6 +318,42 @@ public class BuildImageParams {
         return this;
     }
 
+    /**
+     * Sets CPU cores config that is allowed to use for image build.
+     *
+     * @param cpusetCpus
+     *         CPU cores config
+     * @return this params instance
+     */
+    public BuildImageParams withCpusetCpus(String cpusetCpus) {
+        this.cpusetCpus = cpusetCpus;
+        return this;
+    }
+
+    /**
+     * Sets length of a CPU period for CPU consumption limiting in microseconds.
+     *
+     * @param cpuPeriod
+     *         length of a CPU period
+     * @return this params instance
+     */
+    public BuildImageParams withCpuPeriod(Long cpuPeriod) {
+        this.cpuPeriod = cpuPeriod;
+        return this;
+    }
+
+    /**
+     * Sets amount of CPU time that build container can get in a CPU period.
+     *
+     * @param cpuQuota
+     *         amount of CPU time in microseconds
+     * @return this params instance
+     */
+    public BuildImageParams withCpuQuota(Long cpuQuota) {
+        this.cpuQuota = cpuQuota;
+        return this;
+    }
+
     public String getRepository() {
         return repository;
     }
@@ -371,6 +410,18 @@ public class BuildImageParams {
         return buildArgs;
     }
 
+    public String getCpusetCpus() {
+        return cpusetCpus;
+    }
+
+    public Long getCpuPeriod() {
+        return cpuPeriod;
+    }
+
+    public Long getCpuQuota() {
+        return cpuQuota;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -389,6 +440,9 @@ public class BuildImageParams {
                Objects.equals(noCache, that.noCache) &&
                Objects.equals(removeIntermediateContainer, that.removeIntermediateContainer) &&
                Objects.equals(forceRemoveIntermediateContainers, that.forceRemoveIntermediateContainers) &&
+               Objects.equals(cpusetCpus, that.cpusetCpus) &&
+               Objects.equals(cpuPeriod, that.cpuPeriod) &&
+               Objects.equals(cpuQuota, that.cpuQuota) &&
                Objects.equals(buildArgs, that.buildArgs);
     }
 
@@ -407,6 +461,9 @@ public class BuildImageParams {
                             noCache,
                             removeIntermediateContainer,
                             forceRemoveIntermediateContainers,
+                            cpusetCpus,
+                            cpuPeriod,
+                            cpuQuota,
                             buildArgs);
     }
 
@@ -426,6 +483,9 @@ public class BuildImageParams {
                ", noCache=" + noCache +
                ", removeIntermediateContainer=" + removeIntermediateContainer +
                ", forceRemoveIntermediateContainers=" + forceRemoveIntermediateContainers +
+               ", cpusetCpus=" + cpusetCpus +
+               ", cpuPeriod=" + cpuPeriod +
+               ", cpuQuota=" + cpuQuota +
                ", buildArgs=" + buildArgs +
                '}';
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/params/BuildImageParamsTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/params/BuildImageParamsTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.plugin.docker.client.params;
 
 import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
-
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -28,24 +27,28 @@ import static org.testng.Assert.assertNull;
 
 /**
  * @author Mykola Morhun
+ * @author Alexander Garagatyi
  */
 public class BuildImageParamsTest {
 
-    private static final String             REPOSITORY                           = "repository";
-    private static final String             TAG                                  = "tag";
-    private static final AuthConfigs        AUTH_CONFIGS                         = mock(AuthConfigs.class);
-    private static final Boolean            DO_FORCE_PULL                        = true;
-    private static final Long               MEMORY_LIMIT                         = 12345L;
-    private static final Long               MEMORY_SWAP_LIMIT                    = 67890L;
-    private static final File               FILE                                 = new File(".");
-    private static final List<File>         FILES;
-    private static final String             DOCKERFILE                           = "/tmp/Dockerfile";
-    private static final String             REMOTE                               = "https://github.com/someuser/remote.git";
-    private static final Boolean            QUIET                                = false;
-    private static final Boolean            NO_CACHE                             = false;
-    private static final Boolean            REMOVE_INTERMEDIATE_CONTAINER        = true;
-    private static final Boolean            FORCE_REMOVE_INTERMEDIATE_CONTAINERS = true;
-    private static final Map<String,String> BUILD_ARGS                           = new HashMap<>();
+    private static final String              REPOSITORY                           = "repository";
+    private static final String              TAG                                  = "tag";
+    private static final AuthConfigs         AUTH_CONFIGS                         = mock(AuthConfigs.class);
+    private static final Boolean             DO_FORCE_PULL                        = true;
+    private static final Long                MEMORY_LIMIT                         = 12345L;
+    private static final Long                MEMORY_SWAP_LIMIT                    = 67890L;
+    private static final File                FILE                                 = new File(".");
+    private static final String              DOCKERFILE                           = "/tmp/Dockerfile";
+    private static final String              REMOTE                               = "https://github.com/someuser/remote.git";
+    private static final Boolean             QUIET                                = false;
+    private static final Boolean             NO_CACHE                             = false;
+    private static final Boolean             REMOVE_INTERMEDIATE_CONTAINER        = true;
+    private static final Boolean             FORCE_REMOVE_INTERMEDIATE_CONTAINERS = true;
+    private static final Map<String, String> BUILD_ARGS                           = new HashMap<>();
+    private static final String              CPUSET_CPUS                          = "0-3";
+    private static final Long                CPU_PERIOD                           = 50000L;
+    private static final Long                CPU_QUOTA                            = 150000L;
+    private static final List<File> FILES;
 
     static {
         FILES = new ArrayList<>();
@@ -78,6 +81,9 @@ public class BuildImageParamsTest {
         assertNull(buildImageParams.isRemoveIntermediateContainer());
         assertNull(buildImageParams.isForceRemoveIntermediateContainers());
         assertNull(buildImageParams.getBuildArgs());
+        assertNull(buildImageParams.getCpusetCpus());
+        assertNull(buildImageParams.getCpuPeriod());
+        assertNull(buildImageParams.getCpuQuota());
     }
 
     @Test
@@ -99,8 +105,10 @@ public class BuildImageParamsTest {
         assertNull(buildImageParams.isRemoveIntermediateContainer());
         assertNull(buildImageParams.isForceRemoveIntermediateContainers());
         assertNull(buildImageParams.getBuildArgs());
+        assertNull(buildImageParams.getCpusetCpus());
+        assertNull(buildImageParams.getCpuPeriod());
+        assertNull(buildImageParams.getCpuQuota());
     }
-
 
     @Test
     public void shouldCreateParamsObjectWithAllPossibleParametersFromFiles() {
@@ -116,6 +124,9 @@ public class BuildImageParamsTest {
                                            .withNoCache(NO_CACHE)
                                            .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
                                            .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
+                                           .withCpusetCpus(CPUSET_CPUS)
+                                           .withCpuPeriod(CPU_PERIOD)
+                                           .withCpuQuota(CPU_QUOTA)
                                            .withBuildArgs(BUILD_ARGS);
 
         assertNull(buildImageParams.getRemote());
@@ -133,6 +144,9 @@ public class BuildImageParamsTest {
         assertEquals(buildImageParams.isRemoveIntermediateContainer(), REMOVE_INTERMEDIATE_CONTAINER);
         assertEquals(buildImageParams.isForceRemoveIntermediateContainers(), FORCE_REMOVE_INTERMEDIATE_CONTAINERS);
         assertEquals(buildImageParams.getBuildArgs(), BUILD_ARGS);
+        assertEquals(buildImageParams.getCpusetCpus(), CPUSET_CPUS);
+        assertEquals(buildImageParams.getCpuPeriod(), CPU_PERIOD);
+        assertEquals(buildImageParams.getCpuQuota(), CPU_QUOTA);
     }
 
     @Test
@@ -149,6 +163,9 @@ public class BuildImageParamsTest {
                                            .withNoCache(NO_CACHE)
                                            .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
                                            .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
+                                           .withCpusetCpus(CPUSET_CPUS)
+                                           .withCpuPeriod(CPU_PERIOD)
+                                           .withCpuQuota(CPU_QUOTA)
                                            .withBuildArgs(BUILD_ARGS);
 
         assertNull(buildImageParams.getFiles());
@@ -166,6 +183,9 @@ public class BuildImageParamsTest {
         assertEquals(buildImageParams.isRemoveIntermediateContainer(), REMOVE_INTERMEDIATE_CONTAINER);
         assertEquals(buildImageParams.isForceRemoveIntermediateContainers(), FORCE_REMOVE_INTERMEDIATE_CONTAINERS);
         assertEquals(buildImageParams.getBuildArgs(), BUILD_ARGS);
+        assertEquals(buildImageParams.getCpusetCpus(), CPUSET_CPUS);
+        assertEquals(buildImageParams.getCpuPeriod(), CPU_PERIOD);
+        assertEquals(buildImageParams.getCpuQuota(), CPU_QUOTA);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -211,205 +231,63 @@ public class BuildImageParamsTest {
 
     @Test
     public void repositoryParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.getRepository());
     }
 
     @Test
     public void tagParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.getTag());
     }
 
     @Test
     public void authConfigParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.getAuthConfigs());
     }
 
     @Test
     public void doForcePullParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.isDoForcePull());
     }
 
     @Test
     public void memoryLimitParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.getMemoryLimit());
     }
 
     @Test
     public void memorySwapLimitParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.getMemorySwapLimit());
     }
 
     @Test
     public void dockerfileParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
+        buildImageParams.withRepository(REPOSITORY);
 
         assertNull(buildImageParams.getDockerfile());
     }
 
     @Test
     public void quietParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.isQuiet());
     }
 
     @Test
     public void noCacheParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.isNoCache());
     }
 
     @Test
     public void removeIntermediateContainerParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.isRemoveIntermediateContainer());
     }
 
     @Test
     public void forceRemoveIntermediateContainersParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withBuildArgs(BUILD_ARGS);
-
         assertNull(buildImageParams.isForceRemoveIntermediateContainers());
     }
 
     @Test
     public void buildArgsParameterShouldEqualsNullIfItNotSet() {
-        buildImageParams.withRepository(REPOSITORY)
-                        .withTag(TAG)
-                        .withAuthConfigs(AUTH_CONFIGS)
-                        .withDoForcePull(DO_FORCE_PULL)
-                        .withMemoryLimit(MEMORY_LIMIT)
-                        .withMemorySwapLimit(MEMORY_SWAP_LIMIT)
-                        .withDockerfile(DOCKERFILE)
-                        .withQuiet(QUIET)
-                        .withNoCache(NO_CACHE)
-                        .withRemoveIntermediateContainers(REMOVE_INTERMEDIATE_CONTAINER)
-                        .withForceRemoveIntermediateContainers(FORCE_REMOVE_INTERMEDIATE_CONTAINERS);
-
         assertNull(buildImageParams.getBuildArgs());
     }
 
@@ -447,4 +325,18 @@ public class BuildImageParamsTest {
         assertEquals(buildImageParams.getBuildArgs().get(key), value);
     }
 
+    @Test
+    public void cpuQuotaParameterShouldBeNullIfItNotSet() {
+        assertNull(buildImageParams.getCpuQuota());
+    }
+
+    @Test
+    public void cpuPeriodParameterShouldBeNullIfItNotSet() {
+        assertNull(buildImageParams.getCpuPeriod());
+    }
+
+    @Test
+    public void cpusetCpusParameterShouldBeNullIfItNotSet() {
+        assertNull(buildImageParams.getCpusetCpus());
+    }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -140,12 +140,10 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
             md.put("config.workingDir", config.getWorkingDir());
             md.put("config.cmd", Arrays.toString(config.getCmd()));
             md.put("config.volumes", String.valueOf(config.getVolumes()));
-            md.put("config.cpuset", config.getCpuset());
             md.put("config.entrypoint", Arrays.toString(config.getEntrypoint()));
             md.put("config.exposedPorts", String.valueOf(config.getExposedPorts()));
             md.put("config.macAddress", config.getMacAddress());
             md.put("config.securityOpts", Arrays.toString(config.getSecurityOpts()));
-            md.put("config.cpuShares", Integer.toString(config.getCpuShares()));
             md.put("config.env", Arrays.toString(config.getEnv()));
             md.put("config.attachStderr", Boolean.toString(config.isAttachStderr()));
             md.put("config.attachStdin", Boolean.toString(config.isAttachStdin()));


### PR DESCRIPTION
### What does this PR do?
Adds limits for containers of a workspace.

I added next properties to configure limits:
**che.docker.parent_cgroup=NULL**
Sets parent cgroup for cgroups of containers created by workspaces.
This allows an admin to set custom cgroup limitations to all containers of workspaces by configuring cgroups.
Example:
/my_group
my_another_group
**che.docker.cpuset_cpus=NULL**
Sets set of CPUs that can be used by each container of started workspace.
Example:
0-3
1,4
**che.docker.cpu_period=0
che.docker.cpu_quota=0**
These 2 properties set limits on CPU consumption by containers of started workspaces.
Period sets amount of units per CPU core.
Quota sets amount of units available for container per whole CPU.
Max value of quota could be period * number of CPU cores in a system.
Example:
che.docker.cpu_period=5000
che.docker.cpu_quota=10000


### What issues does this PR fix or reference?
#3199 