### PR TITLE
Reorganize resource api related to obtain bound project

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Resource.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Resource.java
@@ -399,8 +399,20 @@ public interface Resource extends Comparable<Resource> {
      * @return the {@link Optional} with related project
      * @see Project
      * @since 4.4.0
+     * @deprecated use {@link #getProject()}
      */
+    @Deprecated
     Optional<Project> getRelatedProject();
+
+    /**
+     * Returns the {@link Project} which is bound to this resource or {@code null}.
+     *
+     * Returns itself for projects.
+     *
+     * @return the bound instance of {@link Project} or null
+     * @since 5.1.0
+     */
+    Project getProject();
 
     /**
      * Returns the type of this resource.

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceImpl.java
@@ -142,6 +142,13 @@ abstract class ResourceImpl implements Resource {
         return of((Project)parent);
     }
 
+    @Override
+    public Project getProject() {
+        final Optional<Project> project = getRelatedProject();
+
+        return project.isPresent() ? project.get() : null;
+    }
+
     /** {@inheritDoc} */
     @Override
     public abstract int getResourceType();


### PR DESCRIPTION
This PR deprecates exist method `org.eclipse.che.ide.api.resources.Resource#getRelatedProject` and creates the new method with name `org.eclipse.che.ide.api.resources.Resource#getProject`

Related issue: #3243 