### PR TITLE
change AGENT_EXTERNAL_PORT to real ephemeral port

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -904,7 +904,7 @@ run_connectivity_tests() {
   AGENT_INTERNAL_IP=$(docker inspect --format='{{.NetworkSettings.IPAddress}}' fakeagent)
   AGENT_INTERNAL_PORT=80
   AGENT_EXTERNAL_IP=$GLOBAL_GET_DOCKER_HOST_IP
-  AGENT_EXTERNAL_PORT=12345
+  AGENT_EXTERNAL_PORT=32768
 
 
   ### TEST 1: Simulate browser ==> workspace agent HTTP connectivity

--- a/dockerfiles/base/scripts/base/commands/cmd_network.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_network.sh
@@ -29,7 +29,7 @@ cmd_network() {
 
 start_test_server() {
   export AGENT_INTERNAL_PORT=80
-  export AGENT_EXTERNAL_PORT=12345
+  export AGENT_EXTERNAL_PORT=32768
 
   # Start mini httpd server to run simulated tests
   docker run -d -p $AGENT_EXTERNAL_PORT:$AGENT_INTERNAL_PORT --name fakeagent \


### PR DESCRIPTION
@TylerJewell I've made this PR because I think this should fix issues on our nightly env where we are not able to run codenvy due to failed network checs. the problem is that in test we trying to use random port `12345` as ephemeral but ephemeral port rage is `32768:65535` and `12345` port is blocked by firewall while ephemeral range is available.

#### Changelog
Change AGENT_EXTERNAL_PORT to real ephemeral port