### PR TITLE
Use getConfig() instead of null while creating machine metadata

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -382,7 +382,7 @@ public class DockerInstance extends AbstractInstance {
     private MachineRuntimeInfoImpl doGetRuntime() throws MachineException {
         try {
             return new MachineRuntimeInfoImpl(dockerMachineFactory.createMetadata(docker.inspectContainer(container),
-                                                                                  null,
+                                                                                  getConfig(),
                                                                                   node.getHost()));
         } catch (IOException x) {
             throw new MachineException(x.getMessage(), x);


### PR DESCRIPTION
This is a fix for the issue introduced by #3561 conflict miss resolve