### PR TITLE
[cli] Fix #4125 : Default debug port is 8000 when user do not specify it

### DIFF
--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -47,7 +47,7 @@ get_display_url() {
 }
 
 get_debug_display_url() {
-  local CHE_DEBUG_PORT_LOCAL=9000
+  local CHE_DEBUG_PORT_LOCAL=8000
 
   if is_initialized; then 
     DEBUG_PORT_FROM_CONFIG=$(get_value_of_var_from_env_file ${CHE_PRODUCT_NAME}_DEBUG_PORT)


### PR DESCRIPTION
### What does this PR do?
Set default port to the real default value when unspecified in the env file.

### What issues does this PR fix or reference?
#4125 

#### Changelog
[cli] default debug port is 8000 when user do not specify it

#### Release Notes
N/A bugfix

#### Docs PR
N/A bugfix

Change-Id: I1c70b01fe9bfd86c8299f32693bdebefc82d3c89
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
