### PR TITLE
Compare log messages time as seconds

### DIFF
--- a/exec-agent/src/process/file_logger_test.go
+++ b/exec-agent/src/process/file_logger_test.go
@@ -102,17 +102,13 @@ func TestLogsAreFlushedOnClose(t *testing.T) {
 		Time: now,
 		Text: "stdout",
 	}
-	if stdout != expectedStdout {
-		t.Fatalf("Expected %v but found %v", expectedStdout, stdout)
-	}
 	expectedStderr := process.LogMessage{
 		Kind: process.StderrKind,
 		Time: now,
 		Text: "stderr",
 	}
-	if stdout != expectedStdout {
-		t.Fatalf("Expected %v but found %v", expectedStderr, stderr)
-	}
+	failIfDifferent(t, expectedStdout, stdout)
+	failIfDifferent(t, expectedStderr, stderr)
 }
 
 func randomName(length int) string {

--- a/exec-agent/src/process/logs_reader_test.go
+++ b/exec-agent/src/process/logs_reader_test.go
@@ -53,8 +53,12 @@ func TestReadLogs(t *testing.T) {
 		{Kind: process.StderrKind, Time: now.Add(time.Second * 4), Text: "line4"},
 	}
 	for i := 0; i < len(logs); i++ {
-		if *logs[i] != expected[i] {
-			t.Fatalf("Expected: '%v' Found '%v'", expected[i], *logs[i])
-		}
+		failIfDifferent(t, *logs[i], expected[i])
+	}
+}
+
+func failIfDifferent(t *testing.T, expected process.LogMessage, actual process.LogMessage) {
+	if expected.Kind != actual.Kind || expected.Text != actual.Text || expected.Time.Unix() != actual.Time.Unix() {
+		t.Fatalf("Expected: '%v' Found '%v'", expected, actual)
 	}
 }


### PR DESCRIPTION
Sometimes time comparison doesn't work properly when comparing structs that contain time.
The most obvious fix is to compare values that are okay enough for the certain use-case, e.g. seconds or nanoseconds i changed the tests to use seconds `time.Unix()` so everything works like expected.

The integration profile build might fail with a message:
```
main:
     [exec] ?       github.com/eclipse/che/exec-agent    [no test files]
     [exec] === RUN   TestTokenCache
     [exec] --- PASS: TestTokenCache (0.00s)
     [exec] === RUN   TestExpiresTokensCreatedBeforeGivenPointOfTime
     [exec] --- PASS: TestExpiresTokensCreatedBeforeGivenPointOfTime (0.00s)
     [exec] PASS
     [exec] ok      github.com/eclipse/che/exec-agent/auth    0.003s
     [exec] === RUN   TestFileLoggerCreatesFileWhenFileDoesNotExist
     [exec] --- PASS: TestFileLoggerCreatesFileWhenFileDoesNotExist (0.00s)
     [exec] === RUN   TestFileLoggerTruncatesFileIfFileExistsOnCreate
     [exec] --- PASS: TestFileLoggerTruncatesFileIfFileExistsOnCreate (0.00s)
     [exec] === RUN   TestLogsAreFlushedOnClose
     [exec] --- FAIL: TestLogsAreFlushedOnClose (0.00s)
     [exec]     file_logger_test.go:106: Expected {STDOUT 2016-12-08 20:14:24.709955936 +0000 UTC stdout} but found {STDOUT 2016-12-08 20:14:24.709955936 +0000 UTC stdout}
     [exec] === RUN   TestLogsDistributorCreatesSubdirectories
     [exec] --- PASS: TestLogsDistributorCreatesSubdirectories (0.00s)
     [exec] === RUN   TestLogsDistribution
     [exec] --- PASS: TestLogsDistribution (0.00s)
     [exec] === RUN   TestReadLogs
     [exec] --- FAIL: TestReadLogs (0.00s)
     [exec]     logs_reader_test.go:57: Expected: '{STDOUT 2016-12-08 20:14:26.710886639 +0000 UTC line2}' Found '{STDOUT 2016-12-08 20:14:26.710886639 +0000 UTC line2}'
     [exec] === RUN   TestCleanWithZeroThreshold
     [exec] --- PASS: TestCleanWithZeroThreshold (0.00s)
     [exec] === RUN   TestCleansOnlyUnusedProcesses
     [exec] --- PASS: TestCleansOnlyUnusedProcesses (0.50s)
     [exec] === RUN   TestOneLineOutput
     [exec] --- PASS: TestOneLineOutput (0.00s)
     [exec] === RUN   TestEmptyLinesOutput
     [exec] --- PASS: TestEmptyLinesOutput (0.00s)
     [exec] === RUN   TestAddSubscriber
     [exec] --- PASS: TestAddSubscriber (0.00s)
     [exec] === RUN   TestRestoreSubscriberForDeadProcess
     [exec] --- PASS: TestRestoreSubscriberForDeadProcess (0.00s)
     [exec] === RUN   TestMachineProcessIsNotAliveAfterItIsDead
     [exec] --- PASS: TestMachineProcessIsNotAliveAfterItIsDead (0.00s)
     [exec] === RUN   TestItIsNotPossibleToAddSubscriberToDeadProcess
     [exec] --- PASS: TestItIsNotPossibleToAddSubscriberToDeadProcess (0.00s)
     [exec] === RUN   TestReadProcessLogs
     [exec] --- PASS: TestReadProcessLogs (0.00s)
     [exec] FAIL
     [exec] FAIL    github.com/eclipse/che/exec-agent/process    0.525s
     [exec] ?       github.com/eclipse/che/exec-agent/rest    [no test files]
     [exec] ?       github.com/eclipse/che/exec-agent/rest/restutil    [no test files]
     [exec] ?       github.com/eclipse/che/exec-agent/rpc    [no test files]
     [exec] ?       github.com/eclipse/che/exec-agent/term    [no test files]
``` 