### PR TITLE
[OpenShift Integration] Implement createExec() and startExec() in OpenShiftConnector

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/Exec.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/Exec.java
@@ -20,7 +20,7 @@ public class Exec {
     private final String[] command;
     private final String   id;
 
-    Exec(String[] command, String id) {
+    public Exec(String[] command, String id) {
         this.command = command;
         this.id = id;
     }

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-docker-client</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesExecHolder.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesExecHolder.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client.kubernetes;
+
+import java.util.Arrays;
+
+import org.eclipse.che.plugin.openshift.client.OpenShiftConnector;
+
+/**
+ * Holder class for metadata about an exec, to be used with {@link OpenShiftConnector}.
+ *
+ * <p> In OpenShift, {@code createExec()} is not separate from {@code startExec()},
+ * so this class has to be used to pass data between {@code createExec()} and
+ * {@code startExec()} calls.
+ *
+ * @see OpenShiftConnector#createExec(org.eclipse.che.plugin.docker.client.params.CreateExecParams)
+ * @see OpenShiftConnector#startExec(org.eclipse.che.plugin.docker.client.params.StartExecParams, org.eclipse.che.plugin.docker.client.MessageProcessor)
+ */
+public class KubernetesExecHolder {
+
+    private String[] command;
+    private String podName;
+
+    public KubernetesExecHolder withCommand(String[] command) {
+        this.command = command;
+        return this;
+    }
+
+    public KubernetesExecHolder withPod(String podName) {
+        this.podName = podName;
+        return this;
+    }
+
+    public String[] getCommand() {
+        return command;
+    }
+
+    public String getPod() {
+        return podName;
+    }
+
+    public String toString() {
+        return String.format("KubernetesExecHolder {command=%s, podName=%s}",
+                             Arrays.asList(command).toString(),
+                             podName);
+    }
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesOutputAdapter.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesOutputAdapter.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client.kubernetes;
+
+import io.fabric8.kubernetes.client.Callback;
+import io.fabric8.kubernetes.client.utils.InputStreamPumper;
+
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.plugin.docker.client.LogMessage;
+import org.eclipse.che.plugin.docker.client.MessageProcessor;
+
+/**
+ * Adapter class for passing data from a {@code kubernetes-client} output stream (e.g.
+ * for an exec call) to {@link MessageProcessor}. This class should be passed to a
+ * {@link InputStreamPumper} along with the output of the exec call.
+ *
+ * <p> Output passed in via the {@link #call(byte[])} method is parsed into lines,
+ * (respecting {@code '\n'} and {@code CRLF} as line separators), and
+ * passed to the {@link MessageProcessor} as {@link LogMessage}s.
+ */
+public class KubernetesOutputAdapter implements Callback<byte[]> {
+
+    private LogMessage.Type type;
+    private MessageProcessor<LogMessage> execOutputProcessor;
+    private StringBuilder lineBuffer;
+
+    /**
+     * Create a new KubernetesOutputAdapter
+     *
+     * @param type
+     *         the type of LogMessages being passed to the MessageProcessor
+     * @param processor
+     *         the processor receiving LogMessages. If null, calling {@link #call(byte[])}
+     *         will return immediately.
+     */
+    public KubernetesOutputAdapter(LogMessage.Type type,
+                                   @Nullable MessageProcessor<LogMessage> processor) {
+        this.type = type;
+        this.execOutputProcessor = processor;
+        this.lineBuffer = new StringBuilder();
+    }
+
+    @Override
+    public void call(byte[] data) {
+        if (data == null || data.length == 0 || execOutputProcessor == null) {
+            return;
+        }
+        int start = 0;
+        int offset = 0;
+
+        for (int pos = 0; pos < data.length; pos++) {
+            if (data[pos] == '\n' || data[pos] == '\r') {
+                offset = pos - start;
+                String line = new String(data, start, offset);
+                lineBuffer.append(line);
+                execOutputProcessor.process(new LogMessage(type, lineBuffer.toString()));
+                lineBuffer.setLength(0);
+                if (data[pos] == '\r') {
+                    pos += 1;
+                }
+                start = pos + 1;
+            }
+        }
+        String trailingChars = new String(data, start, data.length - start);
+        lineBuffer.append(trailingChars);
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Add implementations of `createExec()` and `startExec()`. Since OpenShift does not separate the create and start steps, a holder class `KubernetesExecHolder` is necessary, to pass information between the call to `createExec()` (which just saves relevant information) and `startExec()`.

Additionally, adds KubernetesOutputAdapter, which parses the output from OpenShift into `LogMessages` that can be handled by Che's `MessageProcessor<LogMessage>` class.

Depends on che-dependencies PR [#32](https://github.com/eclipse/che-dependencies/pull/32), which includes a necessary update to kubernetes-client.

This PR is a necessary component for running Che on OpenShift without depending on docker.sock.

### Changelog
- Add support for exec operations when running Che on OpenShift.

Note: Release notes and docs PR are not ready, as OpenShift integration development is still active and documentation is changing. Documentation will be provided when finalised and `openshift-connector` branch is ready for merge. 