### PR TITLE
Moved functional tests to cli dir to avoid circular dependency

### DIFF
--- a/dockerfiles/base/build.sh
+++ b/dockerfiles/base/build.sh
@@ -6,12 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-base"
-base_dir=$(cd "$(dirname "$0")"; pwd)
-. $base_dir/../build.include
+. $(cd "$(dirname "$0")"; pwd)/../build.include
 
 init "$@"
 build
 
-if [ $(skip_tests "$@") = false ]; then
-  sh $base_dir/test.sh $TAG
-fi

--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -6,7 +6,12 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-cli"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. $base_dir/../build.include
 
 init "$@"
 build
+
+if [ $(skip_tests "$@") = false ]; then
+  sh $base_dir/test.sh $TAG
+fi

--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -8,8 +8,8 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
-BATS_BASE_DIR=$(cd "$(dirname "$0")"; pwd)
-. $BATS_BASE_DIR/../build.include
+BATS_BASE_DIR=$(cd "$(dirname "$0")"/..; pwd)
+. $BATS_BASE_DIR/build.include
 
 init "$@"
 IMAGE_NAME="eclipse/che-bats:$TAG"
@@ -19,7 +19,7 @@ IMAGE_NAME="eclipse/che-bats:$TAG"
 #   The file has to be placed in tests folder in directory containing this script
 # (Optional) second argument is options for a docker run command.
 run_test_in_docker_container() {
-  docker run $2 -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/tests/$1
+  docker run $2 -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/cli/tests/$1
 }
 
 echo "Running tests in container from image $IMAGE_NAME"

--- a/dockerfiles/cli/tests/cli_prompts_usage_tests.bats
+++ b/dockerfiles/cli/tests/cli_prompts_usage_tests.bats
@@ -8,7 +8,7 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
-source $BATS_BASE_DIR/tests/test_base.sh
+source $BATS_BASE_DIR/cli/tests/test_base.sh
 
 @test "test CLI prompt to provide volume for docker sock" {
   #GIVEN

--- a/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
+++ b/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
@@ -8,7 +8,7 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
-source $BATS_BASE_DIR/tests/test_base.sh
+source $BATS_BASE_DIR/cli/tests/test_base.sh
 
 @test "test 'init' and 'destroy --quiet' with existing dir" {
   #GIVEN

--- a/dockerfiles/cli/tests/cmd_start_tests.bats
+++ b/dockerfiles/cli/tests/cmd_start_tests.bats
@@ -8,7 +8,7 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
-source $BATS_BASE_DIR/tests/test_base.sh
+source $BATS_BASE_DIR/cli/tests/test_base.sh
 
 # Kill running che server instance if there is any to be able to run tests
 setup() {

--- a/dockerfiles/cli/tests/test_base.sh
+++ b/dockerfiles/cli/tests/test_base.sh
@@ -9,9 +9,9 @@
 #   Marian Labuda - Initial Implementation
 
 export CLI_IMAGE="eclipse/che-cli:"$CLI_IMAGE_TAG
-source $BATS_BASE_DIR/scripts/base/startup_funcs.sh
-export SCRIPTS_DIR=$BATS_BASE_DIR/scripts/base
-export TESTS_DIR=$BATS_BASE_DIR/tests
+source $BATS_BASE_DIR/base/scripts/base/startup_funcs.sh
+export SCRIPTS_DIR=$BATS_BASE_DIR/base/scripts/base
+export TESTS_DIR=$BATS_BASE_DIR/cli/tests
 export TESTRUN_DIR=$TESTS_DIR/testrun
 if [ -d $TESTRUN_DIR ]; then
  rm -rf $TESTRUN_DIR


### PR DESCRIPTION
### What does this PR do?
CLI tests moved from base folder to cli folder what is more appropriate place to keep them. It removed circular dependency, now there is left only dependency on eclipse/che-bats image.

### What issues does this PR fix or reference?
fixes #3882

### Changelog and Release Note Information
#### Changelog
Moved CLI functional tests from base directory to cli directory

**Release Notes**: N/A


### Docs Pull Request
https://github.com/eclipse/che-docs/pull/99
