### PR TITLE
Che CLI Refactoring

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -118,24 +118,24 @@ initiate_offline_or_network_mode(){
 
 grab_initial_images() {
   # Prep script by getting default image
-  if [ "$(docker images -q alpine:3.4 2> /dev/null)" = "" ]; then
-    info "cli" "Pulling image alpine:3.4"
-    log "docker pull alpine:3.4 >> \"${LOGS}\" 2>&1"
+  if [ "$(docker images -q ${UTILITY_IMAGE_ALPINE} 2> /dev/null)" = "" ]; then
+    info "cli" "Pulling image ${UTILITY_IMAGE_ALPINE}"
+    log "docker pull ${UTILITY_IMAGE_ALPINE} >> \"${LOGS}\" 2>&1"
     TEST=""
-    docker pull alpine:3.4 >> "${LOGS}" > /dev/null 2>&1 || TEST=$?
+    docker pull ${UTILITY_IMAGE_ALPINE} >> "${LOGS}" > /dev/null 2>&1 || TEST=$?
     if [ "$TEST" = "1" ]; then
-      error "Image alpine:3.4 unavailable. Not on dockerhub or built locally."
+      error "Image ${UTILITY_IMAGE_ALPINE} unavailable. Not on dockerhub or built locally."
       return 2;
     fi
   fi
 
-  if [ "$(docker images -q eclipse/che-ip:nightly 2> /dev/null)" = "" ]; then
-    info "cli" "Pulling image eclipse/che-ip:nightly"
-    log "docker pull eclipse/che-ip:nightly >> \"${LOGS}\" 2>&1"
+  if [ "$(docker images -q ${UTILITY_IMAGE_CHEIP} 2> /dev/null)" = "" ]; then
+    info "cli" "Pulling image ${UTILITY_IMAGE_CHEIP}"
+    log "docker pull ${UTILITY_IMAGE_CHEIP} >> \"${LOGS}\" 2>&1"
     TEST=""
-    docker pull eclipse/che-ip:nightly >> "${LOGS}" > /dev/null 2>&1 || TEST=$?
+    docker pull ${UTILITY_IMAGE_CHEIP} >> "${LOGS}" > /dev/null 2>&1 || TEST=$?
     if [ "$TEST" = "1" ]; then
-      error "Image eclipse/che-ip:nightly unavailable. Not on dockerhub or built locally."
+      error "Image ${UTILITY_IMAGE_CHEIP} unavailable. Not on dockerhub or built locally."
       return 2;
     fi
   fi
@@ -460,7 +460,7 @@ confirm_operation() {
 port_open() {
   debug $FUNCNAME
 
-  docker run -d -p $1:$1 --name fake alpine:3.4 httpd -f -p $1 -h /etc/ > /dev/null 2>&1
+  docker run -d -p $1:$1 --name fake ${UTILITY_IMAGE_ALPINE} httpd -f -p $1 -h /etc/ > /dev/null 2>&1
   NETSTAT_EXIT=$?
   docker rm -f fake > /dev/null 2>&1
 

--- a/dockerfiles/base/scripts/base/commands/cmd_action.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_action.sh
@@ -18,8 +18,8 @@ cmd_action() {
        server_is_booted ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
 
         # Not loaded as part of the init process to save on download time
-        update_image_if_not_found eclipse/che-action:nightly
-        docker_run -it eclipse/che-action:nightly "$@"
+        update_image_if_not_found ${UTILITY_IMAGE_CHEACTION}
+        docker_run -it ${UTILITY_IMAGE_CHEACTION} "$@"
 
        return
     fi

--- a/dockerfiles/base/scripts/base/commands/cmd_backup.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_backup.sh
@@ -44,7 +44,7 @@ cmd_backup() {
   docker_run -v "${CHE_HOST_CONFIG}":/root${CHE_CONTAINER_ROOT} \
                -v "${CHE_HOST_BACKUP}":/root/backup \
                $(cmd_backup_extra_args) \
-                 alpine:3.4 sh -c "tar czf /root/backup/${CHE_BACKUP_FILE_NAME} -C /root${CHE_CONTAINER_ROOT} . --exclude='backup' --exclude='instance/dev' --exclude='instance/logs' ${TAR_EXTRA_EXCLUDE}"
+                 ${UTILITY_IMAGE_ALPINE} sh -c "tar czf /root/backup/${CHE_BACKUP_FILE_NAME} -C /root${CHE_CONTAINER_ROOT} . --exclude='backup' --exclude='instance/dev' --exclude='instance/logs' ${TAR_EXTRA_EXCLUDE}"
   info ""
   info "backup" "Codenvy data saved in ${CHE_HOST_BACKUP}/${CHE_BACKUP_FILE_NAME}"
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -52,11 +52,11 @@ cmd_config() {
     # in development mode to avoid permissions issues we copy tomcat assembly to ${CHE_INSTANCE}
     # if ${CHE_FORMAL_PRODUCT_NAME} development tomcat exist we remove it
     if [[ -d "${CHE_CONTAINER_INSTANCE}/dev" ]]; then
-        log "docker_run -v \"${CHE_HOST_INSTANCE}/dev\":/root/dev alpine:3.4 sh -c \"rm -rf /root/dev/*\""
+        log "docker_run -v \"${CHE_HOST_INSTANCE}/dev\":/root/dev ${UTILITY_IMAGE_ALPINE} sh -c \"rm -rf /root/dev/*\""
 
         # Super weird bug - sometimes, the RM command doesn't wipe everything, so we have to repeat it a couple times
         until config_directory_is_empty; do
-          docker_run -v "${CHE_HOST_INSTANCE}/dev":/root/dev alpine:3.4 sh -c "rm -rf /root/dev/${CHE_MINI_PRODUCT_NAME}-tomcat" > /dev/null 2>&1  || true
+          docker_run -v "${CHE_HOST_INSTANCE}/dev":/root/dev ${UTILITY_IMAGE_ALPINE} sh -c "rm -rf /root/dev/${CHE_MINI_PRODUCT_NAME}-tomcat" > /dev/null 2>&1  || true
         done
 
         log "rm -rf \"${CHE_HOST_INSTANCE}/dev\" >> \"${LOGS}\""

--- a/dockerfiles/base/scripts/base/commands/cmd_destroy.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_destroy.sh
@@ -28,7 +28,7 @@ cmd_destroy() {
       --cli)
         DESTROY_CLI="true"
         shift ;;
-      *) error "Unknown parameter: $1" ; return 2 ;;
+      *) error "Unknown parameter: $1; did you mean --quiet or --cli?" ; return 2 ;;
     esac
   done
 
@@ -42,14 +42,14 @@ cmd_destroy() {
   info "destroy" "Deleting instance and config..."
 
   log "docker_run -v \"${CHE_HOST_CONFIG}\":${CHE_CONTAINER_ROOT} \
-                    alpine:3.4 sh -c \"rm -rf /root${CHE_CONTAINER_ROOT}/docs \
+                    ${UTILITY_IMAGE_ALPINE} sh -c \"rm -rf /root${CHE_CONTAINER_ROOT}/docs \
                                    && rm -rf /root${CHE_CONTAINER_ROOT}/instance \
                                    && rm -rf /root${CHE_CONTAINER_ROOT}/${CHE_MINI_PRODUCT_NAME}.env\""
   # Super weird bug.  For some reason on windows, this command has to be run 3x for everything
   # to be destroyed properly if you are in dev mode.
   until directory_is_empty; do
     docker_run -v "${CHE_HOST_CONFIG}":/root${CHE_CONTAINER_ROOT} \
-                  alpine:3.4 sh -c "rm -rf /root${CHE_CONTAINER_ROOT}/docs \
+                  ${UTILITY_IMAGE_ALPINE} sh -c "rm -rf /root${CHE_CONTAINER_ROOT}/docs \
                                  ; rm -rf /root${CHE_CONTAINER_ROOT}/instance \
                                  ; rm -rf /root${CHE_CONTAINER_ROOT}/${CHE_MINI_PRODUCT_NAME}.env" > /dev/null 2>&1  || true
   done
@@ -61,7 +61,7 @@ cmd_destroy() {
   # If they pass destroy --cli then we will also destroy the CLI
   if [[ "${DESTROY_CLI}" = "true" ]]; then
     info "destroy" "Deleting cli.log..."
-    docker_run -v "${CLI_DIR}":/root/cli alpine:3.4 sh -c "rm -rf /root/cli/cli.log"
+    docker_run -v "${CLI_DIR}":/root/cli ${UTILITY_IMAGE_ALPINE} sh -c "rm -rf /root/cli/cli.log"
   fi
 }
 

--- a/dockerfiles/base/scripts/base/commands/cmd_dir.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_dir.sh
@@ -20,5 +20,5 @@ cmd_dir() {
  
   # Not loaded as part of the init process to save on download time
   update_image_if_not_found ${UTILITY_IMAGE_CHEDIR}
-  docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} ${UTILITY_IMAGE_CHEDIR} "$@"
+  docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} ${UTILITY_IMAGE_CHEDIR} ${HOST_FOLDER_TO_USE} "$@"
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_dir.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_dir.sh
@@ -7,15 +7,18 @@
 #
 
 cmd_dir() {
+  debug $FUNCNAME
 
-  if [[ $# -eq 0 ]] ; then
-    error "dir command is requiring a local folder to be given as argument"
-    return 2;
+  CHE_LOCAL_REPO=false
+  if [[ "${CHEDIR_MOUNT}" != "not set" ]]; then
+  	local HOST_FOLDER_TO_USE="${CHEDIR_MOUNT}"
+  else
+  	local HOST_FOLDER_TO_USE="${DATA_MOUNT}"
+
+    warning "':/chedir' not mounted - using ${DATA_MOUNT} as source location"
   fi
-
-  local HOST_FOLDER_TO_USE=${1}
-
+ 
   # Not loaded as part of the init process to save on download time
-  update_image_if_not_found eclipse/che-dir:nightly
-  docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} eclipse/che-dir:nightly "$@"
+  update_image_if_not_found ${UTILITY_IMAGE_CHEDIR}
+  docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} ${UTILITY_IMAGE_CHEDIR} "$@"
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_network.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_network.sh
@@ -21,8 +21,8 @@ cmd_network() {
   info "--------   CONNECTIVITY TEST   --------"
   info "---------------------------------------"
   # Start a fake workspace agent
-  log "docker run -d -p 12345:80 --name fakeagent alpine:3.4 httpd -f -p 80 -h /etc/ >> \"${LOGS}\""
-  docker run -d -p 12345:80 --name fakeagent alpine:3.4 httpd -f -p 80 -h /etc/ >> "${LOGS}"
+  log "docker run -d -p 12345:80 --name fakeagent ${UTILITY_IMAGE_ALPINE} httpd -f -p 80 -h /etc/ >> \"${LOGS}\""
+  docker run -d -p 12345:80 --name fakeagent ${UTILITY_IMAGE_ALPINE} httpd -f -p 80 -h /etc/ >> "${LOGS}"
 
   AGENT_INTERNAL_IP=$(docker inspect --format='{{.NetworkSettings.IPAddress}}' fakeagent)
   AGENT_INTERNAL_PORT=80

--- a/dockerfiles/base/scripts/base/commands/cmd_offline.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_offline.sh
@@ -23,7 +23,7 @@ cmd_offline() {
   readarray -t STACK_IMAGE_LIST < /version/$CHE_VERSION/images-stacks
 
   # List all images to be saved
-  if [ $1 = "--list" ]; then
+  if [[ $# -gt 0 ]] && [[ $1 = "--list" ]]; then
     # First display mandatory 
     info "offline" "Listing images to save for offline usage"
     info ""
@@ -53,6 +53,14 @@ cmd_offline() {
 
   info "offline" "Saving ${CHE_MINI_PRODUCT_NAME} cli image..."
   save_image ${CHE_IMAGE_FULLNAME}
+
+  info "offline" "Saving utility images..."
+  download_and_save_image "${UTILITY_IMAGE_CHEIP}"
+  download_and_save_image "${UTILITY_IMAGE_ALPINE}"
+  download_and_save_image "${UTILITY_IMAGE_CHEACTION}"
+  download_and_save_image "${UTILITY_IMAGE_CHEDIR}"
+  download_and_save_image "${UTILITY_IMAGE_CHETEST}"
+  download_and_save_image "${UTILITY_IMAGE_CHEMOUNT}"
 
   info "offline" "Saving ${CHE_MINI_PRODUCT_NAME} system images..."
   IFS=$'\n'

--- a/dockerfiles/base/scripts/base/commands/cmd_restore.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_restore.sh
@@ -39,13 +39,13 @@ cmd_restore() {
 
   # remove config and instance folders
   log "docker_run -v \"${CHE_HOST_CONFIG}\":${CHE_CONTAINER_ROOT} \
-                    alpine:3.4 sh -c \"rm -rf /root${CHE_CONTAINER_ROOT}/docs \
-                                   && rm -rf /root${CHE_CONTAINER_ROOT}/instance \
-                                   && rm -rf /root${CHE_CONTAINER_ROOT}/${CHE_MINI_PRODUCT_NAME}.env\""
+                    ${UTILITY_IMAGE_ALPINE} sh -c \"rm -rf /root${CHE_CONTAINER_ROOT}/docs \
+                                   ; rm -rf /root${CHE_CONTAINER_ROOT}/instance \
+                                   ; rm -rf /root${CHE_CONTAINER_ROOT}/${CHE_MINI_PRODUCT_NAME}.env\""
   docker_run -v "${CHE_HOST_CONFIG}":/root${CHE_CONTAINER_ROOT} \
-                alpine:3.4 sh -c "rm -rf /root${CHE_CONTAINER_ROOT}/docs \
-                              && rm -rf /root${CHE_CONTAINER_ROOT}/instance \
-                              &&  rm -rf /root${CHE_CONTAINER_ROOT}/${CHE_MINI_PRODUCT_NAME}.env"
+                ${UTILITY_IMAGE_ALPINE} sh -c "rm -rf /root${CHE_CONTAINER_ROOT}/docs \
+                              ; rm -rf /root${CHE_CONTAINER_ROOT}/instance \
+                              ; rm -rf /root${CHE_CONTAINER_ROOT}/${CHE_MINI_PRODUCT_NAME}.env"
 
   info "restore" "Recovering ${CHE_FORMAL_PRODUCT_NAME} data..."
 
@@ -54,5 +54,5 @@ cmd_restore() {
   docker_run -v "${CHE_HOST_CONFIG}":/root${CHE_CONTAINER_ROOT} \
              -v "${CHE_HOST_BACKUP}/${CHE_BACKUP_FILE_NAME}":"/root/backup/${CHE_BACKUP_FILE_NAME}" \
              $(cmd_restore_extra_args) \
-             alpine:3.4 sh -c "tar xf /root/backup/${CHE_BACKUP_FILE_NAME} -C /root${CHE_CONTAINER_ROOT}"
+             ${UTILITY_IMAGE_ALPINE} sh -c "tar xf /root/backup/${CHE_BACKUP_FILE_NAME} -C /root${CHE_CONTAINER_ROOT}"
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -59,7 +59,7 @@ cmd_start_check_ports() {
 
   # If dev mode is on, then we also need to check the debug port set by the user for availability
   if debug_server; then
-    USER_DEBUG_PORT=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" alpine sh -c 'echo $CHE_DEBUG_PORT')
+    USER_DEBUG_PORT=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" ${UTILITY_IMAGE_ALPINE} sh -c 'echo $CHE_DEBUG_PORT')
 
     if [[ "$USER_DEBUG_PORT" = "" ]]; then
       # If the user has not set a debug port, then use the default

--- a/dockerfiles/base/scripts/base/commands/cmd_sync.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_sync.sh
@@ -22,6 +22,8 @@ cmd_sync() {
     return 2;
   fi
 
+  update_image_if_not_found ${UTILITY_IMAGE_CHEMOUNT}
+
   # Determine the mount path to do the mount
   info "mount" "Starting sync process to ${SYNC_MOUNT}"
 
@@ -30,7 +32,7 @@ cmd_sync() {
              -e CHE_VERSION=${CHE_VERSION} \
              --name che-mount \
              -v "${SYNC_MOUNT}":/mnthost \
-                  eclipse/che-mount:nightly $*
+                  ${UTILITY_IMAGE_CHEMOUNT} $*
 
   # Docker doesn't seem to normally clean up this container
   docker rm -f che-mount

--- a/dockerfiles/base/scripts/base/docker.sh
+++ b/dockerfiles/base/scripts/base/docker.sh
@@ -287,6 +287,7 @@ check_mounts() {
   REPO_MOUNT=$(get_container_folder ":/repo")
   SYNC_MOUNT=$(get_container_folder ":/sync")
   UNISON_PROFILE_MOUNT=$(get_container_folder ":/unison")
+  CHEDIR_MOUNT=$(get_container_folder ":/chedir")
 
   if [[ "${DATA_MOUNT}" = "not set" ]]; then
     info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"

--- a/dockerfiles/base/scripts/base/startup.sh
+++ b/dockerfiles/base/scripts/base/startup.sh
@@ -82,6 +82,14 @@ init_constants() {
 
   DEFAULT_CHE_LICENSE=false
   CHE_LICENSE=${CHE_LICENSE:-${DEFAULT_CHE_LICENSE}}
+
+  # Replace all of these with digests
+  UTILITY_IMAGE_ALPINE="alpine:3.4"
+  UTILITY_IMAGE_CHEIP="eclipse/che-ip:nightly"
+  UTILITY_IMAGE_CHEACTION="eclipse/che-action:nightly"
+  UTILITY_IMAGE_CHEDIR="eclipse/che-dir:nightly"
+  UTILITY_IMAGE_CHETEST="eclipse/che-test:nightly"
+  UTILITY_IMAGE_CHEMOUNT="eclipse/che-mount:nightly"
 }
 
 

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -7,7 +7,7 @@
 #
 
 cli_pre_init() {
-  GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host eclipse/che-ip:nightly)}
+  GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host ${UTILITY_IMAGE_CHEIP})}
   DEFAULT_CHE_HOST=$GLOBAL_HOST_IP
   CHE_HOST=${CHE_HOST:-${DEFAULT_CHE_HOST}}
   DEFAULT_CHE_PORT=8080

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -41,7 +41,7 @@ COMMANDS:
   ssh <wksp-name> [machine-name]       SSH to a workspace if SSH agent enabled
   start                                Starts ${CHE_MINI_PRODUCT_NAME} services
   stop                                 Stops ${CHE_MINI_PRODUCT_NAME} services
-  sync <wksp-name>                     Synchronize workspace with current working directory
+  sync <wksp-name>                     Synchronize workspace with local directory mounted to :/sync
   test <test-name>                     Start test on ${CHE_MINI_PRODUCT_NAME} instance
   upgrade                              Upgrades ${CHE_MINI_PRODUCT_NAME} from one version to another with migrations and backups
   version                              Installed version and upgrade paths

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -22,13 +22,14 @@ OPTIONAL DOCKER PARAMETERS:
   -v <LOCAL_PATH>:/repo                ${CHE_MINI_PRODUCT_NAME} git repo - uses local binaries
   -v <LOCAL_PATH>:/sync                Where remote ws files will be copied with sync command
   -v <LOCAL_PATH>:/unison              Where unison profile for optimizing sync command resides
+  -v <LOCAL_PATH>:/chedir              Soure repository to convert into workspace with Chedir utility
     
 COMMANDS:
   action <action-name>                 Start action on ${CHE_MINI_PRODUCT_NAME} instance
   backup                               Backups ${CHE_MINI_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
   config                               Generates a ${CHE_MINI_PRODUCT_NAME} config from vars; run on any start / restart
   destroy                              Stops services, and deletes ${CHE_MINI_PRODUCT_NAME} instance data
-  dir <path> <command>                 Use Chefile feature in the directory <path>
+  dir <command>                        Use Chedir and Chefile in the directory mounted to :/chedir
   download                             Pulls Docker images for the current ${CHE_MINI_PRODUCT_NAME} version
   help                                 This message
   info                                 Displays info about ${CHE_MINI_PRODUCT_NAME} and the CLI


### PR DESCRIPTION
### What does this PR do?
1. Changes Chedir behavior to use the path set by mounting `:/chedir` instead of passing it as a parameter. If `:/chedir` is not volume mounted then uses the value mounted to `:/data` and prints warning.
2. Adds in all UTILITY images into cmd_offline, so that they are available in any offline mode.
3. Places all UTILITY image names as hard coded constants in `startup.sh`, and then uses these constants in all CLI files.

### What issues does this PR fix or reference?
#3645 

### Previous behavior
Previously had syntax of `docker run DOCKER_OPTIONS eclipse/che dir <local-path> up`.  This moves the <local-path> to be derived from a volume mount with DOCKER_OPTIONS instead.

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
