### PR TITLE
Update CentOS Dockerfile to avoid permissions issues

### DIFF
--- a/dockerfiles/che/Dockerfile.centos
+++ b/dockerfiles/che/Dockerfile.centos
@@ -48,3 +48,5 @@ EXPOSE 8000 8080
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 ADD eclipse-che.tar.gz /home/user/
+RUN mkdir /logs && chmod 0777 /logs
+RUN chmod -R 0777 /home/user/


### PR DESCRIPTION
### What does this PR do?
Fix an issue that prevented to run che-server in OpenShift without a privileged security context. 

### What issues does this PR fix or reference?
If Che is run as non root user it cannot write files in /home/user and cannot create folder /log/

#### Changelog
Update CentOS Dockerfile to avoid permissions issues