### PR TITLE
Remove redundant checking for existed project type

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Container.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Container.java
@@ -218,7 +218,6 @@ public interface Container extends Resource {
      *         if arguments is not a valid. Reasons include:
      *         <ul>
      *         <li>Invalid project name</li>
-     *         <li>Invalid project type</li>
      *         </ul>
      * @throws IllegalStateException
      *         if creation was failed. Reasons include:

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ProjectImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ProjectImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.che.api.project.shared.dto.SourceEstimation;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.api.resources.Project;
-import org.eclipse.che.ide.api.resources.marker.Marker;
 import org.eclipse.che.ide.resource.Path;
 
 import java.util.List;
@@ -127,15 +126,15 @@ class ProjectImpl extends ContainerImpl implements Project {
     /** {@inheritDoc} */
     @Override
     public boolean isProblem() {
-        return getMarker(ProblemProjectMarker.PROBLEM_PROJECT).isPresent();
+        return resourceManager.getProblemMarker(this).isPresent();
     }
 
     /** {@inheritDoc} */
     @Override
     public boolean exists() {
-        final Optional<Marker> problemMarker = getMarker(ProblemProjectMarker.PROBLEM_PROJECT);
+        final Optional<ProblemProjectMarker> problemMarker = resourceManager.getProblemMarker(this);
 
-        return !problemMarker.isPresent() || !((ProblemProjectMarker)problemMarker.get()).getProblems().containsKey(FOLDER_NOT_EXISTS_ON_FS);
+        return !problemMarker.isPresent() || !problemMarker.get().getProblems().containsKey(FOLDER_NOT_EXISTS_ON_FS);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This pull request fixes correct project creating flow. There is not need to check if user pass correct project type attribute because server side will create project anyway (with `blank` project type if user pass invalid project type).

Related issue: https://github.com/eclipse/che/issues/3339