### PR TITLE
CHE-117 kubernetes-client will autodetect auth details both inside and outsid…

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -279,10 +279,6 @@ db.schema.flyway.scripts.locations=classpath:che-schema
 db.jndi.datasource.name=java:/comp/env/jdbc/che
 
 # OpenShift related properties
-che.openshift.endpoint=https://192.168.64.2:8443/
-che.openshift.token=
-che.openshift.username=openshift-dev
-che.openshift.password=devel
 che.openshift.project=eclipse-che
 che.openshift.serviceaccountname=cheserviceaccount
 che.openshift.liveness.probe.delay=300

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -56,10 +56,6 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-docker-client</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -143,10 +143,6 @@ public class OpenShiftConnector extends DockerConnector {
                               DockerConnectionFactory connectionFactory,
                               DockerRegistryAuthResolver authResolver,
                               DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider,
-                              @Named("che.openshift.endpoint") String openShiftApiEndpoint,
-                              @Nullable @Named("che.openshift.token") String openShiftToken,
-                              @Nullable @Named("che.openshift.username") String openShiftUserName,
-                              @Nullable @Named("che.openshift.password") String openShiftUserPassword,
                               @Named("che.openshift.project") String openShiftCheProjectName,
                               @Named("che.openshift.serviceaccountname") String openShiftCheServiceAccount,
                               @Named("che.openshift.liveness.probe.delay") int openShiftLivenessProbeDelay,
@@ -158,28 +154,7 @@ public class OpenShiftConnector extends DockerConnector {
         this.openShiftLivenessProbeDelay = openShiftLivenessProbeDelay;
         this.openShiftLivenessProbeTimeout = openShiftLivenessProbeTimeout;
 
-        Config config = getOpenShiftConfig(configBuilder,
-                                           openShiftApiEndpoint,
-                                           openShiftToken,
-                                           openShiftUserName,
-                                           openShiftUserPassword);
-        this.openShiftClient = new DefaultOpenShiftClient(config);
-    }
-
-    private Config getOpenShiftConfig(ConfigBuilder configBuilder,
-                                      String openShiftApiEndpoint,
-                                      String openShiftToken,
-                                      String openShiftUserName,
-                                      String openShiftUserPassword) {
-        if (isNullOrEmpty(openShiftToken)) {
-            return configBuilder.withMasterUrl(openShiftApiEndpoint)
-                    .withUsername(openShiftUserName)
-                    .withPassword(openShiftUserPassword).build();
-        } else {
-            return configBuilder.withMasterUrl(openShiftApiEndpoint)
-                    .withOauthToken(openShiftToken)
-                    .build();
-        }
+        this.openShiftClient = new DefaultOpenShiftClient();
     }
 
     /**

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -36,13 +36,9 @@ public class OpenShiftConnectorTest {
     private static final String[] CONTAINER_ENV_VARIABLES = {"CHE_WORKSPACE_ID=abcd1234"};
     private static final String   CHE_DEFAULT_OPENSHIFT_PROJECT_NAME = "eclipse-che";
     private static final String   CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT = "cheserviceaccount";
-    private static final String   OPENSHIFT_API_ENDPOINT_MINISHIFT = "https://192.168.64.2:8443/";
-    private static final String   OPENSHIFT_DEFAULT_USER_NAME = "openshift-dev";
-    private static final String   OPENSHIFT_DEFAULT_USER_PASSWORD = "devel";
     private static final int      OPENSHIFT_LIVENESS_PROBE_DELAY = 300;
     private static final int      OPENSHIFT_LIVENESS_PROBE_TIMEOUT = 1;
-    private static final String   OPENSHIFT_DEFAULT_TOKEN = "91XMfu-FuNDkGjcIh6b0y1EtCvztGeSsSqRrWhBfyL8";
-
+    
     @Mock
     private DockerConnectorConfiguration       dockerConnectorConfiguration;
     @Mock
@@ -71,10 +67,6 @@ public class OpenShiftConnectorTest {
                 dockerConnectionFactory,
                 authManager,
                 dockerApiVersionPathPrefixProvider,
-                OPENSHIFT_API_ENDPOINT_MINISHIFT,
-                OPENSHIFT_DEFAULT_TOKEN,
-                OPENSHIFT_DEFAULT_USER_NAME,
-                OPENSHIFT_DEFAULT_USER_PASSWORD,
                 CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
                 CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
                 OPENSHIFT_LIVENESS_PROBE_DELAY,
@@ -84,55 +76,4 @@ public class OpenShiftConnectorTest {
         //Then
         assertEquals(workspaceID, expectedWorkspaceID);
     }
-
-    @Test
-    public void shouldUseTokenWhenProvided() {
-        // Given
-        ConfigBuilder configBuilder = spy(new ConfigBuilder());
-
-        // When
-        openShiftConnector = new OpenShiftConnector(configBuilder,
-                dockerConnectorConfiguration,
-                dockerConnectionFactory,
-                authManager,
-                dockerApiVersionPathPrefixProvider,
-                OPENSHIFT_API_ENDPOINT_MINISHIFT,
-                OPENSHIFT_DEFAULT_TOKEN,
-                OPENSHIFT_DEFAULT_USER_NAME,
-                OPENSHIFT_DEFAULT_USER_PASSWORD,
-                CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
-                CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
-                OPENSHIFT_LIVENESS_PROBE_DELAY,
-                OPENSHIFT_LIVENESS_PROBE_TIMEOUT);
-
-        // Then
-        verify(configBuilder,times(1)).withOauthToken(OPENSHIFT_DEFAULT_TOKEN);
-        verify(configBuilder,times(0)).withUsername(OPENSHIFT_DEFAULT_USER_NAME);
-    }
-
-    @Test
-    public void shouldUsePasswordWhenTokenIsNotProvided() {
-        // Given
-        ConfigBuilder configBuilder = spy(new ConfigBuilder());
-
-        // When
-        openShiftConnector = new OpenShiftConnector(configBuilder,
-                dockerConnectorConfiguration,
-                dockerConnectionFactory,
-                authManager,
-                dockerApiVersionPathPrefixProvider,
-                OPENSHIFT_API_ENDPOINT_MINISHIFT,
-                "",
-                OPENSHIFT_DEFAULT_USER_NAME,
-                OPENSHIFT_DEFAULT_USER_PASSWORD,
-                CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
-                CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
-                OPENSHIFT_LIVENESS_PROBE_DELAY,
-                OPENSHIFT_LIVENESS_PROBE_TIMEOUT);
-
-        // Then
-        verify(configBuilder,times(0)).withOauthToken(OPENSHIFT_DEFAULT_TOKEN);
-        verify(configBuilder,times(1)).withUsername(OPENSHIFT_DEFAULT_USER_NAME);
-    }
-
 }


### PR DESCRIPTION
…e openshift so no need to use config

### What does this PR do?
For more information including the order configuration is decided see https://github.com/fabric8io/kubernetes-client#configuring-the-client

TL;DR when running locally simply connect to your OpenShift cluster using `oc login` and kubernetes-client will use the token from the filesystem.  Similarly when running in a pod on OpenShift kubernetes-client will use the token automatically mounted inside the pod by OpenShift.

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-117

#### Changelog
 - OpenShift connector uses filesystem tokens to authenticate with OpenShift API server

#### Release Notes
 - OpenShift connector uses filesystem tokens to authenticate with OpenShift API server
