### PR TITLE
CHE-3733 Exclude assembly's bin folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ docs/_site
 docs/.sass-cache
 docs/.jekyll-metadata
 docs/assets/imgs
+!assembly/assembly-main/src/assembly/bin/


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
assembly/assembly-main/src/assembly/bin folder is no longer ignored by gitignore

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3733

#### Changelog
Exclude `assembly/assembly-main/src/assembly/bin/` source folder from gitignore

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
