### PR TITLE
Loads a new git history page when user scrolled list to the very bottom

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/git/GitServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/git/GitServiceClient.java
@@ -965,8 +965,7 @@ public interface GitServiceClient {
              AsyncRequestCallback<LogResponse> callback);
 
     /**
-     * Get log of commits. The result is the list of {@link Revision}, which is returned by callback in
-     * <code>onSuccess(Revision result)</code>.
+     * Get log of commits.
      *
      * Method is deprecated. Use {@link #log(DevMachine, Path, Path[], int, int, boolean)} to pass
      * {@code skip} and {@code maxCount} parameters to limit the number of returning entries.
@@ -981,11 +980,10 @@ public interface GitServiceClient {
      *         if <code>true</code> the loq response will be in text format
      */
     @Deprecated
-    Promise<LogResponse> log(DevMachine devMachine, Path project, Path[] fileFilter, boolean plainText);
+    Promise<LogResponse> log(DevMachine devMachine, Path project, @Nullable Path[] fileFilter, boolean plainText);
 
     /**
-     * Get log of commits. The result is the list of {@link Revision}, which is returned by callback in
-     * <code>onSuccess(Revision result)</code>.
+     * Get log of commits.
      *
      * @param devMachine
      *         current machine
@@ -1000,7 +998,7 @@ public interface GitServiceClient {
      * @param plainText
      *         if <code>true</code> the loq response will be in text format
      */
-    Promise<LogResponse> log(DevMachine devMachine, Path project, Path[] fileFilter, int skip, int maxCount, boolean plainText);
+    Promise<LogResponse> log(DevMachine devMachine, Path project, @Nullable Path[] fileFilter, int skip, int maxCount, boolean plainText);
 
     /**
      * Merge the pointed commit with current HEAD.

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/git/GitServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/git/GitServiceClient.java
@@ -968,6 +968,9 @@ public interface GitServiceClient {
      * Get log of commits. The result is the list of {@link Revision}, which is returned by callback in
      * <code>onSuccess(Revision result)</code>.
      *
+     * Method is deprecated. Use {@link #log(DevMachine, Path, Path[], int, int, boolean)} to pass
+     * {@code skip} and {@code maxCount} parameters to limit the number of returning entries.
+     *
      * @param devMachine
      *         current machine
      * @param project
@@ -977,7 +980,27 @@ public interface GitServiceClient {
      * @param plainText
      *         if <code>true</code> the loq response will be in text format
      */
+    @Deprecated
     Promise<LogResponse> log(DevMachine devMachine, Path project, Path[] fileFilter, boolean plainText);
