### PR TITLE
[CLI] sync : add option to allow /dev/fuse usage on ubuntu

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_sync.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_sync.sh
@@ -50,6 +50,7 @@ cmd_sync() {
 
   docker_run --cap-add SYS_ADMIN \
              --device /dev/fuse \
+             --security-opt apparmor:unconfined \
              -e CHE_VERSION=${CHE_VERSION} \
              --name che-mount \
              -v "${SYNC_MOUNT}":/mnthost \


### PR DESCRIPTION
### What does this PR do?
Add option to allow /dev/fuse usage on ubuntu of the che sync command.

### What issues does this PR fix or reference?
#4084 

#### Changelog
cli sync : add option to allow /dev/fuse usage on ubuntu

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I6e461b1d98fc361366db9caecd658c9f1c2dea1e
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>

