### PR TITLE
Set correct default hot key scheme. Don't use deprectaed method

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/KeyBindingManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/KeyBindingManager.java
@@ -70,7 +70,7 @@ public class KeyBindingManager implements KeyBindingAgent {
         addScheme(new SchemeImpl(SCHEME_ECLIPSE_ID, "Eclipse Scheme"));
 
         //TODO check user settings
-        activeScheme = SCHEME_ECLIPSE_ID;
+        activeScheme = SCHEME_GLOBAL_ID;
 
         presentationFactory = new PresentationFactory();
 

--- a/plugins/plugin-keybinding-eclipse/plugin-keybinding-eclipse-ide/src/main/java/org/eclipse/che/plugin/keybinding/eclipse/EclipseKeyBinding.java
+++ b/plugins/plugin-keybinding-eclipse/plugin-keybinding-eclipse-ide/src/main/java/org/eclipse/che/plugin/keybinding/eclipse/EclipseKeyBinding.java
@@ -13,6 +13,7 @@ package org.eclipse.che.plugin.keybinding.eclipse;
 import org.eclipse.che.ide.api.extension.Extension;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.KeyBuilder;
+import org.eclipse.che.ide.keybinding.KeyBindingManager;
 import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.ide.util.input.CharCodeWithModifiers;
 import org.eclipse.che.ide.util.input.KeyCodeMap;
@@ -39,6 +40,7 @@ import static org.eclipse.che.ide.ext.java.client.JavaExtension.ORGANIZE_IMPORTS
 import static org.eclipse.che.ide.ext.java.client.JavaExtension.PARAMETERS_INFO;
 import static org.eclipse.che.ide.ext.java.client.JavaExtension.QUICK_FIX;
 import static org.eclipse.che.ide.ext.java.client.JavaExtension.SHOW_QUICK_DOC;
+import static org.eclipse.che.ide.keybinding.KeyBindingManager.SCHEME_ECLIPSE_ID;
 import static org.eclipse.che.plugin.debugger.ide.DebuggerExtension.DEBUG_ID;
 import static org.eclipse.che.plugin.debugger.ide.DebuggerExtension.DISCONNECT_DEBUG_ID;
 import static org.eclipse.che.plugin.debugger.ide.DebuggerExtension.EDIT_DEBUG_CONF_ID;
@@ -111,6 +113,6 @@ public class EclipseKeyBinding {
         keys.put(GIT_COMPARE_WITH_LATEST, new KeyBuilder().action().alt().charCode('d').build());
 
         // Register keys
-        agent.getEclipse().addKeys(keys);
+        agent.getScheme(SCHEME_ECLIPSE_ID).addKeys(keys);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Set correct default hot key scheme. 
Don't use deprecated method


#### Changelog
Set correct default hot key scheme. Don't use deprecated method.

#### Release Notes
N/A


