### PR TITLE
[cli] graceful stop command

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_destroy.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_destroy.sh
@@ -37,7 +37,7 @@ cmd_destroy() {
     return;
   fi
 
-  cmd_stop
+  cmd_stop --force
 
   info "destroy" "Deleting instance and config..."
 

--- a/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
@@ -43,11 +43,8 @@ cmd_upgrade() {
   info "upgrade" "Downloading done."
 
   if get_server_container_id "${CHE_SERVER_CONTAINER_NAME}" >> "${LOGS}" 2>&1; then
-    info "upgrade" "Stopping currently running instance..."
-    CURRENT_CHE_SERVER_CONTAINER_ID=$(get_server_container_id ${CHE_SERVER_CONTAINER_NAME})
-    if server_is_booted ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
-      cmd_stop
-    fi
+    error "$CHE_MINI_PRODUCT_NAME is running. Stop before performing an upgrade."
+    return 2;
   fi
 
   if [[ "${DO_BACKUP}" == "true" ]]; then

--- a/dockerfiles/lib/dto-pom.xml
+++ b/dockerfiles/lib/dto-pom.xml
@@ -105,6 +105,11 @@
                     </dependency>
                     <dependency>
                         <groupId>org.eclipse.che.core</groupId>
+                        <artifactId>che-core-api-system-shared</artifactId>
+                        <version>${che.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.eclipse.che.core</groupId>
                         <artifactId>che-core-api-user-shared</artifactId>
                         <version>${che.version}</version>
                     </dependency>

--- a/dockerfiles/lib/src/api/wsmaster/system/system-stop-event-promise-subscriber.ts
+++ b/dockerfiles/lib/src/api/wsmaster/system/system-stop-event-promise-subscriber.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {org} from "../../../api/dto/che-dto"
+import {MessageBusSubscriber} from "../../../spi/websocket/messagebus-subscriber";
+import {MessageBus} from "../../../spi/websocket/messagebus";
+import {Log} from "../../../spi/log/log";
+/**
+ * Handle a promise that will be resolved when system is stopped.
+ * If system has error, promise will be rejected
+ * @author Florent Benoit
+ */
+export class SystemStopEventPromiseMessageBusSubscriber implements MessageBusSubscriber {
+
+    /**
+     * Bus used to collect events
+     */
+    messageBus : MessageBus;
+
+    /**
+     * Resolve method to call when we're ready to shutdown the system.
+     */
+    resolve : any;
+
+    /**
+     * Reject method on the promise if we need to abort the current process.
+     */
+    reject : any;
+
+    /**
+     * The promise used to defer the resolution.
+     */
+    promise: Promise<string>;
+
+    constructor(messageBus : MessageBus) {
+        this.messageBus = messageBus;
+        this.promise = new Promise<string>((resolve, reject) => {
+            this.resolve = resolve;
+            this.reject = reject;
+        });
+    }
+
+    handleMessage(message: any) {
+        // Ready to shutdown, it means we have finished the graceful stop and we can resolve the promise
+        if ('READY_TO_SHUTDOWN' === message.status) {
+            this.resolve();
+            this.messageBus.close();
+        } else if ('ERROR' === message.status) {
+            try {
+                let stringify: any = JSON.stringify(message);
+                this.reject('Error when stopping the system ' + stringify);
+            } catch (error) {
+                this.reject('Error when stopping the system ' + message.toString());
+            }
+            this.messageBus.close();
+        } else {
+            // Changing the status, displaying it to the user
+            Log.getLogger().info("System going into status '" + message.status + "' (was '" + message.prevStatus + "')");
+        }
+
+    }
+
+}

--- a/dockerfiles/lib/src/api/wsmaster/system/system.ts
+++ b/dockerfiles/lib/src/api/wsmaster/system/system.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {org} from "../../../api/dto/che-dto"
+import {AuthData} from "../auth/auth-data";
+import {Websocket} from "../../../spi/websocket/websocket";
+import {HttpJsonRequest} from "../../../spi/http/default-http-json-request";
+import {DefaultHttpJsonRequest} from "../../../spi/http/default-http-json-request";
+import {HttpJsonResponse} from "../../../spi/http/default-http-json-request";
+import {MessageBus} from "../../../spi/websocket/messagebus";
+import {SystemStopEventPromiseMessageBusSubscriber} from "./system-stop-event-promise-subscriber";
+import {Log} from "../../../spi/log/log";
+
+/**
+ * System class allowing to get state of system and perform graceful stop, etc.
+ * @author Florent Benoit
+ */
+export class System {
+
+    /**
+     * Authentication data
+     */
+    authData:AuthData;
+
+    /**
+     * websocket.
+     */
+    websocket:Websocket;
+
+    constructor(authData:AuthData) {
+        this.authData = authData;
+        this.websocket = new Websocket();
+    }
+
+    /**
+     * Get state of the system
+     */
+    getState():Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
+        var jsonRequest:HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, '/api/system/state', 200);
+        return jsonRequest.request().then((jsonResponse:HttpJsonResponse) => {
+            return jsonResponse.asDto(org.eclipse.che.api.system.shared.dto.SystemStateDtoImpl);
+        });
+    }
+
+    /**
+     * Get the message bus for the given System state DTO.
+     * @param systemStateDto the current DTO
+     * @returns {Promise<MessageBus>}
+     */
+    getMessageBus(systemStateDto : org.eclipse.che.api.system.shared.dto.SystemStateDto): Promise<MessageBus> {
+
+        // get link for websocket
+        var websocketLink:string;
+        systemStateDto.getLinks().forEach(stateLink => {
+            if ('system.state.channel' === stateLink.getRel()) {
+                websocketLink = stateLink.getHref();
+            }
+        });
+
+        return this.websocket.getMessageBus(websocketLink + '?token=' + this.authData.getToken());
+    }
+
+
+    /**
+     * Stop the server and return a promise that will wait for the ready to shutdown event
+     */
+    gracefulStop():Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
+
+        let currentSystemStateDto : org.eclipse.che.api.system.shared.dto.SystemStateDto;
+        let callbackSubscriber : SystemStopEventPromiseMessageBusSubscriber;
+
+        // get workspace DTO
+        return this.getState().then((systemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
+            currentSystemStateDto = systemStateDto;
+            return this.getMessageBus(systemStateDto);
+        }).then((messageBus: MessageBus) => {
+            callbackSubscriber = new SystemStopEventPromiseMessageBusSubscriber(messageBus);
+            let channelToListen : string;
+            currentSystemStateDto.getLinks().forEach(stateLink => {
+                if ('system.state.channel' === stateLink.getRel()) {
+                    channelToListen = stateLink.getParameters()[0].getDefaultValue();
+                }
+            });
+            return messageBus.subscribeAsync(channelToListen, callbackSubscriber);
+        }).then((subscribed: string) => {
+            var jsonRequest:HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, '/api/system/stop', 204).setMethod('POST');
+            return jsonRequest.request().then((jsonResponse:HttpJsonResponse) => {
+                return;
+            }).then(() => {
+                return callbackSubscriber.promise;
+            }).then(() => {
+                return this.getState();
+            });
+        });
+
+
+    }
+}

