### PR TITLE
Don't create a snapshot if agent lost connection

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
@@ -139,6 +139,17 @@ public interface WorkspaceServiceClient {
     Promise<Void> stop(String wsId);
 
     /**
+     * Stops currently run runtime with ability to create snapshot.
+     *
+     * @param wsId
+     *         workspace ID
+     * @param createSnapshot
+     *         create snapshot during the stop operation
+     * @return a promise that will resolve when the workspace has been stopped, or rejects with an error
+     */
+    Promise<Void> stop(String wsId, boolean createSnapshot);
+
+    /**
      * Get all commands from the specified workspace.
      *
      * @param wsId

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClientImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClientImpl.java
@@ -17,7 +17,6 @@ import org.eclipse.che.api.machine.shared.dto.CommandDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 import org.eclipse.che.api.promises.client.Function;
-import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
@@ -37,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.Map;
 
 import static com.google.gwt.http.client.RequestBuilder.PUT;
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
 import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
 import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
@@ -101,17 +101,12 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
 
     @Override
     public Promise<List<WorkspaceDto>> getWorkspaces(final int skip, final int limit) {
-        return fetchWorkspaces().then(new Function<List<WorkspaceDto>, List<WorkspaceDto>>() {
-            @Override
-            public List<WorkspaceDto> apply(List<WorkspaceDto> arg) throws FunctionException {
-                return arg.stream().collect(Collectors.toList());
-            }
-        });
+        return fetchWorkspaces().then((Function<List<WorkspaceDto>, List<WorkspaceDto>>)workspaceDtoList ->
+                workspaceDtoList.stream().collect(toList()));
     }
 
     private Promise<List<WorkspaceDto>> fetchWorkspaces() {
-        final String url = baseHttpUrl;
-        return asyncRequestFactory.createGetRequest(url)
+        return asyncRequestFactory.createGetRequest(baseHttpUrl)
                                   .header(ACCEPT, APPLICATION_JSON)
                                   .loader(loaderFactory.newLoader("Getting info about workspaces..."))
                                   .send(dtoUnmarshallerFactory.newListUnmarshaller(WorkspaceDto.class));
@@ -163,13 +158,17 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
     }
 
     @Override
+    public Promise<Void> stop(String wsId, boolean createSnapshot) {
+        final String url = baseHttpUrl + "/" + wsId + "/runtime?create-snapshot=" + createSnapshot;
+
+        return asyncRequestFactory.createDeleteRequest(url)
+                                  .loader(loaderFactory.newLoader("Stopping workspace..."))
+                                  .send();
+    }
+
+    @Override
     public Promise<List<CommandDto>> getCommands(String wsId) {
-        return getWorkspace(wsId).then(new Function<WorkspaceDto, List<CommandDto>>() {
-            @Override
-            public List<CommandDto> apply(WorkspaceDto arg) throws FunctionException {
-                return arg.getConfig().getCommands();
-            }
-        });
+        return getWorkspace(wsId).then((Function<WorkspaceDto, List<CommandDto>>)workspaceDto -> workspaceDto.getConfig().getCommands());
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Disable creating a snapshot in case if workspace agent lost connection.
When workspace agent loses connection, we currently allow user to reload entire page to allow Che to restore web socket connections. Sometimes, during the restart Che could create a snapshot for a while. So this PR propose to disable snapshot creating and instant instance reloading. 

### What issues does this PR fix or reference?
#3805 

#### Changelog
Disable creating a snapshot in case if workspace agent lost connection.

#### Release Notes
Disable creating a snapshot in case if workspace agent lost connection.

#### Docs PR
N/A
