### PR TITLE
Fix group id is too big issues

### DIFF
--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -72,6 +72,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
                     <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>

--- a/exec-agent/pom.xml
+++ b/exec-agent/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>com.soebes.maven.plugins</groupId>
                 <artifactId>iterator-maven-plugin</artifactId>
-                <version>0.4</version>
+                <version>0.5.0</version>
                 <executions>
                     <execution>
                         <id>compile-exec-agent</id>
@@ -166,6 +166,7 @@
                                     </plugin>
                                     <goal>single</goal>
                                     <configuration>
+                                        <tarLongFileMode>posix</tarLongFileMode>
                                         <descriptors>
                                             <descriptor>${basedir}/src/assembly/assembly.xml</descriptor>
                                         </descriptors>


### PR DESCRIPTION
### What does this PR do?

* Changes the pom files to include `<tarLongFileMode>posix</tarLongFileMode>`
* Updates the use of maven-iterator from 0.4 to 0.5.0 that fixes a bug (see khmarbaise/iterator-maven-plugin#39)

### What issues does this PR fix or reference?

eclipse/che#3378

### Previous behavior

Won't be able to build Che on Mac machines with large user id or group id for the current user. You can verify with `id` on your machine to check if your id is  > 2097151.

### New behavior

Will be able to build Che on Mac machines now even if your user id or group id is  > 2097151.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
