### PR TITLE
Fixed workspace-details page not always displayed

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -117,7 +117,7 @@ export class WorkspaceDetailsController {
 
   init(): void {
     let routeParams = this.$route.current.params;
-    this.workspaceNamespace = this.$location.search().namespace || (this.getNamespaces() ? this.getNamespaces()[0].id : undefined);
+    this.workspaceNamespace = this.$location.search().namespace || (this.getNamespaces().length ? this.getNamespaces()[0].id : undefined);
     if (routeParams && routeParams.namespace && routeParams.workspaceName) {
       this.isCreationFlow = false;
       this.namespace = routeParams.namespace;


### PR DESCRIPTION
### What does this PR do?
This PR fixes bug which prevents to show workspace-details page.

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>

#### Changelog
Fix bug which prevents to show workspace-details page.

### Release note
- [x] Added to Release Note

**Che version:** 5.2.0-SNAPSHOT