### PR TITLE
Show Processes panel when Terminal is opened

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
@@ -404,6 +404,8 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         view.addWidget(terminalId, terminalName, terminalNode.getTitleIcon(), terminalWidget, false);
         refreshStopButtonState(terminalId);
 
+        workspaceAgent.setActivePart(this);
+
         newTerminal.setVisible(true);
         newTerminal.connect();
         newTerminal.setListener(new TerminalPresenter.TerminalStateListener() {

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
@@ -407,6 +407,7 @@ public class ProcessesPanelPresenterTest {
         presenter.onAddTerminal(MACHINE_ID, presenter);
 
         verify(terminalFactory).create(eq(machine), eq(presenter));
+        verify(workspaceAgent).setActivePart(presenter);
         verify(terminal).getView();
         verify(view, times(2)).setProcessesData(anyObject());
         verify(view).selectNode(anyObject());


### PR DESCRIPTION
### What does this PR do?
Activates Process panel when new terminal is added
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3223

### Previous behavior
After adding new terminal, the process panel still be hidden

### New behavior
After adding new terminal, the process panel opens

