### PR TITLE
fix che-ip

### DIFF
--- a/dockerfiles/ip/entrypoint.sh
+++ b/dockerfiles/ip/entrypoint.sh
@@ -40,7 +40,7 @@ if test -z ${NETWORK_IF}; then
 fi
 
 ip a show "${NETWORK_IF}" | \
-            grep "scope global ${NETWORK_IF}" | \
+            grep -e "scope.*${NETWORK_IF}" | \
             grep -v ':' | \
             cut -d/ -f1 | \
             awk '{print $2}'


### PR DESCRIPTION
need to fix https://github.com/eclipse/che/issues/3684

on some OS che-ip does not work because output is different.
here I've added reg-ex `.*` which assume that scope can be differ from `global` and some extra words could appear like `dynamic`.
