### PR TITLE
Remove deprecated getPath method and use getLocation instead

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/File.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/File.java
@@ -32,10 +32,6 @@ import org.eclipse.che.ide.resource.Path;
 @Beta
 public interface File extends Resource, VirtualFile, ModificationTracker {
 
-    /** @see VirtualFile#getPath() */
-    @Override
-    String getPath();
-
     /** @see VirtualFile#getDisplayName() */
     @Override
     String getDisplayName();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/SyntheticFile.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/SyntheticFile.java
@@ -46,13 +46,8 @@ public class SyntheticFile implements VirtualFile {
     }
 
     @Override
-    public String getPath() {
-        return name;
-    }
-
-    @Override
     public Path getLocation() {
-        return Path.valueOf(getPath());
+        return Path.valueOf(name);
     }
 
     @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
@@ -33,20 +33,8 @@ public interface VirtualFile {
      * Path should always be non-null or non-empty.
      *
      * @return non-null unique path.
-     * @deprecated use {@link #getLocation()}
-     */
-    @Deprecated
-    String getPath();
-
-    /**
-     * Returns path for the virtual file. Path may in various representation based on implementation.
-     * Usually it something like physical file or folder path, e.g. `/path/to/som/file`.
-     * Path should always be non-null or non-empty.
-     *
-     * @return non-null unique path.
      * @since 4.4.0
      */
-    @Beta
     Path getLocation();
 
     /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
@@ -34,6 +34,7 @@ import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.event.FileEvent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.util.loging.Log;
 
 import static org.eclipse.che.api.promises.client.callback.CallbackPromiseHelper.createFromCallback;
@@ -125,7 +126,7 @@ public class OpenFileAction extends Action implements PromisableAction {
                         if (event.getActivePart() instanceof EditorPartPresenter) {
                             EditorPartPresenter editor = (EditorPartPresenter)event.getActivePart();
                             handlerRegistration.removeHandler();
-                            if ((pathToOpen).equals(editor.getEditorInput().getFile().getPath())) {
+                            if (Path.valueOf(pathToOpen).equals(editor.getEditorInput().getFile().getLocation())) {
                                 callback.onSuccess(null);
                             }
                         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/debug/BreakpointManagerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/debug/BreakpointManagerImpl.java
@@ -119,7 +119,7 @@ public class BreakpointManagerImpl implements BreakpointManager,
 
         final VirtualFile activeFile = editor.getEditorInput().getFile();
 
-        List<Breakpoint> pathBreakpoints = breakpoints.get(activeFile.getPath());
+        List<Breakpoint> pathBreakpoints = breakpoints.get(activeFile.getLocation().toString());
         if (pathBreakpoints != null) {
             for (final Breakpoint breakpoint : pathBreakpoints) {
                 if (breakpoint.getLineNumber() == lineNumber) {
@@ -133,7 +133,7 @@ public class BreakpointManagerImpl implements BreakpointManager,
         if (isLineNotEmpty(activeFile, lineNumber)) {
             Breakpoint breakpoint = new Breakpoint(BREAKPOINT,
                                                    lineNumber,
-                                                   activeFile.getPath(),
+                                                   activeFile.getLocation().toString(),
                                                    activeFile,
                                                    false);
             addBreakpoint(breakpoint);
@@ -234,7 +234,7 @@ public class BreakpointManagerImpl implements BreakpointManager,
      * Indicates if line of code to add breakpoint at is executable.
      */
     private boolean isLineNotEmpty(final VirtualFile activeFile, int lineNumber) {
-        EditorPartPresenter editor = getEditorForFile(activeFile.getPath());
+        EditorPartPresenter editor = getEditorForFile(activeFile.getLocation().toString());
         if (editor instanceof TextEditor) {
             Document document = ((TextEditor)editor).getDocument();
             return !document.getLineContent(lineNumber).trim().isEmpty();
@@ -273,9 +273,9 @@ public class BreakpointManagerImpl implements BreakpointManager,
     }
 
     private void doSetCurrentBreakpoint(VirtualFile activeFile, int lineNumber) {
-        currentBreakpoint = new Breakpoint(Type.CURRENT, lineNumber, activeFile.getPath(), activeFile, true);
+        currentBreakpoint = new Breakpoint(Type.CURRENT, lineNumber, activeFile.getLocation().toString(), activeFile, true);
 
-        BreakpointRenderer breakpointRenderer = getBreakpointRendererForFile(activeFile.getPath());
+        BreakpointRenderer breakpointRenderer = getBreakpointRendererForFile(activeFile.getLocation().toString());
         if (breakpointRenderer != null) {
             breakpointRenderer.setLineActive(lineNumber, true);
         }
@@ -347,11 +347,11 @@ public class BreakpointManagerImpl implements BreakpointManager,
      */
     @Override
     public void onLineChange(final VirtualFile file, final int firstLine, final int linesAdded, final int linesRemoved) {
-        final List<Breakpoint> fileBreakpoints = breakpoints.get(file.getPath());
+        final List<Breakpoint> fileBreakpoints = breakpoints.get(file.getLocation().toString());
         final int delta = linesAdded - linesRemoved;
 
         if (fileBreakpoints != null) {
-            LOG.fine("Change in file with breakpoints " + file.getPath());
+            LOG.fine("Change in file with breakpoints " + file.getLocation().toString());
 
             final List<Breakpoint> toRemove = new ArrayList<>();
             final List<Breakpoint> toAdd = new ArrayList<>();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/imageviewer/ImageViewer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/imageviewer/ImageViewer.java
@@ -33,6 +33,7 @@ import org.eclipse.che.ide.api.event.FileEvent;
 import org.eclipse.che.ide.api.event.FileEvent.FileEventHandler;
 import org.eclipse.che.ide.api.machine.WsAgentURLModifier;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.resource.Path;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.validation.constraints.NotNull;
@@ -184,8 +185,8 @@ public class ImageViewer extends AbstractEditorPresenter implements FileEventHan
             return;
         }
 
-        final String eventFilePath = event.getFile().getPath();
-        final String filePath = input.getFile().getPath();
+        final Path eventFilePath = event.getFile().getLocation();
+        final Path filePath = input.getFile().getLocation();
         if (filePath.equals(eventFilePath)) {
             workspaceAgent.removePart(this);
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileAction.java
@@ -62,6 +62,6 @@ public class RecentFileAction extends AbstractPerspectiveAction {
      * @return action id
      */
     public String getId() {
-        return "recent/" + file.getPath();
+        return "recent/" + file.getLocation();
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/FileImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/FileImpl.java
@@ -87,12 +87,6 @@ class FileImpl extends ResourceImpl implements File {
 
     /** {@inheritDoc} */
     @Override
-    public String getPath() {
-        return getLocation().toString();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public String getExtension() {
         final String entryName = getName();
         int lastDotIndex = entryName.lastIndexOf('.');

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -890,8 +890,8 @@ public final class ResourceManager {
         File file = (File)resource;
 
         for (EditorPartPresenter editor : editorAgent.getOpenedEditors()) {
-            String editorPath = editor.getEditorInput().getFile().getLocation().toString();
-            if (editorPath.equals(file.getPath())) {
+            Path editorPath = editor.getEditorInput().getFile().getLocation();
+            if (editorPath.equals(file.getLocation())) {
                 return true;
             }
         }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -249,7 +249,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
                                        @Override
                                        public void onSuccess(VirtualFile result) {
                                            for (DebuggerObserver observer : observers) {
-                                               observer.onBreakpointStopped(result.getPath(),
+                                               observer.onBreakpointStopped(result.getLocation().toString(),
                                                                             currentLocation.getTarget(),
                                                                             currentLocation.getLineNumber());
                                            }
@@ -351,7 +351,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
                 }
             });
         } else {
-            Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getPath(), file, false);
+            Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getLocation().toString(), file, false);
             for (DebuggerObserver observer : observers) {
                 observer.onBreakpointAdded(breakpoint);
             }
@@ -377,7 +377,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             @Override
             public void apply(Void arg) throws OperationException {
                 for (DebuggerObserver observer : observers) {
-                    Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getPath(), file, false);
+                    Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getLocation().toString(), file, false);
                     observer.onBreakpointDeleted(breakpoint);
                 }
             }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
@@ -176,7 +176,7 @@ public class DebuggerTest extends BaseTest {
         doReturn(DEBUG_INFO).when(localStorage).getItem(AbstractDebugger.LOCAL_STORAGE_DEBUGGER_SESSION_KEY);
         doReturn(debugSessionDto).when(dtoFactory).createDtoFromJson(anyString(), eq(DebugSessionDto.class));
 
-        doReturn(PATH).when(file).getPath();
+        doReturn(Path.valueOf(PATH)).when(file).getLocation();
 
         debugger = new TestDebugger(service, dtoFactory, localStorageProvider, messageBusProvider, eventBus,
                                     activeFileHandler, debuggerManager, "id");

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/ComparePresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/ComparePresenter.java
@@ -157,7 +157,7 @@ public class ComparePresenter implements CompareView.ActionDelegate {
                             parent.get().synchronize();
                         }
 
-                        eventBus.fireEvent(new FileContentUpdateEvent(comparedFile.getPath()));
+                        eventBus.fireEvent(new FileContentUpdateEvent(comparedFile.getLocation().toString()));
                         view.hide();
                     }
                 });

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebuggerFileHandler.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebuggerFileHandler.java
@@ -74,7 +74,7 @@ public class JavaDebuggerFileHandler implements ActiveFileHandler {
         final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
         if (activeEditor != null) {
             activeFile = editorAgent.getActiveEditor().getEditorInput().getFile();
-            activePath = activeFile.getPath();
+            activePath = activeFile.getLocation().toString();
         }
         if (activePath != null && !activePath.equals(location.getTarget()) && !activePath.equals(location.getResourcePath())) {
             if (location.isExternalResource()) {

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/fqn/JavaClassFqnResolver.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/fqn/JavaClassFqnResolver.java
@@ -28,6 +28,6 @@ public class JavaClassFqnResolver implements FqnResolver {
     @NotNull
     @Override
     public String resolveFqn(@NotNull final VirtualFile file) {
-        return file.getPath();
+        return file.getLocation().toString();
     }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/JarFileNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/JarFileNode.java
@@ -109,16 +109,9 @@ public class JarFileNode extends SyntheticNode<JarEntry> implements VirtualFile,
         return true;
     }
 
-    /** {@inheritDoc} */
-    @NotNull
-    @Override
-    public String getPath() {
-        return getData().getPath();
-    }
-
     @Override
     public Path getLocation() {
-        return Path.valueOf(getPath());
+        return Path.valueOf(getData().getPath());
     }
 
     /** {@inheritDoc} */

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/preview/PreviewPresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/preview/PreviewPresenterTest.java
@@ -189,7 +189,7 @@ public class PreviewPresenterTest {
         verify(view, never()).hide();
         verify(editor, never()).getEditorInput();
         verify(editorInput, never()).getFile();
-        verify(virtualFile, never()).getPath();
+        verify(virtualFile, never()).getLocation();
         verify(view).showErrorMessage(refactoringStatus);
     }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
@@ -137,13 +137,13 @@ public class LanguageServerExtension {
             @Override
             public void apply(String text) throws OperationException {
                 TextDocumentItemDTO documentItem = dtoFactory.createDto(TextDocumentItemDTO.class);
-                documentItem.setUri(event.getFile().getPath());
+                documentItem.setUri(event.getFile().getLocation().toString());
                 documentItem.setVersion(LanguageServerEditorConfiguration.INITIAL_DOCUMENT_VERSION);
                 documentItem.setText(text);
 
                 DidOpenTextDocumentParamsDTO openEvent = dtoFactory.createDto(DidOpenTextDocumentParamsDTO.class);
                 openEvent.setTextDocument(documentItem);
-                openEvent.setUri(event.getFile().getPath());
+                openEvent.setUri(event.getFile().getLocation().toString());
                 openEvent.setText(text);
 
                 serviceClient.didOpen(openEvent);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerEditorProvider.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerEditorProvider.java
@@ -88,7 +88,7 @@ public class LanguageServerEditorProvider implements AsyncEditorProvider, Editor
             File resource = (File)file;
 
             Promise<InitializeResult> promise =
-                    registry.getOrInitializeServer(resource.getRelatedProject().get().getPath(), resource.getExtension(), resource.getPath());
+                    registry.getOrInitializeServer(resource.getRelatedProject().get().getPath(), resource.getExtension(), resource.getLocation().toString());
             final MessageLoader loader = loaderFactory.newLoader("Initializing Language Server for " + resource.getExtension());
             loader.show();
             return promise.thenPromise(new Function<InitializeResult, Promise<EditorPartPresenter>>() {

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -125,7 +125,7 @@ public class LanguageServerFormatter implements ContentFormatter {
         DocumentFormattingParamsDTO params = dtoFactory.createDto(DocumentFormattingParamsDTO.class);
 
         TextDocumentIdentifierDTO identifier = dtoFactory.createDto(TextDocumentIdentifierDTO.class);
-        identifier.setUri(document.getFile().getPath());
+        identifier.setUri(document.getFile().getLocation().toString());
 
         params.setTextDocument(identifier);
         params.setOptions(getFormattingOptions());
@@ -189,7 +189,7 @@ public class LanguageServerFormatter implements ContentFormatter {
         DocumentRangeFormattingParamsDTO params = dtoFactory.createDto(DocumentRangeFormattingParamsDTO.class);
 
         TextDocumentIdentifierDTO identifier = dtoFactory.createDto(TextDocumentIdentifierDTO.class);
-        identifier.setUri(document.getFile().getPath());
+        identifier.setUri(document.getFile().getLocation().toString());
 
         params.setTextDocument(identifier);
         params.setOptions(getFormattingOptions());

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/references/FindReferencesAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/references/FindReferencesAction.java
@@ -82,7 +82,7 @@ public class FindReferencesAction extends AbstractPerspectiveAction {
             return;
         }
         TextEditor textEditor = ((TextEditor)activeEditor);
-        String path = activeEditor.getEditorInput().getFile().getPath();
+        String path = activeEditor.getEditorInput().getFile().getLocation().toString();
         ReferenceParamsDTO paramsDTO = dtoFactory.createDto(ReferenceParamsDTO.class);
 
         PositionDTO positionDTO = dtoFactory.createDto(PositionDTO.class);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/symbol/GoToSymbolAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/symbol/GoToSymbolAction.java
@@ -101,7 +101,7 @@ public class GoToSymbolAction extends AbstractPerspectiveAction implements Quick
     public void actionPerformed(ActionEvent e) {
         DocumentSymbolParamsDTO paramsDTO = dtoFactory.createDto(DocumentSymbolParamsDTO.class);
         TextDocumentIdentifierDTO identifierDTO = dtoFactory.createDto(TextDocumentIdentifierDTO.class);
-        identifierDTO.setUri(editorAgent.getActiveEditor().getEditorInput().getFile().getPath());
+        identifierDTO.setUri(editorAgent.getActiveEditor().getEditorInput().getFile().getLocation().toString());
         paramsDTO.setTextDocument(identifierDTO);
         activeEditor = (TextEditor)editorAgent.getActiveEditor();
         cursorPosition = activeEditor.getDocument().getCursorPosition();

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/workspace/FindSymbolAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/workspace/FindSymbolAction.java
@@ -123,7 +123,7 @@ public class FindSymbolAction extends AbstractPerspectiveAction implements Quick
     private Promise<List<SymbolEntry>> searchSymbols(final String value) {
         WorkspaceSymbolParamsDTO params = dtoFactory.createDto(WorkspaceSymbolParamsDTO.class);
         params.setQuery(value);
-        params.setFileUri(editorAgent.getActiveEditor().getEditorInput().getFile().getPath());
+        params.setFileUri(editorAgent.getActiveEditor().getEditorInput().getFile().getLocation().toString());
         return workspaceServiceClient.symbol(params).then(new Function<List<SymbolInformationDTO>, List<SymbolEntry>>() {
             @Override
             public List<SymbolEntry> apply(List<SymbolInformationDTO> types) throws FunctionException {

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/PomEditorReconciler.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/PomEditorReconciler.java
@@ -48,7 +48,7 @@ public class PomEditorReconciler {
                 Set<String> pomPaths = getPomPath(updatedProjects);
                 List<EditorPartPresenter> openedEditors = editorAgent.getOpenedEditors();
                 for (EditorPartPresenter openedEditor : openedEditors) {
-                    String path = openedEditor.getEditorInput().getFile().getPath();
+                    String path = openedEditor.getEditorInput().getFile().getLocation().toString();
                     if (pomPaths.contains(path)) {
                         if (openedEditor instanceof TextEditor) {
                             final Reconciler reconciler = ((TextEditor)openedEditor).getConfiguration().getReconciler();

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/ClassFileSourcesDownloader.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/ClassFileSourcesDownloader.java
@@ -107,7 +107,7 @@ public class ClassFileSourcesDownloader implements EditorOpenedEventHandler {
     }
 
     private void downloadSources(JarFileNode jarFileNode, final HasNotificationPanel.NotificationRemover remover) {
-        final String path = jarFileNode.getPath();
+        final String path = jarFileNode.getLocation().toString();
         Promise<Boolean> promise = client.downloadSources(jarFileNode.getProjectLocation().toString(), path);
         promise.then(new Operation<Boolean>() {
             @Override

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomReconcilingStrategy.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/editor/PomReconcilingStrategy.java
@@ -53,7 +53,7 @@ public class PomReconcilingStrategy implements ReconcilingStrategy {
 
     @Override
     public void setDocument(Document document) {
-        pomPath = document.getFile().getPath();
+        pomPath = document.getFile().getLocation().toString();
     }
 
     @Override


### PR DESCRIPTION
As method `org.eclipse.che.ide.api.resources.VirtualFile#getPath` is marked as deprecated it was removed completely and code which had used `getPath` method before now is using `getLocation`.

Also was removed `@Beta` annotation from the method `org.eclipse.che.ide.api.resources.VirtualFile#getLocation` to freeze this method as persisted API method.

Artik-ide, plugin-openshift and codenvy based plugins don't have to be refactored and adopted as they didn't use method `org.eclipse.che.ide.api.resources.VirtualFile#getPath`.

Related issue: #3233 