### PR TITLE
[cli/chedir] Fix #2787 Do not write default values of che.server when writing the default Chefile

### DIFF
--- a/dockerfiles/lib/src/internal/dir/che-dir.ts
+++ b/dockerfiles/lib/src/internal/dir/che-dir.ts
@@ -335,6 +335,9 @@ export class CheDir {
     // work on a copy
     let che : CheFileStruct =  JSON.parse(JSON.stringify(this.chefileStruct));
 
+    // Do not write default server values
+    delete che.server;
+
     // make flat the che object
     let flatChe = this.flatJson('che', che);
     flatChe.forEach((value, key) => {


### PR DESCRIPTION
### What does this PR do?
Do not write anymore default values into the initial Chefile file when using chedir

### What issues does this PR fix or reference?
#2787 

### Changelog and Release Note Information
#### Changelog
Do not write default values into the initial Chefile file when using chedir

**Release Notes**:
N/A

### Docs Pull Request
I'm not sure it is required to be documented ? let me know