### PR TITLE
CHE-3686: fix docker machines addresses setting

### DIFF
--- a/assembly/assembly-main/src/assembly/bin/che.sh
+++ b/assembly/assembly-main/src/assembly/bin/che.sh
@@ -184,9 +184,9 @@ usage () {
 set_environment_variables () {
   ### Set value of derived environment variables.
 
-  # CHE_DOCKER_MACHINE_HOST is used internally by Che to set its IP address
+  # CHE_DOCKER_IP is used internally by Che to set its IP address
   if [[ -n "${CHE_IP}" ]]; then
-    export CHE_DOCKER_MACHINE_HOST="${CHE_IP}"
+    export CHE_DOCKER_IP="${CHE_IP}"
   fi
 
   #if [ "${WIN}" == "true" ] && [ ! -z "${JAVA_HOME}" ]; then

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/Server.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/machine/Server.java
@@ -28,8 +28,6 @@ public interface Server {
      * External address of the server in form <b>hostname:port</b>.
      * <p>
      * This address is used by the browser to communicate with the server.
-     * <b>hostname</b> can be configured using property machine.docker.local_node_host.external
-     * or environment variable CHE_DOCKER_MACHINE_HOST_EXTERNAL.
      * <b>port</b> is the external port and cannot be configured.
      * If not explicitly configured that address is set using {@link ServerProperties#getInternalAddress()}
      */

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -79,9 +79,9 @@ usage () {
 set_environment_variables () {
   ### Set value of derived environment variables.
 
-  # CHE_DOCKER_MACHINE_HOST is used internally by Che to set its IP address
+  # CHE_DOCKER_IP is used internally by Che to set its IP address
   if [[ -n "${CHE_IP}" ]]; then
-    export CHE_DOCKER_MACHINE_HOST="${CHE_IP}"
+    export CHE_DOCKER_IP="${CHE_IP}"
   fi
 
   # Convert Tomcat environment variables to POSIX format.

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -134,16 +134,24 @@
 # Che Server --> Workspace Connection (see Workspace Address Resolution Strategy, below):
 #    - If CHE_DOCKER_SERVER__EVALUATION__STRATEGY is 'default':
 #        1. Use the value of che.docker.ip
-#        2. Else, use address of docker0 bridge network, if available
-#        3. Else, use localhost
+#        2. Else, if server connects over Unix socket, then use localhost
+#        3. Else, use DOCKER_HOST
 #    - If CHE_DOCKER_SERVER__EVALUATION__STRATEGY is 'docker-local':
-#        1. Use the address of the workspace container within the docker network
-#        2. If address cannot be read, try localhost
+#        1. Use the address of the workspace container within the docker network and exposed ports
+#        2. If address is missing, if server connects over Unix socket, then use localhost and published ports
+#        3. Else, use DOCKER_HOST and published ports
 #
-# Browser --> Workspace Connection:
-#    1. Use the value of che.docker.ip
-#    2. Else, if server connects over Unix socket, then use localhost
-#    3. Else, use DOCKER_HOST
+# Browser --> Workspace Connection (see Workspace Address Resolution Strategy, below):
+#    - If CHE_DOCKER_SERVER__EVALUATION__STRATEGY is 'default':
+#        1. If set use the value of che.docker.ip.external
+#        2. Else if set use the value of che.docker.ip
+#        3. Else, if server connects over Unix socket, then use localhost
+#        4. Else, use DOCKER_HOST
+#    - If CHE_DOCKER_SERVER__EVALUATION__STRATEGY is 'docker-local':
+#        1. If set use the value of che.docker.ip.external
+#        2. Else use the address of the workspace container within the docker network, if it is set
+#        3. If address is missing, if server connects over Unix socket, then use localhost
+#        4. Else, use DOCKER_HOST
 #
 # Workspace Agent --> Che Server
 #    1. Default is http://che-host:${SERVER_PORT}/wsmaster/api, where che-host is IP of server.

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -74,9 +74,9 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
      */
     public static final String USER_TOKEN = "USER_TOKEN";
 
-    private final ContainerInfo               info;
-    private final Map<String, ServerConfImpl> serversConf;
-    private final String                      internalHost;
+    private final ContainerInfo                    info;
+    private final Map<String, ServerConfImpl>      serversConf;
+    private final String                           internalHost;
     private final ServerEvaluationStrategyProvider provider;
 
     @Inject

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
@@ -8,20 +8,20 @@
  * Contributors:
  *   Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.che.plugin.docker.machine;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.PortBinding;
 
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
@@ -49,8 +49,8 @@ public class LocalDockerServerEvaluationStrategy extends ServerEvaluationStrateg
     protected String externalAddressProperty;
 
     @Inject
-    public LocalDockerServerEvaluationStrategy (@Nullable @Named("che.docker.ip") String internalAddress,
-                                                @Nullable @Named("che.docker.ip.external") String externalAddress) {
+    public LocalDockerServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
+                                               @Nullable @Named("che.docker.ip.external") String externalAddress) {
         this.internalAddressProperty = internalAddress;
         this.externalAddressProperty = externalAddress;
     }
@@ -93,13 +93,6 @@ public class LocalDockerServerEvaluationStrategy extends ServerEvaluationStrateg
                                  externalAddressContainer :
                                  internalHost;
 
-        Map<String, List<PortBinding>> portBindings = containerInfo.getNetworkSettings().getPorts();
-
-        Map<String, String> addressesAndPorts = new HashMap<>();
-        for (String portKey : portBindings.keySet()) {
-            String port = portBindings.get(portKey).get(0).getHostPort();
-            addressesAndPorts.put(portKey, externalAddress + ":" + port);
-        }
-        return addressesAndPorts;
+        return getExposedPortsToAddressPorts(externalAddress, containerInfo.getNetworkSettings().getPorts());
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategyTest.java
@@ -8,18 +8,8 @@
  * Contributors:
  *   Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.che.plugin.docker.machine;
 
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
@@ -33,20 +23,28 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Angel Misevski <amisevsk@redhat.com>
+ * @author Alexander Garagatyi
+ */
 @Listeners(MockitoTestNGListener.class)
 public class DefaultServerEvaluationStrategyTest {
 
     private static final String CHE_DOCKER_IP            = "container-host.com";
     private static final String CHE_DOCKER_IP_EXTERNAL   = "container-host-ext.com";
     private static final String ALL_IP_ADDRESS           = "0.0.0.0";
-    private static final String CONTAINERINFO_GATEWAY    = "172.17.0.1";
-    private static final String CONTAINERINFO_IP_ADDRESS = "172.17.0.200";
     private static final String DEFAULT_HOSTNAME         = "localhost";
 
     @Mock
     private ContainerInfo   containerInfo;
-    @Mock
-    private MachineConfig   machineConfig;
     @Mock
     private ContainerConfig containerConfig;
     @Mock
@@ -56,8 +54,6 @@ public class DefaultServerEvaluationStrategyTest {
 
     private Map<String, ServerConfImpl> serverConfs;
 
-    private Map<String, List<PortBinding>> ports;
-
     @BeforeMethod
     public void setUp() {
 
@@ -65,78 +61,31 @@ public class DefaultServerEvaluationStrategyTest {
         serverConfs.put("4301/tcp", new ServerConfImpl("sysServer1-tcp", "4301/tcp", "http", "/some/path1"));
         serverConfs.put("4305/udp", new ServerConfImpl("devSysServer1-udp", "4305/udp", null, "some/path4"));
 
-        ports = new HashMap<>();
+        Map<String, List<PortBinding>> ports = new HashMap<>();
         ports.put("4301/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
-                                                                .withHostPort("32100")));
+                                                                         .withHostPort("32100")));
         ports.put("4305/udp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
-                                                                .withHostPort("32103")));
+                                                                         .withHostPort("32103")));
 
         when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
-        when(networkSettings.getGateway()).thenReturn(CONTAINERINFO_GATEWAY);
-        when(networkSettings.getIpAddress()).thenReturn(CONTAINERINFO_IP_ADDRESS);
         when(networkSettings.getPorts()).thenReturn(ports);
         when(containerInfo.getConfig()).thenReturn(containerConfig);
         when(containerConfig.getLabels()).thenReturn(Collections.emptyMap());
     }
 
     /**
-     * Test: che.docker.ip property takes highest precedence for internal address
+     * Test: If che.docker.ip is null, and che.docker.ip.external is null or empty, should use provided
+     *       internalHostname value as internal and external addresses in this case.
      * @throws Exception
      */
     @Test
-    public void defaultStrategyShouldUseInternalIpPropertyToOverrideContainerInfo() throws Exception {
-        // given
-        strategy = new DefaultServerEvaluationStrategy(CHE_DOCKER_IP, null);
-
-        final Map<String, ServerImpl> expectedServers = getExpectedServers(CONTAINERINFO_GATEWAY,
-                                                                           CHE_DOCKER_IP,
-                                                                           false);
-
-        // when
-        final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
-                                                                    null,
-                                                                    serverConfs);
-
-        // then
-        assertEquals(servers, expectedServers);
-    }
-
-    /**
-     * Test: If che.docker.ip is null, containerInfo.getGateway() is used for internal address
-     * @throws Exception
-     */
-    @Test
-    public void defaultStrategyShouldUseContainerInfoWhenInternalIpPropertyIsNull() throws Exception {
+    public void defaultStrategyShouldUseInternalHostWhenBothIpPropertyAreNull() throws Exception {
         // given
         strategy = new DefaultServerEvaluationStrategy(null, null);
-
-        final Map<String, ServerImpl> expectedServers = getExpectedServers(CONTAINERINFO_GATEWAY,
-                                                                           CONTAINERINFO_GATEWAY,
-                                                                           false);
-
-        // when
-        final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
-                                                                    null,
-                                                                    serverConfs);
-
-        // then
-        assertEquals(servers, expectedServers);
-    }
-
-    /**
-     * Test: If che.docker.ip is null, and containerInfo.getGateway() is null or empty, should use provided
-     *       internalHostname value. Also tests that this value is used for external address in this case.
-     * @throws Exception
-     */
-    @Test
-    public void defaultStrategyShouldUseInternalHostWhenBothIpPropertyAndContainerInfoAreNull() throws Exception {
-        // given
-        strategy = new DefaultServerEvaluationStrategy(null, null);
-        when(networkSettings.getGateway()).thenReturn("");
 
         final Map<String, ServerImpl> expectedServers = getExpectedServers(DEFAULT_HOSTNAME,
-                                                                           DEFAULT_HOSTNAME,
-                                                                           false);
+                                                                           DEFAULT_HOSTNAME
+        );
 
         // when
         final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
@@ -148,39 +97,60 @@ public class DefaultServerEvaluationStrategyTest {
     }
 
     /**
-     * Test: If che.docker.ip.external is not null, that should take precedence for external address.
+     * Test: If che.docker.ip.external and che.docker.ip are not null, these values should take precedence for external and internal addresses.
      * @throws Exception
      */
     @Test
-    public void defaultStrategyShouldUseExtenalIpPropertyWhenAvailable() throws Exception {
+    public void defaultStrategyShouldUseIpPropertiesWhenAvailable() throws Exception {
+        // given
+        strategy = new DefaultServerEvaluationStrategy(CHE_DOCKER_IP, CHE_DOCKER_IP_EXTERNAL);
+
+        final Map<String, ServerImpl> expectedServers = getExpectedServers(CHE_DOCKER_IP_EXTERNAL,
+                                                                           CHE_DOCKER_IP
+        );
+
+        // when
+        final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
+                                                                    DEFAULT_HOSTNAME,
+                                                                    serverConfs);
+
+        // then
+        assertEquals(servers, expectedServers);
+    }
+
+    /**
+     * Test: If che.docker.ip.external is null, che.docker.ip is used as external address if it is not null.
+     * @throws Exception
+     */
+    @Test
+    public void defaultStrategyShouldUseInternalIpPropertyAsExternalIfExternalIpPropertyIsNull() throws Exception {
+        // given
+        strategy = new DefaultServerEvaluationStrategy(CHE_DOCKER_IP, null);
+
+        final Map<String, ServerImpl> expectedServers = getExpectedServers(CHE_DOCKER_IP,
+                                                                           CHE_DOCKER_IP);
+
+        // when
+        final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
+                                                                    DEFAULT_HOSTNAME,
+                                                                    serverConfs);
+
+        // then
+        assertEquals(servers, expectedServers);
+    }
+
+    /**
+     * Test: If che.docker.ip.external is not null and che.docker.ip is null,
+     * internal address is taken from provided internalAddress and external address is taken from property.
+     * @throws Exception
+     */
+    @Test
+    public void defaultStrategyShouldUseProvidedInternalIpIfInternalIpPropertyIsNull() throws Exception {
         // given
         strategy = new DefaultServerEvaluationStrategy(null, CHE_DOCKER_IP_EXTERNAL);
 
         final Map<String, ServerImpl> expectedServers = getExpectedServers(CHE_DOCKER_IP_EXTERNAL,
-                                                                           CONTAINERINFO_GATEWAY,
-                                                                           false);
-
-        // when
-        final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
-                                                                    DEFAULT_HOSTNAME,
-                                                                    serverConfs);
-
-        // then
-        assertEquals(servers, expectedServers);
-    }
-
-    /**
-     * Test: If che.docker.ip.external is null, should use containerInfo.getGateway()
-     * @throws Exception
-     */
-    @Test
-    public void defaultStrategyShouldUseContainerInfoForExternalWhenPropertyIsNull() throws Exception {
-        // given
-        strategy = new DefaultServerEvaluationStrategy(null, null);
-
-        final Map<String, ServerImpl> expectedServers = getExpectedServers(CONTAINERINFO_GATEWAY,
-                                                                           CONTAINERINFO_GATEWAY,
-                                                                           false);
+                                                                           DEFAULT_HOSTNAME);
 
         // when
         final Map<String, ServerImpl> servers = strategy.getServers(containerInfo,
@@ -192,17 +162,11 @@ public class DefaultServerEvaluationStrategyTest {
     }
 
     private Map<String, ServerImpl> getExpectedServers(String externalAddress,
-                                                       String internalAddress,
-                                                       boolean useExposedPorts) {
+                                                       String internalAddress) {
         String port1;
         String port2;
-        if (useExposedPorts) {
-            port1 = ":4301";
-            port2 = ":4305";
-        } else {
-            port1 = ":32100";
-            port2 = ":32103";
-        }
+        port1 = ":32100";
+        port2 = ":32103";
         Map<String, ServerImpl> expectedServers = new HashMap<>();
         expectedServers.put("4301/tcp", new ServerImpl("sysServer1-tcp",
                 "http",


### PR DESCRIPTION
### What does this PR do?
Set internal machine address by CLI from CHE_IP.
Add and fix docs in che.env.
Change behavior of default machine server address evaluation
to be similar to the previous state.
Code cleanup.

### What issues does this PR fix or reference?
Final addition to fix of #3686 

### Tests written?
Yes

#### Changelog
Fix docker machines addresses setting