### PR TITLE
OpenShiftConnector OAuth token support

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -272,6 +272,7 @@ db.jndi.datasource.name=java:/comp/env/jdbc/che
 
 # OpenShift related properties
 che.openshift.endpoint=https://192.168.64.2:8443/
+che.openshift.token=
 che.openshift.username=openshift-dev
 che.openshift.password=devel
 che.openshift.project=eclipse-che

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-docker-client</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -12,11 +12,14 @@ package org.eclipse.che.plugin.openshift.client;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
 import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
@@ -39,6 +42,7 @@ public class OpenShiftConnectorTest {
     private static final String   OPENSHIFT_DEFAULT_USER_PASSWORD = "devel";
     private static final int      OPENSHIFT_LIVENESS_PROBE_DELAY = 300;
     private static final int      OPENSHIFT_LIVENESS_PROBE_TIMEOUT = 1;
+    private static final String   OPENSHIFT_DEFAULT_TOKEN = "91XMfu-FuNDkGjcIh6b0y1EtCvztGeSsSqRrWhBfyL8";
 
     @Mock
     private DockerConnectorConfiguration       dockerConnectorConfiguration;
@@ -53,21 +57,6 @@ public class OpenShiftConnectorTest {
 
     private OpenShiftConnector                 openShiftConnector;
 
-    @BeforeClass
-    public void setup() {
-        openShiftConnector = spy(new OpenShiftConnector(dockerConnectorConfiguration,
-                                                        dockerConnectionFactory,
-                                                        authManager,
-                                                        dockerApiVersionPathPrefixProvider,
-                                                        OPENSHIFT_API_ENDPOINT_MINISHIFT,
-                                                        OPENSHIFT_DEFAULT_USER_NAME,
-                                                        OPENSHIFT_DEFAULT_USER_PASSWORD,
-                                                        CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
-                                                        CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
-                                                        OPENSHIFT_LIVENESS_PROBE_DELAY,
-                                                        OPENSHIFT_LIVENESS_PROBE_TIMEOUT));
-    }
-
     @Test
     public void shouldGetWorkspaceIDWhenAValidOneIsProvidedInCreateContainerParams() throws IOException {
         //Given
@@ -78,10 +67,81 @@ public class OpenShiftConnectorTest {
         when(containerConfig.getEnv()).thenReturn(CONTAINER_ENV_VARIABLES);
 
         //When
+        openShiftConnector = new OpenShiftConnector(new ConfigBuilder(),
+                dockerConnectorConfiguration,
+                dockerConnectionFactory,
+                authManager,
+                dockerApiVersionPathPrefixProvider,
+                OPENSHIFT_API_ENDPOINT_MINISHIFT,
+                OPENSHIFT_DEFAULT_TOKEN,
+                OPENSHIFT_DEFAULT_USER_NAME,
+                OPENSHIFT_DEFAULT_USER_PASSWORD,
+                CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
+                CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
+                OPENSHIFT_LIVENESS_PROBE_DELAY,
+                OPENSHIFT_LIVENESS_PROBE_TIMEOUT);
         String workspaceID = openShiftConnector.getCheWorkspaceId(createContainerParams);
 
         //Then
-        assertEquals(expectedWorkspaceID, workspaceID);
+        assertEquals(workspaceID, expectedWorkspaceID);
+    }
+
+    @Test
+    public void shouldUseTokenWhenProvided() {
+        // Given
+        ConfigBuilder configBuilder = spy(new ConfigBuilder());
+
+        // When
+        openShiftConnector = new OpenShiftConnector(configBuilder,
+                dockerConnectorConfiguration,
+                dockerConnectionFactory,
+                authManager,
+                kubernetesLabelConverter,
+                kubernetesEnvVar,
+                kubernetesContainer,
+                kubernetesService,
+                dockerApiVersionPathPrefixProvider,
+                OPENSHIFT_API_ENDPOINT_MINISHIFT,
+                OPENSHIFT_DEFAULT_TOKEN,
+                OPENSHIFT_DEFAULT_USER_NAME,
+                OPENSHIFT_DEFAULT_USER_PASSWORD,
+                CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
+                CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
+                OPENSHIFT_LIVENESS_PROBE_DELAY,
+                OPENSHIFT_LIVENESS_PROBE_TIMEOUT);
+
+        // Then
+        verify(configBuilder,times(1)).withOauthToken(OPENSHIFT_DEFAULT_TOKEN);
+        verify(configBuilder,times(0)).withUsername(OPENSHIFT_DEFAULT_USER_NAME);
+    }
+
+    @Test
+    public void shouldUsePasswordWhenTokenIsNotProvided() {
+        // Given
+        ConfigBuilder configBuilder = spy(new ConfigBuilder());
+
+        // When
+        openShiftConnector = new OpenShiftConnector(configBuilder,
+                dockerConnectorConfiguration,
+                dockerConnectionFactory,
+                authManager,
+                kubernetesLabelConverter,
+                kubernetesEnvVar,
+                kubernetesContainer,
+                kubernetesService,
+                dockerApiVersionPathPrefixProvider,
+                OPENSHIFT_API_ENDPOINT_MINISHIFT,
+                "",
+                OPENSHIFT_DEFAULT_USER_NAME,
+                OPENSHIFT_DEFAULT_USER_PASSWORD,
+                CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
+                CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
+                OPENSHIFT_LIVENESS_PROBE_DELAY,
+                OPENSHIFT_LIVENESS_PROBE_TIMEOUT);
+
+        // Then
+        verify(configBuilder,times(0)).withOauthToken(OPENSHIFT_DEFAULT_TOKEN);
+        verify(configBuilder,times(1)).withUsername(OPENSHIFT_DEFAULT_USER_NAME);
     }
 
 }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -28,7 +28,6 @@ import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -96,10 +95,6 @@ public class OpenShiftConnectorTest {
                 dockerConnectorConfiguration,
                 dockerConnectionFactory,
                 authManager,
-                kubernetesLabelConverter,
-                kubernetesEnvVar,
-                kubernetesContainer,
-                kubernetesService,
                 dockerApiVersionPathPrefixProvider,
                 OPENSHIFT_API_ENDPOINT_MINISHIFT,
                 OPENSHIFT_DEFAULT_TOKEN,
@@ -125,10 +120,6 @@ public class OpenShiftConnectorTest {
                 dockerConnectorConfiguration,
                 dockerConnectionFactory,
                 authManager,
-                kubernetesLabelConverter,
-                kubernetesEnvVar,
-                kubernetesContainer,
-                kubernetesService,
                 dockerApiVersionPathPrefixProvider,
                 OPENSHIFT_API_ENDPOINT_MINISHIFT,
                 "",


### PR DESCRIPTION
### What does this PR do?
Add OpenShiftConnector OAuth token support. OpenShift connector authentication can be done via an OAuth token. 

### What issues does this PR fix or reference?
N/A

#### Changelog
Added OpenShiftConnector OAuth token support.

#### Release Notes
N/A (internal change)


#### Docs PR
N/A (will be documented as part of the larger OpenShift documentation)
