### PR TITLE
Add images of docs/ folder using git-lfs

### DIFF
--- a/docs/assets/imgs/.gitattributes
+++ b/docs/assets/imgs/.gitattributes
@@ -1,0 +1,5 @@
+*.PNG filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/docs/assets/imgs/01436220-a2ea-11e6-895f-be29fd448965.png
+++ b/docs/assets/imgs/01436220-a2ea-11e6-895f-be29fd448965.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6f7c2ce8b0aa26996386d2158d4b4e4fc94c87cc4559e1b7674d789b610169d
+size 634569

--- a/docs/assets/imgs/2f03377e-a2e7-11e6-8464-24cd8d2fd2b4.png
+++ b/docs/assets/imgs/2f03377e-a2e7-11e6-8464-24cd8d2fd2b4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f413bb1f29b8122ee34f85169a6094f7748197679af97b68850e0e86a904059
+size 652732

--- a/docs/assets/imgs/439fcb7e-a2e8-11e6-9b3a-4b2e1d5d45d9.png
+++ b/docs/assets/imgs/439fcb7e-a2e8-11e6-9b3a-4b2e1d5d45d9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1941d473cb09f3e9d8189667c7b190e69fe11cae6b8aace03a5b1eb7a4e606b0
+size 626914

--- a/docs/assets/imgs/8f99a700-a696-11e6-8d8a-414e38ec26b2.gif
+++ b/docs/assets/imgs/8f99a700-a696-11e6-8d8a-414e38ec26b2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf1bca2de6dd6a351c5795dd25670ea263103d9d4645d8491a3c0d03670317e2
+size 578349

--- a/docs/assets/imgs/95fbdfd2-a2ea-11e6-8773-6308cb848962.png
+++ b/docs/assets/imgs/95fbdfd2-a2ea-11e6-8773-6308cb848962.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96949b46ce3030a80962bd4913b6e9e19be110a3f20cf5f3f79116bfd1d847ba
+size 652274

--- a/docs/assets/imgs/AgileWorkflowArchitecture-MicrosoftVSTS-Phase1.png
+++ b/docs/assets/imgs/AgileWorkflowArchitecture-MicrosoftVSTS-Phase1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4752c00c7e8c094c406074815185cb238b5a01668c31c132ea8abfbe2bdc82ac
+size 55952

--- a/docs/assets/imgs/Capture.PNG
+++ b/docs/assets/imgs/Capture.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ecbca559eac4b0eff4350f8577a62816c70cd9bc2359966b8c4e34b6748b356
+size 27761

--- a/docs/assets/imgs/Capture2.PNG
+++ b/docs/assets/imgs/Capture2.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34b20d8f4e0e6be0d3099bb09914e5aaac8833a489aab920b51e14480d538b6c
+size 56621

--- a/docs/assets/imgs/Capture2_.PNG
+++ b/docs/assets/imgs/Capture2_.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81e8eea46847b94e1cd39396fa630ea62f5f1b5d685e2b447e910a60a1ea48bf
+size 114335

--- a/docs/assets/imgs/Capture_.png
+++ b/docs/assets/imgs/Capture_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5616aa404eb603132552057d2d4d791294f8a54bbaf7a2f03467a77ac612a231
+size 211214

--- a/docs/assets/imgs/Capture_embed.PNG
+++ b/docs/assets/imgs/Capture_embed.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bd7956bd057c69f94f3c086e406cee8ff24c1221b5c696aa2187945b2f83844
+size 51315

--- a/docs/assets/imgs/Capture_preview.PNG
+++ b/docs/assets/imgs/Capture_preview.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79a387bdda27d6d9b42c9e3af5a83794c9edf2a5b9e9e8ba21e1b9c2a32638e2
+size 42246

--- a/docs/assets/imgs/Che-Stack-Delete.jpg
+++ b/docs/assets/imgs/Che-Stack-Delete.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76a19087ccfef108678beb487c6a05750dd4fcca85d3fe027448ad5e16867fae
+size 130673

--- a/docs/assets/imgs/Che-Stack-Duplicate.jpg
+++ b/docs/assets/imgs/Che-Stack-Duplicate.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73a71d599b08ac62de2d51ba96e83215c42a0f9bc314a1afe6d4da9ce86cfe19
+size 103200

--- a/docs/assets/imgs/Che-machine-information-edit.jpg
+++ b/docs/assets/imgs/Che-machine-information-edit.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85d0e596521d1cdeef5be1aadc3b2899a50fa8cf61d61e08d9692e152258f2c9
+size 240571

--- a/docs/assets/imgs/Che-machine-information.jpg
+++ b/docs/assets/imgs/Che-machine-information.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f911172d246d1d3e1fda8288085f976e949827d0a749c08c39c73310b5bfce0a
+size 109066

--- a/docs/assets/imgs/Che-recipe-expose-ports.jpg
+++ b/docs/assets/imgs/Che-recipe-expose-ports.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ef6677e7168db9c31bf268eafd0b0fa92f9c73b33c26f637b65dfd98f7ca9fd
+size 235450

--- a/docs/assets/imgs/Clipboard.jpg
+++ b/docs/assets/imgs/Clipboard.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a45e1c0685325e845f5db7c553eb9aeca996ad7d936abaff6da14412b348928e
+size 14455

--- a/docs/assets/imgs/Clipboard12.jpg
+++ b/docs/assets/imgs/Clipboard12.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e1b6982eb647563b0cdcb859b84d57a655bd3e52563b001879936f67bf34d7
+size 31034

--- a/docs/assets/imgs/Clipboard13.jpg
+++ b/docs/assets/imgs/Clipboard13.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:782ce7566dd0d8cd96534127a4c3774daebd2f7e68ceb6bb6127e8ee1da309f2
+size 31695

--- a/docs/assets/imgs/Clipboard2.jpg
+++ b/docs/assets/imgs/Clipboard2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3f4a3af3a526b7c8592a023f46138cbbb73845a91e1fbca3a58e279f13a4cc7
+size 14655

--- a/docs/assets/imgs/Clipboard3.jpg
+++ b/docs/assets/imgs/Clipboard3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31287bcc99aa3565e04b013efd3cb3ce784ddbee3f30cb0daed0279258300b22
+size 17976

