### PR TITLE
Add missing scope for servlet-api dependency

### DIFF
--- a/plugins/plugin-composer/che-plugin-composer-shared/pom.xml
+++ b/plugins/plugin-composer/che-plugin-composer-shared/pom.xml
@@ -125,7 +125,7 @@
                             <impl>server</impl>
                         </configuration>
                     </execution>
-                   <execution>
+                    <execution>
                         <id>dto-client</id>
                         <phase>process-sources</phase>
                         <goals>

--- a/wsmaster/che-core-api-workspace/pom.xml
+++ b/wsmaster/che-core-api-workspace/pom.xml
@@ -54,10 +54,6 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-account</artifactId>
         </dependency>
@@ -116,6 +112,11 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-persist</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This will prevent copying of servlet-api dependency where it should by provided by environment.

#### Changelog
Add missing scope for servlet-api dependency