### PR TITLE
use docker-make for images building and pushing

### DIFF
--- a/.docker-make.yml
+++ b/.docker-make.yml
@@ -1,0 +1,105 @@
+builds:
+  base:
+    context: /dockerfiles/base
+    dockerfile: Dockerfile
+    pushes:
+      - "on_branch:master=eclipse/che-base:nightly"
+
+  lib-dto:
+    context: /dockerfiles/lib
+    dockerfile: Dockerfile.dto
+    extract:
+      - /tmp/dto/:./dto.tar
+
+  lib:
+    context: /dockerfiles/lib
+    dockerfile: Dockerfile
+    depends_on:
+      - lib-dto
+    pushes:
+      - "on_branch:master=eclipse/che-lib:nightly"
+
+  action:
+    context: /dockerfiles/action
+    dockerfile: Dockerfile
+    depends_on:
+      - lib
+    rewrite_from: lib
+    pushes:
+      - "on_branch:master=eclipse/che-action:nightly"
+
+  bats:
+    context: /dockerfiles/bats
+    dockerfile: Dockerfile
+    pushes:
+      - "on_branch:master=eclipse/che-bats:nightly"
+
+  che-build:
+    context: /
+    dockerfile: assembly/assembly-main/Dockerfile
+    extract:
+      - /usr/src/che/assembly/assembly-main/target/eclipse-che/.:./dockerfiles/che/eclipse-che.tar
+    dockerignore:
+      - .git
+      - dockerfiles
+
+  che:
+    context: /dockerfiles/che
+    dockerfile: Dockerfile
+    depends_on:
+      - che-build
+    pushes:
+      - "on_branch:master=eclipse/che-server:nightly"
+
+  # *********************************************
+  cli:
+    context: /dockerfiles/cli
+    dockerfile: Dockerfile
+    depends_on:
+      - base
+    rewrite_from: base
+    pushes:
+      - "on_branch:master=eclipse/che-cli:nightly"
+      - "on_branch:master=eclipse/che:nightly"
+
+  dev:
+    context: /dockerfiles/dev
+    dockerfile: Dockerfile
+    pushes:
+      - "on_branch:master=eclipse/che-dev:nightly"
+
+  dir:
+    context: /dockerfiles/dir
+    dockerfile: Dockerfile
+    depends_on:
+      - lib
+    rewrite_from: lib
+    pushes:
+      - "on_branch:master=eclipse/che-dir:nightly"
+
+  init:
+    context: /dockerfiles/init
+    dockerfile: Dockerfile
+    pushes:
+      - "on_branch:master=eclipse/che-init:nightly"
+
+  ip:
+    context: /dockerfiles/ip
+    dockerfile: Dockerfile
+    pushes:
+      - "on_branch:master=eclipse/che-ip:nightly"
+
+  mount:
+    context: /dockerfiles/mount
+    dockerfile: Dockerfile
+    pushes:
+      - "on_branch:master=eclipse/che-mount:nightly"
+
+  test:
+    context: /dockerfiles/test
+    dockerfile: Dockerfile
+    depends_on:
+      - lib
+    rewrite_from: lib
+    pushes:
+      - "on_branch:master=eclipse/che-test:nightly"

--- a/assembly/assembly-main/Dockerfile
+++ b/assembly/assembly-main/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:8-jdk
+
+ARG MAVEN_VERSION=3.3.9
+ARG USER_HOME_DIR="/root"
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    | tar -xzC /usr/share/maven --strip-components=1 \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+WORKDIR /tmp
+RUN wget -O che.zip https://github.com/eclipse/che/archive/master.zip&&\
+    unzip che.zip > /dev/null && cd che-master/assembly/assembly-main/ &&\
+    mvn package
+
+ADD . /usr/src/che/
+WORKDIR  /usr/src/che/assembly/assembly-main
+
+RUN mvn clean install && mv target/eclipse-che-* target/eclipse-che

--- a/assembly/assembly-main/src/assembly/assembly.xml
+++ b/assembly/assembly-main/src/assembly/assembly.xml
@@ -15,8 +15,6 @@
     <id>tomcat-zip</id>
     <formats>
         <format>dir</format>
-        <format>zip</format>
-        <format>tar.gz</format>
     </formats>
     <dependencySets>
         <dependencySet>

--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -37,4 +37,4 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/reposit
 EXPOSE 8000 8080
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-ADD eclipse-che.tar.gz /home/user/
+ADD eclipse-che.tar /home/user/

--- a/dockerfiles/lib/Dockerfile
+++ b/dockerfiles/lib/Dockerfile
@@ -26,8 +26,9 @@ RUN set -x \
 
 COPY runtime-dependencies/package.json /runtime/
 COPY . /lib-typescript/
+ADD dto.tar /lib-typescript/src/api/.
 
-RUN cd /lib-typescript/ && npm install && npm test \
+RUN cd /lib-typescript/ && rm dto.tar && npm install && npm test \
     && cd /runtime && npm install && /lib-typescript/node_modules/.bin/tsc --project /lib-typescript/ \
     && mv /lib-typescript/lib /che-lib && cd /lib-typescript/src && find . -name "*.properties" -exec install -D {} /che-lib/{} \;\
     && rm -rf /lib-typescript && mv /runtime/node_modules /che-lib && rm -rf /runtime

--- a/dockerfiles/lib/Dockerfile.dto
+++ b/dockerfiles/lib/Dockerfile.dto
@@ -1,0 +1,21 @@
+FROM openjdk:8-jdk
+
+ARG MAVEN_VERSION=3.3.9
+ARG USER_HOME_DIR="/root"
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    | tar -xzC /usr/share/maven --strip-components=1 \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+WORKDIR /tmp
+
+RUN wget -O pom.xml https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/lib/dto-pom.xml &&\
+    mvn -q -U -DskipTests=true -Dfindbugs.skip=true -Dskip-validate-sources install
+
+ADD dto-pom.xml /tmp/pom.xml 
+RUN mvn -q -U -DskipTests=true -Dfindbugs.skip=true -Dskip-validate-sources install &&\
+    mkdir -p dto && mv target/dto-typescript.ts dto/che-dto.ts


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
Hi guys,
 I'm a newbie of eclipse/che and the author of [docker-make](https://github.com/CtripCloud/docker-make)-a cli tool for building,tagging,and pushing a bunch of related docker images.

I noticed that eclipse/che builds several Docker images for different parts of the whole system, and these images are managed by some bash scripts since docker has no official `docker-compose` like tool for image building.

We also encountered such scenarios in some of our private projects- building several related images from one code base.Though bash scripts and makefiles can help to automate images management, it also has issues for unclear configurations, bad readability, and unnecessary  copy of scripts for new projects.

So we developed `docker-make` to make such works yaml-configurable, just as we do on containers with the power of `docker-compose`, and I'm very glad to introduce this tool to you.

### What does this PR do?
Introduce in  [docker-make](https://github.com/CtripCloud/docker-make) for building and pushing che's various docker images.

### What issues does this PR fix or reference?
No related issues.

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
