### PR TITLE
CHE-4025: Explicitly set protocol for ssh agent

### DIFF
--- a/agents/ssh/src/main/resources/org.eclipse.che.ssh.json
+++ b/agents/ssh/src/main/resources/org.eclipse.che.ssh.json
@@ -6,7 +6,8 @@
   "properties": {},
   "servers": {
     "ssh": {
-      "port": "22/tcp"
+      "port": "22/tcp",
+      "protocol" : "ssh"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Set `ssh` protocol for ssh agent

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4025

#### Changelog
Adds `ssh` protocol into configuration of the ssh agent.

#### Release Notes
Not required

#### Docs PR
Not required