### PR TITLE
Improve container label handling (replaceLabels() method)

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/OpenShiftConnector.java
@@ -46,6 +46,9 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -62,6 +65,13 @@ public class OpenShiftConnector {
     private static final String OPENSHIFT_API_VERSION = "v1";
     private static final String CHE_WORKSPACE_ID_ENV_VAR = "CHE_WORKSPACE_ID";
     private static final String CHE_OPENSHIFT_RESOURCES_PREFIX = "che-ws-";
+
+    /** Prefix used for che server labels */
+    protected static final String CHE_SERVER_LABEL_PREFIX  = "che:server";
+    /** Padding to use when converting server label to DNS name */
+    protected static final String CHE_SERVER_LABEL_PADDING = "0%s0";
+    /** Regex to use when matching converted labels -- should match {@link CHE_SERVER_LABEL_PADDING} */
+    protected static final Pattern CHE_SERVER_LABEL_KEY    = Pattern.compile("^0(.*)0$");
 
     private static final String OPENSHIFT_SERVICE_TYPE_NODE_PORT = "NodePort";
     private static final int OPENSHIFT_LIVENESS_PROBE_DELAY = 120;
@@ -130,7 +140,9 @@ public class OpenShiftConnector {
         String[] volumes = createContainerParams.getContainerConfig().getHostConfig().getBinds();
 
         IProject cheProject = getCheProject();
-        createOpenShiftService(cheProject, workspaceID, exposedPorts);
+
+        Map<String, String> additionalLabels = createContainerParams.getContainerConfig().getLabels();
+        createOpenShiftService(cheProject, workspaceID, exposedPorts, additionalLabels);
         String deploymentConfigName = createOpenShiftDeploymentConfig(cheProject,
                                                                       workspaceID,
                                                                       imageName,
@@ -160,10 +172,26 @@ public class OpenShiftConnector {
         if (info == null) {
             return null;
         }
+
+        IPod pod = getChePodByContainerId(info.getId());
+        String deploymentConfig = pod.getLabels().get("deploymentConfig");
+        IService svc = getCheServiceBySelector("deploymentConfig", deploymentConfig);
+        Map<String, String> annotations = convertKubernetesNamesToLabels(svc.getAnnotations());
+        Map<String, String> containerLabels = info.getConfig().getLabels();
+
+        Map<String, String> labels = Stream.concat(annotations.entrySet().stream(), containerLabels.entrySet().stream())
+                                           .filter(e -> e.getKey().startsWith(CHE_SERVER_LABEL_PREFIX))
+                                           .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+
+        info.getConfig().setLabels(labels);
+
+        LOG.info("Container labels:");
+        info.getConfig().getLabels().entrySet()
+                        .stream().forEach(e -> LOG.info("- " + e.getKey() + "=" + e.getValue()));
+
         // Ignore portMapping for now: info.getNetworkSettings().setPortMapping();
         // replacePortMapping(info)
         replaceNetworkSettings(info);
-        replaceLabels(info);
 
         return info;
     }
@@ -271,7 +299,10 @@ public class OpenShiftConnector {
         return cheProject;
     }
 
-    private void createOpenShiftService(IProject cheProject, String workspaceID, Set<String> exposedPorts) {
+    private void createOpenShiftService(IProject cheProject,
+                                        String workspaceID,
+                                        Set<String> exposedPorts,
+                                        Map<String, String> additionalLabels) {
         IService service = openShiftFactory.create(OPENSHIFT_API_VERSION, ResourceKind.SERVICE);
         ((Service) service).setNamespace(cheProject.getNamespace());
         ((Service) service).setName(CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceID);
@@ -281,6 +312,13 @@ public class OpenShiftConnector {
         service.setPorts(openShiftPorts);
 
         service.setSelector("deploymentConfig", (CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceID));
+
+        Map<String,String> sanitizedLabels = convertLabelsToKubernetesNames(additionalLabels);
+        for (Map.Entry<String, String> entry : sanitizedLabels.entrySet()) {
+            if (entry.getValue() != null) {
+                service.setAnnotation(entry.getKey(), entry.getValue());
+            }
+        }
         openShiftClient.create(service);
         LOG.info(String.format("OpenShift service %s created", service.getName()));
     }
@@ -328,7 +366,7 @@ public class OpenShiftConnector {
 
         dcFirstContainer.get("securityContext").get("privileged").set(true);
         dcFirstContainer.get("securityContext").get("runAsUser").set(UID);
-        
+
         addLivenessProbe(dcFirstContainer, exposedPorts);
 
         // Add volumes
@@ -454,34 +492,6 @@ public class OpenShiftConnector {
         return env;
     }
 
-    private void replaceLabels(ContainerInfo info) {
-        if (info.getConfig() == null) {
-            return;
-        }
-
-        Map<String,String> configLabels = new HashMap<>();
-        configLabels.put("che:server:22/tcp:ref", "ssh");
-        configLabels.put("che:server:4401/tcp:path", "/api");
-        configLabels.put("che:server:4401/tcp:protocol", "http");
-        configLabels.put("che:server:4401/tcp:ref", "wsagent");
-        configLabels.put("che:server:4411/tcp:protocol", "http");
-        configLabels.put("che:server:4411/tcp:ref", "terminal");
-        configLabels.put("che:server:8000:protocol", "http");
-        configLabels.put("che:server:8000:ref", "tomcat8-debug");
-        configLabels.put("che:server:8080:protocol", "http");
-        configLabels.put("che:server:8080:ref", "tomcat8");
-        configLabels.put("che:server:9876:protocol", "http");
-        configLabels.put("che:server:9876:ref", "codeserver");
-        info.getConfig().setLabels(configLabels);
-
-        LOG.info("Container labels:");
-        for (String key: info.getConfig().getLabels().keySet()) {
-            String value = info.getConfig().getLabels().get(key);
-
-            LOG.info("- " + key + "=" + value);
-        }
-    }
-
     private void replaceNetworkSettings(ContainerInfo info) throws IOException {
 
         if (info.getNetworkSettings() == null) {
@@ -525,18 +535,17 @@ public class OpenShiftConnector {
         return networkSettingsPorts;
     }
 
-
     /**
      * Adds OpenShift liveness probe to the container. Liveness probe is configured
      * via TCP Socket Check - for dev machines by checking Workspace API agent port
      * (4401), for non-dev by checking Terminal port (4411)
-     * 
+     *
      * @param container
      * @param exposedPorts
      * @see <a href=
      *      "https://docs.openshift.com/enterprise/3.0/dev_guide/application_health.html">OpenShift
      *      Application Health</a>
-     * 
+     *
      */
     private void addLivenessProbe(final ModelNode container, final Set<String> exposedPorts) {
         int port = 0;
@@ -557,7 +566,7 @@ public class OpenShiftConnector {
     /**
      * When container is expected to be run as root, user field from {@link ImageConfig} is empty.
      * For non-root user it contains "user" value
-     * 
+     *
      * @param dockerConnector
      * @param imageName
      * @return true if user property from Image config is empty string, false otherwise
@@ -567,7 +576,7 @@ public class OpenShiftConnector {
         String user = dockerConnector.inspectImage(imageName).getConfig().getUser();
         return user != null && user.isEmpty();
     }
-    
+
     /**
      * @param exposedPorts
      * @return true if machine exposes 4411/tcp port used by Terminal agent,
@@ -576,7 +585,7 @@ public class OpenShiftConnector {
     private boolean isTerminalAgentInjected(final Set<String> exposedPorts) {
         return exposedPorts.contains(CHE_TERMINAL_AGENT_PORT + "/tcp");
     }
-    
+
     /**
      * @param exposedPorts
      * @return true if machine exposes 4401/tcp port used by Worspace API agent,
@@ -585,14 +594,90 @@ public class OpenShiftConnector {
     private boolean isDevMachine(final Set<String> exposedPorts) {
         return exposedPorts.contains(CHE_WORKSPACE_AGENT_PORT + "/tcp");
     }
-    
+
     /**
      * Che workspace id is used as OpenShift service / deployment config name
      * and must match the regex [a-z]([-a-z0-9]*[a-z0-9]) e.g. "q5iuhkwjvw1w9emg"
-     * 
+     *
      * @return randomly generated workspace id
      */
     private String generateWorkspaceID() {
         return RandomStringUtils.random(16, true, true).toLowerCase();
+    }
+
+    /**
+     * Converts a map of labels to match Kubernetes label requirements. Names are limited
+     * to alphanumeric characters, {@code '.'}, {@code '_'} and {@code '-'}, and must start and end
+     * with an alphanumeric character, i.e. they must match the regex
+     * {@code ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]}
+     *
+     * <p>Note that entry keys should begin with {@link OpenShiftConnector#CHE_SERVER_LABEL_PREFIX} and
+     * entries should not contain {@code '.'} or {@code '_'} before conversion;
+     * otherwise label will not be converted and included in output.
+     *
+     * @param labels Map of labels to convert
+     * @return Map of labels converted to DNS Names
+     * @see OpenShiftConnector#convertKubernetesNamesToLabels(Map)
+     */
+    protected Map<String, String> convertLabelsToKubernetesNames(Map<String, String> labels) {
+        Map<String, String> names = new HashMap<>();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            if (value == null) {
+                continue;
+            }
+            // Check for potential problems with conversion
+            if (!key.startsWith(CHE_OPENSHIFT_RESOURCES_PREFIX)) {
+                LOG.warn("Expected CreateContainerParams label key " + entry.getKey() +
+                         " to start with " + CHE_SERVER_LABEL_PREFIX);
+            } else if (key.contains(".") || key.contains("_") || value.contains("_")) {
+                LOG.error(String.format("Cannot convert label %s to DNS Name: contains '-' or '.'", entry.toString()));
+                continue;
+            }
+
+            // Convert keys: e.g. "che:server:4401/tcp:ref" -> "che.server.4401-tcp.ref"
+            key = key.replaceAll(":", ".").replaceAll("/", "_");
+            // Convert values: e.g. "/api" -> ".api" -- note values may include '-'
+            value = value.replaceAll("/", "_");
+
+            // Add padding since DNS names must start and end with alphanumeric characters
+            names.put(String.format(CHE_SERVER_LABEL_PADDING, key),
+                      String.format(CHE_SERVER_LABEL_PADDING, value));
+        }
+        return names;
+    }
+
+    /**
+     * Undoes the label conversion done by {@link OpenShiftConnector#convertLabelsToKubernetesNames(Map)}
+     *
+     * @param labels Map of DNS names
+     * @return Map of unconverted labels
+     * @see OpenShiftConnector#convertLabelsToKubernetesNames(Map)
+     */
+    protected Map<String, String> convertKubernetesNamesToLabels(Map<String, String> names) {
+        Map<String, String> labels = new HashMap<>();
+        for (Map.Entry<String, String> entry: names.entrySet()){
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            // Remove padding
+            Matcher keyMatcher   = CHE_SERVER_LABEL_KEY.matcher(key);
+            Matcher valueMatcher = CHE_SERVER_LABEL_KEY.matcher(value);
+            if (!keyMatcher.matches() || !valueMatcher.matches()) {
+                continue;
+            }
+            key = keyMatcher.group(1);
+            value = valueMatcher.group(1);
+
+            // Convert key: e.g. "che.server.4401_tcp.ref" -> "che:server:4401/tcp:ref"
+            key = key.replaceAll("\\.", ":").replaceAll("_", "/");
+            // Convert value: e.g. Convert values: e.g. "_api" -> "/api"
+            value = value.replaceAll("_", "/");
+
+            labels.put(key, value);
+        }
+        return labels;
     }
 }


### PR DESCRIPTION
### What does this PR do?
Improves OpenShiftConnector#createContainer() and OpenShiftConnector#inspectContainer() to properly store and retrieve labels from CreateContainerParams.

Details:
1. Kubernetes annotations are can consist only of alphanumeric characters and `'-'`, `'_'`, `'.'`. This means that the labels provided have to be converted into valid Kubernetes annotations. This is currently done by converting `':' -> '.'` and `'/' -> '_'`, which means that if a label contains `'.'` or `'_'`, it cannot be converted and is skipped. Additionally, padding has to be added to keys and values since they must start and end with an alphanumeric character (and sometimes we encounter e.g. "/api").
2. Considered attaching the annotations to the Pod instead of the Service, but AFAICT these annotations are not persisted if the pod is recreated by OpenShift. An alternative would be to assign the label to the Deployment Config used to create the pod. Thoughts/suggestions here are welcome.

### Previous behavior
Labels returned for inspectContainer() were hard-coded.

### New behavior
Labels are stored as annotations on the Service assigned to the Pod, and can be retrieved.

Signed-off-by: Angel Misevski <amisevsk@redhat.com>