### PR TITLE
update docker hub url in cli tests

### DIFF
--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -102,7 +102,7 @@ initiate_offline_or_network_mode(){
       # Removing this info line as it was appearing before initial CLI output
 #      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
       local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
-      if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
+      if [[ ! $HTTP_STATUS_CODE -eq "301" ]] || [[ ! $HTTP_STATUS_CODE -eq "200" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
         info ""
         info "We could not resolve DockerHub using DNS."

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -74,6 +74,56 @@ server_is_booted() {
   fi
 }
 
+initiate_offline_or_network_mode(){
+  # If you are using ${CHE_FORMAL_PRODUCT_NAME} in offline mode, images must be loaded here
+  # This is the point where we know that docker is working, but before we run any utilities
+  # that require docker.
+  if is_offline; then
+    info "init" "Importing ${CHE_MINI_PRODUCT_NAME} Docker images from tars..."
+
+    if [ ! -d ${CHE_CONTAINER_OFFLINE_FOLDER} ]; then
+      warning "Skipping offline image loading - '${CHE_CONTAINER_OFFLINE_FOLDER}' not found"
+    else
+      IFS=$'\n'
+      for file in "${CHE_CONTAINER_OFFLINE_FOLDER}"/*.tar
+      do
+        if ! $(docker load < "${CHE_CONTAINER_OFFLINE_FOLDER}"/"${file##*/}" > /dev/null); then
+          error "Failed to restore ${CHE_MINI_PRODUCT_NAME} Docker images"
+          return 2;
+        fi
+        info "init" "Loading ${file##*/}..."
+      done
+    fi
+  else
+    # If we are here, then we want to run in networking mode.
+    # If we are in networking mode, we have had some issues where users have failed DNS networking.
+    # See: https://github.com/eclipse/che/issues/3266#issuecomment-265464165
+    if ! is_fast && ! skip_network; then
+      # Removing this info line as it was appearing before initial CLI output
+#      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
+      local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
+      if [[ ! $HTTP_STATUS_CODE -eq "301" ]] || [[ ! $HTTP_STATUS_CODE -eq "200" ]]; then
+        info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
+        info ""
+        info "We could not resolve DockerHub using DNS."
+        info "Either we cannot reach the Internet or Docker's DNS resolver needs a modification."
+        info ""
+        info "You can:"
+        info "  1. Modify Docker's DNS settings." 
+        info "     a. Docker for Windows & Mac have GUIs for this."
+        info "     b. Typically setting DNS to 8.8.8.8 fixes resolver issues."
+        info "  2. Does your network require Docker to use a proxy?"
+        info "     a. Docker for Windows & Mac have GUIs to set proxies."
+        info "  3. Verify that you have access to DockerHub."
+        info "     a. Try 'curl --head hub.docker.com'"
+        info "  4. Skip networking checks."
+        info "     a. Add '--fast' to any command"
+        return 2;
+      fi
+    fi
+  fi
+}
+
 grab_initial_images() {
   # get list of images
   get_image_manifest ${CHE_VERSION}

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -101,7 +101,7 @@ initiate_offline_or_network_mode(){
     if ! is_fast && ! skip_network; then
       # Removing this info line as it was appearing before initial CLI output
 #      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
-      local HTTP_STATUS_CODE=$(curl -I -k dockerhub.com -s -o /dev/null --write-out '%{http_code}')
+      local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
       if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
         info ""
@@ -115,7 +115,7 @@ initiate_offline_or_network_mode(){
         info "  2. Does your network require Docker to use a proxy?"
         info "     a. Docker for Windows & Mac have GUIs to set proxies."
         info "  3. Verify that you have access to DockerHub."
-        info "     a. Try 'curl --head dockerhub.com'"
+        info "     a. Try 'curl --head hub.docker.com'"
         info "  4. Skip networking checks."
         info "     a. Add '--fast' to any command"
         return 2;

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -74,56 +74,6 @@ server_is_booted() {
   fi
 }
 
-initiate_offline_or_network_mode(){
-  # If you are using ${CHE_FORMAL_PRODUCT_NAME} in offline mode, images must be loaded here
-  # This is the point where we know that docker is working, but before we run any utilities
-  # that require docker.
-  if is_offline; then
-    info "init" "Importing ${CHE_MINI_PRODUCT_NAME} Docker images from tars..."
-
-    if [ ! -d ${CHE_CONTAINER_OFFLINE_FOLDER} ]; then
-      warning "Skipping offline image loading - '${CHE_CONTAINER_OFFLINE_FOLDER}' not found"
-    else
-      IFS=$'\n'
-      for file in "${CHE_CONTAINER_OFFLINE_FOLDER}"/*.tar
-      do
-        if ! $(docker load < "${CHE_CONTAINER_OFFLINE_FOLDER}"/"${file##*/}" > /dev/null); then
-          error "Failed to restore ${CHE_MINI_PRODUCT_NAME} Docker images"
-          return 2;
-        fi
-        info "init" "Loading ${file##*/}..."
-      done
-    fi
-  else
-    # If we are here, then we want to run in networking mode.
-    # If we are in networking mode, we have had some issues where users have failed DNS networking.
-    # See: https://github.com/eclipse/che/issues/3266#issuecomment-265464165
-    if ! is_fast && ! skip_network; then
-      # Removing this info line as it was appearing before initial CLI output
-#      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
-      local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
-      if [[ ! $HTTP_STATUS_CODE -eq "301" ]] || [[ ! $HTTP_STATUS_CODE -eq "200" ]]; then
-        info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
-        info ""
-        info "We could not resolve DockerHub using DNS."
-        info "Either we cannot reach the Internet or Docker's DNS resolver needs a modification."
-        info ""
-        info "You can:"
-        info "  1. Modify Docker's DNS settings." 
-        info "     a. Docker for Windows & Mac have GUIs for this."
-        info "     b. Typically setting DNS to 8.8.8.8 fixes resolver issues."
-        info "  2. Does your network require Docker to use a proxy?"
-        info "     a. Docker for Windows & Mac have GUIs to set proxies."
-        info "  3. Verify that you have access to DockerHub."
-        info "     a. Try 'curl --head hub.docker.com'"
-        info "  4. Skip networking checks."
-        info "     a. Add '--fast' to any command"
-        return 2;
-      fi
-    fi
-  fi
-}
-
 grab_initial_images() {
   # get list of images
   get_image_manifest ${CHE_VERSION}

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -32,7 +32,7 @@ initiate_offline_or_network_mode(){
       # Removing this info line as it was appearing before initial CLI output
 #      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
       local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
-      if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
+      if [[ ! $HTTP_STATUS_CODE -eq "301" ]] || [[ ! $HTTP_STATUS_CODE -eq "200" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
         info ""
         info "We could not resolve DockerHub using DNS."

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -31,7 +31,7 @@ initiate_offline_or_network_mode(){
     if ! is_fast && ! skip_network; then
       # Removing this info line as it was appearing before initial CLI output
 #      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
-      local HTTP_STATUS_CODE=$(curl -I -k dockerhub.com -s -o /dev/null --write-out '%{http_code}')
+      local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
       if [[ ! $HTTP_STATUS_CODE -eq "301" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
         info ""
@@ -45,7 +45,7 @@ initiate_offline_or_network_mode(){
         info "  2. Does your network require Docker to use a proxy?"
         info "     a. Docker for Windows & Mac have GUIs to set proxies."
         info "  3. Verify that you have access to DockerHub."
-        info "     a. Try 'curl --head dockerhub.com'"
+        info "     a. Try 'curl --head hub.docker.com'"
         info "  4. Skip networking checks."
         info "     a. Add '--fast' to any command"
         return 2;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
in cli tests we checked old url for docker hub `dockerhub.com` due to some reasons that url is down really often so we switch to new url

#### Changelog
update docker hub url in cli tests