### PR TITLE
CODENVY-1579: show server's address along with URL

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.html
@@ -56,8 +56,10 @@
                    ng-model="editServerDialogController.protocol"
                    type="type"
                    aria-label="Server protocol"
-                   ng-pattern="/^[A-Za-z0-9_\-\.]+$/">
-          <div ng-message="pattern">The reference should not contain special characters like space, dollar, etc.</div>
+                   ng-pattern="/^[A-Za-z0-9_\-\.]+$/"
+                   required>
+          <div ng-message="required">A protocol is required.</div>
+          <div ng-message="pattern">The protocol should not contain special characters like space, dollar, etc.</div>
         </che-input>
       </div>
     </che-label-container>

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.controller.ts
@@ -60,7 +60,7 @@ export class ListServersController {
   buildServersList(): void {
     this.serversList = this.lodash.map(this.servers, (server: IEnvironmentManagerMachineServer, reference: string) => {
       let serverItem: IServerListItem = angular.extend({}, {reference: reference}, server);
-      serverItem.protocol = serverItem.protocol ? serverItem.protocol : 'http';
+      serverItem.protocol = serverItem.protocol ? serverItem.protocol : '-';
       return serverItem;
     });
   }

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.html
@@ -10,7 +10,7 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<div class="list-ports"
+<div class="list-servers"
      layout="column">
 
   <div ng-if="listServersController.serversList.length > 0">
@@ -45,7 +45,7 @@
           <che-list-header-column flex="15"
                                   che-column-title="Protocol"></che-list-header-column>
           <che-list-header-column flex="50"
-                                  che-column-title="Runtime URL"></che-list-header-column>
+                                  che-column-title="Runtime"></che-list-header-column>
           <che-list-header-column flex="10"
                                   che-column-title="Action"></che-list-header-column>
         </div>
@@ -60,7 +60,7 @@
              layout-align="start stretch"
              class="server-item-row">
           <div layout="row"
-               layout-align="start center"
+               layout-align="start start"
                class="che-checkbox-area">
             <che-list-item-checked ng-model="listServersController.serversSelectedStatus[server.reference]"
                                    che-aria-label-checkbox="Port {{server.reference}}"
@@ -69,12 +69,11 @@
           </div>
           <div flex
                layout-xs="column" layout-gt-xs="row"
-               layout-align-gt-xs="start center"
-               layout-align-xs="start start"
+               layout-align="start start"
                class="che-list-item-details">
             <div flex="15"
                  class="che-list-item-name">
-              <span class="che-hover">{{server.reference}}</span>
+              <span class="che-hover">{{server.reference | lowercase}}</span>
             </div>
             <div flex="10"
                  class="che-list-item-name">
@@ -86,9 +85,19 @@
             </div>
             <div flex="50"
                  class="che-list-item-name">
-              <span class="che-hover" ng-if="server.runtime">
-                <a href="{{server.runtime.url}}" target="_blank">{{server.runtime.url}}</a>
-              </span>
+              <div ng-if="server.runtime"
+                   class="che-hover list-servers-item-runtime">
+                <div ng-if="server.runtime.address"
+                     class="list-servers-item-runtime-address">
+                  <div class="title">Address:</div>
+                  <div>{{server.runtime.address}}</div>
+                </div>
+                <div ng-if="server.runtime.url"
+                     class="list-servers-item-runtime-url">
+                  <div class="title">URL:</div>
+                  <div><a href="{{server.runtime.url}}" target="_blank">{{server.runtime.url}}</a></div>
+                </div>
+              </div>
             </div>
             <div flex="10">
               <div class="che-list-actions"

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.styl
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.styl
@@ -1,6 +1,28 @@
-.list-ports
+.list-servers
   *
     outline none !important
+
+  .list-servers-item-runtime
+    display table
+    margin 6px 0
+
+    & div
+      line-height 28px
+
+    .list-servers-item-runtime-address
+      display table-row
+
+      & > div
+        display table-cell
+
+      .title
+        padding-right 5px
+
+    .list-servers-item-runtime-url
+      display table-row
+
+      & > div
+        display table-cell
 
   .che-list
     margin-bottom 12px
@@ -26,3 +48,12 @@
 
   .che-list-header md-item
     border-top none
+
+  .che-list-item-content
+    display block
+
+  .che-list-item-details
+    cursor inherit
+
+  md-item
+    display block


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR improves Service section of machine config to show server's address along with URL.

![che-workspace-running-runtime-servers](https://cloud.githubusercontent.com/assets/16220722/22239090/6a4576ce-e21d-11e6-80df-70dde287fb1d.png)


### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1579

#### Changelog
Show server's address along with URL.

#### Release notes
- [x] Fixed displaying both server's URL and address for runtime and undefined protocol

### Docs Pull Request
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/93