### PR TITLE
Reuse terminal slave command by exec agent

### DIFF
--- a/agents/exec/src/main.go
+++ b/agents/exec/src/main.go
@@ -86,7 +86,6 @@ func init() {
 		"/bin/bash",
 		"shell interpreter and command to execute on slave side of the pty",
 	)
-	process.ShellInterpreter = term.Cmd
 
 	// workspace master server configuration
 	flag.StringVar(
@@ -188,6 +187,7 @@ func main() {
 		cleaner := process.NewCleaner(processCleanupPeriodInMinutes, processCleanupThresholdInMinutes)
 		cleaner.CleanPeriodically()
 	}
+	process.ShellInterpreter = term.Cmd
 
 	// terminal configuration
 	if term.ActivityTrackingEnabled {


### PR DESCRIPTION
### What does this PR do?
Fixed initialization sequence for `process.ShellInterpreter`, so exec-agent reuses `SHELL_INTERPRETER` from terminal agent boot script

#### Changelog
Reuse `$SHELL_INTERPRETER` as shell interpreter for exec-agent

#### Release Notes
N/A

#### Docs PR
N/A