### PR TITLE
Update che-in-che.json

### DIFF
--- a/assembly/assembly-main/src/assembly/stack/che-in-che.json
+++ b/assembly/assembly-main/src/assembly/stack/che-in-che.json
@@ -28,7 +28,7 @@
   ],
   "source": {
     "type": "image",
-    "origin": "codenvy/alpine_jdk8"
+    "origin": "eclipse/alpine_jdk8"
   },
   "workspaceConfig": {
     "environments": {


### PR DESCRIPTION
Updating docker image organization from `codenvy/alpine_jdk8` to `eclipse/alpine_jdk8`. 

### What does this PR do?
Fixes che-in-che stack.

#### Changelog
Fix che-in-che stack.

#### Release Notes
Fix che-in-che stack.


#### Docs PR
TODO

Signed-off-by: James Drummond jdrummond@codenvy.com