### PR TITLE
[cli] Improve UX of graceful shutdown message

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_stop.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_stop.sh
@@ -33,7 +33,7 @@ cmd_stop() {
   FORCE_STOP=false
   if [[ "$@" == *"--skip:graceful"* ]]; then
   	FORCE_STOP=true
-  elif local_repo; then
+  elif local_repo || local_assembly; then
     warning "Development mode [skip graceful stop]"
     FORCE_STOP=true
   fi
@@ -48,7 +48,7 @@ cmd_stop() {
         error "Authentication failed on the system. Please provide --user and -password values or user --skip:graceful to bypass graceful stop."
         return 2;
       elif [[ ${GRACEFUL_STATUS_RESULT} -ne 0 ]]; then
-        error "We encountered an error -- see $CHE_HOST_CONFIG/cli.log. Graceful stop can be skipped with --skip:graceful"
+        error "We encountered an error during graceful stop - see $CHE_HOST_CONFIG/cli.log. (hint: --skip:graceful does not wait for workspace stop)"
         return 2;
       fi
     fi

--- a/dockerfiles/base/scripts/base/commands/cmd_stop.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_stop.sh
@@ -34,7 +34,6 @@ cmd_stop() {
   if [[ "$@" == *"--skip:graceful"* ]]; then
   	FORCE_STOP=true
   elif local_repo || local_assembly; then
-    warning "Development mode [skip graceful stop]"
     FORCE_STOP=true
   fi
 
@@ -45,10 +44,10 @@ cmd_stop() {
       cmd_lifecycle action "graceful-stop" "$@" >> "${LOGS}" 2>&1 || GRACEFUL_STATUS_RESULT=$?
       # error on authentication (401 modulo 256 = 145)
       if [[ ${GRACEFUL_STATUS_RESULT} -eq 145 ]]; then
-        error "Authentication failed on the system. (hint: --user/--password for auth parameters, --skip:graceful does not wait for workspace stop)"
+        error "Authentication failed (hint: --user/--password for auth, --skip:graceful bypasses workspace stop)"
         return 2;
       elif [[ ${GRACEFUL_STATUS_RESULT} -ne 0 ]]; then
-        error "We encountered an error during graceful stop - see $CHE_HOST_CONFIG/cli.log. (hint: --skip:graceful does not wait for workspace stop)"
+        error "Error during graceful stop - see $CHE_HOST_CONFIG/cli.log. (hint: --skip:graceful bypasses workspace stop)"
         return 2;
       fi
     fi

--- a/dockerfiles/base/scripts/base/commands/cmd_stop.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_stop.sh
@@ -45,7 +45,7 @@ cmd_stop() {
       cmd_lifecycle action "graceful-stop" "$@" >> "${LOGS}" 2>&1 || GRACEFUL_STATUS_RESULT=$?
       # error on authentication (401 modulo 256 = 145)
       if [[ ${GRACEFUL_STATUS_RESULT} -eq 145 ]]; then
-        error "Authentication failed on the system. Please provide --user and -password values or user --skip:graceful to bypass graceful stop."
+        error "Authentication failed on the system. (hint: --user/--password for auth parameters, --skip:graceful does not wait for workspace stop)"
         return 2;
       elif [[ ${GRACEFUL_STATUS_RESULT} -ne 0 ]]; then
         error "We encountered an error during graceful stop - see $CHE_HOST_CONFIG/cli.log. (hint: --skip:graceful does not wait for workspace stop)"

--- a/dockerfiles/base/scripts/base/commands/cmd_stop.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_stop.sh
@@ -33,13 +33,23 @@ cmd_stop() {
   FORCE_STOP=false
   if [[ "$@" == *"--skip:graceful"* ]]; then
   	FORCE_STOP=true
+  elif local_repo; then
+    warning "Development mode [skip graceful stop]"
+    FORCE_STOP=true
   fi
 
   if server_is_booted $(get_server_container_id $CHE_CONTAINER_NAME); then 
     if [[ ${FORCE_STOP} = "false" ]]; then
       info "stop" "Stopping workspaces..."
-      if ! $(cmd_lifecycle action "graceful-stop" "$@" >> "${LOGS}" 2>&1 || false); then
-        error "We encountered an error -- see cli.log"
+      local GRACEFUL_STATUS_RESULT=0
+      cmd_lifecycle action "graceful-stop" "$@" >> "${LOGS}" 2>&1 || GRACEFUL_STATUS_RESULT=$?
+      # error on authentication (401 modulo 256 = 145)
+      if [[ ${GRACEFUL_STATUS_RESULT} -eq 145 ]]; then
+        error "Authentication failed on the system. Please provide --user and -password values or user --skip:graceful to bypass graceful stop."
+        return 2;
+      elif [[ ${GRACEFUL_STATUS_RESULT} -ne 0 ]]; then
+        error "We encountered an error -- see $CHE_HOST_CONFIG/cli.log. Graceful stop can be skipped with --skip:graceful"
+        return 2;
       fi
     fi
     # stop containers booted by docker compose

--- a/dockerfiles/base/scripts/base/startup_05_pre_exec.sh
+++ b/dockerfiles/base/scripts/base/startup_05_pre_exec.sh
@@ -60,15 +60,28 @@ cmd_lifecycle() {
     fi
   fi
 
+  local PRE_COMMAND_STATUS=0
   ANSWER=$(declare -f $PRE_COMMAND ) # > /dev/null)
   if [ $? = "0" ]; then
     eval $PRE_COMMAND "$@"
+    PRE_COMMAND_STATUS=$?
   fi
 
   eval $COMMAND "$@"
+  local COMMAND_STATUS=$?
 
+
+
+  local POST_COMMAND_STATUS=0
   ANSWER=$(declare -f $POST_COMMAND > /dev/null)
   if [ $? = "0" ]; then
     eval $POST_COMMAND "$@"
+    POST_COMMAND_STATUS=$?
+  fi
+
+  if [[ POST_COMMAND_STATUS -ne 0 ]]; then
+    return ${POST_COMMAND_STATUS};
+  else
+    return ${COMMAND_STATUS};
   fi
 }

--- a/dockerfiles/lib/src/index.ts
+++ b/dockerfiles/lib/src/index.ts
@@ -15,6 +15,7 @@ import {Log} from "./spi/log/log";
 import {CheDir} from "./internal/dir/che-dir";
 import {CheTest} from "./internal/test/che-test";
 import {CheAction} from "./internal/action/che-action";
+import {ErrorMessage} from "./spi/error/error-message";
 /**
  * Entry point of this library providing commands.
  * @author Florent Benoit
@@ -79,6 +80,12 @@ export class EntryPoint {
 
             // handle error of the promise
             promise.catch((error) => {
+                let exitCode : number = 1;
+                if (error instanceof ErrorMessage) {
+                    exitCode = error.getExitCode();
+                    error = error.getError();
+                }
+
                 try {
                     let errorMessage = JSON.parse(error);
                     if (errorMessage.message) {
@@ -92,7 +99,7 @@ export class EntryPoint {
                         console.log(error.stack);
                     }
                 }
-                process.exit(1);
+                process.exit(exitCode);
             });
 
         } catch (e) {

--- a/dockerfiles/lib/src/spi/error/error-message.ts
+++ b/dockerfiles/lib/src/spi/error/error-message.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+/**
+ * Error message used to provide custom exit code
+ * @author Florent Benoit
+ */
+export class ErrorMessage {
+
+    private exitCode? : number = 1;
+
+    private error : any;
+
+    constructor(error: any, exitCode : number) {
+        this.error = error;
+        if (exitCode) {
+            this.exitCode = exitCode;
+        }
+        console.log("build error message with exit code", exitCode);
+    }
+
+
+
+    getExitCode() : number {
+        return this.exitCode;
+    }
+
+    getError() : any {
+        return this.error;
+    }
+}

--- a/dockerfiles/lib/src/spi/http/default-http-json-request.ts
+++ b/dockerfiles/lib/src/spi/http/default-http-json-request.ts
@@ -11,6 +11,7 @@
 import {AuthData} from "../../api/wsmaster/auth/auth-data";
 import {Log} from "../log/log";
 import {org} from "../../api/dto/che-dto";
+import {ErrorMessage} from "../error/error-message";
 /**
  * Implementation of a Request on the remote server
  * @author Florent Benoit
@@ -90,12 +91,12 @@ export class DefaultHttpJsonRequest implements HttpJsonRequest {
                         try {
                             var parsed = JSON.parse(data);
                             if (parsed.message) {
-                                reject('Call on rest url ' + this.options.path + ' returned invalid response code (' + res.statusCode + ') with error:' + parsed.message);
+                                reject(new ErrorMessage('Call on rest url ' + this.options.path + ' returned invalid response code (' + res.statusCode + ') with error:' + parsed.message, res.statusCode));
                             } else {
-                                reject('Call on rest url ' + this.options.path + ' returned invalid response code (' + res.statusCode + ') with error:' + data);
+                                reject(new ErrorMessage('Call on rest url ' + this.options.path + ' returned invalid response code (' + res.statusCode + ') with error:' + data, res.statusCode));
                             }
                         } catch (error) {
-                            reject('Call on rest url ' + this.options.path + ' returned invalid response code (' + res.statusCode + ') with error:' + data.toString());
+                            reject(new ErrorMessage('Call on rest url ' + this.options.path + ' returned invalid response code (' + res.statusCode + ') with error:' + data.toString(), res.statusCode));
                         }
 
                     }


### PR DESCRIPTION
### What does this PR do?
Improve UX of graceful shutdown message
- base scripts : catch error code of action lifecycle and return it
- cha-lib : return error code based on http error code
- display better message when auth is required
- skip graceful mode when repo is mounted

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1682

#### Changelog
Improves UX of graceful shutdown message.

#### Release Notes
We have made improvements to the CLI graceful shutdown behavior to catch additional errors, communicate more clearly when authentication is required for stop and skip the graceful mode when a repo is mounted.


#### Docs PR
n/a (improvement on UX, command is the same)


Change-Id: I1ad021426444b5b4d880df518512e53ef4828336
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
