### PR TITLE
allow skip backup on upgrade

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
@@ -13,6 +13,16 @@ cmd_upgrade() {
   debug $FUNCNAME
 
   CHE_IMAGE_VERSION=$(get_image_version)
+  DO_BACKUP="true"
+
+  while [ $# -gt 0 ]; do
+    case $1 in
+      --skip-backup)
+        DO_BACKUP="false"
+        shift ;;
+      *) error "Unknown parameter: $1; did you mean --skip-backup?" ; return 2 ;;
+    esac
+  done
 
   # If we got here, this means:
   #   image version > configured & installed version
@@ -39,8 +49,13 @@ cmd_upgrade() {
       cmd_stop
     fi
   fi
-  info "upgrade" "Preparing backup..."
-  cmd_backup
+
+  if [[ "${DO_BACKUP}" == "true" ]]; then
+    info "upgrade" "Preparing backup..."
+    cmd_backup
+  else
+    info "upgrade" "Skipping backup."
+  fi
 
   info "upgrade" "Reinitializing the system with your configuration..."
   cmd_init --accept-license --reinit


### PR DESCRIPTION
as per @skryzhny request for our production we should have a way how to skip backup on upgrade because our storages are huge ~5TB and we have custom backup mechanisms for prod managed by ADM team. We must have this for 5.1.0 because if we will go to prod on 5.0.1 we won;t be able to do upgrade.