### PR TITLE
[cli] Add ability to skip config regeneration when starting

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -22,9 +22,10 @@ before execution. If you have mounted a local repository or assembly, the ${CHE_
 images will use those binaries instead of their embedded ones.\n"
   text "\n"
   text "PARAMETERS:\n"
+  text "  --force                           Uses 'docker rmi' and 'docker pull' to forcibly retrieve latest images\n"
   text "  --no-force                        Updates images if matching tag not found in local cache\n"
   text "  --pull                            Uses 'docker pull' to check for new remote versions of images\n"
-  text "  --force                           Uses 'docker rmi' and 'docker pull' to forcibly retrieve latest images\n"
+  text "  --skip:config                     Skip re-generation of config files placed into /instance\n"
   text "\n"
 }
 

--- a/dockerfiles/base/scripts/base/commands/cmd_restart.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_restart.sh
@@ -19,8 +19,10 @@ help_cmd_restart() {
   text "  --force                           Uses 'docker rmi' and 'docker pull' to forcibly retrieve latest images\n"
   text "  --no-force                        Updates images if matching tag not found in local cache\n"
   text "  --pull                            Uses 'docker pull' to check for new remote versions of images\n"
+  text "  --skip:config                     Skip re-generation of config files placed into /instance\n"
   text "  --skip:graceful                   Do not wait for confirmation that workspaces have stopped\n"
   text "  --skip:preflight                  Skip preflight checks\n"
+  text "  --skip:postflight                 Skip postflight checks\n"
   text "\n"
 }
 

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -19,12 +19,41 @@ help_cmd_start() {
   text "  --force                           Uses 'docker rmi' and 'docker pull' to forcibly retrieve latest images\n"
   text "  --no-force                        Updates images if matching tag not found in local cache\n"
   text "  --pull                            Uses 'docker pull' to check for new remote versions of images\n"
+  text "  --skip:config                     Skip re-generation of config files placed into /instance\n"
   text "  --skip:preflight                  Skip preflight checks\n"
+  text "  --skip:postflight                 Skip postflight checks\n"
   text "\n"  
 }
 
 pre_cmd_start() {
-  :
+  CHE_SKIP_CONFIG=false
+  CHE_SKIP_PREFLIGHT=false
+  CHE_SKIP_POSTFLIGHT=false
+  FORCE_UPDATE="--no-force"
+
+  while [ $# -gt 0 ]; do
+    case $1 in
+      --skip:config)
+        CHE_SKIP_CONFIG=true
+        shift ;;
+      --skip:preflight)
+        CHE_SKIP_PREFLIGHT=true
+        shift ;;
+      --skip:postflight)
+        CHE_SKIP_POSTFLIGHT=true
+        shift ;;
+      --force)
+        FORCE_UPDATE="--force"
+        shift ;;
+      --no-force)
+        FORCE_UPDATE="--no-force"
+        shift ;;
+      --pull)
+        FORCE_UPDATE="--pull"
+        shift ;;
+      *) error "Unknown parameter: $1" return 2 ;;
+    esac
+  done
 }
 
 post_cmd_start() {
@@ -40,12 +69,11 @@ cmd_start() {
     return 1
   fi
 
-  # To protect users from accidentally updating their ${CHE_FORMAL_PRODUCT_NAME} servers when they didn't mean
-  # to, which can happen if CHE_VERSION=latest
-  FORCE_UPDATE=${1:-"--no-force"}
   # Always regenerate puppet configuration from environment variable source, whether changed or not.
   # If the current directory is not configured with an .env file, it will initialize
-  cmd_lifecycle config $FORCE_UPDATE
+  if ! skip_config; then
+    cmd_lifecycle config $FORCE_UPDATE
+  fi
 
   # Preflight checks
   #   a) Check for open ports
@@ -254,4 +282,28 @@ check_containers_are_running() {
       fi
     done <<< "${CONTAINER_ID_MATCHING_SERVICE_NAMES}"
   done <<< "${LIST_OF_COMPOSE_CONTAINERS}"
+}
+
+skip_config() {
+  if [ "${CHE_SKIP_CONFIG}" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+skip_preflight() {
+  if [ "${CHE_SKIP_PREFLIGHT}" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+skip_postflight() {
+  if [ "${CHE_SKIP_POSTFLIGHT}" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -71,7 +71,9 @@ cmd_start() {
 
   # Always regenerate puppet configuration from environment variable source, whether changed or not.
   # If the current directory is not configured with an .env file, it will initialize
-  if ! skip_config; then
+  if skip_config; then
+    cmd_lifecycle config $FORCE_UPDATE --skip:config
+  else
     cmd_lifecycle config $FORCE_UPDATE
   fi
 

--- a/dockerfiles/base/scripts/base/startup_01_init.sh
+++ b/dockerfiles/base/scripts/base/startup_01_init.sh
@@ -73,8 +73,6 @@ init_global_vars() {
   FAST_BOOT=false
   CHE_DEBUG=false
   CHE_OFFLINE=false
-  CHE_SKIP_PREFLIGHT=false
-  CHE_SKIP_POSTFLIGHT=false
   CHE_SKIP_NIGHTLY=false
   CHE_SKIP_NETWORK=false
   CHE_SKIP_PULL=false
@@ -209,14 +207,6 @@ init_usage_check() {
     set -x
   fi
 
-  if [[ "$@" == *"--skip:preflight"* ]]; then
-    CHE_SKIP_PREFLIGHT=true
-  fi
-
-  if [[ "$@" == *"--skip:postflight"* ]]; then
-    CHE_SKIP_POSTFLIGHT=true
-  fi
-
   if [[ "$@" == *"--skip:nightly"* ]]; then
     CHE_SKIP_NIGHTLY=true
   fi
@@ -329,8 +319,6 @@ start() {
   set -- "${@/\-\-debug/}"
   set -- "${@/\-\-offline/}"
   set -- "${@/\-\-trace/}"
-  set -- "${@/\-\-skip\:preflight/}"
-  set -- "${@/\-\-skip\:postflight/}"
   set -- "${@/\-\-skip\:nightly/}"
   set -- "${@/\-\-skip\:network/}"
   set -- "${@/\-\-skip\:pull/}"

--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -171,22 +171,6 @@ is_trace() {
   fi
 }
 
-skip_preflight() {
-  if [ "${CHE_SKIP_PREFLIGHT}" = "true" ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-skip_postflight() {
-  if [ "${CHE_SKIP_POSTFLIGHT}" = "true" ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 skip_nightly() {
   if [ "${CHE_SKIP_NIGHTLY}" = "true" ]; then
     return 0


### PR DESCRIPTION
Signed-off-by: Tyler Jewell <tjewell@codenvy.com>
### What does this PR do?
In some cases, developers want to be able to modify the generated files placed into `/instance` and not have the CLI overwrite these changes during the start sequence. This change adds a `--skip:config` option to the `start` and `restart` commands to allow this.

Also moves the `--skip:preflight` and `--skip:postflight` detection out of the bootstrap sequence into the pre sequence for the `start()` command as these values are not global, but specific to only a few commands.

#### Changelog
[cli] Add `--skip:config` option to start, restart, and config commands

#### Release Notes
You can now skip the automatic generation of configuration files when starting Che. When Che starts, we use Puppet to generate OS-specific files for running the Che servers. For example, the file `/instance/docker-compose.yml` is generated from a puppet template with its internal values having different values based upon the parameters of the CLI or what you have set in `che.env`.  We update these files on every start, restart, or config command. This flag will skip this regeneration.

#### Docs PR
https://github.com/eclipse/che-docs/pull/160