### PR TITLE
Avoid tree jump during file selection

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/TreeView.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/TreeView.java
@@ -238,7 +238,6 @@ public class TreeView {
             if (e != null) {
                 setClassName(e, tree.getTreeStyles().styles().selected(), select);
             }
-            tree.moveFocus(nodeDescriptor.getRootContainer());
         }
     }
 


### PR DESCRIPTION
This PR fixes the bug when tree has visible area more than it can show tree can jumps during file selection.

Related issue: #3762 and https://github.com/codenvy/codenvy/issues/1488#issuecomment-271807440