### PR TITLE
che-4061: change the key format for workspace find method

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_ssh.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_ssh.sh
@@ -15,7 +15,7 @@ help_cmd_ssh() {
   text "\n"
   text "Connect to a workspace in ${CHE_MINI_PRODUCT_NAME} over SSH\n"
   text "\n"
-  text "WORKSPACE:             Accepts workspace name, ID, or namespace:ws-name\n"
+  text "WORKSPACE:             Accepts workspace ID or namespace/ws-name\n"
   text "                       List all workspaces with 'action list-workspaces'\n"
   text "\n"
   text "MACHINE:               Choose machine (default is dev machine) if workspace as multiple containers\n"

--- a/dockerfiles/base/scripts/base/commands/cmd_sync.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_sync.sh
@@ -15,7 +15,7 @@ help_cmd_sync() {
   text "\n"
   text "Synchronizes a ${CHE_MINI_PRODUCT_NAME} workspace to a local path mounted to ':/sync'\n"
   text "\n"
-  text "WORKSPACE:             Accepts workspace name, ID, or namespace:ws-name\n"
+  text "WORKSPACE:             Accepts workspace ID or namespace/ws-name\n"
   text "                       List all workspaces with 'action list-workspaces'\n"
   text "\n"
   text "PARAMETERS:\n"

--- a/dockerfiles/lib/src/api/wsmaster/workspace/workspace.ts
+++ b/dockerfiles/lib/src/api/wsmaster/workspace/workspace.ts
@@ -153,13 +153,6 @@ export class Workspace {
     searchWorkspace(key:string):Promise<org.eclipse.che.api.workspace.shared.dto.WorkspaceDto> {
         Log.getLogger().debug('search workspace with key', key);
 
-        // if workspace key is too short it's a workspace name
-        if (key && key.length < 21) {
-            if (key.indexOf(":") < 0) {
-                key = ":" + key;
-            }
-        }
-
         var jsonRequest:HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, '/api/workspace/' + key, 200);
         return jsonRequest.request().then((jsonResponse:HttpJsonResponse) => {
             Log.getLogger().debug('got workspace with key', key, 'result: ', jsonResponse.getData());

--- a/dockerfiles/lib/src/internal/action/impl/workspace-ssh-action.ts
+++ b/dockerfiles/lib/src/internal/action/impl/workspace-ssh-action.ts
@@ -27,7 +27,7 @@ import {Ssh} from "../../../api/wsmaster/ssh/ssh";
  */
 export class WorkspaceSshAction {
 
-    @Argument({description: "Defines the workspace to be used. use workspaceId, workspaceName or namespace:workspaceName as argument"})
+    @Argument({description: "Defines the workspace to be used. use workspaceId or namespace/workspaceName as argument"})
     workspaceName : string;
 
 

--- a/dockerfiles/mount/entrypoint.sh
+++ b/dockerfiles/mount/entrypoint.sh
@@ -28,7 +28,7 @@ Usage on Linux
             -u \$(id -u \${USER})
             -v <local-mount>/:/mnthost eclipse/che-mount <workspace-id|workspace-name>
 
-     <workspace-id|workspace-name> ID or Name of the workspace or namespace:workspace-name
+     <workspace-id|workspace-name> ID of the workspace or namespace/workspace-name
 
 Usage on Mac or Windows:
   docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
@@ -36,7 +36,7 @@ Usage on Mac or Windows:
             -v <path-to-sync-profile>:/profile
             -v <local-mount>/:/mnthost eclipse/che-mount <workspace-id|workspace-name>
 
-     <workspace-id|workspace-name> ID or Name of the workspace or namespace:workspace-name
+     <workspace-id|workspace-name> ID of the workspace or namespace/workspace-name
 "
  UNISON_REPEAT_DELAY_IN_SEC=2
  WORKSPACE_NAME=


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

### What does this PR do?

The additional changes for this PR https://github.com/eclipse/che/pull/4073

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/4061

#### Changelog
Reworked workspace key to new format where namespace can contain / symbols.

#### Release Notes
Reworked workspace key to new format where namespace can contain / symbols.

#### Docs PR
Current docs doesn't contain mentions about namespace - nothing to be updated. But the planned docs for teams should contain the namespace description.


