### PR TITLE
Input-boxes with 'required' attribute are marked with asterisk

### DIFF
--- a/dashboard/src/components/widget/input/che-input-box.directive.ts
+++ b/dashboard/src/components/widget/input/che-input-box.directive.ts
@@ -52,12 +52,13 @@ export class CheInputBox implements ng.IDirective {
    * @returns {string} the template
    */
   template(element, attrs) {
-    var inputName = attrs.cheName;
-    var labelName = attrs.cheLabelName || '';
-    var placeHolder = attrs.chePlaceHolder;
-    var pattern = attrs.chePattern;
+    let inputName = attrs.cheName;
+    let labelName = attrs.cheLabelName || '';
+    let placeHolder = attrs.chePlaceHolder;
+    let pattern = attrs.chePattern;
+    let isMandatory = angular.isDefined(attrs.required) ? true : false;
 
-    var template = '<div class="che-input-box">'
+    let template = '<div class="che-input-box">'
       + '<md-input-container hide-gt-xs ng-class="{\'che-input-box-mobile-no-label\': !labelName}">'
       + '<label ng-if="labelName">' + labelName + '</label>'
       + '<input type="text" name="' + inputName + '"';
@@ -92,6 +93,9 @@ export class CheInputBox implements ng.IDirective {
       template = template + ' ng-disabled="disabled"';
     }
     template = template + ' data-ng-model="valueModel">';
+    if (isMandatory) {
+      template += '<span class="che-input-asterisk">*</span>';
+    }
 
     if (attrs.cheWidth === 'auto') {
       template = template + '<div class="che-input-box-desktop-hidden-text">{{valueModel ? valueModel : placeHolder}}</div>';

--- a/dashboard/src/components/widget/input/che-input-box.styl
+++ b/dashboard/src/components/widget/input/che-input-box.styl
@@ -57,6 +57,13 @@ label.che-input-box-desktop-label
       white-space nowrap
       background-color inherit
 
+    .che-input-asterisk
+      position absolute
+      right 4px
+      color $error-color
+      font-size 17px
+      line-height 48px
+
     .che-input-box-desktop-hidden-text
       min-width 170px
       overflow hidden

--- a/dashboard/src/components/widget/select/che-select.directive.ts
+++ b/dashboard/src/components/widget/select/che-select.directive.ts
@@ -41,7 +41,7 @@ export class CheSelect {
   }
 
   template(element: ng.IAugmentedJQuery, attrs: any): string {
-    return `<div class="che-select">
+    return `<div class="che-select desktop-untouched">
       <!-- Mobile version -->
       <md-input-container class="che-select-mobile" hide-gt-xs>
         <label ng-if="labelName">{{value ? labelName : placeHolder}}</label>
@@ -106,6 +106,16 @@ export class CheSelect {
       // set the value of the attribute
       selectElements.attr(attrs.$attr[key], attrs[key] !== '' ? attrs[key] : 'true');
       element.removeAttr(attrs.$attr[key]);
+    });
+  }
+
+  link($scope, $element, attrs) {
+    let deregistrationFn = $scope.$watch('myForm.desk' + attrs.cheName + '.$touched', (isTouched) => {
+      if (isTouched) {
+        $element.removeClass('desktop-untouched');
+        $element.addClass('desktop-touched');
+        deregistrationFn();
+      }
     });
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- che-select widget: switch CSS classes when model becomes 'touched'
- che-input-box widget: show asterisk if 'required' attribute is present

![screenshot-localhost 3000-2017-01-26-16-32-46](https://cloud.githubusercontent.com/assets/16220722/22339114/9ccbfe12-e3f1-11e6-8161-d3e85cf58496.png)

### Changelog and Release Note Information
#### Changelog
Input-boxes with 'required' attribute are marked with asterisk.

**Release Notes**: Input-boxes with 'required' attribute are marked with asterisk.
<!-- markdown to be included in marketing announcement - N/A for bugs -->


<!-- ### Docs Pull Request -->
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>
