### PR TITLE
CHE-3964: move popup from Quick documentation in the right place

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCompletionProposal.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCompletionProposal.java
@@ -84,7 +84,6 @@ public class JavaCompletionProposal implements CompletionProposal, CompletionPro
         frame.setSize("100%", "100%");
         frame.getElement().getStyle().setBorderStyle(Style.BorderStyle.NONE);
         frame.getElement().setAttribute("sandbox", ""); // empty value, not null
-        frame.getElement().getStyle().setProperty("resize", "both");
         frame.setUrl(client.getProposalDocUrl(id, sessionId));
         callback.onSuccess(frame);
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes a problem with showing Quick documentation popup
![p1](https://cloud.githubusercontent.com/assets/1271546/22821956/06eaf1dc-ef86-11e6-811b-c3abf322b44e.png)
![pp2](https://cloud.githubusercontent.com/assets/1271546/22821964/0f22172c-ef86-11e6-9599-deb8383c82ed.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3964

#### Changelog
<!-- one line entry to be added to changelog -->
Move popup from Quick documentation in the right place

