### PR TITLE
CHE-3216: Fix kill terminal process and its children on closing terminal.

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/terminal/TerminalPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/perspective/terminal/TerminalPresenter.java
@@ -217,13 +217,12 @@ public class TerminalPresenter implements TabPresenter, TerminalView.ActionDeleg
     }
 
     /**
-     * Sends 'exit' command on server side to stop terminal.
+     * Sends 'close' message on server side to stop terminal.
      */
     public void stopTerminal() {
         if (connected) {
             Jso jso = Jso.create();
-            jso.addField("type", "data");
-            jso.addField("data", "exit\n");
+            jso.addField("type", "close");
             socket.send(jso.serialize());
         }
     }


### PR DESCRIPTION
### What does this PR do?
Create new type websocket message to realise ability to kill terminal process and its child processes when user click "close button". 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3216

@evoevodin and @garagatyi review please.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>