### PR TITLE
CHE-4144: Recognize when nodejs is froze and stop process

### DIFF
--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/NodeJsDebugProcess.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/NodeJsDebugProcess.java
@@ -12,8 +12,8 @@ package org.eclipse.che.plugin.nodejsdbg.server;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.eclipse.che.commons.lang.IoUtil;
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.eclipse.che.plugin.nodejsdbg.server.exception.NodeJsDebuggerException;
 import org.eclipse.che.plugin.nodejsdbg.server.exception.NodeJsDebuggerTerminatedException;
 import org.slf4j.Logger;
@@ -21,9 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,8 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.Math.min;
-
 /**
  * Wrapper over NodeJs process is being run.
  * Communication is performed through standard input/output streams.
@@ -41,61 +37,57 @@ import static java.lang.Math.min;
  * @author Anatoliy Bazko
  */
 public class NodeJsDebugProcess implements NodeJsProcessObservable {
-    private static final Logger LOG        = LoggerFactory.getLogger(NodeJsDebugProcess.class);
-    private static final int    MAX_OUTPUT = 4096;
-
+    private static final Logger LOG            = LoggerFactory.getLogger(NodeJsDebugProcess.class);
     private static final String NODEJS_COMMAND = detectNodeJsCommand();
 
-    private final Process                  process;
-    private final String                   outputSeparator;
-    private final ScheduledExecutorService executor;
-    private final BufferedWriter           processWriter;
-
+    private final Process                     process;
+    private final String                      outputSeparator;
+    private final ScheduledExecutorService    executor;
+    private final BufferedWriter              processWriter;
     private final List<NodeJsProcessObserver> observers;
 
     private NodeJsDebugProcess(String outputSeparator, String... options) throws NodeJsDebuggerException {
         this.observers = new CopyOnWriteArrayList<>();
         this.outputSeparator = outputSeparator;
 
-        List<String> commands = new ArrayList<>(1 + options.length);
-        commands.add(NODEJS_COMMAND);
-        commands.addAll(Arrays.asList(options));
-
-        ProcessBuilder processBuilder = new ProcessBuilder(commands);
-        try {
-            process = processBuilder.start();
-        } catch (IOException e) {
-            throw new NodeJsDebuggerException("NodeJs process failed.", e);
-        }
-
+        process = initializeNodeJsDebugProcess(options);
         processWriter = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()));
 
-        executor = Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setNameFormat("nodejs-debugger-%d")
-                                                                                 .setUncaughtExceptionHandler(
-                                                                                         LoggingUncaughtExceptionHandler.getInstance())
-                                                                                 .setDaemon(true)
-                                                                                 .build());
-        executor.scheduleWithFixedDelay(new OutputReader(), 0, 100, TimeUnit.MILLISECONDS);
+        executor = Executors
+                .newScheduledThreadPool(1, new ThreadFactoryBuilder()
+                        .setNameFormat("nodejs-debugger-%d")
+                        .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+                        .setDaemon(true)
+                        .build());
+
+        OutputReader outputReader = new OutputReader(process, outputSeparator, this::notifyObservers);
+        executor.scheduleWithFixedDelay(outputReader, 0, 100, TimeUnit.MILLISECONDS);
     }
 
     public static NodeJsDebugProcess start(String file) throws NodeJsDebuggerException {
         return new NodeJsDebugProcess("debug> ", "debug", "--debug-brk", file);
     }
 
