### PR TITLE
#3220 use document changes instead of full text replacing

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCodeAssistClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCodeAssistClient.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.machine.WsAgentURLModifier;
 import org.eclipse.che.ide.ext.java.shared.dto.Change;
 import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+import org.eclipse.che.ide.ext.java.shared.dto.OrganizeImportResult;
 import org.eclipse.che.ide.ext.java.shared.dto.Problem;
 import org.eclipse.che.ide.ext.java.shared.dto.ProposalApplyResult;
 import org.eclipse.che.ide.ext.java.shared.dto.Proposals;
@@ -151,13 +152,13 @@ public class JavaCodeAssistClient {
      *         fully qualified name of the java file
      * @return list of imports which have conflicts
      */
-    public Promise<List<ConflictImportDTO>> organizeImports(String projectPath, String fqn) {
+    public Promise<OrganizeImportResult> organizeImports(String projectPath, String fqn) {
         String url =
                 appContext.getDevMachine().getWsAgentBaseUrl() + CODE_ASSIST_URL_PREFIX + "/organize-imports?projectpath=" + projectPath +
                 "&fqn=" + fqn;
         return asyncRequestFactory.createPostRequest(url, null)
                                   .loader(loader)
-                                  .send(unmarshallerFactory.newListUnmarshaller(ConflictImportDTO.class));
+                                  .send(unmarshallerFactory.newUnmarshaller(OrganizeImportResult.class));
     }
 
     /**
@@ -168,12 +169,12 @@ public class JavaCodeAssistClient {
      * @param fqn
      *         fully qualified name of the java file
      */
-    public Promise<Void> applyChosenImports(String projectPath, String fqn, ConflictImportDTO chosen) {
+    public Promise<List<Change>> applyChosenImports(String projectPath, String fqn, ConflictImportDTO chosen) {
         String url = appContext.getDevMachine().getWsAgentBaseUrl() + CODE_ASSIST_URL_PREFIX + "/apply-imports?projectpath=" + projectPath +
                      "&fqn=" + fqn;
         return asyncRequestFactory.createPostRequest(url, chosen)
                                   .loader(loader)
                                   .header(CONTENT_TYPE, MimeType.APPLICATION_JSON)
-                                  .send();
+                                  .send(unmarshallerFactory.newListUnmarshaller(Change.class));
     }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/main/java/org/eclipse/che/plugin/java/server/CodeAssist.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/main/java/org/eclipse/che/plugin/java/server/CodeAssist.java
@@ -20,6 +20,7 @@ import com.google.inject.Singleton;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.ide.ext.java.shared.dto.Change;
 import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+import org.eclipse.che.ide.ext.java.shared.dto.OrganizeImportResult;
 import org.eclipse.che.ide.ext.java.shared.dto.Problem;
 import org.eclipse.che.ide.ext.java.shared.dto.ProposalApplyResult;
 import org.eclipse.che.ide.ext.java.shared.dto.ProposalPresentation;
@@ -55,6 +56,7 @@ import org.eclipse.jdt.internal.core.DocumentAdapter;
 import org.eclipse.jdt.internal.core.JavaModelStatus;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.OrganizeImportsOperation;
+import org.eclipse.jdt.internal.corext.format.DocumentChangeListener;
 import org.eclipse.jdt.internal.corext.refactoring.changes.MoveCompilationUnitChange;
 import org.eclipse.jdt.internal.corext.refactoring.changes.RenameCompilationUnitChange;
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
@@ -66,6 +68,7 @@ import org.eclipse.jdt.internal.ui.text.java.TemplateCompletionProposalComputer;
 import org.eclipse.jdt.ui.text.java.JavaContentAssistInvocationContext;
 import org.eclipse.jdt.ui.text.java.correction.ChangeCorrectionProposal;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
@@ -233,7 +236,7 @@ public class CodeAssist {
      *         fully qualified name of the java file
      * @return list of imports which have conflicts
      */
-    public List<ConflictImportDTO> organizeImports(IJavaProject project, String fqn) throws CoreException, BadLocationException {
+    public OrganizeImportResult organizeImports(IJavaProject project, String fqn) throws CoreException, BadLocationException {
         ICompilationUnit compilationUnit = prepareCompilationUnit(project, fqn);
         return createOrganizeImportOperation(compilationUnit, null);
     }
@@ -248,13 +251,14 @@ public class CodeAssist {
      * @param  chosen
      *          list of chosen imports as result of resolving conflicts which needed to add to all imports.
      */
-    public void applyChosenImports(IJavaProject project, String fqn, List<String> chosen) throws CoreException, BadLocationException {
+    public List<Change> applyChosenImports(IJavaProject project, String fqn, List<String> chosen) throws CoreException, BadLocationException {
         ICompilationUnit compilationUnit = prepareCompilationUnit(project, fqn);
-        createOrganizeImportOperation(compilationUnit, chosen);
+        OrganizeImportResult result = createOrganizeImportOperation(compilationUnit, chosen);
+        return result.getChanges();
     }
 
-    private List<ConflictImportDTO> createOrganizeImportOperation(ICompilationUnit compilationUnit,
-                                                                 List<String> chosen) throws CoreException {
+    private OrganizeImportResult createOrganizeImportOperation(ICompilationUnit compilationUnit,
+                                                               List<String> chosen) throws CoreException {
         CodeGenerationSettings settings = JavaPreferencesSettings.getCodeGenerationSettings(compilationUnit.getJavaProject());
 
         OrganizeImportsOperation operation = new OrganizeImportsOperation(compilationUnit,
@@ -267,16 +271,25 @@ public class CodeAssist {
 
         NullProgressMonitor monitor = new NullProgressMonitor();
         TextEdit edit = operation.createTextEdit(monitor);
-
+        OrganizeImportResult result = DtoFactory.newDto(OrganizeImportResult.class);
         TypeNameMatch[][] choices = operation.getChoices();
         //Apply organize import declarations if operation doesn't have conflicts (choices.length == 0)
         //or all conflicts were resolved (!chosen.isEmpty())
         if ((chosen != null && !chosen.isEmpty()) || choices == null || choices.length == 0) {
-            operation.applyChanges(edit, monitor);
-            return Collections.emptyList();
+            IBuffer buffer = compilationUnit.getBuffer();
+            IDocument document = new Document(buffer.getContents());
+            DocumentChangeListener documentChangeListener = new DocumentChangeListener(document);
+            try {
+                edit.apply(document);
+            } catch (BadLocationException e) {
+                LOG.debug("Applying Organize import text edits goes wrong:", e);
+            }
+            result.setChanges(documentChangeListener.getChanges());
+            return result;
         }
 
-        return createListOfDTOMatches(choices);
+        result.setConflicts(createListOfDTOMatches(choices));
+        return result;
     }
 
     private List<ConflictImportDTO> createListOfDTOMatches(TypeNameMatch[][] choices) {

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/main/java/org/eclipse/che/plugin/java/server/rest/CodeAssistService.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/main/java/org/eclipse/che/plugin/java/server/rest/CodeAssistService.java
@@ -13,12 +13,11 @@ package org.eclipse.che.plugin.java.server.rest;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.ide.ext.java.shared.dto.Change;
 import org.eclipse.che.ide.ext.java.shared.dto.ConflictImportDTO;
+import org.eclipse.che.ide.ext.java.shared.dto.OrganizeImportResult;
 import org.eclipse.che.ide.ext.java.shared.dto.Problem;
 import org.eclipse.che.ide.ext.java.shared.dto.ProposalApplyResult;
 import org.eclipse.che.ide.ext.java.shared.dto.Proposals;
@@ -112,8 +111,8 @@ public class CodeAssistService {
     @POST
     @Path("/organize-imports")
     @Produces({MediaType.APPLICATION_JSON})
-    public List<ConflictImportDTO> organizeImports(@QueryParam("projectpath") String projectPath,
-                                                   @QueryParam("fqn") String fqn) throws NotFoundException,
+    public OrganizeImportResult organizeImports(@QueryParam("projectpath") String projectPath,
+                                                @QueryParam("fqn") String fqn) throws NotFoundException,
                                                                                         CoreException,
                                                                                         BadLocationException {
         IJavaProject project = model.getJavaProject(projectPath);
@@ -128,18 +127,19 @@ public class CodeAssistService {
      * @param fqn
      *         fully qualified name of the java file
      * @param  chosen
-     *          list of chosen imports from conflicts which needed to add to all imports.
+     * @return list of document changes
      */
     @POST
     @Path("/apply-imports")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void applyChosenImports(@QueryParam("projectpath") String projectPath,
-                                   @QueryParam("fqn") String fqn,
-                                   ConflictImportDTO chosen) throws NotFoundException,
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Change> applyChosenImports(@QueryParam("projectpath") String projectPath,
+                                           @QueryParam("fqn") String fqn,
+                                           ConflictImportDTO chosen) throws NotFoundException,
                                                                     CoreException,
                                                                     BadLocationException {
         IJavaProject project = model.getJavaProject(projectPath);
-        codeAssist.applyChosenImports(project, fqn, chosen.getTypeMatches());
+        return codeAssist.applyChosenImports(project, fqn, chosen.getTypeMatches());
     }
 
     @POST

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/dto/OrganizeImportResult.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/dto/OrganizeImportResult.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.ext.java.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+import java.util.List;
+
+/**
+ * Result of Organize import request.
+ */
+@DTO
+public interface OrganizeImportResult {
+
+    /**
+     * The list of organize imports conflicts.
+     *
+     * @return the organize import conflicts
+     */
+    List<ConflictImportDTO> getConflicts();
+
+    void setConflicts(List<ConflictImportDTO> conflicts);
+
+    /**
+     * The changes that should be apply on organize imports
+     *
+     * @return the change list
+     */
+    List<Change> getChanges();
+
+    void setChanges(List<Change> changes);
+}

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -196,7 +196,7 @@ public class OrionDocument extends AbstractDocument {
     }
 
     public void replace(int offset, int length, String text) {
-        this.editorOverlay.setText(text, offset, offset + length);
+        this.editorOverlay.getModel().setText(text, offset, offset + length);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
 use document changes instead of full text replacing on organize import operation to avoid cursor move
### What issues does this PR fix or reference?
#3220 
### Previous behavior
after organize import cursor moves at the end of the document  


Signed-off-by: Evgen Vidolob <evidolob@codenvy.com>