### PR TITLE
Prevent multiple event subscription for single file

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileOpenCloseEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileOpenCloseEventListener.java
@@ -51,9 +51,9 @@ public class FileOpenCloseEventListener {
 
                 switch (event.getOperationType()) {
                     case OPEN: {
-                        if (editorAgent.getOpenedEditor(path) == null) {                // if we haven't any editor for given path yet
-                            Log.info(getClass(), "Subscribe file for event handling");  // we subscribe for event handling otherwise we
-                                                                                        // do nothing
+                        if (editorAgent.getOpenedEditor(path) == null) {                 // if we haven't any editor for given path yet
+                            Log.debug(getClass(), "Subscribe file for event handling");  // we subscribe for event handling otherwise we
+                                                                                         // do nothing
                             processFileOpen(path);
                         }
 

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileOpenCloseEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileOpenCloseEventListener.java
@@ -47,16 +47,21 @@ public class FileOpenCloseEventListener {
             @Override
             public void onFileOperation(FileEvent event) {
                 final Path path = event.getFile().getLocation();
+                final EditorAgent editorAgent = editorAgentProvider.get();
 
                 switch (event.getOperationType()) {
                     case OPEN: {
-                        processFileOpen(path);
+                        if (editorAgent.getOpenedEditor(path) == null) {                // if we haven't any editor for given path yet
+                            Log.info(getClass(), "Subscribe file for event handling");  // we subscribe for event handling otherwise we
+                                                                                        // do nothing
+                            processFileOpen(path);
+                        }
 
                         break;
                     }
                     case CLOSE: {
                         final EditorPartPresenter closingEditor = event.getEditorTab().getRelativeEditorPart();
-                        final List<EditorPartPresenter> openedEditors = editorAgentProvider.get().getOpenedEditors();
+                        final List<EditorPartPresenter> openedEditors = editorAgent.getOpenedEditors();
 
                         processFileClose(closingEditor, openedEditors, path);
 


### PR DESCRIPTION
### What does this PR do?
This PR proposal adds additional check for opened editor for file which opens more than once.
This will prevent multiple event subscription for single file.

Signed-off-by: Vladyslav Zhukovskii <vzhukovskii@codenvy.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4254

#### Changelog
Prevent multiple event subscription for single file

#### Release Notes
Prevent multiple event subscription for single file

#### Docs PR
N/A
