### PR TITLE
[cli] Compare date but by having a delta of 1hour

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -368,9 +368,10 @@ verify_version_compatibility() {
     # Solution is to compare the dates, and only print warning message if the locally created ate
     # is less than the updated date on dockerhub.
 
-    if $(date_less_than ${LOCAL_CREATION_DATE} ${REMOTE_CREATION_DATE}); then
-      warning "Your local ${CHE_IMAGE_FULLNAME} image is older than the version on DockerHub."
-      warning "Run 'docker pull ${CHE_IMAGE_FULLNAME}' to update your CLI."
+    if [[ -z ${REMOTE_CREATION_DATE} ]]; then
+      warning "Unable to get published date on hub.docker.com for ${CHE_IMAGE_FULLNAME}"
+    elif $(newer_date_period ${LOCAL_CREATION_DATE} ${REMOTE_CREATION_DATE}); then
+      warning "There is a newer ${CHE_IMAGE_FULLNAME} image on DockerHub."
     fi
   fi
 }
@@ -381,12 +382,14 @@ timestamp_date_iso8601() {
   echo ${TMP_DATE}
 }
 
-# Compare two dates with ISO 8601 format and return true if the first date is less than the second date
-date_less_than() {
+# Compare two dates with ISO 8601 format and return
+# true if the first date is less than the second date (with a 1hour period)
+# else false
+newer_date_period() {
   local FIRST_DATE=$(timestamp_date_iso8601 $1)
   local SECOND_DATE=$(timestamp_date_iso8601 $2)
 
-  if [[ ${FIRST_DATE} -lt ${SECOND_DATE} ]]; then
+  if [[ $(expr ${FIRST_DATE} + 3600) -lt ${SECOND_DATE} ]]; then
     return 0
   else
     return 1


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1235

### Previous behavior
Compare published date and created date (that have delta)

### New behavior
As created date and published date are not the same (there is always a delay before publishing an image locally (transfer time) we couldn't compare published date and created date

Change two lines to a single line
Instead of "local is older", display that "a newer version is available"

exact message is : "WARN: There is a newer eclipse/che-cli:nightly image on DockerHub."
![image](https://cloud.githubusercontent.com/assets/436777/21236587/f7f6c0e0-c2fb-11e6-9bcd-9a5950e137f0.png)


Change-Id: I80bb2f8c48995b5dd06ecd3cff84009b76fceee7
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>