### PR TITLE
CHE-4294: Handle relative path to source folder at managing maven project classpath

### DIFF
--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenWorkspace.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenWorkspace.java
@@ -220,9 +220,11 @@ public class MavenWorkspace {
             Element sources = configuration.getChild("sources");
             if (sources != null) {
                 for (Object element : sources.getChildren()) {
-                    String path = ((Element)element).getTextTrim();
-                    IPath projectLocation = project.getProject().getLocation();
-                    String sourceFolder = path.substring(projectLocation.toOSString().length() + 1);
+                    final String path = ((Element)element).getTextTrim();
+                    final IPath projectLocation = project.getProject().getLocation();
+                    final String projectPath = projectLocation.toOSString();
+                    final String sourceFolder = path.contains(projectPath) ? path.substring(projectPath.length() + 1) : path;
+
                     helper.addSourceEntry(project.getProject().getFullPath().append(sourceFolder));
                     if (!attributes.contains(sourceFolder)) {
                         attributes.add(sourceFolder);


### PR DESCRIPTION
### What does this PR do?
We handle absolute path only at adding source folder to classpath.
This leads to the bug: #4294.
So we need to handle relative path as well at this case.

### What issues does this PR fix or reference?
#4294 

#### Changelog
Handle relative path to source folder at managing maven project classpath

#### Release Notes
N/A

#### Docs PR
N/A