### PR TITLE
[dockerfiles] Fix scripts to be compliant with sh (and not only bash)

### DIFF
--- a/dockerfiles/action/build.sh
+++ b/dockerfiles/action/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-action"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/base/build.sh
+++ b/dockerfiles/base/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-base"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/build-all.sh
+++ b/dockerfiles/build-all.sh
@@ -9,12 +9,12 @@
 set -e
 set -u
 
-. build.include
+. ./build.include
 init
 
 # loop on all libraries first
 for directory in lib*/ ; do
-  if [[ -e ${directory}/build.sh ]] ; then
+  if [ -e ${directory}/build.sh ] ; then
    echo "Call buid.sh from ${directory}"
    ${directory}build.sh "$@"
  else
@@ -24,7 +24,7 @@ done
 
 # loop on all directories and call build.sh script if present
 for directory in */ ; do
-  if [[ -e ${directory}/build.sh ]] ; then
+  if [ -e ${directory}/build.sh ] ; then
    echo "Call buid.sh from ${directory}"
    ${directory}build.sh "$@"
  else

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -10,7 +10,7 @@ init() {
   GREEN='\033[0;32m'
   RED='\033[0;31m'
   NC='\033[0m'
-  if [[ $# -eq 0 ]] ; then
+  if [ $# -eq 0 ] ; then
     TAG="nightly"
     echo "No tag provided, using nightly as default"
   else

--- a/dockerfiles/che/build.sh
+++ b/dockerfiles/che/build.sh
@@ -6,7 +6,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-server"
-source $(cd "$(dirname "$0")"; pwd)/../build.include
+. $(cd "$(dirname "$0")"; pwd)/../build.include
 
 # grab assembly
 DIR=$(cd "$(dirname "$0")"; pwd)
@@ -26,5 +26,5 @@ fi
 echo "Linking assembly ${BUILD_ASSEMBLY_ZIP} --> ${LOCAL_ASSEMBLY_ZIP}"
 ln ${BUILD_ASSEMBLY_ZIP} ${LOCAL_ASSEMBLY_ZIP}
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-cli"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/dev/build.sh
+++ b/dockerfiles/dev/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-dev"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/dir/build.sh
+++ b/dockerfiles/dir/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-dir"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/init/build.sh
+++ b/dockerfiles/init/build.sh
@@ -6,7 +6,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-init"
-source $(cd "$(dirname "$0")"; pwd)/../build.include
+. $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/ip/build.sh
+++ b/dockerfiles/ip/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-ip"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/launcher/build.sh
+++ b/dockerfiles/launcher/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-launcher"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/lib/build.sh
+++ b/dockerfiles/lib/build.sh
@@ -17,7 +17,7 @@ generate_dto() {
   POM_VERSION=$(cat ${DIR}/dto-pom.xml | grep "^        <version>.*</version>$" | awk -F'[><]' '{print $3}')
   if [ -e "${DIR}/src/api/dto/che-dto.ts" ]; then
     # DTO file exists, Do we have snapshot ?
-    if [[ ${POM_VERSION} != *"SNAPSHOT" ]]
+    if [ ${POM_VERSION} != *"SNAPSHOT" ]
     then
       if [ ${DIR}/src/api/dto/che-dto.ts -nt ${DIR}/dto-pom.xml ]; then
         echo "Using tagged version and dto file is up-to-date. Not generating it."

--- a/dockerfiles/lib/build.sh
+++ b/dockerfiles/lib/build.sh
@@ -51,7 +51,7 @@ native_build() {
   ./node_modules/typescript/bin/tsc --project .
 }
 
-init
+init "$@"
 generate_dto
 
 DIR=$(cd "$(dirname "$0")"; pwd)

--- a/dockerfiles/mount/Dockerfile
+++ b/dockerfiles/mount/Dockerfile
@@ -40,7 +40,7 @@ FROM alpine:3.4
 ENV UNISON_VERSION=2.48.4
 
 RUN apk add --update build-base curl bash sshfs && \
-    apk add ocaml --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
+    apk add ocaml --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted && \
     curl -L https://www.seas.upenn.edu/~bcpierce/unison/download/releases/unison-$UNISON_VERSION/unison-$UNISON_VERSION.tar.gz | tar xzv -C /tmp && \
     cd /tmp/src && \
     sed -i -e 's/GLIBC_SUPPORT_INOTIFY 0/GLIBC_SUPPORT_INOTIFY 1/' fsmonitor/linux/inotify_stubs.c && \

--- a/dockerfiles/mount/build.sh
+++ b/dockerfiles/mount/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-mount"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/test/build.sh
+++ b/dockerfiles/test/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="eclipse/che-test"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"


### PR DESCRIPTION
### What does this PR do?
Adapt sh scripts to be "pure sh" scripts (and not some bash functions)

### Previous behavior
On some systems like Ubuntu, dash is implementation of sh and then iit was failing

### New behavior
Compliant with sh (and then dash)

