### PR TITLE
Start eclipse/che-server docker image as root by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,18 +34,9 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/reposit
     apk add --update ca-certificates curl openssl openjdk8 sudo bash && \
     curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
-    addgroup -S user -g 1000 && \
-    adduser -S user -h /home/user -s /bin/bash -G root -u 1000 -D && \
-    addgroup -S docker -g 101 && \
-    adduser user docker && \
-    adduser user user && \
-    adduser user users && \
-    addgroup -g 50 -S docker4mac && \
-    adduser user docker4mac && \
     echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     rm -rf /tmp/* /var/cache/apk/*
 
 EXPOSE 8000 8080
-USER user
 ADD assembly/assembly-main/target/eclipse-che-*/eclipse-che-* /home/user/che/
 ENTRYPOINT ["/home/user/che/bin/docker.sh"]

--- a/assembly/assembly-main/src/assembly/bin/docker.sh
+++ b/assembly/assembly-main/src/assembly/bin/docker.sh
@@ -121,10 +121,6 @@ init() {
     export CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false
   fi
 
-  # Ensure that the user "user" has permissions for CHE_HOME and CHE_DATA
-  sudo chown -R user:user ${CHE_HOME}
-  sudo chown -R user:user ${CHE_DATA}
-
   # Move files from /lib to /lib-copy.  This puts files onto the host.
   rm -rf ${CHE_DATA}/lib/*
   mkdir -p ${CHE_DATA}/lib  


### PR DESCRIPTION
### What does this PR do?

Start eclipse/che-server docker image as root by default

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3276

### Previous behavior
User user had to be in docker group but with a specific gid which is not always the case

### New behavior
Start che server as root user by default

Use root user by default to start che-server
another PR is about specifying how to run che-server with a custom uid/gid
https://github.com/eclipse/che/pull/3265

Change-Id: Ib2635dc9b8364b92caa768dc8e4de0603cbcf14f
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>