### PR TITLE
revert back pulling CLI if local image older than 24h

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -400,7 +400,10 @@ function verify_nightly_accuracy() {
     elif $(newer_date_period \
          $(timestamp_date_iso8601 "${LOCAL_CREATION_DATE}") \
          $(timestamp_date_iso8601 "${REMOTE_CREATION_DATE}")); then
-     warning "There is a newer ${CHE_IMAGE_FULLNAME} image on DockerHub."
+     warning "Your 'nightly' image is over 24 hours old - checking for newer image..."
+     update_image $CHE_IMAGE_FULLNAME
+     warning "Pulled newer 'nightly' image - please rerun CLI"
+     return 2
     fi
   fi
 }

--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -381,14 +381,9 @@ function verify_nightly_accuracy() {
   # than the one stored on DockerHub.
   if is_nightly; then
 
-#    REMOTE_NIGHTLY_JSON=$(curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/nightly/)
-
     # Retrieve info on current nightly
     LOCAL_CREATION_DATE=$(docker inspect --format="{{.Created }}" ${CHE_IMAGE_FULLNAME})
     CURRENT_DATE=$(date)
-    
-#    REMOTE_CREATION_DATE=$(echo $REMOTE_NIGHTLY_JSON | jq ".last_updated")
-#    REMOTE_CREATION_DATE="${REMOTE_CREATION_DATE//\"}"
 
     # Unfortunatley, the "last_updated" date on DockerHub is the date it was uploaded, not created.
     # So after you download the image locally, then the local image "created" value reflects when it

--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -381,12 +381,14 @@ function verify_nightly_accuracy() {
   # than the one stored on DockerHub.
   if is_nightly; then
 
-    REMOTE_NIGHTLY_JSON=$(curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/nightly/)
+#    REMOTE_NIGHTLY_JSON=$(curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/nightly/)
 
     # Retrieve info on current nightly
     LOCAL_CREATION_DATE=$(docker inspect --format="{{.Created }}" ${CHE_IMAGE_FULLNAME})
-    REMOTE_CREATION_DATE=$(echo $REMOTE_NIGHTLY_JSON | jq ".last_updated")
-    REMOTE_CREATION_DATE="${REMOTE_CREATION_DATE//\"}"
+    CURRENT_DATE=$(date)
+    
+#    REMOTE_CREATION_DATE=$(echo $REMOTE_NIGHTLY_JSON | jq ".last_updated")
+#    REMOTE_CREATION_DATE="${REMOTE_CREATION_DATE//\"}"
 
     # Unfortunatley, the "last_updated" date on DockerHub is the date it was uploaded, not created.
     # So after you download the image locally, then the local image "created" value reflects when it
@@ -395,19 +397,16 @@ function verify_nightly_accuracy() {
     # Solution is to compare the dates, and only print warning message if the locally created ate
     # is less than the updated date on dockerhub.
 
-    if [[ -z ${REMOTE_CREATION_DATE} ]]; then
-      warning "Unable to get published date on hub.docker.com for ${CHE_IMAGE_FULLNAME}"
-    elif $(newer_date_period \
+    if $(newer_date_period \
          $(timestamp_date_iso8601 "${LOCAL_CREATION_DATE}") \
-         $(timestamp_date_iso8601 "${REMOTE_CREATION_DATE}")); then
-     warning "Your 'nightly' image is over 24 hours old - checking for newer image..."
-     update_image $CHE_IMAGE_FULLNAME
-     warning "Pulled newer 'nightly' image - please rerun CLI"
-     return 2
+         $(timestamp_date_iso8601 "${CURRENT_DATE}")); then
+      warning "Your 'nightly' image is over 24 hours old - checking for a newer image..."
+      update_image $CHE_IMAGE_FULLNAME
+      warning "Pulled new 'nightly' image - please rerun CLI"
+      return 2
     fi
   fi
 }
-
 
 # Convert a ISO 8601 date to timestamp
 timestamp_date_iso8601() {


### PR DESCRIPTION
after I've reverted https://github.com/eclipse/che/commit/f7ca10c86a12bc5a6da766dfcf281f2b656c23c3 this I've also removed logic which do pull CLI and exit if CLI is older than 24h
so I'm adding it back with this PR.