### PR TITLE
Refactor inspectContainer() and add commit(), removeImage()

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -281,6 +281,7 @@ public class DockerInstance extends AbstractInstance {
         try {
             docker.removeImage(RemoveImageParams.create(image).withForce(false));
         } catch (IOException ignore) {
+            LOG.error("IOException during destroy(). Ignoring.");
         }
     }
 

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtilsTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtilsTest.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client.kubernetes;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.annotations.Test;
+
+public class KubernetesStringUtilsTest {
+
+    @Test
+    public void getNormalizedStringShouldTrimLongStrings() {
+        // Given
+        String input = RandomStringUtils.random(70, true, true);
+        String expected = input.substring(0, 62);
+
+        // When
+        String output = KubernetesStringUtils.getNormalizedString(input);
+
+        // Then
+        assertEquals(output, expected, "getNormalizedString should limit string length");
+    }
+
+    @Test
+    public void getNormalizedStringShouldDoNothingWithShortStrings() {
+        // Given
+        String input = RandomStringUtils.random(24, true, true);
+        String expected = input;
+
+        // When
+        String output = KubernetesStringUtils.getNormalizedString(input);
+
+        // Then
+        assertEquals(output, expected, "getNormalizedString should do nothing to short strings");
+    }
+
+    @Test
+    public void convertPullSpecToImageStreamNameShouldTrimTag() {
+        // Given
+        String input = "testImage:testTag";
+        String expected = "testImage";
+
+        // When
+        String output = KubernetesStringUtils.convertPullSpecToImageStreamName(input);
+
+        // Then
+        assertEquals(output, expected, "Should trim tag off pull spec");
+    }
+
+    @Test
+    public void convertPullSpecToImageStreamNameShouldBeValidOpenShiftName() {
+        // Given
+        String input = "eclipse/ubuntu_jdk8";
+
+        // When
+        String output = KubernetesStringUtils.convertPullSpecToImageStreamName(input);
+
+        // Then
+        assertTrue(!output.contains("/"), "Should remove invalid chars from ImageStream name");
+    }
+
+    @Test
+    public void converPullSpecToImageStreamNameShouldLimitLength() {
+        // Given
+        String input = RandomStringUtils.random(100, true, false);
+
+        // When
+        String output = KubernetesStringUtils.convertPullSpecToImageStreamName(input);
+
+        // Then
+        assertTrue(output.length() < 64, "ImageStream name cannot be over 63 chars");
+    }
+
+    @Test
+    public void convertPullSpecToTagNameShouldIgnoreRegistryAndTag() {
+        // Given
+        String inputWithRegistry = "registry/organisation/image:tag";
+        String inputWithoutRegistry = "image";
+
+        // When
+        String outputWithRegistry = KubernetesStringUtils.convertPullSpecToTagName(inputWithRegistry);
+        String outputWithoutRegistry = KubernetesStringUtils.convertPullSpecToTagName(inputWithoutRegistry);
+
+        // Then
+        assertEquals(outputWithoutRegistry,
+                     outputWithRegistry,
+                     "Converting pull spec to tag name should only use image name");
+    }
+
+    @Test
+    public void convertPullSpecToTagNameShouldLimitLength() {
+        // Given
+        String input = RandomStringUtils.random(100, true, false);
+
+        // When
+        String output = KubernetesStringUtils.convertPullSpecToTagName(input);
+
+        // Then
+        assertTrue(output.length() < 63, "ImageStream tag cannot be over 63 chars");
+    }
+
+    @Test
+    public void createImageStreamTagNameShouldConvertNameInSameWayAsConvertPullSpec() {
+        // Given
+        String inputOldRepo = "eclipse/ubuntu_jdk8";
+        String inputNewRepo = "eclipse-che/che-workspace_" + RandomStringUtils.random(20);
+        String expectedImageStreamName = KubernetesStringUtils.convertPullSpecToImageStreamName(inputOldRepo);
+
+        // When
+        String rawOutput = KubernetesStringUtils.createImageStreamTagName(inputOldRepo, inputNewRepo);
+
+        // Then
+        assertTrue(rawOutput.contains(":"), "ImageStreamTag name is invalid: must contain ':'");
+        String outputImageStreamName = rawOutput.split(":")[0];
+        assertEquals(outputImageStreamName,
+                     expectedImageStreamName,
+                     "ImageStreamName should match output of convertPullSpecToImageStreamName");
+    }
+
+    @Test
+    public void createImageStreamTagNameShouldConvertTagInSameWayAsConvertPullSpec() {
+        // Given
+        String inputOldRepo = "eclipse/ubuntu_jdk8";
+        String inputNewRepo = "eclipse-che/che-workspace_" + RandomStringUtils.random(20);
+        String expectedTagName = KubernetesStringUtils.convertPullSpecToTagName(inputNewRepo);
+
+        // When
+        String rawOutput = KubernetesStringUtils.createImageStreamTagName(inputOldRepo, inputNewRepo);
+
+        // Then
+        assertTrue(rawOutput.contains(":"), "ImageStreamTag name is invalid: must contain ':'");
+        String outputImageStreamName = rawOutput.split(":")[1];
+        assertEquals(outputImageStreamName,
+                     expectedTagName,
+                     "ImageStream Tag should match output of convertPullSpecToTagName");
+    }
+
+    @Test
+    public void createImageStreamTagNameShouldLimitLengthOfCreatedTag() {
+        // Given
+        String inputOldRepo = RandomStringUtils.random(50, true, false);
+        String inputNewRepo = RandomStringUtils.random(50, true, false);
+
+        // When
+        String output = KubernetesStringUtils.createImageStreamTagName(inputOldRepo, inputNewRepo);
+
+        // Then
+        assertTrue(output.length() < 63, "ImageStreamTags must be shorter than 63 characters");
+    }
+
+    @Test
+    public void getImageStreamNameFromPullSpecShouldReturnOnlyImageName() {
+        // Given
+        String input = "registry/organisation/imagename:tagname";
+        String expected = "imagename";
+
+        // When
+        String output = KubernetesStringUtils.getImageStreamNameFromPullSpec(input);
+
+        // Then
+        assertEquals(output, expected);
+    }
+
+    @Test
+    public void stripTagFromPullSpecShouldRemoveTag() {
+        // Given
+        String input = "registry/organisation/imagename:tagname";
+        String expected = "registry/organisation/imagename";
+
+        // When
+        String output = KubernetesStringUtils.stripTagFromPullSpec(input);
+
+        // Then
+        assertEquals(output, expected);
+    }
+
+    @Test
+    public void stripTagFromPullSpecShouldDoNothingIfNoTag() {
+        // Given
+        String input = "registry/organisation/imagename";
+
+        // When
+        String output = KubernetesStringUtils.stripTagFromPullSpec(input);
+
+        // Then
+        assertEquals(output, input);
+    }
+
+    @Test
+    public void getTagNameFromPullSpecShouldReturnTag() {
+        // Given
+        String input = "registry/organisation/imagename:tagname";
+        String expected = "tagname";
+
+        // When
+        String output = KubernetesStringUtils.getTagNameFromPullSpec(input);
+
+        // Then
+        assertEquals(output, expected);
+    }
+
+    @Test
+    public void getTagNameFromPullSpecShouldReturnNullWhenPullSpecDoesNotHaveTag() {
+        // Given
+        String input = "registry/organisation/imagename";
+
+        // When
+        String output = KubernetesStringUtils.getTagNameFromPullSpec(input);
+
+        // Then
+        assertEquals(output, null);
+    }
+}


### PR DESCRIPTION
Adds `commit()` and `removeImage()` implementations to `OpenShiftConnector`. This requires some refactoring of existing methods (mostly refactoring repeated processes into their own methods -- e.g. creating an `ImageStreamTag` and getting image info from a tag).

Additionally, refactors `inspectContainer()` method to remove a call to `DockerConnector`, instead obtaining the same information from what's available through the OpenShift API. This fixes an issue where the IP address of a workspace was unavailable from the `ContainerInfo` returned by `DockerConnector`.

The benefit of these changes is that -- except for exec-related methods -- most uses of `DockerConnector` are removed when running on OpenShift. Note however that custom stacks are still not supported.

### What does this PR do?
Refactors `inspectContainer()` to use ImageStreamTags instead of Docker, and adds `commit()` and `removeImage()` methods. 


#### Changelog
Improved OpenShift connector independence from DockerConnector

#### Release Notes
(Internal changes -- not ready for public release)

#### Docs PR
Issue tracking work on OpenShift integration docs: https://github.com/eclipse/che-docs/issues/76. 
