### PR TITLE
Get rid of recover from snapshot dialog

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/WorkspaceServiceClient.java
@@ -124,9 +124,8 @@ public interface WorkspaceServiceClient {
      *         if <code>false</code> workspace will not be restored from snapshot
      *         even if auto-restore is enabled and snapshot exists
      * @return a promise that resolves to the {@link WorkspaceDto}, or rejects with an error
-     * @see WorkspaceService#startById(String, String, Boolean, String)
      */
-    Promise<WorkspaceDto> startById(String id, String envName, boolean restore);
+    Promise<WorkspaceDto> startById(String id, String envName, Boolean restore);
 
     /**
      * Stops running workspace.
@@ -273,6 +272,7 @@ public interface WorkspaceServiceClient {
      * @return a promise that will provide a list of {@link SnapshotDto}s, or rejects with an error
      * @see WorkspaceService#getSnapshot(String)
      */
+    @Deprecated
     Promise<List<SnapshotDto>> getSnapshot(String workspaceId);
 
     /**
@@ -283,6 +283,7 @@ public interface WorkspaceServiceClient {
      * @return a promise that will resolve when the snapshot has been created, or rejects with an error
      * @see WorkspaceService#createSnapshot(String)
      */
+    @Deprecated
     Promise<Void> createSnapshot(String workspaceId);
 
     /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/DefaultWorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/DefaultWorkspaceComponent.java
@@ -84,7 +84,7 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent {
                 new Operation<WorkspaceDto>() {
                     @Override
                     public void apply(WorkspaceDto workspaceDto) throws OperationException {
-                        handleWorkspaceEvents(workspaceDto, callback, true, false);
+                        handleWorkspaceEvents(workspaceDto, callback, null);
                     }
                 }).catchError(new Operation<PromiseError>() {
             @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceComponent.java
@@ -16,7 +16,6 @@ import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
-import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Operation;
@@ -26,8 +25,6 @@ import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.component.Component;
-import org.eclipse.che.ide.api.dialogs.CancelCallback;
-import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
@@ -48,7 +45,6 @@ import org.eclipse.che.ide.websocket.events.ConnectionOpenedHandler;
 import org.eclipse.che.ide.workspace.create.CreateWorkspacePresenter;
 import org.eclipse.che.ide.workspace.start.StartWorkspacePresenter;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
@@ -165,13 +161,11 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
      *         workspace to listen
      * @param callback
      *         callback
-     * @param checkForShapshots
-     *         whether is needed checking workspace for snapshots
      * @param restoreFromSnapshot
      *         restore or not the workspace from snapshot
      */
     public void handleWorkspaceEvents(final WorkspaceDto workspace, final Callback<Component, Exception> callback,
-                                      final boolean checkForShapshots, final boolean restoreFromSnapshot) {
+                                      final Boolean restoreFromSnapshot) {
         this.callback = callback;
         if (messageBus != null) {
             messageBus.cancelReconnection();
@@ -211,12 +205,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
                                                   @Override
                                                   public Map<String, String> apply(Map<String, String> settings) throws FunctionException {
                                                       if (Boolean.parseBoolean(settings.getOrDefault(CHE_WORKSPACE_AUTO_START, "true"))) {
-                                                          if (checkForShapshots) {
-                                                              checkWorkspaceForSnapshots(workspace);
-                                                          } else {
-                                                              startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(),
-                                                                                 restoreFromSnapshot);
-                                                          }
+                                                          startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(), restoreFromSnapshot);
                                                       } else {
                                                           loader.show(WORKSPACE_STOPPED);
                                                       }
@@ -235,17 +224,15 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
      *         workspace ID to start
      * @param callback
      *         callback
-     * @param checkForShapshots
-     *         whether is needed checking workspace for snapshots
      * @param restoreFromSnapshot
      *         restore or not the workspace from snapshot
      */
     public void startWorkspace(final String workspaceID, final Callback<Component, Exception> callback,
-                               final boolean checkForShapshots, final boolean restoreFromSnapshot) {
+                               final Boolean restoreFromSnapshot) {
         workspaceServiceClient.getWorkspace(workspaceID).then(new Operation<WorkspaceDto>() {
             @Override
             public void apply(WorkspaceDto workspace) throws OperationException {
-                handleWorkspaceEvents(workspace, callback, checkForShapshots, restoreFromSnapshot);
+                handleWorkspaceEvents(workspace, callback, restoreFromSnapshot);
             }
         });
     }
@@ -259,26 +246,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
      *         callback to be executed
      */
     public void startWorkspace(final Workspace workspace, final Callback<Component, Exception> callback) {
-        startWorkspace(workspace.getId(), callback, true, false);
-    }
-
-    /**
-     * Checks workspace for snapshots and asks the uses for an action.
-     *
-     * @param workspace
-     *         workspace
-     */
-    private void checkWorkspaceForSnapshots(final Workspace workspace) {
-        workspaceServiceClient.getSnapshot(workspace.getId()).then(new Operation<List<SnapshotDto>>() {
-            @Override
-            public void apply(List<SnapshotDto> snapshots) throws OperationException {
-                if (snapshots.isEmpty()) {
-                    startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(), false);
-                } else {
-                    showRecoverWorkspaceConfirmDialog(workspace);
-                }
-            }
-        });
+        startWorkspace(workspace.getId(), callback, null);
     }
 
     /**
@@ -287,30 +255,6 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
     private native void notifyShowIDE() /*-{
         $wnd.parent.postMessage("show-ide", "*");
     }-*/;
-
-    /**
-     * Shows workspace recovering confirm dialog.
-     */
-    private void showRecoverWorkspaceConfirmDialog(final Workspace workspace) {
-        dialogFactory.createConfirmDialog(locale.workspaceRecoveringDialogTitle(),
-                                          locale.workspaceRecoveringDialogText(),
-                                          locale.yesButtonTitle(),
-                                          locale.noButtonTitle(),
-                                          new ConfirmCallback() {
-                                              @Override
-                                              public void accepted() {
-                                                  startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(), true);
-                                              }
-                                          },
-                                          new CancelCallback() {
-                                              @Override
-                                              public void cancelled() {
-                                                  startWorkspaceById(workspace.getId(), workspace.getConfig().getDefaultEnv(), false);
-                                              }
-                                          }).show();
-
-        notifyShowIDE();
-    }
 
     /**
      * Starts specified workspace if it's {@link WorkspaceStatus} different of {@code RUNNING}
@@ -326,7 +270,7 @@ public abstract class WorkspaceComponent implements Component, WsAgentStateHandl
 
     abstract void tryStartWorkspace();
 
-    private void startWorkspaceById(String workspaceId, String defaultEnvironment, boolean restoreFromSnapshot) {
+    private void startWorkspaceById(String workspaceId, String defaultEnvironment, Boolean restoreFromSnapshot) {
         loader.show(STARTING_WORKSPACE_RUNTIME);
         workspaceServiceClient.startById(workspaceId, defaultEnvironment, restoreFromSnapshot).catchError(new Operation<PromiseError>() {
             @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceEventsHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceEventsHandler.java
@@ -34,7 +34,7 @@ import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.DelayedTask;
-import org.eclipse.che.ide.actions.WorkspaceSnapshotCreator;
+import org.eclipse.che.ide.actions.WorkspaceSnapshotNotifier;
 import org.eclipse.che.ide.api.component.Component;
 import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
@@ -92,7 +92,7 @@ public class WorkspaceEventsHandler {
     private final DtoUnmarshallerFactory              dtoUnmarshallerFactory;
     private final Provider<DefaultWorkspaceComponent> wsComponentProvider;
     private final AsyncRequestFactory                 asyncRequestFactory;
-    private final WorkspaceSnapshotCreator            snapshotCreator;
+    private final WorkspaceSnapshotNotifier           snapshotNotifier;
     private final WorkspaceServiceClient              workspaceServiceClient;
     private final StartWorkspaceNotification          startWorkspaceNotification;
     private final ExecAgentCommandManager             execAgentCommandManager;
@@ -124,7 +124,7 @@ public class WorkspaceEventsHandler {
                            final DtoUnmarshallerFactory dtoUnmarshallerFactory,
                            final NotificationManager notificationManager,
                            final MessageBusProvider messageBusProvider,
-                           final WorkspaceSnapshotCreator snapshotCreator,
+                           final WorkspaceSnapshotNotifier snapshotNotifier,
                            final WorkspaceServiceClient workspaceServiceClient,
                            final StartWorkspaceNotification startWorkspaceNotification,
                            final Provider<DefaultWorkspaceComponent> wsComponentProvider,
@@ -134,7 +134,7 @@ public class WorkspaceEventsHandler {
         this.eventBus = eventBus;
         this.locale = locale;
         this.messageBusProvider = messageBusProvider;
-        this.snapshotCreator = snapshotCreator;
+        this.snapshotNotifier = snapshotNotifier;
         this.notificationManager = notificationManager;
         this.dialogFactory = dialogFactory;
         this.dtoUnmarshallerFactory = dtoUnmarshallerFactory;
@@ -417,11 +417,12 @@ public class WorkspaceEventsHandler {
 
                 case SNAPSHOT_CREATING:
                     loader.show(LoaderPresenter.Phase.CREATING_WORKSPACE_SNAPSHOT);
+                    snapshotNotifier.creationStarted();
                     break;
 
                 case SNAPSHOT_CREATED:
                     loader.setSuccess(LoaderPresenter.Phase.CREATING_WORKSPACE_SNAPSHOT);
-                    snapshotCreator.successfullyCreated();
+                    snapshotNotifier.successfullyCreated();
 
                     wsStartedNotification = new DelayedTask() {
                         @Override
@@ -442,7 +443,7 @@ public class WorkspaceEventsHandler {
 
                 case SNAPSHOT_CREATION_ERROR:
                     loader.setError(LoaderPresenter.Phase.CREATING_WORKSPACE_SNAPSHOT);
-                    snapshotCreator.creationError("Snapshot creation error: " + statusEvent.getError());
+                    snapshotNotifier.creationError("Snapshot creation error: " + statusEvent.getError());
                     break;
             }
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClientImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClientImpl.java
@@ -142,10 +142,13 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
     }
 
     @Override
-    public Promise<WorkspaceDto> startById(@NotNull final String id, final String envName, final boolean restore) {
-        String url = baseHttpUrl + "/" + id + "/runtime?restore=" + restore;
+    public Promise<WorkspaceDto> startById(@NotNull final String id, final String envName, final Boolean restore) {
+        String url = baseHttpUrl + "/" + id + "/runtime";
+        if (restore != null) {
+            url += "?restore=" + restore;
+        }
         if (envName != null) {
-            url += "&environment=" + envName;
+            url += (url.contains("?") ? '&' : '?') + "environment=" + envName;
         }
         return asyncRequestFactory.createPostRequest(url, null)
                                   .header(ACCEPT, APPLICATION_JSON)

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspaceNotification.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/start/StartWorkspaceNotification.java
@@ -107,7 +107,7 @@ public class StartWorkspaceNotification {
             @Override
             public void onFailure(Exception reason) {
             }
-        }, false, restore.getValue().booleanValue());
+        }, restore.getValue());
     }
 
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/WorkspaceSnapshotNotifierTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/WorkspaceSnapshotNotifierTest.java
@@ -40,15 +40,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link WorkspaceSnapshotCreator}.
+ * Tests for {@link WorkspaceSnapshotNotifier}.
  *
  * @author Yevhenii Voevodin
  */
 @RunWith(GwtMockitoTestRunner.class)
-public class WorkspaceSnapshotCreatorTest {
-
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    private WorkspaceServiceClient workspaceService;
+public class WorkspaceSnapshotNotifierTest {
 
     @Mock
     private NotificationManager notificationManager;
@@ -72,7 +69,7 @@ public class WorkspaceSnapshotCreatorTest {
     private ArgumentCaptor<Operation<PromiseError>> errorCaptor;
 
     @InjectMocks
-    private WorkspaceSnapshotCreator snapshotCreator;
+    private WorkspaceSnapshotNotifier snapshotCreator;
 
     @Before
     public void setup () throws Exception {
@@ -83,7 +80,7 @@ public class WorkspaceSnapshotCreatorTest {
 
     @Test
     public void shouldShowNotificationWhenCreatingSnapshot() {
-        snapshotCreator.createSnapshot("workspace123");
+        snapshotCreator.creationStarted();
 
         verify(notificationManager).notify(anyString(), eq(StatusNotification.Status.PROGRESS), eq(FLOAT_MODE));
     }
@@ -92,7 +89,7 @@ public class WorkspaceSnapshotCreatorTest {
     public void shouldChangeNotificationAfterCreationError() {
         when(locale.createSnapshotFailed()).thenReturn("Error");
 
-        snapshotCreator.createSnapshot("workspace123");
+        snapshotCreator.creationStarted();
 
         snapshotCreator.creationError("Error");
 
@@ -103,30 +100,11 @@ public class WorkspaceSnapshotCreatorTest {
     @Test
     public void shouldChangeNotificationAfterSuccessfullyCreated() {
         when(locale.createSnapshotSuccess()).thenReturn("Snapshot successfully created");
-        snapshotCreator.createSnapshot("workspace123");
+        snapshotCreator.creationStarted();
 
         snapshotCreator.successfullyCreated();
 
         verify(notification).setStatus(StatusNotification.Status.SUCCESS);
         verify(notification).setTitle("Snapshot successfully created");
-    }
-
-    @Test
-    public void shouldChangeNotificationIfErrorCaughtWhileCreatingSnapshot() throws OperationException {
-        when(workspaceService.createSnapshot(anyString())).thenReturn(createSnapshotPromise);
-        snapshotCreator.createSnapshot("workspace123");
-
-        verify(createSnapshotPromise).catchError(errorCaptor.capture());
-        errorCaptor.getValue().apply(promiseError);
-
-        verify(notification).setTitle(promiseError.getMessage());
-        verify(notification).setStatus(StatusNotification.Status.FAIL);
-    }
-
-    @Test
-    public void shouldBeInProgressAfterCreatingSnapshot() {
-        snapshotCreator.createSnapshot("workspace123");
-
-        assertTrue(snapshotCreator.isInProgress());
     }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/WorkspaceEventsHandlerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/WorkspaceEventsHandlerTest.java
@@ -30,7 +30,7 @@ import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceRuntimeDto;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.actions.WorkspaceSnapshotCreator;
+import org.eclipse.che.ide.actions.WorkspaceSnapshotNotifier;
 import org.eclipse.che.ide.api.component.Component;
 import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
@@ -61,7 +61,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -113,7 +112,7 @@ public class WorkspaceEventsHandlerTest {
     @Mock
     private Provider<DefaultWorkspaceComponent> wsComponentProvider;
     @Mock
-    private WorkspaceSnapshotCreator            snapshotCreator;
+    private WorkspaceSnapshotNotifier           snapshotCreator;
     @Mock
     private WorkspaceServiceClient              workspaceServiceClient;
     @Mock

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/WorkspaceStatusEvent.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/WorkspaceStatusEvent.java
@@ -32,10 +32,7 @@ public interface WorkspaceStatusEvent {
 
     /**
      * Returns the type of this event.
-     *
-     * @deprecated use #getStatus() instead
      */
-    @Deprecated
     EventType getEventType();
 
     void setEventType(EventType eventType);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -386,6 +386,7 @@ public class WorkspaceService extends Service {
                                                       "The operation is not allowed for the user"),
                    @ApiResponse(code = 409, message = "Any conflict occurs during the snapshot creation"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public void createSnapshot(@ApiParam("The workspace id") @PathParam("id") String workspaceId) throws BadRequestException,
                                                                                                          ForbiddenException,
                                                                                                          NotFoundException,
@@ -406,6 +407,7 @@ public class WorkspaceService extends Service {
                                                       "The snapshot doesn't exist for the workspace"),
                    @ApiResponse(code = 403, message = "The user is not workspace owner"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public List<SnapshotDto> getSnapshot(@ApiParam("The id of the workspace") @PathParam("id") String workspaceId)
             throws ServerException,
                    BadRequestException,


### PR DESCRIPTION
### What does this PR do?
Removes recover from snapshot dialog from workspace start sequence. 
The behaviour of IDE is now the same to dashboard, so recovery is enforced 
by either of:
- start workspace request query parameter `restore` 
- workspace attribute `auto_restore` 
- system configuration property `che.workspace.auto_restore` 

The dialog view was:
![image](https://cloud.githubusercontent.com/assets/4053805/23614988/939bea40-028d-11e7-99be-d7e442c17971.png)

It's still possible to choose whether to recover from snapshot or not after workspace stop:
![image](https://cloud.githubusercontent.com/assets/4053805/23615035/c98b05a0-028d-11e7-84c8-a45163ab9943.png)

Along with that i turned on snapshot status notifications:
![image](https://cloud.githubusercontent.com/assets/4053805/23615586/9b89bc08-028f-11e7-9244-ec18f301339a.png)

![image](https://cloud.githubusercontent.com/assets/4053805/23615220/59b1b3d6-028e-11e7-999f-beff281cef7b.png).

### What issues does this PR fix or reference?
Resolves #3611 

#### Changelog
Explicit snapshot creation becomes an internal approach.
Recover from snapshot dialog is removed from IDE.
Workspace REST API methods related to snapshots are deprecated.

#### Release Notes
API methods for creating and getting workspace snapshots are deprecated.
The reason is that snapshotting itself becomes an internal approach which is going to be 
used on workspace stop only.
```
GET  /api/workspace/<id>/snapshot
POST /api/workspace/<id>/snapshot
```
Pull request #3405 introduced a deprecation of `WorkspaceStatusEvent.getEventType()` the alternative would be to use `WorkspaceStatusEvent.getStatus()`, but it turned out that usage of combination of _status_ + _previous status_ + _optional error_ is not always convenient as the usage of the single event type, so it's reverted and not deprecated any more.

#### Docs PR
N/A

As a dialog alternative it could make sense to provide a kind of control like 'checkbox' on dashboard which would allow to decide per workspace whether to snapshot/recover it(discussion is welcome).