### PR TITLE
Added docs warning on renaming environments

### DIFF
--- a/docs/_docs/workspace-administration/ws-machines.md
+++ b/docs/_docs/workspace-administration/ws-machines.md
@@ -33,7 +33,7 @@ Machines can have their internal state saved into a Docker image with a snapshot
 
 Snapshots are important to preserve the internal state of a machine that is not defined by the recipe. For example, you may define a recipe that includes maven, but your project may require numerous dependencies that are downloaded and locally installed into the internal maven repository of the machine. If you stop and restart the machine without a snapshot, that internal state will be lost.
 
-Note that once you've snapshotted a workspace, changing the workspace's name will result in the snapshot being lost.
+Note that once you've snapshotted a workspace, changing the environment name inside the workspace will result in the snapshot being lost.
 
 Snapshots image a machine and then it is committed, tagged, and optionally pushed into a Docker registry. You can use a local Docker registry or a remote one. See [Configuration](https://eclipse-che.readme.io/docs/configuration#section-workspace-snapshots) for information on how to setup a docker registry.
 

--- a/docs/_docs/workspace-administration/ws-machines.md
+++ b/docs/_docs/workspace-administration/ws-machines.md
@@ -33,7 +33,7 @@ Machines can have their internal state saved into a Docker image with a snapshot
 
 Snapshots are important to preserve the internal state of a machine that is not defined by the recipe. For example, you may define a recipe that includes maven, but your project may require numerous dependencies that are downloaded and locally installed into the internal maven repository of the machine. If you stop and restart the machine without a snapshot, that internal state will be lost.
 
-Note that once you've snapshotted a workspace, changing the environment name inside the workspace will result in the snapshot being lost.
+Note that once you've snapshotted a workspace, changing the environment or machine names inside the workspace will result in the snapshot being lost.
 
 Snapshots image a machine and then it is committed, tagged, and optionally pushed into a Docker registry. You can use a local Docker registry or a remote one. See [Configuration](https://eclipse-che.readme.io/docs/configuration#section-workspace-snapshots) for information on how to setup a docker registry.
 

--- a/docs/_docs/workspace-administration/ws-machines.md
+++ b/docs/_docs/workspace-administration/ws-machines.md
@@ -5,6 +5,9 @@ excerpt: ""
 layout: docs
 permalink: /:categories/machines/
 ---
+{% include base.html %}
+
+
 A machine is part of an environment, which are in turn part of a Che workspace. The [workspace administration introduction](https://eclipse-che.readme.io/docs/workspace-admin-intro) explains the details of this relationship.
 
 A machine is created from a [runtime stack](doc:stacks). Che supports both single-machine environments and multi-machine environments. The Che server manages the lifecycle of environments and the machines inside, including creating snapshots of machines.  Additionally, the Che server can inject [workspace agents](doc:workspace-agents) into a machine to provide additional capabilities inside the machine.
@@ -30,6 +33,8 @@ Machines can have their internal state saved into a Docker image with a snapshot
 
 Snapshots are important to preserve the internal state of a machine that is not defined by the recipe. For example, you may define a recipe that includes maven, but your project may require numerous dependencies that are downloaded and locally installed into the internal maven repository of the machine. If you stop and restart the machine without a snapshot, that internal state will be lost.
 
+Note that once you've snapshotted a workspace, changing the workspace's name will result in the snapshot being lost.
+
 Snapshots image a machine and then it is committed, tagged, and optionally pushed into a Docker registry. You can use a local Docker registry or a remote one. See [Configuration](https://eclipse-che.readme.io/docs/configuration#section-workspace-snapshots) for information on how to setup a docker registry.
 
 To snapshot a machine go to the Operations Perspective by clicking the button on the far right of the menu bar. Choose Machines > Snapshot from the top menu bar. See our other docs [for details on setting up a local or remote Docker Registry](https://eclipse-che.readme.io/docs/configuration#section-workspace-snapshots).
@@ -45,6 +50,8 @@ export CHE_PROPERTY_machine_docker_snapshot__use__registry=false
 export CHE_PROPERTY_workspace_runtime_auto__snapshot=true
 export CHE_PROPERTY_workspace_runtime_auto__restore=true\
 ```
+
+
 ## Machine Information
 Information on each machine is provided by Eclipse Che server.
 


### PR DESCRIPTION
### What does this PR do?
- Adds a warning that renaming environments in workspaces that have been snapshotted will lose the snapshot.
