### PR TITLE
Allow to use wget in addition to curl when installing workspace agent + terminal agent

### DIFF
--- a/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
+++ b/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
@@ -12,7 +12,16 @@
 unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
-command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
+CURL_INSTALLED=false
+WGET_INSTALLED=false
+command -v curl >/dev/null 2>&1 && CURL_INSTALLED=true
+command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
+
+# no curl, no wget, install curl
+if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
+  PACKAGES=${PACKAGES}" curl";
+fi
+
 test "$(id -u)" = 0 || SUDO="sudo -E"
 
 CHE_DIR=$HOME/che
@@ -148,23 +157,50 @@ eval "LOCAL_AGENT_BINARIES_URI=${LOCAL_AGENT_BINARIES_URI}"
 eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
 eval "TARGET_AGENT_BINARIES_URI=${TARGET_AGENT_BINARIES_URI}"
 
+LOCAL_AGENT_PATH=
 if [ -f "${LOCAL_AGENT_BINARIES_URI}" ]; then
     AGENT_BINARIES_URI="file://${LOCAL_AGENT_BINARIES_URI}"
+    LOCAL_AGENT_PATH=${LOCAL_AGENT_BINARIES_URI}
 elif [ -f $(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g") ]; then
     AGENT_BINARIES_URI="file://"$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
+    LOCAL_AGENT_PATH=$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
 else
-    echo "Exec Agent will be downloaded from Workspace Master"
     AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
 fi
 
+# If file is already on the filesystem, use it
+if [ ! -z ${LOCAL_AGENT_PATH} ]; then
+  tar zxf ${LOCAL_AGENT_PATH} -C ${CHE_DIR}
+else
+  echo "Exec Agent binary is downloaded remotely"
+  # Use curl
+  if [ ${CURL_INSTALLED} = true ]; then
+    if curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+  else
+    # replace https by http as wget may not be able to handle ssl
+    AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')
 
-if curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
-    curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
-elif curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
-    curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    # use wget
+    WGET_SPIDER="wget --spider"
+    if wget  2>&1 | grep -q BusyBox; then
+      WGET_SPIDER="wget -s"
+    fi
+    LOCAL_DOWNLOAD=$(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g')
+    if ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') >/dev/null; then
+      wget -qO ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      wget -qO- ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    tar xzf ${LOCAL_DOWNLOAD} -C ${CHE_DIR}
+  fi
 fi
 
-curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+
 
 if [ -f /bin/bash ]; then
     SHELL_INTERPRETER="/bin/bash"

--- a/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
@@ -12,7 +12,16 @@
 unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
-command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
+CURL_INSTALLED=false
+WGET_INSTALLED=false
+command -v curl >/dev/null 2>&1 && CURL_INSTALLED=true
+command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
+
+# no curl, no wget, install curl
+if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
+  { PACKAGES=${PACKAGES}" curl"; }
+fi
+
 test "$(id -u)" = 0 || SUDO="sudo -E"
 
 CHE_DIR=$HOME/che
@@ -149,23 +158,49 @@ eval "LOCAL_AGENT_BINARIES_URI=${LOCAL_AGENT_BINARIES_URI}"
 eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
 eval "TARGET_AGENT_BINARIES_URI=${TARGET_AGENT_BINARIES_URI}"
 
+LOCAL_AGENT_PATH=
 if [ -f "${LOCAL_AGENT_BINARIES_URI}" ]; then
     AGENT_BINARIES_URI="file://${LOCAL_AGENT_BINARIES_URI}"
+    LOCAL_AGENT_PATH=${LOCAL_AGENT_BINARIES_URI}
 elif [ -f $(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g") ]; then
     AGENT_BINARIES_URI="file://"$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
+    LOCAL_AGENT_PATH=$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
 else
-    echo "Terminal Agent will be downloaded from Workspace Master"
     AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
 fi
 
+AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
 
-if curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
-    curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
-elif curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
-    curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+# If file is already on the filesystem, use it
+if [ ! -z ${LOCAL_AGENT_PATH} ]; then
+  tar zxf ${LOCAL_AGENT_PATH} -C ${CHE_DIR}
+else
+  echo "Terminal Agent binary is downloaded remotely"
+  # Use curl
+  if [ ${CURL_INSTALLED} = true ]; then
+    if curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+  else
+    # use wget
+    WGET_SPIDER="wget --spider"
+    if wget  2>&1 | grep -q BusyBox; then
+      WGET_SPIDER="wget -s"
+    fi
+    LOCAL_DOWNLOAD=$(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g')
+    if ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') >/dev/null; then
+      wget -qO ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      wget -qO- ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    tar xzf ${LOCAL_DOWNLOAD} -C ${CHE_DIR}
+  fi
 fi
 
-curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+
 
 if [ -f /bin/bash ]; then
     SHELL_INTERPRETER="/bin/bash"

--- a/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
@@ -19,7 +19,7 @@ command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
 
 # no curl, no wget, install curl
 if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
-  { PACKAGES=${PACKAGES}" curl"; }
+  PACKAGES=${PACKAGES}" curl";
 fi
 
 test "$(id -u)" = 0 || SUDO="sudo -E"
@@ -169,8 +169,6 @@ else
     AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
 fi
 
-AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
-
 # If file is already on the filesystem, use it
 if [ ! -z ${LOCAL_AGENT_PATH} ]; then
   tar zxf ${LOCAL_AGENT_PATH} -C ${CHE_DIR}
@@ -185,6 +183,9 @@ else
     fi
     curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
   else
+    # replace https by http as wget may not be able to handle ssl
+    AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')
+
     # use wget
     WGET_SPIDER="wget --spider"
     if wget  2>&1 | grep -q BusyBox; then

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -12,7 +12,16 @@
 unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
-command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
+CURL_INSTALLED=false
+WGET_INSTALLED=false
+command -v curl >/dev/null 2>&1 && CURL_INSTALLED=true
+command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
+
+# no curl, no wget, install curl
+if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
+  { PACKAGES=${PACKAGES}" curl"; }
+fi
+
 test "$(id -u)" = 0 || SUDO="sudo -E"
 
 LOCAL_AGENT_BINARIES_URI="/mnt/che/ws-agent.tar.gz"
@@ -233,13 +242,20 @@ eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
 
 if [ -f "${LOCAL_AGENT_BINARIES_URI}" ] && [ -s "${LOCAL_AGENT_BINARIES_URI}" ]
 then
-    AGENT_BINARIES_URI="file://${LOCAL_AGENT_BINARIES_URI}"
+    tar zxf "${LOCAL_AGENT_BINARIES_URI}" -C ${CHE_DIR}/ws-agent
 else
     echo "Workspace Agent will be downloaded from Workspace Master"
     AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
+    if [ ${CURL_INSTALLED} = true ]; then
+      curl -s  ${AGENT_BINARIES_URI} | tar  xzf - -C ${CHE_DIR}/ws-agent
+    else
+      # use wget
+      wget -qO- ${AGENT_BINARIES_URI} | tar xzf - -C ${CHE_DIR}/ws-agent
+    fi
+
 fi
 
-curl -s  ${AGENT_BINARIES_URI} | tar  xzf - -C ${CHE_DIR}/ws-agent
+
 
 ###############################################
 ### ws-agent run command will be added here ###

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -19,7 +19,7 @@ command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
 
 # no curl, no wget, install curl
 if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
-  { PACKAGES=${PACKAGES}" curl"; }
+  PACKAGES=${PACKAGES}" curl";
 fi
 
 test "$(id -u)" = 0 || SUDO="sudo -E"
@@ -249,6 +249,9 @@ else
     if [ ${CURL_INSTALLED} = true ]; then
       curl -s  ${AGENT_BINARIES_URI} | tar  xzf - -C ${CHE_DIR}/ws-agent
     else
+      # replace https by http as wget may not be able to handle ssl
+      AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')
+
       # use wget
       wget -qO- ${AGENT_BINARIES_URI} | tar xzf - -C ${CHE_DIR}/ws-agent
     fi


### PR DESCRIPTION
### What does this PR do?

For example alpine images have natively wget tool installed (in a busybox version) but not curl by default
So, we could check that either curl or wget is installed instead of only checking if curl is installed as we only need to download binaries which wget can perform easily as well
It is speeding up the first boot of the workspaces based on this configuration. (small alpine images)

### What issues does this PR fix or reference?
#4024 

#### Changelog
Allow to use wget instead of only curl for installing ws agent or terminal agent

#### Release Notes
Allow to use wget instead of only curl for installing ws agent or terminal agent


#### Docs PR
N/A

Change-Id: I7d02fb70f5f2fb03432072f4f33ff27532c8601e
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
