### PR TITLE
Fix bug in CLI Output if user has overridden CHE_HOST

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -40,8 +40,14 @@ get_boot_url() {
 }
 
 get_display_url() {
+
+  # If the user has modified che.env with a custom CHE_HOST, we need to detect that here
+  # and not use the in-memory one which is always set with eclipse/che-ip.
+  local CHE_HOST_LOCAL=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" \
+                                ${UTILITY_IMAGE_ALPINE} sh -c 'echo $CHE_HOST')
+
   if ! is_docker_for_mac; then
-    echo "http://${CHE_HOST}:${CHE_PORT}"
+    echo "http://${CHE_HOST_LOCAL}:${CHE_PORT}"
   else
     echo "http://localhost:${CHE_PORT}"
   fi

--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -39,12 +39,20 @@ get_boot_url() {
   echo "$CHE_HOST:$CHE_PORT/api/"
 }
 
+# Input is a variable that would exist in the che.env file such as CHE_HOST.
+# We then lookup the vlaue of this variable and return it
+get_value_of_var_from_env_file() {
+  local LOOKUP_LOCAL=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" \
+                                ${UTILITY_IMAGE_ALPINE} sh -c "echo \$$1")
+  echo $LOOKUP_LOCAL
+
+}
+
 get_display_url() {
 
   # If the user has modified che.env with a custom CHE_HOST, we need to detect that here
   # and not use the in-memory one which is always set with eclipse/che-ip.
-  local CHE_HOST_LOCAL=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" \
-                                ${UTILITY_IMAGE_ALPINE} sh -c 'echo $CHE_HOST')
+  local CHE_HOST_LOCAL=$(get_value_of_var_from_env_file CHE_HOST)
 
   if ! is_docker_for_mac; then
     echo "http://${CHE_HOST_LOCAL}:${CHE_PORT}"

--- a/dockerfiles/base/scripts/base/commands/cmd_debug.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_debug.sh
@@ -21,8 +21,7 @@ cmd_debug() {
   info "${CHE_PRODUCT_NAME}_CONFIG            = ${CHE_HOST_CONFIG}"
   local CHE_HOST_LOCAL=${CHE_HOST}
   if is_initialized; then
-    CHE_HOST_LOCAL=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" \
-                                ${UTILITY_IMAGE_ALPINE} sh -c 'echo $CHE_HOST')
+    CHE_HOST_LOCAL=$(get_value_of_var_from_env_file CHE_HOST)
   fi
   info "${CHE_PRODUCT_NAME}_HOST              = ${CHE_HOST_LOCAL}"
   info "${CHE_PRODUCT_NAME}_REGISTRY          = ${CHE_MANIFEST_DIR}"

--- a/dockerfiles/base/scripts/base/commands/cmd_debug.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_debug.sh
@@ -19,7 +19,12 @@ cmd_debug() {
   info "${CHE_PRODUCT_NAME}_VERSION           = ${CHE_VERSION}"
   info "${CHE_PRODUCT_NAME}_INSTANCE          = ${CHE_HOST_INSTANCE}"
   info "${CHE_PRODUCT_NAME}_CONFIG            = ${CHE_HOST_CONFIG}"
-  info "${CHE_PRODUCT_NAME}_HOST              = ${CHE_HOST}"
+  local CHE_HOST_LOCAL=${CHE_HOST}
+  if is_initialized; then
+    CHE_HOST_LOCAL=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" \
+                                ${UTILITY_IMAGE_ALPINE} sh -c 'echo $CHE_HOST')
+  fi
+  info "${CHE_PRODUCT_NAME}_HOST              = ${CHE_HOST_LOCAL}"
   info "${CHE_PRODUCT_NAME}_REGISTRY          = ${CHE_MANIFEST_DIR}"
   info "${CHE_PRODUCT_NAME}_DEBUG             = ${CHE_DEBUG}"
   info "${CHE_PRODUCT_NAME}_BACKUP            = ${CHE_HOST_BACKUP}"

--- a/dockerfiles/base/scripts/base/commands/cmd_init.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_init.sh
@@ -123,11 +123,6 @@ cmd_init_reinit_pre_action() {
   # One time only, set the value of CHE_HOST within the environment file.
   sed -i'.bak' "s|#${CHE_PRODUCT_NAME}_HOST=.*|${CHE_PRODUCT_NAME}_HOST=${CHE_HOST}|" "${REFERENCE_CONTAINER_ENVIRONMENT_FILE}"
 
-  # For testing purposes only
-  #HTTP_PROXY=8.8.8.8
-  #HTTPS_PROXY=http://4.4.4.4:9090
-  #NO_PROXY="locahost, *.local, swarm-mode"
-
   if [[ ! ${HTTP_PROXY} = "" ]]; then
     sed -i'.bak' "s|#${CHE_PRODUCT_NAME}_HTTP_PROXY=.*|${CHE_PRODUCT_NAME}_HTTP_PROXY=${HTTP_PROXY}|" "${REFERENCE_CONTAINER_ENVIRONMENT_FILE}"
     sed -i'.bak' "s|#${CHE_PRODUCT_NAME}_WORKSPACE_HTTP__PROXY=.*|${CHE_PRODUCT_NAME}_WORKSPACE_HTTP__PROXY=${HTTP_PROXY}|" "${REFERENCE_CONTAINER_ENVIRONMENT_FILE}"

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -59,7 +59,7 @@ cmd_start_check_ports() {
 
   # If dev mode is on, then we also need to check the debug port set by the user for availability
   if debug_server; then
-    USER_DEBUG_PORT=$(docker_run --env-file="${REFERENCE_CONTAINER_ENVIRONMENT_FILE}" ${UTILITY_IMAGE_ALPINE} sh -c 'echo $CHE_DEBUG_PORT')
+    USER_DEBUG_PORT=$(get_value_of_var_from_env_file CHE_DEBUG_PORT)
 
     if [[ "$USER_DEBUG_PORT" = "" ]]; then
       # If the user has not set a debug port, then use the default


### PR DESCRIPTION
### What does this PR do?
Fixes issue uncovere by @garagatyi where the CLI output in two locations shows the wrong CHE_HOST value if the user has overridden CHE_HOST in the che.env file.

This implements a printout mechanism that uses Docker to print out the value and passes in `che.env` as an input into that.
