### PR TITLE
[cli] revert test of the start command

### DIFF
--- a/dockerfiles/base/test.sh
+++ b/dockerfiles/base/test.sh
@@ -27,6 +27,6 @@ echo "Running functional bats tests for CLI prompts and usage"
 run_test_in_docker_container cli_prompts_usage_tests.bats
 echo "Running functional bats tests for init and destroy commands"
 run_test_in_docker_container cmd_init_destroy_tests.bats
-echo "Running functionals bats tests for start command"
-run_test_in_docker_container cmd_start_tests.bats --net=host
+#echo "Running functionals bats tests for start command"
+#run_test_in_docker_container cmd_start_tests.bats --net=host
 


### PR DESCRIPTION
comment test introduced by PR https://github.com/eclipse/che/pull/3870


CI is failing with
```
17:29:42 Running functionals bats tests for start command
17:29:42 1..2
17:29:57 not ok 1 test cli 'start' with default settings
17:29:57 # (in test file /home/codenvy/workspace/che-base-docker-image-nightly/dockerfiles/base/tests/cmd_start_tests.bats, line 28)
17:29:57 #   `docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE start' failed with status 2
17:29:57 # /tmp/bats.42.src: line 21: [: port_is_free: unary operator expected
```

Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
