### PR TITLE
Update Docker Compose tests to fix test failure

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/CommandDeserializerTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/CommandDeserializerTest.java
@@ -137,7 +137,7 @@ public class CommandDeserializerTest {
                 {"\"echo ${PWD}\"", asList("echo", "${PWD}"), 2},
                 {"\"(Test)\"", singletonList("(Test)"), 1},
 
-                {"", singletonList(""), 1},
+                {"\"\"", singletonList(""), 1},
         };
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/EnvironmentDeserializerTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/EnvironmentDeserializerTest.java
@@ -73,7 +73,7 @@ public class EnvironmentDeserializerTest {
                  + " dev-machine: \n"
                  + "  image: codenvy/ubuntu_jdk8\n"
                  + "  environment:\n"
-                 + "   MYSQL_ROOT_PASSWORD: ",
+                 + "   MYSQL_ROOT_PASSWORD: \"\"",
                  ImmutableMap.of("MYSQL_ROOT_PASSWORD", "")
                 },
 


### PR DESCRIPTION
### What does this PR do?
Updating to Jackson 2.7.7 causes tests in the docker compose plugin to fail. This is due to the fact that the tests expect empty values in dictionaries to be parsed as the empty string, whereas jackson 2.7.7 parses them as null (as specified by the yaml spec).

Modifies the affected tests to explicitly use an empty string (i.e. "") instead of an empty value.

### What issues does this PR fix or reference?
Fixes failed tests in `CommandDeserializerTest.java` and `EnvironmentDeserializerTests.java`

#### Changelog
Update Docker Compose tests to fix test failure