-    @Override
-    public void addObserver(NodeJsProcessObserver observer) {
-        observers.add(observer);
+    private Process initializeNodeJsDebugProcess(String[] options) throws NodeJsDebuggerException {
+        List<String> commands = new ArrayList<>(1 + options.length);
+        commands.add(NODEJS_COMMAND);
+        commands.addAll(Arrays.asList(options));
+
+        ProcessBuilder processBuilder = new ProcessBuilder(commands);
+        try {
+            return processBuilder.start();
+        } catch (IOException e) {
+            throw new NodeJsDebuggerException("NodeJs process initialization failed.", e);
+        }
     }
 
-    @Override
-    public void removeObserver(NodeJsProcessObserver observer) {
-        observers.remove(observer);
-    }
 
     /**
-     * Stops process.
+     * Stops nodejs process.
      */
-    void stop() {
+    public void stop() {
+        observers.clear();
+
         try {
             send("quit");
         } catch (NodeJsDebuggerException e) {
@@ -107,21 +99,24 @@ public class NodeJsDebugProcess implements NodeJsProcessObservable {
             if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
                 executor.shutdownNow();
                 if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
-                    LOG.warn("Unable to terminate main pool");
+                    LOG.warn("Unable to terminate main pool.");
                 }
             }
         } catch (InterruptedException e) {
-            LOG.warn(e.getMessage());
+            if (!executor.isShutdown()) {
+                LOG.warn("Unable to terminate main pool.");
+            }
         }
-
 
         process.destroy();
         try {
             if (!process.waitFor(10, TimeUnit.SECONDS)) {
-                LOG.error("Unable to terminate NodeJs");
+                LOG.error("Unable to terminate NodeJs.");
             }
         } catch (InterruptedException e) {
-            LOG.warn(e.getMessage());
+            if (!process.isAlive()) {
+                LOG.error("Unable to terminate NodeJs.");
+            }
         }
 
         try {
@@ -129,101 +124,22 @@ public class NodeJsDebugProcess implements NodeJsProcessObservable {
         } catch (IOException e) {
             LOG.warn("Failed to close NodeJs process output stream", e);
         }
-        observers.clear();
     }
 
+    /**
+     * Synchronizes sending commands.
+     */
     public synchronized void send(String command) throws NodeJsDebuggerException {
         LOG.debug("Execute: {}", command);
-
         if (!process.isAlive()) {
             throw new NodeJsDebuggerTerminatedException("NodeJs process is terminated.");
         }
-
         try {
             processWriter.write(command);
             processWriter.newLine();
             processWriter.flush();
         } catch (IOException e) {
-            LOG.error(String.format("Command execution <%s> failed", command), e);
-        }
-    }
-
-
-    /**
-     * Continuously reads process output and store in the {@code #outputs}.
-     */
-    private class OutputReader implements Runnable {
-        private final StringBuffer outputBuffer;
-
-        public OutputReader() {
-            this.outputBuffer = new StringBuffer();
-        }
-
-        @Override
-        public void run() {
-            try {
-                InputStream in = getInput();
-                if (in != null) {
-                    String outputData = read(in);
-                    if (!outputData.isEmpty()) {
-                        outputBuffer.append(outputData);
-                        if (outputBuffer.length() > MAX_OUTPUT) {
-                            outputBuffer.delete(0, outputBuffer.length() - MAX_OUTPUT);
-                        }
-
-                        extractOutputs();
-                    }
-                }
-            } catch (IOException e) {
-                LOG.error(e.getMessage(), e);
-            }
-        }
-
-        private InputStream getInput() throws IOException {
-            return hasError() ? process.getErrorStream()
-                              : (hasInput() ? (hasError() ? process.getErrorStream()
-                                                          : process.getInputStream())
-                                            : null);
-        }
-
-        private void extractOutputs() {
-            int indexOf;
-            while ((indexOf = outputBuffer.indexOf(outputSeparator)) >= 0) {
-                NodeJsOutput nodeJsOutput = NodeJsOutput.of(outputBuffer.substring(0, indexOf));
-                outputBuffer.delete(0, indexOf + outputSeparator.length());
-
-                notifyObservers(nodeJsOutput);
-            }
-        }
-
-        private boolean hasError() throws IOException {
-            return process.getErrorStream().available() != 0;
-        }
-
-        private boolean hasInput() throws IOException {
-            return process.getInputStream().available() != 0;
-        }
-
-        private String read(InputStream in) throws IOException {
-            int available = min(in.available(), MAX_OUTPUT);
-            byte[] buf = new byte[available];
-            int read = in.read(buf, 0, available);
-
-            return new String(buf, 0, read, StandardCharsets.UTF_8);
-        }
-    }
-
-    private void notifyObservers(NodeJsOutput nodeJsOutput) {
-        LOG.debug("{}{}", outputSeparator, nodeJsOutput.getOutput());
-
-        for (NodeJsProcessObserver observer : observers) {
-            try {
-                if (observer.onOutputProduced(nodeJsOutput)) {
-                    break;
-                }
-            } catch (NodeJsDebuggerException e) {
-                LOG.error(e.getMessage(), e);
-            }
+            throw new NodeJsDebuggerException(e.getMessage(), e);
         }
     }
 
@@ -246,6 +162,44 @@ public class NodeJsDebugProcess implements NodeJsProcessObservable {
         } catch (IOException | InterruptedException e) {
             throw new IllegalStateException("NodeJs not found", e);
         }
+    }
+
+    private void notifyObservers(NodeJsOutput nodeJsOutput) {
+        LOG.debug("{}{}", outputSeparator, nodeJsOutput.getOutput());
+
+        if (OutputReader.CONNECTIVITY_TEST_NEEDED_MSG.equals(nodeJsOutput.getOutput())) {
+            testConnectivity();
+            return;
+        }
+
+        for (NodeJsProcessObserver observer : observers) {
+            try {
+                if (observer.onOutputProduced(nodeJsOutput)) {
+                    break;
+                }
+            } catch (NodeJsDebuggerException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    private void testConnectivity() {
+        try {
+            send("version");
+        } catch (NodeJsDebuggerException ignored) {
+            // ignore
+        }
+    }
+
+
+    @Override
+    public void addObserver(NodeJsProcessObserver observer) {
+        observers.add(observer);
+    }
+
+    @Override
+    public void removeObserver(NodeJsProcessObserver observer) {
+        observers.remove(observer);
     }
 
 }

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/NodeJsDebugger.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/NodeJsDebugger.java
@@ -43,6 +43,8 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
+import static org.eclipse.che.plugin.nodejsdbg.server.OutputReader.DEBUG_TIMED_OUT_MSG;
+
 /**
  * Server side NodeJs debugger.
  *
@@ -283,7 +285,7 @@ public class NodeJsDebugger implements Debugger, NodeJsProcessObserver {
             SuspendEventImpl suspendEvent = new SuspendEventImpl(NodeJsBackTraceParser.INSTANCE.parse(nodeJsOutput));
             debuggerCallback.onEvent(suspendEvent);
 
-        } else if (nodeJsOutput.getOutput().equals(OutputReader.DEBUG_TIMED_OUT_MSG)) {
+        } else if (DEBUG_TIMED_OUT_MSG.equals(nodeJsOutput.getOutput())) {
             disconnect();
 
         } else {

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/OutputReader.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/OutputReader.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.nodejsdbg.server;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Continuously reads process output and store in the {@code #outputs}.
+ */
+public class OutputReader implements Runnable {
+    public static final String CONNECTIVITY_TEST_NEEDED_MSG = "_CONNECTIVITY_TEST_NEEDED_";
+    public static final String DEBUG_TIMED_OUT_MSG          = "_DEBUG_TIMED_OUT_";
+    public static final int    CONNECTIVITY_TEST_NEEDED     = 10;
+    public static final int    DEBUG_TIMED_OUT              = 20;
+
+    private static final Logger LOG        = LoggerFactory.getLogger(OutputReader.class);
+    private static final int    MAX_OUTPUT = 4096;
+
+    private final StringBuffer    outputBuffer;
+    private final Process         process;
+    private final String          outputSeparator;
+    private final ProcessCallback callback;
+
+    private int noResponseTimes;
+
+    public OutputReader(Process process, String outputSeparator, ProcessCallback callback) {
+        this.process = process;
+        this.outputBuffer = new StringBuffer();
+        this.outputSeparator = outputSeparator;
+        this.callback = callback;
+    }
+
+    @Override
+    public void run() {
+        try {
+            InputStream in = getInputStream();
+            if (in != null) {
+                noResponseTimes = 0;
+                proceedResponse(in);
+            } else {
+                noResponseTimes++;
+                checkConnectivityState();
+            }
+        } catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    private void proceedResponse(InputStream in) throws IOException {
+        String outputData = read(in);
+        if (!outputData.isEmpty()) {
+            outputBuffer.append(outputData);
+            if (outputBuffer.length() > MAX_OUTPUT) {
+                outputBuffer.delete(0, outputBuffer.length() - MAX_OUTPUT);
+            }
+            extractOutputs();
+        }
+    }
+
+    private String read(InputStream in) throws IOException {
+        int available = Math.min(in.available(), MAX_OUTPUT);
+        byte[] buf = new byte[available];
+        int read = in.read(buf, 0, available);
+
+        return new String(buf, 0, read, StandardCharsets.UTF_8);
+    }
+
+
+    private InputStream getInputStream() throws IOException {
+        return hasError() ? process.getErrorStream()
+                          : (hasInput() ? (hasError() ? process.getErrorStream() : process.getInputStream())
+                                        : null);
+    }
+
+    private void extractOutputs() {
+        int indexOf;
+        while ((indexOf = outputBuffer.indexOf(outputSeparator)) >= 0) {
+            NodeJsOutput nodeJsOutput = NodeJsOutput.of(outputBuffer.substring(0, indexOf));
+            outputBuffer.delete(0, indexOf + outputSeparator.length());
+
+            callback.onOutputProduced(nodeJsOutput);
+        }
+    }
+
+    private boolean hasError() throws IOException {
+        return process.getErrorStream().available() != 0;
+    }
+
+    private boolean hasInput() throws IOException {
+        return process.getInputStream().available() != 0;
+    }
+
+
+    private void checkConnectivityState() {
+        if (noResponseTimes == CONNECTIVITY_TEST_NEEDED) {
+            callback.onOutputProduced(NodeJsOutput.of(CONNECTIVITY_TEST_NEEDED_MSG));
+        } else if (noResponseTimes == DEBUG_TIMED_OUT) {
+            callback.onOutputProduced(NodeJsOutput.of(DEBUG_TIMED_OUT_MSG));
+        }
+    }
+
+    public interface ProcessCallback {
+        void onOutputProduced(NodeJsOutput nodeJsOutput);
+    }
+}

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/OutputReader.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/OutputReader.java
@@ -19,6 +19,8 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Continuously reads process output and store in the {@code #outputs}.
+ *
+ * @author Anatolii Bazko
  */
 public class OutputReader implements Runnable {
     public static final String CONNECTIVITY_TEST_NEEDED_MSG = "_CONNECTIVITY_TEST_NEEDED_";

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/command/NodeJsDebugCommandsLibrary.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/command/NodeJsDebugCommandsLibrary.java
@@ -24,7 +24,6 @@ import org.eclipse.che.plugin.nodejsdbg.server.parser.NodeJsOutputParser;
 import org.eclipse.che.plugin.nodejsdbg.server.parser.NodeJsOutputParser.NodeJsOutputRegExpParser;
 import org.eclipse.che.plugin.nodejsdbg.server.parser.NodeJsScriptsParser;
 import org.eclipse.che.plugin.nodejsdbg.server.parser.NodeJsScriptsParser.Scripts;
-import org.eclipse.che.plugin.nodejsdbg.server.parser.NodeJsStepParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,9 +65,9 @@ public class NodeJsDebugCommandsLibrary {
     /**
      * Execute {@code bt} command.
      */
-    public Location backtrace() throws NodeJsDebuggerException {
-        NodeJsDebugCommand<Location> nextCommand = createCommand("bt", NodeJsBackTraceParser.INSTANCE);
-        return doExecute(nextCommand);
+    public Void backtrace() throws NodeJsDebuggerException {
+        doExecute(createCommand("bt", NodeJsOutputParser.VOID));
+        return null;
     }
 
     /**
@@ -99,7 +98,7 @@ public class NodeJsDebugCommandsLibrary {
             String newTarget;
             String[] target = location.getTarget().split(":");
             if (target.length != 2) {
-                LOG.error(format("Illegal breakpoint location format %s", target));
+                LOG.error(format("Illegal breakpoint location format %s", target[0]));
                 continue;
             }
 
@@ -139,33 +138,33 @@ public class NodeJsDebugCommandsLibrary {
     /**
      * Execute {@code next} command.
      */
-    public Location next() throws NodeJsDebuggerException {
-        NodeJsDebugCommand<Location> nextCommand = createCommand("next", NodeJsStepParser.INSTANCE);
-        return doExecute(nextCommand);
+    public Void next() throws NodeJsDebuggerException {
+        doExecute(createCommand("next", NodeJsOutputParser.VOID));
+        return null;
     }
 
     /**
      * Execute {@code cont} command.
      */
-    public Location cont() throws NodeJsDebuggerException {
-        NodeJsDebugCommand<Location> nextCommand = createCommand("cont", NodeJsStepParser.INSTANCE);
-        return doExecute(nextCommand);
+    public Void cont() throws NodeJsDebuggerException {
+        doExecute(createCommand("cont", NodeJsOutputParser.VOID));
+        return null;
     }
 
     /**
      * Execute {@code step in} command.
      */
-    public Location stepIn() throws NodeJsDebuggerException {
-        NodeJsDebugCommand<Location> nextCommand = createCommand("step", NodeJsStepParser.INSTANCE);
-        return doExecute(nextCommand);
+    public Void stepIn() throws NodeJsDebuggerException {
+        doExecute(createCommand("step", NodeJsOutputParser.VOID));
+        return null;
     }
 
     /**
      * Execute {@code step out} command.
      */
-    public Location stepOut() throws NodeJsDebuggerException {
-        NodeJsDebugCommand<Location> nextCommand = createCommand("out", NodeJsStepParser.INSTANCE);
-        return doExecute(nextCommand);
+    public Void stepOut() throws NodeJsDebuggerException {
+        doExecute(createCommand("out", NodeJsOutputParser.VOID));
+        return null;
     }
 
     /**
@@ -243,6 +242,12 @@ public class NodeJsDebugCommandsLibrary {
         return doExecute(command);
     }
 
+    /**
+     * Executes {@link NodeJsDebugCommand} and waits result.
+     *
+     * @throws NodeJsDebuggerException
+     *      if execution failed
+     */
     private <V> V doExecute(NodeJsDebugCommand<V> command) throws NodeJsDebuggerException {
         process.addObserver(command);
         try {

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/parser/NodeJsOutputParser.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/main/java/org/eclipse/che/plugin/nodejsdbg/server/parser/NodeJsOutputParser.java
@@ -12,6 +12,8 @@ package org.eclipse.che.plugin.nodejsdbg.server.parser;
 
 import org.eclipse.che.plugin.nodejsdbg.server.NodeJsOutput;
 import org.eclipse.che.plugin.nodejsdbg.server.exception.NodeJsDebuggerParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.regex.Pattern;
 
@@ -61,6 +63,7 @@ public interface NodeJsOutputParser<T> {
     };
 
     class NodeJsOutputRegExpParser implements NodeJsOutputParser<String> {
+        private static final Logger LOG = LoggerFactory.getLogger(NodeJsOutputRegExpParser.class);
         private final Pattern pattern;
 
         public NodeJsOutputRegExpParser(Pattern pattern) {
@@ -74,6 +77,7 @@ public interface NodeJsOutputParser<T> {
 
         @Override
         public String parse(NodeJsOutput nodeJsOutput) throws NodeJsDebuggerParseException {
+            LOG.debug("{} parse {}", pattern.pattern(), nodeJsOutput.getOutput());
             return nodeJsOutput.getOutput();
         }
     }

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/test/resources/logback-test.xml
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/src/test/resources/logback-test.xml
@@ -18,7 +18,7 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>
 


### PR DESCRIPTION
**Problem**
NodeJs has problem with debugging arbitrary applications.  When application is finished nodejs console is froze.

**Solution**
Continuously execute some command to check if nodejs proceed output.
If no more output after some period of time then debugger will be ended.

### What does this PR do?
Recognize when application is finished and ends debugger.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4144

#### Changelog
Fix situations where node.js debugger doesn't stop and can become frozen.

#### Release Notes
Not required

#### Docs PR
Not required