### PR TITLE
Deprecate getMediaType method as we don't use media type for any purpose

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
@@ -71,6 +71,7 @@ public interface VirtualFile {
      * don't have media type.
      *
      * @return media type or null.
+     * @deprecated this method is going to be removed soon, because we don't use media type for any purposes
      */
     @Deprecated
     String getMediaType();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
@@ -72,6 +72,7 @@ public interface VirtualFile {
      *
      * @return media type or null.
      */
+    @Deprecated
     String getMediaType();
 
     /**


### PR DESCRIPTION
Mark `org.eclipse.che.ide.api.resources.VirtualFile#getMediaType` as deprecated, because we don't use media type for any purpose and for first time it will be deprecated and soon, it will be removed.

Related issue: #3235 