### PR TITLE
[OpenShift] Modifications to the shell scripts that bootstrap the servers

### DIFF
--- a/agents/go-agents/src/main/resources/org.eclipse.che.terminal.script.sh
+++ b/agents/go-agents/src/main/resources/org.eclipse.che.terminal.script.sh
@@ -13,7 +13,7 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 CHE_DIR=$HOME/che
 LOCAL_AGENT_BINARIES_URI='/mnt/che/terminal/websocket-terminal-${PREFIX}.tar.gz'

--- a/agents/ls-csharp/src/main/resources/org.eclipse.che.ls.csharp.script.sh
+++ b/agents/ls-csharp/src/main/resources/org.eclipse.che.ls.csharp.script.sh
@@ -13,7 +13,7 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 AGENT_BINARIES_URI=https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.csharp.binaries
 CHE_DIR=$HOME/che

--- a/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
+++ b/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
@@ -13,7 +13,7 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 AGENT_BINARIES_URI=https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.json.binaries
 CHE_DIR=$HOME/che

--- a/agents/ls-php/src/main/resources/org.eclipse.che.ls.php.script.sh
+++ b/agents/ls-php/src/main/resources/org.eclipse.che.ls.php.script.sh
@@ -13,7 +13,7 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 AGENT_BINARIES_URI=https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.php.binaries
 CHE_DIR=$HOME/che

--- a/agents/ls-python/src/main/resources/org.eclipse.che.ls.python.script.sh
+++ b/agents/ls-python/src/main/resources/org.eclipse.che.ls.python.script.sh
@@ -13,7 +13,7 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 AGENT_BINARIES_URI=https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.python.binaries
 CHE_DIR=$HOME/che

--- a/agents/ls-typescript/src/main/resources/org.eclipse.che.ls.typescript.script.sh
+++ b/agents/ls-typescript/src/main/resources/org.eclipse.che.ls.typescript.script.sh
@@ -13,7 +13,7 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 AGENT_BINARIES_URI=https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.typescript.binaries
 CHE_DIR=$HOME/che

--- a/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
+++ b/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
@@ -11,7 +11,7 @@
 
 unset SUDO
 unset PACKAGES
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 if [ -f /etc/centos-release ]; then
     FILE="/etc/centos-release"

