### PR TITLE
Remove redundant info log call

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -112,7 +112,6 @@ public class AppStateManager {
 
     private Promise<Void> writeStateToPreferences(JsonObject state) {
         final String json = state.toJson();
-        Log.info(getClass(), "write: " + json);
         preferencesManager.setValue(PREFERENCE_PROPERTY_NAME, json);
         return preferencesManager.flushPreferences().catchError(new Operation<PromiseError>() {
             @Override


### PR DESCRIPTION
Remove redundant log info call that displays stored json object which describes application state.

@mshaposhnik @ashumilova review it, please.