+
+    /**
+     * Get log of commits. The result is the list of {@link Revision}, which is returned by callback in
+     * <code>onSuccess(Revision result)</code>.
+     *
+     * @param devMachine
+     *         current machine
+     * @param project
+     *         project (root of GIT repository)
+     * @param fileFilter
+     *         range of files to filter revisions list
+     * @param skip
+     *          the number of commits that will be skipped
+     * @param maxCount
+     *          the number of commits that will be returned
+     * @param plainText
+     *         if <code>true</code> the loq response will be in text format
+     */
+    Promise<LogResponse> log(DevMachine devMachine, Path project, Path[] fileFilter, int skip, int maxCount, boolean plainText);
 
     /**
      * Merge the pointed commit with current HEAD.

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/git/GitServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/git/GitServiceClientImpl.java
@@ -652,19 +652,25 @@ public class GitServiceClientImpl implements GitServiceClient {
 
     @Override
     public Promise<LogResponse> log(DevMachine devMachine, Path project, Path[] fileFilter, boolean plainText) {
+        return log(devMachine, project, fileFilter, -1, -1, plainText);
+    }
+
+    @Override
+    public Promise<LogResponse> log(DevMachine devMachine, Path project, Path[] fileFilter, int skip, int maxCount, boolean plainText) {
         StringBuilder params = new StringBuilder().append("?projectPath=").append(project.toString());
         if (fileFilter != null) {
             for (Path file : fileFilter) {
                 params.append("&fileFilter=").append(file.toString());
             }
         }
+        params.append("&skip=").append(skip);
+        params.append("&maxCount=").append(maxCount);
         String url = appContext.getDevMachine().getWsAgentBaseUrl() + LOG + params;
         if (plainText) {
             return asyncRequestFactory.createGetRequest(url)
                                       .send(dtoUnmarshallerFactory.newUnmarshaller(LogResponse.class));
         } else {
             return asyncRequestFactory.createGetRequest(url)
-                                      .loader(loader)
                                       .header(ACCEPT, APPLICATION_JSON)
                                       .send(dtoUnmarshallerFactory.newUnmarshaller(LogResponse.class));
         }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
@@ -148,8 +148,11 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
             @Override
             public void apply(LogResponse log) throws OperationException {
                 List<Revision> commits = log.getCommits();
-                skip += commits.size();
+                if (commits.isEmpty()) {
+                    return;
+                }
 
+                skip += commits.size();
                 if (append) {
                     revisions.addAll(commits);
                 } else {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.che.api.core.ErrorCodes;
+import org.eclipse.che.api.git.shared.Constants;
 import org.eclipse.che.api.git.shared.LogResponse;
 import org.eclipse.che.api.git.shared.Revision;
 import org.eclipse.che.api.promises.client.Operation;
@@ -26,7 +27,6 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.git.GitServiceClient;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStackType;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.parts.base.BasePresenter;
@@ -85,6 +85,7 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
     private NotificationManager notificationManager;
 
     private Project project;
+    private int     skip;
 
     @Inject
     public HistoryPresenter(HistoryView view,
@@ -115,9 +116,8 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
 
     public void showDialog(Project project) {
         this.project = project;
-        getCommitsLog();
+        initializeHistory();
         selectedRevision = null;
-
         view.selectProjectChangesButton(true);
         view.selectResourceChangesButton(false);
         showChangesInProject = true;
@@ -138,11 +138,24 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
     }
 
     /** Get the log of the commits. If successfully received, then display in revision grid, otherwise - show error in output panel. */
