### PR TITLE
Force maven to use 755 permission for che-websocket-terminal

### DIFF
--- a/exec-agent/src/assembly/assembly.xml
+++ b/exec-agent/src/assembly/assembly.xml
@@ -26,6 +26,7 @@
             <includes>
                 <include>che-websocket-terminal</include>
             </includes>
+            <fileMode>0755</fileMode>
             <outputDirectory></outputDirectory>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
Resolves #3374.

On windows _che-websocket-terminal_  has _644_ permission while it has to be _755_
or the [command](https://github.com/eclipse/che/blob/ab9b0946ecf7549191382640f517aa5d882701a6/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java#L108) will fail with _Permission denied_ error.