### PR TITLE
Cleanup volumes after docker_compose containers stop

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_stop.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_stop.sh
@@ -66,8 +66,8 @@ stop_containers() {
     docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
                    -p=$CHE_COMPOSE_PROJECT_NAME stop -t ${CHE_COMPOSE_STOP_TIMEOUT} >> "${LOGS}" 2>&1 || true
     info "stop" "Removing containers..."
-    log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_COMPOSE_PROJECT_NAME rm >> \"${LOGS}\" 2>&1 || true"
+    log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_COMPOSE_PROJECT_NAME rm -v --force >> \"${LOGS}\" 2>&1 || true"
     docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
-                   -p=$CHE_COMPOSE_PROJECT_NAME rm --force >> "${LOGS}" 2>&1 || true
+                   -p=$CHE_COMPOSE_PROJECT_NAME rm -v --force >> "${LOGS}" 2>&1 || true
   fi
 }


### PR DESCRIPTION
### What does this PR do?
Fixes `cmd_stop` to cleanup volumes after container stopped.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1477

#### Changelog
Fixed CLI  to cleanup volumes after container stopped.

#### Release Notes
In our quest for constant improvement we've tweaked the `stop` command in the CLI to cleanup volumes after the containers are stopped.

#### Docs PR
N/A