### PR TITLE
[cli] Add More Checks

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_info.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_info.sh
@@ -66,6 +66,8 @@ prepare_bundle() {
   info "info" "Preparing diagnostic bundle..."
   docker run --net host ${BOOTSTRAP_IMAGE_ALPINE} ip a show >> "${CLI_DIR}/ip.output"
   docker run --net host ${BOOTSTRAP_IMAGE_ALPINE} route >> "${CLI_DIR}/route.output"
+  curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/ >> "${CLI_DIR}/curlversion.output"
+  curl -I -k https://hub.docker.com >> "${CLI_DIR}/curldockerhub.output"
   df "${CHE_CONTAINER_ROOT}" >> "${CLI_DIR}/df.output"
   cmd_network >> "${CLI_DIR}/cli-network.output"
   print_info >> "${CLI_DIR}/cli-info.output"
@@ -73,6 +75,8 @@ prepare_bundle() {
   tar -cf "${CLI_DIR}"/${CHE_MINI_PRODUCT_NAME}-diagnostic-bundle.tar \
     "${CLI_DIR}/ip.output" \
     "${CLI_DIR}/route.output" \
+    "${CLI_DIR}/curlversion.output" \
+    "${CLI_DIR}/curldockerhub.output" \
     "${CLI_DIR}/df.output" \
     "${CLI_DIR}/cli.log" \
     "${CLI_DIR}/cli-network.output" \
@@ -87,6 +91,8 @@ prepare_bundle() {
                   ${BOOTSTRAP_IMAGE_ALPINE} \
                       sh -c "rm -rf /root${CHE_CONTAINER_ROOT}/ip.output \
                            ; rm -rf /root${CHE_CONTAINER_ROOT}/route.output \
+                           ; rm -rf /root${CHE_CONTAINER_ROOT}/curlversion.output \
+                           ; rm -rf /root${CHE_CONTAINER_ROOT}/curldockerhub.output \
                            ; rm -rf /root${CHE_CONTAINER_ROOT}/df.output \
                            ; rm -rf /root${CHE_CONTAINER_ROOT}/cli-info.output \
                            ; rm -rf /root${CHE_CONTAINER_ROOT}/cli-network.output" > /dev/null 2>&1 || true

--- a/dockerfiles/base/scripts/base/startup_01_init.sh
+++ b/dockerfiles/base/scripts/base/startup_01_init.sh
@@ -309,7 +309,7 @@ start() {
 
   # Pull the list of images that are necessary. If in offline mode, verifies that the images
   # are properly loaded into the cache.
-  init_initial_images
+  init_initial_images "$@"
 
   # Each CLI assembly must provide this cli.sh - loads overridden functions and variables for the CLI
   source "${SCRIPTS_CONTAINER_SOURCE_DIR}"/post_init.sh
@@ -332,10 +332,10 @@ start() {
   cli_init "$@"
 
   # Additional checks for nightly version
-  cli_verify_nightly
+  cli_verify_nightly "$@"
 
   # Additional checks to verify image matches version installed on disk & upgrade suitability
-  cli_verify_version
+  cli_verify_version "$@"
 
   # Allow CLI assemblies to load variables assuming CLI is finished bootstrapping
   cli_post_init

--- a/dockerfiles/base/scripts/base/startup_01_init.sh
+++ b/dockerfiles/base/scripts/base/startup_01_init.sh
@@ -251,9 +251,6 @@ start() {
 
   # pre_init is unique to each CLI assembly. This can be called before
   # networking is established.
-
-  # Each CLI assembly must provide this cli.sh - loads overridden functions and variables for the CLI
-  # Hard code this location
   source "/scripts/pre_init.sh"
   pre_init
 

--- a/dockerfiles/base/scripts/base/startup_01_init.sh
+++ b/dockerfiles/base/scripts/base/startup_01_init.sh
@@ -65,7 +65,7 @@ init_constants() {
   # CLI DEVELOPERS - ONLY INCREMENT THIS CHANGE IF MODIFYING SECTIONS THAT AFFECT LOADING
   #                  BEFORE :/REPO IS VOLUME MOUNTED.  CLI ASSEMBLIES WILL FAIL UNTIL THEY
   #                  ARE RECOMPILED WITH MATCHING VERSION.
-  CHE_BASE_API_VERSION=1
+  CHE_BASE_API_VERSION=2
 }
 
 init_global_vars() {
@@ -235,58 +235,6 @@ init_usage_check() {
   fi
 }
 
-init() {
-  init_constants
-  init_global_vars
-  init_cli_version_check
-  init_usage_check "$@"
-
-  source "${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}"/startup_02_pre_docker.sh
-
-  # Make sure Docker is working and we have /var/run/docker.sock mounted or valid DOCKER_HOST
-  check_docker "$@"
-
-  # Check to see if Docker is configured with a proxy and pull values
-  check_docker_networking
-
-  # Verify that -i is passed on the command line
-  check_interactive "$@"
-
-  # Only verify mounts after Docker is confirmed to be working.
-  check_mounts "$@"
-
-  # Only initialize after mounts have been established so we can write cli.log out to a mount folder
-  init_logging "$@"
-
-  SCRIPTS_CONTAINER_SOURCE_DIR=""
-  SCRIPTS_BASE_CONTAINER_SOURCE_DIR=""
-  if local_repo && ! skip_scripts; then
-     # Use the CLI that is inside the repository.
-     SCRIPTS_CONTAINER_SOURCE_DIR=${CHE_SCRIPTS_CONTAINER_SOURCE_DIR}
-
-    if [[ -d "/repo/dockerfiles/base/scripts/base" ]]; then
-       SCRIPTS_BASE_CONTAINER_SOURCE_DIR="/repo/dockerfiles/base/scripts/base"
-     else
-       SCRIPTS_BASE_CONTAINER_SOURCE_DIR=${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}
-     fi
-  else
-     # Use the CLI that is inside the container.
-     SCRIPTS_CONTAINER_SOURCE_DIR="/scripts"
-     SCRIPTS_BASE_CONTAINER_SOURCE_DIR=${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}
-  fi
-
-  source "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/startup_03_pre_networking.sh
-
-  # If offline mode, then load dependent images from disk and populate the local Docker cache.
-  # If not in offline mode, verify that we have access to DockerHub.
-  # This is also the first usage of curl
-  initiate_offline_or_network_mode "$@"
-
-  # Pull the list of images that are necessary. If in offline mode, verifies that the images
-  # are properly loaded into the cache.
-  grab_initial_images
-}
-
 cleanup() {
   RETURN_CODE=$?
 
@@ -309,8 +257,17 @@ start() {
   source "/scripts/pre_init.sh"
   pre_init
 
-  # Bootstrap networking, docker, logging, and ability to load cli.sh and library.sh
-  init "$@"
+  # Yo, constants
+  init_constants
+
+  # Variables used throughout
+  init_global_vars
+
+  # Check to make sure CLI assembly matches base
+  init_cli_version_check
+
+  # Checks for global parameters
+  init_usage_check "$@"
 
   # Removes global parameters from the positional arguments
   ORIGINAL_PARAMETERS=$@
@@ -325,6 +282,38 @@ start() {
   set -- "${@/\-\-skip\:pull/}"
   set -- "${@/\-\-help/}"
   set -- "${@/\-\-skip\:scripts/}"
+
+  source "${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}"/startup_02_pre_docker.sh
+
+  # Make sure Docker is working and we have /var/run/docker.sock mounted or valid DOCKER_HOST
+  init_check_docker "$@"
+
+  # Check to see if Docker is configured with a proxy and pull values
+  init_check_docker_networking
+
+  # Verify that -i is passed on the command line
+  init_check_interactive "$@"
+
+  # Only verify mounts after Docker is confirmed to be working.
+  init_check_mounts "$@"
+
+  # Only initialize after mounts have been established so we can write cli.log out to a mount folder
+  init_logging "$@"
+
+  # Determine where the remaining scripts will be sourced from (inside image, or repo?)
+  init_scripts "$@"
+
+  # We now know enough to load scripts from different locations - so source from proper source
+  source "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/startup_03_pre_networking.sh
+
+  # If offline mode, then load dependent images from disk and populate the local Docker cache.
+  # If not in offline mode, verify that we have access to DockerHub.
+  # This is also the first usage of curl
+  init_offline_or_network_mode "$@"
+
+  # Pull the list of images that are necessary. If in offline mode, verifies that the images
+  # are properly loaded into the cache.
+  init_initial_images
 
   # Each CLI assembly must provide this cli.sh - loads overridden functions and variables for the CLI
   source "${SCRIPTS_CONTAINER_SOURCE_DIR}"/post_init.sh

--- a/dockerfiles/base/scripts/base/startup_01_init.sh
+++ b/dockerfiles/base/scripts/base/startup_01_init.sh
@@ -328,9 +328,20 @@ start() {
   info "cli" "$CHE_VERSION - using docker ${DOCKER_SERVER_VERSION} / $(get_docker_install_type)"
 
   source "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/startup_04_pre_cli_init.sh
-  
+
+  # Allow CLI assemblies to load variables assuming networking, logging, docker activated  
   cli_pre_init
+
+  # Set CHE_HOST, CHE_PORT, and apply any CLI-specific command-line overrides to variables  
   cli_init "$@"
+
+  # Additional checks for nightly version
+  verify_nightly_accuracy
+
+  # Additional checks to verify image matches version installed on disk & upgrade suitability
+  verify_version_compatibility
+
+  # Allow CLI assemblies to load variables assuming CLI is finished bootstrapping
   cli_post_init
 
   source "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/startup_05_pre_exec.sh

--- a/dockerfiles/base/scripts/base/startup_01_init.sh
+++ b/dockerfiles/base/scripts/base/startup_01_init.sh
@@ -248,7 +248,6 @@ cleanup() {
 }
 
 start() {
-
   # pre_init is unique to each CLI assembly. This can be called before
   # networking is established.
   source "/scripts/pre_init.sh"
@@ -333,10 +332,10 @@ start() {
   cli_init "$@"
 
   # Additional checks for nightly version
-  verify_nightly_accuracy
+  cli_verify_nightly
 
   # Additional checks to verify image matches version installed on disk & upgrade suitability
-  verify_version_compatibility
+  cli_verify_version
 
   # Allow CLI assemblies to load variables assuming CLI is finished bootstrapping
   cli_post_init

--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -243,19 +243,6 @@ skip_scripts() {
   fi
 }
 
-init_logging() {
-  # Initialize CLI folder
-  CLI_DIR=$CHE_CONTAINER_ROOT
-  test -d "${CLI_DIR}" || mkdir -p "${CLI_DIR}"
-
-  # Ensure logs folder exists
-  LOGS="${CLI_DIR}/cli.log"
-  LOG_INITIALIZED=true
-
-  # Log date of CLI execution
-  log "$(date)"
-}
-
 cli_init() {
   CHE_HOST=$(eval "echo \$${CHE_PRODUCT_NAME}_HOST")
   CHE_PORT=$(eval "echo \$${CHE_PRODUCT_NAME}_PORT")
@@ -293,7 +280,7 @@ cli_init() {
   fi
 }
 
-check_docker() {
+init_check_docker() {
   if ! has_docker; then
     error "Docker not found. Get it at https://docs.docker.com/engine/installation/."
     return 1;
@@ -344,7 +331,7 @@ check_docker() {
   CHE_VERSION=$CHE_IMAGE_VERSION
 }
 
-check_docker_networking() {
+init_check_docker_networking() {
   # Check to see if HTTP_PROXY, HTTPS_PROXY, and NO_PROXY is set within the Docker daemon.
   OUTPUT=$(docker info)
   HTTP_PROXY=$(grep "Http Proxy" <<< "$OUTPUT" || true) 
@@ -379,7 +366,7 @@ check_docker_networking() {
   export no_proxy=$NO_PROXY
 }
 
-check_interactive() {
+init_check_interactive() {
   # Detect and verify that the CLI container was started with -it option.
   TTY_ACTIVATED=true
   CHE_CLI_IS_INTERACTIVE=true
@@ -398,10 +385,9 @@ check_interactive() {
     fi
 
   fi
-
 }
 
-check_mounts() {
+init_check_mounts() {
   DATA_MOUNT=$(get_container_folder ":${CHE_CONTAINER_ROOT}")
   INSTANCE_MOUNT=$(get_container_folder ":${CHE_CONTAINER_ROOT}/instance")
   BACKUP_MOUNT=$(get_container_folder ":${CHE_CONTAINER_ROOT}/backup")
@@ -552,6 +538,38 @@ check_mounts() {
       return 2
     fi
     CHE_CONTAINER_ASSEMBLY_FULL_PATH="${CHE_CONTAINER_ASSEMBLY}"
+  fi
+}
+
+init_logging() {
+  # Initialize CLI folder
+  CLI_DIR=$CHE_CONTAINER_ROOT
+  test -d "${CLI_DIR}" || mkdir -p "${CLI_DIR}"
+
+  # Ensure logs folder exists
+  LOGS="${CLI_DIR}/cli.log"
+  LOG_INITIALIZED=true
+
+  # Log date of CLI execution
+  log "$(date)"
+}
+
+init_scripts() {
+  SCRIPTS_CONTAINER_SOURCE_DIR=""
+  SCRIPTS_BASE_CONTAINER_SOURCE_DIR=""
+  if local_repo && ! skip_scripts; then
+     # Use the CLI that is inside the repository.
+     SCRIPTS_CONTAINER_SOURCE_DIR=${CHE_SCRIPTS_CONTAINER_SOURCE_DIR}
+
+    if [[ -d "/repo/dockerfiles/base/scripts/base" ]]; then
+       SCRIPTS_BASE_CONTAINER_SOURCE_DIR="/repo/dockerfiles/base/scripts/base"
+     else
+       SCRIPTS_BASE_CONTAINER_SOURCE_DIR=${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}
+     fi
+  else
+     # Use the CLI that is inside the container.
+     SCRIPTS_CONTAINER_SOURCE_DIR="/scripts"
+     SCRIPTS_BASE_CONTAINER_SOURCE_DIR=${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}
   fi
 }
 

--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -562,10 +562,19 @@ init_scripts() {
      SCRIPTS_CONTAINER_SOURCE_DIR=${CHE_SCRIPTS_CONTAINER_SOURCE_DIR}
 
     if [[ -d "/repo/dockerfiles/base/scripts/base" ]]; then
-       SCRIPTS_BASE_CONTAINER_SOURCE_DIR="/repo/dockerfiles/base/scripts/base"
-     else
-       SCRIPTS_BASE_CONTAINER_SOURCE_DIR=${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}
-     fi
+      SCRIPTS_BASE_CONTAINER_SOURCE_DIR="/repo/dockerfiles/base/scripts/base"
+    else
+      SCRIPTS_BASE_CONTAINER_SOURCE_DIR=${CHE_BASE_SCRIPTS_CONTAINER_SOURCE_DIR}
+    fi
+
+    # Compare scripts inside of the Docker image with those on the repository
+    # Fail if they do not match
+    DIFF_NUM=$(diff -r "/scripts/base" "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}" | wc -l)
+    if [ $DIFF_NUM -gt 0 ]; then 
+      error "The scripts in ${CHE_IMAGE_FULLNAME} do not match those in :/repo."
+      error "Is your repo branch compatible with this image version?"
+      error "Add '--skip:scripts' to skip this check."
+    fi
   else
      # Use the CLI that is inside the container.
      SCRIPTS_CONTAINER_SOURCE_DIR="/scripts"

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
-initiate_offline_or_network_mode(){
+init_offline_or_network_mode(){
   # If you are using ${CHE_FORMAL_PRODUCT_NAME} in offline mode, images must be loaded here
   # This is the point where we know that docker is working, but before we run any utilities
   # that require docker.
@@ -54,7 +54,7 @@ initiate_offline_or_network_mode(){
   fi
 }
 
-grab_initial_images() {
+init_initial_images() {
   # get list of images
   get_image_manifest ${CHE_VERSION}
 

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -31,7 +31,7 @@ init_offline_or_network_mode(){
     if ! is_fast && ! skip_network; then
       # Removing this info line as it was appearing before initial CLI output
 
-      local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
+      local HTTP_STATUS_CODE=$(curl -I -k https://hub.docker.com -s -o /dev/null --write-out '%{http_code}')
       if [[ ! $HTTP_STATUS_CODE -eq "301" ]] && [[ ! $HTTP_STATUS_CODE -eq "200" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
         info ""

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -30,7 +30,7 @@ init_offline_or_network_mode(){
     # See: https://github.com/eclipse/che/issues/3266#issuecomment-265464165
     if ! is_fast && ! skip_network; then
       # Removing this info line as it was appearing before initial CLI output
-#      info "cli" "Checking network... (hint: '--fast' skips nightly, version, network, and preflight checks)"
+
       local HTTP_STATUS_CODE=$(curl -I -k hub.docker.com -s -o /dev/null --write-out '%{http_code}')
       if [[ ! $HTTP_STATUS_CODE -eq "301" ]] && [[ ! $HTTP_STATUS_CODE -eq "200" ]]; then
         info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -75,7 +75,7 @@ cli_init() {
   fi
 }
 
-verify_nightly_accuracy() {
+cli_verify_nightly() {
   # Per request of the engineers, check to see if the locally cached nightly version is older
   # than the one stored on DockerHub.
   if is_nightly; then
@@ -95,7 +95,7 @@ verify_nightly_accuracy() {
   fi
 }
 
-verify_version_compatibility() {
+cli_verify_version() {
   # Do not perform a version compatibility check if running upgrade command.
   # The upgrade command has its own internal checks for version compatibility.
   if [[ "$@" == *"upgrade"* ]]; then

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -73,17 +73,6 @@ cli_init() {
       fi
     fi
   fi
-
-  # Special function to perform special behaviors if you are running nightly version
-  verify_nightly_accuracy
-
-  # Do not perform a version compatibility check if running upgrade command.
-  # The upgrade command has its own internal checks for version compatibility.
-  if [[ "$@" == *"upgrade"* ]]; then
-    verify_version_upgrade_compatibility
-  elif ! is_fast; then
-    verify_version_compatibility
-  fi
 }
 
 verify_nightly_accuracy() {
@@ -106,6 +95,16 @@ verify_nightly_accuracy() {
   fi
 }
 
+verify_version_compatibility() {
+  # Do not perform a version compatibility check if running upgrade command.
+  # The upgrade command has its own internal checks for version compatibility.
+  if [[ "$@" == *"upgrade"* ]]; then
+    verify_upgrade
+  elif ! is_fast; then
+    verify_version
+  fi
+}
+
 is_nightly() {
   if [[ $(get_image_version) = "nightly" ]]; then
     return 0
@@ -114,7 +113,7 @@ is_nightly() {
   fi
 }
 
-verify_version_compatibility() {
+verify_version() {
 
   ## If ! is_initialized, then the system hasn't been installed
   ## First, compare the CLI image version to what version was initialized in /config/*.ver.donotmodify
@@ -171,7 +170,7 @@ verify_version_compatibility() {
   fi
 }
 
-verify_version_upgrade_compatibility() {
+verify_upgrade() {
   ## Two levels of checks
   ## First, compare the CLI image version to what the admin has configured in /config/.env file
   ##      - If they match, nothing to upgrade

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -123,7 +123,7 @@ verify_version() {
   ##      - If they don't match, then if CLLI is newer fail with message to run upgrade first
   CHE_IMAGE_VERSION=$(get_image_version)
 
-  # Only check for newer versions if not in offline mode and not nightly.
+  # Only check for newer versions if not: skip network, offline, nightly.
   if ! is_offline && ! is_nightly && ! is_fast && ! skip_network; then
     NEWER=$(compare_versions $CHE_IMAGE_VERSION)
 

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -259,8 +259,9 @@ compare_versions() {
   local NUMBER_OF_VERSIONS=$(echo $VERSION_LIST_JSON | jq '.count')
 
   if [[ "${NUMBER_OF_VERSIONS}" = "" ]]; then
-    error "Unable to retrieve version list with 'curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/'."
-    error "You can add '--skip:network' to ignore this check"
+    error "Unable to retrieve version list from public Docker Hub."
+    error "Diagnose with 'docker run -it appropriate/curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/'."
+    error "Use '--skip:network' to ignore this check."
     return 2
   fi
 

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -124,7 +124,7 @@ verify_version() {
   CHE_IMAGE_VERSION=$(get_image_version)
 
   # Only check for newer versions if not in offline mode and not nightly.
-  if ! is_offline && ! is_nightly; then
+  if ! is_offline && ! is_nightly && ! is_fast && ! skip_network; then
     NEWER=$(compare_versions $CHE_IMAGE_VERSION)
 
     if [[ "${NEWER}" != "" ]]; then
@@ -257,6 +257,12 @@ compare_versions() {
 
   local VERSION_LIST_JSON=$(curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/)
   local NUMBER_OF_VERSIONS=$(echo $VERSION_LIST_JSON | jq '.count')
+
+  if [[ "${NUMBER_OF_VERSIONS}" = "" ]]; then
+    error "Unable to retrieve version list with 'curl -s https://hub.docker.com/v2/repositories/${CHE_IMAGE_NAME}/tags/'."
+    error "You can add '--skip:network' to ignore this check"
+    return 2
+  fi
 
   DISPLAY_LIMIT=10
   if [ $DISPLAY_LIMIT -gt $NUMBER_OF_VERSIONS ]; then 

--- a/dockerfiles/cli/scripts/pre_init.sh
+++ b/dockerfiles/cli/scripts/pre_init.sh
@@ -17,7 +17,7 @@ pre_init() {
   ADDITIONAL_GLOBAL_OPTIONS=""
  
   # This must be incremented when BASE is incremented by an API developer
-  CHE_CLI_API_VERSION=1
+  CHE_CLI_API_VERSION=2
 
   DEFAULT_CHE_PORT=8080
   CHE_PORT=${CHE_PORT:-${DEFAULT_CHE_PORT}}


### PR DESCRIPTION
Signed-off-by: Tyler Jewell <tjewell@codenvy.com>

### What does this PR do?
Reorganizes the initialization to be easier to follow.  Standardizes all of the `init_` methods with a common name.  Places all script loading (mostly) in the same location for readability. The only exception is the lazy loading of command scripts and the library, which happens in the final library.

Also adds in a check that if you are mounting `:/repo` and you have not `--skip:scripts` then will compare using diff all of the files inside your CLI image to those mounted from the repo.  If they differ, then the CLI does a hard fail with an error message.

Fixed a bug in the CLI where if curling DockerHub for the version list fails, then an unhelpful message appears. Added '--skip:network' option to skip over this along with detecting a failed connection to DockerHub. Also added in all of the curl commands that we execute with their output to be included into the 'info --bundle' diagnostic.

Matching PRs:
1. Codenvy - https://github.com/codenvy/codenvy/pull/1800
2. SaaS - https://github.com/codenvy/saas/pull/147
3. ARTIK - https://github.com/codenvy/artik/pull/348

#### Changelog
[cli] Simplify execution of initialization methods
[cli] Add diff for repo mode
[cli] Add checks for all curl commands and ensure '--skip:network' applied

#### Release Notes
N/A

#### Docs PR
N/A