### PR TITLE
CODENVY-937: stop buttons behavior based on auto-snapshot settings

### DIFF
--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -54,27 +54,8 @@ export class NavbarRecentWorkspacesController {
     // fetch workspaces when initializing
     this.cheWorkspace.fetchWorkspaces();
 
-    this.dropdownItemTempl = [
-      // running
-      {
-        name: 'Stop',
-        scope: 'RUNNING',
-        icon: 'fa fa-stop',
-        _onclick: (workspaceId: string) => {
-          this.stopRecentWorkspace(workspaceId);
-        }
-      },
-      // stopped
-      {
-        name: 'Run',
-        scope: 'STOPPED',
-        icon: 'fa fa-play',
-        _onclick: (workspaceId: string) => {
-          this.runRecentWorkspace(workspaceId);
-        }
-      }
-    ];
     this.dropdownItems = {};
+    this.dropdownItemTempl = [];
 
     let cleanup = $rootScope.$on('recent-workspace:set', (event: ng.IAngularEvent, workspaceId: string) => {
       this.veryRecentWorkspaceId = workspaceId;
@@ -91,6 +72,61 @@ export class NavbarRecentWorkspacesController {
     }, true);
 
     this.updateRecentWorkspaces();
+    this.fetchWorkspaceSettings();
+  }
+
+  /**
+   * Retrieves workspace settings.
+   */
+  fetchWorkspaceSettings(): void {
+    if (this.cheWorkspace.getWorkspaceSettings()) {
+      this.prepareDropdownItemsTemplate();
+    } else {
+      this.cheWorkspace.fetchWorkspaceSettings().then(() => {
+        this.prepareDropdownItemsTemplate();
+      }, (error: any) => {
+        if (error.status === 304) {
+          this.prepareDropdownItemsTemplate();
+        }
+      });
+    }
+  }
+
+  /**
+   * Forms the dropdown items template, based of workspace settings.
+   */
+  prepareDropdownItemsTemplate(): void {
+    let autoSnapshot = this.cheWorkspace.getAutoSnapshotSettings();
+    let oppositeStopTitle = autoSnapshot ? 'Stop without snapshot' : 'Stop with snapshot';
+
+    this.dropdownItemTempl = [
+      // running
+      {
+        name: 'Stop',
+        scope: 'RUNNING',
+        icon: 'fa fa-stop',
+        _onclick: (workspaceId: string) => {
+          this.stopRecentWorkspace(workspaceId, autoSnapshot);
+        }
+      },
+      {
+        name: oppositeStopTitle,
+        scope: 'RUNNING',
+        icon: 'fa fa-stop',
+        _onclick: (workspaceId: string) => {
+          this.stopRecentWorkspace(workspaceId, !autoSnapshot);
+        }
+      },
+      // stopped
+      {
+        name: 'Run',
+        scope: 'STOPPED',
+        icon: 'fa fa-play',
+        _onclick: (workspaceId: string) => {
+          this.runRecentWorkspace(workspaceId);
+        }
+      }
+    ];
   }
 
   /**
@@ -206,6 +242,10 @@ export class NavbarRecentWorkspacesController {
    * @returns {*}
    */
   getDropdownItems(workspaceId: string): any {
+    if (this.dropdownItemTempl.length === 0) {
+      return this.dropdownItemTempl;
+    }
+
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId),
       disabled = workspace && (workspace.status === 'STARTING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING'),
       visibleScope = (workspace && (workspace.status === 'RUNNING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING')) ? 'RUNNING' : 'STOPPED';
@@ -230,8 +270,8 @@ export class NavbarRecentWorkspacesController {
    * Stops specified workspace
    * @param workspaceId {String} workspace id
    */
-  stopRecentWorkspace(workspaceId: string): void {
-    this.cheWorkspace.stopWorkspace(workspaceId).then(() => {
+  stopRecentWorkspace(workspaceId: string, createSnapshot: boolean): void {
+    this.cheWorkspace.stopWorkspace(workspaceId, createSnapshot).then(() => {
     }, (error: any) => {
       this.$log.error(error);
     });

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.styl
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.styl
@@ -35,5 +35,5 @@
     color $recent-workspaces-stopped-color
 
 .recent-workspaces-menu.navbar-dropdown-menu
-  width 140px
-  min-width 140px
+  width 150px
+  min-width 150px

--- a/dashboard/src/app/stacks/stack-details/stack.controller.ts
+++ b/dashboard/src/app/stacks/stack-details/stack.controller.ts
@@ -524,7 +524,7 @@ export class StackController {
    */
   closeStackTestPopup(): void {
     if (this.tmpWorkspaceId) {
-      this.cheWorkspace.stopWorkspace(this.tmpWorkspaceId);
+      this.cheWorkspace.stopWorkspace(this.tmpWorkspaceId, false);
       this.tmpWorkspaceId = '';
     }
     this.cheUIElementsInjectorService.deleteElementById(STACK_TEST_POPUP_ID);

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
@@ -232,7 +232,7 @@ export class ListWorkspacesCtrl {
 
         // stop workspace if it's status is RUNNING
         if (workspace.status === 'RUNNING') {
-          this.cheWorkspace.stopWorkspace(workspaceId);
+          this.cheWorkspace.stopWorkspace(workspaceId, false);
         }
 
         // delete stopped workspace

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -183,6 +183,15 @@ export class WorkspaceDetailsController {
   }
 
   /**
+   * Returns the value of workspace auto-snapshot property.
+   * 
+   * @returns {boolean} workspace auto-snapshot property value
+   */
+  getAutoSnapshot(): boolean {
+    return this.cheWorkspace.getAutoSnapshotSettings();
+  }
+
+  /**
    * Fetches the workspace details.
    *
    * @returns {Promise}
@@ -497,7 +506,7 @@ export class WorkspaceDetailsController {
       .targetEvent(event);
     this.$mdDialog.show(confirm).then(() => {
       if (this.getWorkspaceStatus() === 'RUNNING') {
-        this.cheWorkspace.stopWorkspace(this.workspaceId);
+        this.cheWorkspace.stopWorkspace(this.workspaceId, false);
       }
 
       this.cheWorkspace.fetchStatusChange(this.workspaceId, 'STOPPED').then(() => {
@@ -552,7 +561,7 @@ export class WorkspaceDetailsController {
   }
 
   stopWorkspace(): void {
-    let promise = this.cheWorkspace.stopWorkspace(this.workspaceId);
+    let promise = this.cheWorkspace.stopWorkspace(this.workspaceId, this.getAutoSnapshot());
 
     promise.then(() => {}, (error: any) => {
       this.cheNotification.showError(error.data.message !== null ? error.data.message : 'Stop workspace failed.');

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -85,7 +85,7 @@
                                       ng-click="workspaceDetailsController.runWorkspace()"></che-button-default>
                   <che-button-default ng-disabled="(workspaceDetailsController.isCreationFlow || workspaceDetailsController.getWorkspaceStatus() === 'STOPPING' || workspaceDetailsController.getWorkspaceStatus() === 'SNAPSHOTTING')"
                                       ng-show="(workspaceDetailsController.getWorkspaceStatus() === 'RUNNING' || workspaceDetailsController.getWorkspaceStatus() === 'STOPPING' || workspaceDetailsController.getWorkspaceStatus() === 'SNAPSHOTTING')"
-                                      che-button-title="Stop" name="stopButton"
+                                      che-button-title="{{workspaceDetailsController.getAutoSnapshot() ? 'Stop' : 'Stop without snapshot'}}" name="stopButton"
                                       ng-click="workspaceDetailsController.stopWorkspace()"></che-button-default>
                 </div>
               </div>

--- a/dashboard/src/components/api/che-workspace.factory.ts
+++ b/dashboard/src/components/api/che-workspace.factory.ts
@@ -29,6 +29,7 @@ interface ICHELicenseResource<T> extends ng.resource.IResourceClass<T> {
   startWorkspace: any;
   startTemporaryWorkspace: any;
   addCommand: any;
+  getSettings: any;
 }
 
 /**
@@ -49,6 +50,7 @@ export class CheWorkspace {
   lodash: any;
   cheWebsocket: CheWebsocket;
   statusDefers: Object;
+  workspaceSettings: any;
 
   /**
    * Default constructor that is using resource
@@ -89,16 +91,19 @@ export class CheWorkspace {
         updateWorkspace: {method: 'PUT', url: '/api/workspace/:workspaceId'},
         addProject: {method: 'POST', url: '/api/workspace/:workspaceId/project'},
         deleteProject: {method: 'DELETE', url: '/api/workspace/:workspaceId/project/:path'},
-        stopWorkspace: {method: 'DELETE', url: '/api/workspace/:workspaceId/runtime'},
+        stopWorkspace: {method: 'DELETE', url: '/api/workspace/:workspaceId/runtime?create-snapshot=:createSnapshot'},
         startWorkspace: {method: 'POST', url: '/api/workspace/:workspaceId/runtime?environment=:envName'},
         startTemporaryWorkspace: {method: 'POST', url: '/api/workspace/runtime?temporary=true'},
-        addCommand: {method: 'POST', url: '/api/workspace/:workspaceId/command'}
+        addCommand: {method: 'POST', url: '/api/workspace/:workspaceId/command'},
+        getSettings: {method: 'GET', url: '/api/workspace/settings'}
       }
     );
 
     cheEnvironmentRegistry.addEnvironmentManager('compose', new ComposeEnvironmentManager($log));
     cheEnvironmentRegistry.addEnvironmentManager('dockerfile', new DockerFileEnvironmentManager($log));
     cheEnvironmentRegistry.addEnvironmentManager('dockerimage', new DockerImageEnvironmentManager($log));
+
+    this.fetchWorkspaceSettings();
   }
 
   /**
@@ -411,8 +416,9 @@ export class CheWorkspace {
    * @param workspaceId {string}
    * @returns {ng.IPromise<any>} promise
    */
-  stopWorkspace(workspaceId: string): ng.IPromise<any> {
-    return this.remoteWorkspaceAPI.stopWorkspace({workspaceId: workspaceId}, {}).$promise;
+  stopWorkspace(workspaceId: string, createSnapshot: boolean): ng.IPromise<any> {
+    createSnapshot = createSnapshot === undefined ? this.getAutoSnapshotSettings() : createSnapshot;
+    return this.remoteWorkspaceAPI.stopWorkspace({workspaceId: workspaceId, createSnapshot: createSnapshot}, {}).$promise;
   }
 
   /**
@@ -567,5 +573,37 @@ export class CheWorkspace {
         this.statusDefers[workspaceId][message.eventType].length = 0;
       });
     }
+  }
+
+  /**
+   * Fetches the system settings for workspaces.
+   *
+   * @returns {IPromise<TResult>}
+   */
+  fetchWorkspaceSettings(): ng.IPromise {
+    let promise = this.remoteWorkspaceAPI.getSettings().$promise;
+    let resultPromise = promise.then((settings: any) => {
+      this.workspaceSettings = settings;
+    });
+
+    return resultPromise;
+  }
+
+  /**
+   * Returns the system settings for workspaces.
+   *
+   * @returns {any} the system settings for workspaces
+   */
+  getWorkspaceSettings(): any {
+    return this.workspaceSettings;
+  }
+
+  /**
+   * Returns the value of autosnapshot system property.
+   *
+   * @returns {boolean} 'che.workspace.auto_snapshot' property value
+   */
+  getAutoSnapshotSettings(): boolean {
+    return this.workspaceSettings ? this.workspaceSettings['che.workspace.auto_snapshot'] : true;
   }
 }

--- a/dashboard/src/components/api/test/che-http-backend.ts
+++ b/dashboard/src/components/api/test/che-http-backend.ts
@@ -53,6 +53,7 @@ export class CheHttpBackend {
       this.httpBackend.when('GET', '/api/workspace/' + key).respond(tmpWorkspace);
     }
     this.httpBackend.when('OPTIONS', '/api/').respond({});
+    this.httpBackend.when('GET', '/api/workspace/settings').respond({});
 
     this.httpBackend.when('GET', '/api/workspace').respond(workspaceReturn);
 


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

### What does this PR do?
1. Displays caption on workspace details stop button based on workspace auto-snapshot settings. It can be "Stop" or "Stop without snapshot"
2. Adds one more stop button to context menu (which does opposite in context of create-snapshot behavior).
3. On running workspace deletion - the workspace is alsways stopped without snapshot creation.

### What issues does this PR fix or reference?

https://github.com/codenvy/codenvy/issues/937
https://github.com/eclipse/che/issues/3159
