### PR TITLE
Improve eclipse ssh agent on unknown Linux stacks

### DIFF
--- a/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
+++ b/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
@@ -26,7 +26,7 @@ if [ -f /etc/centos-release ]; then
 fi
 
 ###############################
-### Install Needed packaged ###
+### Install Needed packages ###
 ###############################
 
 # Red Hat Enterprise Linux 7 

--- a/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
+++ b/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
@@ -115,8 +115,11 @@ elif echo ${LINUX_TYPE} | grep -qi "CentOS"; then
 
 else
     >&2 echo "Unrecognized Linux Type"
-    >&2 cat $FILE
-    exit 1
+    command -v sshd >/dev/null 2>&1 || {
+        >&2 cat $FILE;
+        exit 1;
+    }
+    ${SUDO} sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 fi
 
 command -v pidof >/dev/null 2>&1 && {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It improves the situation on custom docker images using a Linux OS which is not listed explicitly in the ssh server script file. (SSH server agent)

Originally I wanted to run a custom docker image with Arch Linux installed (in Codenvy). Currently this does not work because Arch Linux is not supported as docker container. However, the script basically checks whether sshd works or not. On supported systems the package is installed automatically, if it does not work. On unsupported systems the script currently exits regardless of a working sshd server.

This change at least **tries** whether it works or not. If not, you can still exit with an error code.

#### Changelog
Improve behavior of SSH installation script on unknown Linux stacks
