### PR TITLE
Adds system graceful stop tracking events

### DIFF
--- a/wsmaster/che-core-api-system-shared/pom.xml
+++ b/wsmaster/che-core-api-system-shared/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/dto/SystemServiceEventDto.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/dto/SystemServiceEventDto.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * DTO for system service events.
+ *
+ * @author Yevhenii Voevodin
+ */
+@DTO
+public interface SystemServiceEventDto extends SystemEventDto {
+
+    /**
+     * Returns the name of the service described by this event.
+     */
+    String getService();
+
+    void setService(String service);
+
+    SystemServiceEventDto withService(String service);
+}

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/dto/SystemServiceItemStoppedEventDto.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/dto/SystemServiceItemStoppedEventDto.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.shared.dto;
+
+import org.eclipse.che.api.system.shared.event.EventType;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * See {@link EventType#SERVICE_ITEM_STOPPED} for details.
+ *
+ * @author Yevhenii Voevodin
+ */
+@DTO
+public interface SystemServiceItemStoppedEventDto extends SystemServiceEventDto {
+
+    /**
+     * Returns an item for which this event is published(like workspace id).
+     */
+    String getItem();
+
+    void setItem(String item);
+
+    SystemServiceItemStoppedEventDto withItem(String item);
+
+    /**
+     * Returns an amount of items currently stopped, it's either present
+     * with {@link #getTotal()} or missing at all(null is returned).
+     */
+    @Nullable
+    Integer getCurrent();
+
+    void setCurrent(Integer current);
+
+    SystemServiceItemStoppedEventDto withCurrent(Integer current);
+
+    /**
+     * Returns total count of items which had not been stopped before
+     * service shutdown was called. It's either present with {@link #getCurrent()}
+     * or missing at all(null is returned).
+     */
+    @Nullable
+    Integer getTotal();
+
+    void setTotal(Integer total);
+
+    SystemServiceItemStoppedEventDto withTotal(Integer total);
+}

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/EventType.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/EventType.java
@@ -20,5 +20,28 @@ public enum EventType {
     /**
      * Published when system status is changed.
      */
-    STATUS_CHANGED
+    STATUS_CHANGED,
+
+    /**
+     * Published when system is starting shutting down a service.
+     * This is the first event published for a certain service.
+     *
+     * <pre>
+     *     STOPPING_SERVICE -> (0..N)SERVICE_ITEM_STOPPED -> SERVICE_STOPPED
+     * </pre>
+     */
+    STOPPING_SERVICE,
+
+    /**
+     * Published after service item is stopped.
+     * Events of such type are published between {@link #STOPPING_SERVICE}
+     * and {@link #SERVICE_STOPPED} events.
+     */
+    SERVICE_ITEM_STOPPED,
+
+    /**
+     * Published when shutting down of a service is finished.
+     * The last event in the chain for a certain service.
+     */
+    SERVICE_STOPPED
 }

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/StoppingSystemServiceEvent.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/StoppingSystemServiceEvent.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.shared.event.service;
+
+import org.eclipse.che.api.system.shared.event.EventType;
+
+/**
+ * See {@link EventType#STOPPING_SERVICE} description.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class StoppingSystemServiceEvent extends SystemServiceEvent {
+
+    public StoppingSystemServiceEvent(String serviceName) {
+        super(serviceName);
+    }
+
+    @Override
+    public EventType getType() {
+        return EventType.STOPPING_SERVICE;
+    }
+}

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/SystemServiceEvent.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/SystemServiceEvent.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.shared.event.service;
+
+import org.eclipse.che.api.system.shared.event.SystemEvent;
+
+import java.util.Objects;
+
+/**
+ * The base class for system service events.
+ *
+ * @author Yevhenii Voevodin
+ */
+public abstract class SystemServiceEvent implements SystemEvent {
+
+    protected final String serviceName;
+
+    protected SystemServiceEvent(String serviceName) {
+        this.serviceName = Objects.requireNonNull(serviceName, "Service name required");
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SystemServiceEvent)) {
+            return false;
+        }
+        final SystemServiceEvent that = (SystemServiceEvent)obj;
+        return Objects.equals(getType(), that.getType())
+               && Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 17;
+        hash = 31 * hash + Objects.hashCode(getType());
+        hash = 31 * hash + Objects.hashCode(serviceName);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{eventType='" + getType() + "', serviceName=" + serviceName + "'}";
+    }
+}

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/SystemServiceItemStoppedEvent.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/SystemServiceItemStoppedEvent.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.shared.event.service;
+
+import org.eclipse.che.api.system.shared.event.EventType;
+import org.eclipse.che.commons.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * See {@link EventType#SERVICE_ITEM_STOPPED} description.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class SystemServiceItemStoppedEvent extends SystemServiceEvent {
+
+    private final String item;
+
+    private Integer total;
+    private Integer current;
+
+    public SystemServiceItemStoppedEvent(String serviceName, String item) {
+        super(serviceName);
+        this.item = Objects.requireNonNull(item, "Item required");
+    }
+
+    public SystemServiceItemStoppedEvent(String serviceName,
+                                         String item,
+                                         @Nullable Integer current,
+                                         @Nullable Integer total) {
+        this(serviceName, item);
+        this.current = current;
+        this.total = total;
+    }
+
+    @Override
+    public EventType getType() {
+        return EventType.SERVICE_ITEM_STOPPED;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    @Nullable
+    public Integer getTotal() {
+        return total;
+    }
+
+    @Nullable
+    public Integer getCurrent() {
+        return current;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SystemServiceItemStoppedEvent)) {
+            return false;
+        }
+        final SystemServiceItemStoppedEvent that = (SystemServiceItemStoppedEvent)obj;
+        return super.equals(that)
+               && item.equals(that.item)
+               && Objects.equals(total, that.total)
+               && Objects.equals(current, that.current);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + super.hashCode();
+        hash = 31 * hash + item.hashCode();
+        hash = 31 * hash + Objects.hashCode(total);
+        hash = 31 * hash + Objects.hashCode(current);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "SystemServiceItemStoppedEvent{" +
+               "item='" + item + '\'' +
+               ", total=" + total +
+               ", current=" + current +
+               ", eventType='" + getType() + '\'' +
+               ", service='" + getServiceName() +
+               "\'}";
+    }
+}

