### PR TITLE
Implement getVersion method in OpenShiftConnector

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientExtension.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientExtension.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.openshift.client;
+
+import java.net.URL;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.URLUtils;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class OpenShiftClientExtension extends DefaultOpenShiftClient {
+
+    private static final String VERSION = "version";
+
+    public OpenShiftClientExtension(OkHttpClient httpClient, OpenShiftConfig config)
+            throws KubernetesClientException {
+        super(httpClient, config);
+    }
+
+    public String getVersion() {
+        try {
+            URL url = new URL(URLUtils.join(getMasterUrl().toString(), VERSION));
+            Request.Builder requestBuilder = new Request.Builder().get().url(url);
+            Request request = requestBuilder.build();
+            Response response = httpClient.newCall(request).execute();
+            try (ResponseBody body = response.body()) {
+                return body.string();
+            }
+        } catch (Throwable t) {
+            throw KubernetesClientException.launderThrowable(t);
+        }
+    }
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftVersion.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftVersion.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.openshift.client;
+
+import java.util.Date;
+
+import org.eclipse.che.plugin.docker.client.json.Version;
+
+public class OpenShiftVersion {
+    private String major;
+    private String minor;
+    private String gitVersion;
+    private String gitTreeState;
+    private Date buildDate;
+    private String goVersion;
+    private String gitCommit;
+    private String compiler;
+    private String platform;
+
+    public String getMajor() {
+        return major;
+    }
+
+    public void setMajor(String major) {
+        this.major = major;
+    }
+
+    public String getMinor() {
+        return minor;
+    }
+
+    public void setMinor(String minor) {
+        this.minor = minor;
+    }
+
+    public String getGitVersion() {
+        return gitVersion;
+    }
+
+    public void setGitVersion(String gitVersion) {
+        this.gitVersion = gitVersion;
+    }
+
+    public String getGitTreeState() {
+        return gitTreeState;
+    }
+
+    public void setGitTreeState(String gitTreeState) {
+        this.gitTreeState = gitTreeState;
+    }
+
+    public Date getBuildDate() {
+        return buildDate;
+    }
+
+    public void setBuildDate(Date buildDate) {
+        this.buildDate = buildDate;
+    }
+
+    public String getGoVersion() {
+        return goVersion;
+    }
+
+    public void setGoVersion(String goVersion) {
+        this.goVersion = goVersion;
+    }
+
+    public String getGitCommit() {
+        return gitCommit;
+    }
+
+    public void setGitCommit(String gitCommit) {
+        this.gitCommit = gitCommit;
+    }
+
+    public String getCompiler() {
+        return compiler;
+    }
+
+    public void setCompiler(String compiler) {
+        this.compiler = compiler;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+    public Version getVersion() {
+        Version version = new Version();
+        version.setVersion(major + "." + minor);
+        version.setGitCommit(getGitCommit());
+        version.setGoVersion(getGoVersion());
+        if (getPlatform() != null) {
+            String[] elements = getPlatform().split("/");
+            if (elements.length == 2) {
+                version.setOs(elements[0]);
+                version.setArch(elements[1]);
+            }
+        }
+        return version;
+    }
+
+}


### PR DESCRIPTION
What does this PR do?

Implements the getVersion method in OpenShiftConnector.
OpenShift REST API has the version method, but the kubernetes client doesn't implement it. I have created a simple extension that returns version information.

What issues does this PR fix or reference?

Che doesn't start on OpenShift if the Docker socket is not mounted.