### PR TITLE
Add utility methods to cast resource to its particular type

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Resource.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Resource.java
@@ -96,6 +96,28 @@ public interface Resource extends Comparable<Resource> {
     boolean isFile();
 
     /**
+     * Casts current resource to the {@link File} if the last one's represents a file.
+     * <p>
+     * Example of usage:
+     * <pre>
+     *    public void doSome() {
+     *        Resource resource = ...;
+     *        if (resource.isFile()) {
+     *            File file = resource.asFile();
+     *        }
+     *    }
+     * </pre>
+     *
+     * @return instance of {@link File}
+     * @throws IllegalStateException
+     *         in case if current resource is not a file
+     * @see Resource#getResourceType()
+     * @see Resource#FILE
+     * @since 5.1.0
+     */
+    File asFile();
+
+    /**
      * Returns {@code true} if current represents a folder.
      *
      * @return true if current resource is folder based resource.
@@ -106,6 +128,28 @@ public interface Resource extends Comparable<Resource> {
     boolean isFolder();
 
     /**
+     * Casts current resource to the {@link Folder} if the last one's represents a folder.
+     * <p>
+     * Example of usage:
+     * <pre>
+     *    public void doSome() {
+     *        Resource resource = ...;
+     *        if (resource.isFolder()) {
+     *            Folder folder = resource.asFolder();
+     *        }
+     *    }
+     * </pre>
+     *
+     * @return instance of {@link Folder}
+     * @throws IllegalStateException
+     *         in case if current resource is not a folder
+     * @see Resource#getResourceType()
+     * @see Resource#FOLDER
+     * @since 5.1.0
+     */
+    Folder asFolder();
+
+    /**
      * Returns {@code true} if current represents a project.
      *
      * @return true if current resource is project based resource.
@@ -114,6 +158,28 @@ public interface Resource extends Comparable<Resource> {
      * @since 4.4.0
      */
     boolean isProject();
+
+    /**
+     * Casts current resource to the {@link Project} if the last one's represents a project.
+     * <p>
+     * Example of usage:
+     * <pre>
+     *    public void doSome() {
+     *        Resource resource = ...;
+     *        if (resource.isProject()) {
+     *            Project project = resource.asProject();
+     *        }
+     *    }
+     * </pre>
+     *
+     * @return instance of {@link Project}
+     * @throws IllegalStateException
+     *         in case if current resource is not a project
+     * @see Resource#getResourceType()
+     * @see Resource#PROJECT
+     * @since 5.1.0
+     */
+    Project asProject();
 
     /**
      * Copies resource to given {@code destination} path. Copy operation performs asynchronously and result of current

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceImpl.java
@@ -17,6 +17,8 @@ import com.google.common.base.Optional;
 
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.resources.Container;
+import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.api.resources.Folder;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.marker.Marker;
@@ -27,6 +29,7 @@ import static com.google.common.base.Optional.absent;
 import static com.google.common.base.Optional.of;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.copyOf;
@@ -60,16 +63,37 @@ abstract class ResourceImpl implements Resource {
         return getResourceType() == FILE;
     }
 
+    @Override
+    public File asFile() {
+        checkState(isFile(), "Current resource is not a file");
+
+        return (File)this;
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean isFolder() {
         return getResourceType() == FOLDER;
     }
 
+    @Override
+    public Folder asFolder() {
+        checkState(isFolder(), "Current resource is not a folder");
+
+        return (Folder)this;
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean isProject() {
         return getResourceType() == PROJECT;
+    }
+
+    @Override
+    public Project asProject() {
+        checkState(isProject(), "Current resource is not a project");
+
+        return (Project)this;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This enhancement adds three utility methods to cast `org.eclipse.che.ide.api.resources.Resource` to its particular type. For more details see the POC provided in the issue: #3239 