### PR TITLE
CHE-4150 and  CHE-4059: Doesn't perform DeleteResourceAction into partStack which doesn't support resource selection.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DeleteResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DeleteResourceAction.java
@@ -31,6 +31,7 @@ import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.resources.DeleteResourceManager;
 
 import javax.validation.constraints.NotNull;
@@ -104,7 +105,9 @@ public class DeleteResourceAction extends AbstractPerspectiveAction implements P
         final Resource[] resources = appContext.getResources();
 
         event.getPresentation().setVisible(true);
-        event.getPresentation().setEnabled(resources != null && resources.length > 0 && !(partPresenter instanceof TextEditor));
+        event.getPresentation().setEnabled(resources != null
+                                           && resources.length > 0 && !(partPresenter instanceof TextEditor)
+                                           && !(partPresenter.getSelection() instanceof Selection.NoSelectionProvided));
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
### What does this PR do?
Doesn't perform DeleteResourceAction into partStack which doesn't support resource selection.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4059 and https://github.com/eclipse/che/issues/4150

#### Changelog
Doesn't perform DeleteResourceAction into partStack which doesn't support resource selection.

#### Release Notes
Doesn't perform DeleteResourceAction into partStack which doesn't support resource selection. Fix appearing "Delete resource" window on typing key "Delete" in the terminal.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>
