### PR TITLE
CHE-4296 Webkit font-smoothing bug when the IDE is opened in dashboad iframe

### DIFF
--- a/assembly/assembly-ide-war/src/main/resources/org/eclipse/che/ide/public/IDE.css
+++ b/assembly/assembly-ide-war/src/main/resources/org/eclipse/che/ide/public/IDE.css
@@ -77,3 +77,7 @@ a{
 
     color: #333333;
 }
+
+.global-zeroclipboard-container {
+    visibility: hidden;
+}


### PR DESCRIPTION
Fixes rendering of the fonts when the IDE is opened in iframe.

https://github.com/eclipse/che/issues/4296
