### PR TITLE
Change data type of project attribute values from VARCHAR(255) to TEXT

### DIFF
--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.mockito.Matchers.any;
@@ -436,6 +437,24 @@ public class WorkspaceDaoTest {
         workspace1.getConfig().setName(workspace2.getConfig().getName());
 
         workspaceDao.update(workspace1);
+    }
+
+    @Test(dependsOnMethods = "shouldGetWorkspaceById")
+    public void createsWorkspaceWithAProjectConfigContainingLongAttributeValues() throws Exception {
+        WorkspaceImpl workspace = createWorkspace("new-workspace", accounts[0], "new-name");
+        ProjectConfigImpl project = workspace.getConfig().getProjects().get(0);
+
+        // long string
+        char[] chars = new char[100_000];
+        Arrays.fill(chars, 0, chars.length / 2, 'x');
+        Arrays.fill(chars, chars.length / 2, chars.length, 'y');
+        String value = new String(chars);
+        project.getAttributes().put("long_value1", singletonList(value));
+        project.getAttributes().put("long_value2", singletonList(value));
+
+        workspaceDao.create(workspace);
+
+        assertEquals(workspaceDao.get(workspace.getId()), new WorkspaceImpl(workspace));
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.2.0/1__increase_project_attributes_values_length.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.2.0/1__increase_project_attributes_values_length.sql
@@ -1,0 +1,12 @@
+--
+-- Copyright (c) 2012-2017 Codenvy, S.A.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Codenvy, S.A. - initial API and implementation
+--
+
+ALTER TABLE projectattribute_values ALTER COLUMN values TYPE TEXT;


### PR DESCRIPTION
Fixes #3758.
IDE uses project attributes for storing various kind of data
such as commands related to a certain project, 255 is not enough.

#### Changelog
Change data type of project attribute values from VARCHAR(255) to TEXT