### PR TITLE
VFS API deprecation

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFile.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFile.java
@@ -26,6 +26,7 @@ import java.util.Map;
  *
  * @author andrew00x
  */
+@Deprecated
 public interface VirtualFile extends Comparable<VirtualFile> {
     /**
      * Gets name.

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFile.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFile.java
@@ -25,6 +25,8 @@ import java.util.Map;
  * Item of Virtual Filesystem.
  *
  * @author andrew00x
+ *
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
  */
 @Deprecated
 public interface VirtualFile extends Comparable<VirtualFile> {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileFilter.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileFilter.java
@@ -15,6 +15,7 @@ package org.eclipse.che.api.vfs;
  *
  * @author andrew00x
  */
+@Deprecated
 public interface VirtualFileFilter {
     /** Tests whether specified file should be included in result. */
     boolean accept(VirtualFile file);

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileFilter.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileFilter.java
@@ -14,6 +14,8 @@ package org.eclipse.che.api.vfs;
  * Filter for virtual files.
  *
  * @author andrew00x
+ *
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
  */
 @Deprecated
 public interface VirtualFileFilter {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystem.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystem.java
@@ -18,6 +18,8 @@ import org.eclipse.che.api.vfs.search.SearcherProvider;
  * Only children of root folder may be accessible through this API.
  *
  * @author andrew00x
+ *
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
  */
 @Deprecated
 public interface VirtualFileSystem {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystem.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystem.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.vfs.search.SearcherProvider;
  *
  * @author andrew00x
  */
+@Deprecated
 public interface VirtualFileSystem {
     /**
      * Get root folder of virtual file system. Any files in higher level than root are not accessible through virtual file system API.

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystemProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystemProvider.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.vfs;
 
 import org.eclipse.che.api.core.ServerException;
 
+@Deprecated
 public interface VirtualFileSystemProvider {
     /**
      * Get VirtualFileSystem.

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystemProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileSystemProvider.java
@@ -12,6 +12,9 @@ package org.eclipse.che.api.vfs;
 
 import org.eclipse.che.api.core.ServerException;
 
+/**
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
+ */
 @Deprecated
 public interface VirtualFileSystemProvider {
     /**

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileVisitor.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileVisitor.java
@@ -18,6 +18,7 @@ import org.eclipse.che.api.core.ServerException;
  *
  * @author andrew00x
  */
+@Deprecated
 public interface VirtualFileVisitor {
     /**
      * This method is called when the VirtualFileVisitor is passed to the {@link VirtualFile#accept(VirtualFileVisitor) accept} method of a

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileVisitor.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFileVisitor.java
@@ -17,6 +17,8 @@ import org.eclipse.che.api.core.ServerException;
  * VirtualFile#accept(VirtualFileVisitor)} the <code>visit</code> method is called.
  *
  * @author andrew00x
+ *
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
  */
 @Deprecated
 public interface VirtualFileVisitor {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/DataSerializer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/DataSerializer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
  *
  * @author andrew00x
  */
+@Deprecated
 public interface DataSerializer<T> {
     /**
      * Writes <code>value</code> to <code>output</code>.

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/DataSerializer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/DataSerializer.java
@@ -18,6 +18,8 @@ import java.io.IOException;
  * Writes object to stream and restores object from stream. Implementation has full control over format of serialization.
  *
  * @author andrew00x
+ *
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
  */
 @Deprecated
 public interface DataSerializer<T> {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/FileWatcherNotificationHandler.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/FileWatcherNotificationHandler.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType;
 
 import java.io.File;
 
+@Deprecated
 public interface FileWatcherNotificationHandler {
     void handleFileWatcherEvent(FileWatcherEventType eventType, File watchRoot, String subPath, boolean isDir);
 

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/FileWatcherNotificationHandler.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/FileWatcherNotificationHandler.java
@@ -14,6 +14,9 @@ import org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType;
 
 import java.io.File;
 
+/**
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
+ */
 @Deprecated
 public interface FileWatcherNotificationHandler {
     void handleFileWatcherEvent(FileWatcherEventType eventType, File watchRoot, String subPath, boolean isDir);

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/Searcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/Searcher.java
@@ -14,6 +14,9 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.vfs.VirtualFile;
 import org.eclipse.che.api.vfs.VirtualFileFilter;
 
+/**
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
+ */
 @Deprecated
 public interface Searcher {
     /**

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/Searcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/Searcher.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.vfs.VirtualFile;
 import org.eclipse.che.api.vfs.VirtualFileFilter;
 
+@Deprecated
 public interface Searcher {
     /**
      * Return paths of matched items on virtual filesystem.

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/SearcherProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/SearcherProvider.java
@@ -18,6 +18,7 @@ import org.eclipse.che.api.vfs.VirtualFileSystem;
  *
  * @author andrew00x
  */
+@Deprecated
 public interface SearcherProvider {
     /**
      * Get Searcher for specified VirtualFileSystem.

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/SearcherProvider.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/SearcherProvider.java
@@ -17,6 +17,8 @@ import org.eclipse.che.api.vfs.VirtualFileSystem;
  * Manages instances of Searcher.
  *
  * @author andrew00x
+ *
+ * @deprecated VFS components are now considered deprecated and will be replaced by standard JDK routines.
  */
 @Deprecated
 public interface SearcherProvider {


### PR DESCRIPTION
Signed-off-by: Dmitry Kuleshov <dkuleshov@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Sets deprecation on major VFS components, VFS components are now considered deprecated and will be replaced by standard JDK routines.

The benefits that the VFS provided no more actual for current logic and architecture. There is no need for multi tenancy support as long as we're running file system on a single workspace agent instance. 
We are not using/not implemented most of file system items attributes facilities.   As long as any user can intrude a file system via ssh we cannot effectively use file system locks provided by VFS.
We cannot rely on index update routines as we're not tracking external file system events but only track VFS events.

The removal of virtual file system layer will give us the following benefits:
- Removing extra layer - simplified logic, less source cod.
- Reuse of JDK file related libraries - more reliable code
- Make file/text searcher based on file watchers - make index more stable
- Remove synchronization required for multi tenancy - performance improvements
- The general performance and architecture impact is yet to be investigated and analyzed


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4249

#### Changelog
VFS components are now considered deprecated and will be replaced by standard JDK routines.
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
