### PR TITLE
Chefile handling of inner Dockerfile content

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_dir.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_dir.sh
@@ -20,7 +20,5 @@ cmd_dir() {
 
   # Not loaded as part of the init process to save on download time
   load_utilities_images_if_not_done
-  docker_run -it ${UTILITY_IMAGE_CHEDIR} "$@"
-
   docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} ${UTILITY_IMAGE_CHEDIR} ${HOST_FOLDER_TO_USE} "$@"
 }

--- a/dockerfiles/lib/Dockerfile
+++ b/dockerfiles/lib/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x \
 COPY runtime-dependencies/package.json /runtime/
 COPY . /lib-typescript/
 
-RUN cd /lib-typescript/ && npm install \
+RUN cd /lib-typescript/ && npm install && npm test \
     && cd /runtime && npm install && /lib-typescript/node_modules/.bin/tsc --project /lib-typescript/ \
     && mv /lib-typescript/lib /che-lib && cd /lib-typescript/src && find . -name "*.properties" -exec install -D {} /che-lib/{} \;\
     && rm -rf /lib-typescript && mv /runtime/node_modules /che-lib && rm -rf /runtime

--- a/dockerfiles/lib/src/internal/dir/che-dir.ts
+++ b/dockerfiles/lib/src/internal/dir/che-dir.ts
@@ -38,6 +38,7 @@ import {Parameter} from "../../spi/decorator/parameter";
 import {ProductName} from "../../utils/product-name";
 import {SSHGenerator} from "../../spi/docker/ssh-generator";
 import {CheFileStructWorkspaceProject} from "./chefile-struct/che-file-struct";
+import {StringUtils} from "../../utils/string-utils";
 
 /**
  * Entrypoint for the Chefile handling in a directory.
@@ -207,10 +208,13 @@ export class CheDir {
     }
 
     // load the chefile script if defined
-    var script_code = this.fs.readFileSync(this.cheFile).toString();
+    var script_code : string = this.fs.readFileSync(this.cheFile).toString();
 
     // strip the lines that are beginning with # as it may be comments
-    script_code = script_code.replace(/#[^\n]*/g, '');
+    script_code = StringUtils.removeSharpComments(script_code);
+
+    // replace multiline content for workspace by raw strings
+    script_code  = StringUtils.keepWorkspaceRawStrings(script_code);
 
     // create sandboxed object
     var sandbox = { "che": this.chefileStruct,  "workspace": this.chefileStructWorkspace, "console": console};

--- a/dockerfiles/lib/src/utils/string-utils.spec.ts
+++ b/dockerfiles/lib/src/utils/string-utils.spec.ts
@@ -11,7 +11,7 @@
 import {StringUtils} from './string-utils';
 
 let expect = require('chai').expect;
-
+let vm = require('vm');
 
 describe("String Utils tests", () => {
     it("not included", () => {
@@ -21,4 +21,43 @@ describe("String Utils tests", () => {
     it("starts with", () => {
         expect(StringUtils.startsWith("toto", "t")).to.be.true;
     });
+
+
+    it("remove # comments", () => {
+        let text : string = "This is a string\n" + "# THis is a comment\n" + " and here it is not a # comment";
+        let expectedText : string = "This is a string\n\n" + " and here it is not a # comment";
+        expect(StringUtils.removeSharpComments(text)).to.equal(expectedText);
+    });
+
+
+    it("Check dockerfile are handled with raw strings", () => {
+        let workspace : any = {};
+        workspace.content = "";
+        let text : string = "workspace.content=\`" + String.raw`
+            FROM Image
+
+        RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        locales \
+        openssh-server \
+        sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+ mkdir /var/run/sshd && \
+ sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
+ echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+ useradd -u 1000 -G users,sudo -p $(openssl rand -base64 32) -s /bin/bash -m user && \
+ echo "#! /bin/bash\n set -e\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /home/user/entrypoint.sh && \
+ chmod a+x /home/user/entrypoint.sh
+`+ "\`";
+
+        text = StringUtils.keepWorkspaceRawStrings(text);
+
+        // create sandboxed object
+        var sandbox = {  "workspace": workspace};
+        vm.runInNewContext(text, sandbox);
+
+        expect(workspace.content).to.contain(String.raw`s@session\s*required\s*`);
+    });
+
+
 });

--- a/dockerfiles/lib/src/utils/string-utils.ts
+++ b/dockerfiles/lib/src/utils/string-utils.ts
@@ -9,8 +9,39 @@
  *   Codenvy, S.A. - initial API and implementation
  */
 
+/**
+ * Handle some operations on strings.
+ * @author Florent Benoit
+ */
 export class StringUtils {
+
+    /**
+     * Check if the given value string i starting with searchString
+     * @param value the original string
+     * @param searchString the value to search
+     * @returns {boolean} true if it starts with
+     */
     static startsWith(value:string, searchString:string):boolean {
         return value.substr(0, searchString.length) === searchString;
     }
+
+    /**
+     * Remove from the given string all the given comments starting by #
+     * @param value
+     * @returns {string}
+     */
+    static removeSharpComments(value : string) : string {
+        return value.replace(/^#.*/gm, '');
+    }
+
+    /**
+     * If string literals es6 def for workspace, use raw strings to keep dockerfile content
+     * @param value
+     * @returns {string}
+     */
+    static keepWorkspaceRawStrings(value : string) : string {
+        return value.replace(/^(workspace.)(.*)=\`(.*)$/gm, '$1$2=String.raw`$3');
+    }
+
 }
+


### PR DESCRIPTION
### What does this PR do?

Fix #3704 by handling recipe content as a raw content and handle # for comments correctly

1. Multiline content is escaped by default while it shouldn’t for Dockerfile content.
Users may add “String.raw” but it’s not obvious so add it automatically

2. Handle # comments correctly

### What issues does this PR fix or reference?
Fix #3704 

### Changelog and Release Note Information
#### Changelog
Handle dockerfile content in Chefile as raw string

**Release Notes**:
bug only


### Docs Pull Request
no doc, bug fixing.