### PR TITLE
Holds node interceptors in set instead of list to avoid duplicating

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -440,6 +440,7 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
     @Deprecated
     public void showHiddenFiles(boolean show) {
         hiddenFilesAreShown = show;
+        settingsProvider.getSettings().setShowHiddenFiles(show);
         view.showHiddenFilesForAllExpandedNodes(show);
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerViewImpl.java
@@ -258,16 +258,7 @@ public class ProjectExplorerViewImpl extends BaseView<ProjectExplorerView.Action
         }
 
         for (Node node : tree.getRootNodes()) {
-            if (node instanceof HasSettings) {
-                ((HasSettings)node).getSettings().setShowHiddenFiles(show);
-                for (Node child : tree.getNodeStorage().getAllChildren(node)) {
-                    if (child instanceof HasSettings) {
-                        ((HasSettings)child).getSettings().setShowHiddenFiles(show);
-                    }
-                }
-
-                reloadChildren(node, true);
-            }
+            reloadChildren(node, true);
         }
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/tree/SkipHiddenNodesInterceptor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/tree/SkipHiddenNodesInterceptor.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.ide.resources.tree;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
@@ -23,6 +24,7 @@ import java.util.List;
 /**
  * @author Vlad Zhukovskiy
  */
+@Singleton
 public class SkipHiddenNodesInterceptor implements NodeInterceptor {
 
     private final PromiseProvider promises;

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
@@ -38,7 +38,6 @@ import org.eclipse.che.ide.ui.smartTree.handler.GroupingHandlerRegistration;
 import org.eclipse.che.ide.util.loging.Log;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -46,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -71,7 +71,14 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
      *
      * @see NodeInterceptor
      */
-    private List<NodeInterceptor> nodeInterceptors;
+    private TreeSet<NodeInterceptor> nodeInterceptors;
+
+    private final Comparator<NodeInterceptor> priorityComparator = new Comparator<NodeInterceptor>() {
+        @Override
+        public int compare(NodeInterceptor o1, NodeInterceptor o2) {
+            return o1.getPriority() - o2.getPriority();
+        }
+    };
 
     /**
      * When caching is on nodes will be loaded from cache if they exist otherwise nodes will be loaded every time forcibly.
@@ -231,15 +238,9 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
      *         set of {@link NodeInterceptor}
      */
     public NodeLoader(@Nullable Set<NodeInterceptor> nodeInterceptors) {
-        this.nodeInterceptors = new ArrayList<>();
+        this.nodeInterceptors = new TreeSet<>(priorityComparator);
         if (nodeInterceptors != null) {
             this.nodeInterceptors.addAll(nodeInterceptors);
-            Collections.sort(this.nodeInterceptors, new Comparator<NodeInterceptor>() {
-                @Override
-                public int compare(NodeInterceptor o1, NodeInterceptor o2) {
-                    return o1.getPriority() - o2.getPriority();
-                }
-            });
         }
     }
 
@@ -483,11 +484,11 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
     }
 
     /**
-     * Return list of node interceptors.
+     * Return set of node interceptors.
      *
      * @return node interceptors list
      */
-    public List<NodeInterceptor> getNodeInterceptors() {
+    public Set<NodeInterceptor> getNodeInterceptors() {
         return nodeInterceptors;
     }
 


### PR DESCRIPTION
This PR fix the problem when functionality of show/hide hidden files didn't work correctly.

The problem was in node interceptors collection in `NodeLoader` (component of the tree which is responsible for loading children for specific node). Interceptors collection was represented as list, so that's why this collection might contain duplicated interceptors. Changing collection to set resolve the problem.

Related issue: #3770 

#### Changelog
Holds node interceptors in set instead of list to avoid duplicating