### PR TITLE
Machine.getOwner should provide userId and not namespace

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -305,6 +305,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                                                       service.getId(),
                                                       workspaceId);
 
+            final String userId = EnvironmentContext.getCurrent().getSubject().getUserId();
             MachineImpl machine = new MachineImpl(MachineConfigImpl.builder()
                                                                    .setDev(isDev)
                                                                    .setName(machineName)
@@ -323,7 +324,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                                                   service.getId(),
                                                   workspaceId,
                                                   envName,
-                                                  namespace,
+                                                  userId,
                                                   MachineStatus.RUNNING,
                                                   null);
 

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/test/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjectorTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/test/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjectorTest.java
@@ -21,7 +21,6 @@ import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.shared.dto.event.MachineStatusEvent;
 import org.eclipse.che.api.ssh.server.SshManager;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
-import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.Exec;
 import org.eclipse.che.plugin.docker.client.LogMessage;
@@ -61,8 +60,7 @@ import static org.testng.Assert.assertEquals;
 public class KeysInjectorTest {
     private static final String WORKSPACE_ID = "workspace123";
     private static final String MACHINE_ID   = "machine123";
-    private static final String OWNER_NAME   = "user";
-    private static final String USER_ID      = "user123";
+    private static final String OWNER        = "user123";
     private static final String CONTAINER_ID = "container123";
     private static final String EXEC_ID      = "exec123";
 
@@ -91,8 +89,6 @@ public class KeysInjectorTest {
     @Mock
     SshManager           sshManager;
     @Mock
-    UserManager          userManager;
-    @Mock
     User                 user;
 
     EventSubscriber<MachineStatusEvent> subscriber;
@@ -107,16 +103,13 @@ public class KeysInjectorTest {
         when(machineRuntime.getProperties()).thenReturn(metadataProperties);
 
         when(environmentEngine.getMachine(WORKSPACE_ID, MACHINE_ID)).thenReturn(instance);
-        when(instance.getOwner()).thenReturn(OWNER_NAME);
+        when(instance.getOwner()).thenReturn(OWNER);
         when(instance.getRuntime()).thenReturn(machineRuntime);
         when(instance.getLogger()).thenReturn(lineConsumer);
 
         keysInjector.start();
         verify(eventService).subscribe(subscriberCaptor.capture());
         subscriber = subscriberCaptor.getValue();
-
-        when(userManager.getByName(eq(OWNER_NAME))).thenReturn(user);
-        when(user.getId()).thenReturn(USER_ID);
 
         when(docker.createExec(any(CreateExecParams.class))).thenReturn(exec);
         when(exec.getId()).thenReturn(EXEC_ID);
@@ -138,39 +131,39 @@ public class KeysInjectorTest {
                                                            .withWorkspaceId(WORKSPACE_ID));
 
         verify(environmentEngine).getMachine(eq(WORKSPACE_ID), eq(MACHINE_ID));
-        verify(sshManager).getPairs(eq(USER_ID), eq("machine"));
-        verify(sshManager).getPair(eq(USER_ID), eq("workspace"), eq(WORKSPACE_ID));
+        verify(sshManager).getPairs(eq(OWNER), eq("machine"));
+        verify(sshManager).getPair(eq(OWNER), eq("workspace"), eq(WORKSPACE_ID));
         verifyZeroInteractions(docker, environmentEngine, sshManager);
     }
 
     @Test
     public void shouldNotInjectSshKeysWhenThereAreNotAnyPairWithPublicKey() throws Exception {
         when(sshManager.getPairs(anyString(), anyString()))
-                .thenReturn(Collections.singletonList(new SshPairImpl(USER_ID, "machine", "myPair", null, null)));
+                .thenReturn(Collections.singletonList(new SshPairImpl(OWNER, "machine", "myPair", null, null)));
 
         subscriber.onEvent(newDto(MachineStatusEvent.class).withEventType(MachineStatusEvent.EventType.RUNNING)
                                                            .withMachineId(MACHINE_ID)
                                                            .withWorkspaceId(WORKSPACE_ID));
 
         verify(environmentEngine).getMachine(eq(WORKSPACE_ID), eq(MACHINE_ID));
-        verify(sshManager).getPairs(eq(USER_ID), eq("machine"));
-        verify(sshManager).getPair(eq(USER_ID), eq("workspace"), eq(WORKSPACE_ID));
+        verify(sshManager).getPairs(eq(OWNER), eq("machine"));
+        verify(sshManager).getPair(eq(OWNER), eq("workspace"), eq(WORKSPACE_ID));
         verifyZeroInteractions(docker, environmentEngine, sshManager);
     }
 
     @Test
     public void shouldInjectSshKeysWhenThereAreAnyPairWithNotNullPublicKey() throws Exception {
         when(sshManager.getPairs(anyString(), anyString()))
-                .thenReturn(Arrays.asList(new SshPairImpl(USER_ID, "machine", "myPair", "publicKey1", null),
-                                          new SshPairImpl(USER_ID, "machine", "myPair", "publicKey2", null)));
+                .thenReturn(Arrays.asList(new SshPairImpl(OWNER, "machine", "myPair", "publicKey1", null),
+                                          new SshPairImpl(OWNER, "machine", "myPair", "publicKey2", null)));
 
         subscriber.onEvent(newDto(MachineStatusEvent.class).withEventType(MachineStatusEvent.EventType.RUNNING)
                                                            .withMachineId(MACHINE_ID)
                                                            .withWorkspaceId(WORKSPACE_ID));
 
         verify(environmentEngine).getMachine(eq(WORKSPACE_ID), eq(MACHINE_ID));
-        verify(sshManager).getPairs(eq(USER_ID), eq("machine"));
-        verify(sshManager).getPair(eq(USER_ID), eq("workspace"), eq(WORKSPACE_ID));
+        verify(sshManager).getPairs(eq(OWNER), eq("machine"));
+        verify(sshManager).getPair(eq(OWNER), eq("workspace"), eq(WORKSPACE_ID));
 
         ArgumentCaptor<CreateExecParams> argumentCaptor = ArgumentCaptor.forClass(CreateExecParams.class);
         verify(docker).createExec(argumentCaptor.capture());
@@ -193,7 +186,7 @@ public class KeysInjectorTest {
 
         // workspace keypair
         when(sshManager.getPair(anyString(), eq("workspace"), anyString()))
-                .thenReturn(new SshPairImpl(USER_ID, "workspace", WORKSPACE_ID, "publicKeyWorkspace", null));
+                .thenReturn(new SshPairImpl(OWNER, "workspace", WORKSPACE_ID, "publicKeyWorkspace", null));
 
 
         subscriber.onEvent(newDto(MachineStatusEvent.class).withEventType(MachineStatusEvent.EventType.RUNNING)
@@ -202,8 +195,8 @@ public class KeysInjectorTest {
 
         verify(environmentEngine).getMachine(eq(WORKSPACE_ID), eq(MACHINE_ID));
         // check calls for machine and workspace ssh pairs
-        verify(sshManager).getPairs(eq(USER_ID), eq("machine"));
-        verify(sshManager).getPair(eq(USER_ID), eq("workspace"), eq(WORKSPACE_ID));
+        verify(sshManager).getPairs(eq(OWNER), eq("machine"));
+        verify(sshManager).getPair(eq(OWNER), eq("workspace"), eq(WORKSPACE_ID));
 
         ArgumentCaptor<CreateExecParams> argumentCaptor = ArgumentCaptor.forClass(CreateExecParams.class);
         verify(docker).createExec(argumentCaptor.capture());
@@ -221,11 +214,11 @@ public class KeysInjectorTest {
     public void shouldInjectSshKeysWhenThereIsNoPublicWorkspaceKeyButMachineKeys() throws Exception {
         // no machine key pairs
         when(sshManager.getPairs(anyString(), eq("machine")))
-                .thenReturn(Arrays.asList(new SshPairImpl(USER_ID, "machine", "myPair", "publicKey1", null)));
+                .thenReturn(Arrays.asList(new SshPairImpl(OWNER, "machine", "myPair", "publicKey1", null)));
 
         // workspace keypair without public key
         when(sshManager.getPair(anyString(), eq("workspace"), anyString()))
-                .thenReturn(new SshPairImpl(USER_ID, "workspace", WORKSPACE_ID, null, null));
+                .thenReturn(new SshPairImpl(OWNER, "workspace", WORKSPACE_ID, null, null));
 
 
         subscriber.onEvent(newDto(MachineStatusEvent.class).withEventType(MachineStatusEvent.EventType.RUNNING)
@@ -234,8 +227,8 @@ public class KeysInjectorTest {
 
         verify(environmentEngine).getMachine(eq(WORKSPACE_ID), eq(MACHINE_ID));
         // check calls for machine and workspace ssh pairs
-        verify(sshManager).getPairs(eq(USER_ID), eq("machine"));
-        verify(sshManager).getPair(eq(USER_ID), eq("workspace"), eq(WORKSPACE_ID));
+        verify(sshManager).getPairs(eq(OWNER), eq("machine"));
+        verify(sshManager).getPair(eq(OWNER), eq("workspace"), eq(WORKSPACE_ID));
 
         ArgumentCaptor<CreateExecParams> argumentCaptor = ArgumentCaptor.forClass(CreateExecParams.class);
         verify(docker).createExec(argumentCaptor.capture());
@@ -266,8 +259,8 @@ public class KeysInjectorTest {
 
         verify(environmentEngine).getMachine(eq(WORKSPACE_ID), eq(MACHINE_ID));
         // check calls for machine and workspace ssh pairs
-        verify(sshManager).getPairs(eq(USER_ID), eq("machine"));
-        verify(sshManager).getPair(eq(USER_ID), eq("workspace"), eq(WORKSPACE_ID));
+        verify(sshManager).getPairs(eq(OWNER), eq("machine"));
+        verify(sshManager).getPair(eq(OWNER), eq("workspace"), eq(WORKSPACE_ID));
 
         verifyZeroInteractions(docker, environmentEngine, sshManager);
     }
@@ -275,7 +268,7 @@ public class KeysInjectorTest {
     @Test
     public void shouldSendMessageInMachineLoggerWhenSomeErrorOcursOnKeysInjection() throws Exception {
         when(sshManager.getPairs(anyString(), anyString()))
-                .thenReturn(Collections.singletonList(new SshPairImpl(USER_ID, "machine", "myPair", "publicKey1", null)));
+                .thenReturn(Collections.singletonList(new SshPairImpl(OWNER, "machine", "myPair", "publicKey1", null)));
         when(logMessage.getType()).thenReturn(LogMessage.Type.STDERR);
         when(logMessage.getContent()).thenReturn("FAILED");
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fix #3042

### Previous behavior
Machine.getOwner() was returning namespace

### New behavior
machine.getOwner() is returning userId and not a namespace

Change-Id: I64b4cd3931fec502073ead0115a312430f2434b8
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>