### PR TITLE
Simplify Dashboard build by relying on NPM run-script

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
     "babel-loader": "^6.2.1",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
+    "bower": "^1.8.0",
     "browser-sync": "~2.9.2",
     "browser-sync-spa": "~1.0.2",
     "chalk": "~1.1.1",
@@ -66,5 +67,11 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "scripts": {
+    "postinstall": "npm run bower && npm run typings && npm run build",
+    "bower": "bower update",
+    "typings": "typings install",
+    "build": "gulp build"
   }
 }

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -62,18 +62,6 @@
                                 <exec dir="${basedir}" executable="npm" failonerror="true">
                                     <arg value="install" />
                                 </exec>
-                                <!-- Download Typings dependencies -->
-                                <exec dir="${basedir}" executable="typings" failonerror="true">
-                                    <arg value="install" />
-                                </exec>
-                                <!-- Download Bower dependencies -->
-                                <exec dir="${basedir}" executable="bower" failonerror="true">
-                                    <arg value="install" />
-                                </exec>
-                                <!-- Build the application -->
-                                <exec dir="${basedir}" executable="gulp" failonerror="true">
-                                    <arg value="build" />
-                                </exec>
                                 <!-- Change base HREF of the application that will be hosted on /dashboard -->
                                 <replace file="${basedir}/dist/index.html">
                                     <replacetoken><![CDATA[<base href="/">]]></replacetoken>


### PR DESCRIPTION
### What does this PR do?
It simplify NPM dependencies install, and no more require to globally install `typings`, `bower` by relying on run-script env.

### What issues does this PR fix or reference?

### Previous behavior
Required to install several NPM dependencies as global.

### New behavior
Binary location are handled per NPM using local installation; it helps keeping the expected version installed defined in `package.json` file.


### Docs :
https://github.com/codenvy/che-docs/pull/79

### Release Note :
- [x] Added to release note (other enhancement + community PR)

#### Changelog
Simplify Dashboard build by relying on NPM run-script