--- a/dockerfiles/lib/src/internal/action/che-action.ts
+++ b/dockerfiles/lib/src/internal/action/che-action.ts
@@ -19,6 +19,7 @@ import {ListWorkspacesAction} from "./impl/list-workspaces-action";
 import {ProductName} from "../../utils/product-name";
 import {WorkspaceSshAction} from "./impl/workspace-ssh-action";
 import {GetSshDataAction} from "./impl/get-ssh-action";
+import {GracefulStopAction} from "./impl/graceful-stop-action";
 /**
  * Entrypoint for the Actions.
  * @author Florent Benoit
@@ -60,6 +61,7 @@ export class CheAction {
         actionMap.set('list-workspaces', ListWorkspacesAction);
         actionMap.set('workspace-ssh', WorkspaceSshAction);
         actionMap.set('get-ssh-data', GetSshDataAction);
+        actionMap.set('graceful-stop', GracefulStopAction);
 
         return actionMap;
     }

--- a/dockerfiles/lib/src/internal/action/impl/graceful-stop-action.ts
+++ b/dockerfiles/lib/src/internal/action/impl/graceful-stop-action.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+// imports
+import {org} from "../../../api/dto/che-dto"
+import {Parameter} from "../../../spi/decorator/parameter";
+import {AuthData} from "../../../api/wsmaster/auth/auth-data";
+import {ArgumentProcessor} from "../../../spi/decorator/argument-processor";
+import {Log} from "../../../spi/log/log";
+import {System} from "../../../api/wsmaster/system/system";
+/**
+ * This class is handling the graceful stop command to the remote Che system
+ * @author Florent Benoit
+ */
+export class GracefulStopAction {
+
+
+    @Parameter({names: ["-s", "--url"], description: "Defines the url to be used"})
+    url : string;
+
+    @Parameter({names: ["-u", "--user"], description: "Defines the user to be used"})
+    username : string;
+
+    @Parameter({names: ["-w", "--password"], description: "Defines the password to be used"})
+    password : string;
+
+    args: Array<string>;
+    authData: AuthData;
+
+    fs = require('fs');
+    path = require('path');
+
+    system : System;
+
+    constructor(args:Array<string>) {
+        this.args = ArgumentProcessor.inject(this, args);
+        this.authData = AuthData.parse(this.url, this.username, this.password);
+        this.system = new System(this.authData);
+
+    }
+
+    run() : Promise<any> {
+        // first, login
+        return this.authData.login().then(() => {
+            return this.system.getState()
+                .then((state:org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
+                    if (state.getStatus() != "RUNNING") {
+                        return Promise.reject("Status is not in RUNNING state so the graceful can't be called.");
+                    }
+                });
+        }).then(() => {
+            return this.system.gracefulStop();
+        }).then((state:org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
+          Log.getLogger().info("Success: system is now in status '" + state.getStatus() + "'.");
+        });
+    }
+
+
+
+}

