### PR TITLE
[cli] only gives -it docker run option if it was given from the command line

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_action.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_action.sh
@@ -35,5 +35,5 @@ pre_cmd_action() {
 }
 
 cmd_action() {
-  docker_run -it ${UTILITY_IMAGE_CHEACTION} "$@"
+  docker_run $(get_docker_run_terminal_options) ${UTILITY_IMAGE_CHEACTION} "$@"
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_dir.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_dir.sh
@@ -36,6 +36,6 @@ cmd_dir() {
     warning "':/chedir' not mounted - using ${DATA_MOUNT} as source location"
   fi
 
-  docker_run -it -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} \
+  docker_run $(get_docker_run_terminal_options) -v ${HOST_FOLDER_TO_USE}:${HOST_FOLDER_TO_USE} \
             ${UTILITY_IMAGE_CHEDIR} ${HOST_FOLDER_TO_USE} "$@"
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_test.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_test.sh
@@ -28,5 +28,5 @@ pre_cmd_test() {
 }
 
 cmd_test() {
-  docker_run -it ${UTILITY_IMAGE_CHETEST} "$@"
+  docker_run $(get_docker_run_terminal_options) ${UTILITY_IMAGE_CHETEST} "$@"
 }

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -303,7 +303,7 @@ check_all_ports(){
     HTTPD_PORT_STRING+=" -p $PORT"
   done
 
-  EXECUTION_STRING="docker run -it --rm ${DOCKER_PORT_STRING} ${BOOTSTRAP_IMAGE_ALPINE} \
+  EXECUTION_STRING="docker run --rm ${DOCKER_PORT_STRING} ${BOOTSTRAP_IMAGE_ALPINE} \
                          sh -c \"echo hi\" > /dev/null 2>&1"
   eval ${EXECUTION_STRING}
   NETSTAT_EXIT=$?
@@ -463,4 +463,17 @@ check_http_code() {
   else
     return 1
   fi
+}
+
+# return options for docker run used by end-user when calling cli
+get_docker_run_terminal_options() {
+  local DOCKER_RUN_OPTIONS=""
+  # if TTY is there, need to use -ti
+  if [[ ${TTY_ACTIVATED} == "true" ]]; then
+    DOCKER_RUN_OPTIONS="-t"
+  fi
+  if [[ ${CHE_CLI_IS_INTERACTIVE} == "true" ]]; then
+    DOCKER_RUN_OPTIONS+="i"
+  fi
+  echo ${DOCKER_RUN_OPTIONS}
 }

--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -362,10 +362,23 @@ check_docker_networking() {
 check_interactive() {
   # Detect and verify that the CLI container was started with -it option.
   TTY_ACTIVATED=true
+  CHE_CLI_IS_INTERACTIVE=true
+
+  # check if no terminal
   if [ ! -t 1 ]; then
     TTY_ACTIVATED=false
+    CHE_CLI_IS_INTERACTIVE=false
     warning "Did not detect TTY - interactive mode disabled"
+  else
+    # There is a terminal, check if it's in interactive mode
+    CHE_CLI_IS_INTERACTIVE=$(docker inspect --format='{{.Config.AttachStdin}}' $(get_this_container_id))
+    if [[ ${CHE_CLI_IS_INTERACTIVE} == "false" ]]; then
+      CHE_CLI_IS_INTERACTIVE=false
+      warning "Did detect TTY but not in interactive mode"
+    fi
+
   fi
+
 }
 
 check_mounts() {


### PR DESCRIPTION
### What does this PR do?

For now for some commands we were using "-it" while it was not given by user so it was reporting some errors.
Now, we check the current arguments.
It avoids to give the option when it was not added on the original command line and that the sub action is not requiring a terminal

Also now print a warning if a terminal is given without interactive mode

### What issues does this PR fix or reference?
#4005 

#### Changelog
[cli] only gives -it docker run option if it was given from the command line

#### Release Notes
N/A bugfix

#### Docs PR
N/A bugfix

Change-Id: Ib76480ccf4320748a4fbc4704773b9337048ef61
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
