### PR TITLE
Fixed links pointing to stack documentation

### DIFF
--- a/dashboard/src/app/stacks/stack-details/stack.html
+++ b/dashboard/src/app/stacks/stack-details/stack.html
@@ -114,7 +114,7 @@
                         ng-change="stackController.updateStackFromJson()"
                         aria-label="Stack configuration editor">
       </textarea>
-          <a target="_blank" ng-href="https://eclipse-che.readme.io/docs/stacks">Docs: Stack Structure</a>
+          <a target="_blank" ng-href="https://www.eclipse.org/che/docs/workspace/stacks/index.html">Docs: Stack Structure</a>
         </div>
       </che-show-area>
     </che-label-container>

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.html
@@ -13,7 +13,7 @@
         <div ng-message="required">The recipe is required.</div>
       </che-input>
       <div class="recipe-docs-link">
-        <a href="https://eclipse-che.readme.io/docs/stacks#custom-stacks-for-che" target="_blank">Custom stack documentation</a>
+        <a href="https://www.eclipse.org/che/docs/workspace/stacks/index.html#stack-administration" target="_blank">Custom stack documentation</a>
       </div>
     </div>
 


### PR DESCRIPTION
### What does this PR do?
This issue update links which are pointing to stack documentation

### What issues does this PR fix or reference?
Links to stack documentation were not accurate anymore with the move to the new docs

### Changelog and Release Note Information
#### Changelog
Fixed links pointing to stack documentation

**Release Notes**: Fixed links pointing to stack documentation


### Docs Pull Request
Not needed
