### PR TITLE
Issue #1802 - Document highlightings

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/highlighting/OccurrencesProvider.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/highlighting/OccurrencesProvider.java
@@ -1,0 +1,93 @@
+package org.eclipse.che.plugin.languageserver.ide.highlighting;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.che.api.languageserver.shared.lsapi.DocumentHighlightDTO;
+import org.eclipse.che.api.languageserver.shared.lsapi.TextDocumentPositionParamsDTO;
+import org.eclipse.che.api.promises.client.Function;
+import org.eclipse.che.api.promises.client.FunctionException;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.js.JsPromise;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
+import org.eclipse.che.ide.editor.orion.client.OrionOccurrencesHandler;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionOccurrenceContextOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionOccurrenceOverlay;
+import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConfiguration;
+import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Provides occurrences highlights for the Orion Editor.
+ * 
+ * @author Xavier Coulon, Red Hat
+ */
+@Singleton
+public class OccurrencesProvider implements OrionOccurrencesHandler {
+
+	private static final Logger LOGGER = Logger.getLogger(OccurrencesProvider.class.getName());
+	private final EditorAgent               editorAgent;
+    private final TextDocumentServiceClient client;
+    private final DtoBuildHelper            helper;
+
+    /**
+     * Constructor.
+     * @param editorAgent
+     * @param client
+     * @param helper
+     */
+    @Inject
+    public OccurrencesProvider(EditorAgent editorAgent, TextDocumentServiceClient client, DtoBuildHelper helper) {
+        this.editorAgent = editorAgent;
+        this.client = client;
+        this.helper = helper;
+    }
+
+    @Override
+    public JsPromise<OrionOccurrenceOverlay[]> computeOccurrences(
+    		OrionOccurrenceContextOverlay context) {
+        final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+        if (activeEditor == null || !(activeEditor instanceof TextEditor)) {
+            return null;
+        }
+        final TextEditor editor = ((TextEditor)activeEditor);
+        if (!(editor.getConfiguration() instanceof LanguageServerEditorConfiguration)) {
+            return null;
+        }
+        final LanguageServerEditorConfiguration configuration = (LanguageServerEditorConfiguration)editor.getConfiguration();
+        if (configuration.getServerCapabilities().isDocumentHighlightProvider() == null || !configuration.getServerCapabilities().isDocumentHighlightProvider()) {
+            return null;
+        }
+        final Document document = editor.getDocument();
+        final TextDocumentPositionParamsDTO paramsDTO = helper.createTDPP(document, context.getStart());
+        // FIXME: the result should be a Promise<List<DocumentHighlightDTO>> but the typefox API returns a single DocumentHighlightDTO
+        Promise<DocumentHighlightDTO> promise = client.documentHighlight(paramsDTO);
+        Promise<OrionOccurrenceOverlay[]> then = promise.then(new Function<DocumentHighlightDTO, OrionOccurrenceOverlay[]>() {
+            @Override
+            public OrionOccurrenceOverlay[] apply(DocumentHighlightDTO highlight) throws FunctionException {
+            	if(highlight == null) {
+            		return new OrionOccurrenceOverlay[0];
+            	}
+            	final OrionOccurrenceOverlay[] occurrences = new OrionOccurrenceOverlay[1];
+        		final OrionOccurrenceOverlay occurrence = OrionOccurrenceOverlay.create();
+						// FIXME: this assumes that the language server will
+						// compute a range based on 'line 1', ie, the whole
+						// file content is on line 1 and the location to
+						// highlight is given by the 'character' position
+						// only.
+        		occurrence.setStart(highlight.getRange().getStart().getCharacter());
+        		occurrence.setEnd(highlight.getRange().getEnd().getCharacter() + 1);
+        		occurrences[0] = occurrence;
+                return occurrences;
+            }
+        });
+        return (JsPromise<OrionOccurrenceOverlay[]>)then;
+
+    }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
@@ -10,10 +10,11 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.languageserver.ide.service;
 
-import io.typefox.lsapi.CompletionItem;
+import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
+import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
+import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
+import java.util.List;
 
 import org.eclipse.che.api.languageserver.shared.lsapi.CompletionItemDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.CompletionListDTO;
@@ -22,6 +23,7 @@ import org.eclipse.che.api.languageserver.shared.lsapi.DidCloseTextDocumentParam
 import org.eclipse.che.api.languageserver.shared.lsapi.DidOpenTextDocumentParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DidSaveTextDocumentParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DocumentFormattingParamsDTO;
+import org.eclipse.che.api.languageserver.shared.lsapi.DocumentHighlightDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DocumentOnTypeFormattingParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DocumentRangeFormattingParamsDTO;
 import org.eclipse.che.api.languageserver.shared.lsapi.DocumentSymbolParamsDTO;
@@ -52,11 +54,10 @@ import org.eclipse.che.ide.websocket.rest.SubscriptionHandler;
 import org.eclipse.che.plugin.languageserver.ide.editor.PublishDiagnosticsProcessor;
 import org.eclipse.che.plugin.languageserver.ide.editor.ShowMessageProcessor;
 
-import java.util.List;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
-import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
-import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
-import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
+import io.typefox.lsapi.CompletionItem;
 
 
 /**
@@ -291,6 +292,19 @@ public class TextDocumentServiceClient {
                            .header(CONTENT_TYPE, APPLICATION_JSON).data(((JsonSerializable)saveEvent).toJson()).send();
     }
 
+   
+    /**
+     * GWT client implementation of {@link io.typefox.lsapi.TextDocumentService#documentHighlight(io.typefox.lsapi.TextDocumentPositionParams position)}
+     *
+     * @param position
+     * @return a {@link Promise} of an array of {@link DocumentHighlightDTO} which will be computed by the language server.
+     */
+    public Promise<DocumentHighlightDTO> documentHighlight(TextDocumentPositionParamsDTO position) {
+        final String requestUrl = appContext.getDevMachine().getWsAgentBaseUrl() + "/languageserver/textDocument/documentHighlight";
+        final Unmarshallable<DocumentHighlightDTO> unmarshaller = unmarshallerFactory.newUnmarshaller(DocumentHighlightDTO.class);
+        return asyncRequestFactory.createPostRequest(requestUrl, null).header(ACCEPT, APPLICATION_JSON)
+                           .header(CONTENT_TYPE, APPLICATION_JSON).data(((JsonSerializable)position).toJson()).send(unmarshaller);
+    }
     /**
      * Subscribes to websocket for 'textDocument/publishDiagnostics' notifications. 
      */

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionOccurrencesHandler.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionOccurrencesHandler.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client;
+
+import org.eclipse.che.api.promises.client.js.JsPromise;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionOccurrenceContextOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionOccurrenceOverlay;
+
+/**
+ * @author Xavier Coulon, Red Hat
+ */
+public interface OrionOccurrencesHandler {
+	JsPromise<OrionOccurrenceOverlay[]> computeOccurrences(OrionOccurrenceContextOverlay context);
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionOccurrencesRegistrant.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionOccurrencesRegistrant.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client;
+
+import com.google.gwt.core.client.JsArrayString;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionCodeEditWidgetOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionServiceRegistryOverlay;
+
+/**
+ * @author Xavier Coulon,Red Hat
+ */
+@Singleton
+public class OrionOccurrencesRegistrant {
+
+    private final Provider<OrionCodeEditWidgetOverlay> codeEditWidgetProvider;
+    private final EditorInitializePromiseHolder        editorModule;
+
+    @Inject
+    public OrionOccurrencesRegistrant(Provider<OrionCodeEditWidgetOverlay> codeEditWidgetProvider,
+                                EditorInitializePromiseHolder editorModule) {
+        this.codeEditWidgetProvider = codeEditWidgetProvider;
+        this.editorModule = editorModule;
+    }
+
+    public void registerOccurrencesHandler(final JsArrayString contentTypes, final OrionOccurrencesHandler handler) {
+        editorModule.getInitializerPromise().then(new Operation<Void>() {
+            @Override
+            public void apply(Void arg) throws OperationException {
+            	registerOccurrencesHandler(codeEditWidgetProvider.get().getServiceRegistry(), contentTypes, handler);
+            }
+        });
+    }
+
+    private final native void registerOccurrencesHandler(OrionServiceRegistryOverlay serviceRegistry, JsArrayString contentTypes,
+    		OrionOccurrencesHandler handler) /*-{
+        serviceRegistry.registerService("orion.edit.occurrences", {
+            computeOccurrences: function(editorContext, context) {
+           		return handler.@OrionOccurrencesHandler::computeOccurrences(*)(context);
+       		}
+        }, {
+            name: "Occurrences",
+            contentType: contentTypes
+        });
+    }-*/;
+
+
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/inject/OrionEditorGinModule.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/inject/OrionEditorGinModule.java
@@ -43,5 +43,7 @@ public class OrionEditorGinModule extends AbstractGinModule {
         install(new GinFactoryModuleBuilder().build(ContentAssistWidgetFactory.class));
 
         GinMultibinder.newSetBinder(binder(), OrionPlugin.class).addBinding().to(JavaHighlightingOrionPlugin.class);
+
+        //GinMultibinder.newSetBinder(binder(), OrionPlugin.class).addBinding().to(LanguageServerHighlightingOrionPlugin.class);
     }
 }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionOccurrenceContextOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionOccurrenceContextOverlay.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * The 'Occurrence Object' for Orion occurrences
+ * See <a href="https://wiki.eclipse.org/Orion/Documentation/Developer_Guide/Plugging_into_the_editor#orion.edit.occurrences">Orion Occurrences</a>
+ *
+ * @author Xavier Coulon, Red Hat
+ */
+public class OrionOccurrenceContextOverlay extends JavaScriptObject{
+    protected OrionOccurrenceContextOverlay() {}
+
+    public final native String getContentType() /*-{
+    	return this.contentType;
+	}-*/;
+    
+    /**
+     * @return The offset into the file for the start of the occurrence.
+     */
+    public final native int getStart() /*-{
+        return this.selection.start;
+    }-*/;
+
+    /**
+     * @return The offset into the file for the end of the occurrence.
+     */
+    public final native int getEnd() /*-{
+        return this.selection.end;
+    }-*/;
+}
+

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionOccurrenceOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionOccurrenceOverlay.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * The 'Occurrence Object' for Orion occurrences
+ * See <a href="https://wiki.eclipse.org/Orion/Documentation/Developer_Guide/Plugging_into_the_editor#orion.edit.occurrences">Orion Occurrences</a>
+ *
+ * @author Xavier Coulon, Red Hat
+ */
+public class OrionOccurrenceOverlay extends JavaScriptObject{
+    protected OrionOccurrenceOverlay() {}
+
+    public static native OrionOccurrenceOverlay create() /*-{
+	    return {};
+	}-*/;
+
+
+    /**
+     * @param offset The offset into the file for the start of the occurrence.
+     */
+    public final native void setStart(int offset) /*-{
+        this.start = offset;
+    }-*/;
+
+    /**
+     * @param offset The offset into the file for the end of the occurrence.
+     */
+    public final native void setEnd(int offset) /*-{
+        this.end = offset;
+    }-*/;
+}
+

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.languageserver.service;
 
 import io.typefox.lsapi.CompletionItem;
 import io.typefox.lsapi.CompletionList;
+import io.typefox.lsapi.DocumentHighlight;
 import io.typefox.lsapi.Hover;
 import io.typefox.lsapi.Location;
 import io.typefox.lsapi.SignatureHelp;
@@ -291,6 +292,19 @@ public class TextDocumentService {
         if (server != null) {
             server.getTextDocumentService().didSave(saveEvent);
         }
+    }
+
+    @POST
+    @Path("documentHighlight")
+    @Consumes(MediaType.APPLICATION_JSON)
+	public DocumentHighlight documentHighlight(TextDocumentPositionParamsDTO positionParams)
+			throws LanguageServerException, InterruptedException, ExecutionException {
+    	positionParams.getTextDocument().setUri(prefixURI(positionParams.getTextDocument().getUri()));
+    	LanguageServer server = getServer(positionParams.getTextDocument().getUri());
+    	if (server != null) {
+    		return server.getTextDocumentService().documentHighlight(positionParams).get();
+    	}
+    	return null;
     }
 
     private LanguageServer getServer(String uri) throws LanguageServerException {


### PR DESCRIPTION
### What issues does this PR fix or reference?
Addresses issue #1802 - Language Server Protocol: Document Highlights

### New behavior
when the user selects a word, a 'textDocument/documentHighlight' request is sent to the language server associated with the editor. The response contains the (list of) occurrence that the Orion editor has to highlight. 


Providing support for occurrences highlighting, with a
restriction due a bug in the `io.typefox.lsapi.services` version `0.3.0`
bundle, which assumes that the language server will return
a single occurrence to highlight, instead of a list of
occurrences.

see https://github.com/TypeFox/ls-api/blob/63ba665b38c0a942b06b0d866d7d0686bc2fdc0f/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/TextDocumentService.xtend#L81 vs https://github.com/eclipse/lsp4j/blob/master/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java#L96


To test the pull request, please follow the instructions on
#3123 to run the 'test-lang' server.

### Changelog
Adds highlighting for specific terms to the language server protocol support.


Signed-off-by: Xavier Coulon <xcoulon@redhat.com>