### PR TITLE
Remove deprecated method getMediaType

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/File.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/File.java
@@ -36,10 +36,6 @@ public interface File extends Resource, VirtualFile, ModificationTracker {
     @Override
     String getDisplayName();
 
-    /** @see VirtualFile#getMediaType() */
-    @Override
-    String getMediaType();
-
     /** @see VirtualFile#isReadOnly() */
     @Override
     boolean isReadOnly();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/SyntheticFile.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/SyntheticFile.java
@@ -61,11 +61,6 @@ public class SyntheticFile implements VirtualFile {
     }
 
     @Override
-    public String getMediaType() {
-        return null;
-    }
-
-    @Override
     public boolean isReadOnly() {
         return true;
     }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/VirtualFile.java
@@ -55,16 +55,6 @@ public interface VirtualFile {
     String getDisplayName();
 
     /**
-     * Returns media type for the virtual file. Media type may be a {@code null} for folders or for those files that
-     * don't have media type.
-     *
-     * @return media type or null.
-     * @deprecated this method is going to be removed soon, because we don't use media type for any purposes
-     */
-    @Deprecated
-    String getMediaType();
-
-    /**
      * Returns {@code true} in case if virtual file doesn't have ability to be updated.
      *
      * @return {@code true} if file is read only, otherwise false.

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/FileImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/FileImpl.java
@@ -55,12 +55,6 @@ class FileImpl extends ResourceImpl implements File {
 
     /** {@inheritDoc} */
     @Override
-    public String getMediaType() {
-        throw new UnsupportedOperationException();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public boolean isReadOnly() {
         return false;
     }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/JarFileNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/JarFileNode.java
@@ -177,11 +177,6 @@ public class JarFileNode extends SyntheticNode<JarEntry> implements VirtualFile,
     }
 
     @Override
-    public String getMediaType() {
-        return null;
-    }
-
-    @Override
     public Path getProject() {
         return project;
     }


### PR DESCRIPTION
This PR removes deprecated method `org.eclipse.che.ide.api.resources.VirtualFile#getMediaType`

Related issue: #3321 