### PR TITLE
Trigger file saving operation on editor closing only when file has changes

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
@@ -74,7 +74,10 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
 
     @Override
     public void removeEditor(EditorPartPresenter editor) {
-        editor.doSave();
+        if (editor.isDirty()) {
+            editor.doSave();
+        }
+
         HandlerRegistration handlerRegistration = synchronizedEditors.remove(editor);
         if (handlerRegistration != null) {
             handlerRegistration.removeHandler();

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImplTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImplTest.java
@@ -110,6 +110,8 @@ public class EditorGroupSynchronizationImplTest {
 
     @Test
     public void shouldRemoveEditorFromGroup() {
+        when(activeEditor.isDirty()).thenReturn(true);
+
         editorGroupSynchronization.addEditor(activeEditor);
 
         editorGroupSynchronization.removeEditor(activeEditor);


### PR DESCRIPTION
### What does this PR do?

This changes proposal disable automatically file saving on editor closing.

The previous version doesn't care about whether file changed or not and automatically fired file saving. New behavior takes care about current opened file, and if file is dirty then fire file saving.

Signed-off-by: Vladyslav Zhukovskii <vzhukovskii@codenvy.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4076

#### Changelog
Trigger file saving operation on editor closing only when file has changes

#### Release Notes
Trigger file saving operation on editor closing only when file has changes

#### Docs PR
N/A
