### PR TITLE
allow using args for start command in cmd_upgrade

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
@@ -30,16 +30,16 @@ post_cmd_upgrade() {
 cmd_upgrade() {
   CHE_IMAGE_VERSION=$(get_image_version)
   DO_BACKUP="true"
+  ARGS=""
 
-  while [ $# -gt 0 ]; do
-    case $1 in
-      --skip-backup)
-        DO_BACKUP="false"
-        shift ;;
-      *) error "Unknown parameter: $1; did you mean --skip-backup?" ; return 2 ;;
-    esac
+  for var in $@; do
+    if [[ "$var" == *"--skip-backup"* ]]; then
+              DO_BACKUP="false"
+              continue
+    fi
+    ARGS+="$var "
   done
-
+  
   # If we got here, this means:
   #   image version > configured & installed version
   #   configured version = installed version
@@ -73,5 +73,5 @@ cmd_upgrade() {
   info "upgrade" "Reinitializing the system with your configuration..."
   cmd_lifecycle init --accept-license --reinit
 
-  cmd_lifecycle start
+  cmd_lifecycle start ${ARGS}
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_upgrade.sh
@@ -39,7 +39,7 @@ cmd_upgrade() {
     fi
     ARGS+="$var "
   done
-  
+
   # If we got here, this means:
   #   image version > configured & installed version
   #   configured version = installed version


### PR DESCRIPTION
for now there is no way to pass any arg to start command on upgrade, but on our prod we must skip preflight checks because they will not work due to closed ports on firewall. those changes allow using `upgrade --skip-backup --skip:preflight`

### What does this PR do?
allow using args for start command in cmd_upgrade

#### Changelog
allow using args for start command in cmd_upgrade
