### PR TITLE
CHE-3715: fix parsing of dockerfile's ENV instruction

### DIFF
--- a/dashboard/src/components/api/environment/docker-file-parser.spec.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.spec.ts
@@ -25,7 +25,7 @@ describe('Simper dockerfile parser', () => {
   });
 
   describe('method _parseArgument()', () => {
-    it('should parse ENV argument with single environment variable', () => {
+    it('should parse ENV argument with single environment variable #1', () => {
       let instruction = 'ENV',
           argument = 'name environment variable value';
 
@@ -34,6 +34,19 @@ describe('Simper dockerfile parser', () => {
       let expectedResult = [{
         instruction: 'ENV',
         argument: ['name', 'environment variable value']
+      }];
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should parse ENV argument with single environment variable #2', () => {
+      let instruction = 'ENV',
+          argument = 'SBT_OPTS \'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'';
+
+      let result = parser._parseArgument(instruction, argument);
+
+      let expectedResult = [{
+        instruction: 'ENV',
+        argument: ['SBT_OPTS', '\'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'']
       }];
       expect(result).toEqual(expectedResult);
     });
@@ -56,6 +69,7 @@ describe('Simper dockerfile parser', () => {
       }];
       expect(result).toEqual(expectedResult);
     });
+
   });
 
   it('should parse a dockerfile', () => {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix bug in UD  in dockerfile's parser which causes incorrect value of environment variable.

### What issues does this PR fix or reference?
#3715 

#### Changelog
<!-- one line entry to be added to changelog -->
Fixed bug with environment variables parsing in dockerfile in UD

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Bugfix N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
Bugfix N/A


Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>

