### PR TITLE
CHE-4015 Add deleted files to index(Regression)

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -277,21 +277,25 @@ class JGitConnection implements GitConnection {
         try {
             addCommand.call();
 
-            // to add deleted files in index it is required to perform git rm on them
-            Set<String> deletedFiles = getGit().status().call().getMissing();
-            if (!deletedFiles.isEmpty()) {
-                RmCommand rmCommand = getGit().rm();
-                if (filePatterns.contains(".")) {
-                    deletedFiles.forEach(rmCommand::addFilepattern);
-                } else {
-                    filePatterns.forEach(filePattern -> deletedFiles.stream()
-                                                                    .filter(deletedFile -> deletedFile.startsWith(filePattern))
-                                                                    .forEach(rmCommand::addFilepattern));
-                }
-                rmCommand.call();
-            }
+            addDeletedFilesToIndex(filePatterns);
         } catch (GitAPIException exception) {
             throw new GitException(exception.getMessage(), exception);
+        }
+    }
+
+    // to add deleted files in index it is required to perform git rm on them
+    private void addDeletedFilesToIndex(List<String> filePatterns) throws GitAPIException {
+        Set<String> deletedFiles = getGit().status().call().getMissing();
+        if (!deletedFiles.isEmpty()) {
+            RmCommand rmCommand = getGit().rm();
+            if (filePatterns.contains(".")) {
+                deletedFiles.forEach(rmCommand::addFilepattern);
+            } else {
+                filePatterns.forEach(filePattern -> deletedFiles.stream()
+                                                                .filter(deletedFile -> deletedFile.startsWith(filePattern))
+                                                                .forEach(rmCommand::addFilepattern));
+            }
+            rmCommand.call();
         }
     }
 

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -283,7 +283,7 @@ class JGitConnection implements GitConnection {
         }
     }
 
-    // to add deleted files in index it is required to perform git rm on them
+    /** To add deleted files in index it is required to perform git rm on them */
     private void addDeletedFilesToIndex(List<String> filePatterns) throws GitAPIException {
         Set<String> deletedFiles = getGit().status().call().getMissing();
         if (!deletedFiles.isEmpty()) {


### PR DESCRIPTION
### What does this PR do?
Adds ability to add tracked deleted project-file to index.

### What issues does this PR fix or reference?
#4015 

#### Changelog
Fixed bug in`Git`->`Add To Index` menu command that was not adding deleted files to index.

#### Release Notes
Fixed bug in`Git`->`Add To Index` menu command that was not adding deleted files to index. This was an uncaught regression when Eclipse Che started using jGit.

#### Docs PR
N/A