### PR TITLE
[cli] add verbose flag for sync command

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_sync.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_sync.sh
@@ -24,8 +24,6 @@ cmd_sync() {
 
   # Not loaded as part of the init process to save on download time
   load_utilities_images_if_not_done
-  docker_run -it ${UTILITY_IMAGE_CHEMOUNT} "$@"
-
   # Determine the mount path to do the mount
   info "mount" "Starting sync process to ${SYNC_MOUNT}"
 

--- a/dockerfiles/mount/entrypoint.sh
+++ b/dockerfiles/mount/entrypoint.sh
@@ -43,6 +43,16 @@ Usage on Mac or Windows:
  COMMAND_EXTRA_ARGS=
 }
 
+is_verbose() {
+  for i in "$@" ; do
+    if [ $i = "--unison-verbose" ]; then
+      echo "true"
+      exit 0
+    fi
+  done
+  echo "false"
+}
+
 parse_command_line () {
   if [ $# -eq 0 ]; then
     usage
@@ -125,7 +135,20 @@ if [ $status -ne 0 ]; then
 fi
 info "INFO: (che mount): Successfully mounted ${SSH_USER}@${SSH_IP}:/projects (${SSH_PORT})"
 info "INFO: (che mount): Initial sync...Please wait."
-unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer -log=false > /dev/null 2>&1
+
+local UNISON_ARGS="";
+if [ $(is_verbose "$@") = true ]; then
+  UNISON_ARGS="-batch -auto -prefer=newer"
+  info "using verbose mode"
+else
+  UNISON_ARGS="-silent -auto -prefer=newer -log=false > /dev/null 2>&1"
+fi
+
+UNISON_COMMAND="unison /mntssh /mnthost ${UNISON_ARGS}"
+debug "Using command ${UNISON_COMMAND}"
+
+eval "${UNISON_COMMAND}"
+
 status=$?
 if [ $status -ne 0 ]; then
     error "ERROR: Fatal error occurred ($status)"

--- a/dockerfiles/mount/entrypoint.sh
+++ b/dockerfiles/mount/entrypoint.sh
@@ -51,7 +51,9 @@ parse_command_line () {
 
   # See if profile document was provided
   mkdir -p $HOME/.unison
-  cp -rf /profile/default.prf $HOME/.unison/default.prf
+  if [ -f /profile/default.prf ]; then
+    cp -rf /profile/default.prf $HOME/.unison/default.prf
+  fi
 
   WORKSPACE_NAME=$1
   shift


### PR DESCRIPTION
### What does this PR do?

Introduce --unison-verbose mode when using eclipse/che sync command
If enabled it will displays the log on the console. It may be a helper when people have errors.

### What issues does this PR fix or reference?
Help to diagnose #3840 

### Changelog and Release Note Information
#### Changelog
`--unison-verbose` flag for sync command

**Release Notes**:
Allow to get verbose mode on unison utility when using CLI sync command (--unison-verbose)


### Docs Pull Request
https://github.com/eclipse/che-docs/pull/100