### PR TITLE
Add ability to reload page after lose connection with ws agent

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentStateController.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentStateController.java
@@ -33,6 +33,7 @@ import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.RestServiceInfo;
 import org.eclipse.che.ide.rest.StringUnmarshaller;
 import org.eclipse.che.ide.ui.loaders.LoaderPresenter;
+import org.eclipse.che.ide.util.browser.BrowserUtils;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.ide.websocket.MessageBus;
 import org.eclipse.che.ide.websocket.MessageBusProvider;
@@ -203,24 +204,45 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
     private void checkStateOfWsAgent(WsAgentHealthStateDto agentHealthStateDto) {
         final int statusCode = agentHealthStateDto.getCode();
         final String infoWindowTitle = "Workspace Agent Not Responding";
-        final ConfirmCallback stopCallback = new StopCallback();
+        final ConfirmCallback stopCallback = new StopCallback(false);
+        final ConfirmCallback stopAndReloadCallback = new StopCallback(true);
 
         if (statusCode == 200) {
-            dialogFactory.createMessageDialog(infoWindowTitle,
-                                              "Workspace agent is no longer responding. To fix the problem, verify you have a" +
-                                              " good network connection and restart the workspace.",
-                                              stopCallback).show();
+            dialogFactory.createChoiceDialog(infoWindowTitle,
+                                             "Workspace agent is no longer responding. To fix the problem, verify you have a" +
+                                             " good network connection and restart the workspace.",
+                                             "Restart",
+                                             "Close",
+                                             stopAndReloadCallback,
+                                             stopCallback).show();
         } else {
-            dialogFactory.createMessageDialog(infoWindowTitle,
-                                              "Workspace agent is no longer responding. To fix the problem, restart the workspace.",
-                                              stopCallback).show();
+            dialogFactory.createChoiceDialog(infoWindowTitle,
+                                             "Workspace agent is no longer responding. To fix the problem, restart the workspace.",
+                                             "Restart",
+                                             "Close",
+                                             stopAndReloadCallback,
+                                             stopCallback).show();
         }
     }
 
     private class StopCallback implements ConfirmCallback {
+
+        private final boolean reload;
+
+        public StopCallback(boolean reload) {
+            this.reload = reload;
+        }
+
         @Override
         public void accepted() {
-            workspaceServiceClient.stop(devMachine.getWorkspaceId());
+            workspaceServiceClient.stop(devMachine.getWorkspaceId()).then(new Operation<Void>() {
+                @Override
+                public void apply(Void arg) throws OperationException {
+                    if (reload) {
+                        BrowserUtils.reloadPage(false);
+                    }
+                }
+            });
         }
     }
 

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/browser/BrowserUtils.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/browser/BrowserUtils.java
@@ -18,6 +18,7 @@ package org.eclipse.che.ide.util.browser;
 import org.eclipse.che.ide.util.StringUtils;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.Window.Location;
 
 /** Utility methods relating to the browser. */
 public abstract class BrowserUtils {
@@ -67,12 +68,27 @@ public abstract class BrowserUtils {
     }
 
     public static boolean hasUrlParameter(String parameter) {
-        return Window.Location.getParameter(parameter) != null;
+        return Location.getParameter(parameter) != null;
     }
 
     public static boolean hasUrlParameter(String parameter, String value) {
-        return StringUtils.equalNonEmptyStrings(Window.Location.getParameter(parameter), value);
+        return StringUtils.equalNonEmptyStrings(Location.getParameter(parameter), value);
     }
+
+    /**
+     * Wrapper for calling {@link Location#reload()} with ability to force reloading page.
+     * <p>
+     * By default, the reload() method reloads the page from the cache, but you can force
+     * it to reload the page from the server by setting the forceGet parameter to true: location.reload(true).
+     * <p>
+     * See more details about argument {@code forceGet} here: http://www.w3schools.com/jsref/met_loc_reload.asp
+     *
+     * @param forceGet
+     *         reloads the current page from the server
+     */
+    public static native void reloadPage(boolean forceGet) /*-{
+        $wnd.location.reload(forceGet);
+    }-*/;
 
     private BrowserUtils() {
     }


### PR DESCRIPTION
A new flow was added to handle bad connection with workspace agent. If IDE loses connection with workspace agent, then in warning dialog there is an additional option to stop whole workspace and reload entire page. This option need for normal IDE bootstrap process.

Recreated branch from the https://github.com/eclipse/che/pull/3431