### PR TITLE
Pass options and attributes from template model to CreateProjectHandler

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.controller.ts
+++ b/dashboard/src/app/projects/create-project/create-project.controller.ts
@@ -570,7 +570,7 @@ export class CreateProjectController {
       promise = deferred.promise;
       deferred.resolve(true);
 
-    } else if (projectData.source.location.length > 0) {
+    } else {
 
       // if it's a user-defined location we need to cleanup commands that may have been configured by templates
       if (this.selectSourceOption === 'select-source-existing') {

--- a/dashboard/src/app/projects/create-project/samples/create-project-samples.controller.ts
+++ b/dashboard/src/app/projects/create-project/samples/create-project-samples.controller.ts
@@ -50,6 +50,8 @@ export class CreateProjectSamplesController {
     createProjectCtrl.setProjectDescription(template.description);
     createProjectCtrl.importProjectData.project.type = template.projectType;
     createProjectCtrl.importProjectData.project.commands = template.commands;
+    createProjectCtrl.importProjectData.project.attributes = template.attributes;
+    createProjectCtrl.importProjectData.project.options = template.options;
     createProjectCtrl.importProjectData.projects = template.projects;
 
     let name: string = template.displayName;

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -93,6 +93,8 @@ declare namespace _che {
     commands: Array<any>;
     projectType: string;
     tags: Array<string>;
+    attributes: Array<any>;
+    options: Array<any>;
   }
 
   export interface IImportProject {
@@ -106,6 +108,8 @@ declare namespace _che {
       type: string;
       description: string;
       commands: Array<any>;
+      attributes: Array<any>;
+      options: Array<any>;
     };
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/presenter/ProjectWizardPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/presenter/ProjectWizardPresenter.java
@@ -216,6 +216,8 @@ public class ProjectWizardPresenter implements Wizard.UpdateDelegate,
         final NewProjectConfig newProjectConfig = new NewProjectConfigImpl(projectTemplate);
         dataObject.setType(newProjectConfig.getType());
         dataObject.setSource(newProjectConfig.getSource());
+        dataObject.setAttributes(newProjectConfig.getAttributes());
+        dataObject.setOptions(newProjectConfig.getOptions());
     }
 
     /** Creates or returns project wizard for the specified projectType with the given dataObject. */


### PR DESCRIPTION
### What does this PR do?

This PR fixes the Dashboard app and the Create Project wizard in the IDE to pass the `attributes` and `options` from the samples.json configuration to the `CreateProjectHandler.onCreateProject()` method.

### What issues does this PR fix or reference?

This PR blocks PR #2785.

Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>