### PR TITLE
Set Github token through workspace master Rest API. Added a force act…

### DIFF
--- a/assembly/assembly-wsagent-war/src/main/webapp/WEB-INF/classes/codenvy/che-machine-configuration.properties
+++ b/assembly/assembly-wsagent-war/src/main/webapp/WEB-INF/classes/codenvy/che-machine-configuration.properties
@@ -50,6 +50,8 @@ oauth.github.authuri= https://github.com/login/oauth/authorize
 oauth.github.tokenuri= https://github.com/login/oauth/access_token
 #redirected uris
 oauth.github.redirecturis= http://localhost:${SERVER_PORT}/che/api/oauth/callback
+# register github even without client id and secret
+oauth.github.forceactivation=false
 
 git.server.uri.prefix=git
 

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
@@ -45,7 +45,6 @@ che.oauth.github.clientsecret=oauth.github.clientsecret
 che.oauth.github.authuri=oauth.github.authuri
 che.oauth.github.tokenuri=oauth.github.tokenuri
 che.oauth.github.redirecturis=oauth.github.redirecturis
-che.oauth.github.forceactivation=oauth.github.forceactivation
 che.docker.registry=machine.docker.registry
 che.docker.always_pull_image=machine.docker.pull_image
 che.docker.privileged=machine.docker.privilege_mode

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
@@ -45,6 +45,7 @@ che.oauth.github.clientsecret=oauth.github.clientsecret
 che.oauth.github.authuri=oauth.github.authuri
 che.oauth.github.tokenuri=oauth.github.tokenuri
 che.oauth.github.redirecturis=oauth.github.redirecturis
+che.oauth.github.forceactivation=oauth.github.forceactivation
 che.docker.registry=machine.docker.registry
 che.docker.always_pull_image=machine.docker.pull_image
 che.docker.privileged=machine.docker.privilege_mode

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -142,7 +142,8 @@ che.oauth.github.clientsecret=NULL
 che.oauth.github.authuri= https://github.com/login/oauth/authorize
 che.oauth.github.tokenuri= https://github.com/login/oauth/access_token
 che.oauth.github.redirecturis= http://localhost:${SERVER_PORT}/wsmaster/api/oauth/callback
-
+# register github even without client id and secret
+che.oauth.github.forceactivation=false
 
 ### DOCKER PARAMETERS
 # Docker is the default machine implementation within Che. Workspaces are powered by machines

