### PR TITLE
CHE-3774 Add Eclipse Vert.x stack to default assembly

### DIFF
--- a/dockerfiles/cli/version/5.3.0/images-stacks
+++ b/dockerfiles/cli/version/5.3.0/images-stacks
@@ -20,3 +20,4 @@ eclipse/ubuntu_jdk8
 eclipse/ubuntu_jre
 eclipse/ubuntu_python
 eclipse/ubuntu_wildfly8
+registry.centos.org/che-stacks/vertx

--- a/dockerfiles/cli/version/5.3.0/images-stacks
+++ b/dockerfiles/cli/version/5.3.0/images-stacks
@@ -21,3 +21,4 @@ eclipse/ubuntu_jre
 eclipse/ubuntu_python
 eclipse/ubuntu_wildfly8
 registry.centos.org/che-stacks/vertx
+

--- a/dockerfiles/cli/version/nightly/images-stacks
+++ b/dockerfiles/cli/version/nightly/images-stacks
@@ -20,3 +20,4 @@ eclipse/ubuntu_jdk8
 eclipse/ubuntu_jre
 eclipse/ubuntu_python
 eclipse/ubuntu_wildfly8
+registry.centos.org/che-stacks/vertx

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2064,5 +2064,76 @@
       "name": "type-python.svg",
       "mediaType": "image/svg+xml"
     }
-  }
+  },
+  {
+    "id": "vert.x",
+    "creator": "Clement Escoffier",
+    "name": "Eclipse Vert.x",
+    "description": "Eclipse Vert.x Stack on CentOS.",
+    "scope": "advanced",
+    "tags": [
+        "Java",
+        "JDK",
+        "Maven",
+        "Vert.x",
+        "CentOS",
+        "Git"
+    ],
+    "components": [{
+        "name": "CentOS",
+        "version": "---"
+    }, {
+        "name": "JDK",
+        "version": "1.8.0_45"
+    }, {
+        "name": "Maven",
+        "version": "3.2.2"
+    }],
+    "source": {
+        "type": "image",
+        "origin": "registry.centos.org/che-stacks/vertx"
+    },
+    "workspaceConfig": {
+        "environments": {
+            "default": {
+                "machines": {
+                    "dev-machine": {
+                        "agents": [
+                            "org.eclipse.che.terminal",
+                            "org.eclipse.che.ws-agent",
+                            "org.eclipse.che.ssh"
+                        ],
+                        "servers": {},
+                        "attributes": {
+                            "memoryLimitBytes": "2147483648"
+                        }
+                    }
+                },
+                "recipe": {
+                    "location": "registry.centos.org/che-stacks/vertx",
+                    "type": "dockerimage"
+                }
+            }
+        },
+        "name": "default",
+        "defaultEnv": "default",
+        "description": null,
+        "commands": [{
+            "commandLine": "scl enable rh-maven33 'mvn clean install -f ${current.project.path}'",
+            "name": "build",
+            "type": "mvn"
+        }, {
+            "commandLine": "cd ${current.project.path} && scl enable rh-maven33 'java -jar target/*-fat.jar'",
+            "name": "run",
+            "type": "custom",
+            "attributes": {
+                "previewUrl": "http://${server.port.8080}"
+            }
+        }]
+    },
+    "stackIcon": {
+        "name": "type-java.svg",
+        "mediaType": "image/svg+xml"
+    }
+  } 
 ]


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@redhat.com>

This pull request adds the Eclipse Vert.x stack to the default Che assembly.

### What issues does this PR fix or reference?

CHE-3774

#### Changelog
Adds the Eclipse Vert.x stack to the default Che assembly.

#### Release note
We've added a new stack to for the Eclipse Vert.x project. This is a very popular toolkit for building reactive applications on the JVM. You can now build vert.x applications by simply creating a workspace from the vert.x stack - no configuration necessary!