### PR TITLE
Added macros for product name

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,6 +26,10 @@ name: Eclipse Che Docs
 description: Cloud workspaces for development teams
 url: https://www.eclipse.org/che/
 
+product_name: "CHE"
+product_mini_name:  "Che"
+product_formal_name: "Eclipse Che"
+
 twitter:
   username: eclipse_che
 


### PR DESCRIPTION
Allows products that rebrand Che to easily reuse Che docs and have their own product name substituted for Che's.