### PR TITLE
[cli] rename docker image eclipse/che-cli into eclipse/che (+ alias eclipse/che-cli)

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -44,11 +44,27 @@ build() {
   echo "Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG"
   cd "${DIR}" && docker build -t ${IMAGE_NAME}:${TAG} .
   if [ $? -eq 0 ]; then
+    printf "Build of ${BLUE}${IMAGE_NAME}:${TAG} ${GREEN}[OK]${NC}\n"
+    if [ ! -z "${IMAGE_ALIASES}" ]; then
+      for TMP_IMAGE_NAME in ${IMAGE_ALIASES}
+      do
+        docker tag ${IMAGE_NAME}:${TAG} ${TMP_IMAGE_NAME}:${TAG}
+        if [ $? -eq 0 ]; then
+          printf "  /alias ${BLUE}${TMP_IMAGE_NAME}:${TAG}${NC} ${GREEN}[OK]${NC}\n"
+        else
+          printf "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}\n"
+          exit 1
+        fi
+
+      done
+    fi
     printf "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}\n"
-    else
-      printf "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}\n"
-      exit 1
+  else
+    printf "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}\n"
+    exit 1
   fi
+
+
 }
 
 check_docker() {

--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -5,7 +5,12 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-IMAGE_NAME="eclipse/che-cli"
+# Primary name of the docker image
+IMAGE_NAME="eclipse/che"
+
+# Define space separated list of aliases for the docker image
+IMAGE_ALIASES="eclipse/che-cli"
+
 base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}"/../build.include
 

--- a/dockerfiles/lib/build.sh
+++ b/dockerfiles/lib/build.sh
@@ -59,8 +59,8 @@ DIR=$(cd "$(dirname "$0")"; pwd)
 echo "Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG"
 cd "${DIR}" && docker build -t ${IMAGE_NAME}:${TAG} .
 if [ $? -eq 0 ]; then
-  echo -e "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}"
+  printf "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}\n"
 else
-  echo -e "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}"
+  printf "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}\n"
   exit 1
 fi


### PR DESCRIPTION
### What does this PR do?
- rename eclipse/che-cli to eclipse/che
- add eclipse/che-cli as an alias of eclipse/che

### What issues does this PR fix or reference?
N/A

#### Changelog
rename docker image eclipse/che-cli to eclipse/che (and add alias to previous name eclipse/che-cli)

#### Release Notes
N/A for bugs


#### Docs PR
N/A for bugs
