### PR TITLE
CHE-4381 Do not create '/projects' dir if already exists

### DIFF
--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -34,8 +34,11 @@ fi
 MACHINE_TYPE=$(uname -m)
 
 mkdir -p ${CHE_DIR}
-${SUDO} mkdir -p /projects
-${SUDO} sh -c "chown -R $(id -u -n) /projects"
+
+if [ ! -d "/projects" ]; then
+    ${SUDO} mkdir -p /projects
+    ${SUDO} sh -c "chown -R $(id -u -n) /projects"
+fi
 
 
 INSTALL_JDK=false


### PR DESCRIPTION
### What does this PR do?
Do not create '/projects' dir if already exists via workspace agent script

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4381

#### Changelog
 Do not create '/projects' dir if already exists via workspace agent script

#### Release Notes
n/a

#### Docs PR
n/a

