### PR TITLE
Implement workspace start cancellation

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -37,6 +37,24 @@ che.workspace.auto_snapshot=true
 # Otherwise create a new workspace.
 che.workspace.auto_restore=true
 
+
+# Workspace threads pool configuration, this pool is used for workspace related
+# operations that require asynchronous execution e.g. starting/stopping/snapshotting
+
+# possible values are 'fixed', 'cached'
+che.workspace.pool.type=fixed
+
+# This property is ignored when pool type is different from 'fixed'.
+# Configures the exact size of the pool, if it's set multiplier property is ignored.
+# If this property is not set(0, < 0, NULL) then pool sized to number of cores,
+#it can be modified within multiplier
+che.workspace.pool.exact_size=NULL
+
+# This property is ignored when pool type is different from 'fixed' or exact pool size is set.
+# If it's set the pool size will be N_CORES * multiplier
+che.workspace.pool.cores_multiplier=2
+
+
 # Java command line options used to start Che agent in workspace runtime
 che.workspace.java_opts=-Xms256m -Xmx2048m -Djava.security.egd=file:/dev/./urandom
 

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/CompositeLineConsumer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/CompositeLineConsumer.java
@@ -33,7 +33,7 @@ public class CompositeLineConsumer implements LineConsumer {
     private static final Logger LOG = LoggerFactory.getLogger(CompositeLineConsumer.class);
 
     private final List<LineConsumer> lineConsumers;
-    private boolean                  isOpen;
+    private       boolean            isOpen;
 
     public CompositeLineConsumer(LineConsumer... lineConsumers) {
         this.lineConsumers = new CopyOnWriteArrayList<>(lineConsumers);
@@ -70,7 +70,11 @@ public class CompositeLineConsumer implements LineConsumer {
             for (LineConsumer lineConsumer : lineConsumers) {
                 try {
                     lineConsumer.writeLine(line);
-                } catch (ConsumerAlreadyClosedException | ClosedByInterruptException e) {
+                } catch (ClosedByInterruptException interrupted) {
+                    Thread.currentThread().interrupt();
+                    isOpen = false;
+                    return;
+                } catch (ConsumerAlreadyClosedException e) {
                     lineConsumers.remove(lineConsumer); // consumer is already closed, so we cannot write into it any more
                     if (lineConsumers.size() == 0) { // if all consumers are closed then we can close this one
                         isOpen = false;

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/WorkspaceStatus.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/WorkspaceStatus.java
@@ -28,8 +28,9 @@ public enum WorkspaceStatus {
      * <p>Workspace becomes starting only if it was {@link #STOPPED}.
      * The status map:
      * <pre>
-     *  STOPPED -> <b>STARTING</b> -> RUNNING (normal behaviour)
-     *  STOPPED -> <b>STARTING</b> -> STOPPED (failed to start)
+     *  STOPPED -> <b>STARTING</b> -> RUNNING  (normal behaviour)
+     *  STOPPED -> <b>STARTING</b> -> STOPPED  (failed to start)
+     *  STOPPED -> <b>STARTING</b> -> STOPPING (explicitly stopped)
      * </pre>
      */
     STARTING,
@@ -61,10 +62,12 @@ public enum WorkspaceStatus {
     /**
      * Workspace considered as stopping if and only if its active environment is shutting down.
      *
-     * <p>Workspace is in stopping status only if it was in {@link #RUNNING} status before.
+     * <p>Workspace is in stopping status only if it was in {@link #RUNNING} or
+     * {@link #STARTING} status before.
      * The status map:
      * <pre>
-     *  RUNNING -> <b>STOPPING</b> -> STOPPED (normal behaviour)/(error while stopping)
+     *  RUNNING  -> <b>STOPPING</b> -> STOPPED (normal behaviour)/(error while stopping)
+     *  STARTING -> <b>STOPPING</b> -> STOPPED (stopped while starting)
      * </pre>
      */
     STOPPING,

--- a/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/concurrent/StripedLocks.java
+++ b/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/concurrent/StripedLocks.java
@@ -12,34 +12,36 @@ package org.eclipse.che.commons.lang.concurrent;
 
 import com.google.common.util.concurrent.Striped;
 
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 
 /**
  * Helper class to use striped locks in try-with-resources construction.
  * </p>
  * Examples of usage:
- * <pre class="code"><code class="java">
- *     StripedLocks stripedLocks = new StripedLocks(16);
- *     try (CloseableLock lock = stripedLocks.acquireWriteLock(myKey)) {
- *         syncedObject.write();
- *     }
+ * <pre>{@code
+ *  StripedLocks stripedLocks = new StripedLocks(16);
+ *  try (Unlocker u = stripedLocks.writeLock(myKey)) {
+ *      syncedObject.write();
+ *  }
  *
- *     try (CloseableLock lock = stripedLocks.acquireReadLock(myKey)) {
- *         syncedObject.read();
- *     }
+ *  try (Unlocker u = stripedLocks.readLock(myKey)) {
+ *      syncedObject.read();
+ *  }
  *
- *     try (CloseableLock lock = stripedLocks.acquireWriteAllLock(myKey)) {
- *         for (ObjectToSync objectToSync : allObjectsToSync) {
- *             objectToSync.write();
- *         }
- *     }
- * </pre>
+ *  try (Unlocker u = stripedLocks.writeAllLock(myKey)) {
+ *      for (ObjectToSync objectToSync : allObjectsToSync) {
+ *          objectToSync.write();
+ *      }
+ *  }
+ * }</pre>
  *
  * @author Alexander Garagatyi
  * @author Sergii Leschenko
+ * @author Yevhenii Voevodin
  */
-// TODO consider usage of plain map with locks instead of Guava's Striped
 public class StripedLocks {
+
     private final Striped<ReadWriteLock> striped;
 
     public StripedLocks(int stripesCount) {
@@ -49,75 +51,66 @@ public class StripedLocks {
     /**
      * Acquire read lock for provided key.
      */
-    public CloseableLock acquireReadLock(String key) {
-        return new ReadLock(key);
+    public Unlocker readLock(String key) {
+        Lock lock = striped.get(key).readLock();
+        lock.lock();
+        return new LockUnlocker(lock);
     }
 
     /**
      * Acquire write lock for provided key.
      */
-    public CloseableLock acquireWriteLock(String key) {
-        return new WriteLock(key);
+    public Unlocker writeLock(String key) {
+        Lock lock = striped.get(key).writeLock();
+        lock.lock();
+        return new LockUnlocker(lock);
     }
 
     /**
      * Acquire write lock for all possible keys.
      */
-    public CloseableLock acquireWriteAllLock() {
-        return new WriteAllLock();
+    public Unlocker writeAllLock() {
+        Lock[] locks = getAllWriteLocks();
+        for (Lock lock : locks) {
+            lock.lock();
+        }
+        return new LocksUnlocker(locks);
     }
 
-    /**
-     * Represents read lock for the provided key.
-     * Can be used as {@link AutoCloseable} to release lock.
-     */
-    private class ReadLock implements CloseableLock {
-        private String key;
+    private Lock[] getAllWriteLocks() {
+        Lock[] locks = new Lock[striped.size()];
+        for (int i = 0; i < striped.size(); i++) {
+            locks[i] = striped.getAt(i).writeLock();
+        }
+        return locks;
+    }
 
-        private ReadLock(String key) {
-            this.key = key;
-            striped.get(key).readLock().lock();
+    private static class LockUnlocker implements Unlocker {
+
+        private final Lock lock;
+
+        private LockUnlocker(Lock lock) {
+            this.lock = lock;
         }
 
         @Override
-        public void close() {
-            striped.get(key).readLock().unlock();
+        public void unlock() {
+            lock.unlock();
         }
     }
 
-    /**
-     * Represents write lock for the provided key.
-     * Can be used as {@link AutoCloseable} to release lock.
-     */
-    private class WriteLock implements CloseableLock {
-        private String key;
+    private static class LocksUnlocker implements Unlocker {
 
-        private WriteLock(String key) {
-            this.key = key;
-            striped.get(key).writeLock().lock();
+        private final Lock[] locks;
+
+        private LocksUnlocker(Lock[] locks) {
+            this.locks = locks;
         }
 
         @Override
-        public void close() {
-            striped.get(key).writeLock().unlock();
-        }
-    }
-
-    /**
-     * Represents write lock for all possible keys.
-     * Can be used as {@link AutoCloseable} to release locks.
-     */
-    private class WriteAllLock implements CloseableLock {
-        private WriteAllLock() {
-            for (int i = 0; i < striped.size(); i++) {
-                striped.getAt(i).writeLock().lock();
-            }
-        }
-
-        @Override
-        public void close() {
-            for (int i = 0; i < striped.size(); i++) {
-                striped.getAt(i).writeLock().unlock();
+        public void unlock() {
+            for (Lock lock : locks) {
+                lock.unlock();
             }
         }
     }

--- a/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/concurrent/Unlocker.java
+++ b/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/concurrent/Unlocker.java
@@ -11,20 +11,28 @@
 package org.eclipse.che.commons.lang.concurrent;
 
 /**
- * Lock that is designed to use in try-with-resources statement.
+ * An interface that allows implementations to enclose
+ * locked instance and unlock it later by calling {@link #unlock()}.
  *
- * <p>Implementers should lock on instance creation
- * and unlock when {@link CloseableLock#close()} method invokes.
+ * <p>This is designed to be used in try-with-resources statement.
+ *
+ * <p>The example:
+ * <pre>
+ *     try (@SuppressWarnings("unused") Unlocker u = customLocks.lock("key")) {
+ *         // do something in lock
+ *     }
+ * </pre>
  *
  * @author Sergii Leschenko
+ * @author Yevhenii Voevodin
  */
-public interface CloseableLock extends AutoCloseable {
+public interface Unlocker extends AutoCloseable {
+
     /**
-     * Unlocks this lock.
-     *
-     * This method is invoked automatically on objects managed by the
-     * {@code try}-with-resources statement.
+     * Unlocks the corresponding lock in implementation specific manner.
      */
+    void unlock();
+
     @Override
-    void close();
+    default void close() { unlock(); }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -826,6 +826,7 @@ public class DockerConnector {
                     throw new DockerException(e.getCause().getLocalizedMessage(), 500);
                 }
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new DockerException("Docker image build was interrupted", 500);
             }
         }
@@ -952,6 +953,7 @@ public class DockerConnector {
                 // unwrap exception thrown by task with .getCause()
                 throw new DockerException("Docker image pushing failed. Cause: " + e.getCause().getLocalizedMessage(), 500);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new DockerException("Docker image pushing was interrupted", 500);
             }
         }
@@ -1048,6 +1050,7 @@ public class DockerConnector {
                 // unwrap exception thrown by task with .getCause()
                 throw new DockerException(e.getCause().getLocalizedMessage(), 500);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new DockerException("Docker image pulling was interrupted", 500);
             }
         }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -471,8 +471,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                 docker.removeImage(RemoveImageParams.create(fullNameOfPulledImage).withForce(false));
             }
         } catch (IOException e) {
-            LOG.error(e.getLocalizedMessage(), e);
-            throw new MachineException("Can't create machine from image. Cause: " + e.getLocalizedMessage());
+            throw new MachineException("Can't create machine from image. Cause: " + e.getLocalizedMessage(), e);
         }
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineStartedHandler.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineStartedHandler.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.environment.server;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.environment.server.exception.EnvironmentException;
+import org.eclipse.che.api.machine.server.spi.Instance;
+
+/**
+ * Used in couple with {@link CheEnvironmentEngine#start} method to
+ * allow sequential handling and interruption of the start process.
+ *
+ * <p>This interface is a part of a contract for {@link CheEnvironmentEngine}.
+ *
+ * @author Yevhenii Voevodin
+ */
+public interface MachineStartedHandler {
+    void started(Instance machine) throws EnvironmentException, ServerException;
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/exception/EnvironmentStartInterruptedException.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/exception/EnvironmentStartInterruptedException.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.environment.server.exception;
+
+/**
+ * Thrown when environment start is interrupted.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class EnvironmentStartInterruptedException extends EnvironmentException {
+    public EnvironmentStartInterruptedException(String workspaceId, String envName) {
+        super(String.format("Start of environment '%s' in workspace '%s' is interrupted",
+                            envName,
+                            workspaceId));
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -29,7 +29,6 @@ import org.eclipse.che.api.machine.server.exception.SourceNotFoundException;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
-import org.eclipse.che.api.workspace.server.WorkspaceRuntimes.RuntimeDescriptor;
 import org.eclipse.che.api.workspace.server.event.WorkspaceCreatedEvent;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
@@ -46,8 +45,6 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Throwables.getCausalChain;
@@ -130,10 +127,12 @@ public class WorkspaceManager {
                                                                   NotFoundException {
         requireNonNull(config, "Required non-null config");
         requireNonNull(namespace, "Required non-null namespace");
-        return normalizeState(doCreateWorkspace(config,
-                                                accountManager.getByName(namespace),
-                                                emptyMap(),
-                                                false));
+        WorkspaceImpl workspace = doCreateWorkspace(config,
+                                                    accountManager.getByName(namespace),
+                                                    emptyMap(),
+                                                    false);
+        workspace.setStatus(WorkspaceStatus.STOPPED);
+        return workspace;
     }
 
     /**
@@ -164,10 +163,12 @@ public class WorkspaceManager {
         requireNonNull(config, "Required non-null config");
         requireNonNull(namespace, "Required non-null namespace");
         requireNonNull(attributes, "Required non-null attributes");
-        return normalizeState(doCreateWorkspace(config,
-                                                accountManager.getByName(namespace),
-                                                attributes,
-                                                false));
+        WorkspaceImpl workspace = doCreateWorkspace(config,
+                                                    accountManager.getByName(namespace),
+                                                    emptyMap(),
+                                                    false);
+        workspace.setStatus(WorkspaceStatus.STOPPED);
+        return workspace;
     }
 
     /**
@@ -193,7 +194,9 @@ public class WorkspaceManager {
      */
     public WorkspaceImpl getWorkspace(String key) throws NotFoundException, ServerException {
         requireNonNull(key, "Required non-null workspace key");
-        return normalizeState(getByKey(key));
+        WorkspaceImpl workspace = getByKey(key);
+        runtimes.injectRuntime(workspace);
+        return workspace;
     }
 
     /**
@@ -215,7 +218,9 @@ public class WorkspaceManager {
     public WorkspaceImpl getWorkspace(String name, String namespace) throws NotFoundException, ServerException {
         requireNonNull(name, "Required non-null workspace name");
         requireNonNull(namespace, "Required non-null workspace owner");
-        return normalizeState(workspaceDao.get(name, namespace));
+        WorkspaceImpl workspace = workspaceDao.get(name, namespace);
+        runtimes.injectRuntime(workspace);
+        return workspace;
     }
 
     /**
@@ -256,8 +261,10 @@ public class WorkspaceManager {
     public List<WorkspaceImpl> getWorkspaces(String user, boolean includeRuntimes) throws ServerException {
         requireNonNull(user, "Required non-null user id");
         final List<WorkspaceImpl> workspaces = workspaceDao.getWorkspaces(user);
-        for (WorkspaceImpl workspace : workspaces) {
-            normalizeState(workspace, includeRuntimes);
+        if (includeRuntimes) {
+            injectRuntimes(workspaces);
+        } else {
+            injectStatuses(workspaces);
         }
         return workspaces;
     }
@@ -300,8 +307,10 @@ public class WorkspaceManager {
     public List<WorkspaceImpl> getByNamespace(String namespace, boolean includeRuntimes) throws ServerException {
         requireNonNull(namespace, "Required non-null namespace");
         final List<WorkspaceImpl> workspaces = workspaceDao.getByNamespace(namespace);
-        for (WorkspaceImpl workspace : workspaces) {
-            normalizeState(workspace, includeRuntimes);
+        if (includeRuntimes) {
+            injectRuntimes(workspaces);
+        } else {
+            injectStatuses(workspaces);
         }
         return workspaces;
     }
@@ -329,12 +338,14 @@ public class WorkspaceManager {
                                                                              NotFoundException {
         requireNonNull(id, "Required non-null workspace id");
         requireNonNull(update, "Required non-null workspace update");
-        final WorkspaceImpl workspace = workspaceDao.get(id);
+        WorkspaceImpl workspace = workspaceDao.get(id);
         workspace.setConfig(new WorkspaceConfigImpl(update.getConfig()));
         update.getAttributes().put(UPDATED_ATTRIBUTE_NAME, Long.toString(currentTimeMillis()));
         workspace.setAttributes(update.getAttributes());
         workspace.setTemporary(update.isTemporary());
-        return normalizeState(workspaceDao.update(workspace));
+        WorkspaceImpl updated = workspaceDao.update(workspace);
+        runtimes.injectRuntime(updated);
+        return updated;
     }
 
     /**
@@ -401,7 +412,8 @@ public class WorkspaceManager {
         final String restoreAttr = workspace.getAttributes().get(AUTO_RESTORE_FROM_SNAPSHOT);
         final boolean autoRestore = restoreAttr == null ? defaultAutoRestore : parseBoolean(restoreAttr);
         startAsync(workspace, envName, firstNonNull(restore, autoRestore) && !getSnapshot(workspaceId).isEmpty());
-        return normalizeState(workspace);
+        runtimes.injectRuntime(workspace);
+        return workspace;
     }
 
     /**
@@ -431,7 +443,8 @@ public class WorkspaceManager {
                                                           emptyMap(),
                                                           isTemporary);
         startAsync(workspace, workspace.getConfig().getDefaultEnv(), false);
-        return normalizeState(workspace);
+        runtimes.injectRuntime(workspace);
+        return workspace;
     }
 
     /**
@@ -506,8 +519,8 @@ public class WorkspaceManager {
                                                                                            NotFoundException,
                                                                                            ServerException {
         requireNonNull(workspaceId, "Required non-null workspace id");
-        final WorkspaceImpl workspace = normalizeState(workspaceDao.get(workspaceId));
-        checkWorkspaceIsRunning(workspace, "stop");
+        final WorkspaceImpl workspace = workspaceDao.get(workspaceId);
+        workspace.setStatus(runtimes.getStatus(workspaceId));
         stopAsync(workspace, createSnapshot);
     }
 
@@ -615,7 +628,8 @@ public class WorkspaceManager {
                                                      ConflictException {
         requireNonNull(workspaceId, "Required non-null workspace id");
         requireNonNull(machineId, "Required non-null machine id");
-        final WorkspaceImpl workspace = normalizeState(workspaceDao.get(workspaceId));
+        final WorkspaceImpl workspace = workspaceDao.get(workspaceId);
+        workspace.setStatus(runtimes.getStatus(workspaceId));
         checkWorkspaceIsRunning(workspace, format("stop machine with ID '%s' of", machineId));
         runtimes.stopMachine(workspaceId, machineId);
     }
@@ -638,7 +652,7 @@ public class WorkspaceManager {
                                                                 ServerException {
         requireNonNull(workspaceId, "Required non-null workspace id");
         requireNonNull(machineId, "Required non-null machine id");
-        normalizeState(workspaceDao.get(workspaceId));
+        workspaceDao.get(workspaceId);
         return runtimes.getMachine(workspaceId, machineId);
     }
 
@@ -658,33 +672,46 @@ public class WorkspaceManager {
         workspaceDao.update(workspace);
         final String env = firstNonNull(envName, workspace.getConfig().getDefaultEnv());
 
-        // barrier, safely doesn't allow to start the workspace twice
-        final Future<RuntimeDescriptor> descriptor = runtimes.startAsync(workspace, env, recover);
-
-        sharedPool.execute(() -> {
-            try {
-                descriptor.get();
-                LOG.info("Workspace '{}:{}' with id '{}' started by user '{}'",
-                         workspace.getNamespace(),
-                         workspace.getConfig().getName(),
-                         workspace.getId(),
-                         sessionUserNameOr("undefined"));
-            } catch (Exception ex) {
-                if (workspace.isTemporary()) {
-                    removeWorkspaceQuietly(workspace);
-                }
-                for (Throwable cause : getCausalChain(ex)) {
-                    if (cause instanceof SourceNotFoundException) {
-                        return;
+        runtimes.startAsync(workspace, env, recover)
+                .whenComplete((runtime, ex) -> {
+                    if (ex == null) {
+                        LOG.info("Workspace '{}:{}' with id '{}' started by user '{}'",
+                                 workspace.getNamespace(),
+                                 workspace.getConfig().getName(),
+                                 workspace.getId(),
+                                 sessionUserNameOr("undefined"));
+                    } else {
+                        if (workspace.isTemporary()) {
+                            removeWorkspaceQuietly(workspace);
+                        }
+                        for (Throwable cause : getCausalChain(ex)) {
+                            if (cause instanceof SourceNotFoundException) {
+                                return;
+                            }
+                        }
+                        try {
+                            throw ex;
+                        } catch (EnvironmentException envEx) {
+                            // it's okay, e.g. recipe is invalid | start interrupted
+                            LOG.info("Workspace '{}:{}' can't be started because: {}",
+                                     workspace.getNamespace(),
+                                     workspace.getConfig().getName(),
+                                     envEx.getMessage());
+                        } catch (Throwable thr) {
+                            LOG.error(thr.getMessage(), thr);
+                        }
                     }
-                }
-                LOG.error(ex.getLocalizedMessage(), ex);
-            }
-        });
+                });
     }
 
     private void stopAsync(WorkspaceImpl workspace, @Nullable Boolean createSnapshot) throws ConflictException {
-        checkWorkspaceIsRunning(workspace, "stop");
+        if (workspace.getStatus() != WorkspaceStatus.RUNNING && workspace.getStatus() != WorkspaceStatus.STARTING) {
+            throw new ConflictException(format("Could not stop the workspace '%s:%s' because its status is '%s'. " +
+                                               "Workspace must be either 'STARTING' or 'RUNNING'",
+                                               workspace.getNamespace(),
+                                               workspace.getConfig().getName(),
+                                               workspace.getStatus()));
+        }
 
         sharedPool.execute(() -> {
             final String stoppedBy = sessionUserNameOr(workspace.getAttributes().get(WORKSPACE_STOPPED_BY));
@@ -695,7 +722,7 @@ public class WorkspaceManager {
                      firstNonNull(stoppedBy, "undefined"));
 
             final boolean snapshotBeforeStop;
-            if (workspace.isTemporary()) {
+            if (workspace.isTemporary() || workspace.getStatus() == WorkspaceStatus.STARTING) {
                 snapshotBeforeStop = false;
             } else if (createSnapshot != null) {
                 snapshotBeforeStop = createSnapshot;
@@ -728,7 +755,7 @@ public class WorkspaceManager {
                          workspace.getConfig().getName(),
                          workspace.getId(),
                          firstNonNull(stoppedBy, "undefined"));
-            } catch (RuntimeException | ConflictException | NotFoundException | ServerException ex) {
+            } catch (Exception ex) {
                 LOG.error(ex.getLocalizedMessage(), ex);
             } finally {
                 if (workspace.isTemporary()) {
@@ -778,33 +805,6 @@ public class WorkspaceManager {
         return nameIfNoUser;
     }
 
-    private WorkspaceImpl normalizeState(WorkspaceImpl workspace) throws ServerException {
-        return normalizeState(workspace, true);
-    }
-
-    private WorkspaceImpl normalizeState(WorkspaceImpl workspace, boolean includeRuntimes) throws ServerException {
-        if (includeRuntimes) {
-            try {
-                return normalizeState(workspace, runtimes.get(workspace.getId()));
-            } catch (NotFoundException e) {
-                return normalizeState(workspace, null);
-            }
-        } else {
-            workspace.setStatus(runtimes.getStatus(workspace.getId()));
-            return workspace;
-        }
-    }
-
-    private WorkspaceImpl normalizeState(WorkspaceImpl workspace, RuntimeDescriptor descriptor) {
-        if (descriptor != null) {
-            workspace.setStatus(descriptor.getRuntimeStatus());
-            workspace.setRuntime(descriptor.getRuntime());
-        } else {
-            workspace.setStatus(WorkspaceStatus.STOPPED);
-        }
-        return workspace;
-    }
-
     private WorkspaceImpl doCreateWorkspace(WorkspaceConfig config,
                                             Account account,
                                             Map<String, String> attributes,
@@ -842,5 +842,18 @@ public class WorkspaceManager {
         final String wsName = parts[1];
         final String namespace = nsPart.isEmpty() ? sessionUser().getUserName() : nsPart;
         return workspaceDao.get(wsName, namespace);
+    }
+
+
+    private void injectRuntimes(List<? extends WorkspaceImpl> workspaces) {
+        for (WorkspaceImpl workspace : workspaces) {
+            runtimes.injectRuntime(workspace);
+        }
+    }
+
+    private void injectStatuses(List<? extends WorkspaceImpl> workspaces) {
+        for (WorkspaceImpl workspace : workspaces) {
+            workspace.setStatus(runtimes.getStatus(workspace.getId()));
+        }
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceRuntimeImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceRuntimeImpl.java
@@ -34,8 +34,22 @@ public class WorkspaceRuntimeImpl implements WorkspaceRuntime {
     private MachineImpl       devMachine;
     private List<MachineImpl> machines;
 
-    public WorkspaceRuntimeImpl(String activeEnv) {
+    public WorkspaceRuntimeImpl(String activeEnv, Collection<? extends Machine> machines) {
         this.activeEnv = activeEnv;
+        if (machines != null) {
+            this.machines = new ArrayList<>(machines.size());
+            for (Machine machine : machines) {
+                if (machine.getConfig().isDev()) {
+                    if (machine.getRuntime() != null) {
+                        rootFolder = machine.getRuntime().projectsRoot();
+                    }
+                    devMachine = new MachineImpl(machine);
+                    this.machines.add(devMachine);
+                } else {
+                    this.machines.add(new MachineImpl(machine));
+                }
+            }
+        }
     }
 
     public WorkspaceRuntimeImpl(String activeEnv,
@@ -47,9 +61,11 @@ public class WorkspaceRuntimeImpl implements WorkspaceRuntime {
         if (devMachine != null) {
             this.devMachine = new MachineImpl(devMachine);
         }
-        this.machines = machines.stream()
-                                .map(MachineImpl::new)
-                                .collect(toList());
+        if (machines != null) {
+            this.machines = machines.stream()
+                                    .map(MachineImpl::new)
+                                    .collect(toList());
+        }
     }
 
     public WorkspaceRuntimeImpl(WorkspaceRuntime runtime) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -10,20 +10,28 @@
  *******************************************************************************/
 package org.eclipse.che.api.workspace.server;
 
-import org.eclipse.che.account.spi.AccountImpl;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+
 import org.eclipse.che.api.agent.server.AgentRegistry;
 import org.eclipse.che.api.agent.server.impl.AgentSorter;
 import org.eclipse.che.api.agent.server.launcher.AgentLauncherFactory;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.Environment;
+import org.eclipse.che.api.core.model.workspace.ExtendedMachine;
+import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.environment.server.CheEnvironmentEngine;
 import org.eclipse.che.api.environment.server.NoOpMachineInstance;
+import org.eclipse.che.api.environment.server.exception.EnvironmentException;
+import org.eclipse.che.api.environment.server.exception.EnvironmentNotRunningException;
+import org.eclipse.che.api.environment.server.exception.EnvironmentStartInterruptedException;
 import org.eclipse.che.api.machine.server.exception.SnapshotException;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
@@ -33,52 +41,64 @@ import org.eclipse.che.api.machine.server.model.impl.MachineSourceImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.api.machine.server.spi.SnapshotDao;
-import org.eclipse.che.api.workspace.server.WorkspaceRuntimes.RuntimeDescriptor;
+import org.eclipse.che.api.workspace.server.WorkspaceRuntimes.RuntimeState;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ExtendedMachineImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceRuntimeImpl;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent.EventType;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
-import static java.util.Arrays.asList;
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
-import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 /**
  * @author Yevhenii Voevodin
@@ -87,395 +107,514 @@ import static org.testng.Assert.assertNotNull;
 @Listeners(MockitoTestNGListener.class)
 public class WorkspaceRuntimesTest {
 
-    private static final String WORKSPACE_ID = "workspace123";
-    private static final String ENV_NAME     = "default-env";
-
     @Mock
-    private EventService         eventService;
+    private EventService                 eventService;
     @Mock
-    private CheEnvironmentEngine envEngine;
+    private CheEnvironmentEngine         envEngine;
     @Mock
-    private AgentSorter          agentSorter;
+    private AgentSorter                  agentSorter;
     @Mock
-    private AgentLauncherFactory launcherFactory;
+    private AgentLauncherFactory         launcherFactory;
     @Mock
-    private AgentRegistry        agentRegistry;
+    private AgentRegistry                agentRegistry;
     @Mock
-    private WorkspaceSharedPool  sharedPool;
+    private WorkspaceSharedPool          sharedPool;
     @Mock
-    private SnapshotDao          snapshotDao;
+    private SnapshotDao                  snapshotDao;
+    @Mock
+    private Future<WorkspaceRuntimeImpl> runtimeFuture;
+    @Mock
+    private WorkspaceRuntimes.StartTask  startTask;
 
     @Captor
     private ArgumentCaptor<WorkspaceStatusEvent>     eventCaptor;
     @Captor
-    private ArgumentCaptor<Callable>                 taskCaptor;
+    private ArgumentCaptor<Callable<?>>              taskCaptor;
     @Captor
     private ArgumentCaptor<Collection<SnapshotImpl>> snapshotsCaptor;
 
-    private WorkspaceRuntimes runtimes;
+    private WorkspaceRuntimes                   runtimes;
+    private ConcurrentMap<String, RuntimeState> runtimeStates;
 
     @BeforeMethod
-    public void setUp(Method method) throws Exception {
-        runtimes = spy(new WorkspaceRuntimes(eventService,
-                                             envEngine,
-                                             agentSorter,
-                                             launcherFactory,
-                                             agentRegistry,
-                                             snapshotDao,
-                                             sharedPool));
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        runtimes = new WorkspaceRuntimes(eventService,
+                                         envEngine,
+                                         agentSorter,
+                                         launcherFactory,
+                                         agentRegistry,
+                                         snapshotDao,
+                                         sharedPool,
+                                         runtimeStates = new ConcurrentHashMap<>());
+    }
 
-        List<Instance> machines = asList(createMachine(true), createMachine(false));
-        when(envEngine.start(anyString(),
-                             anyString(),
-                             any(Environment.class),
-                             anyBoolean(),
-                             any()))
-                .thenReturn(machines);
-        when(envEngine.getMachines(WORKSPACE_ID)).thenReturn(machines);
+    @Test(dataProvider = "allStatuses")
+    public void getsStatus(WorkspaceStatus status) throws Exception {
+        setRuntime("workspace", status);
+
+        assertEquals(runtimes.getStatus("workspace"), status);
     }
 
     @Test(expectedExceptions = NotFoundException.class,
-          expectedExceptionsMessageRegExp = "Workspace with id '.*' is not running.")
-    public void shouldThrowNotFoundExceptionIfWorkspaceRuntimeDoesNotExist() throws Exception {
-        runtimes.get(WORKSPACE_ID);
-    }
-
-    @Test(expectedExceptions = ServerException.class,
-          expectedExceptionsMessageRegExp = "Dev machine is not found in active environment of workspace 'workspace123'")
-    public void shouldThrowExceptionOnGetRuntimesIfDevMachineIsMissingInTheEnvironment() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        when(envEngine.getMachines(workspace.getId()))
-                .thenReturn(asList(createMachine(false), createMachine(false)));
-
-        // when
-        runtimes.get(workspace.getId());
+          expectedExceptionsMessageRegExp = "Workspace with id 'non_running' is not running")
+    public void throwsNotFoundExceptionWhenGettingNonExistingRuntime() throws Exception {
+        runtimes.getRuntime("non_running");
     }
 
     @Test
-    public void shouldFetchMachinesFromEnvEngineOnGetRuntime() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        Instance devMachine = createMachine(true);
-        List<Instance> machines = asList(devMachine, createMachine(false));
-        when(envEngine.start(anyString(),
-                             anyString(),
-                             any(Environment.class),
-                             anyBoolean(),
-                             any()))
-                .thenReturn(machines);
-        when(envEngine.getMachines(WORKSPACE_ID)).thenReturn(machines);
-
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-
-        // when
-        RuntimeDescriptor runtimeDescriptor = runtimes.get(workspace.getId());
-
-        // then
-        RuntimeDescriptor expected = new RuntimeDescriptor(WorkspaceStatus.RUNNING,
-                                                           new WorkspaceRuntimeImpl(workspace.getConfig()
-                                                                                             .getDefaultEnv(),
-                                                                                    devMachine.getRuntime()
-                                                                                              .projectsRoot(),
-                                                                                    machines,
-                                                                                    devMachine));
-        verify(envEngine, times(2)).getMachines(workspace.getId());
-        assertEquals(runtimeDescriptor, expected);
-    }
-
-    @Test(expectedExceptions = ServerException.class,
-          expectedExceptionsMessageRegExp = "Could not perform operation because application server is stopping")
-    public void shouldNotStartTheWorkspaceIfPostConstructWasIsInvoked() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.cleanup();
-
-        // when
-        runtimes.start(createWorkspace(), workspace.getConfig().getDefaultEnv(), false);
+    public void returnsStoppedStatusWhenWorkspaceIsNotRunning() throws Exception {
+        assertEquals(runtimes.getStatus("not_running"), WorkspaceStatus.STOPPED);
     }
 
     @Test
-    public void workspaceShouldNotHaveRuntimeIfEnvStartFails() throws Exception {
-        // given
-        when(envEngine.start(anyString(),
-                             anyString(),
-                             any(Environment.class),
-                             anyBoolean(),
-                             any()))
-                .thenThrow(new ServerException("Test env start error"));
-        WorkspaceImpl workspaceMock = createWorkspace();
+    public void getsRuntime() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING, "env-name");
+        List<Instance> machines = prepareMachines("workspace", "env-name");
 
-        try {
-            // when
-            runtimes.start(workspaceMock,
-                           workspaceMock.getConfig().getDefaultEnv(),
-                           false);
-        } catch (Exception ex) {
-            // then
-            assertFalse(runtimes.hasRuntime(workspaceMock.getId()));
-        }
+        assertEquals(runtimes.getRuntime("workspace"), new WorkspaceRuntimeImpl("env-name", machines));
+        verify(envEngine).getMachines("workspace");
     }
 
     @Test
-    public void workspaceShouldContainAllMachinesAndBeInRunningStatusAfterSuccessfulStart() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
+    public void hasRuntime() {
+        setRuntime("workspace", WorkspaceStatus.STARTING);
 
-        // when
-        RuntimeDescriptor runningWorkspace = runtimes.start(workspace,
-                                                            workspace.getConfig().getDefaultEnv(),
-                                                            false);
+        assertTrue(runtimes.hasRuntime("workspace"));
+    }
 
-        // then
-        assertEquals(runningWorkspace.getRuntimeStatus(), RUNNING);
-        assertNotNull(runningWorkspace.getRuntime().getDevMachine());
-        assertEquals(runningWorkspace.getRuntime().getMachines().size(), 2);
+    @Test
+    public void doesNotHaveRuntime() {
+        assertFalse(runtimes.hasRuntime("not_running"));
+    }
+
+    @Test
+    public void injectsRuntime() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING, "env-name");
+        List<Instance> machines = prepareMachines("workspace", "env-name");
+        WorkspaceImpl workspace = WorkspaceImpl.builder()
+                                               .setId("workspace")
+                                               .build();
+
+        runtimes.injectRuntime(workspace);
+
+        assertEquals(workspace.getStatus(), WorkspaceStatus.RUNNING);
+        assertEquals(workspace.getRuntime(), new WorkspaceRuntimeImpl("env-name", machines));
+    }
+
+    @Test
+    public void injectsStoppedStatusWhenWorkspaceDoesNotHaveRuntime() throws Exception {
+        WorkspaceImpl workspace = WorkspaceImpl.builder()
+                                               .setId("workspace")
+                                               .build();
+
+        runtimes.injectRuntime(workspace);
+
+        assertEquals(workspace.getStatus(), WorkspaceStatus.STOPPED);
+        assertNull(workspace.getRuntime());
+    }
+
+    @Test
+    public void injectsStatusAndEmptyMachinesWhenCanNotGetEnvironmentMachines() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING, "env-name");
+        setNoMachinesForWorkspace("workspace");
+        WorkspaceImpl workspace = WorkspaceImpl.builder()
+                                               .setId("workspace")
+                                               .build();
+
+        runtimes.injectRuntime(workspace);
+
+        assertEquals(workspace.getStatus(), WorkspaceStatus.RUNNING);
+        assertEquals(workspace.getRuntime().getActiveEnv(), "env-name");
+        assertTrue(workspace.getRuntime().getMachines().isEmpty());
+    }
+
+    @Test
+    public void startsWorkspace() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        List<Instance> machines = allowEnvironmentStart(workspace, "env-name");
+        prepareMachines(workspace.getId(), machines);
+
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+        captureAsyncTaskAndExecuteSynchronously();
+        WorkspaceRuntimeImpl runtime = cmpFuture.get();
+
+        assertEquals(runtimes.getStatus(workspace.getId()), WorkspaceStatus.RUNNING);
+        assertEquals(runtime.getActiveEnv(), "env-name");
+        assertEquals(runtime.getMachines().size(), machines.size());
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.STOPPED,
+                                   WorkspaceStatus.STARTING,
+                                   EventType.STARTING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STARTING,
+                                   WorkspaceStatus.RUNNING,
+                                   EventType.RUNNING,
+                                   null));
     }
 
     @Test(expectedExceptions = ConflictException.class,
-          expectedExceptionsMessageRegExp = "Could not start workspace '.*' because its status is 'RUNNING'")
-    public void shouldNotStartWorkspaceIfItIsAlreadyRunning() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
+          expectedExceptionsMessageRegExp = "Could not start workspace 'test-workspace' because its status is 'RUNNING'")
+    public void throwsConflictExceptionWhenWorkspaceIsRunning() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        setRuntime(workspace.getId(), WorkspaceStatus.RUNNING);
 
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        // when
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
+        runtimes.startAsync(workspace, "env-name", false);
     }
 
     @Test
-    public void testCleanup() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
+    public void cancelsWorkspaceStartIfEnvironmentStartIsInterrupted() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        rejectEnvironmentStart(workspace, "env-name", new EnvironmentStartInterruptedException(workspace.getId(), "env-name"));
 
-        runtimes.cleanup();
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
 
-        // when, then
+        captureAndVerifyRuntimeStateAfterInterruption(workspace, cmpFuture);
+    }
+
+    @Test
+    public void failsWorkspaceStartWhenEnvironmentStartIsFailed() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        rejectEnvironmentStart(workspace, "env-name", new EnvironmentException("no no no!"));
+
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+
+        try {
+            captureAsyncTaskAndExecuteSynchronously();
+        } catch (EnvironmentException x) {
+            assertEquals(x.getMessage(), "no no no!");
+            verifyCompletionException(cmpFuture, EnvironmentException.class, "no no no!");
+        }
         assertFalse(runtimes.hasRuntime(workspace.getId()));
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.STOPPED,
+                                   WorkspaceStatus.STARTING,
+                                   EventType.STARTING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STARTING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.ERROR,
+                                   "Start of environment 'env-name' failed. Error: no no no!"));
     }
 
     @Test
-    public void shouldStopRunningWorkspace() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
+    public void interruptsStartAfterEnvironmentIsStartedButRuntimeStatusIsNotRunning() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        // let's say status is changed to STOPPING by stop method,
+        // but starting thread hasn't been interrupted yet
+        allowEnvironmentStart(workspace, "env-name", () -> setRuntime("workspace", WorkspaceStatus.STOPPING));
 
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        // when
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+
+        captureAndVerifyRuntimeStateAfterInterruption(workspace, cmpFuture);
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.STOPPED,
+                                   WorkspaceStatus.STARTING,
+                                   EventType.STARTING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STARTING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.STOPPED,
+                                   null));
+        verify(envEngine).stop(workspace.getId());
+    }
+
+    @Test
+    public void interruptsStartAfterEnvironmentIsStartedButThreadIsInterrupted() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        // the status is successfully updated from STARTING -> RUNNING but after
+        // that thread is interrupted so #stop is waiting for starting thread to stop the environment
+        allowEnvironmentStart(workspace, "env-name", () -> Thread.currentThread().interrupt());
+
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+
+        captureAndVerifyRuntimeStateAfterInterruption(workspace, cmpFuture);
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.STOPPED,
+                                   WorkspaceStatus.STARTING,
+                                   EventType.STARTING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STARTING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.STOPPED,
+                                   null));
+        verify(envEngine).stop(workspace.getId());
+    }
+
+    @Test
+    public void throwsStartInterruptedExceptionWhenStartIsInterruptedAndEnvironmentStopIsFailed() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        // let's say status is changed to STOPPING by stop method,
+        // but starting thread hasn't been interrupted yet
+        allowEnvironmentStart(workspace, "env-name", () -> Thread.currentThread().interrupt());
+        rejectEnvironmentStop(workspace, new ServerException("no!"));
+
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+
+        captureAndVerifyRuntimeStateAfterInterruption(workspace, cmpFuture);
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.STOPPED,
+                                   WorkspaceStatus.STARTING,
+                                   EventType.STARTING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STARTING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.ERROR,
+                                   "no!"));
+        verify(envEngine).stop(workspace.getId());
+    }
+
+    @Test
+    public void releasesClientsWhoWaitForStartTaskResultAndTaskIsCompleted() throws Exception {
+        ExecutorService pool = Executors.newCachedThreadPool();
+        CountDownLatch releasedLatch = new CountDownLatch(5);
+        // this thread + 5 awaiting threads
+        CyclicBarrier callTaskBarrier = new CyclicBarrier(6);
+
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        allowEnvironmentStart(workspace, "env-name");
+
+        // the action
+        runtimes.startAsync(workspace, "env-name", false);
+
+        // register waiters
+        for (int i = 0; i < 5; i++) {
+            WorkspaceRuntimes.StartTask startTask = runtimeStates.get(workspace.getId()).startTask;
+            pool.submit(() -> {
+                // wait all the task to meet this barrier
+                callTaskBarrier.await();
+
+                // wait for start task to finish
+                startTask.await();
+
+                // good, release a part
+                releasedLatch.countDown();
+                return null;
+            });
+        }
+
+        callTaskBarrier.await();
+        captureAsyncTaskAndExecuteSynchronously();
+        try {
+            assertTrue(releasedLatch.await(2, TimeUnit.SECONDS), "start task wait clients are not released");
+        } finally {
+            shutdownAndWaitPool(pool);
+        }
+    }
+
+    @Test
+    public void stopsRunningWorkspace() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING);
+
+        runtimes.stop("workspace");
+
+        verify(envEngine).stop("workspace");
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.RUNNING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.STOPPED,
+                                   null));
+        assertFalse(runtimeStates.containsKey("workspace"));
+    }
+
+    @Test
+    public void stopsTheRunningWorkspaceWhileServerExceptionOccurs() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING);
+        doThrow(new ServerException("no!")).when(envEngine).stop("workspace");
+
+        try {
+            runtimes.stop("workspace");
+        } catch (ServerException x) {
+            assertEquals(x.getMessage(), "no!");
+        }
+
+        verify(envEngine).stop("workspace");
+        assertFalse(runtimeStates.containsKey("workspace"));
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.RUNNING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.ERROR,
+                                   "no!"));
+    }
+
+    @Test
+    public void stopsTheRunningWorkspaceAndRethrowsTheErrorDifferentFromServerException() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING);
+        doThrow(new EnvironmentNotRunningException("no!")).when(envEngine).stop("workspace");
+
+        try {
+            runtimes.stop("workspace");
+        } catch (ServerException x) {
+            assertEquals(x.getMessage(), "no!");
+            assertTrue(x.getCause() instanceof EnvironmentNotRunningException);
+        }
+
+        verify(envEngine).stop("workspace");
+        assertFalse(runtimeStates.containsKey("workspace"));
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.RUNNING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.ERROR,
+                                   "no!"));
+    }
+
+    @Test
+    public void cancellationOfPendingStartTask() throws Throwable {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        when(sharedPool.submit(any())).thenReturn(Futures.immediateFuture(null));
+
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+
+        // the real start is not being executed, fake sharedPool suppressed it
+        // so the situation is the same to the one if the task is cancelled before
+        // executor service started executing it
         runtimes.stop(workspace.getId());
 
-        // then
-        assertFalse(runtimes.hasRuntime(workspace.getId()));
+        // start awaiting clients MUST receive interruption
+        try {
+            cmpFuture.get();
+        } catch (ExecutionException x) {
+            verifyCompletionException(cmpFuture,
+                                      EnvironmentStartInterruptedException.class,
+                                      "Start of environment 'env-name' in workspace 'workspace' is interrupted");
+        }
+
+        // if there is a state when the future is being cancelled,
+        // and start task is marked as used, executor must not execute the
+        // task but throw cancellation exception instead, once start task is
+        // completed clients receive interrupted exception and cancellation doesn't bother them
+        try {
+            captureAsyncTaskAndExecuteSynchronously();
+        } catch (CancellationException cancelled) {
+            assertEquals(cancelled.getMessage(), "Start of the workspace 'workspace' was cancelled");
+        }
+
+        verifyEventsSequence(event("workspace",
+                                   WorkspaceStatus.STOPPED,
+                                   WorkspaceStatus.STARTING,
+                                   EventType.STARTING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STARTING,
+                                   WorkspaceStatus.STOPPING,
+                                   EventType.STOPPING,
+                                   null),
+                             event("workspace",
+                                   WorkspaceStatus.STOPPING,
+                                   WorkspaceStatus.STOPPED,
+                                   EventType.STOPPED,
+                                   null));
+    }
+
+    @Test
+    public void cancellationOfRunningStartTask() throws Exception {
+        setRuntime("workspace",
+                   WorkspaceStatus.STARTING,
+                   "env-name",
+                   runtimeFuture,
+                   startTask);
+        doThrow(new EnvironmentStartInterruptedException("workspace", "env-name")).when(startTask).await();
+
+        runtimes.stop("workspace");
+
+        verify(runtimeFuture).cancel(true);
+        verify(startTask).await();
     }
 
     @Test(expectedExceptions = NotFoundException.class,
-          expectedExceptionsMessageRegExp = "Workspace with id 'workspace123' is not running.")
-    public void shouldThrowNotFoundExceptionWhenStoppingWorkspaceWhichDoesNotHaveRuntime() throws Exception {
-        runtimes.stop(WORKSPACE_ID);
+          expectedExceptionsMessageRegExp = "Workspace with id 'workspace' is not running")
+    public void throwsNotFoundExceptionWhenStoppingNotRunningWorkspace() throws Exception {
+        runtimes.stop("workspace");
+    }
+
+    @Test(expectedExceptions = ConflictException.class,
+          expectedExceptionsMessageRegExp = "Couldn't stop the workspace 'workspace' because its status is '.*'.*",
+          dataProvider = "notAllowedToStopStatuses")
+    public void doesNotStopTheWorkspaceWhenStatusIsWrong(WorkspaceStatus status) throws Exception {
+        setRuntime("workspace", status);
+
+        runtimes.stop("workspace");
     }
 
     @Test
-    public void startedRuntimeShouldBeTheSameToRuntimeTakenFromGetMethod() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
+    public void cleanup() throws Exception {
+        setRuntime("workspace", WorkspaceStatus.RUNNING, "env-name");
 
-        // when
-        RuntimeDescriptor descriptorFromStartMethod = runtimes.start(workspace,
-                                                                     workspace.getConfig().getDefaultEnv(),
-                                                                     false);
-        RuntimeDescriptor descriptorFromGetMethod = runtimes.get(workspace.getId());
+        runtimes.cleanup();
 
-        // then
-        assertEquals(descriptorFromStartMethod,
-                     descriptorFromGetMethod);
+        assertFalse(runtimes.hasRuntime("workspace"));
+        verify(envEngine).stop("workspace");
     }
 
     @Test
-    public void startingEventShouldBePublishedBeforeStart() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
+    public void startedRuntimeAndReturnedFromGetMethodAreTheSame() throws Exception {
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        allowEnvironmentStart(workspace, "env-name");
+        prepareMachines(workspace.getId(), "env-name");
 
-        // when
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
+        CompletableFuture<WorkspaceRuntimeImpl> cmpFuture = runtimes.startAsync(workspace, "env-name", false);
+        captureAsyncTaskAndExecuteSynchronously();
 
-        // then
-        verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                               .withWorkspaceId(workspace.getId())
-                                               .withStatus(WorkspaceStatus.STARTING)
-                                               .withEventType(EventType.STARTING)
-                                               .withPrevStatus(WorkspaceStatus.STOPPED));
-    }
-
-    @Test
-    public void runningEventShouldBePublishedAfterEnvStart() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-
-        // when
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-
-        // then
-        verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                               .withStatus(WorkspaceStatus.RUNNING)
-                                               .withWorkspaceId(workspace.getId())
-                                               .withEventType(EventType.RUNNING)
-                                               .withPrevStatus(WorkspaceStatus.STARTING));
-    }
-
-    @Test
-    public void errorEventShouldBePublishedIfDevMachineFailedToStart() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        when(envEngine.start(anyString(),
-                             anyString(),
-                             any(Environment.class),
-                             anyBoolean(),
-                             any()))
-                .thenReturn(singletonList(createMachine(false)));
-
-        try {
-            // when
-            runtimes.start(workspace,
-                           workspace.getConfig().getDefaultEnv(),
-                           false);
-
-        } catch (Exception e) {
-            // then
-            verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                                   .withWorkspaceId(workspace.getId())
-                                                   .withEventType(EventType.ERROR)
-                                                   .withPrevStatus(WorkspaceStatus.STARTING));
-        }
-    }
-
-    @Test
-    public void stoppingEventShouldBePublishedBeforeStop() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-
-        // when
-        runtimes.stop(workspace.getId());
-
-        // then
-        verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                               .withStatus(WorkspaceStatus.STOPPING)
-                                               .withWorkspaceId(workspace.getId())
-                                               .withEventType(EventType.STOPPING)
-                                               .withPrevStatus(WorkspaceStatus.RUNNING));
-    }
-
-    @Test
-    public void stoppedEventShouldBePublishedAfterEnvStop() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-
-        // when
-        runtimes.stop(workspace.getId());
-
-        // then
-        verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                               .withStatus(WorkspaceStatus.STOPPED)
-                                               .withWorkspaceId(workspace.getId())
-                                               .withEventType(EventType.STOPPED)
-                                               .withPrevStatus(WorkspaceStatus.STOPPING));
-    }
-
-    @Test
-    public void errorEventShouldBePublishedIfEnvFailedToStop() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-
-        try {
-            // when
-            runtimes.stop(workspace.getId());
-        } catch (Exception e) {
-            // then
-            verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                                   .withWorkspaceId(workspace.getId())
-                                                   .withEventType(EventType.ERROR)
-                                                   .withPrevStatus(WorkspaceStatus.STOPPING)
-                                                   .withError("Test error"));
-        }
+        assertEquals(cmpFuture.get(), runtimes.getRuntime(workspace.getId()));
     }
 
     @Test
     public void shouldBeAbleToStartMachine() throws Exception {
         // when
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        MachineConfigImpl config = createConfig(false);
+        setRuntime("workspace", WorkspaceStatus.RUNNING, "env-name");
+        MachineConfig config = newMachine("workspace", "env-name", "new", false).getConfig();
         Instance instance = mock(Instance.class);
         when(envEngine.startMachine(anyString(), any(MachineConfig.class), any())).thenReturn(instance);
         when(instance.getConfig()).thenReturn(config);
 
         // when
-        Instance actual = runtimes.startMachine(workspace.getId(), config);
+        Instance actual = runtimes.startMachine("workspace", config);
 
         // then
         assertEquals(actual, instance);
-        verify(envEngine).startMachine(eq(workspace.getId()), eq(config), any());
-    }
-
-    @Test
-    public void shouldAddTerminalAgentOnMachineStart() throws Exception {
-        // when
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        MachineConfigImpl config = createConfig(false);
-        Instance instance = mock(Instance.class);
-        when(envEngine.startMachine(anyString(), any(MachineConfig.class), any())).thenReturn(instance);
-        when(instance.getConfig()).thenReturn(config);
-
-        // when
-        Instance actual = runtimes.startMachine(workspace.getId(), config);
-
-        // then
-        assertEquals(actual, instance);
-        verify(envEngine).startMachine(eq(workspace.getId()),
-                                       eq(config),
-                                       eq(singletonList("org.eclipse.che.terminal")));
-        verify(runtimes).launchAgents(instance, singletonList("org.eclipse.che.terminal"));
+        verify(envEngine).startMachine(eq("workspace"), eq(config), any());
     }
 
     @Test(expectedExceptions = NotFoundException.class,
           expectedExceptionsMessageRegExp = "Workspace with id '.*' is not running")
     public void shouldNotStartMachineIfEnvironmentIsNotRunning() throws Exception {
         // when
-        MachineConfigImpl config = createConfig(false);
-
-        // when
-        runtimes.startMachine("someWsID", config);
+        runtimes.startMachine("someWsID", mock(MachineConfig.class));
 
         // then
         verify(envEngine, never()).startMachine(anyString(), any(MachineConfig.class), any());
@@ -484,16 +623,13 @@ public class WorkspaceRuntimesTest {
     @Test
     public void shouldBeAbleToStopMachine() throws Exception {
         // when
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
+        setRuntime("workspace", WorkspaceStatus.RUNNING);
 
         // when
-        runtimes.stopMachine(workspace.getId(), "testMachineId");
+        runtimes.stopMachine("workspace", "testMachineId");
 
         // then
-        verify(envEngine).stopMachine(workspace.getId(), "testMachineId");
+        verify(envEngine).stopMachine("workspace", "testMachineId");
     }
 
     @Test(expectedExceptions = NotFoundException.class,
@@ -509,112 +645,50 @@ public class WorkspaceRuntimesTest {
     @Test
     public void shouldBeAbleToGetMachine() throws Exception {
         // given
-        Instance expected = createMachine(false);
-        when(envEngine.getMachine(WORKSPACE_ID, expected.getId())).thenReturn(expected);
+        Instance expected = newMachine("workspace", "env-name", "existing", false);
+        when(envEngine.getMachine("workspace", expected.getId())).thenReturn(expected);
 
         // when
-        Instance actualMachine = runtimes.getMachine(WORKSPACE_ID, expected.getId());
+        Instance actualMachine = runtimes.getMachine("workspace", expected.getId());
 
         // then
         assertEquals(actualMachine, expected);
-        verify(envEngine).getMachine(WORKSPACE_ID, expected.getId());
-    }
-
-    @Test
-    public void shouldBeAbleToGetStatusOfRunningWorkspace() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-
-        // when
-        WorkspaceStatus status = runtimes.getStatus(workspace.getId());
-
-        // then
-        assertEquals(status, RUNNING);
-    }
-
-
-    @Test
-    public void shouldBeAbleToGetStatusOfStoppedWorkspace() throws Exception {
-        // given
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        runtimes.stop(workspace.getId());
-
-        // when
-        WorkspaceStatus status = runtimes.getStatus(workspace.getId());
-
-        // then
-        assertEquals(status, STOPPED);
+        verify(envEngine).getMachine("workspace", expected.getId());
     }
 
     @Test(expectedExceptions = NotFoundException.class,
           expectedExceptionsMessageRegExp = "test exception")
     public void shouldThrowExceptionIfGetMachineFromEnvEngineThrowsException() throws Exception {
         // given
-        Instance expected = createMachine(false);
-        when(envEngine.getMachine(WORKSPACE_ID, expected.getId()))
+        Instance expected = newMachine("workspace", "env-name", "existing", false);
+        when(envEngine.getMachine("workspace", expected.getId()))
                 .thenThrow(new NotFoundException("test exception"));
 
         // when
-        runtimes.getMachine(WORKSPACE_ID, expected.getId());
+        runtimes.getMachine("workspace", expected.getId());
 
         // then
-        verify(envEngine).getMachine(WORKSPACE_ID, expected.getId());
-    }
-
-    @Test
-    public void shouldBeAbleToGetAllWorkspacesWithExistingRuntime() throws Exception {
-        // then
-        Map<String, WorkspaceRuntimes.WorkspaceState> expectedWorkspaces = new HashMap<>();
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace,
-                       workspace.getConfig().getDefaultEnv(),
-                       false);
-        expectedWorkspaces.put(workspace.getId(),
-                               new WorkspaceRuntimes.WorkspaceState(RUNNING,
-                                                                    workspace.getConfig().getDefaultEnv()));
-        WorkspaceImpl workspace2 = spy(createWorkspace());
-        when(workspace2.getId()).thenReturn("testWsId");
-        when(envEngine.getMachines(workspace2.getId()))
-                .thenReturn(Collections.singletonList(createMachine(true)));
-        runtimes.start(workspace2,
-                       workspace2.getConfig().getDefaultEnv(),
-                       false);
-        expectedWorkspaces.put(workspace2.getId(),
-                               new WorkspaceRuntimes.WorkspaceState(RUNNING,
-                                                                    workspace2.getConfig().getDefaultEnv()));
-
-        // when
-        Map<String, WorkspaceRuntimes.WorkspaceState> actualWorkspaces = runtimes.getWorkspaces();
-
-        // then
-        assertEquals(actualWorkspaces, expectedWorkspaces);
+        verify(envEngine).getMachine("workspace", expected.getId());
     }
 
     @Test
     public void changesStatusFromRunningToSnapshotting() throws Exception {
-        final WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace, workspace.getConfig().getDefaultEnv(), false);
+        setRuntime("workspace", WorkspaceStatus.RUNNING);
 
-        runtimes.snapshotAsync(workspace.getId());
+        runtimes.snapshotAsync("workspace");
 
-        assertEquals(runtimes.get(workspace.getId()).getRuntimeStatus(), WorkspaceStatus.SNAPSHOTTING);
+        assertEquals(runtimes.getStatus("workspace"), WorkspaceStatus.SNAPSHOTTING);
     }
 
     @Test
     public void changesStatusFromSnapshottingToRunning() throws Exception {
-        final WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace, workspace.getConfig().getDefaultEnv(), false);
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        setRuntime(workspace.getId(), WorkspaceStatus.RUNNING, "env-name");
 
         runtimes.snapshotAsync(workspace.getId());
 
         captureAsyncTaskAndExecuteSynchronously();
-        assertEquals(runtimes.get(workspace.getId()).getRuntimeStatus(), WorkspaceStatus.RUNNING);
+        assertEquals(runtimes.getStatus(workspace.getId()), WorkspaceStatus.RUNNING);
     }
 
     @Test(expectedExceptions = NotFoundException.class,
@@ -626,41 +700,40 @@ public class WorkspaceRuntimesTest {
     @Test(expectedExceptions = ConflictException.class,
           expectedExceptionsMessageRegExp = "Workspace with id '.*' is not 'RUNNING', it's status is 'SNAPSHOTTING'")
     public void throwsConflictExceptionWhenBeginningSnapshottingForNotRunningWorkspace() throws Exception {
-        final WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace, workspace.getConfig().getDefaultEnv(), false);
+        setRuntime("workspace", WorkspaceStatus.RUNNING);
 
-        runtimes.snapshotAsync(workspace.getId());
-        runtimes.snapshotAsync(workspace.getId());
+        runtimes.snapshotAsync("workspace");
+        runtimes.snapshotAsync("workspace");
     }
 
     @Test(expectedExceptions = ServerException.class, expectedExceptionsMessageRegExp = "can't save")
     public void failsToCreateSnapshotWhenDevMachineSnapshottingFailed() throws Exception {
-        final WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace, workspace.getConfig().getDefaultEnv(), false);
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        setRuntime(workspace.getId(), WorkspaceStatus.RUNNING);
+        prepareMachines(workspace.getId(), "env-name");
         when(envEngine.saveSnapshot(any(), any())).thenThrow(new ServerException("can't save"));
 
         try {
             runtimes.snapshot(workspace.getId());
         } catch (Exception x) {
-            verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                                   .withWorkspaceId(workspace.getId())
-                                                   .withStatus(WorkspaceStatus.SNAPSHOTTING)
-                                                   .withPrevStatus(WorkspaceStatus.RUNNING)
-                                                   .withEventType(EventType.SNAPSHOT_CREATING));
-            verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                                   .withWorkspaceId(workspace.getId())
-                                                   .withError("can't save")
-                                                   .withStatus(WorkspaceStatus.RUNNING)
-                                                   .withPrevStatus(WorkspaceStatus.SNAPSHOTTING)
-                                                   .withEventType(EventType.SNAPSHOT_CREATION_ERROR));
+            verifyEventsSequence(event(workspace.getId(),
+                                       WorkspaceStatus.RUNNING,
+                                       WorkspaceStatus.SNAPSHOTTING,
+                                       EventType.SNAPSHOT_CREATING,
+                                       null),
+                                 event(workspace.getId(),
+                                       WorkspaceStatus.SNAPSHOTTING,
+                                       WorkspaceStatus.RUNNING,
+                                       EventType.SNAPSHOT_CREATION_ERROR,
+                                       "can't save"));
             throw x;
         }
     }
 
-    @Test(expectedExceptions = ServerException.class, expectedExceptionsMessageRegExp = "test")
+    @Test
     public void removesNewlyCreatedSnapshotsWhenFailedToSaveTheirsMetadata() throws Exception {
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace, workspace.getConfig().getDefaultEnv(), false);
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        setRuntime(workspace.getId(), WorkspaceStatus.RUNNING, "env-name");
         doThrow(new SnapshotException("test")).when(snapshotDao)
                                               .replaceSnapshots(any(), any(), any());
         SnapshotImpl snapshot = mock(SnapshotImpl.class);
@@ -668,101 +741,283 @@ public class WorkspaceRuntimesTest {
 
         try {
             runtimes.snapshot(workspace.getId());
-        } catch (Exception x) {
-            verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                                   .withStatus(WorkspaceStatus.SNAPSHOTTING)
-                                                   .withEventType(EventType.SNAPSHOT_CREATING)
-                                                   .withPrevStatus(WorkspaceStatus.RUNNING)
-                                                   .withWorkspaceId(workspace.getId()));
-            verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                                   .withStatus(WorkspaceStatus.RUNNING)
-                                                   .withEventType(EventType.SNAPSHOT_CREATION_ERROR)
-                                                   .withWorkspaceId(workspace.getId())
-                                                   .withPrevStatus(WorkspaceStatus.SNAPSHOTTING)
-                                                   .withError("test"));
-            verify(snapshotDao).replaceSnapshots(any(),
-                                                 any(),
-                                                 snapshotsCaptor.capture());
-            verify(envEngine, times(snapshotsCaptor.getValue().size())).removeSnapshot(snapshot);
-            throw x;
+        } catch (ServerException x) {
+            assertEquals(x.getMessage(), "test");
         }
+
+        verify(snapshotDao).replaceSnapshots(any(), any(), snapshotsCaptor.capture());
+        verify(envEngine, times(snapshotsCaptor.getValue().size())).removeSnapshot(snapshot);
+        verifyEventsSequence(event(workspace.getId(),
+                                   WorkspaceStatus.RUNNING,
+                                   WorkspaceStatus.SNAPSHOTTING,
+                                   EventType.SNAPSHOT_CREATING,
+                                   null),
+                             event(workspace.getId(),
+                                   WorkspaceStatus.SNAPSHOTTING,
+                                   WorkspaceStatus.RUNNING,
+                                   EventType.SNAPSHOT_CREATION_ERROR,
+                                   "test"));
     }
 
     @Test
     public void removesOldSnapshotsWhenNewSnapshotsMetadataSuccessfullySaved() throws Exception {
-        WorkspaceImpl workspace = createWorkspace();
-        runtimes.start(workspace, workspace.getConfig().getDefaultEnv(), false);
+        WorkspaceImpl workspace = newWorkspace("workspace", "env-name");
+        setRuntime(workspace.getId(), WorkspaceStatus.RUNNING);
         SnapshotImpl oldSnapshot = mock(SnapshotImpl.class);
         doReturn((singletonList(oldSnapshot))).when(snapshotDao)
                                               .replaceSnapshots(any(), any(), any());
 
         runtimes.snapshot(workspace.getId());
 
-        verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                               .withStatus(WorkspaceStatus.SNAPSHOTTING)
-                                               .withEventType(EventType.SNAPSHOT_CREATING)
-                                               .withPrevStatus(WorkspaceStatus.RUNNING)
-                                               .withWorkspaceId(workspace.getId()));
-        verify(eventService).publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                               .withStatus(WorkspaceStatus.RUNNING)
-                                               .withEventType(EventType.SNAPSHOT_CREATED)
-                                               .withPrevStatus(WorkspaceStatus.SNAPSHOTTING)
-                                               .withWorkspaceId(workspace.getId()));
         verify(envEngine).removeSnapshot(oldSnapshot);
+        verifyEventsSequence(event(workspace.getId(),
+                                   WorkspaceStatus.RUNNING,
+                                   WorkspaceStatus.SNAPSHOTTING,
+                                   EventType.SNAPSHOT_CREATING,
+                                   null),
+                             event(workspace.getId(),
+                                   WorkspaceStatus.SNAPSHOTTING,
+                                   WorkspaceStatus.RUNNING,
+                                   EventType.SNAPSHOT_CREATED,
+                                   null));
     }
 
-    private static Instance createMachine(boolean isDev) {
-        return createMachine(createConfig(isDev));
+    @Test
+    public void getsRuntimesIds() {
+        setRuntime("workspace1", WorkspaceStatus.STARTING);
+        setRuntime("workspace2", WorkspaceStatus.RUNNING);
+        setRuntime("workspace3", WorkspaceStatus.STOPPING);
+        setRuntime("workspace4", WorkspaceStatus.SNAPSHOTTING);
+
+        assertEquals(runtimes.getRuntimesIds(), Sets.newHashSet("workspace1",
+                                                                "workspace2",
+                                                                "workspace3",
+                                                                "workspace4"));
     }
 
-    private static Instance createMachine(MachineConfig cfg) {
-        return new TestMachineInstance(MachineImpl.builder()
-                                                  .setId(NameGenerator.generate("machine", 10))
-                                                  .setWorkspaceId(WORKSPACE_ID)
-                                                  .setEnvName(ENV_NAME)
-                                                  .setConfig(new MachineConfigImpl(cfg))
-                                                  .build());
-    }
-
-    private static MachineConfigImpl createConfig(boolean isDev) {
-        return MachineConfigImpl.builder()
-                                .setDev(isDev)
-                                .setType("docker")
-                                .setLimits(new MachineLimitsImpl(1024))
-                                .setSource(new MachineSourceImpl("git").setLocation("location"))
-                                .setName(UUID.randomUUID().toString())
-                                .build();
-    }
-
-    private static WorkspaceImpl createWorkspace() {
-        EnvironmentImpl environment = new EnvironmentImpl(null,
-                                                          null);
-        WorkspaceConfigImpl wsConfig = WorkspaceConfigImpl.builder()
-                                                          .setName("test workspace")
-                                                          .setEnvironments(singletonMap(ENV_NAME, environment))
-                                                          .setDefaultEnv(ENV_NAME)
-                                                          .build();
-        return new WorkspaceImpl(WORKSPACE_ID, new AccountImpl("accountId", "user123", "test"), wsConfig);
-    }
-
-    @SuppressWarnings("unchecked")
     private void captureAsyncTaskAndExecuteSynchronously() throws Exception {
         verify(sharedPool).submit(taskCaptor.capture());
         taskCaptor.getValue().call();
     }
 
-    private static class TestMachineInstance extends NoOpMachineInstance {
 
-        MachineRuntimeInfoImpl runtime;
-
-        public TestMachineInstance(Machine machine) {
-            super(machine);
-            runtime = mock(MachineRuntimeInfoImpl.class);
+    private void captureAndVerifyRuntimeStateAfterInterruption(Workspace workspace,
+                                                               CompletableFuture<WorkspaceRuntimeImpl> cmpFuture) throws Exception {
+        try {
+            captureAsyncTaskAndExecuteSynchronously();
+        } catch (EnvironmentStartInterruptedException x) {
+            String expectedMessage = "Start of environment 'env-name' in workspace 'workspace' is interrupted";
+            assertEquals(x.getMessage(), expectedMessage);
+            verifyCompletionException(cmpFuture, EnvironmentStartInterruptedException.class, expectedMessage);
         }
+        assertFalse(runtimes.hasRuntime(workspace.getId()));
+    }
 
-        @Override
-        public MachineRuntimeInfoImpl getRuntime() {
-            return runtime;
+    private void verifyCompletionException(Future<?> f, Class<? extends Exception> expectedEx, String expectedMessage) {
+        assertTrue(f.isDone());
+        try {
+            f.get();
+        } catch (ExecutionException execEx) {
+            if (expectedEx.isInstance(execEx.getCause())) {
+                assertEquals(execEx.getCause().getMessage(), expectedMessage);
+            } else {
+                fail(execEx.getMessage(), execEx);
+            }
+        } catch (InterruptedException interruptedEx) {
+            fail(interruptedEx.getMessage(), interruptedEx);
         }
+    }
+
+    private void verifyEventsSequence(WorkspaceStatusEvent... expected) {
+        Iterator<WorkspaceStatusEvent> it = captureEvents().iterator();
+        for (WorkspaceStatusEvent expEvent : expected) {
+            if (!it.hasNext()) {
+                fail(format("It is expected to receive the status changed event '%s' -> '%s' " +
+                            "but there are no more events published",
+                            expEvent.getPrevStatus(),
+                            expEvent.getStatus()));
+            }
+            WorkspaceStatusEvent cur = it.next();
+            if (cur.getPrevStatus() != expEvent.getPrevStatus() || cur.getStatus() != expEvent.getStatus()) {
+                fail(format("Expected to receive status change '%s' -> '%s', while received '%s' -> '%s'",
+                            expEvent.getPrevStatus(),
+                            expEvent.getStatus(),
+                            cur.getPrevStatus(),
+                            cur.getStatus()));
+            }
+            assertEquals(cur, expEvent);
+        }
+        if (it.hasNext()) {
+            WorkspaceStatusEvent next = it.next();
+            fail(format("No more events expected, but received '%s' -> '%s'",
+                        next.getPrevStatus(),
+                        next.getStatus()));
+        }
+    }
+
+    private static WorkspaceStatusEvent event(String workspaceId,
+                                              WorkspaceStatus prevStatus,
+                                              WorkspaceStatus status,
+                                              EventType eventType,
+                                              String error) {
+        return DtoFactory.newDto(WorkspaceStatusEvent.class)
+                         .withWorkspaceId(workspaceId)
+                         .withStatus(status)
+                         .withPrevStatus(prevStatus)
+                         .withEventType(eventType)
+                         .withError(error);
+    }
+
+    private List<WorkspaceStatusEvent> captureEvents() {
+        verify(eventService, atLeastOnce()).publish(eventCaptor.capture());
+        return eventCaptor.getAllValues();
+    }
+
+    private void setRuntime(String workspaceId, WorkspaceStatus status) {
+        runtimeStates.put(workspaceId, new RuntimeState(status, null, null, null));
+    }
+
+    private void setRuntime(String workspaceId, WorkspaceStatus status, String envName) {
+        runtimeStates.put(workspaceId, new RuntimeState(status, envName, null, null));
+    }
+
+    private void setRuntime(String workspaceId,
+                            WorkspaceStatus status,
+                            String envName,
+                            Future<WorkspaceRuntimeImpl> startFuture,
+                            WorkspaceRuntimes.StartTask startTask) {
+        runtimeStates.put(workspaceId, new RuntimeState(status, envName, startTask, startFuture));
+    }
+
+    private void setNoMachinesForWorkspace(String workspaceId) throws EnvironmentNotRunningException {
+        when(envEngine.getMachines(workspaceId)).thenThrow(new EnvironmentNotRunningException(""));
+    }
+
+    private List<Instance> allowEnvironmentStart(Workspace workspace,
+                                                 String envName,
+                                                 TestAction beforeReturn) throws Exception {
+        Environment environment = workspace.getConfig().getEnvironments().get(envName);
+        ArrayList<Instance> machines = new ArrayList<>(environment.getMachines().size());
+        for (Map.Entry<String, ? extends ExtendedMachine> entry : environment.getMachines().entrySet()) {
+            machines.add(newMachine(workspace.getId(),
+                                    envName,
+                                    entry.getKey(),
+                                    entry.getValue().getAgents().contains("org.eclipse.che.ws-agent")));
+        }
+        when(envEngine.start(eq(workspace.getId()),
+                             eq(envName),
+                             eq(workspace.getConfig().getEnvironments().get(envName)),
+                             anyBoolean(),
+                             any(),
+                             any())).thenAnswer(invocation -> {
+            if (beforeReturn != null) {
+                beforeReturn.call();
+            }
+            return machines;
+        });
+        return machines;
+    }
+
+    private List<Instance> allowEnvironmentStart(Workspace workspace, String envName) throws Exception {
+        return allowEnvironmentStart(workspace, envName, null);
+    }
+
+    private void rejectEnvironmentStart(Workspace workspace, String envName, Exception x) throws Exception {
+        when(envEngine.start(eq(workspace.getId()),
+                             eq(envName),
+                             eq(workspace.getConfig().getEnvironments().get(envName)),
+                             anyBoolean(),
+                             any(),
+                             any())).thenThrow(x);
+    }
+
+    private void rejectEnvironmentStop(Workspace workspace, Exception x) throws Exception {
+        doThrow(x).when(envEngine).stop(workspace.getId());
+    }
+
+    private List<Instance> prepareMachines(String workspaceId, String envName) throws EnvironmentNotRunningException {
+        List<Instance> machines = new ArrayList<>(3);
+        machines.add(newMachine(workspaceId, envName, "machine1", true));
+        machines.add(newMachine(workspaceId, envName, "machine2", false));
+        machines.add(newMachine(workspaceId, envName, "machine3", false));
+        prepareMachines(workspaceId, machines);
+        return machines;
+    }
+
+    private void prepareMachines(String workspaceId, List<Instance> machines) throws EnvironmentNotRunningException {
+        when(envEngine.getMachines(workspaceId)).thenReturn(machines);
+    }
+
+    private Instance newMachine(String workspaceId, String envName, String name, boolean isDev) {
+        MachineImpl machine = MachineImpl.builder()
+                                         .setConfig(MachineConfigImpl.builder()
+                                                                     .setDev(isDev)
+                                                                     .setName(name)
+                                                                     .setType("docker")
+                                                                     .setSource(new MachineSourceImpl("type"))
+                                                                     .setLimits(new MachineLimitsImpl(1024))
+                                                                     .build())
+                                         .setWorkspaceId(workspaceId)
+                                         .setEnvName(envName)
+                                         .setOwner("owner")
+                                         .setRuntime(new MachineRuntimeInfoImpl(Collections.emptyMap(),
+                                                                                Collections.emptyMap(),
+                                                                                Collections.emptyMap()))
+                                         .setStatus(MachineStatus.RUNNING)
+                                         .build();
+        return new NoOpMachineInstance(machine);
+    }
+
+    private WorkspaceImpl newWorkspace(String workspaceId, String envName) {
+        EnvironmentImpl environment = new EnvironmentImpl();
+        Map<String, ExtendedMachineImpl> machines = environment.getMachines();
+        machines.put("dev", new ExtendedMachineImpl(Arrays.asList("org.eclipse.che.terminal",
+                                                                  "org.eclipse.che.ws-agent"),
+                                                    Collections.emptyMap(),
+                                                    Collections.emptyMap()));
+        machines.put("db", new ExtendedMachineImpl(singletonList("org.eclipse.che.terminal"),
+                                                   Collections.emptyMap(),
+                                                   Collections.emptyMap()));
+        return WorkspaceImpl.builder()
+                            .setId(workspaceId)
+                            .setTemporary(false)
+                            .setConfig(WorkspaceConfigImpl.builder()
+                                                          .setName("test-workspace")
+                                                          .setDescription("this is test workspace")
+                                                          .setDefaultEnv(envName)
+                                                          .setEnvironments(ImmutableMap.of(envName,
+                                                                                           environment))
+                                                          .build())
+                            .build();
+    }
+
+    private void shutdownAndWaitPool(ExecutorService pool) throws InterruptedException {
+        pool.shutdownNow();
+        if (!pool.awaitTermination(10, TimeUnit.SECONDS)) {
+            fail("Can't shutdown test pool");
+        }
+    }
+
+    @FunctionalInterface
+    private interface TestAction {
+        void call() throws Exception;
+    }
+
+    @DataProvider
+    private static Object[][] allStatuses() {
+        WorkspaceStatus[] values = WorkspaceStatus.values();
+        WorkspaceStatus[][] result = new WorkspaceStatus[values.length][1];
+        for (int i = 0; i < values.length; i++) {
+            result[i][0] = values[i];
+        }
+        return result;
+    }
+
+    @DataProvider
+    private static Object[][] notAllowedToStopStatuses() {
+        return new WorkspaceStatus[][] {
+                {WorkspaceStatus.STOPPING},
+                {WorkspaceStatus.SNAPSHOTTING}
+        };
     }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -798,7 +798,7 @@ public class WorkspaceServiceTest {
                                                .get(workspace.getConfig().getDefaultEnv());
         assertNotNull(environment);
 
-        final WorkspaceRuntimeImpl runtime = new WorkspaceRuntimeImpl(workspace.getConfig().getDefaultEnv());
+        final WorkspaceRuntimeImpl runtime = new WorkspaceRuntimeImpl(workspace.getConfig().getDefaultEnv(), null);
         MachineConfigImpl devMachineConfig = MachineConfigImpl.builder()
                                                               .setDev(true)
                                                               .setEnvVariables(emptyMap())

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
@@ -42,6 +42,7 @@ import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
+import org.eclipse.che.api.workspace.server.WorkspaceSharedPool;
 import org.eclipse.che.api.workspace.server.event.BeforeWorkspaceRemovedEvent;
 import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao.RemoveSnapshotsBeforeWorkspaceRemovedEventSubscriber;
 import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao.RemoveWorkspaceBeforeAccountRemovedEventSubscriber;
@@ -142,6 +143,7 @@ public class CascadeRemovalTest {
                 bind(AccountManager.class);
                 bind(Boolean.class).annotatedWith(Names.named("che.workspace.auto_snapshot")).toInstance(false);
                 bind(Boolean.class).annotatedWith(Names.named("che.workspace.auto_restore")).toInstance(false);
+                bind(WorkspaceSharedPool.class).toInstance(new WorkspaceSharedPool("cached", null, null));
             }
         });
 


### PR DESCRIPTION
Allows to cancel workspace start on the API level.

Allows to do things described by #3249, fixes #3742.

Implementation is based on deterministic points of time when components can check whether starting process is interrupted and react appropriately.  The components like `WorkspaceRuntimes` & `CheEnvironmentEngine` are refactored to respect cancellation of starting thread. The other components are refactored to propagate interruption correctly, e.g. `DockerConnector` didn't propagate interrupted flag. So when we start the workspace starting task is saved and we keep it until workspace is started. If the task is canceled within thread interruption e.g. `future.cancel(true)` start task tries to stop the execution and cleanup corresponding resources. The caller of start(e.g. `WorkspaceManager`) will receive `EnvironmentStartInterruptedException` and may do whatever it needs to, for now workspace manager logs the info message that workspace start was directly interrupted and considers it as a normal behaviour.

`WorkspaceRuntimes#startAsync` now returns `CompletableFuture<WorkspaceRuntime>`
instead of regular `Future` which allows to handle start result in the same thread and reduces amount of threads needed for start. Also`WorkspaceRuntimes` doesn't expose `RuntimeDescriptor` anymore, it provides methods for getting & filling workspace with runtime information instead:
- getStatus(workspaceId) - gets status
- getRuntime(workspaceId) - gets  runtime
- injectRuntime(workspace) - injects status + runtime into workspace

`WorkspaceRuntimes#getWorkspaces` is removed as it's not used and it deals
with stale workspace statuses which is not good.
      
Agents now launched after a single machine is launched that allows to fail
faster if there is an error that doesn't allow to start the machine. In current version
of che agents are launched after all the machines are launched.

Also there are new properties for workspace pool adjustment, allows to configure
workspace starting queue dynamically. The properties are:
   - `che.workspace.pool.type` possible values are _fixed_, _cached_
   - `che.workspace.pool.exact_size` optional. This property is ignored when pool type is different from _fixed_. Configures the exact size of the pool, if it's set multiplier property is ignored.
If this property is not set(0, < 0, NULL) then pool sized to number of cores, it can be modified
within multiplier property
   - `che.workspace.pool.cores_multiplier` optional. This property is ignored when pool type is different from _fixed_ or exact pool size is set. If it's set the pool size will be `N_CORES * multiplier`