### PR TITLE
Implement OpenShift pull, tag, and inspectImage

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -127,7 +127,7 @@ import static org.eclipse.che.commons.lang.IoUtil.readAndCloseQuietly;
 public class DockerConnector {
     private static final Logger LOG  = LoggerFactory.getLogger(DockerConnector.class);
     // Docker uses uppercase in first letter in names of json objects, e.g. {"Id":"123"} instead of {"id":"123"}
-    private static final Gson   GSON = new GsonBuilder().disableHtmlEscaping()
+    protected static final Gson GSON = new GsonBuilder().disableHtmlEscaping()
                                                         .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
                                                         .create();
 

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -28,6 +28,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/exception/OpenShiftException.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/exception/OpenShiftException.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.openshift.client.exception;
 
-public class OpenShiftException extends RuntimeException {
+import java.io.IOException;
+
+public class OpenShiftException extends IOException {
 
     public OpenShiftException(String message) {
         super(message);

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesContainer.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesContainer.java
@@ -26,16 +26,19 @@ import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 /**
  * Provides API for managing Kubernetes {@link ContainerPort}
  */
-public class KubernetesContainer {
+public final class KubernetesContainer {
+
+    private KubernetesContainer() {
+    }
 
     /**
      * Retrieves list of ({@link ContainerPort} based on ports defined in
      * {@link ContainerConfig} and {@link ImageConfig}
-     * 
+     *
      * @param exposedPorts
      * @return list of {@link ContainerPort}
      */
-    public List<ContainerPort> getContainerPortsFrom(Set<String> exposedPorts) {
+    public static List<ContainerPort> getContainerPortsFrom(Set<String> exposedPorts) {
         List<ContainerPort> containerPorts = new ArrayList<>(exposedPorts.size());
         for (String exposedPort : exposedPorts) {
             String[] portAndProtocol = exposedPort.split("/", 2);

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesEnvVar.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesEnvVar.java
@@ -23,17 +23,20 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 /**
  * Provides API for managing Kubernetes {@link EnvVar}
  */
-public class KubernetesEnvVar {
+public final class KubernetesEnvVar {
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesEnvVar.class);
+
+    private KubernetesEnvVar() {
+    }
 
     /**
      * Retrieves list of {@link EnvVar} based on environment variables specified
      * in {@link ContainerConfig}
-     * 
+     *
      * @param envVariables
      * @return list of {@link EnvVar}
      */
-    public List<EnvVar> getEnvFrom(String[] envVariables) {
+    public static List<EnvVar> getEnvFrom(String[] envVariables) {
         LOG.info("Container environment variables:");
         List<EnvVar> env = new ArrayList<>();
         for (String envVariable : envVariables) {

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesLabelConverter.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesLabelConverter.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * Converter of labels defined in {@link ContainerConfig} for matching to Kubernetes
  * annotation requirements
  */
-public class KubernetesLabelConverter {
+public final class KubernetesLabelConverter {
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesLabelConverter.class);
     /** Prefix used for che server labels */
     private static final String CHE_SERVER_LABEL_PREFIX  = "che:server";
@@ -34,10 +34,13 @@ public class KubernetesLabelConverter {
     private static final Pattern CHE_SERVER_LABEL_KEY    = Pattern.compile("^0(.*)0$");
     private static final String KUBERNETES_ANNOTATION_REGEX = "([A-Za-z0-9][-A-Za-z0-9_\\.]*)?[A-Za-z0-9]";
 
+    private KubernetesLabelConverter() {
+    }
+
     /**
      * @return prefix that is used for Che server labels
      */
-    public String getCheServerLabelPrefix() {
+    public static String getCheServerLabelPrefix() {
         return CHE_SERVER_LABEL_PREFIX;
     }
 
@@ -59,7 +62,7 @@ public class KubernetesLabelConverter {
      * @param labels Map of labels to convert
      * @return Map of labels converted to DNS Names
      */
-    public Map<String, String> labelsToNames(Map<String, String> labels) {
+    public static Map<String, String> labelsToNames(Map<String, String> labels) {
         Map<String, String> names = new HashMap<>();
         for (Map.Entry<String, String> label : labels.entrySet()) {
 
@@ -98,7 +101,7 @@ public class KubernetesLabelConverter {
      * @param labels Map of DNS names
      * @return Map of unconverted labels
      */
-    public Map<String, String> namesToLabels(Map<String, String> names) {
+    public static Map<String, String> namesToLabels(Map<String, String> names) {
         Map<String, String> labels = new HashMap<>();
         for (Map.Entry<String, String> entry: names.entrySet()){
             String key = entry.getKey();
@@ -126,9 +129,9 @@ public class KubernetesLabelConverter {
     /**
      * Checks if there are any potential problems coupled with label conversion
      * @param label
-     * @return true if label has no conversion issues, false otherwise 
+     * @return true if label has no conversion issues, false otherwise
      */
-    private boolean hasConversionProblems(final Map.Entry<String, String> label) {
+    private static boolean hasConversionProblems(final Map.Entry<String, String> label) {
         boolean hasProblems = false;
         String key = label.getKey();
         String value = label.getValue();
@@ -149,7 +152,7 @@ public class KubernetesLabelConverter {
     /**
      * Convert keys: e.g. "che:server:4401/tcp:ref" -> "che.server.4401-tcp.ref"
      */
-    private String convertLabelKey(final String key) {
+    private static String convertLabelKey(final String key) {
         return key.replaceAll(":", ".").replaceAll("/", "_");
     }
 
@@ -157,7 +160,7 @@ public class KubernetesLabelConverter {
      * Convert values: e.g. "/api" -> ".api" Note: values may include '-' e.g.
      * "tomcat-debug"
      */
-    private String convertLabelValue(final String value) {
+    private static String convertLabelValue(final String value) {
         return value.replaceAll("/", "_");
     }
 
@@ -165,11 +168,11 @@ public class KubernetesLabelConverter {
      * Adds padding since DNS names must start and end with alphanumeric
      * characters
      */
-    private String addPadding(final String label) {
+    private static String addPadding(final String label) {
         return String.format(CHE_SERVER_LABEL_PADDING, label);
     }
 
-    private boolean matchesKubernetesLabelRegex(final String label) {
+    private static boolean matchesKubernetesLabelRegex(final String label) {
         return label.matches(KUBERNETES_ANNOTATION_REGEX);
     }
 }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesService.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesService.java
@@ -26,16 +26,19 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 /**
  * Provides API for managing Kubernetes {@link ServicePort}
  */
-public class KubernetesService {
+public final class KubernetesService {
+
+    private KubernetesService() {
+    }
 
     /**
      * Retrieves list of {@link ServicePort} based on ports defined in
      * {@link ContainerConfig} and {@link ImageConfig}
-     * 
+     *
      * @param exposedPorts
      * @return list of {@link ServicePort}
      */
-    public List<ServicePort> getServicePortsFrom(Set<String> exposedPorts) {
+    public static List<ServicePort> getServicePortsFrom(Set<String> exposedPorts) {
         List<ServicePort> servicePorts = new ArrayList<>(exposedPorts.size());
         for (String exposedPort : exposedPorts) {
             String[] portAndProtocol = exposedPort.split("/", 2);

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtils.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtils.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client.kubernetes;
+
+import org.apache.commons.lang.StringUtils;
+
+public final class KubernetesStringUtils {
+
+    /**
+     * Max length of a Kubernetes name or label;
+     */
+    private static final int    MAX_CHARS     = 63;
+    private static final String DOCKER_PREFIX = "docker://";
+
+    private KubernetesStringUtils() {
+    }
+
+    /**
+     * Converts strings to fit requirements of Kubernetes names and labels.
+     * Names in Kubernetes are limited to 63 characters.
+     * @param input the string to normalize
+     * @return the normalized string.
+     */
+    public static String getNormalizedString(String input) {
+        int end = Math.min(input.length(), MAX_CHARS);
+        return input.substring(0, end);
+    }
+
+    /**
+     * @param containerID
+     * @return normalized version of 'ContainerID' without 'docker://' prefix and double quotes
+     */
+    public static String normalizeContainerID(final String containerID) {
+        return StringUtils.replaceOnce(containerID, DOCKER_PREFIX, "").replace("\"", "");
+    }
+
+    /**
+     * @param containerID
+     * @return label based on 'ContainerID' (first 12 chars of ID)
+     */
+    public static String getLabelFromContainerID(final String containerID) {
+        return StringUtils.substring(containerID, 0, 12);
+    }
+
+    /**
+     * Converts a String into a suitable name for an openshift container.
+     * Kubernetes names are limited to 63 chars and must match the regex
+     * {@code [a-z0-9]([-a-z0-9]*[a-z0-9])?}
+     * @param input the string to convert
+     */
+    public static String getContainerName(String input) {
+        if (input.startsWith("workspace")) {
+            input = input.replaceFirst("workspace", "");
+        }
+        return getNormalizedString(input.replaceAll("_", "-"));
+    }
+
+    /**
+     * Converts image stream name (e.g. eclipse/ubuntu_jdk8 to eclipse_ubuntu_jdk8).
+     * This has to be done because for OpenShift ImageStream names, the organization component
+     * of a docker repository is the namespace of the ImageStream, and so '/' is not supported
+     * in ImageStream names.
+     * @param repository the original docker repository String.
+     * @return
+     */
+    public static String getImageStreamName(String repository) {
+        return getNormalizedString(repository.replaceAll("/", "_"));
+    }
+
+    /**
+     * Generates a name to be used as a tag from a docker repository.
+     * In OpenShift, tagging functionality is limited, so while in Docker we may want to
+     * <p>{@code docker tag eclipse/ubuntu_jdk8 eclipse-che/<workspace-id>},<p> this is not
+     * possible in OpenShift. This method returns a trimmed version of {@code <workspace-id>}
+     * @param repo the target repository spec in a {@code docker tag} command.
+     * @return an appropriate tag name
+     */
+    public static String getTagNameFromRepoString(String repo) {
+        String name;
+        if (repo.contains("/")) {
+            name = repo.split("/")[1];
+        } else {
+            name = repo;
+        }
+        name = name.replaceAll("workspace", "")
+                   .replaceAll("machine", "")
+                   .replaceAll("che_.*", "")
+                   .replaceAll("_", "");
+
+        name = "che-ws-" + name;
+        return getNormalizedString(name);
+    }
+
+    /**
+     * Gets an ImageStreamTag name from docker pull specs by converting repository strings
+     * to suit the convention used in {@link KubernetesStringUtils#getImageStreamName(String)}
+     * and {@link KubernetesStringUtils#getTagNameFromRepoString(String)}.
+     *
+     * <p> e.g. will convert {@code eclipse/ubuntu_jdk8} and {@code eclipse-che/<workspace-id>}
+     * into {@code eclipse_ubuntu_jdk8:<workspace-id>}
+     *
+     * @param oldRepository
+     *          The docker image repository that is tracked by the ImageStream
+     * @param newRepository
+     *          The docker repository that has been tagged to follow oldRepository
+     * @return A string that can be used to refer to the ImageStreamTag formed from these repositories.
+     */
+    public static String getImageStreamTagName(String oldRepository, String newRepository) {
+        String tag = getTagNameFromRepoString(newRepository);
+        String repo = getImageStreamName(oldRepository);
+        return getNormalizedString(String.format("%s:%s", repo, tag));
+    }
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -23,10 +23,6 @@ import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
 import org.eclipse.che.plugin.docker.client.connection.DockerConnectionFactory;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
-import org.eclipse.che.plugin.openshift.client.kubernetes.KubernetesContainer;
-import org.eclipse.che.plugin.openshift.client.kubernetes.KubernetesEnvVar;
-import org.eclipse.che.plugin.openshift.client.kubernetes.KubernetesLabelConverter;
-import org.eclipse.che.plugin.openshift.client.kubernetes.KubernetesService;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeClass;
@@ -54,14 +50,6 @@ public class OpenShiftConnectorTest {
     private DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider;
     @Mock
     private CreateContainerParams              createContainerParams;
-    @Mock
-    private KubernetesLabelConverter           kubernetesLabelConverter;
-    @Mock
-    private KubernetesEnvVar                   kubernetesEnvVar;
-    @Mock
-    private KubernetesContainer                kubernetesContainer;
-    @Mock
-    private KubernetesService                  kubernetesService;
 
     private OpenShiftConnector                 openShiftConnector;
 
@@ -70,10 +58,6 @@ public class OpenShiftConnectorTest {
         openShiftConnector = spy(new OpenShiftConnector(dockerConnectorConfiguration,
                                                         dockerConnectionFactory,
                                                         authManager,
-                                                        kubernetesLabelConverter,
-                                                        kubernetesEnvVar,
-                                                        kubernetesContainer,
-                                                        kubernetesService,
                                                         dockerApiVersionPathPrefixProvider,
                                                         OPENSHIFT_API_ENDPOINT_MINISHIFT,
                                                         OPENSHIFT_DEFAULT_USER_NAME,

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesContainerTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesContainerTest.java
@@ -26,12 +26,6 @@ import org.testng.annotations.Test;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 
 public class KubernetesContainerTest {
-    private KubernetesContainer kubernetesContainer;
-
-    @BeforeClass
-    private void setup() {
-        this.kubernetesContainer = new KubernetesContainer();
-    }
 
     @Test
     public void shouldReturnContainerPortFromExposedPortList() {
@@ -43,7 +37,7 @@ public class KubernetesContainerTest {
         exposedPorts.add("4403/tcp");
 
         // When
-        List<ContainerPort> containerPorts = kubernetesContainer.getContainerPortsFrom(exposedPorts);
+        List<ContainerPort> containerPorts = KubernetesContainer.getContainerPortsFrom(exposedPorts);
 
         // Then
         List<String> portsAndProtocols = containerPorts.stream().
@@ -60,7 +54,7 @@ public class KubernetesContainerTest {
         imageExposedPorts.put("8080/tcp",new ExposedPort());
 
         // When
-        List<ContainerPort> containerPorts = kubernetesContainer.getContainerPortsFrom(imageExposedPorts.keySet());
+        List<ContainerPort> containerPorts = KubernetesContainer.getContainerPortsFrom(imageExposedPorts.keySet());
 
         // Then
         List<String> portsAndProtocols = containerPorts.stream().

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesEnvVarTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesEnvVarTest.java
@@ -22,12 +22,6 @@ import org.testng.annotations.Test;
 import io.fabric8.kubernetes.api.model.EnvVar;
 
 public class KubernetesEnvVarTest {
-    private KubernetesEnvVar kubernetesEnvVar;
-
-    @BeforeClass
-    private void setup() {
-        this.kubernetesEnvVar = new KubernetesEnvVar();
-    }
 
     @Test
     public void shouldReturnContainerEnvFromEnvVariableArray() {
@@ -46,7 +40,7 @@ public class KubernetesEnvVarTest {
         };
 
         // When
-        List<EnvVar> env = kubernetesEnvVar.getEnvFrom(envVariables);
+        List<EnvVar> env = KubernetesEnvVar.getEnvFrom(envVariables);
 
         // Then
         List<String> keysAndValues = env.stream().map(k -> k.getName() + "=" + k.getValue()).collect(Collectors.toList());

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesLabelConverterTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesLabelConverterTest.java
@@ -20,17 +20,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class KubernetesLabelConverterTest {
-    private KubernetesLabelConverter kubernetesLabelConverter;
-
-    @BeforeClass
-    private void setup() {
-        this.kubernetesLabelConverter = new KubernetesLabelConverter();
-    }
 
     @Test
     public void shouldConvertLabelsToValidKubernetesLabelNames() {
         String validLabelRegex = "([A-Za-z0-9][-A-Za-z0-9_\\.]*)?[A-Za-z0-9]";
-        String prefix = kubernetesLabelConverter.getCheServerLabelPrefix();
+        String prefix = KubernetesLabelConverter.getCheServerLabelPrefix();
 
         // Given
         Map<String, String> labels = new HashMap<>();
@@ -38,7 +32,7 @@ public class KubernetesLabelConverterTest {
         labels.put(prefix + "8000/tcp:ref:", "tomcat-debug");
 
         // When
-        Map<String, String> converted = kubernetesLabelConverter.labelsToNames(labels);
+        Map<String, String> converted = KubernetesLabelConverter.labelsToNames(labels);
 
         // Then
         for (Map.Entry<String, String> entry : converted.entrySet()) {
@@ -52,14 +46,14 @@ public class KubernetesLabelConverterTest {
     @Test
     public void shouldBeAbleToRecoverOriginalLabelsAfterConversion() {
         // Given
-        String prefix = kubernetesLabelConverter.getCheServerLabelPrefix();
+        String prefix = KubernetesLabelConverter.getCheServerLabelPrefix();
         Map<String, String> originalLabels = new HashMap<>();
         originalLabels.put(prefix + "4401/tcp:path:", "/api");
         originalLabels.put(prefix + "8000/tcp:ref:", "tomcat-debug");
 
         // When
-        Map<String, String> converted = kubernetesLabelConverter.labelsToNames(originalLabels);
-        Map<String, String> unconverted = kubernetesLabelConverter.namesToLabels(converted);
+        Map<String, String> converted = KubernetesLabelConverter.labelsToNames(originalLabels);
+        Map<String, String> unconverted = KubernetesLabelConverter.namesToLabels(converted);
 
         // Then
         assertEquals(originalLabels, unconverted);

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesServiceTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesServiceTest.java
@@ -26,21 +26,15 @@ import org.testng.annotations.Test;
 import io.fabric8.kubernetes.api.model.ServicePort;
 
 public class KubernetesServiceTest {
-    private KubernetesService kubernetesService;
-
-    @BeforeClass
-    private void setup() {
-        this.kubernetesService = new KubernetesService();
-    }
 
     @Test
     public void shouldReturnServicePortListFromImageExposedPortList() {
         // Given
         Map<String, ExposedPort> imageExposedPorts = new HashMap<>();
-        imageExposedPorts.put("8080/tcp",new ExposedPort());
+        imageExposedPorts.put("8080/TCP",new ExposedPort());
 
         // When
-        List<ServicePort> servicePorts = kubernetesService.getServicePortsFrom(imageExposedPorts.keySet());
+        List<ServicePort> servicePorts = KubernetesService.getServicePortsFrom(imageExposedPorts.keySet());
 
         // Then
         List<String> portsAndProtocols = servicePorts.stream().
@@ -49,18 +43,18 @@ public class KubernetesServiceTest {
                         p.getProtocol()).collect(Collectors.toList());
         assertTrue(imageExposedPorts.keySet().stream().anyMatch(portsAndProtocols::contains));
     }
-    
+
     @Test
     public void shouldReturnServicePortListFromExposedPortList() {
         // Given
         Map<String, Map<String, String>> exposedPorts = new HashMap<>();
-        exposedPorts.put("8080/tcp",null);
-        exposedPorts.put("22/tcp",null);
-        exposedPorts.put("4401/tcp",null);
-        exposedPorts.put("4403/tcp",null);
+        exposedPorts.put("8080/TCP",null);
+        exposedPorts.put("22/TCP",null);
+        exposedPorts.put("4401/TCP",null);
+        exposedPorts.put("4403/TCP",null);
 
         // When
-        List<ServicePort> servicePorts = kubernetesService.getServicePortsFrom(exposedPorts.keySet());
+        List<ServicePort> servicePorts = KubernetesService.getServicePortsFrom(exposedPorts.keySet());
 
         // Then
         List<String> portsAndProtocols = servicePorts.stream().
@@ -92,7 +86,7 @@ public class KubernetesServiceTest {
         expectedPortNames.add("codeserver");
 
         // When
-        List<ServicePort> servicePorts = kubernetesService.getServicePortsFrom(exposedPorts.keySet());
+        List<ServicePort> servicePorts = KubernetesService.getServicePortsFrom(exposedPorts.keySet());
         List<String> actualPortNames = servicePorts.stream().
                 map(p -> p.getName()).collect(Collectors.toList());
 
@@ -110,7 +104,7 @@ public class KubernetesServiceTest {
         expectedPortNames.add("55-tcp");
 
         // When
-        List<ServicePort> servicePorts = kubernetesService.getServicePortsFrom(exposedPorts.keySet());
+        List<ServicePort> servicePorts = KubernetesService.getServicePortsFrom(exposedPorts.keySet());
         List<String> actualPortNames = servicePorts.stream().
                 map(p -> p.getName()).collect(Collectors.toList());
 


### PR DESCRIPTION
Implement OpenShiftConnector `pull`, `tag`, and `inspectImage` through
ImageStreams. Makes changes to how containers are created.

Currently snapshots do not work, as `commit` and `push` methods are not
implemented (these are being worked on by @ibuziuk currently). Additionally, 
pulling a stack from a private repository is not yet implemented.

The changes necessitate reworking `OpenShiftConnector#createContainer()`
to accomodate using ImageStreams instead of the underlying Docker implementation.

### What does this PR do?
Adds implementations of `pull`, `tag` and `inspectImage` to OpenShiftConnector.

Additionally, this PR refactors the helper methods used in OpenShiftConnector to be
static, as they store no state and serve as utility methods. This makes OpenShiftConnector
somewhat cleaner.

#### Changelog
Implement OpenShiftConnector `pull`, `tag`, and `inspectImage` through
ImageStreams. Makes changes to how containers are created.


### Docs Pull Request
https://github.com/eclipse/che-docs/issues/76