--- a/docs/assets/imgs/Clipboard4.jpg
+++ b/docs/assets/imgs/Clipboard4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7756257bd55f4920a0a5a5510b21135862de5b6bf8e6af850c11ce69d50dcc6f
+size 24894

--- a/docs/assets/imgs/Clipboard5.jpg
+++ b/docs/assets/imgs/Clipboard5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebc3ef9c9af0c9372051cb174164d85c1a78e9bd10cd4e63b916166b1404428d
+size 54381

--- a/docs/assets/imgs/Clipboard6.jpg
+++ b/docs/assets/imgs/Clipboard6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6b4ee1021e6690d217c3cc0f56eb9e58a6930d335b6b3637a476a89663e7239
+size 78354

--- a/docs/assets/imgs/Clipboard7.jpg
+++ b/docs/assets/imgs/Clipboard7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3da86436128e6c5e11fef75881abef780ef534a335c13f7b8a639771dd1f721
+size 20855

--- a/docs/assets/imgs/Clipboard8.jpg
+++ b/docs/assets/imgs/Clipboard8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b886473a4ea93df0e80757d7ddf679f631069c405b2ac178bc7fe69fcf547ed4
+size 33780

--- a/docs/assets/imgs/Clipboard9.jpg
+++ b/docs/assets/imgs/Clipboard9.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3d39680abe2bdabb87c0d1d9bc6ad2208dc647856ef59144b67f4f4aabe5ee8
+size 27808

--- a/docs/assets/imgs/Docker--CodenvyMeeting(1).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(1).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f01a37f08c12801e10b40815bbf1db28a304aa4592e6de064ada5b8c17b9ad3c
+size 29066

--- a/docs/assets/imgs/Docker--CodenvyMeeting(2).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(2).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee1cdc6e0589c6ced863aecf9f26e889aeff39f2bbc03a5630527ada40396997
+size 20481

--- a/docs/assets/imgs/Docker--CodenvyMeeting(3).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(3).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a29d7f3d3d407951ed1e72692c3e60e2f260c2e6dba6528838135b819cad7229
+size 27694

--- a/docs/assets/imgs/Docker--CodenvyMeeting(4).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(4).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:790adf7350ba32068b26164cfb8ad1907738a1b3602947dba2047bde952b9363
+size 31760

--- a/docs/assets/imgs/Docker--CodenvyMeeting(5).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(5).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:355723523e10480068fac60809d020352498d45b036f139e77779d5e220ae21a
+size 41627

--- a/docs/assets/imgs/Docker--CodenvyMeeting(6).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(6).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2137b5512520395b680c87e46a49ddd213dc19061732340eaa46af53e4078dcd
+size 29469

--- a/docs/assets/imgs/Docker--CodenvyMeeting(7).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(7).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d94404a1eab61f5b5da937b8383211b1afdf28f5952ba1195fdcfee5ba031a0
+size 31877

--- a/docs/assets/imgs/Docker--CodenvyMeeting(8).png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting(8).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e0a0ae0fa3fec629b066998a6983cf48308aa001fe5f7b0b8ff86fb12943f7c
+size 28335

--- a/docs/assets/imgs/Docker--CodenvyMeeting.png
+++ b/docs/assets/imgs/Docker--CodenvyMeeting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a926074697ea4767e285de0458ceeabb5f1aa6ae4e3f3f058b9fd3b22c482a06
+size 17759

--- a/docs/assets/imgs/Extensibility.PNG
+++ b/docs/assets/imgs/Extensibility.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a8ceba187dfc68ea47ac0dec561f57078d82225dd7e33b67b335ba919debed3
+size 47597

--- a/docs/assets/imgs/GitLabSSH.jpg
+++ b/docs/assets/imgs/GitLabSSH.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6cc9868a58bca596149f58d61772d4f16e1d40581c2f62afa68de5b1a7029d4
+size 38748

--- a/docs/assets/imgs/ImportProjectDashboard.jpg
+++ b/docs/assets/imgs/ImportProjectDashboard.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d75ce2e3a2776242ddab5c6c5b833ce67a8016a90a98eb47be3b6bc7f72973
+size 60479

--- a/docs/assets/imgs/Installation-Manager-API.png
+++ b/docs/assets/imgs/Installation-Manager-API.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:821d971bf32eb58c5058ff6dbb27dc7902eda19b8ffbd35b62d394ca95d75d06
+size 143984

--- a/docs/assets/imgs/JIRAplugin-DevelopandReviewinIDE(1).svg
+++ b/docs/assets/imgs/JIRAplugin-DevelopandReviewinIDE(1).svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f570897d7a98ff0edbeb3b13fcccc048919c57d1bead1ccf9e1bc65a246fe9c
+size 422145

--- a/docs/assets/imgs/ProductInteractionFlowswithContinousDevelopment(1).svg
+++ b/docs/assets/imgs/ProductInteractionFlowswithContinousDevelopment(1).svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:408cd558bd3aedef00aa76f7f63b116426df1e6019d3b98ed4b9444b0e0c2ac2
+size 211598

--- a/docs/assets/imgs/ProjectType-JsonExample.png
+++ b/docs/assets/imgs/ProjectType-JsonExample.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad9351435f1b0373dafa7b28852e382fbaf96505cae009c99c4acaa49b7e9c9f
+size 39078

--- a/docs/assets/imgs/ProjectType.png
+++ b/docs/assets/imgs/ProjectType.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebb4bc52e7b4e83c894dd3dc491da43bfe2a6a5c2ff0daf2d05d333f2c8afc78
+size 29286

--- a/docs/assets/imgs/ScaleCodenvy.PNG
+++ b/docs/assets/imgs/ScaleCodenvy.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2555c1c7c7447edf9ac140d95ef868c19e7f4b16ea51d9695774075539cf99e1
+size 146401

--- a/docs/assets/imgs/ScreenShot2016-02-29at2.31.25PM.png
+++ b/docs/assets/imgs/ScreenShot2016-02-29at2.31.25PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03f6481300a064ff6c36aa79c4a690ea03b51bb314464e22cc5fbfad676aede1
+size 136808

--- a/docs/assets/imgs/ScreenShot2016-03-01at10.16.46AM.png
+++ b/docs/assets/imgs/ScreenShot2016-03-01at10.16.46AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccb9d621055da42de38f5edda3cba0e03ba8cb0ec5b6b6e212164f4d2c6422cd
+size 50984