--- a/agents/unison/src/main/resources/org.eclipse.che.unison.script.sh
+++ b/agents/unison/src/main/resources/org.eclipse.che.unison.script.sh
@@ -11,7 +11,7 @@
 
 unset SUDO
 unset PACKAGES
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
 
 if [ -f /etc/centos-release ]; then
     FILE="/etc/centos-release"

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -99,7 +99,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "eclipse/ubuntu_jdk8"
+      "origin": "rhche/ubuntu_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -107,7 +107,7 @@
           "machines": {
             "dev-machine": {
               "agents": [
-                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {},
               "attributes" : {
@@ -116,7 +116,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/ubuntu_jdk8",
+            "location": "rhche/ubuntu_jdk8",
             "type": "dockerimage"
           }
         }
@@ -2091,7 +2091,7 @@
     }],
     "source": {
         "type": "image",
-        "origin": "registry.centos.org/che-stacks/vertx"
+        "origin": "rhche/vertx"
     },
     "workspaceConfig": {
         "environments": {
@@ -2100,8 +2100,7 @@
                     "dev-machine": {
                         "agents": [
                             "org.eclipse.che.terminal",
-                            "org.eclipse.che.ws-agent",
-                            "org.eclipse.che.ssh"
+                            "org.eclipse.che.ws-agent"
                         ],
                         "servers": {},
                         "attributes": {
@@ -2110,7 +2109,7 @@
                     }
                 },
                 "recipe": {
-                    "location": "registry.centos.org/che-stacks/vertx",
+                    "location": "rhche/vertx",
                     "type": "dockerimage"
                 }
             }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -165,7 +165,6 @@ public class OpenShiftConnector extends DockerConnector {
 
     private final OpenShiftClient openShiftClient;
     private final String          openShiftCheProjectName;
-    private final String          openShiftCheServiceAccount;
     private final int             openShiftLivenessProbeDelay;
     private final int             openShiftLivenessProbeTimeout;
     private final String          workspacesPersistentVolumeClaim;
@@ -181,7 +180,6 @@ public class OpenShiftConnector extends DockerConnector {
                               DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider,
                               @Named("che.docker.ip.external") String cheServerExternalAddress,
                               @Named("che.openshift.project") String openShiftCheProjectName,
-                              @Named("che.openshift.serviceaccountname") String openShiftCheServiceAccount,
                               @Named("che.openshift.liveness.probe.delay") int openShiftLivenessProbeDelay,
                               @Named("che.openshift.liveness.probe.timeout") int openShiftLivenessProbeTimeout,
                               @Named("che.openshift.workspaces.pvc.name") String workspacesPersistentVolumeClaim,
@@ -192,7 +190,6 @@ public class OpenShiftConnector extends DockerConnector {
         super(connectorConfiguration, connectionFactory, authResolver, dockerApiVersionPathPrefixProvider);
         this.cheServerExternalAddress = cheServerExternalAddress;
         this.openShiftCheProjectName = openShiftCheProjectName;
-        this.openShiftCheServiceAccount = openShiftCheServiceAccount;
         this.openShiftLivenessProbeDelay = openShiftLivenessProbeDelay;
         this.openShiftLivenessProbeTimeout = openShiftLivenessProbeTimeout;
         this.workspacesPersistentVolumeClaim = workspacesPersistentVolumeClaim;
@@ -978,7 +975,6 @@ public class OpenShiftConnector extends DockerConnector {
                                     .withPorts(KubernetesContainer.getContainerPortsFrom(exposedPorts))
                                     .withImagePullPolicy(OPENSHIFT_IMAGE_PULL_POLICY_IFNOTPRESENT)
                                     .withNewSecurityContext()
-                                        .withRunAsUser(UID)
                                         .withPrivileged(false)
                                     .endSecurityContext()
                                     .withLivenessProbe(getLivenessProbeFrom(exposedPorts))
@@ -988,7 +984,6 @@ public class OpenShiftConnector extends DockerConnector {
         PodSpec podSpec = new PodSpecBuilder()
                                  .withContainers(container)
                                  .withVolumes(getVolumesFrom(volumes, workspaceID))
-                                 .withServiceAccountName(this.openShiftCheServiceAccount)
                                  .build();
 
         Deployment deployment = new DeploymentBuilder()
@@ -1198,7 +1193,7 @@ public class OpenShiftConnector extends DockerConnector {
                     VolumeMount vm = new VolumeMountBuilder()
                             .withMountPath(mountPath)
                             .withName(workspacesPersistentVolumeClaim)
-                            .withSubPath(subPath)
+//                            .withSubPath(subPath)
                             .build();
                         vms.add(vm);
                 }
@@ -1251,7 +1246,7 @@ public class OpenShiftConnector extends DockerConnector {
 
     private PersistentVolumeClaim getClaimCheWorkspace() {
         PersistentVolumeClaimList pvcList = openShiftClient.persistentVolumeClaims().inNamespace(openShiftCheProjectName).list();
-        for(PersistentVolumeClaim pvc:pvcList.getItems()) {
+        for(PersistentVolumeClaim pvc: pvcList.getItems()) {
             if (workspacesPersistentVolumeClaim.equals(pvc.getMetadata().getName())) {
                 return pvc;
             }
@@ -1265,7 +1260,7 @@ public class OpenShiftConnector extends DockerConnector {
                 .withAnnotations(annotations)
             .endMetadata()
             .withNewSpec()
-                .withAccessModes("ReadWriteMany")
+                .withAccessModes("ReadWriteOnce")
                 .withNewResources()
                     .withRequests(requests)
                 .endResources()

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -31,10 +31,8 @@ import org.testng.annotations.Test;
 public class OpenShiftConnectorTest {
     private static final String[] CONTAINER_ENV_VARIABLES = {"CHE_WORKSPACE_ID=abcd1234"};
     private static final String   CHE_DEFAULT_OPENSHIFT_PROJECT_NAME = "eclipse-che";
-    private static final String   CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT = "cheserviceaccount";
     private static final int      OPENSHIFT_LIVENESS_PROBE_DELAY = 300;
     private static final int      OPENSHIFT_LIVENESS_PROBE_TIMEOUT = 1;
-    private static final String   OPENSHIFT_DEFAULT_TOKEN = "91XMfu-FuNDkGjcIh6b0y1EtCvztGeSsSqRrWhBfyL8";
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_PERSISTENT_VOLUME_CLAIM = "che_claim_data";
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_QUANTITY = "10Gi";
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_STORAGE = "/data/workspaces";
@@ -70,7 +68,6 @@ public class OpenShiftConnectorTest {
                                                     dockerApiVersionPathPrefixProvider,
                                                     CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS,
                                                     CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
-                                                    CHE_DEFAULT_OPENSHIFT_SERVICEACCOUNT,
                                                     OPENSHIFT_LIVENESS_PROBE_DELAY,
                                                     OPENSHIFT_LIVENESS_PROBE_TIMEOUT,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_PERSISTENT_VOLUME_CLAIM,

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -13,7 +13,8 @@ unset PACKAGES
 unset SUDO
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
-test "$(id -u)" = 0 || SUDO="sudo -E"
+test "$(id -u)" = 0 || test -f ${HOME}/is_arbitrary_user || SUDO="sudo -E"
+
 
 LOCAL_AGENT_BINARIES_URI="/mnt/che/ws-agent.tar.gz"
 DOWNLOAD_AGENT_BINARIES_URI='${WORKSPACE_MASTER_URI}/agent-binaries/ws-agent.tar.gz'
@@ -34,9 +35,11 @@ fi
 MACHINE_TYPE=$(uname -m)
 
 mkdir -p ${CHE_DIR}
-${SUDO} mkdir -p /projects
-${SUDO} sh -c "chown -R $(id -u -n) /projects"
 
+if [ ! -f ${HOME}/is_arbitrary_user ]; then
+    ${SUDO} mkdir -p /projects
+    ${SUDO} sh -c "chown -R $(id -u -n) /projects"
+fi
 
 INSTALL_JDK=false
 command -v ${JAVA_HOME}/bin/java >/dev/null 2>&1 || {


### PR DESCRIPTION
### What does this PR do?
- Remove `RunAs` instruction when starting a workspace. Container will run as an arbitrary user (usually with a UID that doesn't match any host UID) and with security constraint `restricted` (that's the most secure scc in OpenShift).
- Modify the scripts that bootstrap the servers (wsagent, terminal etc...) to avoid usage of `sudo` when the container is run as an arbitrary user. That works only if some modified [Docker images are used](https://github.com/redhat-developer/che-dockerfiles).
- Change `stacks.json` to point to these modified Docker images
- Disable SSH 

#### Changelog
Modifications to the shell scripts that bootstrap the servers