### PR TITLE
Che 4416

### DIFF
--- a/core/commons/che-core-commons-schedule/src/test/java/org/eclipse/che/commons/schedule/executor/CronExpressionTest.java
+++ b/core/commons/che-core-commons-schedule/src/test/java/org/eclipse/che/commons/schedule/executor/CronExpressionTest.java
@@ -156,7 +156,7 @@ public class CronExpressionTest {
         Date pdate = cronExpression.getNextValidTimeAfter(new Date());
         while (++i < 26) {
             Date date = cronExpression.getNextValidTimeAfter(pdate);
-            LOG.info("fireTime: " + date + ", previousFireTime: " + pdate);
+            LOG.debug("fireTime: " + date + ", previousFireTime: " + pdate);
             assertFalse(pdate.equals(date), "Next fire time is the same as previous fire time!");
             pdate = date;
         }
@@ -174,7 +174,7 @@ public class CronExpressionTest {
         Date pdate = cronExpression.getNextValidTimeAfter(new Date());
         while (++i < 26) {
             Date date = cronExpression.getNextValidTimeAfter(pdate);
-            LOG.info("fireTime: " + date + ", previousFireTime: " + pdate);
+            LOG.debug("fireTime: " + date + ", previousFireTime: " + pdate);
             assertFalse(pdate.equals(date), "Next fire time is the same as previous fire time!");
             pdate = date;
         }

--- a/core/commons/che-core-commons-schedule/src/test/resources/logback-test.xml
+++ b/core/commons/che-core-commons-schedule/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>
 

--- a/plugins/plugin-svn/che-plugin-svn-ext-server/src/test/resources/logback-test.xml
+++ b/plugins/plugin-svn/che-plugin-svn-ext-server/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>
 


### PR DESCRIPTION
### What does this PR do?
Do not display debug output during tests execution for following modules:
plugin-svn
che-core-commons-scheduler

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4415
https://github.com/eclipse/che/issues/4416

#### Changelog
Reduced build output in "che-core-commons-scheduler" and "plugin-svn" by ommiting debug info logging

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
