### PR TITLE
Exclude IP addresses from aliased interfaces

### DIFF
--- a/dockerfiles/ip/entrypoint.sh
+++ b/dockerfiles/ip/entrypoint.sh
@@ -40,6 +40,7 @@ if test -z ${NETWORK_IF}; then
 fi
 
 ip a show "${NETWORK_IF}" | \
-            grep 'inet ' | \
+            grep "scope global ${NETWORK_IF}" | \
+            grep -v ':' | \
             cut -d/ -f1 | \
             awk '{print $2}'


### PR DESCRIPTION
### What does this PR do?
Adds a different filter to eliminate IP address aliases. In the case where a single network interface returns multiple matching IP addresses, filters out any from a networking interface ":#" at the end, so that the function only returns a single IP address.

### What issues does this PR fix or reference?
#3564 

### Previous behavior
Returns multiple IP addresses - one for each matching interface.

### Tests written?
No

### Docs updated?
N/A