### PR TITLE
Load instance runtime information on machine start

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceTest.java
@@ -85,7 +85,7 @@ public class DockerInstanceTest {
     private DockerInstance dockerInstance;
 
     @BeforeMethod
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, MachineException {
         dockerInstance = getDockerInstance();
         when(dockerConnectorMock.createExec(any(CreateExecParams.class))).thenReturn(execMock);
         when(execMock.getId()).thenReturn(EXEC_ID);
@@ -198,7 +198,7 @@ public class DockerInstanceTest {
         dockerInstance.saveToSnapshot();
     }
 
-    private DockerInstance getDockerInstance() {
+    private DockerInstance getDockerInstance() throws MachineException {
         return getDockerInstance(getMachine(), REGISTRY, CONTAINER, IMAGE, false);
     }
 
@@ -206,11 +206,13 @@ public class DockerInstanceTest {
                                              String registry,
                                              String container,
                                              String image,
-                                             boolean snapshotUseRegistry) {
+                                             boolean snapshotUseRegistry) throws MachineException {
+        DockerMachineFactory machineFactory = mock(DockerMachineFactory.class);
+        when(machineFactory.createMetadata(any(), any(), any())).thenReturn(mock(DockerInstanceRuntimeInfo.class));
         return new DockerInstance(dockerConnectorMock,
                                   registry,
                                   USERNAME,
-                                  mock(DockerMachineFactory.class),
+                                  machineFactory,
                                   machine,
                                   container,
                                   image,

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -46,6 +46,7 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.google.common.base.MoreObjects.firstNonNull;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -68,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -107,15 +109,15 @@ public class WorkspaceRuntimes {
 
     private static final Logger LOG = getLogger(WorkspaceRuntimes.class);
 
-    private final Map<String, WorkspaceState> workspaces;
-    private final EventService                eventsService;
-    private final StripedLocks                locks;
-    private final CheEnvironmentEngine        envEngine;
-    private final AgentSorter                 agentSorter;
-    private final AgentLauncherFactory        launcherFactory;
-    private final AgentRegistry               agentRegistry;
-    private final SnapshotDao                 snapshotDao;
-    private final WorkspaceSharedPool         sharedPool;
+    private final ConcurrentMap<String, WorkspaceState> workspaces;
+    private final EventService                          eventsService;
+    private final StripedLocks                          locks;
+    private final CheEnvironmentEngine                  envEngine;
+    private final AgentSorter                           agentSorter;
+    private final AgentLauncherFactory                  launcherFactory;
+    private final AgentRegistry                         agentRegistry;
+    private final SnapshotDao                           snapshotDao;
+    private final WorkspaceSharedPool                   sharedPool;
 
     private volatile boolean isPreDestroyInvoked;
 
@@ -133,7 +135,7 @@ public class WorkspaceRuntimes {
         this.launcherFactory = launcherFactory;
         this.agentRegistry = agentRegistry;
         this.snapshotDao = snapshotDao;
-        this.workspaces = new HashMap<>();
+        this.workspaces = new ConcurrentHashMap<>();
         // 16 - experimental value for stripes count, it comes from default hash map size
         this.locks = new StripedLocks(16);
         this.sharedPool = sharedPool;


### PR DESCRIPTION
Machine runtime information is lazy-loaded and loading happens when workspace runtime information is requested first time. So basically it is possible to meet the state when workspace machine will be _RUNNING_ but `Instance.getRuntime` won't return anything because it's the first call to get workspace runtime and there is a problem like the following:
```
org.eclipse.che.plugin.docker.client.exception.DockerException:
Error response from docker API, status: 500, message: Get 
http://node6.codenvy.io:2375/containers/<id>/json: dial tcp <ip:port>: i/o timeout
```

The changes introduced in the pull request load machine runtime information on machine start, ones it's loaded machine data is in consistent state with its status, if loading fails machine start will be also considered as failed.
Along with that workspace start problems are logged as warnings, e.g. if docker file is broken.

Fixes [codenvy-1320](https://github.com/codenvy/codenvy/issues/1320).
