### PR TITLE
[cli] Fix for restart failure

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_start.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_start.sh
@@ -56,9 +56,8 @@ pre_cmd_start() {
       --pull)
         FORCE_UPDATE="--pull"
         shift ;;
-      *) error "Unknown parameter: $1"
-         shift
-         return 2 ;;
+      *)
+        shift ;;
     esac
   done
 }

--- a/dockerfiles/base/scripts/base/commands/cmd_stop.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_stop.sh
@@ -17,6 +17,8 @@ help_cmd_stop() {
   text "\n"
   text "PARAMETERS:\n"
   text "  --skip:graceful                   Do not wait for confirmation that workspaces have stopped\n"
+  text "  --user <username>                 Admin user name for authenticated Che systems\n"
+  text "  --password <password>             Admin password for authenticated Che systems\n"
   text "\n"
 }
 


### PR DESCRIPTION
Signed-off-by: Tyler Jewell <tjewell@codenvy.com>
### What does this PR do?
Adds a fix so that `--user` and `--password` are not tripped as error flags for the `restart` command.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1937

#### Changelog
[cli] Fix for restart failure
