### PR TITLE
[cli] docker function : If server is not found, we should return false

### DIFF
--- a/dockerfiles/base/scripts/base/docker.sh
+++ b/dockerfiles/base/scripts/base/docker.sh
@@ -164,7 +164,7 @@ container_exist_by_name(){
 
 get_server_container_id() {
   log "docker inspect -f '{{.Id}}' ${1}"
-  docker inspect -f '{{.Id}}' ${1} 2>&1 || true
+  docker inspect -f '{{.Id}}' ${1} 2>&1 || false
 }
 
 container_is_running() {


### PR DESCRIPTION
### What does this PR do?
Fix issue of checking if a container exists or not
today it's performing 
```
docker inspect -f '{{.Id}}' ${1} 2>&1 || true
````
which means that if first command fails we return true which means command successfully worked
with returning false it will mean that command fails and then that the container has not been found


### What issues does this PR fix or reference?
none

#### Changelog
cli/ docker helper function : does not return false when container is not found

#### Release Notes
Bugfix N/A

#### Docs PR
Bugfix N/A

Change-Id: Ie48d3bd2340f2c1f916b95a3bc9354ff46ae3d6a
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
