### PR TITLE
Use of Chefile in new cli : new 'dir' command

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -24,7 +24,7 @@ cli_parse () {
   COMMAND="cmd_$1"
 
   case $1 in
-      init|config|start|stop|restart|backup|restore|info|offline|destroy|download|rmi|upgrade|version|ssh|sync|action|test|compile|help)
+      init|config|start|stop|restart|backup|restore|info|offline|destroy|download|rmi|upgrade|version|ssh|sync|action|test|compile|dir|help)
       ;;
       *)
          error "You passed an unknown command."

--- a/dockerfiles/base/scripts/base/commands/cmd_dir.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_dir.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2012-2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+
+cmd_dir() {
+
+  if [[ $# -eq 0 ]] ; then
+    error "dir command is requiring a local folder to be given as argument"
+    return 2;
+  fi
+
+  local HOST_FOLDER_TO_USE=${1}
+
+  # Not loaded as part of the init process to save on download time
+  update_image_if_not_found eclipse/che-dir:nightly
+  docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} eclipse/che-dir:nightly "$@"
+}

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -21,13 +21,14 @@ OPTIONAL DOCKER PARAMETERS:
   -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}/backup         Where backup files will be saved
   -v <LOCAL_PATH>:/repo                ${CHE_MINI_PRODUCT_NAME} git repo to activate dev mode
   -v <LOCAL_PATH>:/sync                Where remote ws files will be copied with sync command