--- a/dockerfiles/lib/src/spi/websocket/resolve-subscribe-promise-subscriber.ts
+++ b/dockerfiles/lib/src/spi/websocket/resolve-subscribe-promise-subscriber.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+import {Log} from "../log/log";
+import {MessageBusSubscriber} from "./messagebus-subscriber";
+/**
+ * Handle a promise that will be resolved when system is stopped.
+ * If system has error, promise will be rejected
+ * @author Florent Benoit
+ */
+export class ResolveSubscribePromiseSubscriber implements MessageBusSubscriber {
+
+    resolve : any;
+    reject : any;
+    promise: Promise<string>;
+    channel : string;
+
+    constructor(channel : string) {
+        this.channel = channel;
+        this.promise = new Promise<string>((resolve, reject) => {
+            this.resolve = resolve;
+            this.reject = reject;
+        });
+    }
+
+    handleMessage(message: any) {
+        if (this.channel === message.channel) {
+            this.resolve();
+        } else if ('ERROR' === message.eventType) {
+            try {
+                let stringify: any = JSON.stringify(message);
+                this.reject('Error when getting subscribe channel ' + stringify);
+            } catch (error) {
+                this.reject('Error when getting subscribe channel' + message.toString());
+            }
+        } else {
+            this.reject('Error when getting subscribe channel ' + message.toString());
+        }
+
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?
Introduce graceful stop command for cli
by default, `stop`command is performing a graceful stop : stop all services then stop and remove containers
using `--force`the graceful stop is not done : we stop containers and remove containers

auth can be used with `--user` and `--password`

### What issues does this PR fix or reference?
#3886

### Changelog and Release Note Information
#### Changelog
Add graceful stop (disable with --force) in CLI

**Release Notes**:
We have introduced a way to perform a graceful stop of Che. Previously, Che server stops would be timeout based, meaning that if any workspaces were running when the Che server was stopped, they would continue to run. We have introduced a graceful stop that will initiate shutdown of all workspaces before initiating a shutdown of the server. If workspaces are configured to auto-snapshot during stop, then graceful stop will wait for all workspaces to be snapped before stopping the server. 

The default CLI `stop` command now performs a graceful stop. It stops all services then stops and remove containers. You can optionally add a `--force` option to stop and remove containers without waiting for workspaces to stop. For authenticated servers like Codenvy, authentication can be provided by `--user` and `--password`.

default graceful stop: `docker run  ... eclipse/che stop`
skip graceful stop: `docker run  ... eclipse/che stop --force`
use auth : `docker run  ... eclipse/che stop --user <myemail> --password <my-secret>`

### Docs Pull Request
https://github.com/eclipse/che-docs/pull/117
https://github.com/codenvy/codenvy-docs/pull/61
