### PR TITLE
Improve CLI Boot Speed

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -127,7 +127,7 @@ initiate_offline_or_network_mode(){
         return 2;
       fi
     else
-      warning "Skipping dockerhub.com networking check..."
+      warning "Skipping dockerhub network check..."
     fi
   fi
 }

--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -74,7 +74,7 @@ check_if_booted() {
 
 server_is_booted() {
   PING_URL=$(get_boot_url)
-  HTTP_STATUS_CODE=$(curl -I -k ${PING_URL} -s -o /dev/null --write-out "%{http_code}")
+  HTTP_STATUS_CODE=$(curl -I -k ${PING_URL} -s -o /dev/null --write-out '%{http_code}')
   log "${HTTP_STATUS_CODE}"
   if [[ "${HTTP_STATUS_CODE}" = "200" ]] || [[ "${HTTP_STATUS_CODE}" = "302" ]]; then
     return 0
@@ -109,7 +109,8 @@ initiate_offline_or_network_mode(){
     # If we are in networking mode, we have had some issues where users have failed DNS networking.
     # See: https://github.com/eclipse/che/issues/3266#issuecomment-265464165
     if [[ "${FAST_BOOT}" = "false" ]]; then
-      local HTTP_STATUS_CODE=$(curl -I -k dockerhub.com -s -o /dev/null --write-out "%{http_code}")
+      info "cli" "Checking network... (hint: '--fast' skips version and network checks)"
+      local HTTP_STATUS_CODE=$(curl -I -k dockerhub.com -s -o /dev/null --write-out '%{http_code}')
       if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
         info ""

--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -108,22 +108,26 @@ initiate_offline_or_network_mode(){
     # If we are here, then we want to run in networking mode.
     # If we are in networking mode, we have had some issues where users have failed DNS networking.
     # See: https://github.com/eclipse/che/issues/3266#issuecomment-265464165
-    local HTTP_STATUS_CODE=$(curl -I -k dockerhub.com -s -o /dev/null --write-out "%{http_code}")
-    if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
-      info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
-      info ""
-      info "We could not resolve DockerHub using DNS."
-      info "Either we cannot reach the Internet or Docker's DNS resolver needs a modification."
-      info ""
-      info "You can:"
-      info "  1. Modify Docker's DNS settings." 
-      info "     a. Docker for Windows & Mac have GUIs for this."
-      info "     b. Typically setting DNS to 8.8.8.8 fixes resolver issues."
-      info "  2. Does your network require Docker to use a proxy?"
-      info "     a. Docker for Windows & Mac have GUIs to set proxies."
-      info "  3. Verify that you have access to DockerHub."
-      info "     a. Try 'curl --head dockerhub.com'"
-      return 2;
+    if [[ "${FAST_BOOT}" = "false" ]]; then
+      local HTTP_STATUS_CODE=$(curl -I -k dockerhub.com -s -o /dev/null --write-out "%{http_code}")
+      if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
+        info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
+        info ""
+        info "We could not resolve DockerHub using DNS."
+        info "Either we cannot reach the Internet or Docker's DNS resolver needs a modification."
+        info ""
+        info "You can:"
+        info "  1. Modify Docker's DNS settings." 
+        info "     a. Docker for Windows & Mac have GUIs for this."
+        info "     b. Typically setting DNS to 8.8.8.8 fixes resolver issues."
+        info "  2. Does your network require Docker to use a proxy?"
+        info "     a. Docker for Windows & Mac have GUIs to set proxies."
+        info "  3. Verify that you have access to DockerHub."
+        info "     a. Try 'curl --head dockerhub.com'"
+        return 2;
+      fi
+    else
+      warning "Skipping dockerhub.com networking check..."
     fi
   fi
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_network.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_network.sh
@@ -33,7 +33,7 @@ cmd_network() {
   ### TEST 1: Simulate browser ==> workspace agent HTTP connectivity
   HTTP_CODE=$(curl -I localhost:${AGENT_EXTERNAL_PORT}/alpine-release \
                           -s -o "${LOGS}" --connect-timeout 5 \
-                          --write-out "%{http_code}") || echo "28" >> "${LOGS}"
+                          --write-out '%{http_code}') || echo "28" >> "${LOGS}"
 
   if [ "${HTTP_CODE}" = "200" ]; then
       info "Browser    => Workspace Agent (localhost): Connection succeeded"
@@ -44,7 +44,7 @@ cmd_network() {
   ### TEST 1a: Simulate browser ==> workspace agent HTTP connectivity
   HTTP_CODE=$(curl -I ${AGENT_EXTERNAL_IP}:${AGENT_EXTERNAL_PORT}/alpine-release \
                           -s -o "${LOGS}" --connect-timeout 5 \
-                          --write-out "%{http_code}") || echo "28" >> "${LOGS}"
+                          --write-out '%{http_code}') || echo "28" >> "${LOGS}"
 
   if [ "${HTTP_CODE}" = "200" ]; then
       info "Browser    => Workspace Agent ($AGENT_EXTERNAL_IP): Connection succeeded"
@@ -55,10 +55,10 @@ cmd_network() {
   ### TEST 2: Simulate Che server ==> workspace agent (external IP) connectivity
   export HTTP_CODE=$(docker_run --name fakeserver \
                                 --entrypoint=curl \
-                                ${IMAGE_CODENVY} \
+                                $(eval "echo \${IMAGE_${CHE_PRODUCT_NAME}}") \
                                   -I ${AGENT_EXTERNAL_IP}:${AGENT_EXTERNAL_PORT}/alpine-release \
                                   -s -o "${LOGS}" \
-                                  --write-out "%{http_code}")
+                                  --write-out '%{http_code}')
 
   if [ "${HTTP_CODE}" = "200" ]; then
       info "Server     => Workspace Agent (External IP): Connection succeeded"
@@ -69,10 +69,10 @@ cmd_network() {
   ### TEST 3: Simulate Che server ==> workspace agent (internal IP) connectivity
   export HTTP_CODE=$(docker_run --name fakeserver \
                                 --entrypoint=curl \
-                                ${IMAGE_CODENVY} \
+                                $(eval "echo \${IMAGE_${CHE_PRODUCT_NAME}}") \
                                   -I ${AGENT_INTERNAL_IP}:${AGENT_INTERNAL_PORT}/alpine-release \
                                   -s -o "${LOGS}" \
-                                  --write-out "%{http_code}")
+                                  --write-out '%{http_code}')
 
   if [ "${HTTP_CODE}" = "200" ]; then
       info "Server     => Workspace Agent (Internal IP): Connection succeeded"

--- a/dockerfiles/base/scripts/base/startup.sh
+++ b/dockerfiles/base/scripts/base/startup.sh
@@ -17,7 +17,7 @@ init_constants() {
   NC='\033[0m'
   LOG_INITIALIZED=false
   FAST_BOOT=false
-  
+
   DEFAULT_CHE_PRODUCT_NAME="CHE"
   CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
 
@@ -343,7 +343,11 @@ cli_init() {
   # Do not perform a version compatibility check if running upgrade command.
   # The upgrade command has its own internal checks for version compatibility.
   if [ $1 != "upgrade" ]; then
-    verify_version_compatibility
+  	if [[ "${FAST_BOOT}" = "false" ]]; then
+      verify_version_compatibility
+    else
+      warning "Skipping version compatibility check..."
+    fi
   else
     verify_version_upgrade_compatibility
   fi

--- a/dockerfiles/base/scripts/base/startup.sh
+++ b/dockerfiles/base/scripts/base/startup.sh
@@ -16,7 +16,8 @@ init_constants() {
   UNDERLINE='\033[4m'
   NC='\033[0m'
   LOG_INITIALIZED=false
-
+  FAST_BOOT=false
+  
   DEFAULT_CHE_PRODUCT_NAME="CHE"
   CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
 
@@ -236,6 +237,10 @@ init() {
     usage;
   fi
 
+  if [[ "$@" == *"--fast"* ]]; then
+  	FAST_BOOT=true
+  fi
+
   SCRIPTS_BASE_CONTAINER_SOURCE_DIR="/scripts/base"
   # add helper scripts
   for HELPER_FILE in "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/*.sh
@@ -362,6 +367,7 @@ start() {
 
   # Begin product-specific CLI calls
   info "cli" "Loading cli..."
+
 
   # The pre_init method is unique to each assembly. This method must be provided by 
   # a custom CLI assembly in their container and can set global variables which are 

--- a/dockerfiles/base/scripts/base/startup.sh
+++ b/dockerfiles/base/scripts/base/startup.sh
@@ -369,6 +369,9 @@ start() {
   # Bootstrap enough stuff to load /cli/cli.sh
   init "$@"
 
+  # Removes "--fast" from the positional arguments if it is set.
+  set -- "${@/\-\-fast/}"
+  
   # Begin product-specific CLI calls
   info "cli" "Loading cli..."
 


### PR DESCRIPTION
### What does this PR do?
Reduces 5.5 seconds of boot time of the CLI if a user provides `--fast` parameter on the command line.

1.  Adds a `--fast` parameter which can be added to any command. 
2.  If `--fast` is provided skips the dockerhub.com networking check.
3.  If `--fast` is provided skips the version compatibility check during boot.
4. Fixes error reported in https://github.com/codenvy/codenvy/issues/1374.

These two commands average 2.5-3.5 seconds each while doing performance profiling. 
