### PR TITLE
All stack icons should have the 'viewBox' property

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/images/type-cpp.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/images/type-cpp.svg
@@ -14,7 +14,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="50"
-   height="50">
+   height="50"
+   viewBox="0 0 50 50">
   <g
      transform="translate(0.60832417,9.6327104)"
      style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1">

--- a/ide/che-core-ide-stacks/src/main/resources/images/type-zend.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/images/type-zend.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2016 Rogue Wave Software, Inc. All rights reserved.
+    Copyright (c) 2016-2017 Rogue Wave Software, Inc. All rights reserved.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    height="512"
    width="512"
+   viewBox="0 0 512 512"
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

Fixes the rendering of the Zend and C++ stack icons on the Dashboard by adding the 'viewBox' property to the SVG files.

Before:

![che-stack-icons-before](https://cloud.githubusercontent.com/assets/468091/23166537/a87ff602-f849-11e6-9700-ea2df86a5e37.png)

After:

![che-stack-icons-after](https://cloud.githubusercontent.com/assets/468091/23166543/b186921a-f849-11e6-93f1-2f15a4eb6a05.png)

Note that some 'advanced' stacks are enabled in the 'general' scope so their icons are visible.

### What issues does this PR fix or reference?

None.

#### Changelog
<!-- one line entry to be added to changelog -->

Fixed rendering of some stack icons on the Dashboard.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>