### PR TITLE
Plugin lombok

### DIFF
--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -245,6 +245,17 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-lombok-server</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>lombok</artifactId>
+                    <groupId>org.projectlombok</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/plugins/plugin-lombok/README.md
+++ b/plugins/plugin-lombok/README.md
@@ -1,0 +1,137 @@
+# Description
+
+This provides a plugin to enable lombok in eclipse che.
+
+
+## How to build plugin-lombok
+
+
+### 1- Change Version
+
+change version to your current eclipse che version in these files
+
+	plugin-lombok/che-plugin-lombok-server/pom.xml
+	plugin-lombok/pom.xml
+
+
+### 2- Copy plugin folder to eclipse che plugins
+
+put the repo inside plugins folder of che source
+
+add ```<module>plugin-lombok</module>``` in plugins/pom.xml
+
+
+You can insert the module anywhere in the list. After you have inserted it, run `mvn sortpom:sort` and maven will order the pom.xml for you.
+
+### 3- Link to WS-Agent assembly
+
+Introduce the server part of the extension as a dependency in `/che/assembly/assembly-wsagent-war`. 
+
+Add: 
+
+```
+<dependency>
+     <groupId>org.eclipse.che.plugin</groupId>
+   <artifactId>che-plugin-lombok-server</artifactId>
+    <exclusions>
+        <exclusion>
+            <artifactId>lombok</artifactId>
+            <groupId>org.projectlombok</groupId>
+        </exclusion>
+    </exclusions>
+</dependency>
+```
+
+You can insert the dependency anywhere in the list. After you have inserted it, run `mvn sortpom:sort` and maven will order the pom.xml for you.
+
+### 4- Add dependancy to che-parent
+
+
+```
+<dependency>
+    <groupId>org.eclipse.che.plugin</groupId>
+    <artifactId>che-plugin-lombok-server</artifactId>
+    <version>${che.version}</version>
+</dependency>
+```
+
+You can insert the dependency anywhere in the list. After you have inserted it, run `mvn sortpom:sort` and maven will order the pom.xml for you.
+
+### 5- Build plugin-lombok
+
+Run ```mvn clean install -Denforcer.skip=true``` in plugin-lombok folder
+
+### 6- Rebuild Eclipse Che
+
+
+```Shell
+## Build a new IDE.war
+### This IDE web app will be bundled into the assembly
+cd che/assembly/assembly-ide-war
+mvn clean install
+
+## Create a new web-app that includes the server-side extension
+cd che/assembly/assembly-wsagent-war
+mvn clean install
+
+## Creates a new workspace agent that includes new web app w/ your extension
+cd assembly/assembly-wsagent-server
+mvn clean install
+
+## Create a new Che assembly that includes all new server- and client-side extensions
+cd assembly/assembly-main
+mvn clean install
+```
+
+or
+
+
+
+```Shell
+## Build whole assembly
+### This will bundle into the assembly
+cd che/assembly
+mvn clean install
+```
+
+
+### 7- Change properties
+
+```
+## Replace che.workspace.java_opts with this line
+che.workspace.java_opts=-Xms1024m -Xmx3072m -javaagent:/home/user/lombok.jar=ECJ -Djava.security.egd=file:/dev/./urandom
+
+and put che.properties in <path>data/conf folder
+```
+
+### 8- Run Eclipse Che
+
+```Shell
+## Start Che using the Docker Server with your new assembly
+### 1- Build docker Image containing new assembly
+Under che/assembly folder run
+`sudo docker build -t eclipse/che-server .`
+
+### 2- Build Workspace Image
+Create a workspace image with che-plugin-lombok-server-<version>.jar copied in /home/user/lombok.jar
+
+You can start a container with codenvy/ubuntu_jdk8 and copy the jar to correct path and commit your contaner to a new image
+later you have to start workspace with that image.
+### 3- Run eclipse che with newly created image
+
+sudo docker run \
+	-p 9000:8080 -p 8000:8000 --name che-server --rm \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v <path to data folder>:/data \
+	-v <path to data folder>/conf:/conf \
+	-e CHE_LOG_LEVEL=DEBUG \
+	-e CHE_IP=<your ip> \
+	-e CHE_DEBUG_SERVER=true \
+	eclipse/che-server
+```
+
+### Documentation resources
+
+- IDE Setup: https://eclipse-che.readme.io/v5.0/docs/setup-che-workspace  
+- Building Extensions: https://eclipse-che.readme.io/v5.0/docs/create-and-build-extensions
+- Run local Eclipse Che binaries: https://eclipse-che.readme.io/v5.0/docs/usage-docker#local-eclipse-che-binaries