--- a/plugins/plugin-github/che-plugin-github-oauth2/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticator.java
+++ b/plugins/plugin-github/che-plugin-github-oauth2/src/main/java/org/eclipse/che/security/oauth/GitHubOAuthAuthenticator.java
@@ -30,23 +30,29 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-
 /** OAuth authentication for github account. */
 @Singleton
 public class GitHubOAuthAuthenticator extends OAuthAuthenticator {
     @Inject
-    public GitHubOAuthAuthenticator(@Nullable @Named("che.oauth.github.clientid") String clientId,
-                                    @Nullable @Named("che.oauth.github.clientsecret") String clientSecret,
-                                    @Nullable @Named("che.oauth.github.redirecturis") String[] redirectUris,
-                                    @Nullable @Named("che.oauth.github.authuri") String authUri,
-                                    @Nullable @Named("che.oauth.github.tokenuri") String tokenUri) throws IOException {
-        if (!isNullOrEmpty(clientId)
-            && !isNullOrEmpty(clientSecret)
-            && !isNullOrEmpty(authUri)
-            && !isNullOrEmpty(tokenUri)
+    public GitHubOAuthAuthenticator(@Nullable @Named("che.oauth.github.clientid") String clientId, //
+                                    @Nullable @Named("che.oauth.github.clientsecret") String clientSecret, //
+                                    @Nullable @Named("che.oauth.github.redirecturis") String[] redirectUris, //
+                                    @Nullable @Named("che.oauth.github.authuri") String authUri, //
+                                    @Nullable @Named("che.oauth.github.tokenuri") String tokenUri, //
+                                    @Nullable @Named("che.oauth.github.forceactivation") Boolean forceActivation) throws IOException {
+        if (!isNullOrEmpty(clientId) //
+            && !isNullOrEmpty(clientSecret) //
+            && !isNullOrEmpty(authUri) //
+            && !isNullOrEmpty(tokenUri) //
             && redirectUris != null && redirectUris.length != 0) {
 
             configure(clientId, clientSecret, redirectUris, authUri, tokenUri, new MemoryDataStoreFactory());
+            return;
+        }
+
+        if (forceActivation != null && forceActivation) {
+            configure("NULL", "NULL", redirectUris, authUri, tokenUri, new MemoryDataStoreFactory());
+            return;
         }
     }
 

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticationService.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticationService.java
@@ -208,7 +208,6 @@ public class OAuthAuthenticationService {
 
     @POST
     @Path("token")
-    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public void setToken(@Required @QueryParam("oauth_provider") String oauthProvider, //
                          OAuthToken token) throws ServerException {

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticationService.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticationService.java
@@ -27,9 +27,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -202,5 +204,29 @@ public class OAuthAuthenticationService {
             throw new BadRequestException("Unsupported OAuth provider " + oauthProviderName);
         }
         return oauth;
+    }
+
+    @POST
+    @Path("token")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void setToken(@Required @QueryParam("oauth_provider") String oauthProvider, //
+                         OAuthToken token) throws ServerException {
+        if (token == null) {
+            throw new ServerException("No token provided");
+        }
+
+        OAuthAuthenticator provider = providers.getAuthenticator(oauthProvider);
+        if (provider == null) {
+            throw new ServerException("\"" + oauthProvider + "\" oauth provider not registered");
+        }
+
+        String userId = EnvironmentContext.getCurrent().getSubject().getUserId();
+
+        try {
+            provider.setToken(userId, token);
+        } catch (IOException e) {
+            throw new ServerException(e.getMessage());
+        }
     }
 }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -16,6 +16,7 @@ import com.google.api.client.auth.oauth2.AuthorizationCodeResponseUrl;
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.auth.oauth2.StoredCredential;
 import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -318,5 +319,10 @@ public abstract class OAuthAuthenticator {
      */
     public boolean isConfigured() {
         return flow != null;
+    }
+
+    public void setToken(String userId, OAuthToken token) throws IOException {
+        Credential credential = new Credential(BearerToken.authorizationHeaderAccessMethod()).setAccessToken(token.getToken());
+        flow.getCredentialDataStore().set(userId, new StoredCredential(credential));
     }
 }

--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -322,7 +322,8 @@ public abstract class OAuthAuthenticator {
     }
 
     public void setToken(String userId, OAuthToken token) throws IOException {
-        Credential credential = new Credential(BearerToken.authorizationHeaderAccessMethod()).setAccessToken(token.getToken());
-        flow.getCredentialDataStore().set(userId, new StoredCredential(credential));
+        flow.createAndStoreCredential(new TokenResponse().setAccessToken(token.getToken()) //
+                                                         .setScope(token.getScope()), //
+                                      userId);
     }
 }


### PR DESCRIPTION
Set Github token through workspace master Rest API. Added a force activation property variable to register Github Oauth provider even without client id/secret

Signed-off-by: Sun Seng David Tan <sutan@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- add a new REST operation to set a Oauth token to an existing provider
- add a property `che.oauth.github.forceactivation` to force registration of Github Oauth provider, even without client id/secret (actually set `NULL` string for these value)

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-151

#### Changelog
Set Github token through workspace master Rest API. Added a force activation property variable to register Github Oauth provider even without client id/secret

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Set Github token through workspace master Rest API. Added a force activation property variable to register Github Oauth provider even without client id/secret


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