--- a/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/SystemServiceStoppedEvent.java
+++ b/wsmaster/che-core-api-system-shared/src/main/java/org/eclipse/che/api/system/shared/event/service/SystemServiceStoppedEvent.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.shared.event.service;
+
+import org.eclipse.che.api.system.shared.event.EventType;
+
+/**
+ * See {@link EventType#SERVICE_STOPPED} description.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class SystemServiceStoppedEvent extends SystemServiceEvent {
+
+    public SystemServiceStoppedEvent(String serviceName) {
+        super(serviceName);
+    }
+
+    @Override
+    public EventType getType() {
+        return EventType.SERVICE_STOPPED;
+    }
+}

--- a/wsmaster/che-core-api-system/pom.xml
+++ b/wsmaster/che-core-api-system/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-system-shared</artifactId>
         </dependency>
         <dependency>
@@ -68,11 +72,15 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-lang</artifactId>
+            <artifactId>che-core-api-workspace-shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.everrest</groupId>
-            <artifactId>everrest-websockets</artifactId>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/DtoConverter.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/DtoConverter.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.system.shared.dto.SystemEventDto;
+import org.eclipse.che.api.system.shared.dto.SystemServiceEventDto;
+import org.eclipse.che.api.system.shared.dto.SystemServiceItemStoppedEventDto;
+import org.eclipse.che.api.system.shared.dto.SystemStatusChangedEventDto;
+import org.eclipse.che.api.system.shared.event.SystemEvent;
+import org.eclipse.che.api.system.shared.event.SystemStatusChangedEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
+import org.eclipse.che.dto.server.DtoFactory;
+
+/**
+ * Converts events to corresponding DTOs.
+ *
+ * @author Yevhenii Voevodin
+ */
+public final class DtoConverter {
+
+    /**
+     * Creates {@link SystemStatusChangedEventDto} from event.
+     */
+    public static SystemStatusChangedEventDto asDto(SystemStatusChangedEvent event) {
+        SystemStatusChangedEventDto dto = DtoFactory.newDto(SystemStatusChangedEventDto.class);
+        dto.setType(event.getType());
+        dto.setStatus(event.getStatus());
+        dto.setPrevStatus(event.getPrevStatus());
+        return dto;
+    }
+
+    /**
+     * Creates {@link SystemServiceEventDto} from event.
+     */
+    public static SystemServiceEventDto asDto(SystemServiceEvent event) {
+        SystemServiceEventDto dto = DtoFactory.newDto(SystemServiceEventDto.class);
+        dto.setService(event.getServiceName());
+        dto.setType(event.getType());
+        return dto;
+    }
+
+    /**
+     * Creates {@link SystemServiceItemStoppedEventDto} from event.
+     */
+    public static SystemServiceItemStoppedEventDto asDto(SystemServiceItemStoppedEvent event) {
+        SystemServiceItemStoppedEventDto dto = DtoFactory.newDto(SystemServiceItemStoppedEventDto.class);
+        dto.setService(event.getServiceName());
+        dto.setType(event.getType());
+        dto.setCurrent(event.getCurrent());
+        dto.setTotal(event.getTotal());
+        dto.setItem(event.getItem());
+        return dto;
+    }
+
+    /**
+     * Converts given event to the corresponding DTO, if event type
+     * is unknown throws {@link IllegalArgumentException}.
+     */
+    public static SystemEventDto asDto(SystemEvent event) {
+        switch (event.getType()) {
+            case STATUS_CHANGED:
+                return asDto((SystemStatusChangedEvent)event);
+            case SERVICE_ITEM_STOPPED:
+                return asDto((SystemServiceItemStoppedEvent)event);
+            case SERVICE_STOPPED:
+            case STOPPING_SERVICE:
+                return asDto((SystemServiceEvent)event);
+            default:
+                throw new IllegalArgumentException("Can't convert event to dto, event type '" + event.getType() + "' is unknown");
+        }
+    }
+
+    private DtoConverter() {}
+}

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/ServiceTermination.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/ServiceTermination.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
+import org.eclipse.che.api.system.shared.event.service.StoppingSystemServiceEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceStoppedEvent;
+
+/**
+ * Defines an interface for implementing termination
+ * process for a certain service.
+ *
+ * @author Yevhenii Voevodin
+ */
+interface ServiceTermination {
+
+    /**
+     * Terminates a certain service.
+     * It's expected that termination is synchronous.
+     *
+     * @throws InterruptedException
+     *         as termination is synchronous some of the implementations
+     *         may need to wait for asynchronous jobs to finish their execution,
+     *         so if termination is interrupted and implementation supports termination
+     *         it should throw an interrupted exception
+     */
+    void terminate() throws InterruptedException;
+
+    /**
+     * Returns the name of the service which is terminated by this termination.
+     * The name is used for logging/sending events like {@link StoppingSystemServiceEvent},
+     * {@link SystemServiceItemStoppedEvent} or {@link SystemServiceStoppedEvent}.
+     */
+    String getServiceName();
+}

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/ServiceTerminator.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/ServiceTerminator.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.system.shared.event.service.StoppingSystemServiceEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceStoppedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Terminates system services.
+ *
+ * @author Yevhenii Voevodin
+ */
+class ServiceTerminator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceTerminator.class);
+
+    private final EventService             eventService;
+    private final List<ServiceTermination> terminations;
+
+    @Inject
+    ServiceTerminator(EventService eventService, WorkspaceServiceTermination workspaceTermination) {
+        this(eventService, Collections.singletonList(workspaceTermination));
+    }
+
+    ServiceTerminator(EventService eventService, Collection<? extends ServiceTermination> terminations) {
+        this.eventService = eventService;
+        this.terminations = new ArrayList<>(terminations);
+    }
+
+    /**
+     * Terminates system services.
+     *
+     * @throws InterruptedException
+     *         when termination is interrupted
+     */
+    void terminateAll() throws InterruptedException {
+        for (ServiceTermination termination : terminations) {
+            LOG.info("Shutting down '{}' service", termination.getServiceName());
+            eventService.publish(new StoppingSystemServiceEvent(termination.getServiceName()));
+            try {
+                termination.terminate();
+            } catch (InterruptedException x) {
+                LOG.error("Interrupted while waiting for '{}' service to shutdown", termination.getServiceName());
+                throw x;
+            }
+            LOG.info("Service '{}' is shut down", termination.getServiceName());
+            eventService.publish(new SystemServiceStoppedEvent(termination.getServiceName()));
+        }
+    }
+}

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/WorkspaceServiceTermination.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/WorkspaceServiceTermination.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceStoppedEvent;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Terminates workspace service.
+ *
+ * @author Yevhenii Voevodin
+ */
+class WorkspaceServiceTermination implements ServiceTermination {
+
+    @Inject
+    private WorkspaceManager workspaceManager;
+
+    @Inject
+    private EventService eventService;
+
+    @Override
+    public void terminate() throws InterruptedException {
+        EventSubscriber propagator = new WorkspaceStoppedEventsPropagator();
+        eventService.subscribe(propagator);
+        try {
+            workspaceManager.shutdown();
+        } finally {
+            eventService.unsubscribe(propagator);
+        }
+    }
+
+    @Override
+    public String getServiceName() {
+        return "workspace";
+    }
+
+    /**
+     * Propagates workspace stopped events as {@link SystemServiceStoppedEvent} events.
+     */
+    private class WorkspaceStoppedEventsPropagator implements EventSubscriber<WorkspaceStatusEvent> {
+
+        private final int           totalRunning;
+        private final AtomicInteger currentlyStopped;
+
+        private WorkspaceStoppedEventsPropagator() {
+            this.totalRunning = workspaceManager.getRunningWorkspacesIds().size();
+            this.currentlyStopped = new AtomicInteger(0);
+        }
+
+        @Override
+        public void onEvent(WorkspaceStatusEvent event) {
+            if (event.getStatus() == WorkspaceStatus.STOPPED) {
+                eventService.publish(new SystemServiceItemStoppedEvent(getServiceName(),
+                                                                       event.getWorkspaceId(),
+                                                                       currentlyStopped.incrementAndGet(),
+                                                                       totalRunning));
+            }
+        }
+    }
+}