--- a/plugins/plugin-lombok/README.md
+++ b/plugins/plugin-lombok/README.md
@@ -31,8 +31,9 @@ Add:
 
 ```
 <dependency>
-     <groupId>org.eclipse.che.plugin</groupId>
-   <artifactId>che-plugin-lombok-server</artifactId>
+    <groupId>org.eclipse.che.plugin</groupId>
+    <artifactId>che-plugin-lombok-server</artifactId>
+    <scope>runtime<scope>
     <exclusions>
         <exclusion>
             <artifactId>lombok</artifactId>

--- a/plugins/plugin-lombok/che-plugin-lombok-server/pom.xml
+++ b/plugins/plugin-lombok/che-plugin-lombok-server/pom.xml
@@ -21,14 +21,10 @@
     <artifactId>che-plugin-lombok-server</artifactId>
     <packaging>jar</packaging>
     <name>Che Plugin :: Lombok :: Server</name>
-    <properties>
-        <org.projectlombok.lombok.version>1.16.10</org.projectlombok.lombok.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${org.projectlombok.lombok.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -57,7 +53,6 @@
                                 <artifactItem>
                                     <groupId>org.projectlombok</groupId>
                                     <artifactId>lombok</artifactId>
-                                    <version>${org.projectlombok.lombok.version}</version>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/packager-conf/jar</outputDirectory>

--- a/plugins/plugin-lombok/che-plugin-lombok-server/pom.xml
+++ b/plugins/plugin-lombok/che-plugin-lombok-server/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-lombok-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>5.0.0-M8-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-plugin-lombok-server</artifactId>
+    <packaging>jar</packaging>
+    <name>Che Plugin :: Lombok :: Server</name>
+    <properties>
+        <org.projectlombok.lombok.version>1.16.10</org.projectlombok.lombok.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${org.projectlombok.lombok.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-deps</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>${org.projectlombok.lombok.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/packager-conf/jar</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <unzip dest="${project.build.outputDirectory}" src="${project.build.directory}/packager-conf/jar/lombok-${org.projectlombok.lombok.version}.jar">
+                                    <patternset>
+                                        <exclude name="**/lombok/launch/Main**" />
+                                    </patternset>
+                                </unzip>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/plugin-lombok/che-plugin-lombok-server/src/main/java/lombok/launch/Main.java
+++ b/plugins/plugin-lombok/che-plugin-lombok-server/src/main/java/lombok/launch/Main.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2014-2015 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.launch;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+class Main {
+    static ClassLoader createShadowClassLoader() {
+        // Make the parent of the shadowclasslaoder to current thread class loader so that ecj classes can be found
+        return new ShadowClassLoader(Thread.currentThread().getContextClassLoader(), "lombok", null, Arrays.<String>asList(), Arrays.asList("lombok.patcher.Symbols"));
+    }
+    
+    public static void main(String[] args) throws Throwable {
+        ClassLoader cl = createShadowClassLoader();
+        Class<?> mc = cl.loadClass("lombok.core.Main");
+        try {
+            mc.getMethod("main", String[].class).invoke(null, new Object[] {args});
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/plugins/plugin-lombok/pom.xml
+++ b/plugins/plugin-lombok/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2016 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-plugin-parent</artifactId>
+        <groupId>org.eclipse.che.plugin</groupId>
+        <version>5.0.0-M8-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>che-plugin-lombok-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Che Plugin :: Lombok :: Parent</name>
+    <modules>
+        <module>che-plugin-lombok-server</module>
+    </modules>
+</project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -35,6 +35,7 @@
         <module>plugin-java-debugger</module>
         <module>plugin-java-test-runner</module>
         <module>plugin-maven</module>
+        <module>plugin-lombok</module>
         <module>plugin-gdb</module>
         <module>plugin-sdk</module>
         <module>plugin-orion</module>

--- a/pom.xml
+++ b/pom.xml
@@ -628,6 +628,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-lombok-server</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-machine-ext-client</artifactId>
                 <version>${che.version}</version>
             </dependency>


### PR DESCRIPTION
### What does this PR do?
This added plugin support for lombok in eclipse che workspace

### What issues does this PR fix or reference?
#3185

### Previous behavior
Previously lombok annotations was not suported in eclipse che. Hence Lombok related code shows error 
in IDE.

### New behavior
This PR has changes made to lombok code to work with eclipse che. But the catch is Lombok works as a java agent and in eclipse che case the wsagent tomcat has to be started with -javaagent:lombok.jar 
and the jar has to be in the workspace image. Details of enabling the plugin can be found in README.md file of the plugin. The enabling of the plugin is a little bit messy now. But I will try to improve if i can have guideline from che developers.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
