### PR TITLE
Rework EnvironmentContext#getSubject method to not return null subject

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
@@ -206,7 +206,7 @@ public class DefaultHttpJsonRequest implements HttpJsonRequest {
                                                                               UnauthorizedException,
                                                                               ConflictException,
                                                                               BadRequestException {
-        final String authToken = getAuthenticationToken();
+        final String authToken = EnvironmentContext.getCurrent().getSubject().getToken();
         final boolean hasQueryParams = parameters != null && !parameters.isEmpty();
         if (hasQueryParams || authToken != null) {
             final UriBuilder ub = UriBuilder.fromUri(url);
@@ -291,14 +291,6 @@ public class DefaultHttpJsonRequest implements HttpJsonRequest {
         } finally {
             conn.disconnect();
         }
-    }
-
-    private String getAuthenticationToken() {
-        final Subject subject = EnvironmentContext.getCurrent().getSubject();
-        if (subject != null) {
-            return subject.getToken();
-        }
-        return null;
     }
 
     @Override

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
@@ -400,14 +400,6 @@ public class HttpJsonHelper {
             return null;
         }
 
-        private String getAuthenticationToken() {
-            Subject subject = EnvironmentContext.getCurrent().getSubject();
-            if (subject != null) {
-                return subject.getToken();
-            }
-            return null;
-        }
-
         public String requestString(String url,
                                     String method,
                                     Object body,
@@ -422,7 +414,7 @@ public class HttpJsonHelper {
                                     Object body,
                                     Pair<String, ?>... parameters)
                 throws IOException, ServerException, ForbiddenException, NotFoundException, UnauthorizedException, ConflictException {
-            final String authToken = getAuthenticationToken();
+            final String authToken = EnvironmentContext.getCurrent().getSubject().getToken();
             if ((parameters != null && parameters.length > 0) || authToken != null) {
                 final UriBuilder ub = UriBuilder.fromUri(url);
                 //remove sensitive information from url.

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/commons/env/EnvironmentContext.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/commons/env/EnvironmentContext.java
@@ -57,10 +57,16 @@ public class EnvironmentContext {
         setSubject(other.getSubject());
     }
 
+    /**
+     * Returns subject or {@link Subject#ANONYMOUS} in case when subject is null.
+     */
     public Subject getSubject() {
-        return subject;
+        return subject == null ? Subject.ANONYMOUS : subject;
     }
 
+    /**
+     * Sets subject.
+     */
     public void setSubject(Subject subject) {
         this.subject = subject;
     }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/commons/subject/Subject.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/commons/subject/Subject.java
@@ -47,6 +47,11 @@ public interface Subject {
         }
 
         @Override
+        public boolean isAnonymous() {
+            return true;
+        }
+
+        @Override
         public boolean isTemporary() {
             return false;
         }
@@ -85,6 +90,13 @@ public interface Subject {
      * @return subject auth token to be able to execute request as subject
      */
     String getToken();
+
+    /**
+     * Return {@code true} if subject is anonymous, {@code false} if this is a real authenticated subject.
+     */
+    default boolean isAnonymous() {
+        return false;
+    }
 
     /**
      * @return - true if subject is temporary, false if this is a real persistent subject.

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/everrest/ServerContainerInitializeListener.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/everrest/ServerContainerInitializeListener.java
@@ -187,10 +187,6 @@ public class ServerContainerInitializeListener implements ServletContextListener
         final String authType = "BASIC";
         final Subject subject = EnvironmentContext.getCurrent().getSubject();
 
-        if (subject == null) {
-            return new SimpleSecurityContext(isSecure);
-        }
-
         final Principal principal = new SimplePrincipal(subject.getUserName());
         return new SecurityContext() {
 

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/commons/env/EnvironmentContextTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/commons/env/EnvironmentContextTest.java
@@ -33,6 +33,23 @@ public class EnvironmentContextTest {
         assertFalse(actualSubject.isTemporary());
     }
 
+    @Test
+    public void shouldReturnAnonymousSubjectWhenThereIsNoSubject() {
+        //given
+        EnvironmentContext expected = EnvironmentContext.getCurrent();
+        expected.setSubject(null);
+
+        //when
+        Subject actualSubject = EnvironmentContext.getCurrent().getSubject();
+
+        //then
+        assertEquals(actualSubject.getUserName(), Subject.ANONYMOUS.getUserName());
+        assertEquals(actualSubject.getUserId(), Subject.ANONYMOUS.getUserId());
+        assertEquals(actualSubject.getToken(), Subject.ANONYMOUS.getToken());
+        assertEquals(actualSubject.isTemporary(), Subject.ANONYMOUS.isTemporary());
+        assertEquals(actualSubject.isAnonymous(), Subject.ANONYMOUS.isAnonymous());
+    }
+
     @Test(enabled = false)
     public void shouldNotBeAbleToSeeContextInOtherThread() {
         //given

--- a/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/util/RecipeDownloader.java
+++ b/wsmaster/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/util/RecipeDownloader.java
@@ -71,8 +71,7 @@ public class RecipeDownloader {
                                 .host(apiEndpoint.getHost())
                                 .port(apiEndpoint.getPort())
                                 .replacePath(apiEndpoint.getPath() + location);
-                if (EnvironmentContext.getCurrent().getSubject() != null
-                    && EnvironmentContext.getCurrent().getSubject().getToken() != null) {
+                if (EnvironmentContext.getCurrent().getSubject().getToken() != null) {
                     targetUriBuilder.queryParam("token", EnvironmentContext.getCurrent().getSubject().getToken());
                 }
             }
@@ -114,8 +113,7 @@ public class RecipeDownloader {
                                 .host(apiEndpoint.getHost())
                                 .port(apiEndpoint.getPort())
                                 .replacePath(apiEndpoint.getPath() + location);
-                if (EnvironmentContext.getCurrent().getSubject() != null
-                    && EnvironmentContext.getCurrent().getSubject().getToken() != null) {
+                if (EnvironmentContext.getCurrent().getSubject().getToken() != null) {
                     targetUriBuilder.queryParam("token", EnvironmentContext.getCurrent().getSubject().getToken());
                 }
             }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -798,8 +798,8 @@ public class WorkspaceManager {
     }
 
     private String sessionUserNameOr(String nameIfNoUser) {
-        final Subject subject;
-        if (EnvironmentContext.getCurrent() != null && (subject = EnvironmentContext.getCurrent().getSubject()) != null) {
+        final Subject subject = EnvironmentContext.getCurrent().getSubject();
+        if (!subject.isAnonymous()) {
             return subject.getUserName();
         }
         return nameIfNoUser;


### PR DESCRIPTION
### What does this PR do?
Rework EnvironmentContext#getSubject method to not return null subject. It allows to avoid null pointer exceptions in case missing component which should set subject for request in custom packaging.

### What issues does this PR fix or reference?

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 

#### Changelog
Rework EnvironmentContext#getSubject method to not return null subject 