### PR TITLE
CHE-3438: Reuse shell interpreter passed to command line to start terminal

### DIFF
--- a/exec-agent/src/main.go
+++ b/exec-agent/src/main.go
@@ -86,6 +86,7 @@ func init() {
 		"/bin/bash",
 		"shell interpreter and command to execute on slave side of the pty",
 	)
+	process.ShellInterpreter = term.Cmd
 
 	// workspace master server configuration
 	flag.StringVar(

--- a/exec-agent/src/main.go
+++ b/exec-agent/src/main.go
@@ -84,7 +84,7 @@ func init() {
 		&term.Cmd,
 		"cmd",
 		"/bin/bash",
-		"command to execute on slave side of the pty",
+		"shell interpreter and command to execute on slave side of the pty",
 	)
 
 	// workspace master server configuration

--- a/exec-agent/src/process/process.go
+++ b/exec-agent/src/process/process.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/eclipse/che/exec-agent/rpc"
-	"github.com/eclipse/che/exec-agent/term"
 )
 
 const (
@@ -35,13 +34,16 @@ const (
 
 	StdoutKind = "STDOUT"
 	StderrKind = "STDERR"
+
+	DefaultShellInterpreter = "/bin/bash"
 )
 
 var (
-	prevPid   uint64 = 0
-	processes        = &processesMap{items: make(map[uint64]*MachineProcess)}
-	logsDist         = NewLogsDistributor()
-	LogsDir   string
+	prevPid   		uint64 = 0
+	processes        	= &processesMap{items: make(map[uint64]*MachineProcess)}
+	logsDist         	= NewLogsDistributor()
+	LogsDir   		string
+	ShellInterpreter   	string = DefaultShellInterpreter
 )
 
 type Command struct {
@@ -139,7 +141,7 @@ type processesMap struct {
 
 func Start(process MachineProcess) (MachineProcess, error) {
 	// wrap command to be able to kill child processes see https://github.com/golang/go/issues/8854
-	cmd := exec.Command("setsid", term.Cmd, "-c", process.CommandLine)
+	cmd := exec.Command("setsid", ShellInterpreter, "-c", process.CommandLine)
 
 	// getting stdout pipe
 	stdout, err := cmd.StdoutPipe()

--- a/exec-agent/src/process/process.go
+++ b/exec-agent/src/process/process.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/eclipse/che/exec-agent/rpc"
+	"github.com/eclipse/che/exec-agent/term"
 )
 
 const (
@@ -138,7 +139,7 @@ type processesMap struct {
 
 func Start(process MachineProcess) (MachineProcess, error) {
 	// wrap command to be able to kill child processes see https://github.com/golang/go/issues/8854
-	cmd := exec.Command("setsid", "sh", "-c", process.CommandLine)
+	cmd := exec.Command("setsid", term.Cmd, "-c", process.CommandLine)
 
 	// getting stdout pipe
 	stdout, err := cmd.StdoutPipe()

--- a/exec-agent/src/process/process.go
+++ b/exec-agent/src/process/process.go
@@ -39,11 +39,11 @@ const (
 )
 
 var (
-	prevPid   		uint64 = 0
-	processes        	= &processesMap{items: make(map[uint64]*MachineProcess)}
-	logsDist         	= NewLogsDistributor()
-	LogsDir   		string
-	ShellInterpreter   	string = DefaultShellInterpreter
+	prevPid          uint64 = 0
+	processes               = &processesMap{items: make(map[uint64]*MachineProcess)}
+	logsDist                = NewLogsDistributor()
+	LogsDir          string
+	ShellInterpreter string = DefaultShellInterpreter
 )
 
 type Command struct {

--- a/exec-agent/src/process/process_test.go
+++ b/exec-agent/src/process/process_test.go
@@ -12,7 +12,6 @@
 package process_test
 
 import (
-	"github.com/eclipse/che/exec-agent/term"
 	"github.com/eclipse/che/exec-agent/process"
 	"github.com/eclipse/che/exec-agent/rpc"
 	"os"
@@ -23,7 +22,6 @@ import (
 
 const (
 	testCmd = "printf \"1\n2\n3\n4\n5\n6\n7\n8\n9\n10\""
-	termCmd = "/bin/bash"
 )
 
 func TestOneLineOutput(t *testing.T) {
@@ -199,7 +197,6 @@ func TestReadProcessLogs(t *testing.T) {
 }
 
 func startAndWaitTestProcess(cmd string, t *testing.T) process.MachineProcess {
-	term.Cmd = termCmd
 	process.LogsDir = TmpFile()
 	events := make(chan *rpc.Event)
 	done := make(chan bool)

--- a/exec-agent/src/process/process_test.go
+++ b/exec-agent/src/process/process_test.go
@@ -12,6 +12,7 @@
 package process_test
 
 import (
+	"github.com/eclipse/che/exec-agent/term"
 	"github.com/eclipse/che/exec-agent/process"
 	"github.com/eclipse/che/exec-agent/rpc"
 	"os"
@@ -22,6 +23,7 @@ import (
 
 const (
 	testCmd = "printf \"1\n2\n3\n4\n5\n6\n7\n8\n9\n10\""
+	termCmd = "/bin/bash"
 )
 
 func TestOneLineOutput(t *testing.T) {
@@ -197,6 +199,7 @@ func TestReadProcessLogs(t *testing.T) {
 }
 
 func startAndWaitTestProcess(cmd string, t *testing.T) process.MachineProcess {
+	term.Cmd = termCmd
 	process.LogsDir = TmpFile()
 	events := make(chan *rpc.Event)
 	done := make(chan bool)

--- a/exec-agent/src/term/server.go
+++ b/exec-agent/src/term/server.go
@@ -220,7 +220,7 @@ func sendPtyOutputToConnection(conn *websocket.Conn, reader io.ReadCloser, final
 		}
 		i, err := normalizeBuffer(&buffer, buf, n)
 		if err != nil {
-			log.Printf("Cound't normalize byte buffer to UTF-8 sequence, due to an error: %s", err.Error())
+			log.Printf("Couldn't normalize byte buffer to UTF-8 sequence, due to an error: %s", err.Error())
 			return
 		}
 		if err = conn.WriteMessage(websocket.TextMessage, buffer.Bytes()); err != nil {
@@ -256,7 +256,7 @@ func ptyHandler(w http.ResponseWriter, r *http.Request) {
 	//write input to terminal
 	go sendConnectionInputToPty(conn, reader, wp.PtyFile, &finalizer)
 
-	fmt.Println("New terminal succesfully initialized.")
+	fmt.Println("New terminal successfully initialized.")
 }
 
 func waitAndClose(wp *wsPty, finalizer *ReadWriteRoutingFinalizer, conn *websocket.Conn, reader io.ReadCloser) {


### PR DESCRIPTION
### What does this PR do?
Reuse shell interpreter passed to command line to start terminal

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3438

### Previous behavior
`sh` was always used as shell interpreter to execute commands

### New behavior
Reuse shell interpreter passed to command line to start terminal

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
