### PR TITLE
CLI - Fix for CHE-3993 - Proper integer comparison

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -21,7 +21,7 @@ ENV DOCKER_SHA256 8c2e0c35e3cda11706f54b2d46c2521a6e9026a7b13c7d4b8ae1f3a706fc55
 RUN mkdir -p /version \
     && mkdir -p /cli \
     && mkdir /scripts/ \
-    && apk add --no-cache ca-certificates coreutils curl openssl jq \
+    && apk add --no-cache ca-certificates coreutils curl openssl jq bc \
     && apk add --update bash \
     && rm -rf /var/cache/apk/* \
     && set -x \

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -21,7 +21,7 @@ ENV DOCKER_SHA256 8c2e0c35e3cda11706f54b2d46c2521a6e9026a7b13c7d4b8ae1f3a706fc55
 RUN mkdir -p /version \
     && mkdir -p /cli \
     && mkdir /scripts/ \
-    && apk add --no-cache ca-certificates coreutils curl openssl jq bc \
+    && apk add --no-cache ca-certificates coreutils curl openssl jq \
     && apk add --update bash \
     && rm -rf /var/cache/apk/* \
     && set -x \

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -87,20 +87,23 @@ cmd_start_check_host_resources() {
   HOST_RAM=$(echo ${HOST_RAM#*:} | xargs)
   HOST_RAM=${HOST_RAM% *}
 
+  COMPARE=$(echo "$HOST_RAM<$CHE_MIN_RAM" | bc -l)
+
   PREFLIGHT=""
-  if $(less_than "31.37" "1.5"); then
+  if [[ "$COMPARE" = "0" ]]; then
+    text "         mem ($CHE_MIN_RAM GiB):           ${GREEN}[OK]${NC}\n"
+  else
     text "         mem ($CHE_MIN_RAM GiB):           ${RED}[NOT OK]${NC}\n"
     PREFLIGHT="fail"
-  else
-    text "         mem ($CHE_MIN_RAM GiB):           ${GREEN}[OK]${NC}\n"
   fi
 
   HOST_DISK=$(df "${CHE_CONTAINER_ROOT}" | grep "${CHE_CONTAINER_ROOT}" | cut -d " " -f 6)
-  if $(less_than "$HOST_DISK" "$CHE_MIN_DISK"000000); then
+  COMPARE=$(echo "$HOST_DISK<$CHE_MIN_DISK"000 | bc -l)
+  if [[ "$COMPARE" = "0" ]]; then
+    text "         disk ($CHE_MIN_DISK MB):           ${GREEN}[OK]${NC}\n"
+  else
     text "         disk ($CHE_MIN_DISK MB):           ${RED}[NOT OK]${NC}\n"
     PREFLIGHT="fail"
-  else
-    text "         disk ($CHE_MIN_DISK MB):           ${GREEN}[OK]${NC}\n"
   fi
 
   if [[ "${PREFLIGHT}" = "fail" ]]; then
@@ -108,7 +111,6 @@ cmd_start_check_host_resources() {
     error "${CHE_MINI_PRODUCT_NAME} requires more RAM or disk to guarantee workspaces can start."
     return 2;
   fi
-
 }
 
 cmd_start_check_ports() {

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -86,11 +86,9 @@ cmd_start_check_host_resources() {
   HOST_RAM=$(docker info | grep "Total Memory:")
   HOST_RAM=$(echo ${HOST_RAM#*:} | xargs)
   HOST_RAM=${HOST_RAM% *}
-
-  COMPARE=$(echo "$HOST_RAM<$CHE_MIN_RAM" | bc -l)
-
+  
   PREFLIGHT=""
-  if [[ "$COMPARE" = "0" ]]; then
+  if less_than_numerically $CHE_MIN_RAM $HOST_RAM; then
     text "         mem ($CHE_MIN_RAM GiB):           ${GREEN}[OK]${NC}\n"
   else
     text "         mem ($CHE_MIN_RAM GiB):           ${RED}[NOT OK]${NC}\n"
@@ -98,8 +96,8 @@ cmd_start_check_host_resources() {
   fi
 
   HOST_DISK=$(df "${CHE_CONTAINER_ROOT}" | grep "${CHE_CONTAINER_ROOT}" | cut -d " " -f 6)
-  COMPARE=$(echo "$HOST_DISK<$CHE_MIN_DISK"000 | bc -l)
-  if [[ "$COMPARE" = "0" ]]; then
+
+  if less_than_numerically "$CHE_MIN_DISK"000 $HOST_DISK; then
     text "         disk ($CHE_MIN_DISK MB):           ${GREEN}[OK]${NC}\n"
   else
     text "         disk ($CHE_MIN_DISK MB):           ${RED}[NOT OK]${NC}\n"

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -253,6 +253,25 @@ wait_until_server_is_booted() {
   done
 }
 
+less_than_numerically() {
+  COMPARE=$(awk "BEGIN { print ($1 < $2) ? 0 : 1}")
+  return $COMPARE
+}
+
+# This will compare two same length strings, such as versions
+less_than() {
+  for (( i=0; i<${#1}; i++ )); do
+    if [[ ${1:$i:1} != ${2:$i:1} ]]; then
+      if [ ${1:$i:1} -lt ${2:$i:1} ]; then
+        return 0
+      else
+        return 1
+      fi
+    fi
+  done
+  return 1
+}
+
 # Compares $1 version to the first 10 versions listed as tags on Docker Hub
 # Returns "" if $1 is newest, otherwise returns the newest version available
 # Does not work with nightly versions - do not use this to compare nightly to another version

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -198,19 +198,6 @@ get_image_version() {
   echo "$CHE_IMAGE_VERSION"
 }
 
-less_than() {
-  for (( i=0; i<${#1}; i++ )); do
-    if [[ ${1:$i:1} != ${2:$i:1} ]]; then
-      if [ ${1:$i:1} -lt ${2:$i:1} ]; then
-        return 0
-      else
-        return 1
-      fi
-    fi
-  done
-  return 1
-}
-
 # Check if a version is < than another version (provide like for example : version_lt 5.0 5.1)
 version_lt() {
  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1";

--- a/dockerfiles/cli/tests/test_base.sh
+++ b/dockerfiles/cli/tests/test_base.sh
@@ -9,7 +9,7 @@
 #   Marian Labuda - Initial Implementation
 
 export CLI_IMAGE="eclipse/che-cli:"$CLI_IMAGE_TAG
-source /dockerfiles/base/scripts/base/startup_funcs.sh
+source /dockerfiles/base/scripts/base/*.sh
 export SCRIPTS_DIR="${BATS_BASE_DIR}"/base/scripts/base
 export TESTS_DIR="${BATS_BASE_DIR}"/cli/tests
 export TESTRUN_DIR="${TESTS_DIR}"/testrun


### PR DESCRIPTION
Signed-off-by: Tyler Jewell <tjewell@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR adds a function to the base CLI to use awk to do numerical comparisons. Our default function was having problems if the decimal place was in a different location, and this improvement makes it simpler to do these checks.

This check was being used when comparing RAM and disk sizes to minimums.

### What issues does this PR fix or reference?
#3993 


#### Changelog
Add awk function to do numerical comparisons in CLI but reverted by PR #4035.

#### Release Notes
N/A

#### Docs PR
N/A