--- a/docs/assets/imgs/ScreenShot2016-04-28at10.52.51AM.png
+++ b/docs/assets/imgs/ScreenShot2016-04-28at10.52.51AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8155ed9e81c09bca66f734cc0fc8c83ab5e64bd490834d532359d834a3d41a8
+size 15680

--- a/docs/assets/imgs/ScreenShot2016-05-27at09.16.31.png
+++ b/docs/assets/imgs/ScreenShot2016-05-27at09.16.31.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:921f15b23285bc0525da9f298e77b21214592fd62451e4ed6e7720c133cb47c7
+size 448866

--- a/docs/assets/imgs/ScreenShot2016-06-23at9.40.42AM.png
+++ b/docs/assets/imgs/ScreenShot2016-06-23at9.40.42AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df560bcec942883aea743f69c766421ef7ba346166b42f242eff64fc577b570d
+size 158736

--- a/docs/assets/imgs/ScreenShot2016-08-02at8.18.23AM.png
+++ b/docs/assets/imgs/ScreenShot2016-08-02at8.18.23AM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:376b0509ea3ed803ff06c45ec2e38df289eb61a75d463cc23eec22289967d023
+size 447427

--- a/docs/assets/imgs/ScreenShot2016-09-29at16.14.16.png
+++ b/docs/assets/imgs/ScreenShot2016-09-29at16.14.16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:159616eea6005fd3c2d82982f8ca31dd4bb1a6f31e2bc1c9f4e875ad0dd4505f
+size 54739

--- a/docs/assets/imgs/ScreenShot2016-09-29at16.21.10.png
+++ b/docs/assets/imgs/ScreenShot2016-09-29at16.21.10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2531a6cca3f3b5797af9e84dfea1b56b6584285cfa5a60a7c75fe5fdc16e5de8
+size 55429

--- a/docs/assets/imgs/ScreenShot2016-09-30at5.52.21PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at5.52.21PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2601f9f8d829345947ad0c4bc7b3bcd0ffec8a97c6e27a51183f0db4fd3fa17d
+size 209123

--- a/docs/assets/imgs/ScreenShot2016-09-30at5.53.20PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at5.53.20PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4280a5563a627b82d95a85ca12e223f91620e27955ef985f12eb044af738b7e
+size 59536

--- a/docs/assets/imgs/ScreenShot2016-09-30at5.55.07PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at5.55.07PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:011f30e1f628f2d691ce1f8ff8e2ee590c8a66e32e76ab31718ecbbd13160977
+size 54337

--- a/docs/assets/imgs/ScreenShot2016-09-30at5.55.58PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at5.55.58PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e35015070cbd9a3864e98de478595b281588e5b1d78bd1ec2a240d5d4fff243
+size 80859

--- a/docs/assets/imgs/ScreenShot2016-09-30at5.56.22PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at5.56.22PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9242e38cfc74bff443e57a91ab38139bc0c1ab6a14b0edee2204ffba0e5c64c
+size 32944

--- a/docs/assets/imgs/ScreenShot2016-09-30at6.13.02PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at6.13.02PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad6c2bbdd470cc06007c93d5c917c58d54f33d1d5b9ccd0c53060672786e6c8b
+size 224346

--- a/docs/assets/imgs/ScreenShot2016-09-30at6.15.03PM.png
+++ b/docs/assets/imgs/ScreenShot2016-09-30at6.15.03PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0da7ce1bdc15d4a4c0ea1299f141e2a85ab45b3717ddb322fb8153f944b001dd
+size 47028

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.04.47.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.04.47.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:575b2a3ab7b4a600ef9487bfdf3c21b7204bafb764992c9a522f0e761116cfad
+size 93562

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.05.46.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.05.46.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3101456ad261cc5316be4cbc50f6b5c0271bc0b039ed93fc93e590560bb69b4
+size 103995

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.06.23.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.06.23.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d6b034c471ee57d208e85c55d1c67b1ad87a23cac9ef79505f1048aa2fb6931
+size 111848

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.07.45.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.07.45.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:415149a1300379c8f9786f4df600335650bdac31ab95f4c445bbf34979ac1065
+size 123550

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.14.00.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.14.00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64133a6d9c37228239714c348dad606a9320181fed6897cf0c9276c19c83a09f
+size 120128

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.22.26.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.22.26.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0109f4c2bec8e09201eaed35cccda4092dc28f349d39fac620a3d94ff4891b
+size 104263

--- a/docs/assets/imgs/ScreenShot2016-10-06at15.23.13.png
+++ b/docs/assets/imgs/ScreenShot2016-10-06at15.23.13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6e93172c33ffc11fe5f607a7c079346926f585465c3697a5b32f77c2aaae760
+size 101845

--- a/docs/assets/imgs/ScreenShot2016-10-13at14.13.02.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at14.13.02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fba6b3ebaa42d5e2d395f63b785bda3ffc3c2f637398e05d2590f02fa1c1b4e2
+size 280075

--- a/docs/assets/imgs/ScreenShot2016-10-13at14.15.20.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at14.15.20.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39de762798e647ea08e012d205212be36b678fbb9efef760440f950e89bf8227
+size 265842

--- a/docs/assets/imgs/ScreenShot2016-10-13at14.24.09.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at14.24.09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:616b733ca0094748e4a999d3d7f451471c0045267691d83bc559fa02b3e51a5a
+size 304609

--- a/docs/assets/imgs/ScreenShot2016-10-13at14.27.40.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at14.27.40.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d5d266c629de02c5d83ce3ed0e6d1edce274f3861119a58a33733985b851ae7
+size 295345

--- a/docs/assets/imgs/ScreenShot2016-10-13at14.57.02.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at14.57.02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:032f834dc55e7d6dd8d3df5aabf6d0bf7f8d24d3c5b60ec88468bfe4c603554b
+size 419570

--- a/docs/assets/imgs/ScreenShot2016-10-13at14.59.27.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at14.59.27.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bba4a82e5ddd2734688ed1419d491b873229cdb24a762486ccaf89fcd34d298
+size 418666

--- a/docs/assets/imgs/ScreenShot2016-10-13at15.05.00.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at15.05.00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d3de6002168057146e877aebe9bbd381f21e448988cd28db8752070607daea5
+size 372019

