### PR TITLE
Implement getSystemInfo method in OpenShiftConnector

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -61,6 +61,7 @@ import org.eclipse.che.plugin.docker.client.json.ImageInfo;
 import org.eclipse.che.plugin.docker.client.json.NetworkCreated;
 import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
 import org.eclipse.che.plugin.docker.client.json.PortBinding;
+import org.eclipse.che.plugin.docker.client.json.SystemInfo;
 import org.eclipse.che.plugin.docker.client.json.network.ContainerInNetwork;
 import org.eclipse.che.plugin.docker.client.json.network.Ipam;
 import org.eclipse.che.plugin.docker.client.json.network.IpamConfig;
@@ -100,6 +101,8 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeSystemInfo;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
@@ -778,6 +781,33 @@ public class OpenShiftConnector extends DockerConnector {
         }
     }
 
+    @Override
+    public SystemInfo getSystemInfo() throws IOException {
+        PodList chePods = openShiftClient.pods().inNamespace(this.openShiftCheProjectName).list();
+        if (chePods.getItems().size() > 0) {
+            Pod pod = chePods.getItems().get(0);
+            Node node = openShiftClient.nodes().withName(pod.getSpec().getNodeName()).get();
+            NodeSystemInfo nodeInfo = node.getStatus().getNodeInfo();
+            SystemInfo systemInfo = new SystemInfo();
+            systemInfo.setKernelVersion(nodeInfo.getKernelVersion());
+            systemInfo.setOperatingSystem(nodeInfo.getOperatingSystem());
+            systemInfo.setID(node.getMetadata().getUid());
+            int containers = openShiftClient.pods().inNamespace(this.openShiftCheProjectName).list().getItems().size();
+            int images = node.getStatus().getImages().size();
+            systemInfo.setContainers(containers);
+            systemInfo.setImages(images);
+            systemInfo.setName(node.getMetadata().getName());
+            String[] labels = node.getMetadata()
+                      .getLabels()
+                      .entrySet().stream().map(e -> String.format("%s=%s", e.getKey(), e.getValue()))
+                      .toArray(String[]::new);
+            systemInfo.setLabels(labels);
+            return systemInfo;
+        } else {
+            throw new OpenShiftException("No pod found");
+        }
+    }
+
     /**
      * Gets the ImageStreamTag corresponding to a given tag name (i.e. without the repository)
      * @param imageStreamTagName the tag name to search for
@@ -1452,4 +1482,5 @@ public class OpenShiftConnector extends DockerConnector {
     private boolean isDevMachine(final Set<String> exposedPorts) {
         return exposedPorts.contains(CHE_WORKSPACE_AGENT_PORT + "/tcp");
     }
+
 }


### PR DESCRIPTION
What does this PR do?

Implements the getSystemInfo method in OpenShiftConnector.

The PR implements getSystemInfo partially.
The method requires the cluster-admin role which has already been added for the che service account.

This method isn't called anywhere in che. In order to test it, you need to debug che and call the method manually.

What issues does this PR fix or reference?

Che doesn't start on OpenShift if the Docker socket is not mounted.