### PR TITLE
remove redundant env var for che

### DIFF
--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -69,13 +69,6 @@
 #     your network or access to the Internet.
 #CHE_MACHINE_EXTRA_HOSTS=NULL
 
-# Idle Timeout
-#     The system will suspend the workspace and snapshot it if the end user is idle for
-#     this length of time. Idleness is determined by the length of time that a user has
-#     not interacted with the workspace, meaning that one of our agents has not received
-#     instructions. Leaving a browser window open counts as idleness time.
-#CHE_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS=600000
-
 # Memory
 #     The recommended RAM size for new workspaces when created from the dashboard.
 #CHE_MACHINE_DEFAULT_MEM_SIZE_MB=1024


### PR DESCRIPTION
fixes: https://github.com/eclipse/che/issues/3873

#### Changelog
Change default workspace idle timeout to 4 hours