--- a/docs/assets/imgs/ScreenShot2016-10-13at15.30.00.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at15.30.00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59395f070568fb101910579c85c18a4a2c716e8fab8e31a5655a22a4d095cc16
+size 441823

--- a/docs/assets/imgs/ScreenShot2016-10-13at15.34.00.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at15.34.00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a5f045e3695adcca8a7b24464fc6af52f93d2ec57bcba04b7c646038cd87883
+size 419044

--- a/docs/assets/imgs/ScreenShot2016-10-13at16.28.28.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at16.28.28.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0f7bc914680d68e08e0b4bfdb1c15809789452fe487c06aba4c30cf3949c6a3
+size 458042

--- a/docs/assets/imgs/ScreenShot2016-10-13at16.34.24.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at16.34.24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8532a91879e897e79401e1d5ed2621b95024180d4a16e7548f69311f62191933
+size 461890

--- a/docs/assets/imgs/ScreenShot2016-10-13at16.35.54.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at16.35.54.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e6e7c49bc6e8bef5f7a7f34ee81ee8acc57862636b282f65bcf9413962c6e32
+size 38238

--- a/docs/assets/imgs/ScreenShot2016-10-13at16.40.08.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at16.40.08.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35516a99619c8f7bf7a3baa50699d021ce791f6fb543abe79ad49a7058c37d17
+size 398866

--- a/docs/assets/imgs/ScreenShot2016-10-13at16.55.05.png
+++ b/docs/assets/imgs/ScreenShot2016-10-13at16.55.05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b566d9204e0625961a677a4c8aa6d7cf4793d86ee8b0065ba503417d8e9b49f
+size 141694

--- a/docs/assets/imgs/ScreenShot2016-10-21at11.13.34.png
+++ b/docs/assets/imgs/ScreenShot2016-10-21at11.13.34.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ad214e5975fbc46b18333aa3dd80a41190bd6a4bc8ecc6227de2a328ab62292
+size 185066

--- a/docs/assets/imgs/ScreenShot2016-10-21at11.14.24.png
+++ b/docs/assets/imgs/ScreenShot2016-10-21at11.14.24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73c8300b8495567a759659e7f3dc85b5a5d819661cec5815f9fdaf64d25d0638
+size 140801

--- a/docs/assets/imgs/ScreenShot2016-10-21at15.15.16.png
+++ b/docs/assets/imgs/ScreenShot2016-10-21at15.15.16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e503ce8027e7a428e612354f15304f8889af20ed30e0f264694613205cb2e30
+size 32182

--- a/docs/assets/imgs/ScreenShot2016-11-30at12.40.15PM.png
+++ b/docs/assets/imgs/ScreenShot2016-11-30at12.40.15PM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e7df1be9fe5ea1cecf4c61f13be661171a572c02eb24a7c48a910be9ff43afe
+size 63011

--- a/docs/assets/imgs/Screen_Shot_2016-10-06_at_14_46_36.png
+++ b/docs/assets/imgs/Screen_Shot_2016-10-06_at_14_46_36.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a984ff3b172692395e5a833de3681154a5c704de8a693aba1198768c1fc498a6
+size 204791

--- a/docs/assets/imgs/Screen_Shot_2016-10-13_at_14_17_47.png
+++ b/docs/assets/imgs/Screen_Shot_2016-10-13_at_14_17_47.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b17d616137ea34d01e891a0ee93c2afa02cba6ea4c77732d5a387120d190590
+size 199528

--- a/docs/assets/imgs/Screenshot2.png
+++ b/docs/assets/imgs/Screenshot2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:011c971c3b8845dfd041020ecc725a8d485e61d257f111e5c81db91af1dece06
+size 37582

--- a/docs/assets/imgs/Screenshot3.png
+++ b/docs/assets/imgs/Screenshot3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ba0ac892bac28e09c515703701afbeb4baf2c9b70307197c29591f8a06e4687
+size 99430

--- a/docs/assets/imgs/Selection_005.png
+++ b/docs/assets/imgs/Selection_005.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea025a7d3f061644c82313f41301303d6c5dddedc8ebd5da759f254fcb7cb7f9
+size 20177

--- a/docs/assets/imgs/Selection_009.png
+++ b/docs/assets/imgs/Selection_009.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ca19bf7dc69772dd5b87671717ce0c2e8bd6fe4753004e8c09cd04b9afecce8
+size 22476

--- a/docs/assets/imgs/Selection_017.png
+++ b/docs/assets/imgs/Selection_017.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb2579269401888998f1fdf9c5612b1faecfc7a41e6d022b3f8596eec5bf45b9
+size 27578

--- a/docs/assets/imgs/Slide1.PNG
+++ b/docs/assets/imgs/Slide1.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:506f2347456267fb111eecf081195d0aa7de89b73c0da558a1b7cdeaa19ac9e4
+size 76498

--- a/docs/assets/imgs/Slide2.PNG
+++ b/docs/assets/imgs/Slide2.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd438517676dd5b02d690d30be1594aeba87bd18a85cfc7e1398591943280311
+size 82382

--- a/docs/assets/imgs/Slide3.PNG
+++ b/docs/assets/imgs/Slide3.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f00a13fa2b535ba79738c41d85b78bc911fe2d9eb9fdd435e33b5cdc6cbb643
+size 47324

--- a/docs/assets/imgs/Swagger.PNG
+++ b/docs/assets/imgs/Swagger.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ef19a91de15b4afc491765822e93a742e5f0896c5a529a598d94f51c7b4d30
+size 102056

--- a/docs/assets/imgs/VSTSextension-DevelopandReviewinIDE.png
+++ b/docs/assets/imgs/VSTSextension-DevelopandReviewinIDE.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c17ef8c12c9998c4e24fb83246cdead3ccb0321ff2c4806881ec0770d9d4563
+size 60830

--- a/docs/assets/imgs/Virtualboxaddusb.jpg
+++ b/docs/assets/imgs/Virtualboxaddusb.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6f5187b4fa45b7a20a76f9dbfa1a9d668361d71ccc5f464ac1067e6fab8d1db
+size 182187

