### PR TITLE
cli dev mode consistency

### DIFF
--- a/dockerfiles/base/scripts/base/docker.sh
+++ b/dockerfiles/base/scripts/base/docker.sh
@@ -360,13 +360,6 @@ check_mounts() {
       info "                         ${CHE_IMAGE_FULLNAME} $*"
       return 2
     fi
-    if [[ ! -d $(echo ${CHE_CONTAINER_DEVELOPMENT_REPO}/${CHE_ASSEMBLY_IN_REPO}) ]]; then
-      info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
-      info ""
-      info "You volume mounted a valid $CHE_FORMAL_PRODUCT_NAME repo to ':/repo', but we could not find a ${CHE_FORMAL_PRODUCT_NAME} assembly."
-      info "Have you built ${CHE_ASSEMBLY_IN_REPO_MODULE_NAME} with 'mvn clean install'?"
-      return 2
-    fi
   fi
 }
 


### PR DESCRIPTION
after adding mounts for agents in dev mode we had inconsistent checks in CLI if those packages were not built. So I;ve simply moved check is api server is built from `docker.sh` to `cmd_config` and now we do that check exaclty before copy api server from target to `instance/dev` dir.

the sequence was like
1) check if API server is built
2) do pulling images + config
3) check if ws agent and terminal agent are built.
4) start

now sequence is more clear
1) do pull + config
2) check API, ws agent, terminal agent are built 
3) start