### PR TITLE
[cli] Fix the aliases to use for the che cli image (for now alias was using the same name)

### DIFF
--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -5,13 +5,13 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-# Define space separated list of aliases for the docker image
-IMAGE_ALIASES="eclipse/che-cli"
-
 base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}"/../build.include
 
 init --name:cli "$@"
+
+# Define space separated list of aliases for the docker image
+IMAGE_ALIASES="${ORGANIZATION}/${PREFIX}"
 
 if [[ ! -f "${base_dir}/version/$TAG/images" ]]; then
 	mkdir -p ${base_dir}/version/$TAG/


### PR DESCRIPTION
### What does this PR do?
- Fix the aliases to use for the che cli image (for now alias was using the same name)
- Also add support of Organization and prefix on the alias

### What issues does this PR fix or reference?
N/A

#### Changelog
Fix the aliases to use for the che cli image (for now alias was using the same name)

#### Release Notes
BugFix


#### Docs PR
BugFix

Change-Id: I9f32c8c87cde8bc68a6204ba8c307aed15476bfe
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>

