### PR TITLE
Tree walk based file watchers replacement

### DIFF
--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/JavaDebuggerTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/JavaDebuggerTest.java
@@ -288,7 +288,6 @@ public class JavaDebuggerTest {
         FileWatcherNotificationHandler fileWatcherNotificationHandler = new DefaultFileWatcherNotificationHandler(vfsProvider);
         FileTreeWatcher fileTreeWatcher = new FileTreeWatcher(root, new HashSet<>(), fileWatcherNotificationHandler);
         ProjectManager projectManager = new ProjectManager(vfsProvider,
-                                                           eventService,
                                                            projectTypeRegistry,
                                                            projectRegistry,
                                                            projectHandlerRegistry,

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/test/java/org/eclipse/che/plugin/java/plain/server/BaseTest.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/test/java/org/eclipse/che/plugin/java/plain/server/BaseTest.java
@@ -107,7 +107,6 @@ public abstract class BaseTest {
         FileTreeWatcher fileTreeWatcher = new FileTreeWatcher(root, new HashSet<>(), fileWatcherNotificationHandler);
 
         projectManager = new ProjectManager(vfsProvider,
-                                            eventService,
                                             projectTypeRegistry,
                                             projectRegistry,
                                             projectHandlerRegistry,

--- a/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/BaseTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/BaseTest.java
@@ -147,7 +147,7 @@ public abstract class BaseTest {
         fileTreeWatcher = new FileTreeWatcher(root, new HashSet<>(), fileWatcherNotificationHandler);
 
 
-        pm = new ProjectManager(vfsProvider, eventService, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
+        pm = new ProjectManager(vfsProvider, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
                                 importerRegistry, fileWatcherNotificationHandler, fileTreeWatcher,
                                 new TestWorkspaceHolder(new ArrayList<>()), mock(FileWatcherManager.class));
 

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.project.server;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
@@ -37,12 +38,19 @@ import org.eclipse.che.api.vfs.impl.file.event.detectors.ProjectTreeTracker;
 import org.eclipse.che.api.vfs.search.MediaTypeFilter;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
 import org.eclipse.che.api.vfs.search.impl.FSLuceneSearcherProvider;
+import org.eclipse.che.api.vfs.watcher.FileTreeWalker;
+import org.eclipse.che.api.vfs.watcher.IndexedFileCreateConsumer;
+import org.eclipse.che.api.vfs.watcher.IndexedFileDeleteConsumer;
+import org.eclipse.che.api.vfs.watcher.IndexedFileUpdateConsumer;
 
+import javax.inject.Named;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.WatchService;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -92,6 +100,33 @@ public class ProjectApiModule extends AbstractModule {
         configureVfsFilters(excludeMatcher);
         configureVfsFilters(fileWatcherExcludes);
         configureVfsEvent();
+        configureTreeWalker();
+    }
+
+    private void configureTreeWalker() {
+        bind(FileTreeWalker.class).asEagerSingleton();
+
+        Multibinder<Consumer<Path>> directoryUpdateConsumers =
+                newSetBinder(binder(), new TypeLiteral<Consumer<Path>>(){}, Names.named("che.fs.directory.update"));
+        Multibinder<Consumer<Path>> directoryCreateConsumers =
+                newSetBinder(binder(), new TypeLiteral<Consumer<Path>>(){}, Names.named("che.fs.directory.create"));
+        Multibinder<Consumer<Path>> directoryDeleteConsumers =
+                newSetBinder(binder(), new TypeLiteral<Consumer<Path>>(){}, Names.named("che.fs.directory.delete"));
+        Multibinder<PathMatcher> directoryExcludes =
+                newSetBinder(binder(), new TypeLiteral<PathMatcher>(){}, Names.named("che.fs.directory.excludes"));
+
+        Multibinder<Consumer<Path>> fileUpdateConsumers =
+                newSetBinder(binder(), new TypeLiteral<Consumer<Path>>(){}, Names.named("che.fs.file.update"));
+        Multibinder<Consumer<Path>> fileCreateConsumers =
+                newSetBinder(binder(), new TypeLiteral<Consumer<Path>>(){}, Names.named("che.fs.file.create"));
+        Multibinder<Consumer<Path>> fileDeleteConsumers =
+                newSetBinder(binder(), new TypeLiteral<Consumer<Path>>(){}, Names.named("che.fs.file.delete"));
+        Multibinder<PathMatcher> fileExcludes =
+                newSetBinder(binder(), new TypeLiteral<PathMatcher>(){}, Names.named("che.fs.file.excludes"));
+
+        fileCreateConsumers.addBinding().to(IndexedFileCreateConsumer.class);
+        fileUpdateConsumers.addBinding().to(IndexedFileUpdateConsumer.class);
+        fileDeleteConsumers.addBinding().to(IndexedFileDeleteConsumer.class);
     }
 
     private void configureVfsFilters(Multibinder<PathMatcher> excludeMatcher) {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -14,13 +14,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
-import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
-import org.eclipse.che.api.core.jsonrpc.BuildingRequestTransmitter;
-import org.eclipse.che.api.core.jsonrpc.JsonRpcFactory;
-import org.eclipse.che.api.core.jsonrpc.RequestHandlerConfigurator;
 import org.eclipse.che.api.project.server.handlers.CreateBaseProjectTypeHandler;
 import org.eclipse.che.api.project.server.handlers.ProjectHandler;
 import org.eclipse.che.api.project.server.importer.ProjectImporter;
@@ -44,13 +40,11 @@ import org.eclipse.che.api.vfs.watcher.IndexedFileCreateConsumer;
 import org.eclipse.che.api.vfs.watcher.IndexedFileDeleteConsumer;
 import org.eclipse.che.api.vfs.watcher.IndexedFileUpdateConsumer;
 
-import javax.inject.Named;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.WatchService;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -39,6 +39,7 @@ import org.eclipse.che.api.vfs.search.MediaTypeFilter;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
 import org.eclipse.che.api.vfs.search.impl.FSLuceneSearcherProvider;
 import org.eclipse.che.api.vfs.watcher.FileTreeWalker;
+import org.eclipse.che.api.vfs.watcher.FileWatcherByPathMatcher;
 import org.eclipse.che.api.vfs.watcher.IndexedFileCreateConsumer;
 import org.eclipse.che.api.vfs.watcher.IndexedFileDeleteConsumer;
 import org.eclipse.che.api.vfs.watcher.IndexedFileUpdateConsumer;
@@ -127,6 +128,11 @@ public class ProjectApiModule extends AbstractModule {
         fileCreateConsumers.addBinding().to(IndexedFileCreateConsumer.class);
         fileUpdateConsumers.addBinding().to(IndexedFileUpdateConsumer.class);
         fileDeleteConsumers.addBinding().to(IndexedFileDeleteConsumer.class);
+
+        fileCreateConsumers.addBinding().to(FileWatcherByPathMatcher.class);
+        fileDeleteConsumers.addBinding().to(FileWatcherByPathMatcher.class);
+        directoryCreateConsumers.addBinding().to(FileWatcherByPathMatcher.class);
+        directoryDeleteConsumers.addBinding().to(FileWatcherByPathMatcher.class);
     }
 
     private void configureVfsFilters(Multibinder<PathMatcher> excludeMatcher) {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -88,7 +88,6 @@ public class ProjectManager {
 
     @Inject
     public ProjectManager(VirtualFileSystemProvider vfsProvider,
-                          EventService eventService,
                           ProjectTypeRegistry projectTypeRegistry,
                           ProjectRegistry projectRegistry,
                           ProjectHandlerRegistry handlers,
@@ -114,7 +113,6 @@ public class ProjectManager {
                                                                           .setDaemon(true).build());
     }
 
-    @PostConstruct
     void initWatcher() throws IOException {
         FileWatcherNotificationListener defaultListener =
                 new FileWatcherNotificationListener(file -> !(file.getPath().toString().contains(".che")
@@ -432,8 +430,8 @@ public class ProjectManager {
 
         projectRegistry.fireInitHandlers(project);
 
-        // TODO move to register?
-        reindexProject(project);
+//         TODO move to register?
+//        reindexProject(project);
 
         return project;
     }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -430,9 +430,6 @@ public class ProjectManager {
 
         projectRegistry.fireInitHandlers(project);
 
-//         TODO move to register?
-//        reindexProject(project);
-
         return project;
     }
 
@@ -748,31 +745,5 @@ public class ProjectManager {
         }
 
         return (FileEntry)entry;
-    }
-
-    /**
-     * Some importers don't use virtual file system API and changes are not indexed.
-     * Force searcher to reindex project to fix such issues.
-     *
-     * @param project
-     *
-     * @throws ServerException
-     */
-    private void reindexProject(final RegisteredProject project) throws ServerException {
-        final VirtualFile file = project.getBaseFolder().getVirtualFile();
-        executor.execute(() -> {
-            try {
-                final Searcher searcher;
-                try {
-                    searcher = getSearcher();
-                } catch (NotFoundException e) {
-                    LOG.warn(e.getLocalizedMessage());
-                    return;
-                }
-                searcher.add(file);
-            } catch (Exception e) {
-                LOG.warn(format("Project: %s", project.getPath()), e.getMessage());
-            }
-        });
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import com.google.inject.Inject;
+
+import org.eclipse.che.commons.schedule.executor.ThreadPullLauncher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
+import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.walkFileTree;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toSet;
+
+@Singleton
+public class FileTreeWalker {
+    private static final Logger LOG = LoggerFactory.getLogger(FileTreeWalker.class);
+
+    private final File root;
+
+    private final Set<Consumer<Path>> directoryUpdateConsumers;
+    private final Set<Consumer<Path>> directoryCreateConsumers;
+    private final Set<Consumer<Path>> directoryDeleteConsumers;
+    private final Set<PathMatcher>    directoryExcludes;
+
+    private final Set<Consumer<Path>> fileUpdateConsumers;
+    private final Set<Consumer<Path>> fileCreateConsumers;
+    private final Set<Consumer<Path>> fileDeleteConsumers;
+    private final Set<PathMatcher>    fileExcludes;
+
+    private final ThreadPullLauncher launcher;
+
+    private final Map<Path, Long> files       = new HashMap<>();
+    private final Map<Path, Long> directories = new HashMap<>();
+
+    @Inject
+    public FileTreeWalker(@Named("che.user.workspaces.storage") File root,
+
+                          @Named("che.fs.directory.update") Set<Consumer<Path>> directoryUpdateConsumers,
+                          @Named("che.fs.directory.create") Set<Consumer<Path>> directoryCreateConsumers,
+                          @Named("che.fs.directory.delete") Set<Consumer<Path>> directoryDeleteConsumers,
+                          @Named("che.fs.directory.excludes") Set<PathMatcher> directoryExcludes,
+
+                          @Named("che.fs.file.update") Set<Consumer<Path>> fileUpdateConsumers,
+                          @Named("che.fs.file.create") Set<Consumer<Path>> fileCreateConsumers,
+                          @Named("che.fs.file.delete") Set<Consumer<Path>> fileDeleteConsumers,
+                          @Named("che.fs.file.excludes") Set<PathMatcher> fileExcludes,
+
+                          ThreadPullLauncher launcher) {
+        this.root = root;
+
+        this.directoryUpdateConsumers = directoryUpdateConsumers;
+        this.directoryCreateConsumers = directoryCreateConsumers;
+        this.directoryDeleteConsumers = directoryDeleteConsumers;
+
+        this.fileUpdateConsumers = fileUpdateConsumers;
+        this.fileCreateConsumers = fileCreateConsumers;
+        this.fileDeleteConsumers = fileDeleteConsumers;
+
+        this.directoryExcludes = directoryExcludes;
+        this.fileExcludes = fileExcludes;
+
+        this.launcher = launcher;
+    }
+
+    @PostConstruct
+    public void start() {
+        int initialDelay = 0;
+        int period = 10;
+
+        LOG.error("STARTING WALKER");
+        launcher.scheduleAtFixedRate(this::walk, initialDelay, period, SECONDS);
+    }
+
+    @PreDestroy
+    public void stop() {
+        LOG.error("STOPPING WALKER");
+
+        try {
+            launcher.shutdown();
+        } catch (InterruptedException e) {
+            LOG.error("Can't properly stop thread pull launcher: ", e);
+        }
+    }
+
+    private void walk() {
+        try {
+            LOG.error("WALKING STARTED");
+
+            Set<Path> deletedFiles = files.keySet().stream().filter(it -> !exists(it)).collect(toSet());
+            fileDeleteConsumers.forEach(deletedFiles::forEach);
+            files.keySet().removeAll(deletedFiles);
+
+            Set<Path> deletedDirectories = directories.keySet().stream().filter(it -> !exists(it)).collect(toSet());
+            directoryDeleteConsumers.forEach(deletedDirectories::forEach);
+            directories.keySet().removeAll(deletedDirectories);
+
+            walkFileTree(root.toPath(), new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    for (PathMatcher matcher : directoryExcludes) {
+                        if (matcher.matches(dir)) {
+                            return SKIP_SUBTREE;
+                        }
+                    }
+
+                    updateFsTreeAndAcceptConsumables(directories, directoryUpdateConsumers, directoryCreateConsumers, dir, attrs);
+
+                    return CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    for (PathMatcher matcher : fileExcludes) {
+                        if (matcher.matches(file)) {
+                            return CONTINUE;
+                        }
+                    }
+
+                    updateFsTreeAndAcceptConsumables(files, fileUpdateConsumers, fileCreateConsumers, file, attrs);
+
+                    return CONTINUE;
+                }
+            });
+            LOG.error("WALKING FINISHED");
+        } catch (Exception e) {
+            LOG.error("Error while walking file tree", e);
+        }
+    }
+
+    private void updateFsTreeAndAcceptConsumables(Map<Path, Long> items, Set<Consumer<Path>> updateConsumer,
+                                                  Set<Consumer<Path>> createConsumer,
+                                                  Path path, BasicFileAttributes attrs) {
+        Long lastModifiedActual = attrs.lastModifiedTime().toMillis();
+
+        if (items.containsKey(path)) {
+            Long lastModifiedStored = items.get(path);
+            if (!lastModifiedActual.equals(lastModifiedStored)) {
+                updateConsumer.forEach(it -> it.accept(path));
+                items.put(path, lastModifiedActual);
+            }
+        } else {
+            createConsumer.forEach(it -> it.accept(path));
+            items.put(path, lastModifiedActual);
+        }
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
@@ -61,7 +61,7 @@ public class FileTreeWalker {
     private final Map<Path, Long> files       = new HashMap<>();
     private final Map<Path, Long> directories = new HashMap<>();
 
-    @Inject(optional=true)
+    @Inject
     public FileTreeWalker(@Named("che.user.workspaces.storage") File root,
 
                           @Named("che.fs.directory.update") Set<Consumer<Path>> directoryUpdateConsumers,

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
@@ -29,7 +29,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
@@ -61,7 +61,7 @@ public class FileTreeWalker {
     private final Map<Path, Long> files       = new HashMap<>();
     private final Map<Path, Long> directories = new HashMap<>();
 
-    @Inject
+    @Inject(optional=true)
     public FileTreeWalker(@Named("che.user.workspaces.storage") File root,
 
                           @Named("che.fs.directory.update") Set<Consumer<Path>> directoryUpdateConsumers,
@@ -96,13 +96,13 @@ public class FileTreeWalker {
         int initialDelay = 0;
         int period = 10;
 
-        LOG.error("STARTING WALKER");
+        LOG.debug("Starting file tree walker");
         launcher.scheduleAtFixedRate(this::walk, initialDelay, period, SECONDS);
     }
 
     @PreDestroy
     public void stop() {
-        LOG.error("STOPPING WALKER");
+        LOG.error("Stopping file tree walker");
 
         try {
             launcher.shutdown();
@@ -111,9 +111,9 @@ public class FileTreeWalker {
         }
     }
 
-    private void walk() {
+    void walk() {
         try {
-            LOG.error("WALKING STARTED");
+            LOG.debug("Tree walk started");
 
             Set<Path> deletedFiles = files.keySet().stream().filter(it -> !exists(it)).collect(toSet());
             fileDeleteConsumers.forEach(deletedFiles::forEach);
@@ -150,7 +150,7 @@ public class FileTreeWalker {
                     return CONTINUE;
                 }
             });
-            LOG.error("WALKING FINISHED");
+            LOG.debug("Tree walk finished");
         } catch (Exception e) {
             LOG.error("Error while walking file tree", e);
         }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherByPathMatcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherByPathMatcher.java
@@ -12,21 +12,12 @@ package org.eclipse.che.api.vfs.watcher;
 
 import com.google.inject.Inject;
 
-import org.eclipse.che.commons.schedule.executor.ThreadPullLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,23 +25,17 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import static com.google.common.collect.Sets.newConcurrentHashSet;
-import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.Files.exists;
-import static java.nio.file.Files.walkFileTree;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Singleton
-public class FileWatcherByPathMatcher {
+public class FileWatcherByPathMatcher implements Consumer<Path> {
     private static final Logger LOG = LoggerFactory.getLogger(FileWatcherByPathMatcher.class);
 
     private final AtomicInteger operationIdCounter = new AtomicInteger();
 
-    private final File                   root;
     private final FileWatcherByPathValue watcher;
-    private final ThreadPullLauncher     launcher;
 
     /** Operation ID -> Operation (create, modify, delete) */
     private final Map<Integer, Operation>        operations             = new ConcurrentHashMap<>();
@@ -62,24 +47,35 @@ public class FileWatcherByPathMatcher {
     private final Map<Path, Set<Integer>>        pathWatchRegistrations = new ConcurrentHashMap<>();
 
     @Inject
-    public FileWatcherByPathMatcher(@Named("che.user.workspaces.storage") File root, FileWatcherByPathValue watcher,
-                                    ThreadPullLauncher launcher) {
-        this.root = root;
+    public FileWatcherByPathMatcher(FileWatcherByPathValue watcher) {
         this.watcher = watcher;
-        this.launcher = launcher;
     }
 
-    @PostConstruct
-    public void start() {
-        launcher.scheduleAtFixedRate(this::seek, 0, 3, SECONDS);
-    }
+    @Override
+    public void accept(Path path) {
+        if (!exists(path)) {
+            Set<Integer> operationIds = pathWatchRegistrations.remove(path);
+            operationIds.forEach(watcher::unwatch);
+            paths.values().forEach(it -> it.remove(path));
+            paths.entrySet().removeIf(it -> it.getValue().isEmpty());
+        }
 
-    @PreDestroy
-    public void stop() {
-        try {
-            launcher.shutdown();
-        } catch (InterruptedException e) {
-            LOG.error("Can't properly stop thread pull launcher: ", e);
+        for (PathMatcher matcher : matchers.keySet()) {
+            if (matcher.matches(path)) {
+                for (int operationId : matchers.get(matcher)) {
+                    paths.putIfAbsent(operationId, newConcurrentHashSet());
+                    if (paths.get(operationId).contains(path)) {
+                        return;
+                    }
+
+                    paths.get(operationId).add(path);
+
+                    Operation operation = operations.get(operationId);
+                    int pathWatcherOperationId = watcher.watch(path, operation.create, operation.modify, operation.delete);
+                    pathWatchRegistrations.putIfAbsent(path, newConcurrentHashSet());
+                    pathWatchRegistrations.get(path).add(pathWatcherOperationId);
+                }
+            }
         }
     }
 
@@ -104,7 +100,13 @@ public class FileWatcherByPathMatcher {
             Iterator<Integer> iterator = operationsIdList.iterator();
             while (iterator.hasNext()) {
                 if (iterator.next() == operationId) {
-                    unwatch(matcher::matches);
+                    pathWatchRegistrations.keySet().stream()
+                                          .filter(matcher::matches)
+                                          .flatMap(it -> pathWatchRegistrations.remove(it).stream())
+                                          .forEach(watcher::unwatch);
+
+                    paths.values().forEach(it -> it.removeIf(matcher::matches));
+                    paths.entrySet().removeIf(it -> it.getValue().isEmpty());
                     iterator.remove();
                     operations.remove(operationId);
 
@@ -117,58 +119,6 @@ public class FileWatcherByPathMatcher {
             }
         }
 
-    }
-
-    private void seek() {
-        for (PathMatcher matcher : matchers.keySet()) {
-            unwatch(it -> !exists(it));
-
-            try {
-                walkFileTree(root.toPath(), new SimpleFileVisitor<Path>() {
-                    @Override
-                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                        return watch(dir);
-                    }
-
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                        return watch(file);
-                    }
-
-                    private FileVisitResult watch(Path path) {
-                        if (matcher.matches(path)) {
-                            for (int operationId : matchers.get(matcher)) {
-                                paths.putIfAbsent(operationId, newConcurrentHashSet());
-                                if (paths.get(operationId).contains(path)) {
-                                    return CONTINUE;
-                                }
-
-                                paths.get(operationId).add(path);
-
-                                Operation operation = operations.get(operationId);
-                                int pathWatcherOperationId = watcher.watch(path, operation.create, operation.modify, operation.delete);
-                                pathWatchRegistrations.putIfAbsent(path, newConcurrentHashSet());
-                                pathWatchRegistrations.get(path).add(pathWatcherOperationId);
-                            }
-                        }
-
-                        return CONTINUE;
-                    }
-                });
-            } catch (IOException e) {
-                LOG.error("Error walking file tree for watching file by matcher {}", matcher, e);
-            }
-        }
-    }
-
-    private void unwatch(Predicate<Path> predicate) {
-        pathWatchRegistrations.keySet().stream()
-                              .filter(predicate)
-                              .flatMap(it -> pathWatchRegistrations.remove(it).stream())
-                              .forEach(watcher::unwatch);
-
-        paths.values().forEach(it -> it.removeIf(predicate));
-        paths.entrySet().removeIf(it -> it.getValue().isEmpty());
     }
 
     private static class Operation {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileCreateConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileCreateConsumer.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.vfs.VirtualFile;
+import org.eclipse.che.api.vfs.VirtualFileSystem;
+import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
+import org.eclipse.che.api.vfs.search.Searcher;
+import org.eclipse.che.api.vfs.search.SearcherProvider;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+@Singleton
+public class IndexedFileCreateConsumer implements Consumer<Path> {
+    private File                      root;
+    private VirtualFileSystemProvider vfsProvider;
+
+    @Inject
+    public IndexedFileCreateConsumer(@Named("che.user.workspaces.storage") File root, VirtualFileSystemProvider vfsProvider) {
+        this.root = root;
+        this.vfsProvider = vfsProvider;
+    }
+
+    @Override
+    public void accept(Path path) {
+        try {
+            VirtualFileSystem virtualFileSystem = vfsProvider.getVirtualFileSystem();
+            SearcherProvider searcherProvider = virtualFileSystem.getSearcherProvider();
+            Searcher searcher = searcherProvider.getSearcher(virtualFileSystem);
+            Path innerPath = root.toPath().relativize(path);
+            org.eclipse.che.api.vfs.Path vfsPath = org.eclipse.che.api.vfs.Path.of(innerPath.toString());
+            VirtualFile child = virtualFileSystem.getRoot().getChild(vfsPath);
+            searcher.add(child);
+        } catch (ServerException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileCreateConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileCreateConsumer.java
@@ -16,6 +16,8 @@ import org.eclipse.che.api.vfs.VirtualFileSystem;
 import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
 import org.eclipse.che.api.vfs.search.Searcher;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,6 +28,8 @@ import java.util.function.Consumer;
 
 @Singleton
 public class IndexedFileCreateConsumer implements Consumer<Path> {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexedFileCreateConsumer.class);
+
     private File                      root;
     private VirtualFileSystemProvider vfsProvider;
 
@@ -46,7 +50,7 @@ public class IndexedFileCreateConsumer implements Consumer<Path> {
             VirtualFile child = virtualFileSystem.getRoot().getChild(vfsPath);
             searcher.add(child);
         } catch (ServerException e) {
-            e.printStackTrace();
+            LOG.error("Issue happened during adding created file to index", e);
         }
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileCreateConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileCreateConsumer.java
@@ -48,7 +48,9 @@ public class IndexedFileCreateConsumer implements Consumer<Path> {
             Path innerPath = root.toPath().relativize(path);
             org.eclipse.che.api.vfs.Path vfsPath = org.eclipse.che.api.vfs.Path.of(innerPath.toString());
             VirtualFile child = virtualFileSystem.getRoot().getChild(vfsPath);
-            searcher.add(child);
+            if (child != null) {
+                searcher.add(child);
+            }
         } catch (ServerException e) {
             LOG.error("Issue happened during adding created file to index", e);
         }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileDeleteConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileDeleteConsumer.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.vfs.VirtualFile;
+import org.eclipse.che.api.vfs.VirtualFileSystem;
+import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
+import org.eclipse.che.api.vfs.search.Searcher;
+import org.eclipse.che.api.vfs.search.SearcherProvider;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+@Singleton
+public class IndexedFileDeleteConsumer implements Consumer<Path> {
+    private File                      root;
+    private   VirtualFileSystemProvider vfsProvider;
+
+    @Inject
+    public IndexedFileDeleteConsumer(@Named("che.user.workspaces.storage") File root, VirtualFileSystemProvider vfsProvider) {
+        this.root = root;
+        this.vfsProvider = vfsProvider;
+    }
+
+    @Override
+    public void accept(Path path) {
+        try {
+            VirtualFileSystem virtualFileSystem = vfsProvider.getVirtualFileSystem();
+            SearcherProvider searcherProvider = virtualFileSystem.getSearcherProvider();
+            Searcher searcher = searcherProvider.getSearcher(virtualFileSystem);
+            Path innerPath = root.toPath().relativize(path);
+            searcher.delete("/"+innerPath.toString(), true);
+        } catch (ServerException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileDeleteConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileDeleteConsumer.java
@@ -11,11 +11,12 @@
 package org.eclipse.che.api.vfs.watcher;
 
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.vfs.VirtualFile;
 import org.eclipse.che.api.vfs.VirtualFileSystem;
 import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
 import org.eclipse.che.api.vfs.search.Searcher;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,8 +27,10 @@ import java.util.function.Consumer;
 
 @Singleton
 public class IndexedFileDeleteConsumer implements Consumer<Path> {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexedFileDeleteConsumer.class);
+
     private File                      root;
-    private   VirtualFileSystemProvider vfsProvider;
+    private VirtualFileSystemProvider vfsProvider;
 
     @Inject
     public IndexedFileDeleteConsumer(@Named("che.user.workspaces.storage") File root, VirtualFileSystemProvider vfsProvider) {
@@ -42,9 +45,9 @@ public class IndexedFileDeleteConsumer implements Consumer<Path> {
             SearcherProvider searcherProvider = virtualFileSystem.getSearcherProvider();
             Searcher searcher = searcherProvider.getSearcher(virtualFileSystem);
             Path innerPath = root.toPath().relativize(path);
-            searcher.delete("/"+innerPath.toString(), true);
+            searcher.delete("/" + innerPath.toString(), true);
         } catch (ServerException e) {
-            e.printStackTrace();
+            LOG.error("Issue happened during removing deleted file from index", e);
         }
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileUpdateConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileUpdateConsumer.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.vfs.VirtualFile;
+import org.eclipse.che.api.vfs.VirtualFileSystem;
+import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
+import org.eclipse.che.api.vfs.search.Searcher;
+import org.eclipse.che.api.vfs.search.SearcherProvider;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+@Singleton
+public class IndexedFileUpdateConsumer implements Consumer<Path> {
+    private File                      root;
+    private   VirtualFileSystemProvider vfsProvider;
+
+    @Inject
+    public IndexedFileUpdateConsumer(@Named("che.user.workspaces.storage") File root, VirtualFileSystemProvider vfsProvider) {
+        this.root = root;
+        this.vfsProvider = vfsProvider;
+    }
+
+    @Override
+    public void accept(Path path) {
+        try {
+            VirtualFileSystem virtualFileSystem = vfsProvider.getVirtualFileSystem();
+            SearcherProvider searcherProvider = virtualFileSystem.getSearcherProvider();
+            Searcher searcher = searcherProvider.getSearcher(virtualFileSystem);
+            Path innerPath = root.toPath().relativize(path);
+            org.eclipse.che.api.vfs.Path vfsPath = org.eclipse.che.api.vfs.Path.of(innerPath.toString());
+            VirtualFile child = virtualFileSystem.getRoot().getChild(vfsPath);
+            searcher.update(child);
+        } catch (ServerException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileUpdateConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileUpdateConsumer.java
@@ -16,6 +16,8 @@ import org.eclipse.che.api.vfs.VirtualFileSystem;
 import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
 import org.eclipse.che.api.vfs.search.Searcher;
 import org.eclipse.che.api.vfs.search.SearcherProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,8 +28,10 @@ import java.util.function.Consumer;
 
 @Singleton
 public class IndexedFileUpdateConsumer implements Consumer<Path> {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexedFileDeleteConsumer.class);
+
     private File                      root;
-    private   VirtualFileSystemProvider vfsProvider;
+    private VirtualFileSystemProvider vfsProvider;
 
     @Inject
     public IndexedFileUpdateConsumer(@Named("che.user.workspaces.storage") File root, VirtualFileSystemProvider vfsProvider) {
@@ -46,7 +50,7 @@ public class IndexedFileUpdateConsumer implements Consumer<Path> {
             VirtualFile child = virtualFileSystem.getRoot().getChild(vfsPath);
             searcher.update(child);
         } catch (ServerException e) {
-            e.printStackTrace();
+            LOG.error("Issue happened during updating modified file in index", e);
         }
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileUpdateConsumer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/IndexedFileUpdateConsumer.java
@@ -48,7 +48,9 @@ public class IndexedFileUpdateConsumer implements Consumer<Path> {
             Path innerPath = root.toPath().relativize(path);
             org.eclipse.che.api.vfs.Path vfsPath = org.eclipse.che.api.vfs.Path.of(innerPath.toString());
             VirtualFile child = virtualFileSystem.getRoot().getChild(vfsPath);
-            searcher.update(child);
+            if (child != null) {
+                searcher.update(child);
+            }
         } catch (ServerException e) {
             LOG.error("Issue happened during updating modified file in index", e);
         }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ExtensionCasesTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ExtensionCasesTest.java
@@ -61,7 +61,7 @@ public class ExtensionCasesTest extends WsAgentTestBase {
         projectRegistry = new ProjectRegistry(workspaceHolder, vfsProvider, projectTypeRegistry, projectHandlerRegistry, eventService);
         projectRegistry.initProjects();
 
-        pm = new ProjectManager(vfsProvider, null, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
+        pm = new ProjectManager(vfsProvider, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
                                 null, fileWatcherNotificationHandler, fileTreeWatcher, workspaceHolder, fileWatcherManager);
         pm.initWatcher();
 

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerReadTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerReadTest.java
@@ -75,7 +75,7 @@ public class ProjectManagerReadTest extends WsAgentTestBase {
         projectRegistry = new ProjectRegistry(workspaceHolder, vfsProvider, projectTypeRegistry, projectHandlerRegistry, eventService);
         projectRegistry.initProjects();
 
-        pm = new ProjectManager(vfsProvider, null, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
+        pm = new ProjectManager(vfsProvider, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
                                 null, fileWatcherNotificationHandler, fileTreeWatcher, workspaceHolder, fileWatcherManager);
         pm.initWatcher();
     }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -247,7 +247,7 @@ public class ProjectServiceTest {
         FileWatcherNotificationHandler fileWatcherNotificationHandler = new DefaultFileWatcherNotificationHandler(vfsProvider);
         FileTreeWatcher fileTreeWatcher = new FileTreeWatcher(root, new HashSet<>(), fileWatcherNotificationHandler);
 
-        pm = new ProjectManager(vfsProvider, new EventService(), ptRegistry, projectRegistry, phRegistry,
+        pm = new ProjectManager(vfsProvider, ptRegistry, projectRegistry, phRegistry,
                                 importerRegistry, fileWatcherNotificationHandler, fileTreeWatcher, workspaceHolder,
                                 fileWatcherManager);
         pm.initWatcher();

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/WsAgentTestBase.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/WsAgentTestBase.java
@@ -119,7 +119,7 @@ public class WsAgentTestBase {
         TestWorkspaceHolder wsHolder = new  TestWorkspaceHolder();
 
 
-        pm = new ProjectManager(vfsProvider, eventService, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
+        pm = new ProjectManager(vfsProvider, projectTypeRegistry, projectRegistry, projectHandlerRegistry,
                                 importerRegistry, fileWatcherNotificationHandler, fileTreeWatcher, wsHolder, fileWatcherManager);
         pm.initWatcher();
     }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileTreeWalkerTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileTreeWalkerTest.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.che.commons.schedule.executor.ThreadPullLauncher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static java.io.File.createTempFile;
+import static java.lang.Thread.sleep;
+import static org.apache.commons.io.FileUtils.write;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link FileTreeWalker}
+ */
+@SuppressWarnings({"WeakerAccess", "ResultOfMethodCallIgnored"})
+@RunWith(MockitoJUnitRunner.class)
+public class FileTreeWalkerTest {
+    static final int FS_LATENCY_DELAY = 1_000;
+    static final String TEST_FILE_NAME    = "test-file-name";
+    static final String TEST_FILE_CONTENT = "test-file-content";
+    static final String TEST_FOLDER_NAME = "test-folder-name";
+
+    @Rule
+    public TemporaryFolder rootFolder = new TemporaryFolder();
+
+    FileTreeWalker fileTreeWalker;
+
+    Set<Consumer<Path>> directoryCreateConsumers = new HashSet<>();
+    Set<Consumer<Path>> directoryUpdateConsumers = new HashSet<>();
+    Set<Consumer<Path>> directoryDeleteConsumers = new HashSet<>();
+    Set<PathMatcher>    directoryExcludes        = new HashSet<>();
+    Set<Consumer<Path>> fileCreateConsumers      = new HashSet<>();
+    Set<Consumer<Path>> fileUpdateConsumers      = new HashSet<>();
+    Set<Consumer<Path>> fileDeleteConsumers      = new HashSet<>();
+    Set<PathMatcher>    fileExcludes             = new HashSet<>();
+
+    @Mock
+    ThreadPullLauncher launcher;
+    @Mock
+    Consumer<Path>     fileCreatedConsumerMock;
+    @Mock
+    Consumer<Path>     fileUpdateConsumerMock;
+    @Mock
+    Consumer<Path>     fileDeleteConsumerMock;
+    @Mock
+    Consumer<Path>     directoryCreatedConsumerMock;
+    @Mock
+    Consumer<Path>     directoryUpdateConsumerMock;
+
+    @Mock
+    Consumer<Path> directoryDeleteConsumerMock;
+
+    @Before
+    public void setUp() throws Exception {
+        fileTreeWalker = new FileTreeWalker(rootFolder.getRoot(),
+                                            directoryUpdateConsumers,
+                                            directoryCreateConsumers,
+                                            directoryDeleteConsumers,
+                                            directoryExcludes,
+                                            fileUpdateConsumers,
+                                            fileCreateConsumers,
+                                            fileDeleteConsumers,
+                                            fileExcludes,
+                                            launcher);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        directoryUpdateConsumers.clear();
+        directoryCreateConsumers.clear();
+        directoryDeleteConsumers.clear();
+        directoryExcludes.clear();
+        fileUpdateConsumers.clear();
+        fileCreateConsumers.clear();
+        fileDeleteConsumers.clear();
+        fileExcludes.clear();
+    }
+
+    @Test
+    public void shouldRunFileCreatedConsumer() throws Exception {
+        fileCreateConsumers.add(fileCreatedConsumerMock);
+
+        File file = rootFolder.newFile(TEST_FILE_NAME);
+
+        fileTreeWalker.walk();
+        verify(fileCreatedConsumerMock).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldRunFileUpdateConsumer() throws Exception {
+        fileUpdateConsumers.add(fileUpdateConsumerMock);
+
+        File file = rootFolder.newFile(TEST_FILE_NAME);
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        write(file, TEST_FILE_CONTENT);
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        verify(fileUpdateConsumerMock).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldRunFileDeleteConsumer() throws Exception {
+        fileDeleteConsumers.add(fileDeleteConsumerMock);
+
+        File file = rootFolder.newFile(TEST_FILE_NAME);
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        file.delete();
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        verify(fileDeleteConsumerMock).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldRunDirectoryCreatedConsumer() throws Exception {
+        directoryCreateConsumers.add(directoryCreatedConsumerMock);
+
+        File file = rootFolder.newFolder(TEST_FOLDER_NAME);
+
+        fileTreeWalker.walk();
+        verify(directoryCreatedConsumerMock).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldRunDirectoryUpdateConsumer() throws Exception {
+        directoryUpdateConsumers.add(directoryUpdateConsumerMock);
+
+        File file = rootFolder.newFolder(TEST_FOLDER_NAME);
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        createTempFile(TEST_FILE_NAME, "", file);
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        verify(directoryUpdateConsumerMock).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldRunDirectoryDeleteConsumer() throws Exception {
+        directoryDeleteConsumers.add(directoryDeleteConsumerMock);
+
+        File file = rootFolder.newFolder(TEST_FOLDER_NAME);
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        file.delete();
+        sleep(FS_LATENCY_DELAY);
+        fileTreeWalker.walk();
+
+        verify(directoryDeleteConsumerMock).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldProperlySkipExcludedFile() throws Exception {
+        fileExcludes.add(it-> it.getFileName().toString().equals(TEST_FILE_NAME));
+        fileCreateConsumers.add(fileCreatedConsumerMock);
+
+        File file = rootFolder.newFile(TEST_FILE_NAME);
+
+        fileTreeWalker.walk();
+        verify(fileCreatedConsumerMock, never()).accept(file.toPath());
+    }
+
+    @Test
+    public void shouldProperlySkipExcludedDirectory() throws Exception {
+        directoryExcludes.add(it-> it.getFileName().toString().equals(TEST_FOLDER_NAME));
+        directoryCreateConsumers.add(directoryCreatedConsumerMock);
+
+        File file = rootFolder.newFolder(TEST_FOLDER_NAME);
+
+        fileTreeWalker.walk();
+        verify(directoryCreatedConsumerMock, never()).accept(file.toPath());
+    }
+}

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileTreeWalkerTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileTreeWalkerTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.vfs.watcher;
 
-import org.apache.commons.io.FileUtils;
-import org.eclipse.che.commons.schedule.executor.ThreadPullLauncher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,13 +52,12 @@ public class FileTreeWalkerTest {
     Set<Consumer<Path>> directoryUpdateConsumers = new HashSet<>();
     Set<Consumer<Path>> directoryDeleteConsumers = new HashSet<>();
     Set<PathMatcher>    directoryExcludes        = new HashSet<>();
+
     Set<Consumer<Path>> fileCreateConsumers      = new HashSet<>();
     Set<Consumer<Path>> fileUpdateConsumers      = new HashSet<>();
     Set<Consumer<Path>> fileDeleteConsumers      = new HashSet<>();
     Set<PathMatcher>    fileExcludes             = new HashSet<>();
 
-    @Mock
-    ThreadPullLauncher launcher;
     @Mock
     Consumer<Path>     fileCreatedConsumerMock;
     @Mock
@@ -85,8 +82,7 @@ public class FileTreeWalkerTest {
                                             fileUpdateConsumers,
                                             fileCreateConsumers,
                                             fileDeleteConsumers,
-                                            fileExcludes,
-                                            launcher);
+                                            fileExcludes);
     }
 
     @After


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Replaces current recursive file watchers with new tree walk based 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4248

#### Changelog
Previous recursive file watcher implementation is replaced by tree walk based one
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
