### PR TITLE
Fixes mapping of custom port with CHE_PORT

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -111,7 +111,7 @@ generate_configuration_with_puppet() {
   fi
 
   GENERATE_CONFIG_COMMAND="docker_run \
-                 --env-file=\"${REFERENCE_CONTAINER_ENVIRONMENT_FILE}\" \
+                  --env-file=\"${REFERENCE_CONTAINER_ENVIRONMENT_FILE}\" \
                   --env-file=/version/$CHE_VERSION/images \
                   -v \"${CHE_HOST_INSTANCE}\":/opt/${CHE_MINI_PRODUCT_NAME}:rw \
                   ${WRITE_PARAMETERS} \

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -20,9 +20,9 @@ che:
     - '<%= scope.lookupvar('che::che_assembly') -%>:/assembly'
 <% end -%>
   ports:
-    - '<%= scope.lookupvar('che::che_port') -%>:8080'
+    - '<%= scope.lookupvar('che::che_port') -%>:<%= scope.lookupvar('che::che_port') -%>'
 <% if scope.lookupvar('che::che_env') == 'development' -%>
-    - '<%= scope.lookupvar('che::che_debug_port') -%>:8000'
+    - '<%= scope.lookupvar('che::che_debug_port') -%>:<%= scope.lookupvar('che::che_debug_port') -%>'
 <% end -%>
   restart: always
   container_name: che


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where changing ports would prevent Che from starting due to an unexpected use of `CHE_PORT` being passed into `eclipse/che-server`.  Previously, we always assumed that the internal `eclipse/che-server` container would boot on port `8080` and then we just provide a port mapping from the custom port to the internal port. The new configuration approach actually passes `CHE_PORT` into `eclipse/che-server`, which causes the server to start internally on a different port. 

This quick fix maps the external port to the internal port.

### What issues does this PR fix or reference?
#3179 