-  -v <LOCAL_PATH>:/unison              Where unison profile for optimzing sync command resides
+  -v <LOCAL_PATH>:/unison              Where unison profile for optimizing sync command resides
     
 COMMANDS:
   action <action-name>                 Start action on ${CHE_MINI_PRODUCT_NAME} instance
   backup                               Backups ${CHE_MINI_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
   config                               Generates a ${CHE_MINI_PRODUCT_NAME} config from vars; run on any start / restart
   destroy                              Stops services, and deletes ${CHE_MINI_PRODUCT_NAME} instance data
+  dir <path> <command>                 Use Chefile feature in the directory <path>
   download                             Pulls Docker images for the current ${CHE_MINI_PRODUCT_NAME} version
   help                                 This message
   info                                 Displays info about ${CHE_MINI_PRODUCT_NAME} and the CLI

--- a/dockerfiles/lib/Dockerfile.dev
+++ b/dockerfiles/lib/Dockerfile.dev
@@ -27,4 +27,5 @@ RUN set -x \
         && mkdir /lib-typescript && mv /compile/node_modules /lib-typescript/
 COPY . /lib-typescript/
 RUN /lib-typescript/node_modules/.bin/tsc --project /lib-typescript/ && mv /lib-typescript/lib /che-lib \
+    && cd /lib-typescript/src && find . -name "*.properties" -exec install -D {} /che-lib/{} \;\
     && rm -rf /lib-typescript && mv /runtime/node_modules /che-lib && rm -rf /runtime && rm -rf /compile

--- a/dockerfiles/lib/src/index.ts
+++ b/dockerfiles/lib/src/index.ts
@@ -56,44 +56,51 @@ export class EntryPoint {
             Log.disablePrefix();
         }
 
-
-        var promise : Promise<any>;
-
-        switch(this.commandName) {
-            case 'che-test':
-                let cheTest: CheTest = new CheTest(this.args);
-                promise = cheTest.run();
-                break;
-            case 'che-action':
-                let cheAction: CheAction = new CheAction(this.args);
-                promise = cheAction.run();
-                break;
-            case 'che-dir':
-                let cheDir: CheDir = new CheDir(this.args);
-                promise = cheDir.run();
-                break;
-            default:
-                Log.getLogger().error('Invalid choice of command-name');
-                process.exit(1);
-        }
-
-        // handle error of the promise
-        promise.catch((error) => {
-            try {
-                let errorMessage = JSON.parse(error);
-                if (errorMessage.message) {
-                    Log.getLogger().error(errorMessage.message);
-                } else {
-                    Log.getLogger().error(error.toString());
-                }
-            } catch (e) {
-                Log.getLogger().error(error.toString());
-                if (error instanceof TypeError || error instanceof SyntaxError) {
-                    console.log(error.stack);
-                }
+        try {
+            var promise : Promise<any>;
+            switch(this.commandName) {
+                case 'che-test':
+                    let cheTest: CheTest = new CheTest(this.args);
+                    promise = cheTest.run();
+                    break;
+                case 'che-action':
+                    let cheAction: CheAction = new CheAction(this.args);
+                    promise = cheAction.run();
+                    break;
+                case 'che-dir':
+                    let cheDir: CheDir = new CheDir(this.args);
+                    promise = cheDir.run();
+                    break;
+                default:
+                    Log.getLogger().error('Invalid choice of command-name');
+                    process.exit(1);
             }
-            process.exit(1);
-        });
+
+
+            // handle error of the promise
+            promise.catch((error) => {
+                try {
+                    let errorMessage = JSON.parse(error);
+                    if (errorMessage.message) {
+                        Log.getLogger().error(errorMessage.message);
+                    } else {
+                        Log.getLogger().error(error.toString());
+                    }
+                } catch (e) {
+                    Log.getLogger().error(error.toString());
+                    if (error instanceof TypeError || error instanceof SyntaxError) {
+                        console.log(error.stack);
+                    }
+                }
+                process.exit(1);
+            });
+
+        } catch (e) {
+            Log.getLogger().error(e);
+            if (e instanceof TypeError || e instanceof SyntaxError) {
+                console.log(e.stack);
+            }
+        }
 
     }
 

--- a/dockerfiles/lib/src/internal/dir/che-dir.ts
+++ b/dockerfiles/lib/src/internal/dir/che-dir.ts
@@ -93,6 +93,10 @@ export class CheDir {
     this.args = ArgumentProcessor.inject(this, args);
 
 
+    if (this.args.length == 0) {
+      throw new Error("Missing folder for synchronization.");
+    }
+
     this.currentFolder = this.path.resolve(args[0]);
     this.folderName = this.path.basename(this.currentFolder);
     this.cheFile = this.path.resolve(this.currentFolder, 'Chefile');
@@ -163,9 +167,10 @@ export class CheDir {
 
   parseArgument() : Promise<string> {
     return new Promise<string>( (resolve, reject) => {
-      let invalidCommand : string = 'only init, up, down, ssh and status commands are supported.';
-      if (this.args.length == 0) {
-        reject(invalidCommand);
+      let emptyCommand : string = 'You need to provide an argument to the command : init, up, down, ssh or status';
+      let invalidCommand : string = 'Invalid command given: only init, up, down, ssh and status commands are supported.';
+      if (this.args.length == 1) {
+        reject(emptyCommand);
       } else if ('init' === this.args[1]
                  || 'up' === this.args[1]
                  || 'destroy' === this.args[1]

--- a/docs/_docs/setup/che-setup-cli.md
+++ b/docs/_docs/setup/che-setup-cli.md
@@ -27,6 +27,7 @@ COMMANDS:
   backup                               Backups che configuration and data to /data/backup volume mount
   config                               Generates a che config from vars; run on any start / restart
   destroy                              Stops services, and deletes che instance data
+  dir <path> <command>                 Use Chefile feature in the directory <path>
   download                             Pulls Docker images for the current che version
   help                                 This message
   info                                 Displays info about che and the CLI
@@ -136,7 +137,34 @@ Restores `/instance` to its previous state. You do not need to worry about havin
 
 This command will destroy your existing `/instance` folder, so use with caution, or set these values to different folders when performing a restore.
 
-TODO: NEED SYNTAX FOR SSH, TEST, SYNC, DIR COMMANDS
+## action
+Executes some actions on the Eclipse Che instance or on a workspace running inside Che.
+For example to list all workspaces on Che, the following command can be used
+`action list-workspaces`.
+To execute a command on a workspace `action execute-command <workspace-name> <action>` where action can be any bash command.
+
+## dir
+Boots a new Eclipse Che instance with a workspace for the folder specified in parameter.
+If for example `$HOME/my-project` is given as parameter in `dir $HOME/my-project up`, a new Che instance will be created, using `$HOME/my-project`as project in the IDE.
+So inside the IDE, `/projects` folder will contain a `my-project`folder with your host folder.
+Then, any changes inside the IDE will be reflected in your host folder. And the opposite is also true, updating a file on your local computer will update the content of the file inside the IDE.
+
+Other commands are `init`,`up`, `down`, `ssh` and `status`
+
+  - `init`  : Initialize the directory specified and add a default `Chefile` file if there is none
+  - `up`    : Boot Eclipse Che with workspace on folder
+  - `down`  : Stop Eclipse Che and any workspaces
+  - `ssh`   : Connect to the running workspace by using ssh
+  - `status`: Display if an instance of Eclipse Che is running or not for the specified folder.
+
+## ssh
+Connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it will connect to the default machine which is the dev machine.
+The syntax is `ssh <workspace-name> [machine-name]`
+The ssh connection will work only if there is a workspace ssh key setup. A default ssh key is automatically generated when a workspace is created.
+
+## test
+Performs some tests on your local instance of Che. It can for example check the ability to create a workspace, start the workspace by using a custom Workspace runtime and then use it.
+The list of all the tests available can be obtained by providing only `test` command.
 
 # CLI Development
 You can customize the CLI using a variety of techniques. This section discusses how engineers develop and test the CLI on their local machines.


### PR DESCRIPTION
### What does this PR do?

Add 'dir' command in new cli

### Previous behavior
new cli hasn't the command

### New behavior
`docker run.....   eclipse/che-cli:nightly dir <path-to-the-host-directory> <command>`


Change-Id: Iec4f40cfb503fe60c51d81ef06e07043e102db6a
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>