### PR TITLE
Add validators for CAP inputs and Billing info inputs.

### DIFF
--- a/dashboard/src/components/attribute/attribute-config.ts
+++ b/dashboard/src/components/attribute/attribute-config.ts
@@ -17,6 +17,8 @@ import {CheReloadHref} from './reload-href/che-reload-href.directive';
 import {CheFormatOutput} from './format-output/che-format-output.directive';
 import {CheOnLongTouch} from './touch/che-on-long-touch.directive';
 import {CheOnRightClick} from './click/che-on-right-click.directive';
+import {CheTypeNumber} from './input-type/input-number.directive';
+import {CheTypeCity} from './input-type/input-city.directive';
 
 export class AttributeConfig {
 
@@ -35,5 +37,8 @@ export class AttributeConfig {
     register.directive('cheOnLongTouch', CheOnLongTouch);
 
     register.directive('cheOnRightClick', CheOnRightClick);
+
+    register.directive('cheTypeNumber', CheTypeNumber);
+    register.directive('cheTypeCity', CheTypeCity);
   }
 }

--- a/dashboard/src/components/attribute/input-type/input-city.directive.ts
+++ b/dashboard/src/components/attribute/input-type/input-city.directive.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {CheInputType} from './input-type.directive';
+
+/**
+ * @ngdoc directive
+ * @name components.directive:cheTypeCity
+ * @restrict A
+ * @function
+ * @element
+ *
+ * @description
+ * `che-type-city` defines an attribute for input tag which allows to enter symbols only used in city names. This directive should be used along with city-name-validator.
+ *
+ * @usage
+ *   <input che-type-city city-name-validator />
+ *
+ * @author Oleksii Kurinnyi
+ */
+
+export class CheTypeCity extends CheInputType {
+  private validSymbolsRE = /[.\-' a-zA-Z\u00A0-\u024F]/;
+
+  symbolIsValid(symbol: string): boolean {
+    return this.validSymbolsRE.test(symbol);
+  }
+
+}

--- a/dashboard/src/components/attribute/input-type/input-city.spec.ts
+++ b/dashboard/src/components/attribute/input-type/input-city.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {CheTypeCity} from './input-city.directive';
+
+/**
+ * Test for CheTypeCity class.
+ *
+ * @author Oleksii Kurinnyi
+ */
+
+describe('CheTypeCity', () => {
+  let cheTypeCity: CheTypeCity;
+
+  let validSymbols = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.\' ';
+  let invalidSymbols = '`~!@#$%^&*()[]{}<>_+=:;?0123456789';
+
+  beforeEach(() => {
+    cheTypeCity = new CheTypeCity();
+  });
+
+  validSymbols.split('').forEach((validSymbol: string) => {
+
+    (function shouldPass(symbol: string) {
+      it(`should pass "${symbol}" symbol`, () => {
+        expect(cheTypeCity.symbolIsValid(symbol)).toBeTruthy();
+      });
+    })(validSymbol);
+
+  });
+
+  invalidSymbols.split('').forEach((invalidSymbol: string) => {
+
+    (function (symbol: string) {
+      it(`should not pass "${symbol}" symbol`, () => {
+        expect(cheTypeCity.symbolIsValid(symbol)).toBeFalsy();
+      });
+    })(invalidSymbol);
+
+  });
+
+});

--- a/dashboard/src/components/attribute/input-type/input-number.directive.ts
+++ b/dashboard/src/components/attribute/input-type/input-number.directive.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {CheInputType} from './input-type.directive';
+
+/**
+ * @ngdoc directive
+ * @name components.directive:cheTypeNumber
+ * @restrict A
+ * @function
+ * @element
+ *
+ * @description
+ * `che-type-number` defines an attribute for input tag which allows to enter only digits.
+ *
+ * @usage
+ *   <input che-type-number />
+ *
+ * @author Oleksii Kurinnyi
+ */
+
+export class CheTypeNumber extends CheInputType {
+
+  symbolIsValid(symbol: string): boolean {
+    return '0123456789'.indexOf(symbol) > -1;
+  }
+
+}

--- a/dashboard/src/components/attribute/input-type/input-number.spec.ts
+++ b/dashboard/src/components/attribute/input-type/input-number.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+import {CheTypeNumber} from './input-number.directive';
+
+/**
+ * Test for CheTypeNumber class.
+ *
+ * @author Oleksii Kurinnyi
+ */
+
+describe('CheTypeNumber', () => {
+  let cheTypeNumber: CheTypeNumber;
+
+  let validSymbols = '0123456789';
+  let invalidSymbols = '`~!@#$%^&*()[]{}<>_+=:;.?,/|\'"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  beforeEach(() => {
+    cheTypeNumber = new CheTypeNumber();
+  });
+
+  validSymbols.split('').forEach((validSymbol: string) => {
+
+    (function(symbol: string) {
+      it(`should pass "${symbol}" symbol`, () => {
+        expect(cheTypeNumber.symbolIsValid(symbol)).toBeTruthy();
+      });
+    })(validSymbol);
+
+  });
+
+  invalidSymbols.split('').forEach((invalidSymbol: string) => {
+
+    (function(symbol: string) {
+      it(`should not pass "${symbol}" symbol`, () => {
+        expect(cheTypeNumber.symbolIsValid(symbol)).toBeFalsy();
+      });
+    })(invalidSymbol);
+
+  });
+
+});

