### PR TITLE
ARTIK-318: Add close to JGit clone operation

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -514,7 +514,7 @@ class JGitConnection implements GitConnection {
                 }
             });
 
-            executeRemoteCommand(remoteUri, cloneCommand, params.getUsername(), params.getPassword());
+            ((Git)executeRemoteCommand(remoteUri, cloneCommand, params.getUsername(), params.getPassword())).close();
 
             StoredConfig repositoryConfig = getRepository().getConfig();
             GitUser gitUser = getUser();

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -42,14 +42,12 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -11,19 +11,23 @@
  *******************************************************************************/
 package org.eclipse.che.git.impl.jgit;
 
+import org.eclipse.che.api.core.util.LineConsumerFactory;
 import org.eclipse.che.api.git.CredentialsLoader;
 import org.eclipse.che.api.git.GitUserResolver;
 import org.eclipse.che.api.git.exception.GitException;
+import org.eclipse.che.api.git.params.CloneParams;
 import org.eclipse.che.api.git.params.CommitParams;
 import org.eclipse.che.api.git.shared.GitUser;
 import org.eclipse.che.api.git.shared.Status;
 import org.eclipse.che.plugin.ssh.key.script.SshKeyProvider;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryState;
+import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.Transport;
 import org.eclipse.jgit.transport.TransportHttp;
@@ -36,13 +40,16 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -232,5 +239,23 @@ public class JGitConnectionTest {
 
         //when
         jGitConnection.commit(CommitParams.create("message").withFiles(singletonList("NotChangedSpecified")).withAmend(true).withAll(true));
+    }
+
+    @Test
+    public void shouldCloseCloneCommand() throws Exception {
+        //given
+        File fileMock = mock(File.class);
+        Git cloneCommand = mock(Git.class);
+        jGitConnection.setOutputLineConsumerFactory(mock(LineConsumerFactory.class));
+        when(repository.getWorkTree()).thenReturn(fileMock);
+        when(repository.getDirectory()).thenReturn(fileMock);
+        when(repository.getConfig()).thenReturn(mock(StoredConfig.class));
+        doReturn(cloneCommand).when(jGitConnection).executeRemoteCommand(anyString(), anyObject(), anyString(), anyString());
+
+        //when
+        jGitConnection.clone(CloneParams.create("url").withWorkingDir("fakePath"));
+
+        //then
+        verify(cloneCommand).close();
     }
 }


### PR DESCRIPTION
If Jgit clone command is executed without close, Jgit process will capture `pack` file in `.git` folder.
As a result workspace folder is not deleted after deleting workspace in IDE on Windows OS.

### What does this PR do?
Add `close` operation to result of Jgit's clone command execution to free resources.

### What issues does this PR fix or reference?
https://github.com/codenvy/artik/issues/318

#### Changelog
Fix bug when workspace folder is not deleted after deleting workspace in IDE on Windows OS.

#### Release Notes
Bugfix N/A

#### Docs PR
Bugfix N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
