### PR TITLE
CODENVY-1524: Inject API endpoint env variable into all machines

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ApiEndpointEnvVariableProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ApiEndpointEnvVariableProvider.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.plugin.docker.machine.ext.provider;
+package org.eclipse.che.plugin.docker.machine;
 
 import com.google.common.base.Strings;
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
@@ -83,6 +83,8 @@ public class DockerMachineModule extends AbstractModule {
         envParserMapBinder.addBinding("dockerfile").to(DockerfileEnvironmentParser.class);
         envParserMapBinder.addBinding("dockerimage").to(DockerImageEnvironmentParser.class);
 
+        allMachinesEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ApiEndpointEnvVariableProvider.class);
+
         // Provides set of sets of strings instead of set of strings.
         // This allows providers to return empty set as a value if no value should be added by provider.
         // .permitDuplicates() is needed to allow different providers add empty sets.

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/DockerExtServerModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/DockerExtServerModule.java
@@ -29,7 +29,6 @@ public class DockerExtServerModule extends AbstractModule {
                                                                          String.class,
                                                                          Names.named("machine.docker.dev_machine.machine_env"))
                                                            .permitDuplicates();
-        devMachineEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ext.provider.ApiEndpointEnvVariableProvider.class);
         devMachineEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ext.provider.ProjectsRootEnvVariableProvider.class);
         devMachineEnvVars.addBinding().toProvider(org.eclipse.che.plugin.docker.machine.ext.provider.JavaOptsEnvVariableProvider.class);
     }


### PR DESCRIPTION
### What does this PR do?
Injects `CHE_API` env variable into all machines of workspace.
This is needed for some agents (like terminal) to properly start in non-dev machines.

### What issues does this PR fix or reference?
#https://github.com/codenvy/codenvy/issues/1524