--- a/dashboard/src/components/attribute/input-type/input-type.directive.ts
+++ b/dashboard/src/components/attribute/input-type/input-type.directive.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * Defines a directive to allow to enter only specified subset of symbols.
+ * @author Oleksii Kurinnyi
+ */
+export abstract class CheInputType {
+  private restrict: string = 'A';
+
+  link($scope: ng.IScope, $element: ng.IAugmentedJQuery, attrs: {cheInputType: string, [prop: string]: string}): void {
+
+    $element.on('keydown', (event: KeyboardEvent) => {
+      // delete, backspace
+      if (event.keyCode === 46 || event.keyCode === 8) {
+        return true;
+      }
+      // arrows
+      if (event.keyCode === 37 || event.keyCode === 38 || event.keyCode === 39 || event.keyCode === 40) {
+        return true;
+      }
+      // home, end
+      if (event.keyCode === 36 || event.keyCode === 35) {
+        return true;
+      }
+      // valid symbols
+      return this.symbolIsValid(event.key);
+    });
+  }
+
+  abstract symbolIsValid(symbol: string): boolean;
+
+}

--- a/dashboard/src/components/validator/city-name-validator.directive.ts
+++ b/dashboard/src/components/validator/city-name-validator.directive.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * Defines a directive for a city name validation.
+ *
+ * @author Oleksii Kurinnyi
+ */
+export class CityNameValidator {
+  restrict: string = 'A';
+  require: string = 'ngModel';
+
+  cityNameRE: RegExp = new RegExp(/^(?:[a-zA-Z\u00A0-\u024F]+(?:\. |-| |'))*[a-zA-Z\u00A0-\u024F]+$/);
+
+  link($scope, element, attrs, ctrl) {
+    // validate only input element
+    if ('input' === element[0].localName) {
+      ctrl.$validators.cityNameValidator = (modelValue: string) => {
+        return this.cityNameRE.test(modelValue);
+      };
+    }
+  }
+}
+

--- a/dashboard/src/components/validator/city-name-validator.spec.ts
+++ b/dashboard/src/components/validator/city-name-validator.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * Test for city-name-validator directive
+ *
+ * @author Oleksii Kurinnyi
+ */
+
+describe('city-name-validator', () => {
+  let $scope, form, $compile;
+
+  let validNames = [
+    'Toronto',
+    'St. Catharines',
+    'San Fransisco',
+    'Val-d\'Or',
+    'Presqu\'ile',
+    'Niagara on the Lake',
+    'Niagara-on-the-Lake',
+    'München',
+    'toronto',
+    'toRonTo',
+    'villes du Québec',
+    'Provence-Alpes-Côte d\'Azur',
+    'Île-de-France',
+    'Kópavogur',
+    'Garðabær',
+    'Sauðárkrókur',
+    'Þorlákshöfn'
+  ];
+  let invalidNames = [
+    'San ',
+    'St.',
+    'Val-',
+    'A----B',
+    '------',
+    '*******',
+    '&&',
+    '()',
+    '//',
+    '\\'
+  ];
+
+  /**
+   * Backend for handling http operations
+   */
+  let httpBackend;
+
+  beforeEach(angular.mock.module('userDashboard'));
+
+  beforeEach(inject((_$compile_, $rootScope, cheHttpBackend) => {
+    $scope = $rootScope;
+    $compile = _$compile_;
+
+    httpBackend = cheHttpBackend.getHttpBackend();
+    // avoid tracking requests from branding controller
+    httpBackend.whenGET(/.*/).respond(200, '');
+    httpBackend.when('OPTIONS', '/api/').respond({});
+  }));
+
+  validNames.forEach((validName) => {
+
+    (function shouldPass(validCityName) {
+      it(`"${validCityName}" should be OK`, () => {
+        $scope.model = {value: ''};
+
+        let element = angular.element(
+          '<form name="form">' +
+          '<input ng-model="model.value" name="value" city-name-validator />' +
+          '</form>'
+        );
+        $compile(element)($scope);
+
+        form = $scope.form;
+        form.value.$setViewValue(validCityName);
+
+        // check form (expect invalid)
+        expect(form.value.$invalid).toBe(false);
+        expect(form.value.$valid).toBe(true);
+      });
+    })(validName);
+
+  });
+
+  invalidNames.forEach((invalidName) => {
+
+    (function shouldFail(invalidName) {
+      it(`"${invalidName}" should fail`, () => {
+        $scope.model = {value: ''};
+
+        let element = angular.element(
+          '<form name="form">' +
+          '<input ng-model="model.value" name="value" city-name-validator />' +
+          '</form>'
+        );
+        $compile(element)($scope);
+
+        form = $scope.form;
+        form.value.$setViewValue(invalidName);
+
+        // check form (expect valid)
+        expect(form.value.$invalid).toBe(true);
+        expect(form.value.$valid).toBe(false);
+      });
+    })(invalidName);
+
+  });
+
+});

--- a/dashboard/src/components/validator/validator-config.ts
+++ b/dashboard/src/components/validator/validator-config.ts
@@ -15,6 +15,7 @@ import {UniqueProjectNameValidator} from './unique-project-name-validator.direct
 import {UniqueWorkspaceNameValidator} from './unique-workspace-name-validator.directive';
 import {CustomValidator} from './custom-validator.directive';
 import {UniqueStackNameValidator} from './unique-stack-name-validator.directive';
+import {CityNameValidator} from './city-name-validator.directive';
 
 
 export class ValidatorConfig {
@@ -22,6 +23,7 @@ export class ValidatorConfig {
   constructor(register) {
 
     register.directive('gitUrl', GitUrlValidator)
+      .directive('cityNameValidator', CityNameValidator)
       .directive('uniqueProjectName', UniqueProjectNameValidator)
       .directive('uniqueWorkspaceName', UniqueWorkspaceNameValidator)
       .directive('customValidator', CustomValidator)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR adds
- custom input type directive to allow user to enter only digits;
- custom input type directive to allow user to enter symbols used in city names;
- directive to validate city names;


### What issues does this PR fix or reference?
https://github.com/codenvy/saas/issues/150
https://github.com/codenvy/saas/issues/153

#### Changelog
<!-- one line entry to be added to changelog -->
- UD add directives for custom input types for numbers and city names;
- UD add city name validation directive;


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>
