### PR TITLE
CODENVY-1403: Disable rsync agents on UI

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
@@ -18,6 +18,13 @@ import {CheAPI} from '../../../../../components/api/che-api.factory';
  * @description This class is handling the controller for list of agents
  * @author Ilya Buziuk
  */
+
+/** List of the agents which shouldn't be switched by user */
+const DISABLED_AGENTS: Array<string> = ['org.eclipse.che.ws-agent',
+                                        'com.codenvy.rsync_in_machine',
+                                        'com.codenvy.external_rsync'
+                                       ];
+
 export class ListAgentsController {
   cheAgent: CheAgent;
 
@@ -68,8 +75,7 @@ export class ListAgentsController {
    * @param agentId {string}
    */
   needToDisable(agentId: string): boolean {
-    return (agentId === 'org.eclipse.che.ws-agent' ||
-            agentId === 'com.codenvy.rsync_in_machine' || agentId === 'com.codenvy.external_rsync');
+    return DISABLED_AGENTS.includes(agentId);
   }
 
   isEnabled(agentId: string, agents: string[]): boolean {

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
@@ -74,7 +74,7 @@ export class ListAgentsController {
    * @param agentId {string}
    */
   needToDisable(agentId: string): boolean {
-    return DISABLED_AGENTS.includes(agentId);
+    return DISABLED_AGENTS.indexOf(agentId) !== -1;
   }
 
   isEnabled(agentId: string, agents: string[]): boolean {

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
@@ -22,8 +22,7 @@ import {CheAPI} from '../../../../../components/api/che-api.factory';
 /** List of the agents which shouldn't be switched by user */
 const DISABLED_AGENTS: Array<string> = ['org.eclipse.che.ws-agent',
                                         'com.codenvy.rsync_in_machine',
-                                        'com.codenvy.external_rsync'
-                                       ];
+                                        'com.codenvy.external_rsync'];
 
 export class ListAgentsController {
   cheAgent: CheAgent;

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
@@ -62,12 +62,14 @@ export class ListAgentsController {
   }
 
   /**
+   * Disables agents which shouldn't be switched by user.
    * Switching of the "ws-agent" must happen only via "Dev" slider.
    * "ws-agent" should be listed, but always disabled regardless of the state
    * @param agentId {string}
    */
   needToDisable(agentId: string): boolean {
-    return (agentId === 'org.eclipse.che.ws-agent');
+    return (agentId === 'org.eclipse.che.ws-agent' ||
+            agentId === 'com.codenvy.rsync_in_machine' || agentId === 'com.codenvy.external_rsync');
   }
 
   isEnabled(agentId: string, agents: string[]): boolean {


### PR DESCRIPTION
### What does this PR do?
Disables rsync agents on dashboard UI.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1403

### Previous behavior
A user could switch on rsync agents what might cause concurrent restore and workspace start crash as consequence

### New behavior
Rsync agents switches is disabled