### PR TITLE
Update org.eclipse.che.ws-agent.script.sh

### DIFF
--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -97,7 +97,7 @@ elif echo ${LINUX_TYPE} | grep -qi "ubuntu"; then
 elif echo ${LINUX_TYPE} | grep -qi "debian"; then
 
     if [ ${INSTALL_JDK} = true ]; then
-        PACKAGES=${PACKAGES}" openjdk-8-jdk-headless";
+        PACKAGES=${PACKAGES}" -t jessie-backports openjdk-8-jdk-headless";
         echo "deb http://httpredir.debian.org/debian jessie-backports main" | ${SUDO} tee --append /etc/apt/sources.list
     fi
 


### PR DESCRIPTION
### What does this PR do?
As @james-w explained here https://github.com/eclipse/che/issues/3740#issuecomment-277258807 now to install openJDK we should change install command.

### What issues does this PR fix or reference?
Fixes: https://github.com/eclipse/che/issues/3740

#### Changelog
Change command how to install openJDK on Debian