--- a/docs/assets/imgs/WorksapceBasicArchitecture.png
+++ b/docs/assets/imgs/WorksapceBasicArchitecture.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72443f05bca9ad8dee1cd2eaafdcc2cd022d729e31526573cfdaea2aa5bedc8d
+size 12943

--- a/docs/assets/imgs/a321b248-a2e7-11e6-8229-ba11a26c72c0.png
+++ b/docs/assets/imgs/a321b248-a2e7-11e6-8229-ba11a26c72c0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f424b7800ba47ee62dc2eba9688444ed13c0a384630cd875204130729c4ea60a
+size 541795

--- a/docs/assets/imgs/aio.png
+++ b/docs/assets/imgs/aio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7461351bee4d00e274307b4ab71261c1980a1bd683e585c0eb3f6492a8ca1fe0
+size 23785

--- a/docs/assets/imgs/artik-blink-led-1.jpg
+++ b/docs/assets/imgs/artik-blink-led-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc30948ff2f8c51b80e35580b217e416c967a7c268d3f1d94a650963c386b45
+size 222172

--- a/docs/assets/imgs/artik-blink-led-11.jpg
+++ b/docs/assets/imgs/artik-blink-led-11.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dade138d16a4e1d8ea00255b9b247e3d25489a3db088d1e05e98b14b2425982
+size 51907

--- a/docs/assets/imgs/artik-blink-led-12.jpg
+++ b/docs/assets/imgs/artik-blink-led-12.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdc7ecb4d138b6d7d42873034baa857d794a6348c3bf7f4715e1afd24bd7b811
+size 141224

--- a/docs/assets/imgs/artik-blink-led-13.jpg
+++ b/docs/assets/imgs/artik-blink-led-13.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d572a84d3c46aff9f15e1f19b134d6a065d65f19965fb16c921ef4f898cba5b3
+size 191069

--- a/docs/assets/imgs/artik-blink-led-2.jpg
+++ b/docs/assets/imgs/artik-blink-led-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:869b454d8d7574a0e25059b85e626950a4ad23ba77100e586c6f70a00d2943e7
+size 173729

--- a/docs/assets/imgs/artik-blink-led-3.jpg
+++ b/docs/assets/imgs/artik-blink-led-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a789e98c3f1afed6c2e6b6112286659d6090a39f64ad61d496fe47bfbb4c5c8e
+size 171629

--- a/docs/assets/imgs/artik-blink-led-4.jpg
+++ b/docs/assets/imgs/artik-blink-led-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:124a67539fd5c416bbc69fc75efb01ec86e4a5b238308f0f24328053a55fb6fb
+size 114083

--- a/docs/assets/imgs/artik-blink-led-5.jpg
+++ b/docs/assets/imgs/artik-blink-led-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e02b51ffec0111f276f709f8b1f49bf8af9d61962374478a28acec71f7cd6cdb
+size 76597

--- a/docs/assets/imgs/artik-blink-led-6.jpg
+++ b/docs/assets/imgs/artik-blink-led-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd7f0d566c1526372a835c3ff7e6be6146fc6419654c8a73108ce03c5f86d3fb
+size 83413

--- a/docs/assets/imgs/artik-blink-led-7.jpg
+++ b/docs/assets/imgs/artik-blink-led-7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7576614e372c3318ef50b6a0fb0f265b77396de44c3f182fbd546627b97449b9
+size 49779

--- a/docs/assets/imgs/artik-blink-led-8.jpg
+++ b/docs/assets/imgs/artik-blink-led-8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d563ea747c245645e6d8796d5620b24abefa04d532d50449d1e973ea3d9baa7f
+size 35533

--- a/docs/assets/imgs/artik-blink-led-9.jpg
+++ b/docs/assets/imgs/artik-blink-led-9.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d10c52bc98fc01361124f4d88f68980fe6dcb108b6ff73aa55737a2ce1ecc63b
+size 35059

--- a/docs/assets/imgs/artikIDEafterconnection.jpg
+++ b/docs/assets/imgs/artikIDEafterconnection.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5295af4f1db45204c0f90400bcd2572df65c3a6753c0158e7298b1440941f1c8
+size 81788

--- a/docs/assets/imgs/artikapi.jpg
+++ b/docs/assets/imgs/artikapi.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:608f085315e3e875208c59f3c1812817a2c1c5032a0ec762087aa56fed3d49ee
+size 216384

--- a/docs/assets/imgs/artikctrlq.jpg
+++ b/docs/assets/imgs/artikctrlq.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cdf36befebddf132457fe99524ba5e556926a7687a0e613ee96a795ae7edfb6
+size 236861

--- a/docs/assets/imgs/artikmanager.jpg
+++ b/docs/assets/imgs/artikmanager.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36c72817f9176decb658e3fde6025da96586e9e1a0d1ace86c052eaf950edeb6
+size 72449

--- a/docs/assets/imgs/artikmanageradddevice.jpg
+++ b/docs/assets/imgs/artikmanageradddevice.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:332c5a8dc7d35957ff82524fb1240880eee5dfa2def2c17f9755ddfd96e9d0d9
+size 47756

--- a/docs/assets/imgs/breakpoint.png
+++ b/docs/assets/imgs/breakpoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bdde236ebd36b0638dc028163dde5ba044ffdc4509afd63b174c7ed6eb85ae0
+size 15927

--- a/docs/assets/imgs/che-add-stack.gif
+++ b/docs/assets/imgs/che-add-stack.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ee26c76a0a24c5643f65ab1f252a5c09b18fba8c0b8221d9366802aeb28cae
+size 705266

--- a/docs/assets/imgs/che-create-snapshot.jpg
+++ b/docs/assets/imgs/che-create-snapshot.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0205d020036a0734aaae381e9f8178bae8ec0483397e366a8fdb5117a6c4892e
+size 91982

--- a/docs/assets/imgs/che-edit-stack.gif
+++ b/docs/assets/imgs/che-edit-stack.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05ba427df15f072005d2fad15350775a1d1eed21d84eee85f076c55454bf07bf
+size 2084873

--- a/docs/assets/imgs/che-multimachine-tutorial1.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:301d27b7d45da7c64e737c1fde123cdfd28a2ed52e528324468c4141f0f7bb2b
+size 233873

--- a/docs/assets/imgs/che-multimachine-tutorial2.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a53f358c194c16b4e5d7131a2df1c766197e26b7b9c536e5ebb687fec12c4c00
+size 138813

