### PR TITLE
SAAS-101 : Allow cli inheritance without dockerfiles manifests

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -102,9 +102,19 @@ generate_configuration_with_puppet() {
 
   if local_repo; then
     CHE_REPO="on"
-    WRITE_PARAMETERS="-v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/manifests\":/etc/puppet/manifests:ro \
-                      -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/modules\":/etc/puppet/modules:ro \
-                      -e \"CHE_ASSEMBLY=${CHE_ASSEMBLY}\""
+    WRITE_PARAMETERS=" -e \"CHE_ASSEMBLY=${CHE_ASSEMBLY}\""
+    # add local mounts only if they are present
+    if [ -d "/repo/dockerfiles/init/manifests" ]; then
+      WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/manifests\":/etc/puppet/manifests:ro"
+    fi
+    if [ -d "/repo/dockerfiles/init/modules" ]; then
+      WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/modules\":/etc/puppet/modules:ro"
+    fi
+    # Handle override/addon
+    if [ -d "/repo/dockerfiles/init/addon" ]; then
+      WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/addon/addon.pp\":/etc/puppet/manifests/addon.pp:ro"
+    fi
+
   else
     CHE_REPO="off"
     WRITE_PARAMETERS=""
@@ -125,7 +135,7 @@ generate_configuration_with_puppet() {
                       $IMAGE_INIT \
                           apply --modulepath \
                                 /etc/puppet/modules/ \
-                                /etc/puppet/manifests/${CHE_MINI_PRODUCT_NAME}.pp --show_diff ${WRITE_LOGS}"
+                                /etc/puppet/manifests/ --show_diff ${WRITE_LOGS}"
 
   log ${GENERATE_CONFIG_COMMAND}
   eval ${GENERATE_CONFIG_COMMAND}

--- a/dockerfiles/base/scripts/base/commands/cmd_init.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_init.sh
@@ -86,14 +86,14 @@ cmd_init() {
   fi
 
   # in development mode we use init files from repo otherwise we use it from docker image
+  INIT_RUN_PARAMETERS=""
   if local_repo; then
-    docker_run -v "${CHE_HOST_CONFIG}":/copy \
-               -v "${CHE_HOST_DEVELOPMENT_REPO}"/dockerfiles/init:/files \
-               -v "${CHE_HOST_DEVELOPMENT_REPO}"/dockerfiles/init/manifests/${CHE_MINI_PRODUCT_NAME}.env:/etc/puppet/manifests/${CHE_MINI_PRODUCT_NAME}.env \
-                   $IMAGE_INIT
-  else
-    docker_run -v "${CHE_HOST_CONFIG}":/copy $IMAGE_INIT
+    if [ -d "/repo/dockerfiles/init/manifests" ]; then
+      INIT_RUN_PARAMETERS=" -v "${CHE_HOST_DEVELOPMENT_REPO}"/dockerfiles/init:/files"
+      INIT_RUN_PARAMETERS+=" -v "${CHE_HOST_DEVELOPMENT_REPO}"/dockerfiles/init/manifests/${CHE_MINI_PRODUCT_NAME}.env:/etc/puppet/manifests/${CHE_MINI_PRODUCT_NAME}.env"
+    fi
   fi
+  docker_run -v "${CHE_HOST_CONFIG}":/copy $INIT_RUN_PARAMETERS $IMAGE_INIT
 
   # If this is is a reinit, we should not overwrite these core template files.
   # If this is an initial init, then we have to override some values


### PR DESCRIPTION
https://github.com/codenvy/customer-saas/issues/101

mount repository init files only if they're part of the repository. Else keep files from the image

Also, use of directory mode for manifests file instead of specifying a given pp file. It allows to add more pp files

Change-Id: Ib9ad459b5a24e59eefc5c41a163534abcab7a9ae
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
