### PR TITLE
[cli] graceful stop should work with any system state

### DIFF
--- a/dockerfiles/lib/src/internal/action/impl/graceful-stop-action.ts
+++ b/dockerfiles/lib/src/internal/action/impl/graceful-stop-action.ts
@@ -49,16 +49,9 @@ export class GracefulStopAction {
     run() : Promise<any> {
         // first, login
         return this.authData.login().then(() => {
-            return this.system.getState()
-                .then((state:org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
-                    if (state.getStatus() != "RUNNING") {
-                        return Promise.reject("Status is not in RUNNING state so the graceful can't be called.");
-                    }
-                });
-        }).then(() => {
             return this.system.gracefulStop();
         }).then((state:org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
-          Log.getLogger().info("Success: system is now in status '" + state.getStatus() + "'.");
+          Log.getLogger().info("Success: System state '" + state.getStatus() + "'.");
         });
     }
 


### PR DESCRIPTION
### What does this PR do?
cli graceful stop should work with any system state
until now it was expecting remote state was RUNNING.

Now if state is:
  - RUNNING -> call stop and wait for system to be in READY_TO_SHUTDOWN state
  - READY_TO_SHUTDOWN -> do nothing(maybe print something useful)
  - ANY_OTHER_STATE -> wait for system to be in READY_TO_SHUTDOWN state

### What issues does this PR fix or reference?
#3988 

#### Changelog
[cli] graceful stop work with any remote system state

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I55a8b5ecb2b016d31dbbd95b8793af4952d8116b
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
