### PR TITLE
Avoid duplicate projects in application context

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -255,6 +255,20 @@ public class AppContextImpl implements AppContext,
         }
 
         if (delta.getKind() == ADDED) {
+
+            if (projects != null) {
+                for (int i = 0; i < projects.length; i++) {
+
+                    //this scenario may occurred when we received from the server that root project was created, and if it already exists
+                    //then we update existed record
+
+                    if (projects[i].getLocation().equals(resource.getLocation()) && resource.isProject()) {
+                        projects[i] = resource.asProject();
+                        return;
+                    }
+                }
+            }
+
             Project[] newProjects = copyOf(projects, projects.length + 1);
             newProjects[projects.length] = (Project)resource;
             projects = newProjects;


### PR DESCRIPTION
This PR prevent duplicating project in application context. Duplicating may be occurred when project imports via UI, in that case IDE knows that a new project is appeared and additionally receives a notification from the server that project has been created. Besides there was a little code cleanup performed in _Select main class_ dialog. Related issue: #3896 