--- a/docs/assets/imgs/che-multimachine-tutorial3.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1923b1b5137033925397744d8faa83f8a8e735aa9e52b675bd3afd4560abdd76
+size 82495

--- a/docs/assets/imgs/che-multimachine-tutorial4.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f994ab1eb51b5191153e76b96fc984111c14d4aacd29a65111c59e6933350aa
+size 174304

--- a/docs/assets/imgs/che-multimachine-tutorial6.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1087586fdc750c6cffbded82998af5aca7d368fc532b72b8532209ffab124cf9
+size 455087

--- a/docs/assets/imgs/che-multimachine-tutorial7.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bf18429c59d1d0868c871102d5b983eb7c857179be3659fd1d07f5928e86b49
+size 198760

--- a/docs/assets/imgs/che-multimachine-tutorial8.jpg
+++ b/docs/assets/imgs/che-multimachine-tutorial8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0887fafd014e80e8d64a97f07bf9c0a6cf9c38f4be51505c06d587116da6840e
+size 223732

--- a/docs/assets/imgs/che-mysql-tutorial1.jpg
+++ b/docs/assets/imgs/che-mysql-tutorial1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2f36012b3a6fe85768cefb0c9d215150ba82f7361d169e51ca851c7a0537c88
+size 64687

--- a/docs/assets/imgs/che-previewHTML.jpg
+++ b/docs/assets/imgs/che-previewHTML.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3da317b474fc9706c1c2fe525249f75b80ae4d651343002d88f4b618dc2af2d
+size 81206

--- a/docs/assets/imgs/che-recipe-write.jpg
+++ b/docs/assets/imgs/che-recipe-write.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6509a9906a80259c59598bcb9790597d7c7f8d8edf612b75624961ad2a547a43
+size 122575

--- a/docs/assets/imgs/che-sharing2.jpg
+++ b/docs/assets/imgs/che-sharing2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:015c085e6d9a476bf96de2ab2c2269c773fcdfeddf2cbc0d0273376ed903c640
+size 123371

--- a/docs/assets/imgs/che-sharing3.jpg
+++ b/docs/assets/imgs/che-sharing3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d631c0442ef1ef052bdc3de929068f633ac461ecc502b3f36b4edf3d34b7a61
+size 144617

--- a/docs/assets/imgs/che-sharing4.jpg
+++ b/docs/assets/imgs/che-sharing4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6d66c62587bea6090e584fd2ad4719790b16fc86861dcbf75bd92662795e761
+size 239014

--- a/docs/assets/imgs/che-stacks1.jpg
+++ b/docs/assets/imgs/che-stacks1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37fe9c32c8bc12e307a8d7b570dae63c3d482e2a169911736117aca40eaaa4d1
+size 218351

--- a/docs/assets/imgs/che-stacks2.jpg
+++ b/docs/assets/imgs/che-stacks2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:552170a17e3d62a244e0dee7454c673fe80537fa59b623574d85ab7eeef226dc
+size 434239

--- a/docs/assets/imgs/che-svn-username-password.jpg
+++ b/docs/assets/imgs/che-svn-username-password.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd1646568e80961c7045872419a65b1f97ea02e10e056f7725a5ebcf04439f6f
+size 100000

--- a/docs/assets/imgs/che_helloworld.png
+++ b/docs/assets/imgs/che_helloworld.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aca8f67c1ff25090ae5a1bd40f5aa430c218121dc3093c8b9583ad5b9c858e4d
+size 23271

--- a/docs/assets/imgs/che_networking.png
+++ b/docs/assets/imgs/che_networking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58da7ddc7e53cbcab709eb12f92441b05047fc3de3302d63585db3c00fa76b36
+size 30307

--- a/docs/assets/imgs/compile.png
+++ b/docs/assets/imgs/compile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0682deebb176c2e4fd742bf51108f9b1c5481933b06468389cb28579e4ed734
+size 31076

--- a/docs/assets/imgs/configure-classpath.png
+++ b/docs/assets/imgs/configure-classpath.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acddfceef6819c0097d501a579a4889271f2a0aa3f1c42dbc5bd75edaa85481b
+size 70848

--- a/docs/assets/imgs/consolepanes.gif
+++ b/docs/assets/imgs/consolepanes.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc7f1ef1320c99cc8ccbdc3c157ef01ad39bc8403a095f83c9159bcb36e18822
+size 449473

--- a/docs/assets/imgs/createwsandproject.jpg
+++ b/docs/assets/imgs/createwsandproject.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:916d2ec0f84caa92e08ec26a2105b113b91e850fbc653997400e882fe5da09d9
+size 185850

--- a/docs/assets/imgs/d11893a8-a2e5-11e6-9252-830ab42c4f0e.jpg
+++ b/docs/assets/imgs/d11893a8-a2e5-11e6-9252-830ab42c4f0e.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeef39de60ab77a7fd56552344fbf6b2915ae04c99134a5dcce8c063f87d7cc2
+size 184557

--- a/docs/assets/imgs/debug-configurations.png
+++ b/docs/assets/imgs/debug-configurations.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c4d9387c0aeee27e4b180a8f3a8529ea1493a2fae329d977ea7a0a99e72679c
+size 50147

--- a/docs/assets/imgs/debug.png
+++ b/docs/assets/imgs/debug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:365852ebb548dd2487c0543f0a7c601f23f8854a96420760230a4695dd268164
+size 29877

--- a/docs/assets/imgs/debug_.png
+++ b/docs/assets/imgs/debug_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e770542293850b032b087b5f5ead1ea566da96f33d94225e81e34ff825039aa6
+size 189061

--- a/docs/assets/imgs/debug_chrome.png
+++ b/docs/assets/imgs/debug_chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bd10420b88afae8ada8c9ce519fa677e24ea329b7ff1a1458dc2fb3720f670b
+size 1035308

--- a/docs/assets/imgs/debugger_chrome.png
+++ b/docs/assets/imgs/debugger_chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35e55645e22033ad63d6729808eba8b086bb33869c54a1e0798621ae555ea5b
+size 95156

--- a/docs/assets/imgs/editor-errors.png
+++ b/docs/assets/imgs/editor-errors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af70edd599a5639fac1b278a2bfd7b326a8148effa8913176f81a6ad483f8d90
+size 40213

