### PR TITLE
[cli] do not check state of local server from cli for actions/tests

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_action.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_action.sh
@@ -12,18 +12,8 @@
 cmd_action() {
   debug $FUNCNAME
 
-  if container_exist_by_name $CHE_SERVER_CONTAINER_NAME; then
-    CURRENT_CHE_SERVER_CONTAINER_ID=$(get_server_container_id $CHE_SERVER_CONTAINER_NAME)
-    if container_is_running ${CURRENT_CHE_SERVER_CONTAINER_ID} && \
-       server_is_booted ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
+  # Not loaded as part of the init process to save on download time
+  update_image_if_not_found ${UTILITY_IMAGE_CHEACTION}
+  docker_run -it ${UTILITY_IMAGE_CHEACTION} "$@"
 
-        # Not loaded as part of the init process to save on download time
-        update_image_if_not_found ${UTILITY_IMAGE_CHEACTION}
-        docker_run -it ${UTILITY_IMAGE_CHEACTION} "$@"
-
-       return
-    fi
-  fi
-
-  info "action" "The system is not running."
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_test.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_test.sh
@@ -9,18 +9,8 @@
 cmd_test() {
   debug $FUNCNAME
 
-  if container_exist_by_name $CHE_SERVER_CONTAINER_NAME; then
-    CURRENT_CHE_SERVER_CONTAINER_ID=$(get_server_container_id $CHE_SERVER_CONTAINER_NAME)
-    if container_is_running ${CURRENT_CHE_SERVER_CONTAINER_ID} && \
-       server_is_booted ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
+  # Not loaded as part of the init process to save on download time
+  update_image_if_not_found eclipse/che-test:nightly
+  docker_run -it eclipse/che-test:nightly "$@"
 
-        # Not loaded as part of the init process to save on download time
-        update_image_if_not_found eclipse/che-test:nightly
-        docker_run -it eclipse/che-test:nightly "$@"
-
-       return
-    fi
-  fi
-
-  info "test" "The system is not running."
 }


### PR DESCRIPTION
### What does this PR do?
Remove the local check from cli about the state of the server.
The command that is called is already performing the check and as we can ask a remote server we should not check the local state.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1562

### Previous behavior
Check for local state before executing the command

### New behavior
let the command performed the check

### Tests written?
No

### Docs updated?
None (bugfix)

Change-Id: I4ab90b19e5d060d4518ca26c93810df81be67d81
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>

