### PR TITLE
CHE-3616; deprecate old Machine API methods

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineService.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
  */
 @Api(value = "/machine", description = "Machine REST API")
 @Path("/workspace/{workspaceId}/machine")
+@Deprecated
 public class MachineService extends Service {
     private final MachineProcessManager       machineProcessManager;
     private final MachineServiceLinksInjector linksInjector;
@@ -142,6 +143,7 @@ public class MachineService extends Service {
                                                       "(e.g. The machine with such name already exists)." +
                                                       "Workspace is not in RUNNING state"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public void startMachine(@ApiParam("The workspace id")
                              @PathParam("workspaceId")
                              String workspaceId,
@@ -175,6 +177,7 @@ public class MachineService extends Service {
     @ApiResponses({@ApiResponse(code = 204, message = "Machine was successfully stopped"),
                    @ApiResponse(code = 404, message = "Machine with specified id does not exist"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public void stopMachine(@ApiParam(value = "Workspace ID")
                             @PathParam("workspaceId") String workspaceId,
                             @ApiParam(value = "Machine ID")
@@ -193,6 +196,7 @@ public class MachineService extends Service {
                    @ApiResponse(code = 400, message = "Command entity is invalid"),
                    @ApiResponse(code = 404, message = "Machine with specified ID does not exist"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public MachineProcessDto executeCommandInMachine(@ApiParam(value = "Workspace ID")
                                                      @PathParam("workspaceId")
                                                      String workspaceId,
@@ -229,6 +233,7 @@ public class MachineService extends Service {
     @ApiResponses({@ApiResponse(code = 200, message = "The response contains machine process entities"),
                    @ApiResponse(code = 404, message = "Machine with specified ID does not exist"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public List<MachineProcessDto> getProcesses(@ApiParam(value = "Workspace ID")
                                                 @PathParam("workspaceId")
                                                 String workspaceId,
@@ -255,6 +260,7 @@ public class MachineService extends Service {
     @ApiResponses({@ApiResponse(code = 204, message = "Process was successfully stopped"),
                    @ApiResponse(code = 404, message = "Machine with specified ID does not exist"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public void stopProcess(@ApiParam(value = "Workspace ID")
                             @PathParam("workspaceId")
                             String workspaceId,
@@ -278,6 +284,7 @@ public class MachineService extends Service {
     @ApiResponses({@ApiResponse(code = 200, message = "The response contains logs"),
                    @ApiResponse(code = 404, message = "Machine or process with specified ID does not exist"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public void getProcessLogs(@ApiParam(value = "Workspace ID")
                                @PathParam("workspaceId")
                                String workspaceId,


### PR DESCRIPTION
### What does this PR do?
Deprecates old Machine API methods since they are not used anymore and probably will be removed in 5.3.0. Clients should use agents exec [REST](https://github.com/eclipse/che/blame/master/agents/exec/src/process/rest_service.go) or [websocket](https://github.com/eclipse/che/blob/master/agents/exec/src/process/ws_service.go) service: 

### What issues does this PR fix or reference?
#3616 

### Changelog and Release Note Information
#### Changelog
Machine API has been deprecated in this release.

**Release notes**: The Machine API has been deprecated in this release. Clients should use the agents exec REST or websocket service instead.