### PR TITLE
[UD] Add diagnostic page with ability to check if workspaces can work or not

### DIFF
--- a/dashboard/src/app/diagnostics/diagnostic-callback-state.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-callback-state.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+/**
+ * Defines the state of the diagnostic callback
+ * @author Florent Benoit
+ */
+export const enum DiagnosticCallbackState {
+  OK,
+  FAILURE,
+  ERROR,
+  RUNNING,
+  HINT
+}

--- a/dashboard/src/app/diagnostics/diagnostic-callback.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-callback.ts
@@ -81,6 +81,12 @@ export class DiagnosticCallback {
   private content: string;
 
   /**
+   * All items attached to this category.
+   */
+  private items : Array<DiagnosticItem>;
+
+
+  /**
    * Constructor.
    */
   constructor($q : ng.IQService, cheWebsocket : CheWebsocket, $timeout : ng.ITimeoutService, name: string, sharedMap : Map<string, any>, builder : any, diagnosticPart : DiagnosticPart) {
@@ -94,6 +100,7 @@ export class DiagnosticCallback {
     this.sharedMap = sharedMap;
     this.builder = builder;
     this.diagnosticPart = diagnosticPart;
+    this.items = new Array<DiagnosticItem>();
   }
 
   /**
@@ -131,6 +138,7 @@ export class DiagnosticCallback {
     diagnosticItem.state = state;
     diagnosticItem.content = this.content;
     this.diagnosticPart.addItem(diagnosticItem);
+    this.items.push(diagnosticItem);
     return diagnosticItem;
   }
 

--- a/dashboard/src/app/diagnostics/diagnostic-callback.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-callback.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+import {DiagnosticItem} from './diagnostic-item';
+import {DiagnosticCallbackState} from './diagnostic-callback-state';
+import {MessageBus, CheWebsocket} from '../../components/api/che-websocket.factory';
+import {DiagnosticPart} from './diagnostic-part';
+import {DiagnosticsController} from './diagnostics.controller';
+
+/**
+ * Defines a callback of diagnostic. Allow to notify/report states, messages, etc.
+ * @author Florent Benoit
+ */
+export class DiagnosticCallback {
+
+  /**
+   * Parent item.
+   */
+  private diagnosticPart : DiagnosticPart;
+
+  /**
+   * Promise service handling.
+   */
+  private $q : ng.IQService;
+
+  /**
+   * Websocket API used to deal with websockets.
+   */
+  private cheWebsocket : CheWebsocket;
+
+  /**
+   * Angular Timeout service
+   */
+  private $timeout : ng.ITimeoutService;
+
+  /**
+   * defered object instance from q service
+   */
+  private defered : ng.IDeferred;
+
+  /**
+   * List of all channels on which we're listening for websockets.
+   */
+  private listeningChannels : Array<string>;
+
+  /**
+   * All timeouts that we're starting as part of this callback. They need to be stopped at the end.
+   */
+  private timeoutPromises : Array<ng.IPromise>;
+
+  /**
+   * Map used to send data across different fonctions.
+   */
+  private sharedMap : Map<string, any>;
+
+  /**
+   * Builder when a new sibling callback is required to be added/build.
+   */
+  private builder : DiagnosticsController;
+
+  /**
+   * Allow to override the messagebus (originally it's grabbing it from cheWebsocket service)
+   */
+  private messageBus : MessageBus;
+
+  /**
+   * Name of the callback.
+   */
+  private name : string;
+
+  /**
+   * Content associated to the callback.
+   */
+  private content: string;
+
+  /**
+   * Constructor.
+   */
+  constructor($q : ng.IQService, cheWebsocket : CheWebsocket, $timeout : ng.ITimeoutService, name: string, sharedMap : Map<string, any>, builder : any, diagnosticPart : DiagnosticPart) {
+    this.$q = $q;
+    this.cheWebsocket = cheWebsocket;
+    this.$timeout = $timeout;
+    this.defered = $q.defer();
+    this.listeningChannels = new Array<string>();
+    this.timeoutPromises = new Array<ng.IPromise>();
+    this.name = name;
+    this.sharedMap = sharedMap;
+    this.builder = builder;
+    this.diagnosticPart = diagnosticPart;
+  }
+
+  /**
+   * Add the given value under the given key name.
+   * @param key the key for the storage (a string)
+   * @param value the value object
+   */
+  public shared(key:string, value : any) : void {
+    this.sharedMap.set(key, value);
+  }
+
+  /**
+   * Allow to retrieved an object based on its key (string)
+   * @param key the string name
+   * @returns {undefined|any}
+   */
+  public getShared(key:string) : any {
+    return this.sharedMap.get(key);
+  }
+
+  /**
+   * Build a new item instance
+   * @param message the message to store in the item
+   * @param hint any hint to add to the item
+   * @param state the state of this newly item
+   * @returns {DiagnosticItem} the newly created object
+   */
+  private newItem(message, hint : string, state : DiagnosticCallbackState) {
+    let diagnosticItem = new DiagnosticItem();
+    diagnosticItem.title = this.name;
+    diagnosticItem.message = message;
+    if (hint) {
+      diagnosticItem.hint = hint;
+    }
+    diagnosticItem.state = state;
+    diagnosticItem.content = this.content;
+    this.diagnosticPart.addItem(diagnosticItem);
+    return diagnosticItem;
+  }
+
+  /**
+   * Adds a running state item [like a new service that is now running received by server side event]
+   * @param message the message to display
+   * @param hint extra hint
+   */
+  public stateRunning(message : string, hint? : string) : void {
+    this.newItem(message, hint, DiagnosticCallbackState.RUNNING);
+    this.cleanup();
+    this.defered.resolve(message);
+  }
+
+
+  /**
+   * Adds a success item [like the result of a test]
+   * @param message the message to display
+   * @param hint extra hint
+   */
+  public success(message : string, hint? : string) : void {
+    this.newItem(message, hint, DiagnosticCallbackState.OK);
+    this.cleanup();
+    this.defered.resolve(message);
+  }
+
+  /**
+   * Notify a failure. note: it doesn't stop the execution flow. A success or an error will come after a failure.
+   * @param message the message to display
+   * @param hint extra hint
+   */
+  notifyFailure(message : string, hint? : string) : void {
+    this.newItem(message, hint, DiagnosticCallbackState.FAILURE);
+  }
+
+  /**
+   * Only notify a hint.
+   * @param hint the hint to display
+   */
+  notifyHint(hint : string) : void {
+    this.newItem('', hint, DiagnosticCallbackState.HINT);
+  }
+
+  /**
+   * Adds an error item [like the result of a test]. Note: it will break the current flow and cancel all existing promises.
+   * @param message the message to display
+   * @param hint extra hint
+   */
+  public error(message : string, hint? : string) : void {
+    this.newItem(message, hint, DiagnosticCallbackState.ERROR);
+    this.cleanup();
+    this.defered.reject(message);
+  }
+
+  /**
+   * Add content to the callback
+   * @param content the content to add
+   */
+  public addContent(content : string) : void {
+    if (!this.content) {
+      this.content = content;
+    } else {
+      this.content += '\n' + content;
+    }
+  }
+
+  /**
+   * Promise associated to this callback
+   * @returns {IPromise}
+   */
+  public getPromise() : ng.IPromise {
+    return this.defered.promise;
+  }
+
+  /**
+   * MessageBus used to connect with websockets.
+   * @returns {MessageBus}
+   */
+  public getMessageBus() : MessageBus {
+    if (this.messageBus) {
+      return this.messageBus;
+    } else {
+      return this.cheWebsocket.getBus();
+    }
+  }
+
+  /**
+   * Override the current messagebus
+   * @param messageBus
+   */
+  public setMessageBus(messageBus : MessageBus) {
+    this.messageBus = messageBus;
+  }
+
+  /**
+   * Delay an error after a timeout. Allow to stop a test if there is no answer after some time.
+   * @param message
+   * @param delay the number of seconds to wait
+   */
+  delayError(message: string, delay: number) {
+    let promise = this.$timeout(() => {this.error(message)}, delay);
+    this.timeoutPromises.push(promise);
+  }
+
+  /**
+   * Delay a function after a timeout.
+   * @param funct the callback function
+   * @param delay the number of seconds to wait
+   */
+  delayFunction(funct: any, delay: number) {
+    let promise = this.$timeout(funct, delay);
+    this.timeoutPromises.push(promise);
+  }
+
+  /**
+   * Subscribe on message bus channel
+   */
+  public subscribeChannel(channel : string, callback : any) : void {
+    this.getMessageBus().subscribe(channel, callback);
+    this.listeningChannels.push(channel);
+  }
+
+  /**
+   * Unsubscribe from message bus channel
+   */
+  public unsubscribeChannel(channel : string) : void {
+    this.getMessageBus().unsubscribe(channel);
+    let index : number = this.listeningChannels.indexOf(channel);
+    if (index >= 0) {
+      delete this.listeningChannels[index];
+    }
+  }
+
+  /**
+   * Cleanup all resources (like current promises)
+   */
+  protected cleanup() : void {
+    this.timeoutPromises.forEach((promise: ng.IPromise) => {
+      this.$timeout.cancel(promise);
+    });
+    this.timeoutPromises.length = 0;
+
+    this.listeningChannels.forEach((channel: string) => {
+      this.getMessageBus().unsubscribe(channel);
+    });
+    this.listeningChannels.length = 0;
+
+  }
+
+  /**
+   * Builder of a sibling callback
+   * @param text
+   * @returns {DiagnosticCallback}
+   */
+  newCallback(text : string) : DiagnosticCallback{
+    return this.builder.newItem(text, this.diagnosticPart);
+  }
+
+}

--- a/dashboard/src/app/diagnostics/diagnostic-item.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-item.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+import {DiagnosticCallbackState} from './diagnostic-callback-state';
+
+/**
+ * Item is a result of a test or an event to be notified to end user
+ * @author Florent Benoit
+ */
+export class DiagnosticItem {
+
+  /**
+   * Title of the item. Describe the global stuff.
+   */
+  public title: string;
+
+  /**
+   * Message used to be displayed after the title of the item.
+   */
+  public message : string;
+
+  /**
+   * State of the current item.
+   */
+  public state : DiagnosticCallbackState;
+
+  /**
+   * Content is extra verbose stuff that could be displayed as part of the logs of the item.
+   */
+  public content : string;
+
+  /**
+   * Hint to report to the end-user. Something that could be helpful regarding the item.
+   */
+  public hint : string;
+
+  /**
+   * Checks the state of the item
+   * @returns {boolean} true if state is OK
+   */
+  public isOk() : boolean {
+    return DiagnosticCallbackState.OK === this.state;
+  }
+
+  /**
+   * Checks the state of the item
+   * @returns {boolean} true if state is OK
+   */
+  public isSuccess() : boolean {
+    return DiagnosticCallbackState.OK === this.state;
+  }
+
+  /**
+   * Checks the state of the item
+   * @returns {boolean} true if state is ERROR
+   */
+  public isError() : boolean {
+    return DiagnosticCallbackState.ERROR === this.state;
+  }
+
+  /**
+   * Checks the state of the item
+   * @returns {boolean} true if state is FAILURE
+   */
+  public isFailure() : boolean {
+    return DiagnosticCallbackState.FAILURE === this.state;
+  }
+
+  /**
+   * Checks the state of the item
+   * @returns {boolean} true if state is RUNNING
+   */
+  public isRunning() : boolean{
+    return DiagnosticCallbackState.RUNNING === this.state;
+  }
+
+  /**
+   * Checks the state of the item
+   * @returns {boolean} true if state is HINT
+   */
+  public isHint() : boolean {
+    return DiagnosticCallbackState.HINT === this.state;
+  }
+
+}

--- a/dashboard/src/app/diagnostics/diagnostic-item.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-item.ts
@@ -89,4 +89,23 @@ export class DiagnosticItem {
     return DiagnosticCallbackState.HINT === this.state;
   }
 
+  /**
+   * Convert state to friendly text.
+   * @returns {any}
+   */
+  public stateToText() : string {
+    switch (this.state) {
+      case DiagnosticCallbackState.RUNNING :
+        return "STATE_RUNNING";
+      case DiagnosticCallbackState.HINT :
+        return "HINT";
+      case DiagnosticCallbackState.OK :
+        return "SUCCESS";
+      case DiagnosticCallbackState.FAILURE :
+        return "FAILURE";
+      case DiagnosticCallbackState.ERROR :
+        return "ERROR"
+    }
+  }
+
 }

--- a/dashboard/src/app/diagnostics/diagnostic-part-state.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-part-state.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+
+/**
+ * Defines the state of the diagnostic part
+ * @author Florent Benoit
+ */
+export const enum DiagnosticPartState {
+  READY,
+  IN_PROGRESS,
+  SUCCESS,
+  FAILURE,
+  ERROR
+}

--- a/dashboard/src/app/diagnostics/diagnostic-part.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-part.ts
@@ -158,6 +158,25 @@ export class DiagnosticPart {
   }
 
   /**
+   * Convert state to friendly text.
+   * @returns {any}
+   */
+  public stateToText() : string {
+    switch (this.state) {
+      case DiagnosticPartState.READY :
+        return "READY (planned)";
+      case DiagnosticPartState.IN_PROGRESS :
+        return "IN PROGRESS";
+      case DiagnosticPartState.SUCCESS :
+        return "SUCCESS";
+      case DiagnosticPartState.FAILURE :
+        return "FAILURE";
+      case DiagnosticPartState.ERROR :
+        return "ERROR"
+    }
+  }
+
+  /**
    * Clear the values
    */
   clear() : void {

--- a/dashboard/src/app/diagnostics/diagnostic-part.ts
+++ b/dashboard/src/app/diagnostics/diagnostic-part.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+import {DiagnosticItem} from './diagnostic-item';
+import {DiagnosticPartState} from './diagnostic-part-state';
+import {DiagnosticCallback} from './diagnostic-callback';
+
+/**
+ * A part or category is a grouping capability of Diagnostics callbacks. It allows to group callback in some groups.
+ * @author Florent Benoit
+ */
+export class DiagnosticPart {
+
+  /**
+   * The title of the part.
+   */
+  title: string;
+
+  /**
+   * An optional subtitle of this part.
+   */
+  subtitle : string;
+
+  /**
+   * The current state of this category
+   */
+  state : DiagnosticPartState;
+
+  /**
+   * Display icon of this part.
+   */
+  icon : string;
+
+  /**
+   * All items attached to this category.
+   */
+  private items : Array<DiagnosticItem>;
+
+  /**
+   * All callbacks attached to this category.
+   */
+  private callbacks : Array<DiagnosticCallback>;
+
+  /**
+   * Current promises of all callbacks
+   */
+  private callbackPromises : Array<ng.IPromise>;
+
+  /**
+   * Number of callbacks (tests) that have finished.
+   */
+  private nbEndedCallbacks : number;
+
+  /**
+   * Number of callbacks (tests) that have been successful.
+   */
+  private nbSuccessCallbacks : number;
+
+  /**
+   * Number of callbacks that had errors
+   */
+  private nbErrorCallbacks : number;
+
+  /**
+   * Callbacks that have ended
+   */
+  private callbacksEnded : Array<DiagnosticCallback>;
+
+  /**
+   * Constructor.
+   */
+  constructor() {
+    this.items = new Array<DiagnosticItem>();
+    this.callbacks = new Array<DiagnosticCallback>();
+    this.callbacksEnded = new Array<DiagnosticCallback>();
+    this.callbackPromises = new Array<ng.IPromise>();
+    this.nbEndedCallbacks = 0;
+    this.nbSuccessCallbacks = 0;
+    this.nbErrorCallbacks = 0;
+  }
+
+  /**
+   * Add an item to this part.
+   * @param item the item to add
+   */
+  addItem(item : DiagnosticItem) : void {
+    this.items.push(item);
+  }
+
+  /**
+   * Test callback to add to this part
+   * @param callback the test callback to add.
+   */
+  addCallback(callback: DiagnosticCallback) : void {
+
+    callback.getPromise().then(() => {
+      this.nbSuccessCallbacks++;
+    });
+
+    callback.getPromise().catch(() => {
+      this.nbErrorCallbacks++;
+    });
+
+    callback.getPromise().finally(() => {
+      this.callbacksEnded.push(callback);
+      this.nbEndedCallbacks++;
+    });
+
+    this.callbackPromises.push(callback.getPromise());
+    this.callbacks.push(callback);
+  }
+
+  /**
+   * Checks the state of the part
+   * @returns {boolean} true if state is READY
+   */
+  public isReady() : boolean {
+    return DiagnosticPartState.READY === this.state;
+  }
+
+  /**
+   * Checks the state of the part
+   * @returns {boolean} true if state is IN_PROGRESS
+   */
+  public isInProgress() : boolean {
+    return DiagnosticPartState.IN_PROGRESS === this.state;
+  }
+
+  /**
+   * Checks the state of the part
+   * @returns {boolean} true if state is SUCCESS
+   */
+  public isSuccess() : boolean {
+    return DiagnosticPartState.SUCCESS === this.state;
+  }
+
+  /**
+   * Checks the state of the part
+   * @returns {boolean} true if state is FAILURE
+   */
+  public isFailure() : boolean {
+    return DiagnosticPartState.FAILURE === this.state;
+  }
+
+  /**
+   * Checks the state of the part
+   * @returns {boolean} true if state is ERROR
+   */
+  public isError() : boolean {
+    return DiagnosticPartState.ERROR === this.state;
+  }
+
+  /**
+   * Clear the values
+   */
+  clear() : void {
+    this.nbEndedCallbacks = 0;
+    this.nbSuccessCallbacks = 0;
+    this.nbErrorCallbacks = 0;
+    this.items.length = 0;
+    this.callbacks.length = 0;
+    this.callbacksEnded.length = 0;
+    this.callbackPromises.length = 0;
+  }
+
+  /**
+   * Gets the total number of callbacks
+   * @returns {number}
+   */
+  public getNumberOfCallbacks() : number {
+    return this.callbacks.length;
+  }
+
+  /**
+   * Gets the total number of ended callbacks
+   * @returns {number}
+   */
+  public getNumberOfEndedCallbacks() : number {
+    return this.nbEndedCallbacks;
+  }
+
+
+}

--- a/dashboard/src/app/diagnostics/diagnostics-config.ts
+++ b/dashboard/src/app/diagnostics/diagnostics-config.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+
+
+import {Diagnostics} from './diagnostics.directive';
+import {DiagnosticsController} from './diagnostics.controller';
+import {DiagnosticsWebsocketWsMaster} from './test/diagnostics-websocket-wsmaster.factory';
+import {DiagnosticsWorkspaceStartCheck} from './test/diagnostics-workspace-start-check.factory';
+import {DiagnosticsRunningWorkspaceCheck} from './test/diagnostics-workspace-check-workspace.factory';
+
+/**
+ * Diagnostics configuration
+ * @author Florent Benoit
+ */
+export class DiagnosticsConfig {
+
+  constructor(register) {
+
+    register.factory('diagnosticsWebsocketWsMaster', DiagnosticsWebsocketWsMaster);
+    register.factory('diagnosticsWorkspaceStartCheck', DiagnosticsWorkspaceStartCheck);
+    register.factory('diagnosticsRunningWorkspaceCheck', DiagnosticsRunningWorkspaceCheck);
+
+    register.directive('diagnostics', Diagnostics);
+    register.controller('DiagnosticsController', DiagnosticsController);
+
+    // config routes
+    register.app.config(($routeProvider) => {
+      $routeProvider.accessWhen('/diagnostic', {
+        title: 'Diagnostic',
+        templateUrl: 'app/diagnostics/diagnostics.html'
+      });
+    });
+
+  }
+}

--- a/dashboard/src/app/diagnostics/diagnostics-widget.html
+++ b/dashboard/src/app/diagnostics/diagnostics-widget.html
@@ -1,0 +1,143 @@
+<!--
+
+    Copyright (c) 2015 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<md-progress-linear md-mode="indeterminate" ng-show="diagnosticsController.isLoading"></md-progress-linear>
+<div ng-show="!diagnosticsController.isLoading">
+  <md-content class="diagnostics-content">
+
+    <div layout="row" flex class="diagnostics-toolbar">
+      <div layout="row" flex layout-align="center center">
+        <div layout="row" layout-align="center center" class="diagnostics-toolbar-progress">
+          <md-progress-circular ng-if="diagnosticsController.isInProgress()" md-theme="maincontent" class="md-accent md-hue-2" md-mode="indeterminate" md-diameter="150">
+          </md-progress-circular>
+          <md-progress-circular ng-if="diagnosticsController.isReady()" md-theme="maincontent" class="md-hue-1" md-mode="determinate" md-diameter="75" value="100">
+          </md-progress-circular>
+          <md-progress-circular ng-if="diagnosticsController.isError()" md-theme="danger" class="md-accent md-hue-3" md-mode="determinate" md-diameter="75" value="100">
+          </md-progress-circular>
+          <md-progress-circular ng-if="diagnosticsController.isSuccess()" md-theme="chesave" class="md-accent md-hue-1" md-mode="determinate" md-diameter="75" value="100">
+          </md-progress-circular>
+        </div>
+        <div layout="column">
+          <div ng-class="{'diagnostics-toolbar-main-title-success': diagnosticsController.isSuccess(), 'diagnostics-toolbar-main-title-error': diagnosticsController.isError(), 'diagnostics-toolbar-main-title-ready': diagnosticsController.isReady(), 'diagnostics-toolbar-main-title-progress': diagnosticsController.isInProgress(), 'diagnostics-toolbar-main-title-failure': diagnosticsController.isFailure()}" class="diagnostics-toolbar-main-title">{{diagnosticsController.globalStatusText}}</div>
+          <div class="diagnostics-toolbar-main-subtitle" ng-if="diagnosticsController.isInProgress()">No Errors Found</div>
+          <div class="diagnostics-toolbar-main-subtitle" ng-if="diagnosticsController.isSuccess()">All Tests Passed</div>
+          <div class="diagnostics-toolbar-main-subtitle" ng-if="diagnosticsController.isError()">Error!</div>
+          <che-button-default che-button-title="Start diagnostics"
+                              che-button-icon="fa fa-play-circle-o"
+                              ng-click="diagnosticsController.start()"
+                              ng-if="diagnosticsController.isReady()"></che-button-default>
+        </div>
+      </div>
+      <div layout="column" layout-align="center center">
+
+        <che-button-default che-button-title="Re run diagnostics"
+                            che-button-icon="fa fa-play-circle-o"
+                            ng-click="diagnosticsController.start()"
+                            ng-if="diagnosticsController.isSuccess() || diagnosticsController.isError()"></che-button-default>
+        <!--<che-button-default che-button-title="Download Logs"></che-button-default>-->
+      </div>
+    </div>
+
+    <div layout="row" flex class="diagnostics-action" layout-align="start start" flex>
+      <div layout="column" flex="50"  ng-if="diagnosticsController.parts && diagnosticsController.parts.length > 0">
+        <div flex  ng-repeat="part in diagnosticsController.parts" >
+          <div class="diagnostic-part" ng-class="{'diagnostic-part-selected' : diagnosticsController.currentPart == part}" layout-align="center center" flex layout="row"  ng-click="diagnosticsController.setDetailsPart(part)">
+            <div flex class="diagnostic-part-content" layout="column">
+              <div layout="row" layout-align="start center">
+                <div flex layout-align="start end" layout="row">
+                  <div class="diagnostic-part-title"><i class="{{part.icon}}"></i> {{part.title}} - </div>
+                  <div class="diagnostic-part-subtitle">
+                    {{part.subtitle}}</div>
+                </div>
+                <div class="diagnostic-part-percent">{{(part.getNumberOfEndedCallbacks() / part.getNumberOfCallbacks()) * 100 | number:0}}%</div>
+              </div>
+              <div>
+                <md-progress-linear ng-if="part.isInProgress()" md-theme="maincontent" class="diagnostic-part-progress md-accent md-hue-2" md-mode="determinate" value="{{(part.getNumberOfEndedCallbacks() / part.getNumberOfCallbacks()) * 100 | number:0}}">
+                </md-progress-linear>
+                <md-progress-linear  ng-if="part.isReady()" md-theme="maincontent" class="diagnostic-part-progress md-hue-1" md-mode="determinate" value="100">
+                </md-progress-linear>
+                <md-progress-linear ng-if="part.isError()" md-theme="danger" class="diagnostic-part-progress md-accent md-hue-3" md-mode="determinate" value="100">
+                </md-progress-linear>
+                <md-progress-linear ng-if="part.isSuccess()" md-theme="chesave" class="diagnostic-part-progress md-accent md-hue-1" md-mode="determinate" value="100">
+                </md-progress-linear>
+              </div>
+              <div ng-if="part.getNumberOfEndedCallbacks() == 0" class="diagnostic-test-numbers">
+                Initializing...
+              </div>
+              <div ng-if="part.getNumberOfEndedCallbacks() > 0" class="diagnostic-test-numbers">
+                <span ng-if="part.isInProgress()">Testing</span><span ng-if="!part.isInProgress()">Tested</span> {{part.getNumberOfEndedCallbacks()}} of {{part.getNumberOfCallbacks()}}
+              </div>
+            </div>
+            <div class="diagnostic-part-link-details" layout="row" layout-align="center center">
+              <i class="fa fa-angle-double-right" aria-hidden="true"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div layout="column" flex="50"  ng-if="diagnosticsController.parts && diagnosticsController.parts.length > 0">
+        <div flex layout="row" layout-align="start start" >
+          <md-content flex class="che-diagnostic-parent-list" che-auto-scroll ng-model="diagnosticsController.currentPart.items" md-scroll-y>
+            <div flex class="che-list-diagnostic-empty-state" layout="row" layout-align="center start" ng-if="diagnosticsController.currentPart.items.length == 0">Testing {{diagnosticsController.currentPart.title}}. Wait for results.
+            </div>
+            <che-list flex class="che-list-diagnostic" ng-if="diagnosticsController.currentPart.items.length > 0">
+              <che-list-item
+                ng-repeat="item in diagnosticsController.currentPart.items"
+                ng-mouseover="hover=true"
+                class="che-list-item-diagnostic"
+                ng-mouseout="hover=false">
+                <div flex=
+                       layout="column"
+                     layout-align="start stretch"
+                     class="che-list-item-row">
+                  <div flex
+                       layout-xs="row" layout-gt-xs="row"
+                       layout-align-gt-xs="start start"
+                       layout-align-xs="start start"
+                       class="che-list-item-details">
+                    <div class="che-list-item-name">
+                      <i class="fa fa-circle-o check-item-icon check-item-icon-ready" ng-if="item.isReady()"></i>
+                      <div class="check-spinner">
+                        <div class="spinner" ng-if="item.isInProgress()">
+                          <div class="rect1"></div>
+                          <div class="rect2"></div>
+                          <div class="rect3"></div>
+                        </div>
+                      </div>
+                      <i class="fa fa-check check-item-icon check-item-ok" ng-if="item.isOk()"></i>
+                      <i class="fa fa-circle check-item-icon check-item-ok" ng-if="item.isRunning()"></i>
+                      <i class="fa fa-info check-item-icon check-item-hint" ng-if="item.isHint()"></i>
+                      <i class="fa fa-exclamation-triangle check-item-icon check-item-fail" ng-if="item.isFailure()"></i>
+                      <i class="fa fa-times check-item-icon check-item-ko" ng-if="item.isError()"></i>
+                      <i class="fa fa-stop check-item-icon check-item-ko" ng-if="item.isAbort()"></i>
+                    </div>
+                    <div flex-gt-xs="70" layout="column">
+                      <div ng-class="{'check-item-ok': item.isSuccess(), 'check-item-running': item.isRunning(), 'check-item-ko': item.isError(), 'check-item-fail': item.isFailure()}" >
+                        {{item.title}}
+                      </div>
+                      <div class="diagnostic-item-message">{{item.message}}</div>
+                      <div ng-if="item.hint" class="hint-item"><i class="fa fa-hand-o-right hint-item-icon"></i>Hint: {{item.hint}}</div>
+                    </div>
+                  </div>
+                  <div flex layout-xs="column" layout-gt-xs="column"
+                       layout-align-gt-xs="start start"
+                       layout-align-xs="start start"
+                       class="che-list-item-details">
+                  </div>
+                </div>
+              </che-list-item>
+            </che-list>
+          </md-content>
+        </div>
+      </div>
+    </div>
+  </md-content>
+</div>

--- a/dashboard/src/app/diagnostics/diagnostics-widget.html
+++ b/dashboard/src/app/diagnostics/diagnostics-widget.html
@@ -17,9 +17,9 @@
     <div layout="row" flex class="diagnostics-toolbar">
       <div layout="row" flex layout-align="center center">
         <div layout="row" layout-align="center center" class="diagnostics-toolbar-progress">
-          <md-progress-circular ng-if="diagnosticsController.isInProgress()" md-theme="maincontent" class="md-accent md-hue-2" md-mode="indeterminate" md-diameter="150">
+          <md-progress-circular ng-if="diagnosticsController.isInProgress()" md-theme="maincontent-theme" class="md-accent md-hue-2" md-mode="indeterminate" md-diameter="150">
           </md-progress-circular>
-          <md-progress-circular ng-if="diagnosticsController.isReady()" md-theme="maincontent" class="md-hue-1" md-mode="determinate" md-diameter="75" value="100">
+          <md-progress-circular ng-if="diagnosticsController.isReady()" md-theme="maincontent-theme" class="md-hue-1" md-mode="determinate" md-diameter="75" value="100">
           </md-progress-circular>
           <md-progress-circular ng-if="diagnosticsController.isError()" md-theme="danger" class="md-accent md-hue-3" md-mode="determinate" md-diameter="75" value="100">
           </md-progress-circular>
@@ -39,11 +39,19 @@
       </div>
       <div layout="column" layout-align="center center">
 
-        <che-button-default che-button-title="Re run diagnostics"
-                            che-button-icon="fa fa-play-circle-o"
-                            ng-click="diagnosticsController.start()"
-                            ng-if="diagnosticsController.isSuccess() || diagnosticsController.isError()"></che-button-default>
-        <!--<che-button-default che-button-title="Download Logs"></che-button-default>-->
+        <div class="diagnostic-button" layout="row" layout-align="end center">
+          <che-button-default che-button-title="Re run diagnostics"
+                              che-button-icon="fa fa-play-circle-o"
+                              ng-click="diagnosticsController.start()"
+                              ng-if="diagnosticsController.isSuccess() || diagnosticsController.isError()"></che-button-default>
+          <div ng-if="diagnosticsController.isInProgress()">&nbsp;</div>
+        </div>
+        <div class="diagnostic-button" layout="row" layout-align="end center">
+          <che-button-default che-button-title="{{diagnosticsController.isLogDisplayed === false ? 'Show Logs' : 'Hide Logs'}}"
+                            che-button-icon="fa fa-file-text-o"
+                            ng-click="diagnosticsController.showLogs()"
+                            ng-if="!diagnosticsController.isReady()"></che-button-default>
+        </div>
       </div>
     </div>
 
@@ -61,9 +69,9 @@
                 <div class="diagnostic-part-percent">{{(part.getNumberOfEndedCallbacks() / part.getNumberOfCallbacks()) * 100 | number:0}}%</div>
               </div>
               <div>
-                <md-progress-linear ng-if="part.isInProgress()" md-theme="maincontent" class="diagnostic-part-progress md-accent md-hue-2" md-mode="determinate" value="{{(part.getNumberOfEndedCallbacks() / part.getNumberOfCallbacks()) * 100 | number:0}}">
+                <md-progress-linear ng-if="part.isInProgress()" md-theme="maincontent-theme" class="diagnostic-part-progress md-accent md-hue-2" md-mode="determinate" value="{{(part.getNumberOfEndedCallbacks() / part.getNumberOfCallbacks()) * 100 | number:0}}">
                 </md-progress-linear>
-                <md-progress-linear  ng-if="part.isReady()" md-theme="maincontent" class="diagnostic-part-progress md-hue-1" md-mode="determinate" value="100">
+                <md-progress-linear  ng-if="part.isReady()" md-theme="maincontent-theme" class="diagnostic-part-progress md-hue-1" md-mode="determinate" value="100">
                 </md-progress-linear>
                 <md-progress-linear ng-if="part.isError()" md-theme="danger" class="diagnostic-part-progress md-accent md-hue-3" md-mode="determinate" value="100">
                 </md-progress-linear>
@@ -139,5 +147,25 @@
         </div>
       </div>
     </div>
+
+    <div ng-if="diagnosticsController.parts && diagnosticsController.parts.length > 0 && diagnosticsController.isLogDisplayed === true">
+      <div class="diagnostic-log-title">Logs</div>
+      <div flex ng-repeat="part in diagnosticsController.parts" class="diagnostic-log-part" layout="column">
+        <div class="diagnostic-log-part-title" layout="row">{{part.title}} {{part.subtitle}} : {{part.stateToText()}}</div>
+        <div ng-repeat="callback in part.callbacks" class="diagnostic-log-callback" layout="column">
+          <div class="diagnostic-log-callback-title" layout="column">{{callback.name}}</div>
+          <div class="diagnostic-log-callback-content" layout="row">{{callback.content}}</div>
+          <div ng-repeat="item in callback.items" class="diagnostic-log-callback-item" layout="row">
+            <div layout="row">
+              <div>{{item.message}}</div>
+              <div>&nbsp;---&nbsp;{{item.stateToText()}}</div>
+            </div>
+            <div class="diagnostic-log-item-hint" layout="row">{{item.hint}}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+
   </md-content>
 </div>

--- a/dashboard/src/app/diagnostics/diagnostics.controller.ts
+++ b/dashboard/src/app/diagnostics/diagnostics.controller.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {DiagnosticsWebsocketWsMaster} from './test/diagnostics-websocket-wsmaster.factory';
+import {DiagnosticCallback} from './diagnostic-callback';
+import {DiagnosticsWorkspaceStartCheck} from './test/diagnostics-workspace-start-check.factory';
+import {CheWebsocket} from '../../components/api/che-websocket.factory';
+import {DiagnosticsRunningWorkspaceCheck} from './test/diagnostics-workspace-check-workspace.factory';
+import {DiagnosticPart} from './diagnostic-part';
+import {DiagnosticPartState} from './diagnostic-part-state';
+
+/**
+ * @ngdoc controller
+ * @name diagnostics.controller:DiagnosticsController
+ * @description This class is handling the controller for the diagnostics page
+ * @author Florent Benoit
+ */
+export class DiagnosticsController {
+
+  /**
+   * Promise service handling.
+   */
+  private $q: ng.IQService;
+
+  /**
+   * Log service.
+   */
+  private $log: ng.ILogService;
+
+  /**
+   * Lodash utility.
+   */
+  private lodash: any;
+
+  /**
+   * Instance of checker for websockets
+   */
+  private diagnosticsWebsocketWsMaster : DiagnosticsWebsocketWsMaster;
+
+  /**
+   * Instance of checker for workspace
+   */
+  private diagnosticsWorkspaceStartCheck : DiagnosticsWorkspaceStartCheck;
+
+  /**
+   * Che Websocket library.
+   */
+  private cheWebsocket : CheWebsocket;
+
+  /**
+   * Angular timeout service.
+   */
+  private $timeout : ng.ITimeoutService;
+
+  /**
+   * Shared Map across all parts.
+   */
+  private sharedMap : Map<string, any>;
+
+  /**
+   * Reference to the diagnostic workspace checker.
+   */
+  private diagnosticsRunningWorkspaceCheck : DiagnosticsRunningWorkspaceCheck;
+
+  /**
+   * List of all parts.
+   */
+  private parts : Array<DiagnosticPart>;
+
+  /**
+   * Link to the workspace master part
+   */
+  private wsMasterPart : DiagnosticPart;
+
+  /**
+   * Link to the workspace agent part
+   */
+  private wsAgentPart : DiagnosticPart;
+
+  /**
+   * Alias for the current part being tested
+   */
+  private currentPart : DiagnosticPart;
+
+  /**
+   * Allow to turn on/off details
+   */
+  private showDetails: boolean = false;
+
+  /**
+   * Global state
+   */
+  private state : DiagnosticPartState;
+
+  /**
+   * Text to be displayed as global status
+   */
+  private globalStatusText : string;
+
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor($log: ng.ILogService, $q: ng.IQService, lodash: any,
+              $timeout : ng.ITimeoutService,
+              diagnosticsWebsocketWsMaster : DiagnosticsWebsocketWsMaster,
+              cheWebsocket: CheWebsocket,
+              diagnosticsRunningWorkspaceCheck : DiagnosticsRunningWorkspaceCheck,
+              diagnosticsWorkspaceStartCheck : DiagnosticsWorkspaceStartCheck) {
+    this.$q = $q;
+    this.$log = $log;
+    this.lodash = lodash;
+    this.$timeout = $timeout;
+    this.diagnosticsWebsocketWsMaster = diagnosticsWebsocketWsMaster;
+    this.diagnosticsWorkspaceStartCheck = diagnosticsWorkspaceStartCheck;
+    this.diagnosticsRunningWorkspaceCheck = diagnosticsRunningWorkspaceCheck;
+    this.parts = new Array<DiagnosticPart>();
+    this.cheWebsocket = cheWebsocket;
+    this.sharedMap = new Map<string, any>();
+    this.state = DiagnosticPartState.READY;
+    this.globalStatusText = 'Ready to start';
+
+    this.wsMasterPart = new DiagnosticPart();
+    this.wsMasterPart.icon = 'fa fa-cube';
+    this.wsMasterPart.title = 'Server Tests';
+    this.wsMasterPart.state = DiagnosticPartState.READY;
+    this.wsMasterPart.subtitle = 'Connectivity checks on Workspace Master';
+
+    this.wsAgentPart = new DiagnosticPart();
+    this.wsAgentPart.icon = 'fa fa-cubes';
+    this.wsAgentPart.title = 'Workspace Tests';
+    this.wsAgentPart.state = DiagnosticPartState.READY;
+    this.wsAgentPart.subtitle = 'Connectivity checks on Workspace Agents';
+  }
+
+  /**
+   * Start the tests.
+   */
+  public start() : void {
+    this.sharedMap.clear();
+    this.globalStatusText = 'Running Tests';
+    this.state = DiagnosticPartState.IN_PROGRESS;
+
+    this.parts.length = 0;
+    this.parts.push(this.wsMasterPart);
+    this.parts.push(this.wsAgentPart);
+    this.parts.forEach((part) => {
+      part.clear();
+    });
+
+    this.currentPart = this.wsMasterPart;
+
+
+    // First check websocket on workspace master
+    this.checkWorkspaceMaster().then(() => {
+      return this.checkWorkspaceAgent();
+    }).then(() => {
+      return this.$q.all([this.checkWorkspaceCheck(), this.checkWebSocketWsAgent()]);
+    }).then(()=> {
+      this.globalStatusText = 'Successfully Tested';
+      this.state = DiagnosticPartState.SUCCESS;
+    }).catch(error => {
+      this.globalStatusText = 'Finished with error';
+      this.state = DiagnosticPartState.ERROR;
+      }
+    )
+  }
+
+  /**
+   * Build a new callback item
+   * @param text the text to set in the callback
+   * @param diagnosticPart the diagnostic part
+   * @returns {DiagnosticCallback} the newly callback
+   */
+  public newItem(text: string, diagnosticPart : DiagnosticPart) : DiagnosticCallback {
+    let callback : DiagnosticCallback = new DiagnosticCallback(this.$q, this.cheWebsocket, this.$timeout, text, this.sharedMap, this, diagnosticPart);
+    diagnosticPart.addCallback(callback);
+    return callback;
+  }
+
+  /**
+   * Sets the details part.
+   * @param part the part to be displayed for the details
+   */
+  public setDetailsPart(part : DiagnosticPart) : void {
+    this.currentPart = part;
+  }
+
+  /**
+   * Checks the workspace master.
+   * @returns {ng.IPromise}
+   */
+  public checkWorkspaceMaster() : ng.IPromise {
+    this.currentPart = this.wsMasterPart;
+
+    this.wsMasterPart.state = DiagnosticPartState.IN_PROGRESS;
+    let promiseWorkspaceMaster : ng.IPromise = this.diagnosticsWebsocketWsMaster.start(this.newItem('Test Websocket', this.wsMasterPart));
+    promiseWorkspaceMaster.then(() => {
+      this.wsMasterPart.state = DiagnosticPartState.SUCCESS;
+    }).catch(error => {
+      this.wsMasterPart.state = DiagnosticPartState.ERROR;
+    });
+
+    return promiseWorkspaceMaster;
+  }
+
+  /**
+   * Checks the workspace agent.
+   * @returns {ng.IPromise}
+   */
+  public checkWorkspaceAgent() : ng.IPromise {
+    this.currentPart = this.wsAgentPart;
+
+    this.wsAgentPart.state = DiagnosticPartState.IN_PROGRESS;
+    let promiseWorkspaceAgent : ng.IPromise = this.diagnosticsWorkspaceStartCheck.start(this.newItem('Test Workspace creation', this.wsAgentPart));
+    promiseWorkspaceAgent.then(() => {
+      this.wsAgentPart.state = DiagnosticPartState.SUCCESS;
+    }).catch(error => {
+      this.wsAgentPart.state = DiagnosticPartState.ERROR;
+    });
+
+    return promiseWorkspaceAgent;
+  }
+
+  /**
+   * Check the REST API on ws agent
+   * @returns {ng.IPromise}
+   */
+  public checkWorkspaceCheck() : ng.IPromise {
+    return this.diagnosticsRunningWorkspaceCheck.checkWsAgent(this.newItem('REST Call on Workspace Agent', this.wsAgentPart))
+  }
+
+  /**
+   * Check the websockets on ws agent
+   * @returns {ng.IPromise}
+   */
+  public checkWebSocketWsAgent() : ng.IPromise {
+    return this.diagnosticsRunningWorkspaceCheck.checkWebSocketWsAgent(this.newItem('Websocket on Workspace Agent', this.wsAgentPart))
+  }
+
+  /**
+   * Allow to toggle details
+   * @returns {ng.IPromise}
+   */
+  public toggleDetails() : void {
+    this.showDetails = !this.showDetails;
+  }
+
+  /**
+   * Checks the state of the controller
+   * @returns {boolean} true if state is READY
+   */
+  public isReady() : boolean {
+    return DiagnosticPartState.READY === this.state;
+  }
+
+  /**
+   * Checks the state of the controller
+   * @returns {boolean} true if state is IN_PROGRESS
+   */
+  public isInProgress() : boolean {
+    return DiagnosticPartState.IN_PROGRESS === this.state;
+  }
+
+  /**
+   * Checks the state of the controller
+   * @returns {boolean} true if state is SUCCESS
+   */
+  public isSuccess() : boolean {
+    return DiagnosticPartState.SUCCESS === this.state;
+  }
+
+  /**
+   * Checks the state of the controller
+   * @returns {boolean} true if state is FAILURE
+   */
+  public isFailure() : boolean {
+    return DiagnosticPartState.FAILURE === this.state;
+  }
+
+  /**
+   * Checks the state of the controller
+   * @returns {boolean} true if state is ERROR
+   */
+  public isError() : boolean {
+    return DiagnosticPartState.ERROR === this.state;
+  }
+
+}

--- a/dashboard/src/app/diagnostics/diagnostics.directive.ts
+++ b/dashboard/src/app/diagnostics/diagnostics.directive.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name diagnostics.directive:diagnostics
+ * @restrict E
+ * @element
+ *
+ * @description
+ * <diagnostics></diagnostics>` for displaying diagnostics.
+ *
+ * @usage
+ *   <diagnostics></diagnostics>
+ *
+ * @author Florent Benoit
+ */
+export class Diagnostics {
+
+  replace : boolean = false;
+  restrict: string = 'E';
+  templateUrl: string = 'app/diagnostics/diagnostics-widget.html';
+  controller: string = 'DiagnosticsController';
+  controllerAs: string = 'diagnosticsController';
+  bindToController: boolean = true;
+
+  scope: {
+    [propName: string]: string
+  };
+
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor () {
+    // scope values
+    this.scope = {
+    };
+  }
+
+}

--- a/dashboard/src/app/diagnostics/diagnostics.html
+++ b/dashboard/src/app/diagnostics/diagnostics.html
@@ -1,0 +1,17 @@
+<!--
+
+    Copyright (c) 2015 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<che-toolbar che-title="Diagnostic Tool" border-none></che-toolbar>
+<che-description>Self diagnostic tool.</che-description>
+<md-content md-scroll-y flex>
+  <diagnostics></diagnostics>
+</md-content>

--- a/dashboard/src/app/diagnostics/diagnostics.styl
+++ b/dashboard/src/app/diagnostics/diagnostics.styl
@@ -84,6 +84,10 @@
     font-size 22px
     font-weight bold
 
+  .diagnostic-button
+    min-height 50px
+    min-width 220px
+
   .diagnostic-part
     position relative
     min-height 150px
@@ -177,3 +181,30 @@
      margin-right 2px
 
 
+  .diagnostic-log-part
+    margin 20px
+
+  .diagnostic-log-part-title
+    font-size 1.2em
+    text-transform uppercase
+    font-weight bold
+    letter-spacing 1.1px
+
+  .diagnostic-log-callback
+    margin-left 20px
+    padding 10px
+    background lightgrey
+    margin-top 16px
+
+  .diagnostic-log-callback-title
+    font-weight bold
+
+  .diagnostic-log-callback-content
+    font-size 9px
+    white-space pre-wrap
+    margin-left 20px
+    font-family monospace
+
+  .diagnostic-log-title
+    font-size 2em
+    text-transform uppercase

--- a/dashboard/src/app/diagnostics/diagnostics.styl
+++ b/dashboard/src/app/diagnostics/diagnostics.styl
@@ -1,0 +1,179 @@
+.diagnostics-content
+  overflow visible
+  min-height 110px
+  padding 0 0 15px 0
+
+  .che-diagnostic-parent-list
+    margin-left 20px
+    margin-right 20px
+    border 1px solid $list-separator-color
+
+  .che-list-diagnostic
+    min-height 50vh
+    max-height 50vh
+    margin-left 0px
+    margin-right 0px
+
+  .diagnostics-toolbar-progress
+    width 150px
+    height 150px
+
+  .che-list-item-diagnostic
+    padding 20px
+
+   .che-list-diagnostic-empty-state
+    margin 40px
+    min-height 50vh
+    max-height 50vh
+
+  .che-list-item-content
+    line-height 20px !important
+
+  .diagnostics-toolbar
+    margin-left 40px
+    margin-right 40px
+    margin-bottom 20px
+    margin-top 20px
+
+  .diagnostics-action
+    margin-left 20px
+    margin-right 20px
+    border-top 1px solid $list-separator-color
+    padding-top 40px
+
+  .diagnostic-part-content
+    padding 20px
+
+  .diagnostic-test-numbers
+    color $list-action-color
+
+  .diagnostic-item-message
+    color $list-action-color
+
+  .diagnostic-part-link-details
+    min-width 70px
+    font-weight bold
+    font-size 1.4em
+    color $list-action-color
+
+  .diagnostics-toolbar-main-title
+    font-size 2.5em
+
+  .diagnostics-toolbar-main-title-success
+    color $secondary-color
+
+  .diagnostics-toolbar-main-title-error
+    color $error-color
+
+  .diagnostics-toolbar-main-title-ready
+    color $label-primary-color
+
+  .diagnostics-toolbar-main-title-progress
+    color $primary-color
+
+  .diagnostics-toolbar-main-title-failure
+    color $warning-color
+
+
+  .diagnostics-toolbar-main-subtitle
+    font-size 1.5em
+    color $label-primary-color
+
+  .diagnotic-hints-title
+    margin-left 10px
+    font-size 22px
+    font-weight bold
+
+  .diagnostic-part
+    position relative
+    min-height 150px
+    max-height 150px
+    padding 10px
+    cursor pointer
+    outline none
+
+  .diagnostic-part:hover
+    background-color $list-checkbox-background-color
+
+  .diagnostic-part-selected
+    background-color $table-header-color
+
+  .diagnostics-dropdown
+    position absolute
+    right 15px
+    bottom 10px
+    font-size 13px
+    cursor pointer
+
+  .diagnostic-part-subtitle
+    color $list-action-color
+    margin-bottom 3px
+    margin-left 5px
+
+  .diagnostic-part-percent
+    color $list-action-color
+    margin-top 3px
+
+  .diagnostic-part-title
+    font-size 1.5em
+    font-weight bold
+    text-transform uppercase
+    letter-spacing 1.95px
+
+  .diagnostic-part-icon
+    font-size 48px
+
+  .diagnostic-part-progress
+    margin-top 20px
+    margin-bottom 20px !important
+
+  .diagnostics-output
+    white-space pre !important
+    line-height 22px
+    font-family monospace
+    background-color lightgrey
+    margin-left 45px
+    padding 5px
+    overflow-y scroll !important
+    max-height 200px
+
+  .check-item-icon
+    color $label-info-color
+    line-height inherit
+    font-size 20px !important
+    margin 1px 5px
+
+  .check-item-ok
+    color $secondary-color
+
+  .check-item-running
+    color $secondary-color
+
+  .check-item-ko
+    color $error-color
+
+  .check-item-fail
+    color $warning-color
+
+  .hint-item
+    color $secondary-light
+
+  .hint-item-icon
+    margin-right 5px
+    line-height inherit
+    font-size 17px
+    margin-bottom -7px
+
+  .check-spinner
+    margin-left 10px
+  .check-spinner .spinner
+    margin-top 5px
+    width 24px
+    height 30px
+    font-size 30px
+    div
+     width 4px
+     border-radius 0
+     margin-right 2px
+
+

--- a/dashboard/src/app/diagnostics/test/diagnostics-websocket-wsmaster.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-websocket-wsmaster.factory.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {CheWebsocket} from '../../../components/api/che-websocket.factory';
+import {DiagnosticCallback} from '../diagnostic-callback';
+
+/**
+ * Test for launching websocket connection to the workspace master
+ * @author Florent Benoit
+ */
+export class DiagnosticsWebsocketWsMaster {
+
+  /**
+   * Websocket handling.
+   */
+  private cheWebsocket : CheWebsocket;
+
+  /**
+   * Timeout handling.
+   */
+  private $timeout : ng.ITimeoutService;
+
+  /**
+   * Default constructor
+   * @ngInject for Dependency injection
+   */
+  constructor (cheWebsocket: CheWebsocket, $timeout : ng.ITimeoutService) {
+    this.cheWebsocket = cheWebsocket;
+    this.$timeout = $timeout;
+  }
+
+  /**
+   * Start the diagnostic and report all progress through the callback
+   * @param diagnosticCallback
+   * @returns {IPromise} when test is finished
+   */
+  start(diagnosticCallback : DiagnosticCallback) : ng.IPromise {
+
+    try {
+      // define callback
+      let callback = (message: any) => {
+        if (!message) {
+          diagnosticCallback.getMessageBus().unsubscribe('pong');
+          diagnosticCallback.success('Websocket message received');
+        }
+      };
+
+      // subscribe to the event
+      diagnosticCallback.subscribeChannel('pong', callback);
+
+      // default fallback if no answer in 5 seconds
+      diagnosticCallback.delayError('No reply of websocket test after 5 seconds. Websocket is failing to connect to ' + this.cheWebsocket.wsUrl, 5000);
+
+      // send the message
+      diagnosticCallback.getMessageBus().ping();
+
+    } catch (error : any) {
+      diagnosticCallback.error('Unable to connect with websocket to ' + this.cheWebsocket.wsUrl + ': ' + error);
+    }
+    return diagnosticCallback.getPromise();
+  }
+
+
+}

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-check-workspace.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-check-workspace.factory.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {DiagnosticCallback} from '../diagnostic-callback';
+import {CheWorkspace} from '../../../components/api/che-workspace.factory';
+import {CheWebsocket, MessageBus} from '../../../components/api/che-websocket.factory';
+
+/**
+ * Ability to tests a running workspace.
+ * @author Florent Benoit
+ */
+export class DiagnosticsRunningWorkspaceCheck {
+
+  /**
+   * Q service for creating delayed promises.
+   */
+  private $q : ng.IQService;
+
+  /**
+   * Workspace API used to grab details.
+   */
+  private cheWorkspace;
+
+  /**
+   * Lodash utility.
+   */
+  private lodash : any;
+
+  /**
+   * Resource service used in tests.
+   */
+  private $resource : ng.resource.IResourceService;
+
+  /**
+   * Location service used to get data from browser URL.
+   */
+  private $location : ng.ILocationService;
+
+  /**
+   * Websocket handling.
+   */
+  private cheWebsocket : CheWebsocket;
+
+  /**
+   * Default constructor
+   * @ngInject for Dependency injection
+   */
+  constructor ($q : ng.IQService, lodash : any, cheWebsocket : CheWebsocket, cheWorkspace: CheWorkspace, $resource : ng.resource.IResourceService, $location : ng.ILocationService) {
+    this.$q =$q;
+    this.lodash = lodash;
+    this.cheWorkspace = cheWorkspace;
+    this.cheWebsocket = cheWebsocket;
+    this.$resource = $resource;
+    this.$location = $location;
+
+  }
+
+  /**
+   * Check WS Agent by using the browser host
+   * @param diagnosticCallback
+   * @returns {ng.IPromise}
+   */
+  checkAgentWithBrowserHost(diagnosticCallback : DiagnosticCallback) : ng.IPromise {
+
+    let wsAgentHRef = this.getWsAgentURL(diagnosticCallback);
+    let parser = document.createElement('a');
+    parser.href = wsAgentHRef;
+    wsAgentHRef = parser.protocol + '//' + this.$location.host() + ':' + parser.port + parser.pathname;
+
+    let promise : ng.IPromise = this.callSCM(diagnosticCallback, wsAgentHRef);
+    promise.then(() => {
+      diagnosticCallback.notifyHint('the host value in configuration file should use the hostname ' + this.$location.host() + ' instead of ' + parser.hostname);
+    });
+    return diagnosticCallback.getPromise();
+  }
+
+  /**
+   * Utility method used to get Workspace Agent URL from a callback shared data
+   * @param diagnosticCallback
+   */
+  private getWsAgentURL(diagnosticCallback : DiagnosticCallback) : string {
+    let workspace : che.IWorkspace = diagnosticCallback.getShared('workspace');
+
+    let errMessage : string = 'Workspace has no runtime: unable to test workspace not started';
+    let runtime : any = workspace.runtime;
+    if (!runtime) {
+      diagnosticCallback.error(errMessage);
+      throw errMessage;
+    }
+    let devMachine = runtime.devMachine;
+    if (!devMachine) {
+      diagnosticCallback.error(errMessage);
+      throw errMessage;
+    }
+    let servers : any = devMachine.runtime.servers;
+    if (!servers) {
+      diagnosticCallback.error(errMessage);
+      throw errMessage;
+    }
+    let wsAgentServer = this.lodash.find(servers, (server: any) => {
+      return server.ref === 'wsagent';
+    });
+
+
+    return wsAgentServer.url;
+  }
+
+
+  /**
+   * Check the Workspace Agent by calling REST API.
+   * @param diagnosticCallback
+   * @returns {ng.IPromise}
+   */
+  checkWsAgent(diagnosticCallback : DiagnosticCallback) : ng.IPromise {
+    let wsAgentHRef = this.getWsAgentURL(diagnosticCallback);
+
+    let promise = this.callSCM(diagnosticCallback, wsAgentHRef);
+    promise.catch(() => {
+      // try with browser host if different location
+      let parser = document.createElement('a');
+      parser.href = wsAgentHRef;
+
+      if (parser.hostname !== this.$location.host()) {
+        this.checkAgentWithBrowserHost(diagnosticCallback.newCallback('Try WsAgent on browser host'));
+      }
+    });
+
+    return diagnosticCallback.getPromise();
+
+  }
+
+
+
+  /**
+   * Start the diagnostic and report all progress through the callback
+   * @param diagnosticCallback
+   * @returns {IPromise} when test is finished
+   */
+  checkWebSocketWsAgent(diagnosticCallback : DiagnosticCallback) : ng.IPromise {
+    let workspace: che.IWorkspace = diagnosticCallback.getShared('workspace');
+
+    let wsAgentSocketWebLink = this.lodash.find(workspace.runtime.links, (link: any) => {
+      return link.rel === 'wsagent.websocket';
+    });
+    if (!wsAgentSocketWebLink) {
+      wsAgentSocketWebLink = this.getWsAgentURL(diagnosticCallback).replace('http', 'ws') + '/ws';
+    } else {
+      wsAgentSocketWebLink = wsAgentSocketWebLink.href;
+    }
+    let wsAgentRemoteBus : MessageBus = this.cheWebsocket.getRemoteBus(wsAgentSocketWebLink);
+    diagnosticCallback.setMessageBus(wsAgentRemoteBus);
+
+    try {
+      // define callback
+      let callback = (message: any) => {
+        if (!message) {
+          diagnosticCallback.getMessageBus().unsubscribe('pong');
+          diagnosticCallback.success('Websocket Agent Message received');
+          wsAgentRemoteBus.datastream.close(true);
+        }
+      };
+
+      // subscribe to the event
+      diagnosticCallback.subscribeChannel('pong', callback);
+
+      // default fallback if no answer in 5 seconds
+      diagnosticCallback.delayError('No reply of websocket test after 5 seconds. Websocket is failing to connect to ' + wsAgentSocketWebLink.href, 5000);
+
+      // send the message
+      diagnosticCallback.getMessageBus().ping();
+
+    } catch (error : any) {
+      diagnosticCallback.error('Unable to connect with websocket to ' + wsAgentSocketWebLink.href + ': ' + error);
+    }
+    return diagnosticCallback.getPromise();
+  }
+
+  /**
+   * Get data on API and retrieve SCM revision.
+   * @param diagnosticCallback
+   * @param wsAgentHRef
+   * @returns {Promise}
+   */
+  callSCM(diagnosticCallback : DiagnosticCallback, wsAgentHRef : string) : ng.IPromise {
+    // connect to the workspace agent
+    let resourceAPI : any = this.$resource(wsAgentHRef + '/', {}, {
+      getDetails: {method: 'OPTIONS'}
+    }, {
+      stripTrailingSlashes: false
+    });
+
+    return resourceAPI.getDetails().$promise.then((data) => {
+      diagnosticCallback.success(wsAgentHRef + '. Got SCM revision ' + angular.fromJson(data).scmRevision);
+    }).catch((error) => {
+      diagnosticCallback.notifyFailure('Unable to perform call on ' + wsAgentHRef + ': Status ' + error.status + ', statusText:' + error.statusText + '/' + error.data);
+      throw error;
+    });
+
+  }
+
+}

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {DiagnosticCallback} from '../diagnostic-callback';
+import {CheWorkspace} from '../../../components/api/che-workspace.factory';
+import {DiagnosticsRunningWorkspaceCheck} from './diagnostics-workspace-check-workspace.factory';
+
+/**
+ * Test the start of a workspace
+ * @author Florent Benoit
+ */
+export class DiagnosticsWorkspaceStartCheck {
+
+  /**
+   * Q service for creating delayed promises.
+   */
+  private $q : ng.IQService;
+
+  /**
+   * Workspace API used to grab details.
+   */
+  private cheWorkspace;
+
+  /**
+   * Lodash utility.
+   */
+  private lodash : any;
+
+  /**
+   * Other checker used to spawn new tests.
+   */
+  private diagnosticsRunningWorkspaceCheck : DiagnosticsRunningWorkspaceCheck;
+
+  /**
+   * Keep a reference to the workspace Agent callback
+   */
+  private wsAgentCallback : DiagnosticCallback;
+
+  /**
+   * Keep a reference to the workspace callback
+   */
+  private workspaceCallback : DiagnosticCallback;
+
+  /**
+   * Keep a reference to the machine callback
+   */
+  private machineCallback : DiagnosticCallback;
+
+  /**
+   * Keep a reference to the exec agent callback
+   */
+  private execAgentCallback : DiagnosticCallback;
+
+  /**
+   * Default constructor
+   * @ngInject for Dependency injection
+   */
+  constructor ($q : ng.IQService, lodash : any, cheWorkspace: CheWorkspace, diagnosticsRunningWorkspaceCheck : DiagnosticsRunningWorkspaceCheck) {
+    this.$q =$q;
+    this.lodash = lodash;
+    this.cheWorkspace = cheWorkspace;
+    this.diagnosticsRunningWorkspaceCheck = diagnosticsRunningWorkspaceCheck;
+  }
+
+  /**
+   * Delete the diagnostic workspace (by stopping it first) if it's already running
+   * @param diagnosticCallback the callback used to send response
+   * @returns {IPromise}
+   */
+  deleteDiagnosticWorkspaceIfPresent(diagnosticCallback : DiagnosticCallback) : ng.IPromise {
+    let defered = this.$q.defer();
+    this.cheWorkspace.fetchWorkspaces().finally(() => {
+      let workspaces: Array<che.IWorkspace> = this.cheWorkspace.getWorkspaces();
+      let workspace: any = this.lodash.find(workspaces, (workspace: che.IWorkspace) => {
+        return workspace.config.name === 'diagnostics';
+      });
+      // need to delete it
+      if (workspace) {
+        // first stop
+        if (workspace.status === 'RUNNING' || workspace.status === 'STARTING') {
+          // listen on the events
+          let eventChannelLink = this.lodash.find(workspace.links, (link: any) => {
+            return link.rel === 'get workspace events channel';
+          });
+          let eventChannel = eventChannelLink ? eventChannelLink.parameters[0].defaultValue : null;
+          diagnosticCallback.subscribeChannel(eventChannel, (message: any) => {
+            if (message.eventType === 'STOPPED') {
+              diagnosticCallback.unsubscribeChannel(eventChannel);
+              this.cheWorkspace.deleteWorkspaceConfig(workspace.id).finally(() => {
+                defered.resolve(true);
+              });
+            } else if ('ERROR' === message.eventType) {
+              defered.reject(message.content);
+            }
+          });
+          this.cheWorkspace.stopWorkspace(workspace.id, false);
+        } else {
+          this.cheWorkspace.deleteWorkspaceConfig(workspace.id).finally(() => {
+            defered.resolve(true);
+          });
+        }
+      } else {
+        defered.resolve(true);
+      }
+    }).catch((error) => {
+      defered.reject(error);
+    });
+    return defered.promise;
+  }
+
+  /**
+   * Always create a fresh workspace (by removing the old one if it exists)
+   * @param diagnosticCallback
+   * @returns {IPromise<T>}
+   */
+  recreateDiagnosticWorkspace(diagnosticCallback : DiagnosticCallback) : ng.IPromise<che.IWorkspace> {
+    let defered = this.$q.defer();
+
+    // delete if present
+    this.deleteDiagnosticWorkspaceIfPresent(diagnosticCallback).then(() => {
+      // now create workspace config
+      let workspaceConfig: che.IWorkspaceConfig = {
+        "projects": [],
+        "environments": {
+          "diagnostics": {
+            "machines": {
+              "dev-machine": {
+                "agents": ["org.eclipse.che.ws-agent"],
+                "servers": {},
+                "attributes": {"memoryLimitBytes": "1147483648"}
+              }
+            },
+            "recipe": {
+              "content": "FROM openjdk:8-jre-alpine\nCMD tail -f /dev/null\n",
+              "contentType": "text/x-dockerfile",
+              "type": "dockerfile"
+            }
+          }
+        },
+        "name": "diagnostics",
+        "defaultEnv": "diagnostics",
+        "description": "Diagnostics Workspace",
+        "commands": []
+      };
+      return this.cheWorkspace.createWorkspaceFromConfig(null, workspaceConfig);
+    }).then((workspace) => {
+      defered.resolve(workspace);
+    }).catch((error) => {
+        defered.reject(error);
+      }
+    );
+    return defered.promise;
+  }
+
+  /**
+   * Starts the test by adding new callbacks after this one
+   * @param diagnosticCallback the original check
+   * @returns {ng.IPromise}
+   */
+  start(diagnosticCallback : DiagnosticCallback) : ng.IPromise {
+    this.workspaceCallback = diagnosticCallback.newCallback('Workspace state');
+    this.wsAgentCallback = diagnosticCallback.newCallback('Workspace Agent running state');
+    this.machineCallback = diagnosticCallback.newCallback('Workspace machine state');
+    this.execAgentCallback = diagnosticCallback.newCallback('Workspace Exec Agent state');
+
+    let workspaceIsStarted : boolean = false;
+    this.recreateDiagnosticWorkspace(diagnosticCallback).then((workspace : che.IWorkspace) => {
+
+      let statusLink = this.lodash.find(workspace.links, (link: any) => {
+        return link.rel === 'environment.status_channel';
+      });
+
+      let eventChannelLink = this.lodash.find(workspace.links, (link: any) => {
+        return link.rel === 'get workspace events channel';
+      });
+
+      let outputLink = this.lodash.find(workspace.links, (link: any) => {
+        return link.rel === 'environment.output_channel';
+      });
+
+      let eventChannel = eventChannelLink ? eventChannelLink.parameters[0].defaultValue : null;
+      let agentChannel = eventChannel + ':ext-server:output';
+      let statusChannel = statusLink ? statusLink.parameters[0].defaultValue : null;
+      let outputChannel = outputLink ? outputLink.parameters[0].defaultValue : null;
+
+      diagnosticCallback.shared('workspace', workspace);
+      diagnosticCallback.subscribeChannel(eventChannel, (message: any) => {
+        diagnosticCallback.addContent('EventChannel : ' + JSON.stringify(message));
+        if (message.eventType === 'RUNNING') {
+          workspaceIsStarted = true;
+          this.workspaceCallback.stateRunning('RUNNING');
+          this.cheWorkspace.fetchWorkspaces().then(() => {
+            let workspace = diagnosticCallback.getShared('workspace');
+            this.cheWorkspace.fetchWorkspaceDetails(workspace.id).then(() => {
+              diagnosticCallback.shared('workspace', this.cheWorkspace.getWorkspaceById(workspace.id));
+              diagnosticCallback.success('Starting workspace OK');
+            })
+          });
+        }
+      });
+
+      if (statusChannel) {
+        diagnosticCallback.subscribeChannel(statusChannel, (message: any) => {
+          if (message.eventType === 'DESTROYED' && message.workspaceId === workspace.id) {
+            diagnosticCallback.error('Error while starting the workspace : Workspace has been destroyed', 'Workspace has not been able to start. Please check the log displayed in diagnostic tool.');
+          }
+          if (message.eventType === 'ERROR' && message.workspaceId === workspace.id) {
+            diagnosticCallback.error('Error while starting the workspace : ' + JSON.stringify(message));
+          }
+
+          if (message.eventType === 'RUNNING' && message.workspaceId === workspace.id && message.machineName === 'dev-machine') {
+            this.machineCallback.stateRunning('RUNNING');
+          }
+
+          diagnosticCallback.addContent('StatusChannel : ' + JSON.stringify(message));
+
+        });
+      }
+
+      diagnosticCallback.subscribeChannel(agentChannel, (message: any) => {
+        diagnosticCallback.addContent('agent channel :' + message);
+
+        if (message.indexOf(' Server startup') > 0) {
+          this.wsAgentCallback.stateRunning('RUNNING');
+
+          // Server has been startup in the workspace agent and tries to reach workspace agent but is unable to do it
+          // try with the browser ip
+          diagnosticCallback.delayFunction(() => {
+            diagnosticCallback.notifyFailure('Network failure WS Master <--> WS Agent', 'The Workspace Agent has been started since few seconds but the state of the workspace is not yet in RUNNING state. It means that there is a failure to connect workspace master and workspace agent. Please check HOST value in .env file and firewall.');
+            this.cheWorkspace.fetchWorkspaceDetails(workspace.id).then(() => {
+              diagnosticCallback.shared('workspace', this.cheWorkspace.getWorkspaceById(workspace.id));
+              let newCallback : DiagnosticCallback = diagnosticCallback.newCallback('Test connection from browser to workspace agent by using Workspace Agent IP');
+              this.diagnosticsRunningWorkspaceCheck.checkWsAgent(newCallback);
+              let websocketCallback : DiagnosticCallback = diagnosticCallback.newCallback('Test connection from browser to workspace agent with websocket');
+              this.diagnosticsRunningWorkspaceCheck.checkWebSocketWsAgent(websocketCallback);
+            });
+
+          }, 7000)
+        }
+
+        diagnosticCallback.addContent(message);
+      });
+
+      if (outputChannel) {
+        diagnosticCallback.subscribeChannel(outputChannel, (message: any) => {
+          let content : string = angular.fromJson(message).content;
+          diagnosticCallback.addContent(content);
+
+          // check if connected (always pull)
+          if (content.indexOf('Client.Timeout exceeded while awaiting headers') > 0) {
+            diagnosticCallback.error('Network connection issue', 'Docker is trying to pull the image with auto pull mode. Try to disable the flag che.docker.always_pull_image (off) or enable Internet Connection from Docker node.');
+          }
+
+          if (content.indexOf('dial tcp: lookup') > 0 && content.indexOf('server misbehaving') > 0) {
+            diagnosticCallback.error('Network connection issue', 'Docker is trying to connect to registry but the connection is failing. Check DNS settings of docker daemon or network connectivity.');
+          }
+
+          if (content.indexOf('Exec-agent configuration') > 0) {
+            this.execAgentCallback.stateRunning('RUNNING');
+          }
+          diagnosticCallback.addContent('output channel message :' + JSON.stringify(message));
+        });
+      }
+
+      diagnosticCallback.delayError('Test limit is for up to 5minutes. Time has exceed.', 5 * 60 * 1000);
+
+      let startWorkspacePromise = this.cheWorkspace.startWorkspace(workspace.id, workspace.config.defaultEnv);
+      startWorkspacePromise.then((workspaceData) => {
+        diagnosticCallback.shared('workspace', workspaceData);
+      });
+
+    }).catch((error) => {
+      diagnosticCallback.error('Unable to start workspace: ' + error);
+    });
+
+
+    return diagnosticCallback.getPromise();
+
+  }
+
+
+}

--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -16,6 +16,7 @@ import {ComponentsConfig} from '../components/components-config';
 
 import {AdminsConfig} from './admin/admin-config';
 import {AdministrationConfig} from './administration/administration-config';
+import {DiagnosticsConfig} from './diagnostics/diagnostics-config';
 import {CheColorsConfig} from './colors/che-color.constant';
 import {CheOutputColorsConfig} from './colors/che-output-colors.constant';
 import {CheCountriesConfig} from './constants/che-countries.constant';
@@ -374,6 +375,7 @@ new ComponentsConfig(instanceRegister);
 new AdminsConfig(instanceRegister);
 new AdministrationConfig(instanceRegister);
 new IdeConfig(instanceRegister);
+new DiagnosticsConfig(instanceRegister);
 
 new NavbarConfig(instanceRegister);
 new ProjectsConfig(instanceRegister);

--- a/dashboard/src/assets/branding/product.json
+++ b/dashboard/src/assets/branding/product.json
@@ -9,5 +9,9 @@
   "helpPath": "https://www.eclipse.org/che/",
   "helpTitle": "Community",
   "supportEmail": "wish@codenvy.com",
-  "oauthDocs": "Configure OAuth in the che.properties file."
+  "oauthDocs": "Configure OAuth in the che.properties file.",
+  "cli" : {
+    "configName" : "che.env",
+    "name" : "CHE"
+  }
 }

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -75,6 +75,14 @@ export class CheBranding {
             this.helpTitle = this.$rootScope.branding.helpTitle;
             this.supportEmail = this.$rootScope.branding.supportEmail;
             this.oauthDocs = this.$rootScope.branding.oauthDocs;
+            if (!this.$rootScope.branding.cli) {
+              this.cli = {
+                configName : this.name + 'env file',
+                name : 'PRODUCT_'
+              }
+            } else {
+              this.cli = this.$rootScope.branding.cli;
+            }
             this.deferred.resolve(this.$rootScope.branding);
         });
 
@@ -111,5 +119,10 @@ export class CheBranding {
     getProductSupportEmail() {
         return this.supportEmail;
     }
+
+    getCLI() {
+        return this.cli;
+    }
+
 }
 

--- a/dashboard/src/components/widget/footer/che-footer.directive.ts
+++ b/dashboard/src/components/widget/footer/che-footer.directive.ts
@@ -93,6 +93,10 @@ export class CheFooter {
     if (supportHelpPath && supportHelpTitle) {
       template += '<a class=\"che-footer-button-blue che-footer-button\" ng-href=\"' + supportHelpPath + '\" target=\"_blank\">' + supportHelpTitle + '<a/>';
     }
+
+    // diagnostics
+    template += '<a class=\"che-footer-button-blue che-footer-button\" ng-href=\"#/diagnostic\">Diagnostics<a/>';
+
     template += '</div>';
     return template;
   }


### PR DESCRIPTION
### What does this PR do?
Add diagnostic page with ability to check if workspaces can work or not

![diagnostic-tool](https://cloud.githubusercontent.com/assets/436777/23312302/881ef170-fab9-11e6-8393-9d2f783e3d68.gif)

### What issues does this PR fix or reference?
#3748 

#### Changelog
Add a diagnostic page to the dashboard that can check workspace requirements.

#### Release Notes
_Title:_
Diagnostic utility added to dashboard: find and diagnose install problems

_Description:_
We are now providing two diagnostic utilities to help users who are having a problems starting the Che or its workspaces. Run `docker run eclipse/che info` on the command-line to diagnose startup issues or use the new "diagnostic" page that you can launch from the lower corner of the dashboard.

[insert image of button for diagnostic page]

The diagnostic page in the dashboard tests for blocked ports, firewalls, network connectivity issues and websocket problems that might prevent Che workspaces from starting properly. Because these tests are executed from the client to the server and workspace they can highlight issues that the startup tests can't

#### Docs PR
Che PR - https://github.com/eclipse/che-docs/pull/159
Codenvy PR - https://github.com/codenvy/docs/pull/84

Docs improvements needed:

1. In the installation doc, where we discuss getting help, we should outline this option along with the "info --bundle" command.

2. In the installation page where we discuss networking, we should talk about how a developer can get more detailed insight to diagnose the installation - a) with "info", b) with "info --network", c) with UD diagnostic tool tests, and then if these things do not reveal anything, opening a ticket with GitHub, perhaps attaching these outputs or files for support.

3. Also add this to Codenvy


#### Text to be reviewed

Title of the page: Diagnostic Tool
Subtitle of the page (grey outline area) : Run browser, server and workspace tests

1. Main toolbar (Where we see "Running Tests")
**Ready**
title: Ready To Start
subtitle: + button "Start Diagnostics"
**In Progress**
title: Running Tests
subtitle: No Errors Found
**Success**
title: Completed Diagnostics
subtitle: All Tests Passed
**Error**
title: Diagnostics Finished With Error
subtitle: Error!


2. Categories
wsMasterPart.icon = 'fa fa-cube';
wsMasterPart.title = 'Server Tests';
wsMasterPart.subtitle = 'Connectivity checks to the Che server';
wsAgentPart.icon = 'fa fa-cubes';
wsAgentPart.title = 'Workspace Tests';
wsAgentPart.subtitle = 'Connectivity checks to Dockerized workspaces';

3. Tests
a/wsMasterPart:
```
title: Websockets
success result : Websocket message received
error: Unable to connect with websocket to ' + this.cheWebsocket.wsUrl + ': ' + error
```
b/wsAgent part
```
title: Create Workspace
success: Successful workspace start
1.
when receive DESTROYED event
error1: Error while starting the workspace : Workspace has been destroyed
hint error1: Please check the diagnostic logs.
2.
if output contains Client.Timeout exceeded while awaiting headers
error2: Network connection issue
hint error2: Docker was unable to pull the right Docker image for the workspace. Either networking is not working from your Docker daemon or try disabling CHE_DOCKER_ALWAYSE__PULL__IMAGE in `che.env` to avoid pulling images over the network.
3.
if output contains 'dial tcp: lookup && 'server misbehaving'
error 3: Network connection issue
hint error3 : Docker is trying to connect to a Docker registry but the connection is failing. Check Docker's DNS settings and network connectivity.
4
if we detect server start but not received start event
failure message: The workspace started, but Che <--> Workspace connection not established
hint failure: The workspace agent has started in the workspace, but the Che server cannot verify this. There is a failure for Che server to connect to your workspace's agent. Either your firewall is blocking essential ports or you can change CHE_DOCKER_IP and DOCKER_HOST to values specific to your environment. See the `che.env` file for specifics.'

We also run tests
    Test connection from browser to workspace agent by using Workspace Agent IP
and
  Test connection from browser to workspace agent with websocket
```

5. REST API Readiness
success message: wsAgentHRef + '. Got SCM revision ' + angular.fromJson(data).scmRevision


events
```
title:Workspace State
success: RUNNING

Workspace Agent State
success: RUNNING

Workspace Runtime State
success: RUNNING

Workspace Exec Agent State
success: RUNNING
```



Change-Id: I535f8a9e5f8e344176319089e2afba0ba7acdefd
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>

