### PR TITLE
CHE-3937: Introducing properties for OpenShift liveness probe initial delay / timeout

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -276,6 +276,8 @@ che.openshift.username=openshift-dev
 che.openshift.password=devel
 che.openshift.project=eclipse-che
 che.openshift.serviceaccountname=cheserviceaccount
+che.openshift.liveness.probe.delay=300
+che.openshift.liveness.probe.timeout=1
 
 # Which implementation of DockerConnector to use in managing containers. In general,
 # the base implementation of DockerConnector is appropriate, but OpenShiftConnector

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -101,8 +101,6 @@ public class OpenShiftConnector extends DockerConnector {
     private static final String DOCKER_PREFIX                            = "docker://";
     private static final String DOCKER_PROTOCOL_PORT_DELIMITER           = "/";
     private static final String OPENSHIFT_SERVICE_TYPE_NODE_PORT         = "NodePort";
-    private static final int OPENSHIFT_LIVENESS_PROBE_DELAY              = 120;
-    private static final int OPENSHIFT_LIVENESS_PROBE_TIMEOUT            = 1;
     private static final int OPENSHIFT_WAIT_POD_DELAY                    = 1000;
     private static final int OPENSHIFT_WAIT_POD_TIMEOUT                  = 120;
     private static final String OPENSHIFT_POD_STATUS_RUNNING             = "Running";
@@ -118,6 +116,8 @@ public class OpenShiftConnector extends DockerConnector {
     private final KubernetesService        kubernetesService;
     private final String                   openShiftCheProjectName;
     private final String                   openShiftCheServiceAccount;
+    private final int                      openShiftLivenessProbeDelay;
+    private final int                      openShiftLivenessProbeTimeout;
 
     @Inject
     public OpenShiftConnector(DockerConnectorConfiguration connectorConfiguration,
@@ -132,7 +132,10 @@ public class OpenShiftConnector extends DockerConnector {
                               @Named("che.openshift.username") String openShiftUserName,
                               @Named("che.openshift.password") String openShiftUserPassword,
                               @Named("che.openshift.project") String openShiftCheProjectName,
-                              @Named("che.openshift.serviceaccountname") String openShiftCheServiceAccount) {
+                              @Named("che.openshift.serviceaccountname") String openShiftCheServiceAccount,
+                              @Named("che.openshift.liveness.probe.delay") int openShiftLivenessProbeDelay,
+                              @Named("che.openshift.liveness.probe.timeout") int openShiftLivenessProbeTimeout) {
+
         super(connectorConfiguration, connectionFactory, authResolver, dockerApiVersionPathPrefixProvider);
         this.openShiftCheProjectName = openShiftCheProjectName;
         this.openShiftCheServiceAccount = openShiftCheServiceAccount;
@@ -140,6 +143,8 @@ public class OpenShiftConnector extends DockerConnector {
         this.kubernetesEnvVar = kubernetesEnvVar;
         this.kubernetesContainer = kubernetesContainer;
         this.kubernetesService = kubernetesService;
+        this.openShiftLivenessProbeDelay = openShiftLivenessProbeDelay;
+        this.openShiftLivenessProbeTimeout = openShiftLivenessProbeTimeout;
 
         Config config = new ConfigBuilder().withMasterUrl(openShiftApiEndpoint)
                 .withUsername(openShiftUserName)
@@ -671,8 +676,8 @@ public class OpenShiftConnector extends DockerConnector {
                             .withNewTcpSocket()
                             .withNewPort(port)
                             .endTcpSocket()
-                            .withInitialDelaySeconds(OPENSHIFT_LIVENESS_PROBE_DELAY)
-                            .withTimeoutSeconds(OPENSHIFT_LIVENESS_PROBE_TIMEOUT)
+                            .withInitialDelaySeconds(openShiftLivenessProbeDelay)
+                            .withTimeoutSeconds(openShiftLivenessProbeTimeout)
                             .build();
         }
 

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -41,6 +41,8 @@ public class OpenShiftConnectorTest {
     private static final String   OPENSHIFT_API_ENDPOINT_MINISHIFT = "https://192.168.64.2:8443/";
     private static final String   OPENSHIFT_DEFAULT_USER_NAME = "openshift-dev";
     private static final String   OPENSHIFT_DEFAULT_USER_PASSWORD = "devel";
+    private static final int      OPENSHIFT_LIVENESS_PROBE_DELAY = 300;
+    private static final int      OPENSHIFT_LIVENESS_PROBE_TIMEOUT = 1;
 
     @Mock
     private DockerConnectorConfiguration       dockerConnectorConfiguration;
@@ -77,7 +79,9 @@ public class OpenShiftConnectorTest {
                                                         OPENSHIFT_DEFAULT_USER_NAME,
                                                         OPENSHIFT_DEFAULT_USER_PASSWORD,
                                                         CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
-                                                        CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT));
+                                                        CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
+                                                        OPENSHIFT_LIVENESS_PROBE_DELAY,
+                                                        OPENSHIFT_LIVENESS_PROBE_TIMEOUT));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Introduces properties for OpenShift liveness probe initial delay / timeout

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3937

### Changelog and Release Note Information
#### Changelog
Introducing properties for OpenShift liveness probe initial delay / timeout

### Docs Pull Request
Will be provided as part of https://github.com/eclipse/che/issues/3817

