### PR TITLE
[cli] Make preflight test containers with unique name

### DIFF
--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -265,13 +265,13 @@ generate_random_string() {
 start_test_server() {
   export AGENT_INTERNAL_PORT=80
   export AGENT_EXTERNAL_PORT=32768
-  export AGENT_CONTAINER_NAME="fakeagent-"$(generate_random_string 10)
+  export AGENT_CONTAINER_NAME="fakeagent-$CHE_PORT"
 
   # Start mini httpd server to run simulated tests
   docker run -d -p $AGENT_EXTERNAL_PORT:$AGENT_INTERNAL_PORT --name $AGENT_CONTAINER_NAME \
              ${BOOTSTRAP_IMAGE_ALPINE} httpd -f -p $AGENT_INTERNAL_PORT -h /etc/ >> "${LOGS}"
 
-  export AGENT_INTERNAL_IP=$(docker inspect --format='{{.NetworkSettings.IPAddress}}' fakeagent)
+  export AGENT_INTERNAL_IP=$(docker inspect --format='{{.NetworkSettings.IPAddress}}' $AGENT_CONTAINER_NAME)
   export AGENT_EXTERNAL_IP=$CHE_HOST
 }
 

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -256,12 +256,6 @@ docker_compose() {
   fi
 }
 
-# Return srandom character alphanumeric string (upper and lower case) of length $1
-generate_random_string() {
-  NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $1 | head -n 1)
-  echo $NEW_UUID
-}
-
 start_test_server() {
   export AGENT_INTERNAL_PORT=80
   export AGENT_EXTERNAL_PORT=32768


### PR DESCRIPTION
### What does this PR do?
Solves race condition when starting multiple Che servers quickly where the preflight test containers were sharing the same name and running into conflicts. This sets the name of preflight containers to be unique by appending the port of the Che server.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4353

#### Changelog
[cli] Give containers used in preflight tests unique name
 
#### Release Notes
N/A

#### Docs PR
N/A