### PR TITLE
[cli] When starting docker containers, adds the CHE_* env variables

### DIFF
--- a/dockerfiles/lib/src/internal/action/che-action.ts
+++ b/dockerfiles/lib/src/internal/action/che-action.ts
@@ -51,7 +51,7 @@ export class CheAction {
 
 
     static init() : Map<string,any> {
-        Log.context = ProductName.getDisplayName() + '(action)';
+        Log.context = '(' + ProductName.getMiniDisplayName() + ' action)';
         let actionMap : Map<string, any> = new Map<string, any>();
         actionMap.set('create-start-workspace', CreateStartWorkspaceAction);
         actionMap.set('add-user', AddUserAction);
@@ -71,7 +71,7 @@ export class CheAction {
     run() : Promise<any> {
        let classOfAction: any = this.mapOfActions.get(this.actionName);
        if (classOfAction) {
-           Log.context = ProductName.getDisplayName() + '(action/' + this.actionName + ')';
+           Log.context = '(' + ProductName.getMiniDisplayName() + ' action/' + this.actionName + ')';
            var instance = new classOfAction(this.args);
            return instance.run();
        } else {
@@ -86,7 +86,7 @@ export class CheAction {
     help() : void {
         Log.getLogger().info("Available actions are : ");
         for (var [key, value] of this.mapOfActions.entries()) {
-            Log.getLogger().info('\u001b[1m' + key + '\u001b[0m');
+            Log.getLogger().direct('\u001b[1m' + key + '\u001b[0m');
             ArgumentProcessor.help(Object.create(value.prototype));
         }
     }

--- a/dockerfiles/lib/src/internal/dir/che-dir.ts
+++ b/dockerfiles/lib/src/internal/dir/che-dir.ts
@@ -183,7 +183,7 @@ export class CheDir {
   }
 
   run() : Promise<string> {
-    Log.context = ProductName.getDisplayName() + '(dir)';
+    Log.context = '(' + ProductName.getMiniDisplayName() + ' dir)';
 
     // call the method analyzed from the argument
     return this.parseArgument().then((methodName) => {

--- a/dockerfiles/lib/src/internal/test/che-test.ts
+++ b/dockerfiles/lib/src/internal/test/che-test.ts
@@ -39,7 +39,7 @@ export class CheTest {
     mapOfTests : Map<string, any> = CheTest.init();
 
     static init() : Map<string,any> {
-        Log.context = ProductName.getDisplayName() + '(test)';
+        Log.context = '(' + ProductName.getMiniDisplayName() + ' test)';
         let testMap : Map<string, any> = new Map<string, any>();
         testMap.set('post-flight-check', PostFlightCheckTest);
         return testMap;
@@ -61,7 +61,7 @@ export class CheTest {
        let classOfTest: any = this.mapOfTests.get(this.testName);
        if (classOfTest) {
            // update logger
-           Log.context = ProductName.getDisplayName() + '(test/' + this.testName + ')';
+           Log.context = '(' + ProductName.getMiniDisplayName() + ' test/' + this.testName + ')';
            var instance = new classOfTest(this.args);
            return instance.run();
        } else {

--- a/dockerfiles/lib/src/spi/decorator/argument-processor.ts
+++ b/dockerfiles/lib/src/spi/decorator/argument-processor.ts
@@ -42,7 +42,7 @@ export class ArgumentProcessor {
                 asciiFormParameters.withEntry("    <" + metadataArgument.fieldName + ">", metadataArgument.description);
             });
         }
-        Log.getLogger().log("multiline:info", asciiFormParameters.toAscii());
+        Log.getLogger().log("multiline:direct", asciiFormParameters.toAscii());
     }
 
     static help(object : any) : void {

--- a/dockerfiles/lib/src/spi/log/log.ts
+++ b/dockerfiles/lib/src/spi/log/log.ts
@@ -83,6 +83,10 @@ export class Log {
         } else if ('multiline:info' === type) {
             prefix = Log.INFO_PREFIX;
             displayEachLine = true;
+        } else if ('multiline:direct' === type) {
+            prefix = '';
+            useContext = false;
+            displayEachLine = true;
         }
 
         if (useContext && Log.context) {
@@ -125,4 +129,4 @@ export class Log {
 }
 
 
-export type LogType = 'info' | 'debug' | 'warn' | 'error' | 'direct' | 'multiline:info';
+export type LogType = 'info' | 'debug' | 'warn' | 'error' | 'direct' | 'multiline:info' | 'multiline:direct';

--- a/dockerfiles/lib/src/utils/product-name.ts
+++ b/dockerfiles/lib/src/utils/product-name.ts
@@ -22,4 +22,12 @@ export class ProductName {
         return productName;
     }
 
+    static getMiniDisplayName() : string {
+        let miniProductName: string = process.env.CHE_MINI_PRODUCT_NAME;
+        if (!miniProductName) {
+            return 'Eclipse Che';
+        }
+        return miniProductName;
+    }
+
 }


### PR DESCRIPTION
- By providing to docker run calls the CHE_* variables, the docker containers can have access for example to CHE_MINI_PRODUCT_NAME, etc so they can adapt the output
- For action, test and che-dir containers, improve log output to match the new cli output
which is  ```LOG_LEVEL: (mini-product-name <container-name>) <message>```

Change-Id: I2f7da27f9a9658e2fbc49f3a766593203b172f4d
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