--- a/docs/assets/imgs/editor-prefs.png
+++ b/docs/assets/imgs/editor-prefs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08681b8d12d5f410d1d396fbede7a2fe8d76d704e4df9f9de185e1397a05de2a
+size 42009

--- a/docs/assets/imgs/editor-simple.png
+++ b/docs/assets/imgs/editor-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d9cbb3e11c8f53fe48ebbf643b315c3099a134fa00f2e2a0a337c810681da80
+size 48564

--- a/docs/assets/imgs/editorpanes.gif
+++ b/docs/assets/imgs/editorpanes.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c1b4a064f2b58340573cee7ef2c87d07a3a27d15bee99c66927cfca842818ff
+size 2299192

--- a/docs/assets/imgs/fef09b90-a696-11e6-9a37-70f827677830.gif
+++ b/docs/assets/imgs/fef09b90-a696-11e6-9a37-70f827677830.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0713df91d4585eb7ebf2f43c265c55053dce98da945c178c2696e745e67ef2fc
+size 176833

--- a/docs/assets/imgs/find-editor.png
+++ b/docs/assets/imgs/find-editor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03a43fd078d949b0936661cd4ba6546ed021a360761c0b30cc439fbd154b9f25
+size 99366

--- a/docs/assets/imgs/find-usages.png
+++ b/docs/assets/imgs/find-usages.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5466b719bc03682f2fa9a762a692a50b13cbe9ff82401f05f4f04aae8f402284
+size 327114

--- a/docs/assets/imgs/git-menu.png
+++ b/docs/assets/imgs/git-menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4882301d6f7b325a678b68053a94934c75e8fa7c403cd7bd54853c8a9becc562
+size 23079

--- a/docs/assets/imgs/github-button.png
+++ b/docs/assets/imgs/github-button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d20e375514e63f7878c1bd02a7be3edebd59bda4b331b2820501341713ac608
+size 29140

--- a/docs/assets/imgs/ide-update-dep.png
+++ b/docs/assets/imgs/ide-update-dep.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7638b63e39858c204d30fa5e9a14ca55336350ba06f3c3b723ea864903323520
+size 183441

--- a/docs/assets/imgs/image.png
+++ b/docs/assets/imgs/image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:317d5f90b5e2e24ebcde1a0b3b41e29e303c06251df7345b5dd0967fb45cfc60
+size 10698

--- a/docs/assets/imgs/image00.png
+++ b/docs/assets/imgs/image00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd00906df6034ef71fb6a19ae2eb53e694967f6930ee233a8fea8b59c4b76770
+size 3537

--- a/docs/assets/imgs/image01.png
+++ b/docs/assets/imgs/image01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a86f99469045479158731f5572cafcbba5898022c474ddc51b9f4f636e98d82
+size 4440

--- a/docs/assets/imgs/image03.png
+++ b/docs/assets/imgs/image03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72dd12641fee29c48202fa1fd1716b5328aec26cee6f137ae6b1aa6df8599752
+size 19373

--- a/docs/assets/imgs/image04.png
+++ b/docs/assets/imgs/image04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37affccd69e79459726bbc27a806aab07c33a7bc5a936a27c10039c264140ca7
+size 24893

--- a/docs/assets/imgs/image05.png
+++ b/docs/assets/imgs/image05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c42ff10f692f1c42142d39bb6d9942e6f7ad7ff0d317ee83712cb5251492197
+size 129843

--- a/docs/assets/imgs/image06.png
+++ b/docs/assets/imgs/image06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:349cb80a4bbd7bb91f3a3a005af37cc9c4da821153074a0aa19f5b1f7006534c
+size 28165

--- a/docs/assets/imgs/image07.png
+++ b/docs/assets/imgs/image07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:720fc82e40a63d9184dd1c3931bf105c8fe0b80f64eb5a0e1422ed89b7495fbe
+size 7811

--- a/docs/assets/imgs/image08.png
+++ b/docs/assets/imgs/image08.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc21df1cb24741a08be419414948fa9e9f7556ecbb6eee8392fadfca4805affc
+size 7755

--- a/docs/assets/imgs/image11.png
+++ b/docs/assets/imgs/image11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:205390daba3f51f0d53a15f2f8f6de962c811ae7fbf061d63eafcf5ff30028f2
+size 21997

--- a/docs/assets/imgs/image13.png
+++ b/docs/assets/imgs/image13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1587bd4e931b35e32d2868b0656b3fe3485b007eb06934d7f128efdebb1abb5c
+size 10177

--- a/docs/assets/imgs/image14.png
+++ b/docs/assets/imgs/image14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60c1e23bc984a6f6da719527f8c14647c8dc615598c3951594f66168515b8b95
+size 5242

--- a/docs/assets/imgs/image15.png
+++ b/docs/assets/imgs/image15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7736dd7db959cc6cf1711297d76c9aad0db85b6428ee08be62af03bf9c847b23
+size 22956

--- a/docs/assets/imgs/img-features-commands.png
+++ b/docs/assets/imgs/img-features-commands.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40a41ee27b604a7c34646b1442c8bd84007dd9080216b28fac4773f4918cfd1f
+size 236050

--- a/docs/assets/imgs/import-existing-maven-projects.png
+++ b/docs/assets/imgs/import-existing-maven-projects.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8521831e26b2c943b5e6f1c03744174cfebf018b798a71c2d7f3534ce5dfd98
+size 512143

--- a/docs/assets/imgs/install-jetty8.png
+++ b/docs/assets/imgs/install-jetty8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d16fb2520c7f581071eeb765cee55b88843d0321f24b09430d3755ddd56cf4f
+size 281339

--- a/docs/assets/imgs/install-plugin1.png
+++ b/docs/assets/imgs/install-plugin1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:629e6a676589af27f5db444908c7f6f0862dcaa161bd740f987594d4f16c98c8
+size 1153339

--- a/docs/assets/imgs/install-plugin2.png
+++ b/docs/assets/imgs/install-plugin2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a80de284d651dc3124df4fd593860af107727ea1c748658eaf2510d5d11ba45
+size 1142598

--- a/docs/assets/imgs/install-plugin3.png
+++ b/docs/assets/imgs/install-plugin3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c1baa59920ed97a19e47216810d6edc548f6ba6a93862ba08876694a61a18f2
+size 1217395

