### PR TITLE
CHE-4301: fix bug when "Save" button was visible for untouched workspace.

### DIFF
--- a/dashboard/src/app/projects/create-project/samples/create-project-samples.controller.ts
+++ b/dashboard/src/app/projects/create-project/samples/create-project-samples.controller.ts
@@ -40,6 +40,11 @@ export class CreateProjectSamplesController {
    */
   getFilteredTemplates(): che.IProjectTemplate[] {
     let stackTags = !this.currentStackTags ? [] : this.currentStackTags.map((tag: string) => tag.toLowerCase());
+
+    if (!stackTags.length) {
+      return this.templates;
+    }
+
     return this.templates.filter((template: che.IProjectTemplate) => {
       let templateTags = template.tags.map((tag: string) => tag.toLowerCase());
       return stackTags.some((tag: string) => templateTags.indexOf(tag) > -1);

--- a/dashboard/src/components/api/environment/environment-manager.ts
+++ b/dashboard/src/components/api/environment/environment-manager.ts
@@ -163,24 +163,26 @@ export abstract class EnvironmentManager {
   }
 
   getServers(machine: IEnvironmentManagerMachine): {[serverName: string]: IEnvironmentManagerMachineServer} {
-    if (!machine.servers) {
+    let servers = angular.copy(machine.servers);
+
+    if (!servers) {
       return {};
     }
 
-    Object.keys(machine.servers).forEach((serverName: string) => {
-      machine.servers[serverName].userScope = true;
+    Object.keys(servers).forEach((serverName: string) => {
+      servers[serverName].userScope = true;
     });
 
     if (!machine.runtime) {
-      return machine.servers;
+      return servers;
     }
 
     Object.keys(machine.runtime.servers).forEach((runtimeServerName: string) => {
       let runtimeServer: che.IWorkspaceRuntimeMachineServer = machine.runtime.servers[runtimeServerName],
           runtimeServerReference = runtimeServer.ref;
 
-      if (machine.servers[runtimeServerReference]) {
-        machine.servers[runtimeServerReference].runtime = runtimeServer;
+      if (servers[runtimeServerReference]) {
+        servers[runtimeServerReference].runtime = runtimeServer;
       } else {
         let port;
         if (runtimeServer.port) {
@@ -188,7 +190,7 @@ export abstract class EnvironmentManager {
         } else {
           [port, ] = runtimeServerName.split('/');
         }
-        machine.servers[runtimeServerReference] = {
+        servers[runtimeServerReference] = {
           userScope: false,
           port: port,
           protocol: runtimeServer.protocol,
@@ -197,7 +199,7 @@ export abstract class EnvironmentManager {
       }
     });
 
-    return machine.servers;
+    return servers;
   }
 
   setServers(machine: IEnvironmentManagerMachine, _servers: {[serverRef: string]: IEnvironmentManagerMachineServer}): void {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR fixes couple bugs in UD:
- "Save" and "Cancel" buttons were visible for untouched workspace in Workspace details;
- list of samples was empty for custom stack in Create workspace flow.

### What issues does this PR fix or reference?
#4301 

#### Changelog
<!-- one line entry to be added to changelog -->
[UD] fixed bug when "Save" and "Cancel" buttons were visible for untouched workspace in Workspace details.
[UD] fixed bug when list of samples was empty for custom stack in Create workspace flow.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix
