### PR TITLE
CHE-3167: show import/create hotkeys in empty editor panel

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
@@ -23,6 +23,7 @@ import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Provider;
@@ -98,12 +99,13 @@ public class EmptyEditorsPanel extends Composite implements ResourceChangedEvent
 
         eventBus.addHandler(ResourceChangedEvent.getType(), this);
         logo.appendChild(new SVGImage(productInfoDataProvider.getLogo()).getSvgElement().getElement());
-        Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+        Timer hoverToRenderTimer = new Timer() {
             @Override
-            public void execute() {
+            public void run() {
                 renderNoProjects();
             }
-        });
+        };
+        hoverToRenderTimer.schedule(500);
     }
 
     public EmptyEditorsPanel(ActionManager actionManager,

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
@@ -99,6 +99,8 @@ public class EmptyEditorsPanel extends Composite implements ResourceChangedEvent
 
         eventBus.addHandler(ResourceChangedEvent.getType(), this);
         logo.appendChild(new SVGImage(productInfoDataProvider.getLogo()).getSvgElement().getElement());
+        //Sometimes initialization of Create/Import Project actions are completed after the Empty editor page is rendered.
+        //In this case we need to wait when actions will be initialized.
         Timer hoverToRenderTimer = new Timer() {
             @Override
             public void run() {


### PR DESCRIPTION
### What does this PR do?
Use timer to render import/create hotkeys. It's needed for waiting of initializing all actions. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3167

