### PR TITLE
Add Key Binding Scheme Selector

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/hotkeys/HotKeyItem.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/hotkeys/HotKeyItem.java
@@ -12,19 +12,28 @@ package org.eclipse.che.ide.api.hotkeys;
 
 /**
  * Representation hotKey which performs some action
+ *
  * @author Alexander Andrienko
+ * @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
  */
 public class HotKeyItem {
-    private String actionDescription;
-    private String hotKey;
+    private String  actionDescription;
+    private String  hotKey;
+    private boolean isGlobal;
 
     public HotKeyItem(String actionDescription, String hotKey) {
+        this(actionDescription, hotKey, false);
+    }
+
+    public HotKeyItem(String actionDescription, String hotKey, boolean isGlobal) {
         this.actionDescription = actionDescription;
         this.hotKey = hotKey;
+        this.isGlobal = isGlobal;
     }
 
     /**
      * Get action description
+     *
      * @return action description
      */
     public String getActionDescription() {
@@ -33,9 +42,15 @@ public class HotKeyItem {
 
     /**
      * Get hotKey
+     *
      * @return readable hotKey line
      */
     public String getHotKey() {
         return hotKey;
+    }
+
+    /** Return a boolean to know if the hot key is handled globally or by the selected schema */
+    public boolean isGlobal() {
+        return isGlobal;
     }
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/keybinding/KeyBindingAgent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/keybinding/KeyBindingAgent.java
@@ -16,6 +16,8 @@ import org.eclipse.che.ide.util.input.CharCodeWithModifiers;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.commons.annotation.Nullable;
 
+import java.util.List;
+
 /**
  * Public interface of the key binding management.
  * The key binding defines the key sequence that should be used to invoke the command.
@@ -23,6 +25,7 @@ import org.eclipse.che.commons.annotation.Nullable;
  * named schemes that the user may activate.
  *
  * @author <a href="mailto:evidolob@exoplatform.com">Evgen Vidolob</a>
+ * @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
  * @version $Id:
  */
 @SDK(title = "ide.api.ui.keyBinding")
@@ -39,8 +42,11 @@ public interface KeyBindingAgent {
     /**
      * Get build in Eclipse key binding scheme.
      *
+     * @deprecated Eclipse should not be accessed like that, use {@link KeyBindingAgent#getScheme(String)} or
+     *             {@link KeyBindingAgent#getActive()}
      * @return the Eclipse scheme.
      */
+    @Deprecated
     Scheme getEclipse();
 
     /**
@@ -49,6 +55,25 @@ public interface KeyBindingAgent {
      * @return the scheme
      */
     Scheme getActive();
+
+    /**
+     * Register a new scheme
+     * @param scheme to register
+     */
+    void addScheme(Scheme scheme);
+
+    /**
+     * Get a registered Scheme, and return null if nothing is corresponding.
+     * @param id of the registered scheme
+     * @return the expected scheme, or null.
+     */
+    Scheme getScheme(String id);
+
+    /** List registered schemes */
+    List<Scheme> getSchemes();
+
+    /** Change active scheme using his identifier */
+    void setActive(@NotNull String scheme);
 
     /**
      * @return keyboard shortcut for the action with the specified <code>actionId</code>

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/keybinding/Scheme.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/keybinding/Scheme.java
@@ -21,6 +21,7 @@ import java.util.List;
  *
  * @author Evgen Vidolob
  * @author Artem Zatsarynnyi
+ * @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
  */
 public interface Scheme {
 
@@ -71,4 +72,9 @@ public interface Scheme {
      */
     @Nullable
     CharCodeWithModifiers getKeyBinding(@NotNull String actionId);
+
+    /**
+     * @return a boolean to check if the action is handled by this scheme
+     */
+    boolean contains(@NotNull String actionId);
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/HotKeyResources.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/HotKeyResources.java
@@ -44,10 +44,13 @@ public interface HotKeyResources extends ClientBundle {
 
         String isGlobal();
 
+        /** Returns the CSS class name for scheme selection text label in 'Key Bindings' form. */
         String selectionLabel();
 
+        /** Returns the CSS class name for scheme selection list box in 'Key Bindings' form. */
         String selectionListBox();
 
+        /** Returns the CSS class name for scheme selection panel in 'Key Bindings' form. */
         String selectionPanel();
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/HotKeyResources.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/HotKeyResources.java
@@ -18,6 +18,7 @@ import com.google.gwt.resources.client.DataResource;
  * Resources for KeyBindings widget
  *
  * @author Alexander Andrienko
+ * @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
  */
 public interface HotKeyResources extends ClientBundle {
 
@@ -40,6 +41,14 @@ public interface HotKeyResources extends ClientBundle {
         String categories();
 
         String description();
+
+        String isGlobal();
+
+        String selectionLabel();
+
+        String selectionListBox();
+
+        String selectionPanel();
     }
 
     @DataResource.MimeType("image/svg+xml")

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/dialog/HotKeysDialogView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/dialog/HotKeysDialogView.java
@@ -12,8 +12,9 @@ package org.eclipse.che.ide.hotkeys.dialog;
 
 import com.google.inject.ImplementedBy;
 
-import org.eclipse.che.ide.api.mvp.View;
 import org.eclipse.che.ide.api.hotkeys.HotKeyItem;
+import org.eclipse.che.ide.api.keybinding.Scheme;
+import org.eclipse.che.ide.api.mvp.View;
 
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import java.util.Map;
  *
  * @author Alexander Andrienko
  * @author Artem Zatsarynnyi
+ * @author @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
  */
 @ImplementedBy(HotKeysDialogViewImpl.class)
 public interface HotKeysDialogView extends View<HotKeysDialogView.ActionDelegate> {
@@ -44,13 +46,21 @@ public interface HotKeysDialogView extends View<HotKeysDialogView.ActionDelegate
      */
     void setData(Map<String, List<HotKeyItem>> data);
 
+    void setSchemes(String select, List<Scheme> schemes);
+
+    /** Value of selected scheme in the ListBox field */
+    String getSelectedScheme();
+
     interface ActionDelegate {
 
         /** Show list hotKeys. */
         void showHotKeys();
 
-        /** Perform some action in response to user's clicking 'Ok' button. */
-        void onOkClicked();
+        /** Perform some action in response to user's clicking 'Save' button. */
+        void onSaveClicked();
+
+        /** Perform some action in response to user's clicking 'Close' button. */
+        void onCloseClicked();
 
         /** Will be called when 'Print' button clicked. */
         void onPrintClicked();
@@ -62,5 +72,8 @@ public interface HotKeysDialogView extends View<HotKeysDialogView.ActionDelegate
          *         text for filter keybindings
          */
         void onFilterValueChanged(String filteredText);
+
+        /** Perform some action in response to scheme selection change */
+        void onSchemeSelectionChanged();
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/dialog/HotKeysDialogViewImpl.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/dialog/HotKeysDialogViewImpl.ui.xml
@@ -8,6 +8,7 @@
 
     Contributors:
       Codenvy, S.A. - initial API and implementation
+
 -->
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/dialog/HotKeysDialogViewImpl.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/hotkeys/dialog/HotKeysDialogViewImpl.ui.xml
@@ -8,16 +8,22 @@
 
     Contributors:
       Codenvy, S.A. - initial API and implementation
-
 -->
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:che='urn:import:org.eclipse.che.ide.ui.listbox'>
     <ui:with field="res" type="org.eclipse.che.ide.hotkeys.HotKeyResources"/>
 
     <g:DockLayoutPanel unit="PX" width="675px" height="450px" addStyleNames="{res.css.blackBorder}">
         <g:north size="28">
             <g:TextBox ui:field="filterInput" addStyleNames="{res.css.filter}"/>
+        </g:north>
+        <g:north size="28">
+            <g:FlowPanel addStyleNames="{res.css.selectionPanel}" ui:field="selectionPanel">
+                <g:Label addStyleNames="{res.css.selectionLabel}">Scheme:</g:Label>
+                <che:CustomListBox addStyleNames="{res.css.selectionListBox}" ui:field="selectionListBox"/>
+            </g:FlowPanel>
         </g:north>
         <g:center>
             <g:FlowPanel ui:field="category" addStyleNames="{res.css.categories}"/>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/SchemeImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/SchemeImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 /**
  * @author Evgen Vidolob
  * @author Artem Zatsarynnyi
+ * @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
  */
 public class SchemeImpl implements Scheme {
 
@@ -95,5 +96,10 @@ public class SchemeImpl implements Scheme {
     @Override
     public CharCodeWithModifiers getKeyBinding(@NotNull String actionId) {
         return actionId2CharCode.get(actionId);
+    }
+
+    @Override
+    public boolean contains(String actionId) {
+        return actionId2CharCode.containsKey(actionId);
     }
 }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/hotkeys/HotKeysCss.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/hotkeys/HotKeysCss.css
@@ -57,3 +57,20 @@
     margin-left: 10px;
 }
 
+.isGlobal > div {
+    opacity: 0.6;
+}
+
+.selectionPanel {
+    margin: 3px 4px;
+}
+
+.selectionListBox {
+    float: right;
+}
+
+.selectionLabel {
+    float: left;
+    margin-top: 3px;
+    margin-left: 5px;
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/keybinding/KeyBindingManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/keybinding/KeyBindingManagerTest.java
@@ -1,0 +1,83 @@
+package org.eclipse.che.ide.keybinding;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+import org.eclipse.che.ide.api.keybinding.Scheme;
+import org.eclipse.che.ide.util.input.CharCodeWithModifiers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author <a href="mailto:ak@nuxeo.com">Arnaud Kervern</a>
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class KeyBindingManagerTest {
+
+    protected KeyBindingManager keyManager;
+    protected Scheme            testScheme;
+
+    @Before
+    public void setUp() {
+        keyManager = new KeyBindingManager(null, null);
+        testScheme = new SchemeImpl("org.eclipse.che.test.scheme", "Sample Description");
+    }
+
+    @Test
+    public void testSchemeRegistration() {
+        assertNull(keyManager.getScheme(testScheme.getSchemeId()));
+        keyManager.addScheme(testScheme);
+        assertNotNull(keyManager.getScheme(testScheme.getSchemeId()));
+    }
+
+    @Test
+    public void testGlobalSchemeFallback() {
+        String actionId = "fallback";
+        keyManager.getGlobal().addKey(mock(CharCodeWithModifiers.class), actionId);
+        keyManager.addScheme(testScheme);
+        assertTrue(keyManager.getGlobal().contains(actionId));
+
+        // Assert Global scheme is responding to the action
+        keyManager.setActive(keyManager.getGlobal().getSchemeId());
+        assertNotNull(keyManager.getKeyBinding(actionId));
+
+        // Set TestScheme as active, and assert action is still registered
+        keyManager.setActive(testScheme.getSchemeId());
+        assertFalse(testScheme.contains(actionId));
+        assertNotNull(keyManager.getKeyBinding(actionId));
+    }
+
+    @Test
+    public void testKeyBindingGetter() {
+        assertEquals(2, keyManager.getSchemes().size());
+        String actionId = "testAction1";
+        assertNull(keyManager.getKeyBinding(actionId));
+
+        testScheme.addKey(mock(CharCodeWithModifiers.class), actionId);
+        // Action should not be handled yet - scheme not added / selected
+        assertNull(keyManager.getKeyBinding(actionId));
+
+        keyManager.addScheme(testScheme);
+        // Action should not be handled yet - scheme not selected
+        assertNull(keyManager.getKeyBinding(actionId));
+
+        keyManager.setActive(testScheme.getSchemeId());
+        assertNotNull(keyManager.getKeyBinding(actionId));
+    }
+
+    @Test
+    public void testActionContainsCheck() {
+        String actionId = "testAction2";
+        assertFalse(testScheme.contains(actionId));
+        testScheme.addKey(mock(CharCodeWithModifiers.class), actionId);
+        assertTrue(testScheme.contains(actionId));
+    }
+}
+

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/keybinding/KeyBindingManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/keybinding/KeyBindingManagerTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.che.ide.keybinding;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;


### PR DESCRIPTION
### What does this PR do?

Here is a primarily work before trying to contribute an Eclipse based Key Binding:

This PR add the ability to switch between registered Key Bindings Scheme.
 - Refactor the way `org.eclipse.che.ide.keybinding.KeyBindingManager` worked. Using a Map of registered schemes instead of manager's attributes.
 - Expose accessor / helper methods on `org.eclipse.che.ide.keybinding.KeyBindingManager`
 - Fallback selected scheme missing bindings to the global one

In the key binding popup:
 - Add a listbox listing to select any registered scheme
 - Show witch action is fallback-ing on the global one

https://github.com/codenvy/qa/pull/581

#### Changelog
 `org.eclipse.che.ide.api.keybinding.KeyBindingAgent#getEclipse` has been deprecated: use `KeyBindingAgent#getActive()` or `KeyBindingAgent#getScheme(String)` if you want to access a Scheme

#### Release Notes
We have deprecated `org.eclipse.che.ide.api.keybinding.KeyBindingAgent#getEclipse`. You can access a scheme via `KeyBindingAgent#getActive()` or `KeyBindingAgent#getScheme(String)`.
