### PR TITLE
Don't sort node interceptors at initialization state

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
@@ -41,11 +41,11 @@ import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -71,7 +71,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
      *
      * @see NodeInterceptor
      */
-    private TreeSet<NodeInterceptor> nodeInterceptors;
+    private Set<NodeInterceptor> nodeInterceptors;
 
     private final Comparator<NodeInterceptor> priorityComparator = new Comparator<NodeInterceptor>() {
         @Override
@@ -238,7 +238,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
      *         set of {@link NodeInterceptor}
      */
     public NodeLoader(@Nullable Set<NodeInterceptor> nodeInterceptors) {
-        this.nodeInterceptors = new TreeSet<>(priorityComparator);
+        this.nodeInterceptors = new HashSet<>();
         if (nodeInterceptors != null) {
             this.nodeInterceptors.addAll(nodeInterceptors);
         }
@@ -393,7 +393,10 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
                     onLoadSuccess(parent, children);
                 }
 
-                iterate(new LinkedList<>(nodeInterceptors), parent, children);
+                LinkedList<NodeInterceptor> sortedByPriorityQueue = new LinkedList<>(nodeInterceptors);
+                Collections.sort(sortedByPriorityQueue, priorityComparator);
+
+                iterate(sortedByPriorityQueue, parent, children);
             }
         };
     }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/LibraryNodeProvider.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/LibraryNodeProvider.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.ext.java.client.tree;
 
 import com.google.common.annotations.Beta;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
@@ -32,6 +33,7 @@ import static org.eclipse.che.ide.ext.java.client.util.JavaUtil.isJavaProject;
  * @author Vlad Zhukovskiy
  */
 @Beta
+@Singleton
 public class LibraryNodeProvider implements NodeInterceptor {
 
     private final JavaNodeFactory  nodeFactory;


### PR DESCRIPTION
This PR changes behavior of initialization `org.eclipse.che.ide.ui.smartTree.NodeLoader` so the incoming set of `org.eclipse.che.ide.api.data.tree.NodeInterceptor`s doesn't sort to prevent randomly deletion of particular interceptors. See more description in related issue: #3894 

#### Changelog
Don't sort node interceptors at initialization state