### PR TITLE
Fix starting terminal/exec agent on alpine (which doesn’t have glibc)

### DIFF
--- a/agents/exec/pom.xml
+++ b/agents/exec/pom.xml
@@ -161,6 +161,7 @@
                                             <argument>${project.build.directory}/${item}/che-websocket-terminal</argument>
                                         </arguments>
                                         <environmentVariables>
+                                            <CGO_ENABLED>0</CGO_ENABLED>
                                             <GOPATH>${project.build.directory}/${go.workspace.name}</GOPATH>
                                             <GOOS>${terminal.target.os}</GOOS>
                                             <GOARCH>${terminal.target.architecture}</GOARCH>


### PR DESCRIPTION
### What does this PR do?
Allow to start exec-agent/terminal agent on alpine image (base image) when glibc is not installed

here is the issue
```
$ docker run -ti alpine:3.5 sh
/ # cd /root
~ # wget http://maven.codenvycorp.com/content/groups/public/org/eclipse/che/exec-agent/5.3.0-SNAPSHOT/exec-agent-5.3.0-20170206.092944-20-linux_amd64.tar.gz
Connecting to maven.codenvycorp.com (54.226.78.192:80)
exec-agent-5.3.0-201 100% |*****************************************************************************************************************|  2763k  0:00:00 ETA
~ # tar zxf exec-agent-5.3.0-20170206.092944-20-linux_amd64.tar.gz 
~ # ./terminal/che-websocket-terminal 
sh: ./terminal/che-websocket-terminal: not found
```



```
The cgo tool is enabled by default for native builds on systems where it is expected to work.
 It is disabled by default when cross-compiling. 
You can control this by setting the CGO_ENABLED environment variable when running the go tool: 
set it to 1 to enable the use of cgo, and to 0 to disable it. 
The go tool will set the build constraint "cgo" if cgo is enabled.

```

### What issues does this PR fix or reference?
#4024 

#### Changelog
Allow to start exec-agent/terminal agent on alpine image (base image without glibc)

#### Release Notes
Allow to start exec-agent/terminal agent on alpine image (base image without glibc)


#### Docs PR
N/A

Change-Id: I32c7a1ddbd6d86bf8e5dcd9f9a230fd41edb82bd
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
