### PR TITLE
Temporary remove loader from get tree method

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
@@ -59,6 +59,8 @@ import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
 /**
  * Implementation of {@link ProjectServiceClient}.
  *
+ * TODO need to remove interface as this component is internal one and couldn't have more than one instance
+ *
  * @author Vitaly Parfonov
  * @author Artem Zatsarynnyi
  * @author Valeriy Svydenko
@@ -310,9 +312,11 @@ public class ProjectServiceClientImpl implements ProjectServiceClient {
     public Promise<TreeElement> getTree(Path path, int depth, boolean includeFiles) {
         final String url = getBaseUrl() + TREE + path(path.toString()) + "?depth=" + depth + "&includeFiles=" + includeFiles;
 
+        // temporary workaround for CHE-3467, remove loader for disable UI blocking
+        // later this loader should be added with the new mechanism of client-server synchronization
+
         return reqFactory.createGetRequest(url)
                          .header(ACCEPT, MimeType.APPLICATION_JSON)
-                         .loader(loaderFactory.newLoader("Reading project structure..."))
                          .send(unmarshaller.newUnmarshaller(TreeElement.class));
     }
 

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/project/ProjectServiceClientImplTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/project/ProjectServiceClientImplTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.project;
+
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.machine.WsAgentStateController;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.ide.rest.AsyncRequest;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.AsyncRequestLoader;
+import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
+import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link ProjectServiceClientImpl}.
+ *
+ * @author Vlad Zhukovskyi
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectServiceClientImplTest {
+
+    @Mock
+    private WsAgentStateController wsAgentStateController;
+    @Mock
+    private LoaderFactory          loaderFactory;
+    @Mock
+    private AsyncRequestFactory    asyncRequestFactory;
+    @Mock
+    private DtoFactory             dtoFactory;
+    @Mock
+    private DtoUnmarshallerFactory dtoUnmarshallerFactory;
+    @Mock
+    private AppContext             appContext;
+
+    private ProjectServiceClientImpl projectServiceClient;
+
+    @Before
+    public void setUp() throws Exception {
+        projectServiceClient = new ProjectServiceClientImpl(wsAgentStateController,
+                                                            loaderFactory,
+                                                            asyncRequestFactory,
+                                                            dtoFactory,
+                                                            dtoUnmarshallerFactory,
+                                                            appContext);
+        DevMachine devMachine = mock(DevMachine.class);
+        when(devMachine.getWsAgentBaseUrl()).thenReturn("");
+
+        when(appContext.getDevMachine()).thenReturn(devMachine);
+    }
+
+    @Test
+    public void testShouldNotSetupLoaderForTheGetTreeMethod() throws Exception {
+        AsyncRequest asyncRequest = mock(AsyncRequest.class);
+
+        when(asyncRequestFactory.createGetRequest(anyString())).thenReturn(asyncRequest);
+        when(asyncRequest.header(anyString(), anyString())).thenReturn(asyncRequest);
+
+        projectServiceClient.getTree(Path.EMPTY, 1, true);
+
+        verify(asyncRequest, never()).loader(any(AsyncRequestLoader.class)); //see CHE-3467
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Add temporary workaround to the project service client implementation to not display the loader for the get tree method to disallow UI blocking for the long requests.

### What issues does this PR fix or reference?
#3467 as temporary workaround

### Previous behavior
when get tree operation works more than 0.5sec then loader is shown

### New behavior
loader temporary removed
