### PR TITLE
Make backward compliance for the workspace keys with ":" and optional namespace value

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -895,13 +895,27 @@ public class WorkspaceManager {
     }
 
     private WorkspaceImpl getByKey(String key) throws NotFoundException, ServerException {
+
+        int lastColonIndex = key.indexOf(":");
         int lastSlashIndex = key.lastIndexOf("/");
-        if (lastSlashIndex == -1) {
+        if (lastSlashIndex == -1 && lastColonIndex == -1) {
             // key is id
             return workspaceDao.get(key);
         }
-        final String namespace = key.substring(0, lastSlashIndex);
-        final String wsName = key.substring(lastSlashIndex + 1);
+
+        final String namespace;
+        final String wsName;
+        if (lastColonIndex == 0) {
+            // no namespace, use current user namespace
+            namespace = EnvironmentContext.getCurrent().getSubject().getUserName();
+            wsName = key.substring(1);
+        } else if (lastColonIndex > 0) {
+            wsName = key.substring(lastColonIndex + 1);
+            namespace = key.substring(0, lastColonIndex);
+        } else {
+            namespace = key.substring(0, lastSlashIndex);
+            wsName = key.substring(lastSlashIndex + 1);
+        }
         return workspaceDao.get(wsName, namespace);
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -180,7 +180,7 @@ public class WorkspaceManager {
      * <p> Key rules:
      * <ul>
      * <li>@Deprecated : If it contains <b>:</b> character then that key is combination of namespace and workspace name
-     * <li>@Deprecated : <b></>:workspace_name</b> is valid abstract key and user will be detected from Environment.
+     * <li>@Deprecated : <b></>:workspace_name</b> is valid abstract key and current user name will be used as namespace
      * <li>If it doesn't contain <b>/</b> character then that key is id(e.g. workspace123456)
      * <li>If it contains <b>/</b> character then that key is combination of namespace and workspace name
      * </ul>

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -179,6 +179,8 @@ public class WorkspaceManager {
      *
      * <p> Key rules:
      * <ul>
+     * <li>@Deprecated : If it contains <b>:</b> character then that key is combination of namespace and workspace name
+     * <li>@Deprecated : <b></>:workspace_name</b> is valid abstract key and user will be detected from Environment.
      * <li>If it doesn't contain <b>/</b> character then that key is id(e.g. workspace123456)
      * <li>If it contains <b>/</b> character then that key is combination of namespace and workspace name
      * </ul>

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -172,6 +172,7 @@ public class WorkspaceService extends Service {
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = "Get the workspace by the composite key",
                   notes = "Composite key can be just workspace ID or in the " +
+                          "namespace:workspace_name form, where namespace is optional (e.g :workspace_name is valid key too." +
                           "namespace/workspace_name form, where namespace can contain '/' character.")
     @ApiResponses({@ApiResponse(code = 200, message = "The response contains requested workspace entity"),
                    @ApiResponse(code = 404, message = "The workspace with specified id does not exist"),

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -204,6 +204,30 @@ public class WorkspaceManagerTest {
         assertEquals(result, workspace);
     }
 
+
+    @Test
+    public void shouldBeAbleToGetWorkspaceByKeyPreviousFormat() throws Exception {
+        WorkspaceImpl workspace = createAndMockWorkspace();
+        WorkspaceImpl result = workspaceManager.getWorkspace(workspace.getNamespace() + ":" + workspace.getConfig().getName());
+        assertEquals(result, workspace);
+    }
+
+    @Test
+    public void shouldBeAbleToGetWorkspaceByKeyNamespaceOptionalPreviousFormat() throws Exception {
+        WorkspaceImpl workspace = createAndMockWorkspace();
+        WorkspaceImpl result = workspaceManager.getWorkspace(":" + workspace.getConfig().getName());
+        assertEquals(result, workspace);
+    }
+
+    @Test
+    public void shouldBeAbleToGetWorkspaceByKeyWithoutOwner() throws Exception {
+        WorkspaceImpl workspace = createAndMockWorkspace();
+        WorkspaceImpl result = workspaceManager.getWorkspace(":" + workspace.getConfig().getName());
+        assertEquals(result, workspace);
+    }
+
+
+
     @Test
     public void shouldBeAbleToGetWorkspacesAvailableForUser() throws Exception {
         // given


### PR DESCRIPTION
### What does this PR do?
PR https://github.com/eclipse/che/pull/4073 has broken any client using existing workspace keys
Restore the handling of previous keys format

### What issues does this PR fix or reference?
#4061 

#### Changelog
Restore backward compliance broken on workspace keys by  https://github.com/eclipse/che/pull/4073
so clients don't need to be updated

#### Release Notes
Restore backward compliance broken on workspace keys https://github.com/eclipse/che/pull/4073

#### Docs PR
N/A


Change-Id: I884e8adef2f01774f00a9f6c08ca834fc22b5917
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
