### PR TITLE
Perspective switcher for IDE assemblies

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/Perspective.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/Perspective.java
@@ -28,14 +28,12 @@ public interface Perspective extends StateComponent {
 
 
     /**
-     * Some Unique id will used for set/switch current perspective in workbench layout
-     * @return
+     * Some unique id will used to set/switch current perspective in workbench layout logic
      */
     String getPerspectiveId();
 
     /**
-     * human readable name of perspective will be use in UI element for switching perspective
-     * @return
+     * Human readable name of perspective will be used in UI element for switching perspective
      */
     String getPerspectiveName();
 

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/Perspective.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/Perspective.java
@@ -26,6 +26,19 @@ import javax.validation.constraints.NotNull;
  */
 public interface Perspective extends StateComponent {
 
+
+    /**
+     * Some Unique id will used for set/switch current perspective in workbench layout
+     * @return
+     */
+    String getPerspectiveId();
+
+    /**
+     * human readable name of perspective will be use in UI element for switching perspective
+     * @return
+     */
+    String getPerspectiveName();
+
     /** Maximizes central part stack */
     void maximizeCentralPartStack();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/perspectives/project/ProjectPerspective.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/perspectives/project/ProjectPerspective.java
@@ -77,6 +77,18 @@ public class ProjectPerspective extends AbstractPerspective {
         infoPanel.go(view.getInformationPanel());
     }
 
+
+    @Override
+    public String getPerspectiveId() {
+        return PROJECT_PERSPECTIVE_ID;
+    }
+
+
+    @Override
+    public String getPerspectiveName() {
+        return PROJECT_PERSPECTIVE_ID;
+    }
+
     /** {@inheritDoc} */
     @Override
     public void go(@NotNull AcceptsOneWidget container) {

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/perspectives/general/AbstractPerspectiveTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/perspectives/general/AbstractPerspectiveTest.java
@@ -23,7 +23,6 @@ import org.eclipse.che.ide.api.editor.AbstractEditorPresenter;
 import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStack;
-import static org.eclipse.che.ide.api.parts.PartStackType.NAVIGATION;
 import org.eclipse.che.ide.api.parts.PartStackView;
 import org.eclipse.che.ide.api.parts.PartStackView.TabPosition;
 import org.eclipse.che.ide.part.PartStackPresenter;
@@ -44,11 +43,11 @@ import java.util.Arrays;
 
 import static org.eclipse.che.ide.api.parts.PartStackType.EDITING;
 import static org.eclipse.che.ide.api.parts.PartStackType.INFORMATION;
+import static org.eclipse.che.ide.api.parts.PartStackType.NAVIGATION;
 import static org.eclipse.che.ide.api.parts.PartStackView.TabPosition.BELOW;
 import static org.eclipse.che.ide.api.parts.PartStackView.TabPosition.LEFT;
 import static org.eclipse.che.ide.api.parts.PartStackView.TabPosition.RIGHT;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -295,6 +294,16 @@ public class AbstractPerspectiveTest {
             if (editingPartStackPresenter != null) {
                 partStacks.put(EDITING, editingPartStackPresenter);
             }
+        }
+
+        @Override
+        public String getPerspectiveId() {
+            return SOME_TEXT;
+        }
+
+        @Override
+        public String getPerspectiveName() {
+            return "Dummy";
         }
 
         @Override


### PR DESCRIPTION
### What does this PR do?
1. If assembly of Che has more than one registered implementations of Perspective, they will be automatically added to the 'Window' menu as a corresponding sub-menu items. With this feature you can easily switch between your perspectives. 

2. Change interface Perspective add two new methods 
  ``` 
     /**
     * Some Unique id will used for set/switch current perspective in workbench layout logic
     */
    String getPerspectiveId();

    /**
     * human readable name of perspective will be use in UI element for switching perspective
     */
    String getPerspectiveName();
```

#### Changelog
Perspectives are shown in 'Window' menu if their number is more than one
If a Che assembly includes 1+ perspectives they are now listed in the IDE's Window menu.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
With Che it's possible to create a custom assembly that includes multiple IDE perspectives each with unique IDE panels, menus and visualizations. If an assembly includes one or more perspectives each will be automatically added to the Window menu in the IDE making it easy to switch from one to another:

![window-perspective](https://cloud.githubusercontent.com/assets/1636592/23749365/85e71ec0-04d0-11e7-9518-0fd62226d323.png)


