### PR TITLE
[cli] - Add check for exec on file system

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -16,6 +16,7 @@ help_cmd_start() {
   text "Starts ${CHE_MINI_PRODUCT_NAME} and verifies its operation\n"
   text "\n"
   text "PARAMETERS:\n"
+  text "  --follow                          Displays server logs to console and blocks until user interrupts\n"
   text "  --force                           Uses 'docker rmi' and 'docker pull' to forcibly retrieve latest images\n"
   text "  --no-force                        Updates images if matching tag not found in local cache\n"
   text "  --pull                            Uses 'docker pull' to check for new remote versions of images\n"
@@ -29,6 +30,7 @@ pre_cmd_start() {
   CHE_SKIP_CONFIG=false
   CHE_SKIP_PREFLIGHT=false
   CHE_SKIP_POSTFLIGHT=false
+  CHE_FOLLOW_LOGS=false
   FORCE_UPDATE="--no-force"
 
   while [ $# -gt 0 ]; do
@@ -41,6 +43,9 @@ pre_cmd_start() {
         shift ;;
       --skip:postflight)
         CHE_SKIP_POSTFLIGHT=true
+        shift ;;
+      --follow)
+        CHE_FOLLOW_LOGS=true
         shift ;;
       --force)
         FORCE_UPDATE="--force"
@@ -226,8 +231,14 @@ wait_until_booted() {
 
   # CHE-3546 - if in development mode, then display the che server logs to STDOUT
   #            automatically kill the streaming of the log output when the server is booted
-  if debug_server; then
-    docker logs -f ${CHE_CONTAINER_NAME} &
+  if debug_server || follow_logs; then
+    DOCKER_LOGS_COMMAND="docker logs -f ${CHE_CONTAINER_NAME}"
+
+    if debug_server; then 
+      DOCKER_LOGS_COMMAND+=" &"
+    fi
+
+    eval $DOCKER_LOGS_COMMAND
     LOG_PID=$!
   else
     info "start" "Server logs at \"docker logs -f ${CHE_CONTAINER_NAME}\""
@@ -304,6 +315,14 @@ skip_preflight() {
 
 skip_postflight() {
   if [ "${CHE_SKIP_POSTFLIGHT}" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+follow_logs() {
+  if [ "${CHE_FOLLOW_LOGS}" = "true" ]; then
     return 0
   else
     return 1

--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -428,7 +428,10 @@ init_check_mounts() {
   fi
 
   # Verify that we can write to the host file system from the container
-  check_host_volume_mount
+  if ! is_fast; then 
+    check_host_volume_mount
+  fi
+return 2
 
   DEFAULT_CHE_CONFIG="${DATA_MOUNT}"
   DEFAULT_CHE_INSTANCE="${DATA_MOUNT}"/instance
@@ -642,20 +645,37 @@ check_host_volume_mount() {
     warning "Boot2docker detected - ensure :/data is mounted to %userprofile%"
   fi
 
-  if file_system_writable "${CHE_CONTAINER_ROOT}/test"; then 
-    delete_file_system_test "${CHE_CONTAINER_ROOT}/test"
-  else 
-    error "Unable to write files to your host"
+  add_file_system_test "${CHE_CONTAINER_ROOT}/test"
+
+  if ! file_system_writable "${CHE_CONTAINER_ROOT}/test" ||
+     ! file_system_executable "${CHE_CONTAINER_ROOT}/test"; then 
+    error "Unable to write or execute files on your host."
     error "Have you enabled Docker to allow mounting host directories?"
-    error "Did you give our CLI rights to create files on your host?"
+    error "Did you give our CLI rights to create + exec files on your host?"
+    delete_file_system_test "${CHE_CONTAINER_ROOT}/test"
     return 2;
   fi
+
+  delete_file_system_test "${CHE_CONTAINER_ROOT}/test"
+}
+
+add_file_system_test() {
+  echo '#!/bin/sh' > "${1}"
+  echo 'echo hi' >> "${1}"
+  chmod +x "${1}" > /dev/null
 }
 
 file_system_writable() {
-  echo 'test' > "${1}" 
-
   if [[ -f "${1}" ]]; then
+    return 0
+  else 
+    return 1
+  fi
+}
+
+file_system_executable() {
+  EXEC_OUTPUT=$(bash "${1}")
+  if [ $EXEC_OUTPUT = "hi" ]; then
     return 0
   else 
     return 1
@@ -667,7 +687,6 @@ delete_file_system_test() {
 }
 
 is_boot2docker() {
-#  debug $FUNCNAME
   if uname -r | grep -q 'boot2docker'; then
     return 0
   else

--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -431,7 +431,6 @@ init_check_mounts() {
   if ! is_fast; then 
     check_host_volume_mount
   fi
-return 2
 
   DEFAULT_CHE_CONFIG="${DATA_MOUNT}"
   DEFAULT_CHE_INSTANCE="${DATA_MOUNT}"/instance

--- a/dockerfiles/base/scripts/base/startup_05_pre_exec.sh
+++ b/dockerfiles/base/scripts/base/startup_05_pre_exec.sh
@@ -23,7 +23,7 @@ cli_parse () {
     rmi|upgrade|version|ssh|sync|action|test|compile|dir|help)
     ;;
   *)
-    error "You passed an unknown command."
+    error "You passed an unknown command: $1"
     usage
     return 2
     ;;


### PR DESCRIPTION
### What does this PR do?
This adds a check for the ability to execute a file on the file system mounted to `:/data`.  Also adds in the ability to skip this check if `--fast` is provided on the command line.  We previously checked to see if the file system is writable, but never checked to see if files could execute on the system. 

Also adds in `--follow` option to the start command which will provide blocking following of Che logs to the output screen. This will not let you know when the server has finished booting. The user must provide CTRL-C on the command line to kill this process.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1877#issuecomment-284386189

#### Changelog
[cli] Add check to ensure `:/data` can execute files written to it from a container
[cli] Add `--follow` parameter to start command to follow logs while booting

#### Release Notes
In the CLI, as part of the `start` command, you can now optionally provide the `--follow` flag which will provide a blocking follow of the logs of the Che server.

#### Docs PR
https://github.com/eclipse/che-docs/pull/164
https://github.com/codenvy/docs/pull/94