### PR TITLE
CODENVY-1392: fix SSH agent start check

### DIFF
--- a/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncher.java
+++ b/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncher.java
@@ -97,7 +97,6 @@ public abstract class AbstractAgentLauncher implements AgentLauncher {
         throw new ServerException(errMsg);
     }
 
-
     protected InstanceProcess start(Instance machine, Agent agent) throws ServerException {
         Command command = new CommandImpl(agent.getId(), agent.getScript(), "agent");
         InstanceProcess process = machine.createProcess(command, null);

--- a/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/CommandExistsAgentChecker.java
+++ b/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/CommandExistsAgentChecker.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.launcher;
+
+import org.eclipse.che.api.agent.shared.model.Agent;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.model.machine.Command;
+import org.eclipse.che.api.core.util.ListLineConsumer;
+import org.eclipse.che.api.machine.server.exception.MachineException;
+import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
+import org.eclipse.che.api.machine.server.spi.Instance;
+import org.eclipse.che.api.machine.server.spi.InstanceProcess;
+
+import static java.lang.String.format;
+
+/**
+ * Verifies if agent installed a command with specific name.
+ * It is an indicator that agent start had been finished.
+ *
+ * @author Alexander Garagatyi
+ */
+public class CommandExistsAgentChecker implements AgentLaunchingChecker {
+
+    private static final String CHECK_COMMAND = "command -v %1$s >/dev/null 2>&1 && echo 0 || echo 1";
+    private final String checkingCommand;
+    private       long   counter;
+
+    public CommandExistsAgentChecker(String commandToCheck) {
+        this.checkingCommand = format(CHECK_COMMAND, commandToCheck);
+    }
+
+    @Override
+    public boolean isLaunched(Agent agent, InstanceProcess process, Instance machine) throws MachineException {
+        Command command = new CommandImpl(format("Wait for %s, try %d", agent.getId(), ++counter),
+                                          checkingCommand,
+                                          "test");
+
+        try (ListLineConsumer lineConsumer = new ListLineConsumer()) {
+            InstanceProcess waitProcess = machine.createProcess(command, null);
+            waitProcess.start(lineConsumer);
+            return lineConsumer.getText().endsWith("[STDOUT] 0");
+        } catch (ConflictException e) {
+            throw new MachineException(e.getServiceError());
+        }
+    }
+}

--- a/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/CompositeAgentLaunchingChecker.java
+++ b/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/CompositeAgentLaunchingChecker.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.launcher;
+
+import org.eclipse.che.api.agent.shared.model.Agent;
+import org.eclipse.che.api.machine.server.exception.MachineException;
+import org.eclipse.che.api.machine.server.spi.Instance;
+import org.eclipse.che.api.machine.server.spi.InstanceProcess;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Verifies that agent was started successfully by calling verification of several specified verifiers.
+ * </p>
+ * Verification passes if and only if all verifiers pass verification.
+ *
+ * @author Alexander Garagatyi
+ */
+public class CompositeAgentLaunchingChecker implements AgentLaunchingChecker {
+
+    private final List<AgentLaunchingChecker> agentLaunchingCheckers;
+
+    public CompositeAgentLaunchingChecker(AgentLaunchingChecker... agentLaunchingCheckers) {
+        checkArgument(agentLaunchingCheckers != null && agentLaunchingCheckers.length > 0,
+                      "Array of agent launching checkers should neither be null nor empty");
+        for (AgentLaunchingChecker agentLaunchingChecker : agentLaunchingCheckers) {
+            checkArgument(agentLaunchingChecker != null,
+                          "Array of agent launching checker should not contain null");
+        }
+        this.agentLaunchingCheckers = Arrays.asList(agentLaunchingCheckers);
+    }
+
+    @Override
+    public boolean isLaunched(Agent agent, InstanceProcess process, Instance machine) throws MachineException {
+        for (AgentLaunchingChecker agentLaunchingChecker : agentLaunchingCheckers) {
+            if (!agentLaunchingChecker.isLaunched(agent, process, machine)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/MappedPortIsListeningAgentChecker.java
+++ b/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/MappedPortIsListeningAgentChecker.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.launcher;
+
+import org.eclipse.che.api.agent.shared.model.Agent;
+import org.eclipse.che.api.core.model.machine.Server;
+import org.eclipse.che.api.machine.server.exception.MachineException;
+import org.eclipse.che.api.machine.server.spi.Instance;
+import org.eclipse.che.api.machine.server.spi.InstanceProcess;
+import org.slf4j.Logger;
+
+import java.net.Socket;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Verifies that agent was started successfully by checking that specified local port is listened in a machine.
+ *
+ * @author Alexander Garagatyi
+ */
+public class MappedPortIsListeningAgentChecker implements AgentLaunchingChecker {
+    private static final Logger LOG = getLogger(MappedPortIsListeningAgentChecker.class);
+    private final String exposedPort;
+
+    public MappedPortIsListeningAgentChecker(String exposedPort) {
+        // normalize port/transport value
+        this.exposedPort = exposedPort.contains("/") ? exposedPort : exposedPort + "/tcp";
+    }
+
+    @Override
+    public boolean isLaunched(Agent agent, InstanceProcess process, Instance machine) throws MachineException {
+        Server server = machine.getRuntime().getServers().get(exposedPort);
+        if (server != null) {
+            try {
+                LOG.error("Ping ssh agent");
+                String[] hostPort = server.getAddress().split(":");
+                try (@SuppressWarnings("unused") Socket socket = new Socket(hostPort[0],
+                                                                            Integer.parseInt(hostPort[1]))) {
+                    return true;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
+}

--- a/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/MappedPortIsListeningAgentChecker.java
+++ b/wsmaster/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/MappedPortIsListeningAgentChecker.java
@@ -15,11 +15,8 @@ import org.eclipse.che.api.core.model.machine.Server;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.server.spi.InstanceProcess;
-import org.slf4j.Logger;
 
 import java.net.Socket;
-
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Verifies that agent was started successfully by checking that specified local port is listened in a machine.
@@ -27,7 +24,6 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author Alexander Garagatyi
  */
 public class MappedPortIsListeningAgentChecker implements AgentLaunchingChecker {
-    private static final Logger LOG = getLogger(MappedPortIsListeningAgentChecker.class);
     private final String exposedPort;
 
     public MappedPortIsListeningAgentChecker(String exposedPort) {
@@ -40,7 +36,6 @@ public class MappedPortIsListeningAgentChecker implements AgentLaunchingChecker 
         Server server = machine.getRuntime().getServers().get(exposedPort);
         if (server != null) {
             try {
-                LOG.error("Ping ssh agent");
                 String[] hostPort = server.getAddress().split(":");
                 try (@SuppressWarnings("unused") Socket socket = new Socket(hostPort[0],
                                                                             Integer.parseInt(hostPort[1]))) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/launcher/SshAgentLauncherImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/launcher/SshAgentLauncherImpl.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.api.workspace.server.launcher;
 
 import org.eclipse.che.api.agent.server.launcher.AbstractAgentLauncher;
+import org.eclipse.che.api.agent.server.launcher.CompositeAgentLaunchingChecker;
+import org.eclipse.che.api.agent.server.launcher.MappedPortIsListeningAgentChecker;
 import org.eclipse.che.api.agent.server.launcher.ProcessIsLaunchedChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +22,10 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
- * Starts terminal agent.
+ * Starts SSH agent.
  *
  * @author Anatolii Bazko
+ * @author Alexander Garagatyi
  */
 @Singleton
 public class SshAgentLauncherImpl extends AbstractAgentLauncher {
@@ -31,7 +34,10 @@ public class SshAgentLauncherImpl extends AbstractAgentLauncher {
     @Inject
     public SshAgentLauncherImpl(@Named("che.agent.dev.max_start_time_ms") long agentMaxStartTimeMs,
                                 @Named("che.agent.dev.ping_delay_ms") long agentPingDelayMs) {
-        super(agentMaxStartTimeMs, agentPingDelayMs, new ProcessIsLaunchedChecker("sshd"));
+        super(agentMaxStartTimeMs,
+              agentPingDelayMs,
+              new CompositeAgentLaunchingChecker(new ProcessIsLaunchedChecker("sshd"),
+                                                 new MappedPortIsListeningAgentChecker("22/tcp")));
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Chenge check of launch of SSH agent.
Add agent launching checker that checks if command exists
in machine.
Add agent launching checker that checks if port is listened
in machine.
Add agent launching checker that forward check to
several specified checkers.

### What issues does this PR fix or reference?
Fixes codenvy/codenvy#1392

### Previous behavior
Sometimes SSH agent was treated as launched but immediate SSH into container failed.

### New behavior
When SSH agent is treated as launched immediate SSH into container works. 
