### PR TITLE
fix env property name

### DIFF
--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -114,7 +114,7 @@
 #     The length of time that a workspace will be allowed to boot before the system terminates the
 #     boot process. If the Che container cannot establish two way communications with the
 #     agents within the workspace when it boots, then the workspace will not be started.
-#CHE_MACHINE_WS_AGENT_MAX_START_TIME_MS=300000
+#CHE_WORKSPACE_AGENT_DEV_MAX__START__TIME__MS=300000
 
 # Workspace Agent Java Options
 #   Java command line options to be added to JVM's that run agents within workspaces.


### PR DESCRIPTION
env var should reflect actual propery name which is: https://github.com/eclipse/che/blob/fix_property/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties#L105

### What does this PR do?
fixes ENV property name

#### Changelog
fix env property name