--- a/docs/assets/imgs/install-plugin4.png
+++ b/docs/assets/imgs/install-plugin4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cb9c1ebc868cd750643d488ad061f6c8a72b75c61cd29bdb6b90bf0e3c3404a
+size 1007361

--- a/docs/assets/imgs/java-compiler-prefs.png
+++ b/docs/assets/imgs/java-compiler-prefs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd6f672dceb196277228aeb67f5acaebc0adaf04b2e1e694d7919abf308eded0
+size 65473

--- a/docs/assets/imgs/jenkinsjob.png
+++ b/docs/assets/imgs/jenkinsjob.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7aa085f8733302cf8f9c4ea1d605214efe1a3254d7fe225a676335c398904d55
+size 30709

--- a/docs/assets/imgs/keybindings.png
+++ b/docs/assets/imgs/keybindings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27fd6cf18469fb099b513e1fc7531a0a5f6fd607ccde963e7a1337f599b2f36f
+size 64705

--- a/docs/assets/imgs/logo-eclipseche.svg
+++ b/docs/assets/imgs/logo-eclipseche.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e8928f7a76252ccc9b1232ab87b650c5e3ad535e4370655f1e3c51363f75d71
+size 6071

--- a/docs/assets/imgs/machine.png
+++ b/docs/assets/imgs/machine.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f56bfc230c971d7967d60688e7ff91678981f6292b041b1f0566526123e44925
+size 9280

--- a/docs/assets/imgs/maven.png
+++ b/docs/assets/imgs/maven.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6b4e801ca0d7f2dae0696e7789ed7a7ce3a05152aeb9cb20550d28c31456f1
+size 148311

--- a/docs/assets/imgs/module.png
+++ b/docs/assets/imgs/module.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9691ddd9012b53a9c4363fdce7d68444064ea96e352104febd97c632c25ec6a0
+size 7910

--- a/docs/assets/imgs/move-item.png
+++ b/docs/assets/imgs/move-item.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35fcacc6316b1731de0ce8cd3062128ee105956e1d5f711ae0a8c460bdf81de1
+size 32564

--- a/docs/assets/imgs/nonexistent-dependency.png
+++ b/docs/assets/imgs/nonexistent-dependency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6a2fafe29511bf4a743d00c7b59bee62a1a07e514d31033048a83b272eb41b4
+size 3666

--- a/docs/assets/imgs/open-declaration.png
+++ b/docs/assets/imgs/open-declaration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:392992bd5730b6e49e11cadf30048ff4be9680d97a2d6e0d563bff92c1c4a693
+size 161268

--- a/docs/assets/imgs/php.png
+++ b/docs/assets/imgs/php.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbad1444ebcad0915f5302164fd62be9d884e8ddaed1b170375ee4cea27e1dd0
+size 90682

--- a/docs/assets/imgs/plugins.png
+++ b/docs/assets/imgs/plugins.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f73345ef9d67883aa928ab00328ac759944facc54b1173f6f6df15b401164b7a
+size 141994

--- a/docs/assets/imgs/postbuild.png
+++ b/docs/assets/imgs/postbuild.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c861cab3fbd8ec29976cabff1f2ff634a3a80f73c52934b8e702ed644068dac1
+size 80276

--- a/docs/assets/imgs/preview.png
+++ b/docs/assets/imgs/preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1c25da2b2eace0689cb3d29313e4ae3dd1470f9582ac7d052f06712a6d69ed4
+size 35450

--- a/docs/assets/imgs/project-tree.png
+++ b/docs/assets/imgs/project-tree.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb787ddde1b443ac63e8d3b15c34686f87d672c4821f4d0e823ae0ebe07deee5
+size 70582

--- a/docs/assets/imgs/quick-documentation.png
+++ b/docs/assets/imgs/quick-documentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13b24328eeec32ac739d0864317651cdd1ea6975530c65cf44878b10ec812fb9
+size 155929

--- a/docs/assets/imgs/rename.png
+++ b/docs/assets/imgs/rename.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cda841f8847b1cee9b92c5eff28209f016e79a8afde96c8545ccf841d11eb1ad
+size 23725

--- a/docs/assets/imgs/sdm-intellij.jpg
+++ b/docs/assets/imgs/sdm-intellij.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81cda9e6663cb683e3a6b6c40f02910105a8d84062ea364ac0693246e7b4027e
+size 273971

--- a/docs/assets/imgs/selectjava.png
+++ b/docs/assets/imgs/selectjava.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28c48c4bb0413e0a9a0c8d2fafa3d9eadd5a93a30b3c85dd6e5556616e626ed3
+size 59458

--- a/docs/assets/imgs/server.png
+++ b/docs/assets/imgs/server.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6141449d6a46fb467e39c1014782a5d8be2c1773406c5288f1cb9aeb4127ef
+size 33716

--- a/docs/assets/imgs/slim.png
+++ b/docs/assets/imgs/slim.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcce3293415a4be7b9e5b16c59df346b357271a58b8cf6c82ff766a1d2fd0471
+size 17857

--- a/docs/assets/imgs/svn-menu.png
+++ b/docs/assets/imgs/svn-menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:162d5a10f57c083747d6bae6e92a5b7670cdc44414b630781e590f1a849bfe12
+size 17986

--- a/docs/assets/imgs/templates.png
+++ b/docs/assets/imgs/templates.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8da660ab0c7218d39a0ea55eae62e1e6ca34e1802cfe4cde0226e4d959ff6f12
+size 92795

--- a/docs/assets/imgs/tokens.png
+++ b/docs/assets/imgs/tokens.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98a91f2340639bc34d5fb27d49647ca480388961baaeba2640e32125b76a6b43
+size 9618

--- a/docs/assets/imgs/yatta-installer.png
+++ b/docs/assets/imgs/yatta-installer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cfdd37cae4fbcfb24a1c56256e7cb0b60d76301ff93ffe52a58a38a926315ea
+size 58450


### PR DESCRIPTION
Add back images of docs but now using git-lfs
Images will be stored on github lfs storage (reduce git repository size)

https://help.github.com/articles/versioning-large-files/

![image](https://cloud.githubusercontent.com/assets/436777/21343933/83994f1e-c699-11e6-84a6-b19cca3d3649.png)
