### PR TITLE
codenvy-1871: avoid iframe script execution on source changes

### DIFF
--- a/dashboard/src/app/ide/ide-iframe/ide-iframe.html
+++ b/dashboard/src/app/ide/ide-iframe/ide-iframe.html
@@ -1,4 +1,4 @@
-<div flex class="animate-show">
+<div flex class="animate-show" id="ide-application-frame">
     <ide-iframe-button-link></ide-iframe-button-link>
-    <iframe class="ide-page-frame" ng-src="{{ideIframeLink}}"></iframe>
+    <iframe class="ide-page-frame" ng-src="{{ideIframeLink}}" ></iframe>
 </div>


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

### What does this PR do?
This PR fixes problem with execution the iframe scripts on source changes. What we have now: the iframe with IDE is not loaded yet and we change it's source, the previous scripts start getting canceled requests status and throw initialization errors. Removing iframe from DOM fixes the problem.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1871 (not related to teams, it's quick workspace switching in navbar bug)

#### Changelog
[UD] Avoid any IDE iframe script execution, when not loaded yet and source changes.

#### Release Notes
N/A

#### Docs PR
N/A
