### PR TITLE
[OpenShift] Update versions of OpenShift connector projects

### DIFF
--- a/agents/go-agents/pom.xml
+++ b/agents/go-agents/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>go-agents</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Agent :: Golang agents</name>
     <properties>
         <go.workspace.name>go-workspace</go.workspace.name>

--- a/agents/ls-csharp/pom.xml
+++ b/agents/ls-csharp/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-csharp-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server C# Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-json/pom.xml
+++ b/agents/ls-json/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-json-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server Json Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-php/pom.xml
+++ b/agents/ls-php/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-php-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server PHP Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-python/pom.xml
+++ b/agents/ls-python/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-python-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server python Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-typescript/pom.xml
+++ b/agents/ls-typescript/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-typescript-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server typescript Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ssh/pom.xml
+++ b/agents/ssh/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ssh-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>SSH Agent</name>
     <dependencies>
         <dependency>

--- a/agents/unison/pom.xml
+++ b/agents/unison/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>unison-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Unison Agent</name>
     <dependencies>
         <dependency>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-ide-war</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che IDE :: Compiling GWT Application</name>
     <properties>
@@ -26,6 +27,17 @@
         <gwt.log.enable>false</gwt.log.enable>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -407,7 +419,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-dyna-provider-generator-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-main</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che IDE :: Assemblies Tomcat</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.eclipse.che</groupId>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-wsagent-server</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Assembly Workspace Agent Server</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>log4j</groupId>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-wsagent-war</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che Workspace Agent War Packaging</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -19,12 +19,24 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-wsmaster-war</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che IDE :: Compiling WS Master WAR</name>
     <properties>
         <generated.sources.directory>${project.build.directory}/generated-sources/gen</generated.sources.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>aopalliance</groupId>

--- a/ide/che-core-ide-stacks/pom.xml
+++ b/ide/che-core-ide-stacks/pom.xml
@@ -20,6 +20,7 @@
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-stacks</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: STACKS</name>
     <build>

--- a/plugins/plugin-docker/che-plugin-docker-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-client/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-docker-client</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: Docker Client</name>
     <properties>
@@ -144,7 +145,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-dto-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <executions>
                     <execution>
                         <id>server</id>

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -19,11 +19,23 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-docker-machine</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: Machine</name>
     <properties>
         <findbugs.failonerror>false</findbugs.failonerror>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-openshift-client</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: OpenShift Client</name>
     <properties>
@@ -26,6 +27,17 @@
         <license_copyrightOwner>Red Hat, Inc.</license_copyrightOwner>
         <license_header>license-header.txt</license_header>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/plugins/plugin-github/che-plugin-github-oauth2/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-oauth2/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-github-oauth2</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Github :: OAuth2</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Parent</name>
     <modules>
@@ -31,7 +31,11 @@
         <module>agents</module>
         <module>plugins</module>
         <module>samples</module>
+        <!--
+        We avoid to build/maintain dashboard
+        since we are not going to use it
         <module>dashboard</module>
+        -->
         <module>assembly</module>
     </modules>
     <scm>
@@ -43,6 +47,7 @@
     <properties>
         <che.docs.version>5.5.0</che.docs.version>
         <che.lib.version>5.5.0</che.lib.version>
+        <che.openshift.version>5.6.0-openshift-connector-SNAPSHOT</che.openshift.version>
         <che.version>5.5.0</che.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
@@ -56,96 +61,96 @@
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <classifier>classes</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-main</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsagent-server</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>tar.gz</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsagent-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsmaster-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>tar.gz</type>
                 <classifier>linux_amd64</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>tar.gz</type>
                 <classifier>linux_arm7</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-csharp-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-json-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-php-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-python-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-typescript-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ssh-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>unison-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -155,7 +160,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-account</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -171,7 +176,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-auth</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -206,7 +211,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-factory</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -253,7 +258,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-machine</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -325,7 +330,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-user</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -397,17 +402,17 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-db</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-db-vendor-h2</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-db-vendor-postgresql</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -432,7 +437,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-ide-stacks</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -452,7 +457,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>wsagent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -556,7 +561,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-docker-client</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -566,7 +571,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-docker-machine</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -596,7 +601,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-github-oauth2</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -681,7 +686,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-languageserver-ide</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -751,7 +756,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-openshift-client</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -801,7 +806,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-requirejs</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>

--- a/wsagent/agent/pom.xml
+++ b/wsagent/agent/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>wsagent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Workspace Agent</name>
     <dependencies>
         <dependency>

--- a/wsmaster/che-core-api-auth/pom.xml
+++ b/wsmaster/che-core-api-auth/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-core-api-auth</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Core :: API :: Authentication</name>
     <properties>
@@ -175,7 +176,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-dto-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>


### PR DESCRIPTION
### What does this PR do?
Update versions of OpenShift connector projects to `5.6.0-openshift-connector-SNAPSHOT` while keeping the rest of to release version `5.5.0`.

Is related to https://github.com/eclipse/che-dependencies/pull/35

#### Changelog
Update versions of OpenShift connector projects