### PR TITLE
Skip failed project resolving in case if the last one is empty

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectResolver.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectResolver.java
@@ -19,11 +19,13 @@ import org.eclipse.che.api.project.shared.dto.SourceEstimation;
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.project.type.ProjectTypeRegistry;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.projecttype.wizard.presenter.ProjectWizardPresenter;
+import org.eclipse.che.ide.util.loging.Log;
 
 import java.util.List;
 
@@ -81,6 +83,18 @@ public class ProjectResolver {
 
                     return promiseProvider.resolve(project);
                 }
+
+                return project.update().withBody(config).send();
+            }
+        }).catchErrorPromise(new Function<PromiseError, Promise<Project>>() {
+            @Override
+            public Promise<Project> apply(PromiseError error) throws FunctionException {
+                Log.warn(ProjectResolver.class, error.getMessage());
+
+                //this error may be occurred when resolve method is called on empty project, so just skip it and return empty configuration
+
+                final MutableProjectConfig config = new MutableProjectConfig(project);
+                config.setType(Constants.BLANK_ID);
 
                 return project.update().withBody(config).send();
             }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectResolver.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectResolver.java
@@ -91,12 +91,7 @@ public class ProjectResolver {
             public Promise<Project> apply(PromiseError error) throws FunctionException {
                 Log.warn(ProjectResolver.class, error.getMessage());
 
-                //this error may be occurred when resolve method is called on empty project, so just skip it and return empty configuration
-
-                final MutableProjectConfig config = new MutableProjectConfig(project);
-                config.setType(Constants.BLANK_ID);
-
-                return project.update().withBody(config).send();
+                return promiseProvider.resolve(project);
             }
         });
     }

--- a/plugins/plugin-composer/che-plugin-composer-server/src/main/java/org/eclipse/che/plugin/composer/server/projecttype/ComposerValueProviderFactory.java
+++ b/plugins/plugin-composer/che-plugin-composer-server/src/main/java/org/eclipse/che/plugin/composer/server/projecttype/ComposerValueProviderFactory.java
@@ -48,6 +48,9 @@ public class ComposerValueProviderFactory implements ValueProviderFactory {
         @Override
         public List<String> getValues(String attributeName) throws ValueStorageException {
             try {
+                if (projectFolder.getChild("composer.json") == null) {
+                    return Collections.emptyList();
+                }
                 JsonObject model = readModel(projectFolder);
                 String value = "";
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <module>agents</module>
         <module>plugins</module>
         <module>samples</module>
-        <!--module>dashboard</module-->
+        <module>dashboard</module>
         <module>assembly</module>
     </modules>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <module>agents</module>
         <module>plugins</module>
         <module>samples</module>
-        <module>dashboard</module>
+        <!--module>dashboard</module-->
         <module>assembly</module>
     </modules>
     <scm>


### PR DESCRIPTION
This proposal fixes that bug when user is trying to import an empty project through the UI. In this case project resolving fails with 500 Internal server error, client side should process this exception without any warning dialogs, but server side should be also return empty estimation list on empty project.

This PR fixes only client side.

Related issue: #3766 