### PR TITLE
Java Testing support Bug fixes and Enhancements - Step 2

### DIFF
--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/pom.xml
@@ -31,10 +31,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-testing-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-gwt</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/JUnitTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/JUnitTestAction.java
@@ -17,6 +17,7 @@ import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.KeyBuilder;
 import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.plugin.testing.ide.TestAction;
+import org.eclipse.che.plugin.testing.junit.ide.action.RunAllContextTestAction;
 import org.eclipse.che.plugin.testing.junit.ide.action.RunAllTestAction;
 import org.eclipse.che.plugin.testing.junit.ide.action.RunClassContextTestAction;
 import org.eclipse.che.plugin.testing.junit.ide.action.RunClassTestAction;
@@ -33,20 +34,23 @@ public class JUnitTestAction implements TestAction {
     public static final String TEST_ACTION_RUN_ALL           = "TestActionRunAll";
     public static final String TEST_ACTION_RUN_CLASS         = "TestActionRunClass";
     public static final String TEST_ACTION_RUN_CLASS_CONTEXT = "TestActionRunClassContext";
+    public static final String TEST_ACTION_RUN_ALL_CONTEXT   = "TestActionRunAllContext";
     private final Action runClassTestAction;
     private final Action runAllTestAction;
     private final Action runClassContextTestAction;
+    private final Action runAllContextTestAction;
 
     @Inject
     public JUnitTestAction(ActionManager actionManager, 
                            RunClassTestAction runClassTestAction,
                            RunAllTestAction runAllTestAction, 
                            RunClassContextTestAction runClassContextTestAction,
+                           RunAllContextTestAction runAllContextTestAction,
                            KeyBindingAgent keyBinding) {
-
         actionManager.registerAction(TEST_ACTION_RUN_CLASS, runClassTestAction);
         actionManager.registerAction(TEST_ACTION_RUN_ALL, runAllTestAction);
         actionManager.registerAction(TEST_ACTION_RUN_CLASS_CONTEXT, runClassContextTestAction);
+        actionManager.registerAction(TEST_ACTION_RUN_ALL_CONTEXT, runAllContextTestAction);
 
         if (UserAgent.isMac()) {
             keyBinding.getGlobal().addKey(new KeyBuilder().control().alt().charCode('z').build(), TEST_ACTION_RUN_ALL);
@@ -59,6 +63,7 @@ public class JUnitTestAction implements TestAction {
         this.runAllTestAction = runAllTestAction;
         this.runClassContextTestAction = runClassContextTestAction;
         this.runClassTestAction = runClassTestAction;
+        this.runAllContextTestAction = runAllContextTestAction;
     }
 
 
@@ -71,6 +76,6 @@ public class JUnitTestAction implements TestAction {
     @Override
     public void addContextMenuItems(DefaultActionGroup testContextMenu) {
         testContextMenu.add(runClassContextTestAction);
-        testContextMenu.add(runAllTestAction);
+        testContextMenu.add(runAllContextTestAction);
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunAllTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunAllTestAction.java
@@ -20,6 +20,7 @@ import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.ext.java.client.action.JavaEditorAction;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
+import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
 import org.eclipse.che.plugin.testing.junit.ide.JUnitTestLocalizationConstant;
 import org.eclipse.che.plugin.testing.junit.ide.JUnitTestResources;
@@ -79,5 +80,10 @@ public class RunAllTestAction extends JavaEditorAction
     @Override
     public TestResultPresenter getPresenter() {
         return presenter;
+    }
+    
+    @Override
+    public String getTestingFramework() {
+        return "junit";
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunClassTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunClassTestAction.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.ext.java.client.action.JavaEditorAction;
 import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
+import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
 import org.eclipse.che.plugin.testing.junit.ide.JUnitTestLocalizationConstant;
 import org.eclipse.che.plugin.testing.junit.ide.JUnitTestResources;
@@ -67,7 +68,6 @@ public class RunClassTestAction extends JavaEditorAction
         Map<String, String> parameters = new HashMap<>();
         parameters.put("fqn", fqn);
         parameters.put("runClass", "true");
-        parameters.put("updateClasspath", "true");
         delegate.doRunTests(e, parameters);
     }
 
@@ -95,5 +95,10 @@ public class RunClassTestAction extends JavaEditorAction
     @Override
     public TestResultPresenter getPresenter() {
         return presenter;
+    }
+
+    @Override
+    public String getTestingFramework() {
+        return "junit";
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
         </dependency>
         <dependency>
@@ -65,23 +61,5 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/**/AbstractTestListener.java</exclude>
-                        <exclude>**/**/OutputTestListener.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/src/main/java/org/eclipse/che/plugin/testing/junit/server/JUnitTestRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/src/main/java/org/eclipse/che/plugin/testing/junit/server/JUnitTestRunner.java
@@ -134,6 +134,7 @@ public class JUnitTestRunner implements TestRunner {
             } else {
                 testResult = useJUnitV3API ? runAll3x(projectAbsolutePath) : runAll4x(projectAbsolutePath);
             }
+            testResult.setProjectPath(projectPath);
             return testResult;
         } finally {
             System.setProperty("user.dir", currentWorkingDir);
@@ -408,6 +409,7 @@ public class JUnitTestRunner implements TestRunner {
         });
         Class< ? > c = f.createClass();
         MethodHandler mi = new MethodHandler() {
+            @Override
             public Object invoke(Object self, Method method, Method proceed, Object[] args) throws Throwable {
                 Object testCaseObject = args[0];
                 allRunTests.add(testCaseObject);

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/src/main/java/org/eclipse/che/plugin/testing/junit/server/JUnitTestRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/src/main/java/org/eclipse/che/plugin/testing/junit/server/JUnitTestRunner.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,13 +28,13 @@ import javax.inject.Inject;
 
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.testing.server.framework.TestRunner;
-import org.eclipse.che.api.testing.shared.Failure;
+import org.eclipse.che.api.testing.server.listener.AbstractTestListener;
+import org.eclipse.che.api.testing.server.listener.OutputTestListener;
+import org.eclipse.che.api.testing.shared.TestCase;
 import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.plugin.testing.classpath.server.TestClasspathProvider;
 import org.eclipse.che.plugin.testing.classpath.server.TestClasspathRegistry;
-import org.eclipse.che.plugin.testing.junit.server.listener.AbstractTestListener;
-import org.eclipse.che.plugin.testing.junit.server.listener.OutputTestListener;
 
 import javassist.util.proxy.MethodFilter;
 import javassist.util.proxy.MethodHandler;
@@ -86,7 +87,8 @@ public class JUnitTestRunner implements TestRunner {
 
         ClassLoader currentClassLoader = this.getClass().getClassLoader();
         TestClasspathProvider classpathProvider = classpathRegistry.getTestClasspathProvider(projectType);
-        URLClassLoader providedClassLoader = (URLClassLoader)classpathProvider.getClassLoader(projectAbsolutePath, projectPath, updateClasspath);
+        URLClassLoader providedClassLoader = (URLClassLoader)classpathProvider.getClassLoader(projectAbsolutePath, projectPath,
+                                                                                              updateClasspath);
         projectClassLoader = new URLClassLoader(providedClassLoader.getURLs(), null) {
             @Override
             protected Class< ? > findClass(String name) throws ClassNotFoundException {
@@ -184,7 +186,10 @@ public class JUnitTestRunner implements TestRunner {
         return false;
     }
 
-    private Object create4xTestListener(ClassLoader loader, Class< ? > listenerClass, AbstractTestListener delegate) throws Exception {
+    private Object create4xTestListener(ClassLoader loader,
+                                        Class< ? > listenerClass,
+                                        List<Object> allTests,
+                                        AbstractTestListener delegate) throws Exception {
         ProxyFactory f = new ProxyFactory();
         f.setSuperclass(listenerClass);
         f.setFilter(new MethodFilter() {
@@ -229,6 +234,7 @@ public class JUnitTestRunner implements TestRunner {
                 switch (methodName) {
                     case "testStarted":
                         delegate.startTest(testKey, testName);
+                        allTests.add(description);
                         break;
 
                     case "testFinished":
@@ -254,6 +260,8 @@ public class JUnitTestRunner implements TestRunner {
     private TestResult run4xTestClasses(Class< ? >... classes) throws Exception {
         ClassLoader classLoader = projectClassLoader;
         Class< ? > clsJUnitCore = Class.forName("org.junit.runner.JUnitCore", true, classLoader);
+        Class< ? > clsRequest = Class.forName("org.junit.runner.Request", true, classLoader);
+        Class< ? > clsRunner = Class.forName("org.junit.runner.Runner", true, classLoader);
         Class< ? > clsResult = Class.forName("org.junit.runner.Result", true, classLoader);
         Class< ? > clsFailure = Class.forName("org.junit.runner.notification.Failure", true, classLoader);
         Class< ? > clsDescription = Class.forName("org.junit.runner.Description", true, classLoader);
@@ -263,13 +271,18 @@ public class JUnitTestRunner implements TestRunner {
         Object jUnitCore = clsJUnitCore.getConstructor().newInstance();
 
         Object result;
+
+        List<Object> allRunTests = new ArrayList<Object>();
         try (OutputTestListener outputListener = new OutputTestListener(this.getClass().getName() + ".run4xTestClasses")) {
-            Object testListener = create4xTestListener(classLoader, clsTestRunner, outputListener);
+            Object testListener = create4xTestListener(classLoader, clsTestRunner, allRunTests, outputListener);
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             try {
                 Thread.currentThread().setContextClassLoader(projectClassLoader);
                 clsJUnitCore.getMethod("addListener", clsTestRunner).invoke(jUnitCore, testListener);
-                result = clsJUnitCore.getMethod("run", Class[].class).invoke(jUnitCore, new Object[]{classes});
+                Object request = clsRequest.getMethod("classes", Class[].class).invoke(null, new Object[]{classes});
+                Object runner = clsRequest.getMethod("getRunner").invoke(request);
+                Object suiteDescription = clsRunner.getMethod("getDescription").invoke(runner);
+                result = clsJUnitCore.getMethod("run", clsRequest).invoke(jUnitCore, request);
             } finally {
                 Thread.currentThread().setContextClassLoader(tccl);
                 clsJUnitCore.getMethod("removeListener", clsTestRunner).invoke(jUnitCore, testListener);
@@ -278,41 +291,64 @@ public class JUnitTestRunner implements TestRunner {
 
         TestResult dtoResult = DtoFactory.getInstance().createDto(TestResult.class);
         boolean isSuccess = (Boolean)clsResult.getMethod("wasSuccessful").invoke(result);
+
+        Map<String, TestCase> testCases = new HashMap<>();
+
+        for (Object testDescription : allRunTests) {
+            String testKey = (String)clsDescription.getMethod("getDisplayName").invoke(testDescription);
+            TestCase dtoTestCase = DtoFactory.getInstance().createDto(TestCase.class);
+            String className = (String)clsDescription.getMethod("getClassName").invoke(testDescription);
+            String methodName = (String)clsDescription.getMethod("getMethodName").invoke(testDescription);
+            dtoTestCase.setClassName(className);
+            dtoTestCase.setMethod(methodName);
+            dtoTestCase.setFailingLine(-1);
+            dtoTestCase.setMessage("");
+            dtoTestCase.setTrace("");
+            testCases.put(testKey, dtoTestCase);
+        }
+
         List< ? > failures = (List< ? >)clsResult.getMethod("getFailures").invoke(result);
-        List<Failure> jUnitFailures = new ArrayList<>();
         for (Object failure : failures) {
-            Failure dtoFailure = DtoFactory.getInstance().createDto(Failure.class);
-            String message = (String)clsFailure.getMethod("getMessage").invoke(failure);
+            TestCase dtoFailure = DtoFactory.getInstance().createDto(TestCase.class);
             Object description = clsFailure.getMethod("getDescription").invoke(failure);
-            String failClassName = (String)clsDescription.getMethod("getClassName").invoke(description);
+            String testKey = (String)clsDescription.getMethod("getDisplayName").invoke(description);
+
+            String className = (String)clsDescription.getMethod("getClassName").invoke(description);
+            String methodName = (String)clsDescription.getMethod("getMethodName").invoke(description);
+
+            String message = (String)clsFailure.getMethod("getMessage").invoke(failure);
             Object exception = clsFailure.getMethod("getException").invoke(failure);
             Object stackTrace = clsThrowable.getMethod("getStackTrace").invoke(exception);
-            String failMethod = "";
             Integer failLine = null;
             if (stackTrace.getClass().isArray()) {
                 int length = Array.getLength(stackTrace);
                 for (int i = 0; i < length; i++) {
                     Object stackElement = Array.get(stackTrace, i);
                     String failClass = (String)clsStackTraceElement.getMethod("getClassName").invoke(stackElement);
-                    if (failClass.equals(failClassName)) {
-                        failMethod = (String)clsStackTraceElement.getMethod("getMethodName").invoke(stackElement);
+                    String failMethod = (String)clsStackTraceElement.getMethod("getMethodName").invoke(stackElement);
+                    if (failClass.equals(className) && failMethod.equals(methodName)) {
                         failLine = (Integer)clsStackTraceElement.getMethod("getLineNumber").invoke(stackElement);
                         break;
                     }
                 }
             }
             String trace = (String)clsFailure.getMethod("getTrace").invoke(failure);
-            dtoFailure.setFailingClass(failClassName);
-            dtoFailure.setFailingMethod(failMethod);
-            dtoFailure.setFailingLine(failLine);
+            dtoFailure.setClassName(className);
+            dtoFailure.setMethod(methodName);
+            dtoFailure.setFailed(true);
+            dtoFailure.setFailingLine(failLine == null ? -1 : failLine);
             dtoFailure.setMessage(message);
             dtoFailure.setTrace(trace);
-            jUnitFailures.add(dtoFailure);
+            testCases.put(testKey, dtoFailure);
         }
+
         dtoResult.setTestFramework("JUnit4x");
         dtoResult.setSuccess(isSuccess);
-        dtoResult.setFailureCount(jUnitFailures.size());
-        dtoResult.setFailures(jUnitFailures);
+        dtoResult.setFailureCount(failures.size());
+        dtoResult.setTestCaseCount(testCases.size());
+        List<TestCase> testList = new ArrayList<>(testCases.size());
+        testList.addAll(testCases.values());
+        dtoResult.setTestCases(testList);
         return dtoResult;
     }
 
@@ -349,7 +385,10 @@ public class JUnitTestRunner implements TestRunner {
         return superClass.isAssignableFrom(clazz);
     }
 
-    private Object create3xTestListener(ClassLoader loader, Class< ? > listenerClass, AbstractTestListener delegate) throws Exception {
+    private Object create3xTestListener(ClassLoader loader,
+                                        Class< ? > listenerClass,
+                                        List<Object> allRunTests,
+                                        AbstractTestListener delegate) throws Exception {
         ProxyFactory f = new ProxyFactory();
         f.setSuperclass(Object.class);
         f.setInterfaces(new Class< ? >[]{listenerClass});
@@ -370,8 +409,14 @@ public class JUnitTestRunner implements TestRunner {
         Class< ? > c = f.createClass();
         MethodHandler mi = new MethodHandler() {
             public Object invoke(Object self, Method method, Method proceed, Object[] args) throws Throwable {
-                String testKey = args[0].getClass().toString();
-                String testName = args[0].getClass().getName();
+                Object testCaseObject = args[0];
+                allRunTests.add(testCaseObject);
+                Class< ? > testCaseClass = testCaseObject.getClass();
+                String testClassName = testCaseClass.getName();
+                String testMethodName = (String)testCaseClass.getMethod("getName").invoke(testCaseObject);
+
+                String testKey = testMethodName + "(" + testClassName + ")";
+                String testName = testKey;
                 String methodName = method.getName();
                 switch (methodName) {
                     case "startTest":
@@ -401,6 +446,7 @@ public class JUnitTestRunner implements TestRunner {
     private TestResult run3xTestClasses(Class< ? >... classes) throws Exception {
         ClassLoader classLoader = projectClassLoader;
         Class< ? > clsTestSuite = Class.forName("junit.framework.TestSuite", true, classLoader);
+        Class< ? > clsTestCase = Class.forName("junit.framework.TestCase", true, classLoader);
         Class< ? > clsTestResult = Class.forName("junit.framework.TestResult", true, classLoader);
         Class< ? > clsThrowable = Class.forName("java.lang.Throwable", true, classLoader);
         Class< ? > clsStackTraceElement = Class.forName("java.lang.StackTraceElement", true, classLoader);
@@ -409,8 +455,10 @@ public class JUnitTestRunner implements TestRunner {
         Object testResult = clsTestResult.getConstructor().newInstance();
         Class< ? > clsTestListener = Class.forName("junit.framework.TestListener", true, classLoader);
 
+        List<Object> allRunTests = new ArrayList<>();
+
         try (OutputTestListener outputListener = new OutputTestListener(this.getClass().getName() + ".run3xTestClasses")) {
-            Object testListener = create3xTestListener(classLoader, clsTestListener, outputListener);
+            Object testListener = create3xTestListener(classLoader, clsTestListener, allRunTests, outputListener);
             ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             try {
                 Thread.currentThread().setContextClassLoader(projectClassLoader);
@@ -426,44 +474,70 @@ public class JUnitTestRunner implements TestRunner {
                                                                                   testResult, testListener);
             }
         }
-        TestResult dtoResult = DtoFactory.getInstance().createDto(TestResult.class);
+
         boolean isSuccess = (Boolean)clsTestResult.getMethod("wasSuccessful").invoke(testResult);
+
+        Map<String, TestCase> testCases = new HashMap<>();
+
+        TestResult dtoResult = DtoFactory.getInstance().createDto(TestResult.class);
         Enumeration< ? > failures = (Enumeration< ? >)clsTestResult.getMethod("failures").invoke(testResult);
-        List<Failure> jUnitFailures = new ArrayList<>();
+
+        for (Object testDescription : allRunTests) {
+            String className = testDescription.getClass().getName();
+            String methodName = (String)clsTestCase.getMethod("getName").invoke(testDescription);
+            String testKey = methodName + "(" + className + ")";
+            TestCase dtoTestCase = DtoFactory.getInstance().createDto(TestCase.class);
+            dtoTestCase.setClassName(className);
+            dtoTestCase.setMethod(methodName);
+            dtoTestCase.setFailingLine(-1);
+            dtoTestCase.setMessage("");
+            dtoTestCase.setTrace("");
+            testCases.put(testKey, dtoTestCase);
+        }
+
+        int failureCount = 0;
         while (failures.hasMoreElements()) {
-            Failure dtoFailure = DtoFactory.getInstance().createDto(Failure.class);
+            failureCount++;
+            TestCase dtoTestCase = DtoFactory.getInstance().createDto(TestCase.class);
             Object failure = failures.nextElement();
+            Object failClassObject = clsFailure.getMethod("failedTest").invoke(failure);
+            String className = failClassObject.getClass().getName();
+            String methodName = (String)clsTestCase.getMethod("getName").invoke(failClassObject);
+            String testFailureKey = methodName + "(" + className + ")";
+
             String message = (String)clsFailure.getMethod("exceptionMessage").invoke(failure);
             String trace = (String)clsFailure.getMethod("trace").invoke(failure);
-            Object failClassObject = clsFailure.getMethod("failedTest").invoke(failure);
-            String failClassName = failClassObject.getClass().getName();
             Object exception = clsFailure.getMethod("thrownException").invoke(failure);
             Object stackTrace = clsThrowable.getMethod("getStackTrace").invoke(exception);
-            String failMethod = "";
             Integer failLine = null;
             if (stackTrace.getClass().isArray()) {
                 int length = Array.getLength(stackTrace);
                 for (int i = 0; i < length; i++) {
                     Object arrayElement = Array.get(stackTrace, i);
                     String failClass = (String)clsStackTraceElement.getMethod("getClassName").invoke(arrayElement);
-                    if (failClass.equals(failClassName)) {
-                        failMethod = (String)clsStackTraceElement.getMethod("getMethodName").invoke(arrayElement);
+                    String failMethod = (String)clsStackTraceElement.getMethod("getMethodName").invoke(arrayElement);
+                    if (failClass.equals(className) && failMethod.equals(methodName)) {
                         failLine = (Integer)clsStackTraceElement.getMethod("getLineNumber").invoke(arrayElement);
                         break;
                     }
                 }
             }
-            dtoFailure.setFailingClass(failClassName);
-            dtoFailure.setFailingMethod(failMethod);
-            dtoFailure.setFailingLine(failLine);
-            dtoFailure.setMessage(message);
-            dtoFailure.setTrace(trace);
-            jUnitFailures.add(dtoFailure);
+            dtoTestCase.setClassName(className);
+            dtoTestCase.setMethod(methodName);
+            dtoTestCase.setFailed(true);
+            dtoTestCase.setFailingLine(failLine == null ? -1 : failLine);
+            dtoTestCase.setMessage(message);
+            dtoTestCase.setTrace(trace);
+            testCases.put(testFailureKey, dtoTestCase);
         }
+
         dtoResult.setTestFramework("JUnit3x");
         dtoResult.setSuccess(isSuccess);
-        dtoResult.setFailureCount(jUnitFailures.size());
-        dtoResult.setFailures(jUnitFailures);
+        dtoResult.setFailureCount(failureCount);
+        dtoResult.setTestCaseCount(testCases.size());
+        List<TestCase> testList = new ArrayList<>(testCases.size());
+        testList.addAll(testCases.values());
+        dtoResult.setTestCases(testList);
         return dtoResult;
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/pom.xml
@@ -31,10 +31,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-testing-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-gwt</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/TestNGTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/TestNGTestAction.java
@@ -17,10 +17,12 @@ import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.KeyBuilder;
 import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.plugin.testing.ide.TestAction;
+import org.eclipse.che.plugin.testing.testng.ide.action.RunAllContextTestAction;
 import org.eclipse.che.plugin.testing.testng.ide.action.RunAllTestAction;
 import org.eclipse.che.plugin.testing.testng.ide.action.RunClassContextTestAction;
 import org.eclipse.che.plugin.testing.testng.ide.action.RunClassTestAction;
 import org.eclipse.che.plugin.testing.testng.ide.action.RunTestXMLAction;
+import org.eclipse.che.plugin.testing.testng.ide.action.RunTestXMLContextAction;
 
 import com.google.inject.Inject;
 
@@ -34,19 +36,25 @@ public class TestNGTestAction implements TestAction {
     private final Action runClassTestAction;
     private final Action runAllTestAction;
     private final Action runClassContextTestAction;
+    private final Action runAllContextTestAction;
     private final Action runTestXMLAction;
+    private final Action runTestXMLContextAction;
 
     @Inject
     public TestNGTestAction(ActionManager actionManager,
                             RunClassTestAction runClassTestAction,
                             RunAllTestAction runAllTestAction,
                             RunClassContextTestAction runClassContextTestAction,
+                            RunAllContextTestAction runAllContextTestAction,
                             RunTestXMLAction runTestXMLAction,
+                            RunTestXMLContextAction runTestXMLContextAction,
                             KeyBindingAgent keyBinding) {
         actionManager.registerAction("TestNGActionRunClass", runClassTestAction);
         actionManager.registerAction("TestNGActionRunAll", runAllTestAction);
         actionManager.registerAction("TestNGActionRunXML", runTestXMLAction);
         actionManager.registerAction("TestNGActionRunClassContext", runClassContextTestAction);
+        actionManager.registerAction("TestNGActionRunAllContext", runAllContextTestAction);
+        actionManager.registerAction("TestNGActionRunXMLContext", runTestXMLContextAction);
         if (UserAgent.isMac()) {
             keyBinding.getGlobal().addKey(new KeyBuilder().control().alt().charCode('g').build(), "TestNGActionRunAll");
             keyBinding.getGlobal().addKey(new KeyBuilder().control().shift().charCode('g').build(), "TestNGActionRunClass");
@@ -54,12 +62,13 @@ public class TestNGTestAction implements TestAction {
             keyBinding.getGlobal().addKey(new KeyBuilder().action().alt().charCode('g').build(), "TestNGActionRunAll");
             keyBinding.getGlobal().addKey(new KeyBuilder().action().shift().charCode('g').build(), "TestNGActionRunClass");
         }
-        this.runAllTestAction = runAllTestAction;
-        this.runClassContextTestAction = runClassContextTestAction;
         this.runClassTestAction = runClassTestAction;
+        this.runClassContextTestAction = runClassContextTestAction;
+        this.runAllTestAction = runAllTestAction;
+        this.runAllContextTestAction = runAllContextTestAction;
         this.runTestXMLAction = runTestXMLAction;
+        this.runTestXMLContextAction = runTestXMLContextAction;
     }
-
 
     @Override
     public void addMainMenuItems(DefaultActionGroup testMainMenu) {
@@ -71,7 +80,7 @@ public class TestNGTestAction implements TestAction {
     @Override
     public void addContextMenuItems(DefaultActionGroup testContextMenu) {
         testContextMenu.add(runClassContextTestAction);
-        testContextMenu.add(runAllTestAction);
-        testContextMenu.add(runTestXMLAction);
+        testContextMenu.add(runAllContextTestAction);
+        testContextMenu.add(runTestXMLContextAction);
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllContextTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllContextTestAction.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.plugin.testing.junit.ide.action;
+package org.eclipse.che.plugin.testing.testng.ide.action;
 
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
@@ -22,16 +22,17 @@ import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.resources.VirtualFile;
+import org.eclipse.che.ide.api.resources.Container;
+import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.api.selection.SelectionAgent;
-import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
+import org.eclipse.che.ide.resources.tree.ContainerNode;
 import org.eclipse.che.ide.resources.tree.FileNode;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
 import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
-import org.eclipse.che.plugin.testing.junit.ide.JUnitTestLocalizationConstant;
-import org.eclipse.che.plugin.testing.junit.ide.JUnitTestResources;
+import org.eclipse.che.plugin.testing.testng.ide.TestNGLocalizationConstant;
+import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
 
 import com.google.inject.Inject;
 
@@ -39,8 +40,8 @@ import com.google.inject.Inject;
  * @author Mirage Abeysekara
  * @author David Festal
  */
-public class RunClassContextTestAction extends AbstractPerspectiveAction
-                                       implements RunTestActionDelegate.Source {
+public class RunAllContextTestAction extends AbstractPerspectiveAction
+                              implements RunTestActionDelegate.Source {
 
     private final NotificationManager   notificationManager;
     private final TestResultPresenter   presenter;
@@ -50,15 +51,15 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction
     private final RunTestActionDelegate delegate;
 
     @Inject
-    public RunClassContextTestAction(JUnitTestResources resources,
-                                     NotificationManager notificationManager,
-                                     AppContext appContext,
-                                     TestResultPresenter presenter,
-                                     TestServiceClient service,
-                                     SelectionAgent selectionAgent,
-                                     JUnitTestLocalizationConstant localization) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunClassContextTitle(),
-              localization.actionRunClassContextDescription(), null, resources.testIcon());
+    public RunAllContextTestAction(TestNGResources resources,
+                                   NotificationManager notificationManager,
+                                   AppContext appContext,
+                                   TestResultPresenter presenter,
+                                   TestServiceClient service,
+                                   SelectionAgent selectionAgent,
+                                   TestNGLocalizationConstant localization) {
+        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunAllTitle(),
+              localization.actionRunAllDescription(), null, resources.testAllIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
         this.service = service;
@@ -71,42 +72,49 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction
     public void actionPerformed(ActionEvent e) {
         final Selection< ? > selection = selectionAgent.getSelection();
         final Object possibleNode = selection.getHeadElement();
-        if (possibleNode instanceof FileNode) {
-            VirtualFile file = ((FileNode)possibleNode).getData();
-            String fqn = JavaUtil.resolveFQN(file);
-            Map<String, String> parameters = new HashMap<>();
-            parameters.put("fqn", fqn);
-            parameters.put("runClass", "true");
-            delegate.doRunTests(e, parameters);
+        if (possibleNode instanceof ContainerNode) {
+            Container container = ((ContainerNode)possibleNode).getData();
+            Project project = container.getProject();
+            if (project != null) {
+                Map<String, String> parameters = new HashMap<>();
+                delegate.doRunTests(e, parameters);
+            }
         }
     }
 
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
+        e.getPresentation().setVisible(true);
         if ((appContext.getRootProject() == null)) {
-            e.getPresentation().setEnabledAndVisible(false);
+            e.getPresentation().setEnabled(false);
             return;
         }
         final Selection< ? > selection = selectionAgent.getSelection();
         if (selection == null || selection.isEmpty()) {
-            e.getPresentation().setEnabledAndVisible(false);
+            e.getPresentation().setEnabled(false);
             return;
         }
         if (selection.isMultiSelection()) {
-            e.getPresentation().setEnabledAndVisible(false);
+            e.getPresentation().setEnabled(false);
             return;
         }
         final Object possibleNode = selection.getHeadElement();
-        if (!(possibleNode instanceof FileNode)) {
-            e.getPresentation().setEnabledAndVisible(false);
-            return;
+        if (possibleNode instanceof FileNode) {
+            e.getPresentation().setVisible(false);
         }
-
-        e.getPresentation().setVisible(true);
-        boolean enable = "java".equals(((FileNode)possibleNode).getData().getExtension());
-        e.getPresentation().setEnabled(enable);
+        if (possibleNode instanceof ContainerNode) {
+            Container container = ((ContainerNode)possibleNode).getData();
+            Project project = container.getProject();
+            if (project != null) {
+                String projectType = project.getType();
+                boolean enable = "maven".equals(projectType);
+                e.getPresentation().setEnabled(enable);
+                return;
+            }
+        }
+        e.getPresentation().setEnabled(false);
     }
-
+    
     @Override
     public NotificationManager getNotificationManager() {
         return notificationManager;
@@ -127,9 +135,8 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction
         return presenter;
     }
 
-
     @Override
     public String getTestingFramework() {
-        return "junit";
+        return "testng";
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllTestAction.java
@@ -38,14 +38,13 @@ import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
 import com.google.inject.Inject;
 
 /**
- *
  * @author Mirage Abeysekara
  */
 public class RunAllTestAction extends JavaEditorAction {
 
     private final NotificationManager notificationManager;
-    private TestResultPresenter presenter;
-    private final TestServiceClient service;
+    private TestResultPresenter       presenter;
+    private final TestServiceClient   service;
 
     @Inject
     public RunAllTestAction(TestNGResources resources,
@@ -56,7 +55,7 @@ public class RunAllTestAction extends JavaEditorAction {
                             TestServiceClient service,
                             TestNGLocalizationConstant localization) {
         super(localization.actionRunAllTitle(), localization.actionRunAllDescription(), resources.testAllIcon(),
-                editorAgent, fileTypeRegistry);
+              editorAgent, fileTypeRegistry);
         this.notificationManager = notificationManager;
         this.presenter = presenter;
         this.service = service;
@@ -69,7 +68,7 @@ public class RunAllTestAction extends JavaEditorAction {
         final Project project = appContext.getRootProject();
         Map<String, String> parameters = new HashMap<>();
         parameters.put("updateClasspath", "true");
-        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters);
+        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
         testResultPromise.then(new Operation<TestResult>() {
             @Override
             public void apply(TestResult result) throws OperationException {
@@ -87,7 +86,7 @@ public class RunAllTestAction extends JavaEditorAction {
             @Override
             public void apply(PromiseError exception) throws OperationException {
                 final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                        : "Failed to run test cases";
+                    : "Failed to run test cases";
                 notification.setContent(errorMessage);
                 notification.setStatus(FAIL);
             }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllTestAction.java
@@ -10,27 +10,17 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
-import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.PROGRESS;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.PromiseError;
-import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.notification.StatusNotification;
-import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.ext.java.client.action.JavaEditorAction;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
+import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGLocalizationConstant;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
@@ -40,11 +30,13 @@ import com.google.inject.Inject;
 /**
  * @author Mirage Abeysekara
  */
-public class RunAllTestAction extends JavaEditorAction {
+public class RunAllTestAction extends JavaEditorAction
+                              implements RunTestActionDelegate.Source {
 
-    private final NotificationManager notificationManager;
-    private TestResultPresenter       presenter;
-    private final TestServiceClient   service;
+    private final NotificationManager   notificationManager;
+    private TestResultPresenter         presenter;
+    private final TestServiceClient     service;
+    private final RunTestActionDelegate delegate;
 
     @Inject
     public RunAllTestAction(TestNGResources resources,
@@ -59,38 +51,38 @@ public class RunAllTestAction extends JavaEditorAction {
         this.notificationManager = notificationManager;
         this.presenter = presenter;
         this.service = service;
+        this.delegate = new RunTestActionDelegate(this);
     }
+
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        final StatusNotification notification = new StatusNotification("Running Tests...", PROGRESS, FLOAT_MODE);
-        notificationManager.notify(notification);
-        final Project project = appContext.getRootProject();
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("updateClasspath", "true");
-        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
-        testResultPromise.then(new Operation<TestResult>() {
-            @Override
-            public void apply(TestResult result) throws OperationException {
-                notification.setStatus(SUCCESS);
-                if (result.isSuccess()) {
-                    notification.setTitle("Test runner executed successfully");
-                    notification.setContent("All tests are passed");
-                } else {
-                    notification.setTitle("Test runner executed successfully with test failures.");
-                    notification.setContent(result.getFailureCount() + " test(s) failed.\n");
-                }
-                presenter.handleResponse(result);
-            }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError exception) throws OperationException {
-                final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                    : "Failed to run test cases";
-                notification.setContent(errorMessage);
-                notification.setStatus(FAIL);
-            }
-        });
+        delegate.doRunTests(e, parameters);
     }
 
+    @Override
+    public NotificationManager getNotificationManager() {
+        return notificationManager;
+    }
+
+    @Override
+    public AppContext getAppContext() {
+        return appContext;
+    }
+
+    @Override
+    public TestServiceClient getService() {
+        return service;
+    }
+
+    @Override
+    public TestResultPresenter getPresenter() {
+        return presenter;
+    }
+
+    @Override
+    public String getTestingFramework() {
+        return "testng";
+    }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassContextTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassContextTestAction.java
@@ -92,7 +92,7 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction {
             parameters.put("fqn", fqn);
             parameters.put("runClass", "true");
             parameters.put("updateClasspath", "true");
-            Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters);
+            Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
             testResultPromise.then(new Operation<TestResult>() {
                 @Override
                 public void apply(TestResult result) throws OperationException {

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassContextTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassContextTestAction.java
@@ -10,10 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
-import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.PROGRESS;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
 import java.util.Arrays;
@@ -22,18 +18,11 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.PromiseError;
-import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.notification.StatusNotification;
-import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.api.selection.SelectionAgent;
@@ -41,6 +30,7 @@ import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
 import org.eclipse.che.ide.resources.tree.FileNode;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
+import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGLocalizationConstant;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
@@ -48,16 +38,17 @@ import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
 import com.google.inject.Inject;
 
 /**
- *
  * @author Mirage Abeysekara
  */
-public class RunClassContextTestAction extends AbstractPerspectiveAction {
+public class RunClassContextTestAction extends AbstractPerspectiveAction
+                                       implements RunTestActionDelegate.Source {
 
-    private final NotificationManager notificationManager;
-    private final TestResultPresenter presenter;
-    private final TestServiceClient service;
-    private final AppContext appContext;
-    private final SelectionAgent selectionAgent;
+    private final NotificationManager   notificationManager;
+    private final TestResultPresenter   presenter;
+    private final TestServiceClient     service;
+    private final AppContext            appContext;
+    private final SelectionAgent        selectionAgent;
+    private final RunTestActionDelegate delegate;
 
     @Inject
     public RunClassContextTestAction(TestNGResources resources,
@@ -70,74 +61,77 @@ public class RunClassContextTestAction extends AbstractPerspectiveAction {
                                      SelectionAgent selectionAgent,
                                      TestNGLocalizationConstant localization) {
         super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunClassContextTitle(),
-                localization.actionRunClassContextDescription(), null, resources.testIcon());
+              localization.actionRunClassContextDescription(), null, resources.testIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
         this.service = service;
         this.appContext = appContext;
         this.selectionAgent = selectionAgent;
+        this.delegate = new RunTestActionDelegate(this);
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        final StatusNotification notification = new StatusNotification("Running Tests...", PROGRESS, FLOAT_MODE);
-        notificationManager.notify(notification);
-        final Selection<?> selection = selectionAgent.getSelection();
+        final Selection< ? > selection = selectionAgent.getSelection();
         final Object possibleNode = selection.getHeadElement();
         if (possibleNode instanceof FileNode) {
-            VirtualFile file = ((FileNode) possibleNode).getData();
-            final Project project = appContext.getRootProject();
+            VirtualFile file = ((FileNode)possibleNode).getData();
             String fqn = JavaUtil.resolveFQN(file);
             Map<String, String> parameters = new HashMap<>();
             parameters.put("fqn", fqn);
             parameters.put("runClass", "true");
-            parameters.put("updateClasspath", "true");
-            Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
-            testResultPromise.then(new Operation<TestResult>() {
-                @Override
-                public void apply(TestResult result) throws OperationException {
-                    notification.setStatus(SUCCESS);
-                    if (result.isSuccess()) {
-                        notification.setTitle("Test runner executed successfully");
-                        notification.setContent("All tests are passed");
-                    } else {
-                        notification.setTitle("Test runner executed successfully with test failures.");
-                        notification.setContent(result.getFailureCount() + " test(s) failed.\n");
-                    }
-                    presenter.handleResponse(result);
-                }
-            }).catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError exception) throws OperationException {
-                    final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                            : "Failed to run test cases";
-                    notification.setContent(errorMessage);
-                    notification.setStatus(FAIL);
-                }
-            });
+            delegate.doRunTests(e, parameters);
         }
     }
 
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         if ((appContext.getRootProject() == null)) {
-            e.getPresentation().setVisible(true);
-            e.getPresentation().setEnabled(false);
+            e.getPresentation().setEnabledAndVisible(false);
             return;
         }
-        final Selection<?> selection = selectionAgent.getSelection();
+        final Selection< ? > selection = selectionAgent.getSelection();
         if (selection == null || selection.isEmpty()) {
-            e.getPresentation().setEnabled(false);
+            e.getPresentation().setEnabledAndVisible(false);
             return;
         }
         if (selection.isMultiSelection()) {
-            e.getPresentation().setEnabled(false);
+            e.getPresentation().setEnabledAndVisible(false);
             return;
         }
         final Object possibleNode = selection.getHeadElement();
-        boolean enable = possibleNode instanceof FileNode
-                && "java".equals(((FileNode) possibleNode).getData().getExtension());
+        if (!(possibleNode instanceof FileNode)) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
 
+        e.getPresentation().setVisible(true);
+        boolean enable = "java".equals(((FileNode)possibleNode).getData().getExtension());
         e.getPresentation().setEnabled(enable);
+    }
+
+    @Override
+    public NotificationManager getNotificationManager() {
+        return notificationManager;
+    }
+
+    @Override
+    public AppContext getAppContext() {
+        return appContext;
+    }
+
+    @Override
+    public TestServiceClient getService() {
+        return service;
+    }
+
+    @Override
+    public TestResultPresenter getPresenter() {
+        return presenter;
+    }
+
+    @Override
+    public String getTestingFramework() {
+        return "testng";
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassTestAction.java
@@ -41,15 +41,14 @@ import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
 import com.google.inject.Inject;
 
 /**
- *
  * @author Mirage Abeysekara
  */
 public class RunClassTestAction extends JavaEditorAction {
 
     private final NotificationManager notificationManager;
-    private final EditorAgent editorAgent;
+    private final EditorAgent         editorAgent;
     private final TestResultPresenter presenter;
-    private final TestServiceClient service;
+    private final TestServiceClient   service;
 
     @Inject
     public RunClassTestAction(TestNGResources resources,
@@ -60,7 +59,7 @@ public class RunClassTestAction extends JavaEditorAction {
                               TestServiceClient service,
                               TestNGLocalizationConstant localization) {
         super(localization.actionRunClassTitle(), localization.actionRunClassDescription(), resources.testIcon(),
-                editorAgent, fileTypeRegistry);
+              editorAgent, fileTypeRegistry);
         this.notificationManager = notificationManager;
         this.editorAgent = editorAgent;
         this.presenter = presenter;
@@ -79,7 +78,7 @@ public class RunClassTestAction extends JavaEditorAction {
         parameters.put("fqn", fqn);
         parameters.put("runClass", "true");
         parameters.put("updateClasspath", "true");
-        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters);
+        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
         testResultPromise.then(new Operation<TestResult>() {
             @Override
             public void apply(TestResult result) throws OperationException {
@@ -97,7 +96,7 @@ public class RunClassTestAction extends JavaEditorAction {
             @Override
             public void apply(PromiseError exception) throws OperationException {
                 final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                        : "Failed to run test cases";
+                    : "Failed to run test cases";
                 notification.setContent(errorMessage);
                 notification.setStatus(FAIL);
             }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassTestAction.java
@@ -10,30 +10,20 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
-import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.PROGRESS;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.PromiseError;
-import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.notification.StatusNotification;
-import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.ext.java.client.action.JavaEditorAction;
 import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
+import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGLocalizationConstant;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
@@ -43,12 +33,13 @@ import com.google.inject.Inject;
 /**
  * @author Mirage Abeysekara
  */
-public class RunClassTestAction extends JavaEditorAction {
+public class RunClassTestAction extends JavaEditorAction 
+implements RunTestActionDelegate.Source {
 
     private final NotificationManager notificationManager;
-    private final EditorAgent         editorAgent;
     private final TestResultPresenter presenter;
     private final TestServiceClient   service;
+    private final RunTestActionDelegate delegate;
 
     @Inject
     public RunClassTestAction(TestNGResources resources,
@@ -64,48 +55,49 @@ public class RunClassTestAction extends JavaEditorAction {
         this.editorAgent = editorAgent;
         this.presenter = presenter;
         this.service = service;
+        this.delegate = new RunTestActionDelegate(this);
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        final StatusNotification notification = new StatusNotification("Running Tests...", PROGRESS, FLOAT_MODE);
-        notificationManager.notify(notification);
-        final Project project = appContext.getRootProject();
+        Map<String, String> parameters = new HashMap<>();
         EditorPartPresenter editorPart = editorAgent.getActiveEditor();
         final VirtualFile file = editorPart.getEditorInput().getFile();
         String fqn = JavaUtil.resolveFQN(file);
-        Map<String, String> parameters = new HashMap<>();
         parameters.put("fqn", fqn);
         parameters.put("runClass", "true");
-        parameters.put("updateClasspath", "true");
-        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
-        testResultPromise.then(new Operation<TestResult>() {
-            @Override
-            public void apply(TestResult result) throws OperationException {
-                notification.setStatus(SUCCESS);
-                if (result.isSuccess()) {
-                    notification.setTitle("Test runner executed successfully");
-                    notification.setContent("All tests are passed");
-                } else {
-                    notification.setTitle("Test runner executed successfully with test failures.");
-                    notification.setContent(result.getFailureCount() + " test(s) failed.\n");
-                }
-                presenter.handleResponse(result);
-            }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError exception) throws OperationException {
-                final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                    : "Failed to run test cases";
-                notification.setContent(errorMessage);
-                notification.setStatus(FAIL);
-            }
-        });
+        
+        delegate.doRunTests(e, parameters);
     }
 
     @Override
     protected void updateProjectAction(ActionEvent e) {
         super.updateProjectAction(e);
         e.getPresentation().setVisible(true);
+    }
+    
+    @Override
+    public NotificationManager getNotificationManager() {
+        return notificationManager;
+    }
+
+    @Override
+    public AppContext getAppContext() {
+        return appContext;
+    }
+
+    @Override
+    public TestServiceClient getService() {
+        return service;
+    }
+
+    @Override
+    public TestResultPresenter getPresenter() {
+        return presenter;
+    }
+
+    @Override
+    public String getTestingFramework() {
+        return "testng";
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunTestXMLAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunTestXMLAction.java
@@ -10,28 +10,19 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
-import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.PROGRESS;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.PromiseError;
-import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.ext.java.client.action.JavaEditorAction;
 import org.eclipse.che.plugin.maven.shared.MavenAttributes;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
+import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGLocalizationConstant;
 import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
@@ -41,11 +32,13 @@ import com.google.inject.Inject;
 /**
  * @author Mirage Abeysekara
  */
-public class RunTestXMLAction extends JavaEditorAction {
+public class RunTestXMLAction extends JavaEditorAction
+                              implements RunTestActionDelegate.Source {
 
-    private final NotificationManager notificationManager;
-    private TestResultPresenter       presenter;
-    private final TestServiceClient   service;
+    private final NotificationManager   notificationManager;
+    private TestResultPresenter         presenter;
+    private final TestServiceClient     service;
+    private final RunTestActionDelegate delegate;
 
     @Inject
     public RunTestXMLAction(TestNGResources resources,
@@ -61,39 +54,43 @@ public class RunTestXMLAction extends JavaEditorAction {
         this.editorAgent = editorAgent;
         this.presenter = presenter;
         this.service = service;
+        this.delegate = new RunTestActionDelegate(this);
+
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        final StatusNotification notification = new StatusNotification("Running Tests...", PROGRESS, FLOAT_MODE);
-        notificationManager.notify(notification);
         final Project project = appContext.getRootProject();
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("updateClasspath", "true");
+
         parameters.put("testngXML",
                        project.getPath() + "/" + MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER + "/testng.xml");
-        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
-        testResultPromise.then(new Operation<TestResult>() {
-            @Override
-            public void apply(TestResult result) throws OperationException {
-                notification.setStatus(SUCCESS);
-                if (result.isSuccess()) {
-                    notification.setTitle("Test runner executed successfully");
-                    notification.setContent("All tests are passed");
-                } else {
-                    notification.setTitle("Test runner executed successfully with test failures.");
-                    notification.setContent(result.getFailureCount() + " test(s) failed.\n");
-                }
-                presenter.handleResponse(result);
-            }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError exception) throws OperationException {
-                final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                    : "Failed to run test cases";
-                notification.setContent(errorMessage);
-                notification.setStatus(FAIL);
-            }
-        });
+
+        delegate.doRunTests(e, parameters);
+    }
+
+    @Override
+    public NotificationManager getNotificationManager() {
+        return notificationManager;
+    }
+
+    @Override
+    public AppContext getAppContext() {
+        return appContext;
+    }
+
+    @Override
+    public TestServiceClient getService() {
+        return service;
+    }
+
+    @Override
+    public TestResultPresenter getPresenter() {
+        return presenter;
+    }
+
+    @Override
+    public String getTestingFramework() {
+        return "testng";
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunTestXMLAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunTestXMLAction.java
@@ -39,14 +39,13 @@ import org.eclipse.che.plugin.testing.testng.ide.TestNGResources;
 import com.google.inject.Inject;
 
 /**
- *
  * @author Mirage Abeysekara
  */
 public class RunTestXMLAction extends JavaEditorAction {
 
     private final NotificationManager notificationManager;
-    private TestResultPresenter presenter;
-    private final TestServiceClient service;
+    private TestResultPresenter       presenter;
+    private final TestServiceClient   service;
 
     @Inject
     public RunTestXMLAction(TestNGResources resources,
@@ -57,7 +56,7 @@ public class RunTestXMLAction extends JavaEditorAction {
                             TestServiceClient service,
                             TestNGLocalizationConstant localization) {
         super(localization.actionRunXMLTitle(), localization.actionRunXMLDescription(), resources.testAllIcon(),
-                editorAgent, fileTypeRegistry);
+              editorAgent, fileTypeRegistry);
         this.notificationManager = notificationManager;
         this.editorAgent = editorAgent;
         this.presenter = presenter;
@@ -72,8 +71,8 @@ public class RunTestXMLAction extends JavaEditorAction {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("updateClasspath", "true");
         parameters.put("testngXML",
-                project.getPath() + "/" + MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER + "/testng.xml");
-        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters);
+                       project.getPath() + "/" + MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER + "/testng.xml");
+        Promise<TestResult> testResultPromise = service.getTestResult(project.getPath(), "testng", parameters, notification);
         testResultPromise.then(new Operation<TestResult>() {
             @Override
             public void apply(TestResult result) throws OperationException {
@@ -91,7 +90,7 @@ public class RunTestXMLAction extends JavaEditorAction {
             @Override
             public void apply(PromiseError exception) throws OperationException {
                 final String errorMessage = (exception.getMessage() != null) ? exception.getMessage()
-                        : "Failed to run test cases";
+                    : "Failed to run test cases";
                 notification.setContent(errorMessage);
                 notification.setStatus(FAIL);
             }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/pom.xml
@@ -61,5 +61,9 @@
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>org.eclipse.core.resources</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
@@ -16,22 +16,30 @@ import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import javax.inject.Inject;
 
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.testing.server.framework.TestRunner;
-import org.eclipse.che.api.testing.shared.Failure;
+import org.eclipse.che.api.testing.server.listener.AbstractTestListener;
+import org.eclipse.che.api.testing.server.listener.OutputTestListener;
+import org.eclipse.che.api.testing.shared.TestCase;
 import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.plugin.testing.classpath.server.TestClasspathProvider;
 import org.eclipse.che.plugin.testing.classpath.server.TestClasspathRegistry;
 import org.eclipse.core.resources.ResourcesPlugin;
+
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
 
 /**
  * TestNG implementation for the test runner service.
@@ -47,15 +55,14 @@ import org.eclipse.core.resources.ResourcesPlugin;
  * <em>testngXML</em> : Relative path to the testng.xml file. If this parameter is set, the TestNG test runner will
  *             execute given testng.xml test suite, otherwise all the test classes are get executed.
  *             (Note: If the <em>runClass</em> parameter is true then <em>testngXML</em> parameter gets ignored.)
- *
  * </pre>
  * 
  * @author Mirage Abeysekara
  */
 public class TestNGRunner implements TestRunner {
 
-    private ClassLoader projectClassLoader;
-    private ProjectManager projectManager;
+    private ClassLoader           projectClassLoader;
+    private ProjectManager        projectManager;
     private TestClasspathRegistry classpathRegistry;
 
     @Inject
@@ -78,8 +85,21 @@ public class TestNGRunner implements TestRunner {
         if (projectManager != null) {
             projectType = projectManager.getProject(projectPath).getType();
         }
+
+        ClassLoader currentClassLoader = this.getClass().getClassLoader();
         TestClasspathProvider classpathProvider = classpathRegistry.getTestClasspathProvider(projectType);
-        projectClassLoader = classpathProvider.getClassLoader(projectAbsolutePath, projectPath, updateClasspath);
+        URLClassLoader providedClassLoader = (URLClassLoader)classpathProvider.getClassLoader(projectAbsolutePath, projectPath,
+                                                                                              updateClasspath);
+        projectClassLoader = new URLClassLoader(providedClassLoader.getURLs(), null) {
+            @Override
+            protected Class< ? > findClass(String name) throws ClassNotFoundException {
+                if (name.startsWith("javassist.")) {
+                    return currentClassLoader.loadClass(name);
+                }
+                return super.findClass(name);
+            }
+        };
+
         TestResult testResult;
         if (runClass) {
             String fqn = testParameters.get("fqn");
@@ -104,7 +124,7 @@ public class TestNGRunner implements TestRunner {
 
     private TestResult run(String projectAbsolutePath, String testClass) throws Exception {
         ClassLoader classLoader = projectClassLoader;
-        Class<?> clsTest = Class.forName(testClass, true, classLoader);
+        Class< ? > clsTest = Class.forName(testClass, true, classLoader);
         return runTestClasses(projectAbsolutePath, clsTest);
 
     }
@@ -122,7 +142,7 @@ public class TestNGRunner implements TestRunner {
         @SuppressWarnings("rawtypes")
         List<Class> testableClasses = new ArrayList<>();
         for (String className : testClassNames) {
-            Class<?> clazz = Class.forName(className, false, projectClassLoader);
+            Class< ? > clazz = Class.forName(className, false, projectClassLoader);
             if (isTestable(clazz)) {
                 testableClasses.add(clazz);
             }
@@ -131,7 +151,7 @@ public class TestNGRunner implements TestRunner {
 
     }
 
-    private boolean isTestable(Class<?> clazz) throws ClassNotFoundException {
+    private boolean isTestable(Class< ? > clazz) throws ClassNotFoundException {
         for (Method method : clazz.getDeclaredMethods()) {
             for (Annotation annotation : method.getAnnotations()) {
                 if (annotation.annotationType().getName().equals("org.testng.annotations.Test")) {
@@ -142,123 +162,191 @@ public class TestNGRunner implements TestRunner {
         return false;
     }
 
-    private TestResult runTestClasses(String projectAbsolutePath, Class<?>... classes) throws Exception {
-        ClassLoader classLoader = projectClassLoader;
-        Class<?> clsTestNG = Class.forName("org.testng.TestNG", true, classLoader);
-        Class<?> clsTestListner = Class.forName("org.testng.TestListenerAdapter", true, classLoader);
-        Class<?> clsITestListner = Class.forName("org.testng.ITestListener", true, classLoader);
-        Class<?> clsResult = Class.forName("org.testng.ITestResult", true, classLoader);
-        Class<?> clsIClass = Class.forName("org.testng.IClass", true, classLoader);
-        Class<?> clsThrowable = Class.forName("java.lang.Throwable", true, classLoader);
-        Class<?> clsStackTraceElement = Class.forName("java.lang.StackTraceElement", true, classLoader);
-        Object testNG = clsTestNG.newInstance();
-        Object testListner = clsTestListner.newInstance();
-        clsTestNG.getMethod("addListener", clsITestListner).invoke(testNG, testListner);
-        clsTestNG.getMethod("setTestClasses", Class[].class).invoke(testNG, new Object[] { classes });
-        clsTestNG.getMethod("setOutputDirectory", String.class).invoke(testNG,
-                Paths.get(projectAbsolutePath, "target", "testng-out").toString());
-        clsTestNG.getMethod("run").invoke(testNG);
-        List<?> failures = (List<?>) clsTestListner.getMethod("getFailedTests").invoke(testListner);
-        TestResult dtoResult = DtoFactory.getInstance().createDto(TestResult.class);
-        boolean isSuccess = (failures.size() == 0);
-        List<Failure> testNGFailures = new ArrayList<>();
-        for (Object failure : failures) {
-            Failure dtoFailure = DtoFactory.getInstance().createDto(Failure.class);
-            Object throwable = clsResult.getMethod("getThrowable").invoke(failure);
-            String message = (String) clsThrowable.getMethod("getMessage").invoke(throwable);
-            Object failingClass = clsResult.getMethod("getTestClass").invoke(failure);
-            String failClassName = (String) clsIClass.getMethod("getName").invoke(failingClass);
-            Object stackTrace = clsThrowable.getMethod("getStackTrace").invoke(throwable);
-            String failMethod = "";
-            Integer failLine = null;
-            if (stackTrace.getClass().isArray()) {
-                int length = Array.getLength(stackTrace);
-                for (int i = 0; i < length; i++) {
-                    Object arrayElement = Array.get(stackTrace, i);
-                    String failClass = (String) clsStackTraceElement.getMethod("getClassName").invoke(arrayElement);
-                    if (failClass.equals(failClassName)) {
-                        failMethod = (String) clsStackTraceElement.getMethod("getMethodName").invoke(arrayElement);
-                        failLine = (Integer) clsStackTraceElement.getMethod("getLineNumber").invoke(arrayElement);
+    private Object createTestListener(ClassLoader loader, Class< ? > listenerClass, AbstractTestListener delegate) throws Exception {
+        ProxyFactory f = new ProxyFactory();
+        f.setSuperclass(listenerClass);
+        f.setFilter(new MethodFilter() {
+            @Override
+            public boolean isHandled(Method m) {
+                String methodName = m.getName();
+                switch (methodName) {
+                    case "onTestStart":
+                    case "onTestSuccess":
+                    case "testFailure":
+                    case "onTestFailure":
+                        return true;
+                }
+                return false;
+            }
+        });
+        Class< ? > c = f.createClass();
+        MethodHandler mi = new MethodHandler() {
+            @Override
+            public Object invoke(Object self, Method m, Method method, Object[] args) throws Throwable {
+                String methodName = m.getName();
+                Object testResult = null;
+                Throwable throwable = null;
+
+                switch (methodName) {
+                    case "onTestStart":
+                    case "onTestSuccess":
+                        testResult = args[0];
+                        throwable = null;
                         break;
+                    case "onTestFailure":
+                        testResult = args[0];
+                        throwable = (Throwable)testResult.getClass().getMethod("getThrowable", new Class< ? >[0]).invoke(args[0]);
+                        break;
+                }
+
+                Object testClass = testResult.getClass().getMethod("getTestClass").invoke(testResult);
+                Object testMethod = testResult.getClass().getMethod("getMethod").invoke(testResult);
+                String testClassName = (String)testClass.getClass().getMethod("getName").invoke(testClass);
+                String testMethodName = (String)testMethod.getClass().getMethod("getMethodName").invoke(testMethod);
+
+                String testKey = new StringBuilder().append(testMethodName)
+                                                    .append('(').append(testClassName).append(')').toString();
+                String testName = testKey;
+                switch (methodName) {
+                    case "onTestStart":
+                        delegate.startTest(testKey, testName);
+                        break;
+
+                    case "onTestSuccess":
+                        delegate.endTest(testKey, testName);
+                        break;
+
+                    case "onTestFailure":
+                        delegate.addFailure(testKey, throwable);
+                        delegate.endTest(testKey, testName);
+                        break;
+
+                    default:
+
+                }
+                return method.invoke(self, args);
+            }
+        };
+        Object listener = c.getConstructor().newInstance();
+        ((javassist.util.proxy.Proxy)listener).setHandler(mi);
+        return listener;
+    }
+
+
+    private TestResult runTest(String projectAbsolutePath, BiConsumer<Class< ? >, Object> configure) throws Exception {
+        ClassLoader classLoader = projectClassLoader;
+        Class< ? > clsTestNG = Class.forName("org.testng.TestNG", true, classLoader);
+        Class< ? > clsTestListner = Class.forName("org.testng.TestListenerAdapter", true, classLoader);
+        Class< ? > clsITestListner = Class.forName("org.testng.ITestListener", true, classLoader);
+        Class< ? > clsResult = Class.forName("org.testng.ITestResult", true, classLoader);
+        Class< ? > clsIClass = Class.forName("org.testng.IClass", true, classLoader);
+        Class< ? > clsITestNGMethod = Class.forName("org.testng.ITestNGMethod", true, classLoader);
+        Class< ? > clsThrowable = Class.forName("java.lang.Throwable", true, classLoader);
+        Class< ? > clsStackTraceElement = Class.forName("java.lang.StackTraceElement", true, classLoader);
+        Object testNG = clsTestNG.newInstance();
+
+        Object testListner;
+        try (OutputTestListener outputListener = new OutputTestListener(this.getClass().getName() + ".runTest")) {
+            testListner = createTestListener(classLoader, clsTestListner, outputListener);
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(projectClassLoader);
+
+                clsTestNG.getMethod("addListener", clsITestListner).invoke(testNG, testListner);
+
+                configure.accept(clsTestNG, testNG);
+
+                clsTestNG.getMethod("setOutputDirectory", String.class).invoke(testNG,
+                                                                               Paths.get(projectAbsolutePath, "target", "testng-out")
+                                                                                    .toString());
+                clsTestNG.getMethod("run").invoke(testNG);
+            } finally {
+                Thread.currentThread().setContextClassLoader(tccl);
+            }
+        }
+
+        List<Object> allTests = new ArrayList<>();
+        for (Object failure : (List< ? >)clsTestListner.getMethod("getFailedTests").invoke(testListner)) {
+            allTests.add(failure);
+        }
+        int failureCount = allTests.size();
+
+        for (Object success : (List< ? >)clsTestListner.getMethod("getPassedTests").invoke(testListner)) {
+            allTests.add(success);
+        }
+
+        TestResult dtoResult = DtoFactory.getInstance().createDto(TestResult.class);
+        boolean isSuccess = (failureCount == 0);
+        List<TestCase> testCases = new ArrayList<>();
+        for (Object test : allTests) {
+            TestCase dtoFailure = DtoFactory.getInstance().createDto(TestCase.class);
+            Object testClass = clsResult.getMethod("getTestClass").invoke(test);
+            Object testMethod = clsResult.getMethod("getMethod").invoke(test);
+            String testClassName = (String)clsIClass.getMethod("getName").invoke(testClass);
+            String testMethodName = (String)clsITestNGMethod.getMethod("getMethodName").invoke(testMethod);
+
+            dtoFailure.setClassName(testClassName);
+            dtoFailure.setMethod(testMethodName);
+
+            Object throwable = clsResult.getMethod("getThrowable").invoke(test);
+            if (throwable != null) {
+                String message = (String)clsThrowable.getMethod("getMessage").invoke(throwable);
+                Object stackTrace = clsThrowable.getMethod("getStackTrace").invoke(throwable);
+                Integer failLine = null;
+                if (stackTrace.getClass().isArray()) {
+                    int length = Array.getLength(stackTrace);
+                    for (int i = 0; i < length; i++) {
+                        Object arrayElement = Array.get(stackTrace, i);
+                        String failClass = (String)clsStackTraceElement.getMethod("getClassName").invoke(arrayElement);
+                        String failMethod = (String)clsStackTraceElement.getMethod("getMethodName").invoke(arrayElement);
+                        if (failClass.equals(testClassName) && failMethod.equals(testMethodName)) {
+                            failLine = (Integer)clsStackTraceElement.getMethod("getLineNumber").invoke(arrayElement);
+                            break;
+                        }
                     }
                 }
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                clsThrowable.getMethod("printStackTrace", PrintWriter.class).invoke(throwable, pw);
+                String trace = sw.toString();
+                dtoFailure.setFailingLine(failLine == null ? -1 : failLine);
+                dtoFailure.setMessage(message);
+                dtoFailure.setTrace(trace);
+                dtoFailure.setFailed(true);
+            } else {
+                dtoFailure.setFailingLine(-1);
+                dtoFailure.setFailed(false);
             }
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            clsThrowable.getMethod("printStackTrace", PrintWriter.class).invoke(throwable, pw);
-            String trace = sw.toString();
-            dtoFailure.setFailingClass(failClassName);
-            dtoFailure.setFailingMethod(failMethod);
-            dtoFailure.setFailingLine(failLine);
-            dtoFailure.setMessage(message);
-            dtoFailure.setTrace(trace);
-            testNGFailures.add(dtoFailure);
+            testCases.add(dtoFailure);
         }
+
         dtoResult.setTestFramework("TestNG");
         dtoResult.setSuccess(isSuccess);
-        dtoResult.setFailureCount(testNGFailures.size());
-        dtoResult.setFailures(testNGFailures);
+        dtoResult.setFailureCount(failureCount);
+        dtoResult.setTestCaseCount(testCases.size());
+        dtoResult.setTestCases(testCases);
         return dtoResult;
     }
 
     private TestResult runTestXML(String projectAbsolutePath, String xmlPath) throws Exception {
-        ClassLoader classLoader = projectClassLoader;
-        Class<?> clsTestNG = Class.forName("org.testng.TestNG", true, classLoader);
-        Class<?> clsTestListner = Class.forName("org.testng.TestListenerAdapter", true, classLoader);
-        Class<?> clsITestListner = Class.forName("org.testng.ITestListener", true, classLoader);
-        Class<?> clsResult = Class.forName("org.testng.ITestResult", true, classLoader);
-        Class<?> clsIClass = Class.forName("org.testng.IClass", true, classLoader);
-        Class<?> clsThrowable = Class.forName("java.lang.Throwable", true, classLoader);
-        Class<?> clsStackTraceElement = Class.forName("java.lang.StackTraceElement", true, classLoader);
-        Object testNG = clsTestNG.newInstance();
-        Object testListner = clsTestListner.newInstance();
-        clsTestNG.getMethod("addListener", clsITestListner).invoke(testNG, testListner);
-        List<String> testSuites = new ArrayList<>();
-        testSuites.add(xmlPath);
-        clsTestNG.getMethod("setTestSuites", List.class).invoke(testNG, testSuites);
-        clsTestNG.getMethod("setOutputDirectory", String.class).invoke(testNG,
-                Paths.get(projectAbsolutePath, "target", "testng-out").toString());
-        clsTestNG.getMethod("run").invoke(testNG);
-        List<?> failures = (List<?>) clsTestListner.getMethod("getFailedTests").invoke(testListner);
-        TestResult dtoResult = DtoFactory.getInstance().createDto(TestResult.class);
-        boolean isSuccess = (failures.size() == 0);
-        List<Failure> testNGFailures = new ArrayList<>();
-        for (Object failure : failures) {
-            Failure dtoFailure = DtoFactory.getInstance().createDto(Failure.class);
-            Object throwable = clsResult.getMethod("getThrowable").invoke(failure);
-            String message = (String) clsThrowable.getMethod("getMessage").invoke(throwable);
-            Object failingClass = clsResult.getMethod("getTestClass").invoke(failure);
-            String failClassName = (String) clsIClass.getMethod("getName").invoke(failingClass);
-            Object stackTrace = clsThrowable.getMethod("getStackTrace").invoke(throwable);
-            String failMethod = "";
-            Integer failLine = null;
-            if (stackTrace.getClass().isArray()) {
-                int length = Array.getLength(stackTrace);
-                for (int i = 0; i < length; i++) {
-                    Object arrayElement = Array.get(stackTrace, i);
-                    String failClass = (String) clsStackTraceElement.getMethod("getClassName").invoke(arrayElement);
-                    if (failClass.equals(failClassName)) {
-                        failMethod = (String) clsStackTraceElement.getMethod("getMethodName").invoke(arrayElement);
-                        failLine = (Integer) clsStackTraceElement.getMethod("getLineNumber").invoke(arrayElement);
-                        break;
-                    }
-                }
+        return runTest(projectAbsolutePath, (clsTestNG, testNG) -> {
+            try {
+                List<String> testSuites = new ArrayList<>();
+                testSuites.add(xmlPath);
+                clsTestNG.getMethod("setTestSuites", List.class).invoke(testNG, testSuites);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            clsThrowable.getMethod("printStackTrace", PrintWriter.class).invoke(throwable, pw);
-            String trace = sw.toString();
-            dtoFailure.setFailingClass(failClassName);
-            dtoFailure.setFailingMethod(failMethod);
-            dtoFailure.setFailingLine(failLine);
-            dtoFailure.setMessage(message);
-            dtoFailure.setTrace(trace);
-            testNGFailures.add(dtoFailure);
-        }
-        dtoResult.setTestFramework("TestNG");
-        dtoResult.setSuccess(isSuccess);
-        dtoResult.setFailureCount(testNGFailures.size());
-        dtoResult.setFailures(testNGFailures);
-        return dtoResult;
+        });
+    }
+
+    private TestResult runTestClasses(String projectAbsolutePath, Class< ? >... classes) throws Exception {
+        return runTest(projectAbsolutePath, (clsTestNG, testNG) -> {
+            try {
+                clsTestNG.getMethod("setTestClasses", Class[].class).invoke(testNG, new Object[]{classes});
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
@@ -111,6 +111,7 @@ public class TestNGRunner implements TestRunner {
                 testResult = runTestXML(projectAbsolutePath, ResourcesPlugin.getPathToWorkspace() + xmlPath);
             }
         }
+        testResult.setProjectPath(projectPath);
         return testResult;
     }
 

--- a/plugins/plugin-testing/che-plugin-testing-ide/pom.xml
+++ b/plugins/plugin-testing/che-plugin-testing-ide/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-elemental</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-testing/che-plugin-testing-ide/pom.xml
+++ b/plugins/plugin-testing/che-plugin-testing-ide/pom.xml
@@ -90,6 +90,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-java-ext-lang-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-machine-ext-client</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestLocalizationConstant.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestLocalizationConstant.java
@@ -25,6 +25,9 @@ public interface TestLocalizationConstant extends Messages {
     @Key("actionGroup.menu.name")
     String actionGroupMenuName();
 
+    @Key("contextActionGroup.menu.name")
+    String contextActionGroupMenuName();
+    
     /* Titles */
 
     @Key("title.testResultPresenter")

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestResources.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestResources.java
@@ -18,6 +18,7 @@ import com.google.gwt.resources.client.ClientBundle;
  * Resources for test extension.
  *
  * @author Mirage Abeysekara
+ * 
  */
 public interface TestResources extends ClientBundle {
 
@@ -29,4 +30,16 @@ public interface TestResources extends ClientBundle {
 
     @Source("org/eclipse/che/plugin/testing/ide/svg/test_results_fail.svg")
     SVGResource testResultsFail();
+
+    @Source("org/eclipse/che/plugin/testing/ide/svg/test_method_fail.svg")
+    SVGResource testMethodFail();
+
+    @Source("org/eclipse/che/plugin/testing/ide/svg/test_class_fail.svg")
+    SVGResource testClassFail();
+
+    @Source("org/eclipse/che/plugin/testing/ide/svg/show_all_tests_icon.svg")
+    SVGResource showAllTestsButtonIcon();
+
+    @Source("org/eclipse/che/plugin/testing/ide/svg/show_failures_only_icon.svg")
+    SVGResource showFailuresOnlyButtonIcon();
 }

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -35,6 +35,7 @@ import org.eclipse.che.ide.api.macro.MacroProcessor;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.command.goal.TestGoal;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.extension.machine.client.command.CommandManagerImpl;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandConsoleFactory;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandOutputConsole;
 import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPanelPresenter;
@@ -109,6 +110,7 @@ public class TestServiceClient {
 
     public Promise<CommandImpl> getOrCreateTestCompileCommand() {
         List<CommandImpl> commands = commandManager.getCommands();
+        
         for (CommandImpl command : commands) {
             if (command.getName() != null && command.getName().startsWith("test-compile") && "mvn".equals(command.getType())) {
                 return promiseProvider.resolve(command);
@@ -169,8 +171,12 @@ public class TestServiceClient {
                     macroProcessor.expandMacros(command.getCommandLine()).then(new Operation<String>() {
                         @Override
                         public void apply(String expandedCommandLine) throws OperationException {
+                            Map<String, String> attributes = new HashMap<>();
+                            attributes.putAll(command.getAttributes());
+                            attributes.remove(CommandManagerImpl.PREVIEW_URL_ATTR);
+                            
                             CommandImpl expandedCommand = new CommandImpl(command.getName(), expandedCommandLine,
-                                                                          command.getType(), command.getAttributes());
+                                                                          command.getType(), attributes);
 
                             final CommandOutputConsole console = commandConsoleFactory.create(expandedCommand, machine);
                             final String machineId = machine.getId();

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.machine.shared.dto.execagent.ProcessStartResponseDto;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
@@ -31,6 +32,7 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandManager;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
+import org.eclipse.che.ide.api.machine.execagent.ExecAgentPromise;
 import org.eclipse.che.ide.api.macro.MacroProcessor;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.command.goal.TestGoal;
@@ -58,20 +60,20 @@ import com.google.inject.Singleton;
 @Singleton
 public class TestServiceClient {
 
-    private final static RegExp           mavenCleanBuildPattern =
+    private final static RegExp           mavenCleanBuildPattern            =
                                                                  RegExp.compile("(.*)mvn +clean +install +(\\-f +\\$\\{current\\.project\\.path\\}.*)");
 
-    public static final String PROJECT_BUILD_NOT_STARTED_MESSAGE = "The project build could not be started (see Build output). "
-        + "Test run is cancelled.\n"
-        + "You should probably check the settings of the 'test-compile' command.";
+    public static final String            PROJECT_BUILD_NOT_STARTED_MESSAGE = "The project build could not be started (see Build output). "
+                                                                              + "Test run is cancelled.\n"
+                                                                              + "You should probably check the settings of the 'test-compile' command.";
 
-    public static final String PROJECT_BUILD_FAILED_MESSAGE = "The project build failed (see Build output). "
-        + "Test run is cancelled.\n"
-        + "You might want to check the settings of the 'test-compile' command.";
-    
-    public static final String EXECUTING_TESTS_MESSAGE = "Executing test session.";
-    
-    
+    public static final String            PROJECT_BUILD_FAILED_MESSAGE      = "The project build failed (see Build output). "
+                                                                              + "Test run is cancelled.\n"
+                                                                              + "You might want to check the settings of the 'test-compile' command.";
+
+    public static final String            EXECUTING_TESTS_MESSAGE           = "Executing test session.";
+
+
     private final AppContext              appContext;
     private final AsyncRequestFactory     asyncRequestFactory;
     private final DtoUnmarshallerFactory  dtoUnmarshallerFactory;
@@ -110,7 +112,7 @@ public class TestServiceClient {
 
     public Promise<CommandImpl> getOrCreateTestCompileCommand() {
         List<CommandImpl> commands = commandManager.getCommands();
-        
+
         for (CommandImpl command : commands) {
             if (command.getName() != null && command.getName().startsWith("test-compile") && "mvn".equals(command.getType())) {
                 return promiseProvider.resolve(command);
@@ -174,7 +176,7 @@ public class TestServiceClient {
                             Map<String, String> attributes = new HashMap<>();
                             attributes.putAll(command.getAttributes());
                             attributes.remove(CommandManagerImpl.PREVIEW_URL_ATTR);
-                            
+
                             CommandImpl expandedCommand = new CommandImpl(command.getName(), expandedCommandLine,
                                                                           command.getType(), attributes);
 
@@ -182,43 +184,45 @@ public class TestServiceClient {
                             final String machineId = machine.getId();
 
                             processesPanelPresenter.addCommandOutput(machineId, console);
-                            execAgentCommandManager.startProcess(machineId, expandedCommand)
-                                                   .then(startResonse -> {
-                                                       if (!startResonse.getAlive()) {
-                                                           reject.apply(promiseFromThrowable(new Throwable(PROJECT_BUILD_NOT_STARTED_MESSAGE)));
-                                                       }
-                                                   })
-                                                   .thenIfProcessStartedEvent(console.getProcessStartedOperation())
-                                                   .thenIfProcessStdErrEvent(evt -> {
-                                                       if (evt.getText().contains("BUILD SUCCESS")) {
-                                                           compiled = true;
-                                                       }
-                                                       console.getStdErrOperation().apply(evt);
-                                                   })
-                                                   .thenIfProcessStdOutEvent(evt -> {
-                                                       if (evt.getText().contains("BUILD SUCCESS")) {
-                                                           compiled = true;
-                                                       }
-                                                       console.getStdOutOperation().apply(evt);
-                                                   })
-                                                   .thenIfProcessDiedEvent(evt -> {
-                                                       console.getProcessDiedOperation().apply(evt);
-                                                       if (compiled) {
-                                                           if (statusNotification != null) {
-                                                               statusNotification.setContent(EXECUTING_TESTS_MESSAGE);
-                                                           }
-                                                           sendTests(projectPath,
-                                                                     testFramework,
-                                                                     parameters).then(new Operation<TestResult>() {
-                                                                         @Override
-                                                                         public void apply(TestResult result) throws OperationException {
-                                                                             resolve.apply(result);
-                                                                         }
-                                                                     });
-                                                       } else {
-                                                           reject.apply(promiseFromThrowable(new Throwable(PROJECT_BUILD_FAILED_MESSAGE)));
-                                                       }
-                                                   });
+                            ExecAgentPromise<ProcessStartResponseDto> processPromise = execAgentCommandManager.startProcess(machineId,
+                                                                                                                            expandedCommand);
+                            processPromise.then(startResonse -> {
+                                if (!startResonse.getAlive()) {
+                                    reject.apply(promiseFromThrowable(new Throwable(PROJECT_BUILD_NOT_STARTED_MESSAGE)));
+                                }
+                            }).thenIfProcessStartedEvent(console.getProcessStartedOperation()).thenIfProcessStdErrEvent(evt -> {
+                                if (evt.getText().contains("BUILD SUCCESS")) {
+                                    compiled = true;
+                                }
+                                console.getStdErrOperation().apply(evt);
+                            }).thenIfProcessStdOutEvent(evt -> {
+                                if (evt.getText().contains("BUILD SUCCESS")) {
+                                    compiled = true;
+                                }
+                                console.getStdOutOperation().apply(evt);
+                            }).thenIfProcessDiedEvent(evt -> {
+                                console.getProcessDiedOperation().apply(evt);
+                                if (compiled) {
+                                    if (statusNotification != null) {
+                                        statusNotification.setContent(EXECUTING_TESTS_MESSAGE);
+                                    }
+                                    sendTests(projectPath,
+                                              testFramework,
+                                              parameters).then(new Operation<TestResult>() {
+                                                  @Override
+                                                  public void apply(TestResult result) throws OperationException {
+                                                      resolve.apply(result);
+                                                  }
+                                              }, new Operation<PromiseError>() {
+                                                  @Override
+                                                  public void apply(PromiseError error) throws OperationException {
+                                                      reject.apply(error);
+                                                  }
+                                              });
+                                } else {
+                                    reject.apply(promiseFromThrowable(new Throwable(PROJECT_BUILD_FAILED_MESSAGE)));
+                                }
+                            });
                         }
                     });
                 }

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -37,7 +37,6 @@ import org.eclipse.che.ide.api.macro.MacroProcessor;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.command.goal.TestGoal;
 import org.eclipse.che.ide.dto.DtoFactory;
-import org.eclipse.che.ide.extension.machine.client.command.CommandManagerImpl;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandConsoleFactory;
 import org.eclipse.che.ide.extension.machine.client.outputspanel.console.CommandOutputConsole;
 import org.eclipse.che.ide.extension.machine.client.processes.panel.ProcessesPanelPresenter;
@@ -50,6 +49,8 @@ import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import static org.eclipse.che.api.workspace.shared.Constants.COMMAND_PREVIEW_URL_ATTRIBUTE_NAME;
 
 /**
  * Client for calling test services
@@ -175,7 +176,7 @@ public class TestServiceClient {
                         public void apply(String expandedCommandLine) throws OperationException {
                             Map<String, String> attributes = new HashMap<>();
                             attributes.putAll(command.getAttributes());
-                            attributes.remove(CommandManagerImpl.PREVIEW_URL_ATTR);
+                            attributes.remove(COMMAND_PREVIEW_URL_ATTRIBUTE_NAME);
 
                             CommandImpl expandedCommand = new CommandImpl(command.getName(), expandedCommandLine,
                                                                           command.getType(), attributes);

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestingExtension.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestingExtension.java
@@ -48,7 +48,7 @@ public class TestingExtension {
         runMenu.addSeparator();
         runMenu.add(testMainMenu);
         DefaultActionGroup explorerMenu = (DefaultActionGroup) actionManager.getAction(GROUP_MAIN_CONTEXT_MENU);
-        DefaultActionGroup testContextMenu = new DefaultActionGroup(localization.actionGroupMenuName(), true,
+        DefaultActionGroup testContextMenu = new DefaultActionGroup(localization.contextActionGroupMenuName(), true,
                 actionManager);
         actionManager.registerAction("TestingContextGroup", testContextMenu);
         for (TestAction testAction : testActions) {

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/action/RunTestActionDelegate.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/action/RunTestActionDelegate.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.plugin.testing.junit.ide.action;
+package org.eclipse.che.plugin.testing.ide.action;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
@@ -45,6 +45,8 @@ public class RunTestActionDelegate {
         TestServiceClient getService();
 
         TestResultPresenter getPresenter();
+        
+        String getTestingFramework();
     }
 
     public RunTestActionDelegate(Source source) {
@@ -56,7 +58,7 @@ public class RunTestActionDelegate {
         source.getNotificationManager().notify(notification);
         final Project project = source.getAppContext().getRootProject();
         parameters.put("updateClasspath", "true");
-        Promise<TestResult> testResultPromise = source.getService().getTestResult(project.getPath(), "junit", parameters, notification);
+        Promise<TestResult> testResultPromise = source.getService().getTestResult(project.getPath(), source.getTestingFramework(), parameters, notification);
         testResultPromise.then(new Operation<TestResult>() {
             @Override
             public void apply(TestResult result) throws OperationException {

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/handler/TestingHandler.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/handler/TestingHandler.java
@@ -86,7 +86,6 @@ public class TestingHandler {
             messageBus.subscribe(TESTING_OUTPUT_CHANNEL_NAME, new MessageHandler() {
                 @Override
                 public void onMessage(String message) {
-                    Log.info(getClass(), message);
                     TestingOutput archetypeOutput = factory.createDtoFromJson(message, TestingOutput.class);
                     switch (archetypeOutput.getState()) {
                         case SESSION_START:

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/TestClassNavigation.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/TestClassNavigation.java
@@ -22,5 +22,5 @@ public interface TestClassNavigation {
      * @param packagePath
      * @param line
      */
-    void gotoClass(String packagePath, int line);
+    void gotoClass(String packagePath, String className, String methodName, int line);
 }

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/factory/TestResultNodeFactory.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/factory/TestResultNodeFactory.java
@@ -25,11 +25,14 @@ import com.google.inject.assistedinject.Assisted;
  */
 public interface TestResultNodeFactory {
 
-    TestResultGroupNode getTestResultGroupNode(TestResult result);
+    TestResultGroupNode getTestResultGroupNode(TestResult result,
+                                               boolean showFailuresOnly,
+                                               Runnable showOnlyFailuresDelegate);
 
     TestResultClassNode getTestResultClassNodeNode(String className);
 
-    TestResultMethodNode getTestResultMethodNodeNode(@Assisted("methodName") String methodName,
+    TestResultMethodNode getTestResultMethodNodeNode(boolean success,
+                                                     @Assisted("methodName") String methodName,
                                                      @Assisted("stackTrace") String stackTrace,
                                                      @Assisted("message") String message,
                                                      int lineNumber,

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/nodes/TestResultGroupNode.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/nodes/TestResultGroupNode.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.ide.view.navigation.nodes;
 
+import static org.eclipse.che.ide.ui.menu.PositionController.HorizontalAlign.MIDDLE;
+import static org.eclipse.che.ide.ui.menu.PositionController.VerticalAlign.BOTTOM;
+
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
@@ -19,27 +22,48 @@ import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.ide.api.data.tree.AbstractTreeNode;
 import org.eclipse.che.ide.api.data.tree.Node;
+import org.eclipse.che.ide.ui.Tooltip;
+import org.eclipse.che.ide.ui.smartTree.TreeStyles;
 import org.eclipse.che.ide.ui.smartTree.presentation.HasPresentation;
 import org.eclipse.che.ide.ui.smartTree.presentation.NodePresentation;
+import org.eclipse.che.ide.util.dom.Elements;
 import org.eclipse.che.plugin.testing.ide.TestResources;
+import org.vectomatic.dom.svg.ui.SVGImage;
+import org.vectomatic.dom.svg.ui.SVGResource;
 
+import com.google.gwt.dom.client.Element;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+
+import elemental.events.Event;
+import elemental.events.EventListener;
+import elemental.html.SpanElement;
+
 /**
  * Tree node for display the failing class.
+ * 
  * @author Mirage Abeysekara
  */
 public class TestResultGroupNode extends AbstractTreeNode implements HasPresentation {
 
-    int failureCount;
-    private NodePresentation nodePresentation;
+    private NodePresentation    nodePresentation;
     private final TestResources testResources;
+    private final TreeStyles    treeStylesResources;
+    private final Runnable      showOnlyFailuresDelegate;
+    private int                 failureCount;
+    private boolean             showFailuresOnly;
 
     @Inject
     public TestResultGroupNode(TestResources testResources,
-                               @Assisted TestResult result) {
+                               TreeStyles treeStylesResources,
+                               @Assisted TestResult result,
+                               @Assisted boolean showFailuresOnly,
+                               @Assisted Runnable showOnlyFailuresDelegate) {
         failureCount = result.getFailureCount();
         this.testResources = testResources;
+        this.treeStylesResources = treeStylesResources;
+        this.showOnlyFailuresDelegate = showOnlyFailuresDelegate;
+        this.showFailuresOnly = showFailuresOnly;
     }
 
     @Override
@@ -68,7 +92,61 @@ public class TestResultGroupNode extends AbstractTreeNode implements HasPresenta
         } else {
             presentation.setPresentableIcon(testResources.testResultsPass());
         }
-        presentation.setPresentableText(getName());
+
+        SpanElement root = Elements.createSpanElement();
+        SpanElement textElement = Elements.createSpanElement(treeStylesResources.styles().presentableTextContainer());
+        textElement.setTextContent(getName());
+        root.appendChild(textElement);
+        SpanElement button = Elements.createSpanElement();
+        SVGResource svg = showFailuresOnly ? testResources.showAllTestsButtonIcon() : testResources.showFailuresOnlyButtonIcon();
+        String tooltip = showFailuresOnly ? "Include successful tests" : "Hide successful tests";
+
+        Tooltip.create(button,
+                       BOTTOM,
+                       MIDDLE,
+                       tooltip);
+
+        button.appendChild((elemental.dom.Node)new SVGImage(svg).getElement());
+        button.getStyle().setProperty("float", "right");
+        button.getStyle().setProperty("padding-right", "9px");
+        button.getStyle().setProperty("padding-left", "8px");
+
+        if (failureCount == 0) {
+            button.getStyle().setDisplay("none");
+        } else {
+            button.addEventListener(Event.CLICK, new EventListener() {
+                @Override
+                public void handleEvent(Event event) {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    showOnlyFailuresDelegate.run();
+                }
+            }, true);
+            button.getStyle().setDisplay("inline");
+        }
+
+        /**
+         * This listener cancels mouse events on '+' button and prevents the jitter of the selection in the tree.
+         */
+        EventListener blockMouseListener = new EventListener() {
+            @Override
+            public void handleEvent(Event event) {
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        };
+
+        /**
+         * Prevent jitter when pressing mouse on '+' button.
+         */
+        button.addEventListener(Event.MOUSEDOWN, blockMouseListener, true);
+        button.addEventListener(Event.MOUSEUP, blockMouseListener, true);
+        button.addEventListener(Event.CLICK, blockMouseListener, true);
+        button.addEventListener(Event.DBLCLICK, blockMouseListener, true);
+
+        root.appendChild(button);
+
+        presentation.setUserElement((Element)root);
     }
 
     @Override

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/nodes/TestResultMethodNode.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/nodes/TestResultMethodNode.java
@@ -21,10 +21,13 @@ import org.eclipse.che.ide.api.data.tree.Node;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
 import org.eclipse.che.ide.ui.smartTree.presentation.HasPresentation;
 import org.eclipse.che.ide.ui.smartTree.presentation.NodePresentation;
+import org.eclipse.che.plugin.testing.ide.TestResources;
 import org.eclipse.che.plugin.testing.ide.view.navigation.TestClassNavigation;
+import org.vectomatic.dom.svg.ui.SVGResource;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+
 /**
  * Tree node for display the failing methods.
  * 
@@ -32,27 +35,33 @@ import com.google.inject.assistedinject.Assisted;
  */
 public class TestResultMethodNode extends AbstractTreeNode implements HasAction, HasPresentation {
 
-    private String methodName;
-    private String stackTrace;
-    private String message;
-    private int lineNumber;
+    private String              methodName;
+    private boolean             success;
+    private String              stackTrace;
+    private String              message;
+    private int                 lineNumber;
     private TestClassNavigation navigationHandler;
+    private final TestResources testResources;
     private final JavaResources javaResources;
-    private NodePresentation nodePresentation;
+    private NodePresentation    nodePresentation;
 
 
     @Inject
-    public TestResultMethodNode(JavaResources javaResources,
+    public TestResultMethodNode(TestResources testResources,
+                                JavaResources javaResources,
+                                @Assisted boolean success,
                                 @Assisted("methodName") String methodName,
                                 @Assisted("stackTrace") String stackTrace,
                                 @Assisted("message") String message,
                                 @Assisted int lineNumber,
                                 @Assisted TestClassNavigation navigationHandler) {
         this.methodName = methodName;
+        this.success = success;
         this.stackTrace = stackTrace;
         this.message = message;
         this.lineNumber = lineNumber;
         this.navigationHandler = navigationHandler;
+        this.testResources = testResources;
         this.javaResources = javaResources;
     }
 
@@ -78,10 +87,14 @@ public class TestResultMethodNode extends AbstractTreeNode implements HasAction,
         return stackTrace;
     }
 
+    public boolean isSuccess() {
+        return success;
+    }
+
     @Override
     public void actionPerformed() {
         if (getParent() instanceof TestResultClassNode) {
-            String packagePath = ((TestResultClassNode) getParent()).getClassName().replace(".", "/") + ".java";
+            String packagePath = ((TestResultClassNode)getParent()).getClassName().replace(".", "/") + ".java";
             navigationHandler.gotoClass(packagePath, lineNumber);
         }
     }
@@ -93,6 +106,8 @@ public class TestResultMethodNode extends AbstractTreeNode implements HasAction,
         }
         presentation.setPresentableText(methodName);
         presentation.setPresentableIcon(javaResources.publicMethod());
+        SVGResource svg = success ? javaResources.publicMethod() : testResources.testMethodFail();
+        presentation.setPresentableIcon(svg);
     }
 
     @Override

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/nodes/TestResultMethodNode.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/view/navigation/nodes/TestResultMethodNode.java
@@ -95,7 +95,8 @@ public class TestResultMethodNode extends AbstractTreeNode implements HasAction,
     public void actionPerformed() {
         if (getParent() instanceof TestResultClassNode) {
             String packagePath = ((TestResultClassNode)getParent()).getClassName().replace(".", "/") + ".java";
-            navigationHandler.gotoClass(packagePath, lineNumber);
+            String className = ((TestResultClassNode)getParent()).getClassName();
+            navigationHandler.gotoClass(packagePath, className, methodName, lineNumber);
         }
     }
 

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/TestLocalizationConstant.properties
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/TestLocalizationConstant.properties
@@ -10,6 +10,7 @@
 #
 
 actionGroup.menu.name = Test
+contextActionGroup.menu.name = Run Test
 
 ########## Titles ############
 title.testResultPresenter = Test Results

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/show_all_tests_icon.svg
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/show_all_tests_icon.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<svg
+   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="16"
+   height="16"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="show_all_tests_icon">
+  <path
+     style="fill:#ff0000;fill-rule:evenodd;fill-opacity:1;stroke:none;stroke-opacity:1;stroke-width:0.20000000000000001;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path3"
+     d="m 19.661016,0.94814034 c 6.290593,0 11.390843,5.10024916 11.390843,11.39084166 0,6.290593 -5.10025,11.390843 -11.390843,11.390843 -6.290593,0 -11.3908418,-5.10025 -11.3908418,-11.390843 0,-6.2905925 5.1002488,-11.39084166 11.3908418,-11.39084166 l 0,0 z m 0,3.79599816 c -4.193253,0 -7.594844,3.401591 -7.594844,7.5948435 0,4.193253 3.401591,7.594844 7.594844,7.594844 4.193254,0 7.594844,-3.401591 7.594844,-7.594844 0,-4.1932525 -3.40159,-7.5948435 -7.594844,-7.5948435 z" />
+  <path
+     style="fill:#72ad42;fill-rule:evenodd;fill-opacity:1;stroke:none;stroke-opacity:1;stroke-width:0.20000000000000001;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path3-5"
+     d="m 12.474576,8.2701739 c 6.290593,0 11.390843,5.1002491 11.390843,11.3908421 0,6.290593 -5.10025,11.390844 -11.390843,11.390844 -6.2905932,0 -11.3908432,-5.100251 -11.3908432,-11.390844 0,-6.290593 5.10025,-11.3908421 11.3908432,-11.3908421 l 0,0 z m 0,3.7959981 c -4.1932532,0 -7.5948442,3.401591 -7.5948442,7.594844 0,4.193253 3.401591,7.594844 7.5948442,7.594844 4.193254,0 7.594844,-3.401591 7.594844,-7.594844 0,-4.193253 -3.40159,-7.594844 -7.594844,-7.594844 z" />
+</svg>

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/show_failures_only_icon.svg
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/show_failures_only_icon.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<svg
+   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="16"
+   height="16"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="show_failures_only_icon">
+  <path
+     style="fill:#ff0000;fill-rule:evenodd;fill-opacity:1;stroke:#565656;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path3"
+     d="m 19.661016,0.94814034 c 6.290593,0 11.390843,5.10024916 11.390843,11.39084166 0,6.290593 -5.10025,11.390843 -11.390843,11.390843 -6.290593,0 -11.3908418,-5.10025 -11.3908418,-11.390843 0,-6.2905925 5.1002488,-11.39084166 11.3908418,-11.39084166 l 0,0 z m 0,3.79599816 c -4.193253,0 -7.594844,3.401591 -7.594844,7.5948435 0,4.193253 3.401591,7.594844 7.594844,7.594844 4.193254,0 7.594844,-3.401591 7.594844,-7.594844 0,-4.1932525 -3.40159,-7.5948435 -7.594844,-7.5948435 z" />
+  <path
+     style="fill:#ff0000;fill-rule:evenodd;fill-opacity:1;stroke:#565656;stroke-opacity:1;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path3-5"
+     d="m 12.474576,8.2701739 c 6.290593,0 11.390843,5.1002491 11.390843,11.3908421 0,6.290593 -5.10025,11.390844 -11.390843,11.390844 -6.2905932,0 -11.3908432,-5.100251 -11.3908432,-11.390844 0,-6.290593 5.10025,-11.3908421 11.3908432,-11.3908421 l 0,0 z m 0,3.7959981 c -4.1932532,0 -7.5948442,3.401591 -7.5948442,7.594844 0,4.193253 3.401591,7.594844 7.5948442,7.594844 4.193254,0 7.594844,-3.401591 7.594844,-7.594844 0,-4.193253 -3.40159,-7.594844 -7.594844,-7.594844 z" />
+</svg>

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/test_class_fail.svg
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/test_class_fail.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<svg version="1.1" id="class" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	x="0px" y="0px" width="16px" height="16px" viewBox="7 7 18 18"
+	enable-background="new 0 0 32 32" xml:space="preserve">
+<g>
+	<path fill-rule="evenodd" clip-rule="evenodd" fill="red" d="M16,24c4.406,0,8-3.594,8-8c0-4.406-3.594-8-8-8
+		c-4.406,0-8,3.594-8,8C8,20.406,11.594,24,16,24z"/>
+	<path fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" d="M16,12c0.729,0,1.412,0.195,2.001,0.536l0.648,0.375
+		c0.119,0.069,0.16,0.222,0.091,0.341l-0.75,1.299c-0.068,0.119-0.222,0.16-0.341,0.091l-0.611-0.353C16.736,14.106,16.38,14,16,14
+		c-1.105,0-2,0.896-2,2c0,1.104,0.896,2,2,2c0.552,0,1.052-0.224,1.413-0.585l0.531-0.53c0.097-0.098,0.256-0.098,0.353,0
+		l1.062,1.061c0.097,0.098,0.097,0.256,0,0.354l-0.531,0.53C18.104,19.553,17.104,20,16,20c-2.209,0-4-1.791-4-4S13.791,12,16,12z"
+		/>
+</g>
+</svg>

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/test_method_fail.svg
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/resources/org/eclipse/che/plugin/testing/ide/svg/test_method_fail.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<svg version="1.1" id="public_method" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="16px" height="16px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<path fill-rule="evenodd" clip-rule="evenodd" fill="red" d="M16,8c4.418,0,8,3.582,8,8s-3.582,8-8,8s-8-3.582-8-8
+	S11.582,8,16,8L16,8z M16,10.666c-2.945,0-5.334,2.389-5.334,5.334s2.389,5.334,5.334,5.334s5.334-2.389,5.334-5.334
+	S18.945,10.666,16,10.666z"/>
+</svg>

--- a/wsagent/che-core-api-testing-shared/src/main/java/org/eclipse/che/api/testing/shared/TestCase.java
+++ b/wsagent/che-core-api-testing-shared/src/main/java/org/eclipse/che/api/testing/shared/TestCase.java
@@ -18,54 +18,68 @@ import org.eclipse.che.dto.shared.DTO;
  * @author Mirage Abeysekara
  */
 @DTO
-public interface Failure {
+public interface TestCase {
 
     /**
-     * Returns the fully qualified class name of the failing test class.
+     * Returns the fully qualified class name of the test class.
      *
-     * @return fully qualified class name of the failing test class
+     * @return fully qualified class name of the test class
      */
-    String getFailingClass();
+    String getClassName();
 
     /**
-     * Sets the fully qualified class name of the failing test class.
+     * Sets the fully qualified class name of the test class.
      * 
      * @param className
      */
-    void setFailingClass(String className);
+    void setClassName(String className);
 
     /**
-     * Returns the method name of the failing test case.
+     * Returns the method name of the test case.
      *
-     * @return the method name of the failing test case.
+     * @return the method name of the test case.
      */
-    String getFailingMethod();
+    String getMethod();
 
     /**
-     * Sets the method name of the failing test case.
+     * Sets the method name of the test case.
      * 
      * @param methodName
      */
-    void setFailingMethod(String methodName);
+    void setMethod(String methodName);
 
     /**
-     * Returns the line number of the failing test case according to the stack trace.
+     * Returns whether a test case failed.
      *
-     * @return the line number of the failing test case.
+     * @return true if the test case failed, and false if the test succeeded.
+     */
+    Boolean isFailed();
+
+    /**
+     * Sets the test case as failed.
+     * 
+     * @param failed status
+     */
+    void setFailed(Boolean failed);
+
+    /**
+     * Returns the line number of a failing test case according to the stack trace.
+     *
+     * @return the line number of the failing test case, or -1 if the test succeeded.
      */
     Integer getFailingLine();
 
     /**
-     * Sets the line number of the failing test case according to the stack trace.
+     * Sets the line number of a failing test case according to the stack trace.
      * 
      * @param lineNumber
      */
     void setFailingLine(Integer lineNumber);
 
     /**
-     * Returns the error message for the test failure.
+     * Returns the error message for a test failure.
      *
-     * @return the error message
+     * @return the error message, or an empty string if the test succeeded
      */
     String getMessage();
 
@@ -77,9 +91,9 @@ public interface Failure {
     void setMessage(String message);
 
     /**
-     * Returns the stack trace of the failing test case.
+     * Returns the stack trace of a failing test case.
      *
-     * @return the stack trace of the failing test case.
+     * @return the stack trace of the failing test case, or an empty string if the test succeeded.
      */
     String getTrace();
 

--- a/wsagent/che-core-api-testing-shared/src/main/java/org/eclipse/che/api/testing/shared/TestResult.java
+++ b/wsagent/che-core-api-testing-shared/src/main/java/org/eclipse/che/api/testing/shared/TestResult.java
@@ -23,6 +23,20 @@ import org.eclipse.che.dto.shared.DTO;
 public interface TestResult {
 
     /**
+     * Returns the path of the project containing the test cases.
+     * 
+     * @return the framework name
+     */
+    String getProjectPath();
+
+    /**
+     * Sets the path of the project containing the test cases.
+     * 
+     * @param projectPath
+     */
+    void setProjectPath(String projectPath);
+
+    /**
      * Returns the framework name used for executing the test cases.
      * 
      * @return the framework name

--- a/wsagent/che-core-api-testing-shared/src/main/java/org/eclipse/che/api/testing/shared/TestResult.java
+++ b/wsagent/che-core-api-testing-shared/src/main/java/org/eclipse/che/api/testing/shared/TestResult.java
@@ -51,18 +51,32 @@ public interface TestResult {
     void setSuccess(boolean success);
 
     /**
-     * Returns the details of the failing test cases.
+     * Returns the details of the test cases.
      * 
-     * @return a list of test failures.
+     * @return a list of test cases.
      */
-    List<Failure> getFailures();
+    List<TestCase> getTestCases();
 
     /**
-     * Sets the details of the failing test cases.
+     * Sets the details of the test cases.
      * 
      * @param failures
      */
-    void setFailures(List<Failure> failures);
+    void setTestCases(List<TestCase> failures);
+
+    /**
+     * Indicates how many tests were run.
+     * 
+     * @return the count of run test cases.
+     */
+    int getTestCaseCount();
+
+    /**
+     * Sets how many tests were run.
+     * 
+     * @param count
+     */
+    void setTestCaseCount(int count);
 
     /**
      * Indicates how many tests were failed.

--- a/wsagent/che-core-api-testing/pom.xml
+++ b/wsagent/che-core-api-testing/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
         </dependency>
         <dependency>
@@ -71,6 +75,10 @@
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>org.eclipse.core.resources</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>
@@ -117,6 +125,8 @@
                 <configuration>
                     <excludes>
                         <exclude>**/**/TestingOutputImpl.java</exclude>
+                        <exclude>**/**/AbstractTestListener.java</exclude>
+                        <exclude>**/**/OutputTestListener.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/wsagent/che-core-api-testing/src/main/java/org/eclipse/che/api/testing/server/listener/AbstractTestListener.java
+++ b/wsagent/che-core-api-testing/src/main/java/org/eclipse/che/api/testing/server/listener/AbstractTestListener.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   RedHat, Inc. - initial commit
  *******************************************************************************/
-package org.eclipse.che.plugin.testing.junit.server.listener;
+package org.eclipse.che.api.testing.server.listener;
 
 import java.util.HashMap;
 

--- a/wsagent/che-core-api-testing/src/main/java/org/eclipse/che/api/testing/server/listener/OutputTestListener.java
+++ b/wsagent/che-core-api-testing/src/main/java/org/eclipse/che/api/testing/server/listener/OutputTestListener.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   RedHat, Inc. - initial commit
  *******************************************************************************/
-package org.eclipse.che.plugin.testing.junit.server.listener;
+package org.eclipse.che.api.testing.server.listener;
 
 import static org.eclipse.che.api.testing.shared.Constants.TESTING_OUTPUT_CHANNEL_NAME;
 


### PR DESCRIPTION
### What does this PR do?

This pull request is the second step of the work started in PR https://github.com/eclipse/che/pull/4303.
More precisely:
- it provides a better Test result view that also contains succeeded tests, with a small button to allow filtering successful tests, thus focusing on failures,
- it fixes navigation problems from the test result view to the related source code,
- it fixes the erratic behaviour of the `Test` contextual menu, that sometimes used to hide the project-wide test menu entries for no clear reason.
- it adds a better client-side error notification when an exception is triggered on the server-side during the test execution,   
- it adds the same enhancements / bug fixes to the TestNG testing support.

### What issues does this PR fix or reference?

https://issues.jboss.org/browse/CHE-111

and more precisely the following sub-tasks:

https://issues.jboss.org/browse/CHE-148
https://issues.jboss.org/browse/CHE-149
https://issues.jboss.org/browse/CHE-154
https://issues.jboss.org/browse/CHE-157

#### Changelog

Java Testing support Bug fixes and Enhancements - Step 2

#### Release Notes

Testing support enhancements:
- Faster test execution with on-the-fly project compilation if necessary
- Real-time notification of test execution,
- Better view of the successful tests with a filtering option,
- Navigation from the test view to the source code,
