### PR TITLE
[OpenShiftConnector] Minor fixes following rebase

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2016 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Codenvy, S.A.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/test/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjectorTest.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/test/java/org/eclipse/che/ide/ext/machine/server/ssh/KeysInjectorTest.java
@@ -122,8 +122,7 @@ public class KeysInjectorTest {
         keysInjector = new KeysInjector(eventService,
                                         new MockConnectorProvider(),
                                         sshManager,
-                                        environmentEngine,
-                                        userManager);
+                                        environmentEngine);
 
         keysInjector.start();
         verify(eventService).subscribe(subscriberCaptor.capture());


### PR DESCRIPTION
Fixes two minor issues resulting from rebase.
1) Compilation error in KeysInjectorTest, caused by change in constructor signature for KeysInjector (commit [5266cd9](https://github.com/eclipse/che/commit/5266cd9))
2) Update copyright year on DockerConnectorProvider

