### PR TITLE
Add go to the PATH Fix for 

### DIFF
--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -68,3 +68,4 @@ ENV GOPATH=/home/user/gopath
 RUN echo "export PATH=$GOROOT/bin:$PATH" >> ~/.bashrc && \
     sudo chown -R user:user /opt
 WORKDIR /home/user
+ENV PATH $GOROOT/bin:$PATH


### PR DESCRIPTION
### What does this PR do?

Add go to the PATH of eclipse/che-dev docker image

### What issues does this PR fix or reference?

Fix Bug #4168

#### Changelog

Add go to the `PATH` of `eclipse/che-dev` docker image

#### Release Notes

N/A

#### Docs PR

N/A