### PR TITLE
Package assembly-ide-war as classes artifact

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -458,6 +458,7 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <packagingExcludes>%regex[WEB-INF\/lib\/(?!.*j2ee).*.jar]</packagingExcludes>
+                    <attachClasses>true</attachClasses>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
+                <artifactId>assembly-ide-war</artifactId>
+                <version>${che.version}</version>
+                <classifier>classes</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-main</artifactId>
                 <version>${che.version}</version>
             </dependency>


### PR DESCRIPTION
It's very hard for plugin developers to extend assembly-ide-war.
To do that they need to copy all dependencies declared assembly-ide-war
because assembly-ide-war as war dependency can be reused in dependency section of pom.
If we package it as classes it can be reused to inject transitive dependencies
Examples how to reuse https://github.com/skabashnyuk/sample/blob/master/assembly/assembly-ide-war/pom.xml#L31-L35

#### Changelog
Package assembly-ide-war as classes artifact