--- a/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/DtoConverterTest.java
+++ b/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/DtoConverterTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.system.shared.dto.SystemServiceEventDto;
+import org.eclipse.che.api.system.shared.dto.SystemServiceItemStoppedEventDto;
+import org.eclipse.che.api.system.shared.dto.SystemStatusChangedEventDto;
+import org.eclipse.che.api.system.shared.event.EventType;
+import org.eclipse.che.api.system.shared.event.SystemStatusChangedEvent;
+import org.eclipse.che.api.system.shared.event.service.StoppingSystemServiceEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceStoppedEvent;
+import org.testng.annotations.Test;
+
+import java.util.EnumSet;
+
+import static org.eclipse.che.api.system.shared.SystemStatus.PREPARING_TO_SHUTDOWN;
+import static org.eclipse.che.api.system.shared.SystemStatus.RUNNING;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests {@link DtoConverter}.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class DtoConverterTest {
+
+    @Test
+    public void convertsSystemStatusChangedEvent() {
+        SystemStatusChangedEvent event = new SystemStatusChangedEvent(RUNNING, PREPARING_TO_SHUTDOWN);
+
+        SystemStatusChangedEventDto dto = DtoConverter.asDto(event);
+
+        assertEquals(dto.getType(), EventType.STATUS_CHANGED);
+        assertEquals(dto.getPrevStatus(), event.getPrevStatus());
+        assertEquals(dto.getStatus(), event.getStatus());
+    }
+
+    @Test
+    public void convertsSystemServiceStoppingEvent() {
+        StoppingSystemServiceEvent event = new StoppingSystemServiceEvent("service1");
+
+        SystemServiceEventDto dto = DtoConverter.asDto(event);
+
+        assertEquals(dto.getType(), EventType.STOPPING_SERVICE);
+        assertEquals(dto.getService(), event.getServiceName());
+    }
+
+    @Test
+    public void convertsSystemServiceStoppedEvent() {
+        SystemServiceStoppedEvent event = new SystemServiceStoppedEvent("service1");
+
+        SystemServiceEventDto dto = DtoConverter.asDto(event);
+
+        assertEquals(dto.getType(), EventType.SERVICE_STOPPED);
+        assertEquals(dto.getService(), event.getServiceName());
+    }
+
+    @Test
+    public void convertsSystemServiceItemStoppedEvent() {
+        SystemServiceItemStoppedEvent event = new SystemServiceItemStoppedEvent("service1", "workspace1", 3, 5);
+
+        SystemServiceItemStoppedEventDto dto = DtoConverter.asDto(event);
+
+        assertEquals(dto.getType(), EventType.SERVICE_ITEM_STOPPED);
+        assertEquals(dto.getService(), event.getServiceName());
+        assertEquals(dto.getItem(), event.getItem());
+        assertEquals(dto.getCurrent(), event.getCurrent());
+        assertEquals(dto.getTotal(), event.getTotal());
+    }
+
+    @Test
+    public void allEventTypesAreHandled() {
+        EnumSet<EventType> handled = EnumSet.of(EventType.STATUS_CHANGED,
+                                                EventType.STOPPING_SERVICE,
+                                                EventType.SERVICE_ITEM_STOPPED,
+                                                EventType.SERVICE_STOPPED);
+        assertEquals(handled, EnumSet.allOf(EventType.class));
+    }
+}

