### PR TITLE
Fixes display URL error when not initialized

### DIFF
--- a/dockerfiles/base/scripts/base/cli/cli-functions.sh
+++ b/dockerfiles/base/scripts/base/cli/cli-functions.sh
@@ -52,7 +52,11 @@ get_display_url() {
 
   # If the user has modified che.env with a custom CHE_HOST, we need to detect that here
   # and not use the in-memory one which is always set with eclipse/che-ip.
-  local CHE_HOST_LOCAL=$(get_value_of_var_from_env_file CHE_HOST)
+  local CHE_HOST_LOCAL=$CHE_HOST
+
+  if is_initialized; then 
+    CHE_HOST_LOCAL=$(get_value_of_var_from_env_file CHE_HOST)
+  fi
 
   if ! is_docker_for_mac; then
     echo "http://${CHE_HOST_LOCAL}:${CHE_PORT}"

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -12,10 +12,9 @@
 cmd_start() {
   debug $FUNCNAME
 
-  DISPLAY_URL=$(get_display_url)
-
   # If ${CHE_FORMAL_PRODUCT_NAME} is already started or booted, then terminate early.
   if container_exist_by_name $CHE_SERVER_CONTAINER_NAME; then
+    DISPLAY_URL=$(get_display_url)
     CURRENT_CHE_SERVER_CONTAINER_ID=$(get_server_container_id $CHE_SERVER_CONTAINER_NAME)
     if container_is_running ${CURRENT_CHE_SERVER_CONTAINER_ID} && \
        server_is_booted ${CURRENT_CHE_SERVER_CONTAINER_ID}; then


### PR DESCRIPTION
### What does this PR do?
We recently made an improvement to have more flexibility in the display URL that is printed out.  We derive the value of `CHE_HOST` from a `che.env` file. However, this function can be called when the `:/data` folder has not been initialized generated an error that it could not find the `che.env` file.  

This adds a check to only perform this call if the folder has been initialized otherwise default to the in-memory value.

Note - all new users and installations will see this error.  It will not stop the starting of the system, but it is an ugly looking error.

#### Changelog
Fixes display URL error when not initialized
