### PR TITLE
Remove gwt-test-util redundant dependency

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/pom.xml
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/pom.xml
@@ -97,11 +97,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.gwt-test-utils</groupId>
-            <artifactId>gwt-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/pom.xml
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/pom.xml
@@ -94,11 +94,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.gwt-test-utils</groupId>
-            <artifactId>gwt-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/pom.xml
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/pom.xml
@@ -94,11 +94,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.gwt-test-utils</groupId>
-            <artifactId>gwt-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/pom.xml
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/pom.xml
@@ -99,11 +99,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.gwt-test-utils</groupId>
-            <artifactId>gwt-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/plugins/plugin-zend-debugger/che-plugin-zend-debugger-ide/pom.xml
+++ b/plugins/plugin-zend-debugger/che-plugin-zend-debugger-ide/pom.xml
@@ -71,11 +71,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.gwt-test-utils</groupId>
-            <artifactId>gwt-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### What does this PR do?
Removes gwt-test-util redundant dependency

#### Changelog
Removes gwt-test-util redundant dependency

#### Release Notes
No required


#### Docs PR
No required