--- a/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemEventsWebsocketBroadcasterTest.java
+++ b/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemEventsWebsocketBroadcasterTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.core.util.WebsocketLineConsumer;
+import org.eclipse.che.api.system.shared.dto.SystemEventDto;
+import org.eclipse.che.api.system.shared.event.SystemEvent;
+import org.eclipse.che.api.system.shared.event.SystemStatusChangedEvent;
+import org.eclipse.che.api.system.shared.event.service.StoppingSystemServiceEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceStoppedEvent;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.eclipse.che.api.system.shared.SystemStatus.PREPARING_TO_SHUTDOWN;
+import static org.eclipse.che.api.system.shared.SystemStatus.RUNNING;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test {@link SystemEventsWebsocketBroadcaster}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SystemEventsWebsocketBroadcasterTest {
+
+    @Mock
+    private WebsocketLineConsumer messageCustomer;
+
+    private SystemEventsWebsocketBroadcaster broadcaster;
+
+    @BeforeMethod
+    public void setUp() {
+        broadcaster = new SystemEventsWebsocketBroadcaster(messageCustomer);
+    }
+
+    @Test(dataProvider = "eventToDto")
+    public void sendsMessage(SystemEvent event, SystemEventDto dto) throws Exception {
+        broadcaster.onEvent(event);
+
+        verify(messageCustomer).writeLine(DtoFactory.getInstance().toJson(dto));
+    }
+
+    @Test
+    public void sendExceptionsAreLoggedAndNotThrown() throws Exception {
+        doThrow(new IOException("exception!")).when(messageCustomer).writeLine(anyString());
+
+        broadcaster.onEvent(new SystemServiceStoppedEvent("service1"));
+    }
+
+    @DataProvider(name = "eventToDto")
+    private static Object[][] eventToDto() {
+        SystemStatusChangedEvent statusChanged = new SystemStatusChangedEvent(RUNNING, PREPARING_TO_SHUTDOWN);
+        StoppingSystemServiceEvent stoppingService = new StoppingSystemServiceEvent("service1");
+        SystemServiceStoppedEvent serviceStopped = new SystemServiceStoppedEvent("service1");
+        SystemServiceItemStoppedEvent itemStopped = new SystemServiceItemStoppedEvent("service1", "item1", 5, 10);
+        return new Object[][] {
+                {statusChanged, DtoConverter.asDto(statusChanged)},
+                {stoppingService, DtoConverter.asDto(stoppingService)},
+                {serviceStopped, DtoConverter.asDto(serviceStopped)},
+                {itemStopped, DtoConverter.asDto(itemStopped)}
+        };
+    }
+}

