### PR TITLE
CLI improvements for handling of nightly images

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -382,8 +382,7 @@ timestamp_date_iso8601() {
 }
 
 # Compare two dates with ISO 8601 format and return
-# true if the first date is less than the second date (with a 1hour period)
-# else false
+# true if the first date is 24 hours less than the second date
 newer_date_period() {
   if [[ $(expr ${1} + 86400) -lt ${2} ]]; then
     return 0

--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -357,7 +357,7 @@ function verify_nightly_accuracy() {
     NIGHTLY_IMAGE=${NIGHTLY_IMAGE#sha256:}
 
     NIGHTLY_IMAGE_DATE_WRITTEN=$(docker run -it -v /var/lib/docker:/var/lib/docker \
-                  alpine date -r /var/lib/docker/image/aufs/imagedb/content/sha256/$NIGHTLY_IMAGE)
+                  $UTILITY_IMAGE_ALPINE date -r /var/lib/docker/image/aufs/imagedb/content/sha256/$NIGHTLY_IMAGE)
     CURRENT_DATE=$(date)
 
     if newer_date_period \

--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -23,6 +23,8 @@ cmd_config() {
   elif [[ "${FORCE_UPDATE}" == "--pull" ]] || \
        [[ "${FORCE_UPDATE}" == "--force" ]]; then
     cmd_download $FORCE_UPDATE
+  elif is_nightly && ! is_fast; then
+    cmd_download --pull
   fi
 
   if [ -z ${IMAGE_PUPPET+x} ]; then

--- a/dockerfiles/base/scripts/base/commands/cmd_init.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_init.sh
@@ -12,7 +12,12 @@
 cmd_init() {
 
   # set an initial value for the flag
-  FORCE_UPDATE="--no-force"
+  if is_nightly && ! is_fast; then 
+    FORCE_UPDATE="--pull"
+  else
+    FORCE_UPDATE="--no-force"
+  fi
+
   AUTO_ACCEPT_LICENSE="false"
   REINIT="false"
 

--- a/dockerfiles/base/scripts/base/startup.sh
+++ b/dockerfiles/base/scripts/base/startup.sh
@@ -230,6 +230,14 @@ debug_server() {
   fi
 }
 
+is_fast() {
+  if [ "${FAST_BOOT}" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 init_logging() {
   # Initialize CLI folder
   CLI_DIR=$CHE_CONTAINER_ROOT
@@ -357,6 +365,9 @@ cli_init() {
       warning "Boot2docker for Windows - CHE_CONFIG set to $CHE_HOST_CONFIG"
     fi
   fi
+
+  # Special function to perform special behaviors if you are running nightly version
+  verify_nightly_accuracy
 
   # Do not perform a version compatibility check if running upgrade command.
   # The upgrade command has its own internal checks for version compatibility.


### PR DESCRIPTION
### What does this PR do?
1. Improves the error message that is printed when running nighlty image against install that is not nightly
2. Changes behavior to always use --pull whenever init() or config() a nightly image.
3. If --fast, skips the default pull behavior.
4. Changes the nightly CLI check. It now checks the date at which the image this container was created from was written to disk. If it was written to disk > 24 hours ago, it repulls the latest image and then stops with a message to rerun the CLI.

### What issues does this PR fix or reference?
#3664 
#3640 

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
