### PR TITLE
Rework personal account to be optional for packaging.

### DIFF
--- a/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/api/AccountManager.java
+++ b/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/api/AccountManager.java
@@ -12,6 +12,8 @@ package org.eclipse.che.account.api;
 
 import org.eclipse.che.account.shared.model.Account;
 import org.eclipse.che.account.spi.AccountDao;
+import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 
@@ -33,6 +35,42 @@ public class AccountManager {
     @Inject
     public AccountManager(AccountDao accountDao) {
         this.accountDao = accountDao;
+    }
+
+    /**
+     * Creates account.
+     *
+     * @param account
+     *         account to create
+     * @throws NullPointerException
+     *         when {@code account} is null
+     * @throws ConflictException
+     *         when account with such name or id already exists
+     * @throws ServerException
+     *         when any other error occurs during account creating
+     */
+    public void create(Account account) throws ConflictException, ServerException {
+        requireNonNull(account, "Required non-null account");
+        accountDao.create(new AccountImpl(account));
+    }
+
+    /**
+     * Updates account by replacing an existing account entity with a new one.
+     *
+     * @param account
+     *         account to update
+     * @throws NullPointerException
+     *         when {@code account} is null
+     * @throws NotFoundException
+     *         when account with id {@code account.getId()} is not found
+     * @throws ConflictException
+     *         when account's new name is not unique
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    public void update(Account account) throws NotFoundException, ConflictException, ServerException {
+        requireNonNull(account, "Required non-null account");
+        accountDao.update(new AccountImpl(account));
     }
 
     /**
@@ -69,5 +107,20 @@ public class AccountManager {
     public Account getByName(String name) throws NotFoundException, ServerException {
         requireNonNull(name, "Required non-null account name");
         return accountDao.getByName(name);
+    }
+
+    /**
+     * Removes account by specified {@code id}
+     *
+     * @param id
+     *         account identifier
+     * @throws NullPointerException
+     *         when {@code id} is null
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    public void remove(String id) throws ServerException {
+        requireNonNull(id, "Required non-null account id");
+        accountDao.remove(id);
     }
 }

--- a/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/spi/AccountDao.java
+++ b/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/spi/AccountDao.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.account.spi;
 
+import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 
@@ -19,6 +20,36 @@ import org.eclipse.che.api.core.ServerException;
  * @author Sergii Leschenko
  */
 public interface AccountDao {
+    /**
+     * Creates account.
+     *
+     * @param account
+     *         account to create
+     * @throws NullPointerException
+     *         when {@code account} is null
+     * @throws ConflictException
+     *         when account with such name or id already exists
+     * @throws ServerException
+     *         when any other error occurs during account creating
+     */
+    void create(AccountImpl account) throws ConflictException, ServerException;
+
+    /**
+     * Updates account by replacing an existing entity with a new one.
+     *
+     * @param account
+     *         account to update
+     * @throws NullPointerException
+     *         when {@code account} is null
+     * @throws NotFoundException
+     *         when account with id {@code account.getId()} doesn't exist
+     * @throws ConflictException
+     *         when name updated with a value which is not unique
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    void update(AccountImpl account) throws NotFoundException, ConflictException, ServerException;
+
     /**
      * Gets account by identifier.
      *
@@ -48,4 +79,16 @@ public interface AccountDao {
      *         when any other error occurs during account fetching
      */
     AccountImpl getByName(String name) throws ServerException, NotFoundException;
+
+    /**
+     * Removes account by specified {@code id}
+     *
+     * @param id
+     *         account identifier
+     * @throws NullPointerException
+     *         when {@code id} is null
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    void remove(String id) throws ServerException;
 }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/CheUserCreator.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/CheUserCreator.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.user.server;
 
+import org.eclipse.che.account.api.AccountManager;
+import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
@@ -34,6 +36,8 @@ public class CheUserCreator {
     private UserManager userManager;
 
     @Inject
+    private AccountManager accountManager;
+
     @SuppressWarnings("unused")
     private DBInitializer initializer;
 
@@ -49,6 +53,15 @@ public class CheUserCreator {
                                                       "secret",
                                                       emptyList());
                 userManager.create(cheUser, false);
+            } catch (ConflictException ignore) {
+            }
+        }
+
+        try {
+            accountManager.getById("che");
+        } catch (NotFoundException e) {
+            try {
+                accountManager.create(new AccountImpl("che", "che", "personal"));
             } catch (ConflictException ignore) {
             }
         }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.user.server.model.impl;
 
-import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.model.user.User;
 
-import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -23,7 +21,6 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,12 +38,12 @@ import java.util.Objects;
                 @NamedQuery(name = "User.getByAliasAndPassword",
                             query = "SELECT u " +
                                     "FROM Usr u " +
-                                    "WHERE :alias = u.account.name OR" +
+                                    "WHERE :alias = u.name OR" +
                                     "      :alias = u.email"),
                 @NamedQuery(name = "User.getByAlias",
                             query = "SELECT u FROM Usr u WHERE :alias MEMBER OF u.aliases"),
                 @NamedQuery(name = "User.getByName",
-                            query = "SELECT u FROM Usr u WHERE u.account.name = :name"),
+                            query = "SELECT u FROM Usr u WHERE u.name = :name"),
                 @NamedQuery(name = "User.getByEmail",
                             query = "SELECT u FROM Usr u WHERE u.email = :email"),
                 @NamedQuery(name = "User.getAll",
@@ -58,18 +55,15 @@ import java.util.Objects;
 )
 @Table(name = "usr")
 public class UserImpl implements User {
-    public static final String PERSONAL_ACCOUNT = "personal";
-
     @Id
     @Column(name = "id")
     private String id;
 
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(nullable = false, name = "account_id")
-    private AccountImpl account;
-
     @Column(nullable = false, name = "email")
     private String email;
+
+    @Column(nullable = false, name = "name")
+    private String name;
 
     @Column(name = "password")
     private String password;
@@ -82,13 +76,11 @@ public class UserImpl implements User {
     private List<String> aliases;
 
     public UserImpl() {
-        this.account = new AccountImpl();
-        account.setType(PERSONAL_ACCOUNT);
     }
 
     public UserImpl(String id, String email, String name) {
-        this.account = new AccountImpl(id, name, PERSONAL_ACCOUNT);
         this.id = id;
+        this.name = name;
         this.email = email;
     }
 
@@ -119,9 +111,6 @@ public class UserImpl implements User {
 
     public void setId(String id) {
         this.id = id;
-        if (account != null) {
-            account.setId(id);
-        }
     }
 
     @Override
@@ -135,16 +124,11 @@ public class UserImpl implements User {
 
     @Override
     public String getName() {
-        if (account != null) {
-            return account.getName();
-        }
-        return null;
+        return name;
     }
 
     public void setName(String name) {
-        if (account != null) {
-            account.setName(name);
-        }
+        this.name = name;
     }
 
     @Override
@@ -168,14 +152,6 @@ public class UserImpl implements User {
         this.aliases = aliases;
     }
 
-    public AccountImpl getAccount() {
-        return account;
-    }
-
-    public void setAccount(AccountImpl account) {
-        this.account = account;
-    }
-
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -187,7 +163,7 @@ public class UserImpl implements User {
         final UserImpl that = (UserImpl)obj;
         return Objects.equals(id, that.id)
                && Objects.equals(email, that.email)
-               && Objects.equals(getName(), that.getName())
+               && Objects.equals(name, that.name)
                && Objects.equals(password, that.password)
                && getAliases().equals(that.getAliases());
     }
@@ -197,7 +173,7 @@ public class UserImpl implements User {
         int hash = 7;
         hash = 31 * hash + Objects.hashCode(id);
         hash = 31 * hash + Objects.hashCode(email);
-        hash = 31 * hash + Objects.hashCode(getName());
+        hash = 31 * hash + Objects.hashCode(name);
         hash = 31 * hash + Objects.hashCode(password);
         hash = 31 * hash + getAliases().hashCode();
         return hash;
@@ -208,7 +184,7 @@ public class UserImpl implements User {
         return "UserImpl{" +
                "id='" + id + '\'' +
                ", email='" + email + '\'' +
-               ", name='" + getName() + '\'' +
+               ", name='" + name + '\'' +
                ", password='" + password + '\'' +
                ", aliases=" + aliases +
                '}';

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.4.0/1__drop_user_to_account_relation.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.4.0/1__drop_user_to_account_relation.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright (c) 2012-2017 Codenvy, S.A.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Codenvy, S.A. - initial API and implementation
+--
+
+ALTER TABLE usr ADD name VARCHAR(255);
+
+UPDATE usr
+SET name = ( SELECT name
+             FROM account
+             WHERE id = usr.account_id );
+
+ALTER TABLE usr ALTER COLUMN name SET NOT NULL;
+
+CREATE UNIQUE INDEX index_user_name ON usr (name);
+
+ALTER TABLE usr DROP COLUMN account_id;

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.4.0/2__create_missed_account_indexes.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.4.0/2__create_missed_account_indexes.sql
@@ -1,0 +1,13 @@
+--
+-- Copyright (c) 2012-2017 Codenvy, S.A.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Codenvy, S.A. - initial API and implementation
+--
+
+CREATE INDEX index_account_type ON account (type);
+CREATE INDEX index_workspace_accountid ON workspace (accountid);

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.eclipse.che.account.shared.model.Account;
+import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
 import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;
@@ -46,6 +47,12 @@ import static java.util.Collections.singletonMap;
  * @author Yevhenii Voevodin
  */
 public final class TestObjectsFactory {
+
+    public static AccountImpl createAccount(String id) {
+        return new AccountImpl(id,
+                               id + "_name",
+                               "personal");
+    }
 
     public static UserImpl createUser(String id) {
         return new UserImpl(id,


### PR DESCRIPTION
### What does this PR do?
Makes personal account as optional by reworking UserImpl object not to include personal account.
Adds methods in AccountManager to add abilities to provide personal account manually.
It allows not to have personal accounts in each packaging.
Add missed indexes for type field of account and foreign key to account id in workspace table. Indexes for foreign keys is required to speed up getting records by this field. Also it can speed up another operation like removing because this field can be used by data base for consistency checking.

### Previous behavior
Personal accounts are integrated to UserImpl. In this way each user has his own personal account.

### New behavior
Reworked personal account not to be required for each packaging.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

#### Changelog
- Internal refactoring: move account out of user entity
- Allow personal account to be optional
- Add missed indexes for type field of account and foreign key to account id in workspace table. 

#### Release Notes
- N/A

#### Docs PR
N/A

### Docs updated?
N/A

### Tests written?
Yes

