### PR TITLE
Added functional tests for CLI start command

### DIFF
--- a/dockerfiles/base/test.sh
+++ b/dockerfiles/base/test.sh
@@ -14,10 +14,18 @@ BATS_BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 init "$@"
 IMAGE_NAME="eclipse/che-bats:$TAG"
 
+# Runs functional CLI tests in a docker container.
+# Pass a file name of functional bats tests as an argument.
+# The file has to be placed in tests folder in directory containing this script
+run_test_in_docker_container() {
+  docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/$1
+}
+
 echo "Running tests in container from image $IMAGE_NAME"
 echo "Running functional bats tests for CLI prompts and usage"
-docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/cli_prompts_usage_tests.bats
+run_test_in_docker_container cli_prompts_usage_tests.bats
 echo "Running functional bats tests for init and destroy commands"
-docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/cmd_init_destroy_tests.bats
+run_test_in_docker_container cmd_init_destroy_tests.bats
 echo "Running functionals bats tests for start command"
-docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/cmd_start_tests.bats
+run_test_in_docker_container cmd_start_tests.bats
+

--- a/dockerfiles/base/test.sh
+++ b/dockerfiles/base/test.sh
@@ -17,6 +17,7 @@ IMAGE_NAME="eclipse/che-bats:$TAG"
 echo "Running tests in container from image $IMAGE_NAME"
 echo "Running functional bats tests for CLI prompts and usage"
 docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/cli_prompts_usage_tests.bats
-echo "Running functional bats tests for init and destroy"
+echo "Running functional bats tests for init and destroy commands"
 docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/cmd_init_destroy_tests.bats
-
+echo "Running functionals bats tests for start command"
+docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/cmd_start_tests.bats

--- a/dockerfiles/base/test.sh
+++ b/dockerfiles/base/test.sh
@@ -16,9 +16,10 @@ IMAGE_NAME="eclipse/che-bats:$TAG"
 
 # Runs functional CLI tests in a docker container.
 # Pass a file name of functional bats tests as an argument.
-# The file has to be placed in tests folder in directory containing this script
+#   The file has to be placed in tests folder in directory containing this script
+# (Optional) second argument is options for a docker run command.
 run_test_in_docker_container() {
-  docker run -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/$1
+  docker run $2 -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/$1
 }
 
 echo "Running tests in container from image $IMAGE_NAME"
@@ -27,5 +28,5 @@ run_test_in_docker_container cli_prompts_usage_tests.bats
 echo "Running functional bats tests for init and destroy commands"
 run_test_in_docker_container cmd_init_destroy_tests.bats
 echo "Running functionals bats tests for start command"
-run_test_in_docker_container cmd_start_tests.bats
+run_test_in_docker_container cmd_start_tests.bats --net=host
 

--- a/dockerfiles/base/tests/cli_prompts_usage_tests.bats
+++ b/dockerfiles/base/tests/cli_prompts_usage_tests.bats
@@ -15,7 +15,7 @@ source $BATS_BASE_DIR/tests/test_base.sh
   prompt_substring="-v /var/run/docker.sock:/var/run/docker.sock"
 
   #WHEN
-  result=$(docker run eclipse/che-cli:nightly start || true)
+  result=$(docker run $CLI_IMAGE start || true)
 
   #THEN
   [[ $result == *"$prompt_substring"* ]]

--- a/dockerfiles/base/tests/cmd_start_tests.bats
+++ b/dockerfiles/base/tests/cmd_start_tests.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Copyright (c) 2012-2017 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Marian Labuda - Initial Implementation
+
+source $BATS_BASE_DIR/tests/test_base.sh
+
+# Kill running che server instance if there is any to be able to run tests
+setup() {
+  kill_running_named_container che
+  remove_named_container che
+}
+
+@test "test cli 'start' with default settings" {
+  #GIVEN
+  if [ ! port_is_free 8080 ]; then
+    [ "$status" -eq 1 ]
+    [ "$output" = "Default port 8080 for che server is used. Cannot run this test on default che server port" ]
+  fi
+  tmp_path=${TESTRUN_DIR}/start1
+
+  #WHEN
+  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE start
+
+  #THEN
+  [[ $(docker inspect --format="{{.State.Running}}" che) -eq "true" ]]
+  ip_address=$(docker inspect -f {{.NetworkSettings.Networks.bridge.IPAddress}} che)
+  curl -fsS http://${ip_address}:8080  > /dev/null
+}
+
+@test "test cli 'start' with custom port" {
+  #GIVEN
+  tmp_path=${TESTRUN_DIR}/start2
+  free_port=$(get_free_port)
+  
+  #WHEN
+  docker run -e CHE_PORT=$free_port -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE start
+
+  #THEN
+  [[ $(docker inspect --format="{{.State.Running}}" che) -eq "true" ]]
+  ip_address=$(docker inspect -f {{.NetworkSettings.Networks.bridge.IPAddress}} che)
+  curl -fsS http://${ip_address}:${free_port}  > /dev/null
+}
+

--- a/dockerfiles/base/tests/test_base.sh
+++ b/dockerfiles/base/tests/test_base.sh
@@ -19,15 +19,39 @@ fi
 mkdir $TESTRUN_DIR -p
 
 kill_running_named_container() {
-  if [ $(docker ps --format '{{.Names}}' | grep $1 | wc -l) -eq 1 ]; then
+  if [[ $(docker ps --format '{{.Names}}' | grep $1 | wc -l) -eq 1 ]]; then
     echo "Stopping named container $1"
     docker kill $1 1>/dev/null
   fi
 }
 
 remove_named_container() {
-  if [ $(docker ps -a --format '{{.Names}}' | grep $1 | wc -l) -eq 1 ]; then
+  if [[ $(docker ps -a --format '{{.Names}}' | grep $1 | wc -l) -eq 1 ]]; then
     echo "Removing named container $1"
     docker rm $1 1>/dev/null
   fi
 }
+
+# Pass a port as an argument to check whether is free or not
+# Returns 0 if port is free (not listening), 1 otherwise
+port_is_free() {
+  if [[ $(netstat -lnt | awk -v port=$1 '$6 == "LISTEN" && $4 ~ "."port' | wc -l) -gt 0 ]]; then
+    return 1
+  else 
+    return 0
+  fi
+}
+
+# Get first free port from range of dynamic/private ports
+get_free_port() {
+  local port=49200
+  while [[ $(port_is_free $port) -eq 1 ]]; do
+    if [[ $port -eq 65535 ]]; then
+       echo ""
+       return 1
+    fi
+    port=$((port+1))
+  done
+  echo $port
+}
+


### PR DESCRIPTION
Signed-off-by: Marian Labuda <mlabuda@redhat.com>

### What does this PR do?
Added basic functional tests for CLI start command. Plus few minors:
- fixed usage of CLI image in cli prompts and usage tests suite
- extended test base with function to get free port and find out whether a passed port is free 

### Changelog and Release Note Information
#### Changelog
Added basic CLI 'start' functional tests

**Relase Notes and Docs PR** N/A
- [x] Added to release note in community section
