### PR TITLE
CLI - Fix error with version check on nightly

### DIFF
--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -368,7 +368,7 @@ verify_version_compatibility() {
   ##      - If they don't match, then if CLLI is newer fail with message to run upgrade first
   CHE_IMAGE_VERSION=$(get_image_version)
 
-  # Only check for newer versions if not in offline mode.
+  # Only check for newer versions if not in offline mode and not nightly.
   if ! is_offline && ! is_nightly; then
     NEWER=$(compare_versions $CHE_IMAGE_VERSION)
 

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -369,7 +369,7 @@ verify_version_compatibility() {
   CHE_IMAGE_VERSION=$(get_image_version)
 
   # Only check for newer versions if not in offline mode.
-  if ! is_offline; then
+  if ! is_offline && ! is_nightly; then
     NEWER=$(compare_versions $CHE_IMAGE_VERSION)
 
     if [[ "${NEWER}" != "" ]]; then
@@ -423,7 +423,7 @@ is_nightly() {
   fi
 }
 
-function verify_nightly_accuracy() {
+verify_nightly_accuracy() {
   # Per request of the engineers, check to see if the locally cached nightly version is older
   # than the one stored on DockerHub.
   if is_nightly; then
@@ -549,6 +549,7 @@ wait_until_server_is_booted() {
 
 # Compares $1 version to the first 10 versions listed as tags on Docker Hub
 # Returns "" if $1 is newest, otherwise returns the newest version available
+# Does not work with nightly versions - do not use this to compare nightly to another version
 compare_versions() {
 
   local VERSION_LIST_JSON=$(curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/)

--- a/dockerfiles/base/scripts/base/paths.sh
+++ b/dockerfiles/base/scripts/base/paths.sh
@@ -8,16 +8,32 @@
 # Contains path utilities
 
 check_host_volume_mount() {
-  echo 'test' > ${CHE_CONTAINER_ROOT}/test
+  if is_boot2docker; then
+    warning "Boot2docker detected - ensure :/data is mounted to %userprofile%"
+  fi
 
-  if [[ ! -f ${CHE_CONTAINER_ROOT}/test ]]; then
-    error "Docker installed, but unable to write files to your host."
+  if file_system_writable "${CHE_CONTAINER_ROOT}/test"; then 
+    delete_file_system_test "${CHE_CONTAINER_ROOT}/test"
+  else 
+    error "Unable to write files to your host"
     error "Have you enabled Docker to allow mounting host directories?"
     error "Did you give our CLI rights to create files on your host?"
     return 2;
   fi
+}
 
-  rm -rf ${CHE_CONTAINER_ROOT}/test
+file_system_writable() {
+  echo 'test' > "${1}" 
+
+  if [[ -f "${1}" ]]; then
+    return 0
+  else 
+    return 1
+  fi
+}
+
+delete_file_system_test() {
+  rm -rf $1 > /dev/null 2>&1
 }
 
 get_mount_path() {

--- a/dockerfiles/base/scripts/base/startup_funcs.sh
+++ b/dockerfiles/base/scripts/base/startup_funcs.sh
@@ -310,7 +310,6 @@ init() {
      SCRIPTS_CONTAINER_SOURCE_DIR="/scripts"
   fi
 
-
   # Primary source directory
   source "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/library.sh
 
@@ -350,18 +349,6 @@ cli_init() {
     return 2;
   fi
 
-  # TODO: Change this to use the current folder or perhaps ~?
-  if is_boot2docker && has_docker_for_windows_client; then
-    if [[ "${CHE_HOST_INSTANCE,,}" != *"${USERPROFILE,,}"* ]]; then
-      CHE_HOST_INSTANCE=$(get_mount_path "${USERPROFILE}/.${CHE_MINI_PRODUCT_NAME}/")
-      warning "Boot2docker for Windows - CHE_INSTANCE set to $CHE_HOST_INSTANCE"
-    fi
-    if [[ "${CHE_HOST_CONFIG,,}" != *"${USERPROFILE,,}"* ]]; then
-      CHE_HOST_CONFIG=$(get_mount_path "${USERPROFILE}/.${CHE_MINI_PRODUCT_NAME}/")
-      warning "Boot2docker for Windows - CHE_CONFIG set to $CHE_HOST_CONFIG"
-    fi
-  fi
-
   # Special function to perform special behaviors if you are running nightly version
   verify_nightly_accuracy
 
@@ -399,7 +386,6 @@ start() {
   
   # Begin product-specific CLI calls
   info "cli" "Loading cli..."
-
 
   # The pre_init method is unique to each assembly. This method must be provided by 
   # a custom CLI assembly in their container and can set global variables which are 


### PR DESCRIPTION
Signed-off-by: Tyler Jewell tjewell@codenvy.com <tjewell@codenvy.com>

With the new commit made where we check for newer versions on DockerHub, this check was being done for all versions including nightly.  The `compare_versions` method would break if you had a nightly image. This fix adds a test to only do this check if you are not nightly.

Also, this cleans up some of the code around boot2docker checks. Unfortunately, since we are running our client inside of a Docker container, all we can do is print a warning message that you are on boot2docker and that you need to verify your host mounts.

### Changelog and Release Note Information
**Changelog**: Skips DockerHub newer version check if using `nightly` image

### Release Note
- [x] Added to release note