### PR TITLE
Fix potential NPE

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/JavaEditorAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/JavaEditorAction.java
@@ -48,7 +48,7 @@ public abstract class JavaEditorAction extends ProjectAction {
             EditorInput input = editorAgent.getActiveEditor().getEditorInput();
             VirtualFile file = input.getFile();
             final String fileExtension = fileTypeRegistry.getFileTypeByFile(file).getExtension();
-            if (fileExtension.equals("java") || fileExtension.equals("class")) {
+            if ("java".equals(fileExtension) || "class".equals(fileExtension)) {
                 e.getPresentation().setEnabledAndVisible(true);
                 return;
             }

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunClassContextTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunClassContextTestAction.java
@@ -132,7 +132,7 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction {
         }
         final Object possibleNode = selection.getHeadElement();
         boolean enable = possibleNode instanceof FileNode
-                && ((FileNode) possibleNode).getData().getExtension().equals("java");
+                && "java".equals(((FileNode) possibleNode).getData().getExtension());
         e.getPresentation().setEnabled(enable);
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassContextTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassContextTestAction.java
@@ -136,7 +136,7 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction {
         }
         final Object possibleNode = selection.getHeadElement();
         boolean enable = possibleNode instanceof FileNode
-                && ((FileNode) possibleNode).getData().getExtension().equals("java");
+                && "java".equals(((FileNode) possibleNode).getData().getExtension());
 
         e.getPresentation().setEnabled(enable);
     }


### PR DESCRIPTION
Prevent potential `NullPointerException` during string comparison.

### What issues does this PR fix or reference?
Context menu is not opened on the simple file - https://github.com/eclipse/che/issues/4055

#### Changelog
Prevent potential `NullPointerException` during string comparison.

#### Release Notes
NA

#### Docs PR
NA
