### PR TITLE
set nightly versions for M9-SN iteration

### DIFF
--- a/dockerfiles/action/Dockerfile
+++ b/dockerfiles/action/Dockerfile
@@ -10,6 +10,6 @@
 # use:
 #    docker run -v /var/run/docker.sock:/var/run/docker.sock eclipse/che-action [command]
 
-FROM eclipse/che-lib:5.0.0-M8
+FROM eclipse/che-lib:nightly
 
 ENTRYPOINT ["node", "/che-lib/index.js", "che-action"]

--- a/dockerfiles/cli/Dockerfile
+++ b/dockerfiles/cli/Dockerfile
@@ -9,7 +9,7 @@
 #
 # use:
 #    docker run -v $(pwd):/che eclipse/che-cli [command]
-FROM eclipse/che-base:5.0.0-M8
+FROM eclipse/che-base:nightly
 
 COPY scripts /scripts/
 COPY version /version/

--- a/dockerfiles/dir/Dockerfile
+++ b/dockerfiles/dir/Dockerfile
@@ -10,6 +10,6 @@
 # use:
 #    docker run -v /var/run/docker.sock:/var/run/docker.sock eclipse/che-dir [command]
 
-FROM eclipse/che-lib:5.0.0-M8
+FROM eclipse/che-lib:nightly
 
 ENTRYPOINT ["node", "/che-lib/index.js", "che-dir"]

--- a/dockerfiles/lib/dto-pom.xml
+++ b/dockerfiles/lib/dto-pom.xml
@@ -17,13 +17,13 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.0.0-M8</version>
+        <version>5.0.0-M9-SNAPSHOT</version>
     </parent>
     <artifactId>dto-typescript</artifactId>
     <packaging>pom</packaging>
     <name>Che TypeScript DTO</name>
     <properties>
-        <che.version>5.0.0-M8</che.version>
+        <che.version>5.0.0-M9-SNAPSHOT</che.version>
     </properties>
     <repositories>
         <repository>

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -10,6 +10,6 @@
 # use:
 #    docker run -v /var/run/docker.sock:/var/run/docker.sock eclipse/che-test [command]
 
-FROM eclipse/che-lib:5.0.0-M8
+FROM eclipse/che-lib:nightly
 
 ENTRYPOINT ["node", "/che-lib/index.js", "che-test"]


### PR DESCRIPTION
this need to make M9-SNAPSHOT available as nightly tag

@benoitf @skabashnyuk 

later this will be automated during release process