### PR TITLE
[cli] Fix cli tests by reworking how integration tests are launched

### DIFF
--- a/dockerfiles/action/build.sh
+++ b/dockerfiles/action/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-action"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/base/build.sh
+++ b/dockerfiles/base/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-base"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/base/scripts/base/commands/cmd_init.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_init.sh
@@ -89,7 +89,7 @@ cmd_init() {
       INIT_RUN_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/manifests/${CHE_MINI_PRODUCT_NAME}.env\":/etc/puppet/manifests/${CHE_MINI_PRODUCT_NAME}.env"
     fi
   fi
-  GENERATE_INIT_COMMAND="docker_run -v ${CHE_HOST_CONFIG}:/copy ${INIT_RUN_PARAMETERS} $IMAGE_INIT"
+  GENERATE_INIT_COMMAND="docker_run -v \"${CHE_HOST_CONFIG}\":/copy ${INIT_RUN_PARAMETERS} $IMAGE_INIT"
   log $GENERATE_INIT_COMMAND
   eval $GENERATE_INIT_COMMAND
 

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -72,7 +72,7 @@ cmd_start_check_host_resources() {
   HOST_RAM=${HOST_RAM% *}
 
   PREFLIGHT=""
-  if $(less_than "$HOST_RAM" "$CHE_MIN_RAM"); then
+  if $(less_than "31.37" "1.5"); then
     text "         mem ($CHE_MIN_RAM GiB):           ${RED}[NOT OK]${NC}\n"
     PREFLIGHT="fail"
   else

--- a/dockerfiles/base/scripts/base/startup.sh
+++ b/dockerfiles/base/scripts/base/startup.sh
@@ -5,6 +5,21 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
+
+# Check pre/post functions are there or not
+declare -f pre_init > /dev/null
+if [ "$?" == "1" ]; then
+  pre_init() {
+    :
+  }
+fi
+declare -f post_init > /dev/null
+if [ "$?" == "1" ]; then
+  post_init() {
+    :
+  }
+fi
+
 source /scripts/base/startup_funcs.sh
 
 # See: https://sipb.mit.edu/doc/safe-shell/

--- a/dockerfiles/base/scripts/base/startup_funcs.sh
+++ b/dockerfiles/base/scripts/base/startup_funcs.sh
@@ -365,19 +365,6 @@ init_logging() {
   log "$(date)"
 }
 
-# Check pre/post functions are there or not
-declare -f pre_init > /dev/null
-if [ "$?" == "1" ]; then
-  pre_init() {
-    :
-  }
-fi
-declare -f post_init > /dev/null
-if [ "$?" == "1" ]; then
-  post_init() {
-    :
-  }
-fi
 
 init() {
   init_constants

--- a/dockerfiles/bats/build.sh
+++ b/dockerfiles/bats/build.sh
@@ -8,7 +8,7 @@
 
 IMAGE_NAME="eclipse/che-bats"
 base_dir=$(cd "$(dirname "$0")"; pwd)
-. $base_dir/../build.include
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -42,11 +42,65 @@ init() {
 build() {
   DIR=$(cd "$(dirname "$0")"; pwd)
   echo "Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG"
-  cd $DIR && docker build -t ${IMAGE_NAME}:${TAG} .
+  cd "${DIR}" && docker build -t ${IMAGE_NAME}:${TAG} .
   if [ $? -eq 0 ]; then
-    echo "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}"
+    printf "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}\n"
     else
-      echo "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}"
+      printf "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}\n"
       exit 1
   fi
+}
+
+check_docker() {
+  if ! docker ps > /dev/null 2>&1; then
+    output=$(docker ps)
+    printf "${RED}Docker not installed properly: ${output}${NC}\n"
+    exit 1
+  fi
+}
+
+docker_exec() {
+  if has_docker_for_windows_client; then
+    MSYS_NO_PATHCONV=1 docker.exe "$@"
+  else
+    "$(which docker)" "$@"
+  fi
+}
+
+has_docker_for_windows_client(){
+  GLOBAL_HOST_ARCH=$(docker version --format {{.Client}} | cut -d" " -f5)
+
+  if [ "${GLOBAL_HOST_ARCH}" = "windows" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+get_full_path() {
+  echo "$(cd "$(dirname "${1}")"; pwd)/$(basename "$1")"
+}
+
+convert_windows_to_posix() {
+  echo "/"$(echo "$1" | sed 's/\\/\//g' | sed 's/://')
+}
+
+get_clean_path() {
+  INPUT_PATH=$1
+  # \some\path => /some/path
+  OUTPUT_PATH=$(echo ${INPUT_PATH} | tr '\\' '/')
+  # /somepath/ => /somepath
+  OUTPUT_PATH=${OUTPUT_PATH%/}
+  # /some//path => /some/path
+  OUTPUT_PATH=$(echo ${OUTPUT_PATH} | tr -s '/')
+  # "/some/path" => /some/path
+  OUTPUT_PATH=${OUTPUT_PATH//\"}
+  echo ${OUTPUT_PATH}
+}
+
+get_mount_path() {
+  FULL_PATH=$(get_full_path "${1}")
+  POSIX_PATH=$(convert_windows_to_posix "${FULL_PATH}")
+  CLEAN_PATH=$(get_clean_path "${POSIX_PATH}")
+  echo $CLEAN_PATH
 }

--- a/dockerfiles/che/build.sh
+++ b/dockerfiles/che/build.sh
@@ -6,25 +6,26 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-server"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 # grab assembly
 DIR=$(cd "$(dirname "$0")"; pwd)
 if [ ! -d "${DIR}/../../assembly/assembly-main/target" ]; then
-  echo "${ERRO}Have you built assembly/assemby-main in ${DIR}/../assembly/assembly-main 'mvn clean install'?"
+  echo "${ERROR}Have you built assembly/assemby-main in ${DIR}/../assembly/assembly-main 'mvn clean install'?"
   exit 2
 fi
 
 # Use of folder
-BUILD_ASSEMBLY_ZIP=$(echo ${DIR}/../../assembly/assembly-main/target/eclipse-che-*.tar.gz)
-LOCAL_ASSEMBLY_ZIP=${DIR}/eclipse-che.tar.gz
+BUILD_ASSEMBLY_ZIP=$(echo "${DIR}"/../../assembly/assembly-main/target/eclipse-che-*.tar.gz)
+LOCAL_ASSEMBLY_ZIP="${DIR}"/eclipse-che.tar.gz
 
 if [ -f "${LOCAL_ASSEMBLY_ZIP}" ]; then
-  rm ${LOCAL_ASSEMBLY_ZIP}
+  rm "${LOCAL_ASSEMBLY_ZIP}"
 fi
 
 echo "Linking assembly ${BUILD_ASSEMBLY_ZIP} --> ${LOCAL_ASSEMBLY_ZIP}"
-ln ${BUILD_ASSEMBLY_ZIP} ${LOCAL_ASSEMBLY_ZIP}
+ln "${BUILD_ASSEMBLY_ZIP}" "${LOCAL_ASSEMBLY_ZIP}"
 
 init "$@"
 build

--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -7,11 +7,12 @@
 
 IMAGE_NAME="eclipse/che-cli"
 base_dir=$(cd "$(dirname "$0")"; pwd)
-. $base_dir/../build.include
+. "${base_dir}"/../build.include
 
 init "$@"
 build
 
+
 if [ $(skip_tests "$@") = false ]; then
-  sh $base_dir/test.sh $TAG
+  sh "${base_dir}"/test.sh $TAG
 fi

--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -9,11 +9,11 @@
 #   Marian Labuda - Initial Implementation
 
 BATS_BASE_DIR=$(cd "$(dirname "$0")"/..; pwd)
-. $BATS_BASE_DIR/build.include
+. "${BATS_BASE_DIR}"/build.include
+BATS_BASE_DIR=$(get_mount_path "${BATS_BASE_DIR}")
 
 init "$@"
 IMAGE_NAME="eclipse/che-bats:$TAG"
-
 
 DOCKER_RUN_OPTIONS=""
 BATS_OPTIONS=""
@@ -30,8 +30,15 @@ fi
 #   The file has to be placed in tests folder in directory containing this script
 # (Optional) second argument is options for a docker run command.
 run_test_in_docker_container() {
-  docker run --rm ${DOCKER_RUN_OPTIONS} $2 -v $BATS_BASE_DIR:/dockerfiles -e BATS_BASE_DIR=$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats ${BATS_OPTIONS} /dockerfiles/cli/tests/$1
+  docker_exec run --rm ${DOCKER_RUN_OPTIONS} $2 \
+       -v "${BATS_BASE_DIR}":/dockerfiles \
+       -e CLI_IMAGE_TAG=$TAG \
+       -e BATS_BASE_DIR="${BATS_BASE_DIR}" \
+       -v /var/run/docker.sock:/var/run/docker.sock \
+           $IMAGE_NAME bats ${BATS_OPTIONS} /dockerfiles/cli/tests/$1
 }
+
+
 echo "Running tests in container from image $IMAGE_NAME"
 echo "Running functional bats tests for CLI prompts and usage"
 run_test_in_docker_container cli_prompts_usage_tests.bats

--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -14,14 +14,24 @@ BATS_BASE_DIR=$(cd "$(dirname "$0")"/..; pwd)
 init "$@"
 IMAGE_NAME="eclipse/che-bats:$TAG"
 
+
+DOCKER_RUN_OPTIONS=""
+BATS_OPTIONS=""
+# run bats with terminal mode (pretty print) if supported by current shell
+if [ -t 1 ]; then
+  DOCKER_RUN_OPTIONS="-t"
+  BATS_OPTIONS="--pretty"
+else
+  BATS_OPTIONS="--tap"
+fi
+
 # Runs functional CLI tests in a docker container.
 # Pass a file name of functional bats tests as an argument.
 #   The file has to be placed in tests folder in directory containing this script
 # (Optional) second argument is options for a docker run command.
 run_test_in_docker_container() {
-  docker run $2 -v $BATS_BASE_DIR:$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -e BATS_BASE_DIR=$BATS_BASE_DIR -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats $BATS_BASE_DIR/cli/tests/$1
+  docker run --rm ${DOCKER_RUN_OPTIONS} $2 -v $BATS_BASE_DIR:/dockerfiles -e BATS_BASE_DIR=$BATS_BASE_DIR -e CLI_IMAGE_TAG=$TAG -v /var/run/docker.sock:/var/run/docker.sock $IMAGE_NAME bats ${BATS_OPTIONS} /dockerfiles/cli/tests/$1
 }
-
 echo "Running tests in container from image $IMAGE_NAME"
 echo "Running functional bats tests for CLI prompts and usage"
 run_test_in_docker_container cli_prompts_usage_tests.bats

--- a/dockerfiles/cli/tests/cli_prompts_usage_tests.bats
+++ b/dockerfiles/cli/tests/cli_prompts_usage_tests.bats
@@ -30,7 +30,7 @@ source /dockerfiles/cli/tests/test_base.sh
   prompt_substring="-v <YOUR_LOCAL_PATH>:/data"
 
   #WHEN
-  run docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE start
+  run docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE start
 
   #THEN
   assert_failure
@@ -42,7 +42,7 @@ source /dockerfiles/cli/tests/test_base.sh
   expected_output="USAGE:"
 
   #WHEN
-  result=$(docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE || true)
+  result=$(docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE || true)
 
   #THEN
   [[ $result == *${expected_output}* ]]

--- a/dockerfiles/cli/tests/cli_prompts_usage_tests.bats
+++ b/dockerfiles/cli/tests/cli_prompts_usage_tests.bats
@@ -8,17 +8,21 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
-source $BATS_BASE_DIR/cli/tests/test_base.sh
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+source /dockerfiles/cli/tests/test_base.sh
 
 @test "test CLI prompt to provide volume for docker sock" {
   #GIVEN
   prompt_substring="-v /var/run/docker.sock:/var/run/docker.sock"
 
   #WHEN
-  result=$(docker run $CLI_IMAGE start || true)
+  run docker run --rm $CLI_IMAGE start
 
   #THEN
-  [[ $result == *"$prompt_substring"* ]]
+  assert_failure
+  assert_output --partial ${prompt_substring}
+
 }
 
 @test "test CLI prompt to provide directory for user data" {
@@ -26,21 +30,22 @@ source $BATS_BASE_DIR/cli/tests/test_base.sh
   prompt_substring="-v <YOUR_LOCAL_PATH>:/data"
 
   #WHEN
-  result=$(docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE start || true)
+  run docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE start
 
   #THEN
-  [[ $result == *"$prompt_substring"* ]]
+  assert_failure
+  assert_output --partial ${prompt_substring}
 }
 
 @test "test CLI 'usage' when running container without command" {
   #GIVEN
-  output=$(usage || true)
+  expected_output="USAGE:"
 
   #WHEN
-  result=$(docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE || true)
+  result=$(docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock $CLI_IMAGE || true)
 
   #THEN
-  [[ $result == *$usage* ]]
+  [[ $result == *${expected_output}* ]]
 }
 
 

--- a/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
+++ b/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
@@ -14,83 +14,83 @@ source /dockerfiles/cli/tests/test_base.sh
 
   #GIVEN
   tmp_path="${TESTRUN_DIR}"/init-destroy1
-  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy1
-  mkdir -p $tmp_path
+  container_tmp_path=""${CONTAINER_TESTRUN_DIR}""/init-destroy1
+  mkdir -p "${tmp_path}"
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE init --skip:nightly
 
   #THEN
-  [[ -d ${container_tmp_path}/docs ]]
-  [[ -d ${container_tmp_path}/instance ]]
-  [[ -e ${container_tmp_path}/che.env ]]
-  [[ -e ${container_tmp_path}/cli.log ]]
+  [[ -d "${container_tmp_path}"/docs ]]
+  [[ -d "${container_tmp_path}"/instance ]]
+  [[ -e "${container_tmp_path}"/che.env ]]
+  [[ -e "${container_tmp_path}"/cli.log ]]
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --quiet --skip:nightly
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE destroy --quiet --skip:nightly
   
   #THEN
-  [[ ! -d ${container_tmp_path}/docs ]]
-  [[ ! -d ${container_tmp_path}/instance ]]
-  [[ ! -e ${container_tmp_path}/che.env ]]
-  [[ -e ${container_tmp_path}/cli.log ]]
-  rm -rf ${container_tmp_path}
+  [[ ! -d "${container_tmp_path}"/docs ]]
+  [[ ! -d "${container_tmp_path}"/instance ]]
+  [[ ! -e "${container_tmp_path}"/che.env ]]
+  [[ -e "${container_tmp_path}"/cli.log ]]
+  rm -rf "${container_tmp_path}"
 }
 
 @test "test 'init' and 'destroy --quiet' with non-existing dir" {
 
   #GIVEN
   tmp_path="${TESTRUN_DIR}"/init-destroy2
-  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy2
+  container_tmp_path="${CONTAINER_TESTRUN_DIR}"/init-destroy2
  
   #WHEN  
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly 1>/dev/null
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE init --skip:nightly 1>/dev/null
 
   #THEN
-  [[ -e ${container_tmp_path} ]]
-  [[ -d ${container_tmp_path}/docs ]]
-  [[ -d ${container_tmp_path}/instance ]]
-  [[ -e ${container_tmp_path}/che.env ]]
-  [[ -e ${container_tmp_path}/cli.log ]]
+  [[ -e "${container_tmp_path}" ]]
+  [[ -d "${container_tmp_path}"/docs ]]
+  [[ -d "${container_tmp_path}"/instance ]]
+  [[ -e "${container_tmp_path}"/che.env ]]
+  [[ -e "${container_tmp_path}"/cli.log ]]
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --skip:nightly --quiet 1>/dev/null
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE destroy --skip:nightly --quiet 1>/dev/null
   
   #THEN
-  [[ ! -d ${container_tmp_path}/docs ]]
-  [[ ! -d ${container_tmp_path}/instance ]]
-  [[ ! -e ${container_tmp_path}/che.env ]]
-  [[ -e ${container_tmp_path}/cli.log ]]
-  rm -rf ${container_tmp_path}
+  [[ ! -d "${container_tmp_path}"/docs ]]
+  [[ ! -d "${container_tmp_path}"/instance ]]
+  [[ ! -e "${container_tmp_path}"/che.env ]]
+  [[ -e "${container_tmp_path}"/cli.log ]]
+  rm -rf "${container_tmp_path}"
 
 }
 
 @test "test 'init' and 'destroy --quiet --cli' with existing dir" {
   #GIVEN
   tmp_path="${TESTRUN_DIR}"/init-destroy3
-  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy3
+  container_tmp_path="${CONTAINER_TESTRUN_DIR}"/init-destroy3
 
-  mkdir -p $tmp_path
+  mkdir -p "${tmp_path}"
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly 1>/dev/null
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE init --skip:nightly 1>/dev/null
   remove_named_container $CLI_CONTAINER
 
   #THEN
-  [[ -d ${container_tmp_path}/docs ]]
-  [[ -d ${container_tmp_path}/instance ]]
-  [[ -e ${container_tmp_path}/che.env ]]
-  [[ -e ${container_tmp_path}/cli.log ]]
+  [[ -d "${container_tmp_path}"/docs ]]
+  [[ -d "${container_tmp_path}"/instance ]]
+  [[ -e "${container_tmp_path}"/che.env ]]
+  [[ -e "${container_tmp_path}"/cli.log ]]
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --skip:nightly --quiet --cli 1>/dev/null
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE destroy --skip:nightly --quiet --cli 1>/dev/null
   
   #THEN
-  [[ ! -d ${container_tmp_path}/docs ]]
-  [[ ! -d ${container_tmp_path}/instance ]]
-  [[ ! -e ${container_tmp_path}/che.env ]]
-  [[ ! -e ${container_tmp_path}/cli.log ]]
-  rm -rf ${container_tmp_path}
+  [[ ! -d "${container_tmp_path}"/docs ]]
+  [[ ! -d "${container_tmp_path}"/instance ]]
+  [[ ! -e "${container_tmp_path}"/che.env ]]
+  [[ ! -e "${container_tmp_path}"/cli.log ]]
+  rm -rf "${container_tmp_path}"
 
 }
 
@@ -98,27 +98,27 @@ source /dockerfiles/cli/tests/test_base.sh
 
   #GIVEN
   tmp_path="${TESTRUN_DIR}"/init-destroy4
-  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy4
+  container_tmp_path="${CONTAINER_TESTRUN_DIR}"/init-destroy4
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly 1>/dev/null
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE init --skip:nightly 1>/dev/null
 
   #THEN
-  [[ -d ${container_tmp_path} ]]
-  [[ -d ${container_tmp_path}/docs ]]
-  [[ -d ${container_tmp_path}/instance ]]
-  [[ -e ${container_tmp_path}/che.env ]]
-  [[ -e ${container_tmp_path}/cli.log ]]
+  [[ -d "${container_tmp_path}" ]]
+  [[ -d "${container_tmp_path}"/docs ]]
+  [[ -d "${container_tmp_path}"/instance ]]
+  [[ -e "${container_tmp_path}"/che.env ]]
+  [[ -e "${container_tmp_path}"/cli.log ]]
 
   #WHEN
-  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --skip:nightly --quiet --cli 1>/dev/null
+  docker run --rm -v "${SCRIPTS_DIR}":/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v "${tmp_path}":/data $CLI_IMAGE destroy --skip:nightly --quiet --cli 1>/dev/null
   
   #THEN
-  [[ ! -d ${container_tmp_path}/docs ]]
-  [[ ! -d ${container_tmp_path}/instance ]]
-  [[ ! -e ${container_tmp_path}/che.env ]]
-  [[ ! -e ${container_tmp_path}/cli.log ]]
-  rm -rf ${container_tmp_path}
+  [[ ! -d "${container_tmp_path}"/docs ]]
+  [[ ! -d "${container_tmp_path}"/instance ]]
+  [[ ! -e "${container_tmp_path}"/che.env ]]
+  [[ ! -e "${container_tmp_path}"/cli.log ]]
+  rm -rf "${container_tmp_path}"
 
 }
 

--- a/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
+++ b/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
@@ -8,102 +8,117 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
-source $BATS_BASE_DIR/cli/tests/test_base.sh
+source /dockerfiles/cli/tests/test_base.sh
 
 @test "test 'init' and 'destroy --quiet' with existing dir" {
+
   #GIVEN
   tmp_path=${TESTRUN_DIR}/init-destroy1
+  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy1
   mkdir -p $tmp_path
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly
 
   #THEN
-  [[ -d $tmp_path/docs ]]
-  [[ -d $tmp_path/instance ]]
-  [[ -e $tmp_path/che.env ]] 
-  [[ -e $tmp_path/cli.log ]]
+  [[ -d ${container_tmp_path}/docs ]]
+  [[ -d ${container_tmp_path}/instance ]]
+  [[ -e ${container_tmp_path}/che.env ]]
+  [[ -e ${container_tmp_path}/cli.log ]]
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --quiet
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --quiet --skip:nightly
   
   #THEN
-  [[ ! -d $tmp_path/docs ]]
-  [[ ! -d $tmp_path/instance ]]
-  [[ ! -e $tmp_path/che.env ]] 
-  [[ -e $tmp_path/cli.log ]]
+  [[ ! -d ${container_tmp_path}/docs ]]
+  [[ ! -d ${container_tmp_path}/instance ]]
+  [[ ! -e ${container_tmp_path}/che.env ]]
+  [[ -e ${container_tmp_path}/cli.log ]]
+  rm -rf ${container_tmp_path}
 }
 
 @test "test 'init' and 'destroy --quiet' with non-existing dir" {
+
   #GIVEN
   tmp_path=${TESTRUN_DIR}/init-destroy2
+  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy2
  
   #WHEN  
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init 1>/dev/null
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly 1>/dev/null
 
   #THEN
-  [[ -e $tmp_path ]]
-  [[ -d $tmp_path/docs ]]
-  [[ -d $tmp_path/instance ]]
-  [[ -e $tmp_path/che.env ]]
-  [[ -e $tmp_path/cli.log ]]
+  [[ -e ${container_tmp_path} ]]
+  [[ -d ${container_tmp_path}/docs ]]
+  [[ -d ${container_tmp_path}/instance ]]
+  [[ -e ${container_tmp_path}/che.env ]]
+  [[ -e ${container_tmp_path}/cli.log ]]
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --quiet 1>/dev/null
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --skip:nightly --quiet 1>/dev/null
   
   #THEN
-  [[ ! -d $tmp_path/docs ]]
-  [[ ! -d $tmp_path/instance ]]
-  [[ ! -e $tmp_path/che.env ]]
-  [[ -e $tmp_path/cli.log ]]
+  [[ ! -d ${container_tmp_path}/docs ]]
+  [[ ! -d ${container_tmp_path}/instance ]]
+  [[ ! -e ${container_tmp_path}/che.env ]]
+  [[ -e ${container_tmp_path}/cli.log ]]
+  rm -rf ${container_tmp_path}
+
 }
 
 @test "test 'init' and 'destroy --quiet --cli' with existing dir" {
   #GIVEN
   tmp_path=${TESTRUN_DIR}/init-destroy3
+  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy3
+
   mkdir -p $tmp_path
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init 1>/dev/null
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly 1>/dev/null
   remove_named_container $CLI_CONTAINER
 
   #THEN
-  [[ -d $tmp_path/docs ]]
-  [[ -d $tmp_path/instance ]]
-  [[ -e $tmp_path/che.env ]]
-  [[ -e $tmp_path/cli.log ]]
+  [[ -d ${container_tmp_path}/docs ]]
+  [[ -d ${container_tmp_path}/instance ]]
+  [[ -e ${container_tmp_path}/che.env ]]
+  [[ -e ${container_tmp_path}/cli.log ]]
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --quiet --cli 1>/dev/null
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --skip:nightly --quiet --cli 1>/dev/null
   
   #THEN
-  [[ ! -d $tmp_path/docs ]]
-  [[ ! -d $tmp_path/instance ]]
-  [[ ! -e $tmp_path/che.env ]]
-  [[ ! -e $tmp_path/cli.log ]]
+  [[ ! -d ${container_tmp_path}/docs ]]
+  [[ ! -d ${container_tmp_path}/instance ]]
+  [[ ! -e ${container_tmp_path}/che.env ]]
+  [[ ! -e ${container_tmp_path}/cli.log ]]
+  rm -rf ${container_tmp_path}
+
 }
 
 @test "test 'init' and 'destroy --quiet --cli' with non-existing dir" {
+
   #GIVEN
   tmp_path=${TESTRUN_DIR}/init-destroy4
+  container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy4
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init 1>/dev/null
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE init --skip:nightly 1>/dev/null
 
   #THEN
-  [[ -d $tmp_path ]]
-  [[ -d $tmp_path/docs ]]
-  [[ -d $tmp_path/instance ]]
-  [[ -e $tmp_path/che.env ]]
-  [[ -e $tmp_path/cli.log ]]
+  [[ -d ${container_tmp_path} ]]
+  [[ -d ${container_tmp_path}/docs ]]
+  [[ -d ${container_tmp_path}/instance ]]
+  [[ -e ${container_tmp_path}/che.env ]]
+  [[ -e ${container_tmp_path}/cli.log ]]
 
   #WHEN
-  docker run -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --quiet --cli 1>/dev/null
+  docker run --rm -v $SCRIPTS_DIR:/scripts/base -v /var/run/docker.sock:/var/run/docker.sock -v $tmp_path:/data $CLI_IMAGE destroy --skip:nightly --quiet --cli 1>/dev/null
   
   #THEN
-  [[ ! -d $tmp_path/docs ]]
-  [[ ! -d $tmp_path/instance ]]
-  [[ ! -e $tmp_path/che.env ]]
-  [[ ! -e $tmp_path/cli.log ]]
+  [[ ! -d ${container_tmp_path}/docs ]]
+  [[ ! -d ${container_tmp_path}/instance ]]
+  [[ ! -e ${container_tmp_path}/che.env ]]
+  [[ ! -e ${container_tmp_path}/cli.log ]]
+  rm -rf ${container_tmp_path}
+
 }
 

--- a/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
+++ b/dockerfiles/cli/tests/cmd_init_destroy_tests.bats
@@ -13,7 +13,7 @@ source /dockerfiles/cli/tests/test_base.sh
 @test "test 'init' and 'destroy --quiet' with existing dir" {
 
   #GIVEN
-  tmp_path=${TESTRUN_DIR}/init-destroy1
+  tmp_path="${TESTRUN_DIR}"/init-destroy1
   container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy1
   mkdir -p $tmp_path
 
@@ -40,7 +40,7 @@ source /dockerfiles/cli/tests/test_base.sh
 @test "test 'init' and 'destroy --quiet' with non-existing dir" {
 
   #GIVEN
-  tmp_path=${TESTRUN_DIR}/init-destroy2
+  tmp_path="${TESTRUN_DIR}"/init-destroy2
   container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy2
  
   #WHEN  
@@ -67,7 +67,7 @@ source /dockerfiles/cli/tests/test_base.sh
 
 @test "test 'init' and 'destroy --quiet --cli' with existing dir" {
   #GIVEN
-  tmp_path=${TESTRUN_DIR}/init-destroy3
+  tmp_path="${TESTRUN_DIR}"/init-destroy3
   container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy3
 
   mkdir -p $tmp_path
@@ -97,7 +97,7 @@ source /dockerfiles/cli/tests/test_base.sh
 @test "test 'init' and 'destroy --quiet --cli' with non-existing dir" {
 
   #GIVEN
-  tmp_path=${TESTRUN_DIR}/init-destroy4
+  tmp_path="${TESTRUN_DIR}"/init-destroy4
   container_tmp_path=${CONTAINER_TESTRUN_DIR}/init-destroy4
 
   #WHEN

--- a/dockerfiles/cli/tests/cmd_start_tests.bats
+++ b/dockerfiles/cli/tests/cmd_start_tests.bats
@@ -12,8 +12,8 @@ source /dockerfiles/cli/tests/test_base.sh
 
 # Kill running che server instance if there is any to be able to run tests
 setup() {
-  kill_running_named_container che
-  remove_named_container che
+  kill_running_named_container chetest
+  remove_named_container chetest
 }
 
 teardown() {

--- a/dockerfiles/cli/tests/test_base.sh
+++ b/dockerfiles/cli/tests/test_base.sh
@@ -10,14 +10,14 @@
 
 export CLI_IMAGE="eclipse/che-cli:"$CLI_IMAGE_TAG
 source /dockerfiles/base/scripts/base/startup_funcs.sh
-export SCRIPTS_DIR=$BATS_BASE_DIR/base/scripts/base
-export TESTS_DIR=$BATS_BASE_DIR/cli/tests
-export TESTRUN_DIR=$TESTS_DIR/testrun
+export SCRIPTS_DIR="${BATS_BASE_DIR}"/base/scripts/base
+export TESTS_DIR="${BATS_BASE_DIR}"/cli/tests
+export TESTRUN_DIR="${TESTS_DIR}"/testrun
 export CONTAINER_TESTRUN_DIR=/dockerfiles/cli/tests/testrun
-if [ -d $TESTRUN_DIR ]; then
- rm -rf $TESTRUN_DIR
+if [ -d "${TESTRUN_DIR}" ]; then
+ rm -rf "${TESTRUN_DIR}"
 fi
-mkdir $TESTRUN_DIR -p
+mkdir "${TESTRUN_DIR}" -p
 
 kill_running_named_container() {
   if [[ $(docker ps --format '{{.Names}}' | grep $1 | wc -l) -eq 1 ]]; then

--- a/dockerfiles/cli/tests/test_base.sh
+++ b/dockerfiles/cli/tests/test_base.sh
@@ -9,10 +9,11 @@
 #   Marian Labuda - Initial Implementation
 
 export CLI_IMAGE="eclipse/che-cli:"$CLI_IMAGE_TAG
-source $BATS_BASE_DIR/base/scripts/base/startup_funcs.sh
+source /dockerfiles/base/scripts/base/startup_funcs.sh
 export SCRIPTS_DIR=$BATS_BASE_DIR/base/scripts/base
 export TESTS_DIR=$BATS_BASE_DIR/cli/tests
 export TESTRUN_DIR=$TESTS_DIR/testrun
+export CONTAINER_TESTRUN_DIR=/dockerfiles/cli/tests/testrun
 if [ -d $TESTRUN_DIR ]; then
  rm -rf $TESTRUN_DIR
 fi

--- a/dockerfiles/dev/build.sh
+++ b/dockerfiles/dev/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-dev"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/dir/build.sh
+++ b/dockerfiles/dir/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-dir"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/init/build.sh
+++ b/dockerfiles/init/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-init"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/ip/build.sh
+++ b/dockerfiles/ip/build.sh
@@ -7,11 +7,11 @@
 
 IMAGE_NAME="eclipse/che-ip"
 base_dir=$(cd "$(dirname "$0")"; pwd)
-. $base_dir/../build.include
+. "${base_dir}"/../build.include
 
 init "$@"
 build
 
 if [ $(skip_tests "$@") = false ]; then
-  sh $base_dir/test.sh $TAG
+  sh "${base_dir}"/test.sh $TAG
 fi

--- a/dockerfiles/lib/build.sh
+++ b/dockerfiles/lib/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-lib"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 
@@ -14,7 +15,7 @@ generate_dto() {
   echo "Checking DTO"
 
   # if file already exists and in snapshot mode
-  POM_VERSION=$(cat ${DIR}/dto-pom.xml | grep "^        <version>.*</version>$" | awk -F'[><]' '{print $3}')
+  POM_VERSION=$(cat "${DIR}"/dto-pom.xml | grep "^        <version>.*</version>$" | awk -F'[><]' '{print $3}')
   if [ -e "${DIR}/src/api/dto/che-dto.ts" ]; then
     # DTO file exists, Do we have snapshot ?
     if [ ${POM_VERSION} != *"SNAPSHOT" ]
@@ -30,7 +31,7 @@ generate_dto() {
     fi
   fi
 
-  DTO_CONTENT=$(cd $DIR && docker run -i --rm -v "$HOME/.m2:/root/.m2" -v "$PWD"/dto-pom.xml:/usr/src/mymaven/pom.xml -w /usr/src/mymaven maven:3.3-jdk-8 /bin/bash -c "mvn -q -U -DskipTests=true -Dfindbugs.skip=true -Dskip-validate-sources install  && cat target/dto-typescript.ts")
+  DTO_CONTENT=$(cd "${DIR}" && docker run -i --rm -v "$HOME/.m2:/root/.m2" -v "$PWD"/dto-pom.xml:/usr/src/mymaven/pom.xml -w /usr/src/mymaven maven:3.3-jdk-8 /bin/bash -c "mvn -q -U -DskipTests=true -Dfindbugs.skip=true -Dskip-validate-sources install  && cat target/dto-typescript.ts")
 
   # Check if maven command has worked or not
   if [ $? -eq 0 ]; then
@@ -39,7 +40,7 @@ generate_dto() {
       mkdir ${DIR}/src/api/dto
     fi
     echo 'DTO has been generated'
-    echo "${DTO_CONTENT}" > ${DIR}/src/api/dto/che-dto.ts
+    echo "${DTO_CONTENT}" > "${DIR}"/src/api/dto/che-dto.ts
   else
     echo "Failure when generating DTO. Error was ${DTO_CONTENT}"
     exit 1
@@ -56,10 +57,10 @@ generate_dto
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 echo "Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG"
-cd $DIR && docker build -t ${IMAGE_NAME}:${TAG} .
+cd "${DIR}" && docker build -t ${IMAGE_NAME}:${TAG} .
 if [ $? -eq 0 ]; then
-  echo "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}"
+  echo -e "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}"
 else
-  echo "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}"
+  echo -e "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}"
   exit 1
 fi

--- a/dockerfiles/mount/build.sh
+++ b/dockerfiles/mount/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-mount"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/dockerfiles/test/build.sh
+++ b/dockerfiles/test/build.sh
@@ -6,7 +6,8 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 IMAGE_NAME="eclipse/che-test"
-. $(cd "$(dirname "$0")"; pwd)/../build.include
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
 
 init "$@"
 build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-Docs are located in seperate repository [https://github.com/codenvy/che-docs](https://github.com/codenvy/che-docs).
+Docs are located at [https://github.com/codenvy/che-docs](https://github.com/codenvy/che-docs).


### PR DESCRIPTION
### What does this PR do?
- We used OS path mounted into container path (it makes issues as on Windows we don’t have these paths)
- Now use /dockerfiles path inside the container
- add skip check for nightlies or it was downloading new images while testing the current nightly
- add —rm for cleaning containers at the end of docker run
- introduce of some asserts instead of custom checks
- Fix windows issue (like path with spaces)
- Fix teardown of che start tests

### What issues does this PR fix or reference?
#3980

#### Changelog
Use `/dockerfiles` path inside CLI container for launch
Add skip check for nightlies 
Add `--rm` for cleaning containers at the end of the start
Introduce asserts instead of custom checks

#### Release Notes
N/A for bugs


#### Docs PR
N/A for bugs