--- a/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemManagerTest.java
+++ b/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemManagerTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.system.server;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.system.shared.event.SystemStatusChangedEvent;
-import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -42,7 +41,7 @@ import static org.testng.Assert.assertEquals;
 public class SystemManagerTest {
 
     @Mock
-    private WorkspaceManager wsManager;
+    private ServiceTerminator terminator;
 
     @Mock
     private EventService eventService;
@@ -55,7 +54,7 @@ public class SystemManagerTest {
     @BeforeMethod
     public void init() {
         MockitoAnnotations.initMocks(this);
-        systemManager = new SystemManager(wsManager, eventService);
+        systemManager = new SystemManager(terminator, eventService);
     }
 
     @Test
@@ -92,7 +91,7 @@ public class SystemManagerTest {
     }
 
     private void verifyShutdownCompleted() throws InterruptedException {
-        verify(wsManager, timeout(2000)).shutdown();
+        verify(terminator, timeout(2000)).terminateAll();
         verify(eventService, times(2)).publish(eventsCaptor.capture());
         Iterator<SystemStatusChangedEvent> eventsIt = eventsCaptor.getAllValues().iterator();
         assertEquals(eventsIt.next(), new SystemStatusChangedEvent(RUNNING, PREPARING_TO_SHUTDOWN));

--- a/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemTerminatorTest.java
+++ b/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemTerminatorTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.system.shared.event.service.StoppingSystemServiceEvent;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceStoppedEvent;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link ServiceTerminator}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SystemTerminatorTest {
+
+    @Mock
+    private EventService       eventService;
+    @Mock
+    private ServiceTermination termination1;
+    @Mock
+    private ServiceTermination termination2;
+
+    private ServiceTerminator terminator;
+
+    @BeforeMethod
+    public void setUp() {
+        when(termination1.getServiceName()).thenReturn("service1");
+        when(termination2.getServiceName()).thenReturn("service2");
+        terminator = new ServiceTerminator(eventService, Arrays.asList(termination1, termination2));
+    }
+
+    @Test
+    public void executesTerminations() throws Exception {
+        terminator.terminateAll();
+
+        verify(termination1).terminate();
+        verify(termination2).terminate();
+        verify(eventService).publish(new StoppingSystemServiceEvent("service1"));
+        verify(eventService).publish(new SystemServiceStoppedEvent("service1"));
+        verify(eventService).publish(new StoppingSystemServiceEvent("service2"));
+        verify(eventService).publish(new SystemServiceStoppedEvent("service2"));
+    }
+
+    @Test(expectedExceptions = InterruptedException.class, expectedExceptionsMessageRegExp = "interrupt!")
+    public void stopsExecutingTerminationIfOneIsInterrupted() throws Exception {
+        doThrow(new InterruptedException("interrupt!")).when(termination1).terminate();
+
+        terminator.terminateAll();
+    }
+}

--- a/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/WorkspaceServiceTerminationTest.java
+++ b/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/WorkspaceServiceTerminationTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.system.server;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link WorkspaceServiceTermination}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceServiceTerminationTest {
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private WorkspaceManager workspaceManager;
+
+    @InjectMocks
+    private WorkspaceServiceTermination termination;
+
+    @Test
+    public void shutsDownWorkspaceService() throws Exception {
+        termination.terminate();
+
+        verify(workspaceManager).shutdown();
+    }
+
+    @Test
+    public void publishesStoppedWorkspaceStoppedEventsAsServiceItemStoppedEvents() throws Exception {
+        when(workspaceManager.getRunningWorkspacesIds()).thenReturn(ImmutableSet.of("id1", "id2", "id3"));
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            EventSubscriber<WorkspaceStatusEvent> subscriber = (EventSubscriber<WorkspaceStatusEvent>)inv.getArguments()[0];
+
+            // id1
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.STARTING, "id1"));
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.RUNNING, "id1"));
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.STOPPING, "id1"));
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.STOPPED, "id1"));
+
+            // id2
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.RUNNING, "id2"));
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.STOPPING, "id2"));
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.STOPPED, "id2"));
+
+            // id3
+            subscriber.onEvent(newWorkspaceStatusEvent(WorkspaceStatus.STOPPED, "id3"));
+
+            return null;
+        }).when(eventService).subscribe(any());
+
+        termination.terminate();
+
+        verify(eventService).publish(new SystemServiceItemStoppedEvent("workspace", "id1", 1, 3));
+        verify(eventService).publish(new SystemServiceItemStoppedEvent("workspace", "id2", 2, 3));
+        verify(eventService).publish(new SystemServiceItemStoppedEvent("workspace", "id3", 3, 3));
+    }
+
+    private static WorkspaceStatusEvent newWorkspaceStatusEvent(WorkspaceStatus status, String workspaceId) {
+        return DtoFactory.newDto(WorkspaceStatusEvent.class)
+                         .withStatus(status)
+                         .withWorkspaceId(workspaceId);
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -678,11 +678,16 @@ public class WorkspaceManager {
         if (!runtimes.refuseWorkspacesStart()) {
             throw new IllegalStateException("Workspace service shutdown has been already called");
         }
-        LOG.info("Shutting down workspace service");
         stopRunningWorkspacesNormally();
         runtimes.shutdown();
         sharedPool.shutdown();
-        LOG.info("Workspace service stopped");
+    }
+
+    /**
+     * Returns set of workspace ids that are not {@link WorkspaceStatus#STOPPED}.
+     */
+    public Set<String> getRunningWorkspacesIds() {
+        return runtimes.getRuntimesIds();
     }
 
     /**

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.workspace.server;
 
+import com.google.common.collect.ImmutableSet;
+
 import org.eclipse.che.account.api.AccountManager;
 import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.ConflictException;
@@ -880,6 +882,14 @@ public class WorkspaceManagerTest {
         verify(runtimes, never()).stop(stopped.getId());
         verify(runtimes).shutdown();
         verify(sharedPool).shutdown();
+    }
+
+    @Test
+    public void getsRunningWorkspacesIds() {
+        ImmutableSet<String> ids = ImmutableSet.of("id1", "id2", "id3");
+        when(runtimes.getRuntimesIds()).thenReturn(ids);
+
+        assertEquals(workspaceManager.getRunningWorkspacesIds(), ids);
     }
 
     private void captureRunAsyncCallsAndRunSynchronously() {


### PR DESCRIPTION
### What does this PR do?

Adds 3 new tracking events published during system shutdown, they are:

* STOPPING_SERVICE - published before service is stopped. This event is always published
```json
{
        "type" : "STOPPING_SERVICE",
        "service" : "workspace"
}
```
* SERVICE_ITEM_STOPPED - published each time service item(like workspace) is stopped.
This event may be published 0 or N times between (STOPPING_SERVICE and SERVICE_STOPPED) events.
```json
{
        "type" : "SERVICE_ITEM_STOPPED",
        "service" : "workspace",
        "item" : "workspace0x12345",
        "current" : 13,
        "total" : 32
}
```
The fields `current` & `total` are optional and either present or missing both.
So if service manages quantity of its items then "current" & "total" should 
be present in the event, otherwise they must not be included to the event body.

* SERVICE_STOPPED - published after service is stopped. This event is always published
```json
{
        "type" : "SERVICE_STOPPED",
        "service" : "workspace"
}        
```

Resolves #3921 

#### Changelog
Publish tracking events during system graceful stop

#### Release Notes
System events set is reached with 3 new events: _STOPPING_SERVICE_, 
_SERVICE_ITEM_STOPPED_, _SERVICE_STOPPED_. These events provide more useful 
information about services being stopped during graceful system shutdown.

#### Docs PR
N/A
