### PR TITLE
[cli] Add back in check for `--user` on command line

### DIFF
--- a/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
+++ b/dockerfiles/base/scripts/base/startup_02_pre_docker.sh
@@ -384,7 +384,7 @@ init_check_interactive() {
 }
 
 # Add check to see if --user uid:gid passed in.
-check_user() {
+init_check_user() {
   DOCKER_CHE_USER=$(docker inspect --format='{{.Config.User}}' $(get_this_container_id))
   if [[ "${DOCKER_CHE_USER}" != "" ]]; then
     CHE_USER=$DOCKER_CHE_USER


### PR DESCRIPTION
Signed-off-by: Tyler Jewell <tjewell@codenvy.com>
In the refactoring to simplify the CLI for 5.4, the `check_user` method was not included and it seems that the original `init()` method was left in tact.  This adds that check back into the bootstrap sequence and removes the redundant method.
 
### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/3376#issuecomment-284819093

#### Changelog
Add back in check for `--user` on command line

#### Release Notes
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
