### PR TITLE
che-plugin-docker-client remove all gwt code 

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-client/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-user</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -84,10 +80,6 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-gwt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -154,21 +146,6 @@
                 <artifactId>che-core-api-dto-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <executions>
-                    <execution>
-                        <id>client</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <dtoPackages>
-                                <package>org.eclipse.che.plugin.docker.client.dto</package>
-                            </dtoPackages>
-                            <outputDirectory>${dto-generator-out-directory}</outputDirectory>
-                            <genClassName>org.eclipse.che.plugin.docker.client.dto.DtoClientImpls</genClassName>
-                            <impl>client</impl>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>server</id>
                         <phase>process-sources</phase>


### PR DESCRIPTION
### What does this PR do?
remove client DTO generation since it's only ws-master source code
We need that because it has compile dependency  for gwt libraries, it means all of them goes to ws-master war.
### What issues does this PR fix or reference?


#### Changelog
Removed unused transitive dependency for GWT code in `che-plugin-docker-client`.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
