### PR TITLE
CODENVY-1337 Logs of workspace containers and agents are not shown when WS starts in IDE

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
@@ -19,12 +19,14 @@ import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.core.model.machine.Machine;
+import static org.eclipse.che.api.core.model.machine.MachineStatus.CREATING;
 import org.eclipse.che.api.core.model.machine.Server;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.ExtendedMachine;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceRuntime;
+import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.execagent.GetProcessLogsResponseDto;
 import org.eclipse.che.api.machine.shared.dto.execagent.GetProcessesResponseDto;
@@ -41,7 +43,6 @@ import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.MachineEntity;
-import org.eclipse.che.ide.api.machine.MachineServiceClient;
 import org.eclipse.che.ide.api.machine.events.MachineStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
@@ -56,10 +57,12 @@ import org.eclipse.che.ide.api.ssh.SshServiceClient;
 import org.eclipse.che.ide.api.workspace.event.EnvironmentOutputEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStartedEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
 import org.eclipse.che.ide.extension.machine.client.MachineResources;
 import org.eclipse.che.ide.extension.machine.client.inject.factories.EntityFactory;
 import org.eclipse.che.ide.extension.machine.client.inject.factories.TerminalFactory;
+import org.eclipse.che.ide.extension.machine.client.machine.MachineEntityImpl;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandConsoleFactory;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandOutputConsole;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandOutputConsolePresenter;
@@ -126,7 +129,6 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
     private final ProcessesPanelView            view;
     private final MachineLocalizationConstant   localizationConstant;
     private final MachineResources              resources;
-    private final MachineServiceClient          machineServiceClient;
     private final WorkspaceAgent                workspaceAgent;
     private final SshServiceClient              sshServiceClient;
     private final AppContext                    appContext;
@@ -139,6 +141,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
     private final CommandTypeRegistry           commandTypeRegistry;
     private final ExecAgentCommandManager       execAgentCommandManager;
     private final EventBus                      eventBus;
+    private final DtoFactory                    dtoFactory;
 
     ProcessTreeNode                             rootNode;
     private final Map<String, ProcessTreeNode>  machineNodes;
@@ -151,7 +154,6 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
                                    MachineLocalizationConstant localizationConstant,
                                    MachineResources resources,
                                    EventBus eventBus,
-                                   MachineServiceClient machineServiceClient,
                                    WorkspaceAgent workspaceAgent,
                                    AppContext appContext,
                                    NotificationManager notificationManager,
@@ -162,11 +164,11 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
                                    ConsoleTreeContextMenuFactory consoleTreeContextMenuFactory,
                                    CommandTypeRegistry commandTypeRegistry,
                                    SshServiceClient sshServiceClient,
-                                   ExecAgentCommandManager execAgentCommandManager) {
+                                   ExecAgentCommandManager execAgentCommandManager,
+                                   DtoFactory dtoFactory) {
         this.view = view;
         this.localizationConstant = localizationConstant;
         this.resources = resources;
-        this.machineServiceClient = machineServiceClient;
         this.workspaceAgent = workspaceAgent;
         this.sshServiceClient = sshServiceClient;
         this.appContext = appContext;
@@ -179,6 +181,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         this.eventBus = eventBus;
         this.commandTypeRegistry = commandTypeRegistry;
         this.execAgentCommandManager = execAgentCommandManager;
+        this.dtoFactory = dtoFactory;
 
         machineNodes = new HashMap<>();
         machines = new HashMap<>();
@@ -1092,7 +1095,19 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
      * @param text
      *          text to be printed
      */
-    public void printMachineOutput(String machineName, String text) {
+    public void printMachineOutput(final String machineName, final String text) {
+        // Create a temporary machine node to display outputs.
+        if (!consoles.containsKey(machineName)) {
+            MachineDto machineDto = dtoFactory.createDto(MachineDto.class)
+                    .withId(machineName)
+                    .withStatus(CREATING)
+                    .withConfig(dtoFactory.createDto(MachineConfigDto.class)
+                                    .withDev("dev-machine".equals(machineName))
+                                    .withName(machineName)
+                    );
+            provideMachineNode(new MachineEntityImpl(machineDto), true);
+        }
+
         OutputConsole console = consoles.get(machineName);
         if (console != null && console instanceof DefaultOutputConsole) {
             ((DefaultOutputConsole)console).printText(text);

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenter.java
@@ -198,8 +198,6 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         eventBus.addHandler(DownloadWorkspaceOutputEvent.TYPE, this);
         eventBus.addHandler(PartStackStateChangedEvent.TYPE, this);
 
-        updateMachineList();
-
         final PartStack partStack = checkNotNull(workspaceAgent.getPartStack(PartStackType.INFORMATION),
                                                  "Information part stack should not be a null");
         partStack.addPart(this);
@@ -207,6 +205,13 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         if (appContext.getFactory() == null) {
             partStack.setActivePart(this);
         }
+
+        Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+            @Override
+            public void execute() {
+                updateMachineList();
+            }
+        });
     }
 
     /**
@@ -276,11 +281,8 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
 
     @Override
     public void onMachineRunning(MachineStateEvent event) {
-        final MachineEntity machine = event.getMachine();
-        if (!machine.isDev()) {
-            machines.put(event.getMachineId(), event.getMachine());
-            provideMachineNode(machine, true);
-        }
+        machines.put(event.getMachineId(), event.getMachine());
+        provideMachineNode(event.getMachine(), true);
     }
 
     @Override

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/panel/ProcessesPanelPresenterTest.java
@@ -45,6 +45,7 @@ import org.eclipse.che.ide.api.parts.PartStack;
 import org.eclipse.che.ide.api.parts.PartStackType;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.ssh.SshServiceClient;
+import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant;
 import org.eclipse.che.ide.extension.machine.client.MachineResources;
 import org.eclipse.che.ide.extension.machine.client.inject.factories.EntityFactory;
@@ -116,8 +117,6 @@ public class ProcessesPanelPresenterTest {
     @Mock
     private AppContext                    appContext;
     @Mock
-    private MachineServiceClient          machineService;
-    @Mock
     private SshServiceClient              sshService;
     @Mock
     private EventBus                      eventBus;
@@ -135,6 +134,8 @@ public class ProcessesPanelPresenterTest {
     private PartStack                     partStack;
     @Mock
     private ExecAgentCommandManager       execAgentCommandManager;
+    @Mock
+    private DtoFactory                    dtoFactory;
 
     @Mock
     private Promise<List<MachineProcessDto>> processesPromise;
@@ -173,7 +174,6 @@ public class ProcessesPanelPresenterTest {
                                                 localizationConstant,
                                                 resources,
                                                 eventBus,
-                                                machineService,
                                                 workspaceAgent,
                                                 appContext,
                                                 notificationManager,
@@ -184,7 +184,8 @@ public class ProcessesPanelPresenterTest {
                                                 consoleTreeContextMenuFactory,
                                                 commandTypeRegistry,
                                                 sshService,
-                                                execAgentCommandManager);
+                                                execAgentCommandManager,
+                                                dtoFactory);
     }
 
     @Test


### PR DESCRIPTION
The part of logs are lost and not shown in the dev-machine console.

https://github.com/codenvy/codenvy/issues/1337
