### PR TITLE
CODENVY-959: Get rid of WSocketEventBusClient 

### DIFF
--- a/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -24,7 +24,6 @@ import org.eclipse.che.api.core.jsonrpc.RequestHandler;
 import org.eclipse.che.api.core.jsonrpc.RequestTransmitter;
 import org.eclipse.che.api.core.jsonrpc.impl.WebSocketToJsonRpcDispatcher;
 import org.eclipse.che.api.core.jsonrpc.impl.WebSocketTransmitter;
-import org.eclipse.che.api.core.notification.WSocketEventBusClient;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.api.core.rest.CoreRestModule;
 import org.eclipse.che.api.core.util.FileCleaner.FileCleanerModule;
@@ -77,7 +76,6 @@ public class WsAgentModule extends AbstractModule {
 
         bind(URI.class).annotatedWith(Names.named("che.api")).toProvider(UriApiEndpointProvider.class);
         bind(String.class).annotatedWith(Names.named("user.token")).toProvider(UserTokenProvider.class);
-        bind(WSocketEventBusClient.class).asEagerSingleton();
 
         bind(String.class).annotatedWith(Names.named("event.bus.url")).toProvider(EventBusURLProvider.class);
         bind(ApiEndpointAccessibilityChecker.class);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/WSocketEventBusClient.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/WSocketEventBusClient.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.notification;
 
-import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
-import org.eclipse.che.commons.lang.Pair;
-
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.everrest.websockets.client.BaseClientMessageListener;
 import org.everrest.websockets.client.WSClient;
 import org.everrest.websockets.message.JsonMessageConverter;
@@ -22,7 +22,6 @@ import org.everrest.websockets.message.RestOutputMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.eclipse.che.commons.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/WSocketEventBusClient.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/WSocketEventBusClient.java
@@ -10,12 +10,11 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.notification;
 
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.eclipse.che.commons.lang.Pair;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.commons.lang.IoUtil;
-import org.eclipse.che.commons.lang.Pair;
-import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.everrest.websockets.client.BaseClientMessageListener;
 import org.everrest.websockets.client.WSClient;
 import org.everrest.websockets.message.JsonMessageConverter;
@@ -23,14 +22,13 @@ import org.everrest.websockets.message.RestOutputMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.che.commons.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.websocket.DeploymentException;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -59,13 +57,6 @@ public final class WSocketEventBusClient {
     private static final Logger LOG = LoggerFactory.getLogger(WSocketEventBusClient.class);
 
     private static final long WS_CONNECTION_TIMEOUT = 2;
-    private static final long MAX_ATTEMPTS          = 10;
-
-    public static final String WORKSPACE_AGENT_STOPPED_MESSAGE = "The workspace agent has been forcefully stopped. " +
-                                                                 "This error happens when the agent cannot resolve the location of the Che server. " +
-                                                                 "This error can usually be fixed with additional configuration settings in /conf/che.properties. " +
-                                                                 "The Che server will stop this workspace after a short timeout. " +
-                                                                 "You can get help by posting your config, stacktrace and workspace /etc/hosts below as a GitHub issue.";
 
     private final EventService                         eventService;
     private final Pair<String, String>[]               eventSubscriptions;
@@ -255,7 +246,6 @@ public final class WSocketEventBusClient {
 
         @Override
         public void run() {
-            int reconnectAttempts = 0;
             for (; ; ) {
 
                 if (Thread.currentThread().isInterrupted()) {
@@ -264,26 +254,11 @@ public final class WSocketEventBusClient {
                 LOG.debug("Start connection loop {} channels {} ", wsUri, channels);
                 try {
                     connect(wsUri, channels);
-                    reconnectAttempts = 0;
                     LOG.debug("Connection complete");
                     return;
                 } catch (IOException | DeploymentException e) {
                     LOG.warn("Not able to connect to {} because {}. Retrying ", wsUri, e.getLocalizedMessage());
                     LOG.debug(e.getLocalizedMessage(), e);
-
-                    if (reconnectAttempts++ > MAX_ATTEMPTS) {
-                        LOG.error(WORKSPACE_AGENT_STOPPED_MESSAGE);
-
-                        try {
-                            // content of /etc/hosts file may provide clues on why the connection failed, e.g. how che-host is resolved
-                            LOG.info("Workspace /etc/hosts: " + IoUtil.readAndCloseQuietly(new FileInputStream(new File("/etc/hosts"))));
-                        } catch (Exception ex) {
-                            LOG.info(e.getLocalizedMessage(), ex);
-                        }
-
-                        System.exit(0);
-                    }
-
                     synchronized (this) {
                         try {
                             wait(WS_CONNECTION_TIMEOUT * 2 * 1000);

--- a/wsagent/wsagent-local/src/main/java/org/eclipse/che/ApiEndpointAccessibilityChecker.java
+++ b/wsagent/wsagent-local/src/main/java/org/eclipse/che/ApiEndpointAccessibilityChecker.java
@@ -11,7 +11,6 @@
 package org.eclipse.che;
 
 import org.eclipse.che.api.core.ApiException;
-import org.eclipse.che.api.core.notification.WSocketEventBusClient;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonResponse;
 import org.eclipse.che.commons.lang.IoUtil;
@@ -23,10 +22,10 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.HttpMethod;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.io.File;
 
 /**
  * Checks whether API is accessible from WS agent or not on app start to prevent usage of illegal configuration.
@@ -64,7 +63,11 @@ public class ApiEndpointAccessibilityChecker {
             }
 
             LOG.error("The workspace agent has attempted to start, but it is unable to ping the Che server at " + apiEndpoint);
-            LOG.error(WSocketEventBusClient.WORKSPACE_AGENT_STOPPED_MESSAGE);
+            LOG.error("The workspace agent has been forcefully stopped. " +
+                      "This error happens when the agent cannot resolve the location of the Che server. " +
+                      "This error can usually be fixed with additional configuration settings in /conf/che.properties. " +
+                      "The Che server will stop this workspace after a short timeout. " +
+                      "You can get help by posting your config, stacktrace and workspace /etc/hosts below as a GitHub issue.");
 
             // content of /etc/hosts file may provide clues on why the connection failed, e.g. how che-host is resolved
             try {

--- a/wsagent/wsagent-local/src/main/java/org/eclipse/che/ApiEndpointAccessibilityChecker.java
+++ b/wsagent/wsagent-local/src/main/java/org/eclipse/che/ApiEndpointAccessibilityChecker.java
@@ -11,6 +11,7 @@
 package org.eclipse.che;
 
 import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.notification.WSocketEventBusClient;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonResponse;
 import org.eclipse.che.commons.lang.IoUtil;
@@ -22,10 +23,10 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.HttpMethod;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.io.File;
 
 /**
  * Checks whether API is accessible from WS agent or not on app start to prevent usage of illegal configuration.
@@ -63,11 +64,7 @@ public class ApiEndpointAccessibilityChecker {
             }
 
             LOG.error("The workspace agent has attempted to start, but it is unable to ping the Che server at " + apiEndpoint);
-            LOG.error("The workspace agent has been forcefully stopped. " +
-                      "This error happens when the agent cannot resolve the location of the Che server. " +
-                      "This error can usually be fixed with additional configuration settings in /conf/che.properties. " +
-                      "The Che server will stop this workspace after a short timeout. " +
-                      "You can get help by posting your config, stacktrace and workspace /etc/hosts below as a GitHub issue.");
+            LOG.error(WSocketEventBusClient.WORKSPACE_AGENT_STOPPED_MESSAGE);
 
             // content of /etc/hosts file may provide clues on why the connection failed, e.g. how che-host is resolved
             try {


### PR DESCRIPTION
### What does this PR do?
Get rid of WSocketEventBusClient 

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/959

### Previous behavior
Ws agent produced enormous number of logs

### New behavior
Get rid of WSocketEventBusClient. It isn't used anymore

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
