### PR TITLE
CHE-4527: fix bug in dockerfile parser

### DIFF
--- a/dashboard/src/components/api/environment/docker-file-parser.spec.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.spec.ts
@@ -25,7 +25,7 @@ describe('Simper dockerfile parser', () => {
   });
 
   describe('method _parseArgument()', () => {
-    it('should parse ENV argument with single environment variable #1', () => {
+    it('should parse ENV argument as single variable form #1', () => {
       let instruction = 'ENV',
           argument = 'name environment variable value';
 
@@ -38,7 +38,7 @@ describe('Simper dockerfile parser', () => {
       expect(result).toEqual(expectedResult);
     });
 
-    it('should parse ENV argument with single environment variable #2', () => {
+    it('should parse ENV argument as single variable form #2', () => {
       let instruction = 'ENV',
           argument = 'SBT_OPTS \'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'';
 
@@ -51,7 +51,19 @@ describe('Simper dockerfile parser', () => {
       expect(result).toEqual(expectedResult);
     });
 
-    it('should parse ENV argument with several environment variables', () => {
+    it('should parse ENV argument as multiple variables form #1', () => {
+      let instruction = 'ENV',
+          argument = 'key=value';
+      let result = parser._parseArgument(instruction, argument);
+
+      let expectedResult = [{
+        instruction: 'ENV',
+        argument: ['key', 'value']
+      }];
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should parse ENV argument as multiple variables form #2', () => {
       let instruction = 'ENV',
           argument = 'myName="John Doe" myDog=Rex\ The\ Dog myCat=fluffy';
 
@@ -74,9 +86,9 @@ describe('Simper dockerfile parser', () => {
 
   it('should parse a dockerfile', () => {
     let dockerfile = 'FROM codenvy/ubuntu_jdk8ENV'
-    + '\n#ENV myCat fluffy'
-    + '\nENV myDog Rex The Dog'
-    + '\nENV myName John Doe';
+      + '\n#ENV myCat fluffy'
+      + '\nENV myDog Rex The Dog'
+      + '\nENV myName="John Doe"';
 
     let result = parser.parse(dockerfile);
 

--- a/dashboard/src/components/api/environment/docker-file-parser.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.ts
@@ -122,7 +122,7 @@ export class DockerfileParser {
       case 'ENV':
         let firstSpaceIndex = argumentStr.indexOf(' '),
             firstEqualIndex = argumentStr.indexOf('=');
-        if (firstEqualIndex > -1 && firstEqualIndex < firstSpaceIndex) {
+        if (firstEqualIndex > -1 && (firstSpaceIndex === -1 || firstEqualIndex < firstSpaceIndex)) {
           // this argument string contains one or more environment variables
           let match;
           while (match = this.envVariablesRE.exec(argumentStr)) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It fixes bug in dockerfile parser when instruction `ENV key=value` was not parsed correctly.


### What issues does this PR fix or reference?
#4527 


#### Changelog
[UD] fixed bug in parsing provided environment variables in dockerfile

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>