### PR TITLE
[cli/mount] Fix #4171 use fat option to allow to work on FAT filesystems (like Windows)

### DIFF
--- a/dockerfiles/mount/entrypoint.sh
+++ b/dockerfiles/mount/entrypoint.sh
@@ -138,10 +138,10 @@ info "INFO: (che mount): Initial sync...Please wait."
 
 local UNISON_ARGS="";
 if [ $(is_verbose "$@") = true ]; then
-  UNISON_ARGS="-batch -auto -prefer=newer"
+  UNISON_ARGS="-batch -fat -auto -prefer=newer"
   info "using verbose mode"
 else
-  UNISON_ARGS="-silent -auto -prefer=newer -log=false > /dev/null 2>&1"
+  UNISON_ARGS="-silent -fat -auto -prefer=newer -log=false > /dev/null 2>&1"
 fi
 
 UNISON_COMMAND="unison /mntssh /mnthost ${UNISON_ARGS}"


### PR DESCRIPTION
### What does this PR do?
On Windows sync command is failing on permissions as FAT is not handling correct permissions

### What issues does this PR fix or reference?
#4171 

#### Changelog
Add option to unison to handle Windows FAT filesystems.

#### Release Notes
BugFix


#### Docs PR
BugFix

Change-Id: I6ded03a2591150f6b1cfc5fa6f86eb07db8c3462
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
