### PR TITLE
Boolean server property to enable or disable auto start of a workspac…

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -40,6 +40,9 @@ che.workspace.auto_snapshot=true
 # Otherwise create a new workspace.
 che.workspace.auto_restore=true
 
+# By default, when users access to a workspace with its URL the workspace
+# automatically starts if it is stopped. You can set this to false to disable this.
+che.workspace.auto_start=true
 
 # Workspace threads pool configuration, this pool is used for workspace related
 # operations that require asynchronous execution e.g. starting/stopping/snapshotting

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -262,6 +262,11 @@
 #CHE_WORKSPACE_AUTO__SNAPSHOT=false
 #CHE_WORKSPACE_AUTO__RESTORE=false
 
+#    By default, if a user accesses a workspace from its unique URL (instead of the
+#    dashboard interface), then the workspace is automatically started by Che.
+#    You can set this property to false to disable this behavior.
+#CHE_WORKSPACE_AUTO__START=true
+
 # Private Docker Images
 #     If pushing snap images to a registry requires authenticated access to the
 #     registry. Or, if your stacks reference private images which require authenticated

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.WsAgentHealthStateDto;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * GWT Client for Workspace Service.
@@ -293,5 +294,11 @@ public interface WorkspaceServiceClient {
      * @see WorkspaceService#checkAgentHealth(String)
      */
     Promise<WsAgentHealthStateDto> getWsAgentState(String workspaceId);
+
+    /**
+     * Get workspace related server configuration values defined in che.properties
+     * @see WorkspaceService#getSettings()
+     */
+    Promise<Map<String, String>> getSettings();
 
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -18,6 +18,8 @@ import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
+import org.eclipse.che.api.promises.client.Function;
+import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.PromiseError;
@@ -49,10 +51,13 @@ import org.eclipse.che.ide.workspace.create.CreateWorkspacePresenter;
 import org.eclipse.che.ide.workspace.start.StartWorkspacePresenter;
 
 import java.util.List;
+import java.util.Map;
 
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.ui.loaders.LoaderPresenter.Phase.CREATING_WORKSPACE_SNAPSHOT;
 import static org.eclipse.che.ide.ui.loaders.LoaderPresenter.Phase.STARTING_WORKSPACE_RUNTIME;
+import static org.eclipse.che.ide.ui.loaders.LoaderPresenter.Phase.WORKSPACE_STOPPED;
 
 /**
  * @author Evgen Vidolob
@@ -207,11 +212,23 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
                         });
                         break;
                     default:
-                        if (checkForShapshots) {
-                            checkWorkspaceForSnapshots(workspace);
-                        } else {
-                            startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(), restoreFromSnapshot);
-                        }
+                        workspaceServiceClient.getSettings() //
+                                              .then(new Function<Map<String, String>, Map<String, String>>() {
+                                                  @Override
+                                                  public Map<String, String> apply(Map<String, String> settings) throws FunctionException {
+                                                      if (Boolean.parseBoolean(settings.get(CHE_WORKSPACE_AUTO_START))) {
+                                                          if (checkForShapshots) {
+                                                              checkWorkspaceForSnapshots(workspace);
+                                                          } else {
+                                                              startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(),
+                                                                                 restoreFromSnapshot);
+                                                          }
+                                                      } else {
+                                                          loader.show(WORKSPACE_STOPPED);
+                                                      }
+                                                      return settings;
+                                                  }
+                                              });
                 }
             }
         });

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -216,7 +216,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
                                               .then(new Function<Map<String, String>, Map<String, String>>() {
                                                   @Override
                                                   public Map<String, String> apply(Map<String, String> settings) throws FunctionException {
-                                                      if (Boolean.parseBoolean(settings.get(CHE_WORKSPACE_AUTO_START))) {
+                                                      if (Boolean.parseBoolean(settings.getOrDefault(CHE_WORKSPACE_AUTO_START, "true"))) {
                                                           if (checkForShapshots) {
                                                               checkWorkspaceForSnapshots(workspace);
                                                           } else {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClientImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClientImpl.java
@@ -28,11 +28,13 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.workspace.WorkspaceServiceClient;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
+import org.eclipse.che.ide.rest.StringMapUnmarshaller;
 import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Map;
 
 import static com.google.gwt.http.client.RequestBuilder.PUT;
 import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
@@ -266,5 +268,13 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
         return asyncRequestFactory.createGetRequest(baseHttpUrl + '/' + workspaceId + "/check")
                                   .header(ACCEPT, APPLICATION_JSON)
                                   .send(dtoUnmarshallerFactory.newUnmarshaller(WsAgentHealthStateDto.class));
+    }
+
+    @Override
+    public Promise<Map<String, String>> getSettings() {
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + "/settings") //
+                                  .header(ACCEPT, APPLICATION_JSON) //
+                                  .header(CONTENT_TYPE, APPLICATION_JSON) //
+                                  .send(new StringMapUnmarshaller());
     }
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -48,6 +48,9 @@ public final class Constants {
 
     public static final String WS_AGENT_PROCESS_NAME          = "CheWsAgent";
 
+    public static final String CHE_WORKSPACE_AUTO_SNAPSHOT           = "che.workspace.auto_snapshot";
+    public static final String CHE_WORKSPACE_AUTO_RESTORE            = "che.workspace.auto_restore";
+    public static final String CHE_WORKSPACE_AUTO_START              = "che.workspace.auto_start";
 
     private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -70,6 +70,9 @@ import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_RESTORE;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_SNAPSHOT;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_CREATE_WORKSPACE;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_GET_BY_NAMESPACE;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_GET_WORKSPACES;
@@ -84,8 +87,6 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 @Api(value = "/workspace", description = "Workspace REST API")
 @Path("/workspace")
 public class WorkspaceService extends Service {
-    private static final String CHE_WORKSPACE_AUTO_SNAPSHOT= "che.workspace.auto_snapshot";
-    private static final String CHE_WORKSPACE_AUTO_RESTORE= "che.workspace.auto_restore";
 
     private final WorkspaceManager              workspaceManager;
     private final WorkspaceValidator            validator;
@@ -94,6 +95,7 @@ public class WorkspaceService extends Service {
     private final String                        apiEndpoint;
     private final boolean                       cheWorkspaceAutoSnapshot;
     private final boolean                       cheWorkspaceAutoRestore;
+    private final boolean                       cheWorkspaceAutoStart;
     @Context
     private SecurityContext securityContext;
 
@@ -104,7 +106,8 @@ public class WorkspaceService extends Service {
                             WsAgentHealthChecker agentHealthChecker,
                             WorkspaceServiceLinksInjector workspaceServiceLinksInjector,
                             @Named(CHE_WORKSPACE_AUTO_SNAPSHOT) boolean cheWorkspaceAutoSnapshot,
-                            @Named(CHE_WORKSPACE_AUTO_RESTORE) boolean cheWorkspaceAutoRestore) {
+                            @Named(CHE_WORKSPACE_AUTO_RESTORE) boolean cheWorkspaceAutoRestore,
+                            @Named(CHE_WORKSPACE_AUTO_START) boolean cheWorkspaceAutoStart) {
         this.apiEndpoint = apiEndpoint;
         this.workspaceManager = workspaceManager;
         this.validator = validator;
@@ -112,6 +115,7 @@ public class WorkspaceService extends Service {
         this.linksInjector = workspaceServiceLinksInjector;
         this.cheWorkspaceAutoSnapshot = cheWorkspaceAutoSnapshot;
         this.cheWorkspaceAutoRestore = cheWorkspaceAutoRestore;
+        this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
     }
 
     @POST
@@ -719,8 +723,9 @@ public class WorkspaceService extends Service {
     @ApiOperation(value = "Get workspace server configuration values")
     @ApiResponses({@ApiResponse(code = 200, message = "The response contains server settings")})
     public Map<String, String> getSettings() {
-        return ImmutableMap.of(CHE_WORKSPACE_AUTO_SNAPSHOT, Boolean.toString(cheWorkspaceAutoSnapshot),
-                               CHE_WORKSPACE_AUTO_RESTORE, Boolean.toString(cheWorkspaceAutoRestore));
+        return ImmutableMap.of(CHE_WORKSPACE_AUTO_SNAPSHOT, Boolean.toString(cheWorkspaceAutoSnapshot), //
+                               CHE_WORKSPACE_AUTO_RESTORE, Boolean.toString(cheWorkspaceAutoRestore), //
+                               CHE_WORKSPACE_AUTO_START, Boolean.toString(cheWorkspaceAutoStart));
     }
 
     private static Map<String, String> parseAttrs(List<String> attributes) throws BadRequestException {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -153,7 +153,8 @@ public class WorkspaceServiceTest {
                                        wsAgentHealthChecker,
                                        new WorkspaceServiceLinksInjector(new MachineServiceLinksInjector()),
                                        true,
-                                       false);
+                                       false,
+                                       true);
     }
 
     @Test
@@ -988,8 +989,9 @@ public class WorkspaceServiceTest {
         assertEquals(response.getStatusCode(), 200);
         final Map<String, String> settings = new Gson().fromJson(response.print(),
                                                                  new TypeToken<Map<String, String>>() {}.getType());
-        assertEquals(settings, ImmutableMap.of("che.workspace.auto_snapshot", "true",
-                                               "che.workspace.auto_restore", "false"));
+        assertEquals(settings, ImmutableMap.of("che.workspace.auto_snapshot", "true", //
+                                               "che.workspace.auto_restore", "false", //
+                                               "che.workspace.auto_start", "true"));
     }
 
     private static String unwrapError(Response response) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adding a boolean server property to enable or disable auto start of a workspace when accessing to it through its url
The property could be set with
- `che.workspace.auto_start=true` or `che.workspace.auto_start=false` in che.properties
- `CHE_WORKSPACE_AUTO__START=true` or `CHE_WORKSPACE_AUTO__START=false` in che.env

The default value true doesn't change the current behavior: accessing to the workspace through its URL will start it ( if stopped)
 
### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-116

#### Changelog
<!-- one line entry to be added to changelog -->
Add `che.workspace.auto_start=<bool>` property to set whether URL acceptance auto-starts a workspace 

#### Release Notes
N/A

#### Docs PR
N/A