-    private void getCommitsLog() {
-        service.log(appContext.getDevMachine(), project.getLocation(), null, false).then(new Operation<LogResponse>() {
+    private void fetchHistoryPage(final boolean append) {
+        service.log(appContext.getDevMachine(),
+                    project.getLocation(),
+                    null,
+                    skip,
+                    Constants.DEFAULT_PAGE_SIZE,
+                    false).then(new Operation<LogResponse>() {
             @Override
             public void apply(LogResponse log) throws OperationException {
-                revisions = log.getCommits();
+                List<Revision> commits = log.getCommits();
+                skip += commits.size();
+
+                if (append) {
+                    revisions.addAll(commits);
+                } else {
+                    revisions = commits;
+                }
+
                 view.setRevisions(revisions);
             }
         }).catchError(new Operation<PromiseError>() {
@@ -214,7 +227,12 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
     /** {@inheritDoc} */
     @Override
     public void onRefreshClicked() {
-        getCommitsLog();
+        initializeHistory();
+    }
+
+    private void initializeHistory() {
+        skip = 0;
+        fetchHistoryPage(false);
     }
 
     /** {@inheritDoc} */
@@ -226,7 +244,7 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
         showChangesInProject = true;
         view.selectProjectChangesButton(true);
         view.selectResourceChangesButton(false);
-        update();
+        updateDiff();
     }
 
     /** {@inheritDoc} */
@@ -238,7 +256,7 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
         showChangesInProject = false;
         view.selectProjectChangesButton(false);
         view.selectResourceChangesButton(true);
-        update();
+        updateDiff();
     }
 
     /** {@inheritDoc} */
@@ -251,7 +269,7 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
         view.selectDiffWithIndexButton(true);
         view.selectDiffWithPrevVersionButton(false);
         view.selectDiffWithWorkingTreeButton(false);
-        update();
+        updateDiff();
     }
 
     /** {@inheritDoc} */
@@ -264,7 +282,7 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
         view.selectDiffWithIndexButton(false);
         view.selectDiffWithPrevVersionButton(false);
         view.selectDiffWithWorkingTreeButton(true);
-        update();
+        updateDiff();
     }
 
     /** {@inheritDoc} */
@@ -277,24 +295,23 @@ public class HistoryPresenter extends BasePresenter implements HistoryView.Actio
         view.selectDiffWithIndexButton(false);
         view.selectDiffWithPrevVersionButton(true);
         view.selectDiffWithWorkingTreeButton(false);
-        update();
+        updateDiff();
     }
 
     /** {@inheritDoc} */
     @Override
     public void onRevisionSelected(@NotNull Revision revision) {
         selectedRevision = revision;
-        update();
+        updateDiff();
     }
 
-    /** Update content. */
-    private void update() {
-        getDiff();
-        getCommitsLog();
+    @Override
+    public void onScrolledToButton() {
+        fetchHistoryPage(true);
     }
 
     /** Get the changes between revisions. On success - display diff in text format, otherwise - show the error message in output panel. */
-    private void getDiff() {
+    private void updateDiff() {
         Path path = Path.EMPTY;
 
         if (!showChangesInProject) {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryView.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryView.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public interface HistoryView extends View<HistoryView.ActionDelegate> {
     /** Needs for delegate some function into History view. */
-    public interface ActionDelegate extends BaseActionDelegate {
+    interface ActionDelegate extends BaseActionDelegate {
         /** Performs any actions appropriate in response to the user having pressed the Refresh button. */
         void onRefreshClicked();
 
@@ -50,6 +50,11 @@ public interface HistoryView extends View<HistoryView.ActionDelegate> {
          *         selected revision
          */
         void onRevisionSelected(@NotNull Revision revision);
+
+        /**
+         * Occurs when the last entry in the list has been displayed.
+         */
+        void onScrolledToButton();
     }
 
     void setVisible(boolean visible);

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.ext.git.client.history;
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.TextCell;
 import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -23,6 +24,7 @@ import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.UIObject;
@@ -32,6 +34,7 @@ import com.google.gwt.view.client.SingleSelectionModel;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import org.eclipse.che.api.git.shared.Constants;
 import org.eclipse.che.api.git.shared.Revision;
 import org.eclipse.che.ide.Resources;
 import org.eclipse.che.ide.api.parts.PartStackUIResources;
@@ -42,6 +45,7 @@ import org.vectomatic.dom.svg.ui.SVGImage;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -87,6 +91,8 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
     Button              btnDiffWithWorkTree;
     @UiField
     Button              btnDiffWithPrevCommit;
+    @UiField
+    ScrollPanel scrollPanel;
     @UiField(provided = true)
     final GitResources            res;
     @UiField(provided = true)
@@ -94,10 +100,6 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
 
     /**
      * Create view.
-     *
-     * @param resources
-     * @param locale
-     * @param partStackUIResources
      */
     @Inject
     protected HistoryViewImpl(final GitResources resources,
@@ -113,6 +115,7 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
         createCommitsTable(res);
         setContentWidget(uiBinder.createAndBindUi(this));
         minimizeButton.ensureDebugId("git-showHistory-minimizeBut");
+        this.scrollPanel.getElement().setTabIndex(-1);
 
         btnProjectChanges.getElement().appendChild(new SVGImage(resources.projectLevel()).getElement());
         btnResourceChanges.getElement().appendChild(new SVGImage(resources.resourceLevel()).getElement());
@@ -122,10 +125,10 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
         btnRefresh.getElement().appendChild(new SVGImage(resources.refresh()).getElement());
     }
 
-    /** Creates table what contains list of available commits.
-     * @param res*/
+    /** Creates table what contains list of available commits. */
     private void createCommitsTable(Resources res) {
-        commits = new CellTable<Revision>(15, res);
+        commits = new CellTable<Revision>(Constants.DEFAULT_PAGE_SIZE, res);
+        commits.setRowData(Collections.<Revision>emptyList());
 
         Column<Revision, String> dateColumn = new Column<Revision, String>(new TextCell()) {
             @Override
@@ -178,12 +181,10 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
     /** {@inheritDoc} */
     @Override
     public void setRevisions(@NotNull List<Revision> revisions) {
-        // Wraps Array in java.util.List
-        List<Revision> list = new ArrayList<>();
-        for (Revision revision : revisions) {
-            list.add(revision);
-        }
-        this.commits.setRowData(list);
+        commits.setRowData(revisions);
+
+        // if the size of the panel is greater then the size of the loaded list of the history then no scroller has been appeared yet
+        onPanelScrolled(null);
     }
 
     /** {@inheritDoc} */
@@ -304,5 +305,15 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
     @UiHandler("btnDiffWithPrevCommit")
     public void onDiffWithPrevCommitClicked(ClickEvent event) {
         delegate.onDiffWithPrevCommitClicked();
+    }
+
+    @UiHandler("scrollPanel")
+    public void onPanelScrolled(ScrollEvent event) {
+        if (scrollPanel.getVerticalScrollPosition() == scrollPanel.getMaximumVerticalScrollPosition()) {
+            // to avoid autoscrolling to selected item
+            scrollPanel.getElement().focus();
+
+            delegate.onScrolledToButton();
+        }
     }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.java
@@ -92,7 +92,7 @@ public class HistoryViewImpl extends BaseView<HistoryView.ActionDelegate> implem
     @UiField
     Button              btnDiffWithPrevCommit;
     @UiField
-    ScrollPanel scrollPanel;
+    ScrollPanel         scrollPanel;
     @UiField(provided = true)
     final GitResources            res;
     @UiField(provided = true)

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.ui.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.ui.xml
@@ -75,7 +75,7 @@
             <g:SplitLayoutPanel width="100%" height="100%">
                 <g:north size="300">
                     <g:FlowPanel addStyleNames="{style.emptyBorder}">
-                        <g:ScrollPanel width="99%" height="99%">
+                        <g:ScrollPanel width="99%" height="99%" ui:field="scrollPanel">
                             <p1:CellTable width="100%" height="100%" ui:field="commits" focus="false" addStyleNames="{style.emptyBorder}"
                                           debugId="git-showHistory-tableCommits"/>
                         </g:ScrollPanel>

--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Constants.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Constants.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.git.shared;
+
+/**
+ * @author Anatoliy Bazko
+ */
+public class Constants {
+    public static final int    DEFAULT_PAGE_SIZE             = 20;
+    public static final String DEFAULT_PAGE_SIZE_QUERY_PARAM = "20";
+
+    private Constants() { }
+}

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitService.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitService.java
@@ -36,6 +36,7 @@ import org.eclipse.che.api.git.shared.CloneRequest;
 import org.eclipse.che.api.git.shared.CommitRequest;
 import org.eclipse.che.api.git.shared.Commiters;
 import org.eclipse.che.api.git.shared.ConfigRequest;
+import org.eclipse.che.api.git.shared.Constants;
 import org.eclipse.che.api.git.shared.DiffType;
 import org.eclipse.che.api.git.shared.FetchRequest;
 import org.eclipse.che.api.git.shared.MergeRequest;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -275,12 +277,16 @@ public class GitService {
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
     public LogPage log(@QueryParam("fileFilter") List<String> fileFilter,
                        @QueryParam("since") String revisionRangeSince,
-                       @QueryParam("until") String revisionRangeUntil) throws ApiException {
+                       @QueryParam("until") String revisionRangeUntil,
+                       @QueryParam("skip") @DefaultValue("0") int skip,
+                       @QueryParam("maxCount") @DefaultValue(Constants.DEFAULT_PAGE_SIZE_QUERY_PARAM) int maxCount) throws ApiException {
         try (GitConnection gitConnection = getGitConnection()) {
             return gitConnection.log(LogParams.create()
                                               .withFileFilter(fileFilter)
                                               .withRevisionRangeSince(revisionRangeSince)
-                                              .withRevisionRangeUntil(revisionRangeUntil));
+                                              .withRevisionRangeUntil(revisionRangeUntil)
+                                              .withMaxCount(maxCount)
+                                              .withSkip(skip));
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
Pagination at loading git history

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3353

### Previous behavior
All git history was loaded at one request and blocked ide.

### New behavior
Loads git history by page when user scrolled list to the very bottom

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.
