### PR TITLE
CHE-3761: Workaround illegal response from docker

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/cleaner/DockerAbandonedResourcesCleaner.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/cleaner/DockerAbandonedResourcesCleaner.java
@@ -161,7 +161,14 @@ public class DockerAbandonedResourcesCleaner implements Runnable {
     @VisibleForTesting
     void cleanNetworks() {
         try {
-            for (Network network : dockerConnector.getNetworks(GET_NETWORKS_PARAMS)) {
+            List<Network> customNetworks = dockerConnector.getNetworks(GET_NETWORKS_PARAMS);
+            // This workaround is added because of docker bug which returns null instead of empty list
+            // See https://github.com/docker/docker/issues/29946
+            if (customNetworks == null) {
+                return;
+            }
+
+            for (Network network : customNetworks) {
                 Matcher cheNetworkMatcher = CHE_NETWORK_PATTERN.matcher(network.getName());
                 if (cheNetworkMatcher.matches() && network.getContainers().isEmpty() && !additionalNetworks.contains(network.getName()) &&
                     !runtimes.hasRuntime(cheNetworkMatcher.group(WORKSPACE_ID_REGEX_GROUP))) {


### PR DESCRIPTION
### What does this PR do?
Adds check on retrieving networks list from docker for null response value.
This PR is workaround for bug in docker when null is returned instead of empty list on getting list of custom networks.

### What issues does this PR fix or reference?
#3761 

#### Changelog
Workaround illegal response from docker




