### PR TITLE
Fix duplicating node during the project import

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -266,7 +266,9 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
         // process root projects, they have only one segment in path
         if (resource.getLocation().segmentCount() == 1) {
             if (delta.getKind() == ADDED) {
-                tree.getNodeStorage().add(nodeFactory.newContainerNode((Container)resource, nodeSettings));
+                if (getNode(resource.getLocation()) == null) {
+                    tree.getNodeStorage().add(nodeFactory.newContainerNode((Container)resource, nodeSettings));
+                }
             } else if (delta.getKind() == REMOVED) {
                 Node node = getNode(resource.getLocation());
 


### PR DESCRIPTION
Don't add a new node with the same path to the tree if such node already exists.

Related issue: #3463 