### PR TITLE
Fix #3686 : Property around external docker has been changed in a refactoring

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -264,12 +264,11 @@ init() {
   sed -i "/che.workspace.terminal_linux_amd64=/c\che.workspace.terminal_linux_amd64=${CHE_DATA_HOST}/lib/linux_amd64/terminal" $CHE_LOCAL_CONF_DIR/che.properties
   sed -i "/che.workspace.terminal_linux_arm7=/c\che.workspace.terminal_linux_arm7=${CHE_DATA_HOST}/lib/linux_arm7/terminal" $CHE_LOCAL_CONF_DIR/che.properties
 
-  # CHE_DOCKER_MACHINE_HOST_EXTERNAL must be set if you are in a VM.
-  HOSTNAME=${CHE_DOCKER_MACHINE_HOST_EXTERNAL:-$(get_docker_external_hostname)}
+  # CHE_DOCKER_IP_EXTERNAL must be set if you are in a VM.
+  HOSTNAME=${CHE_DOCKER_IP_EXTERNAL:-$(get_docker_external_hostname)}
   if has_external_hostname; then
     # Internal property used by Che to set hostname.
-    # See: LocalDockerInstanceRuntimeInfo.java#L9
-    export CHE_DOCKER_MACHINE_HOST_EXTERNAL=${HOSTNAME}
+    export CHE_DOCKER_IP_EXTERNAL=${HOSTNAME}
   fi
   ### Necessary to allow the container to write projects to the folder
   export CHE_WORKSPACE_STORAGE="${CHE_DATA_HOST}/workspaces"


### PR DESCRIPTION
but it has not been updated everywhere

I did a look for 10 minutes as blocker https://github.com/eclipse/che/issues/3686 is not solved for a long time?
it seems to be broken by https://github.com/eclipse/che/pull/3282 merge

### What does this PR do?
Fix boot of Che workspaces on mac (and maybe windows) with CLI

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3686


Change-Id: I6da2c6f33cc063dda08b953eb2fab16abe4a0c86
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
