### PR TITLE
Update version on all packages to 5.6.0-openshift-connector-SNAPSHOT

### DIFF
--- a/agents/che-core-api-agent-shared/pom.xml
+++ b/agents/che-core-api-agent-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-api-agent-shared</artifactId>

--- a/agents/che-core-api-agent/pom.xml
+++ b/agents/che-core-api-agent/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-api-agent</artifactId>

--- a/agents/go-agents/pom.xml
+++ b/agents/go-agents/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>go-agents</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Agent :: Golang agents</name>
     <properties>
         <go.workspace.name>go-workspace</go.workspace.name>

--- a/agents/go-agents/pom.xml
+++ b/agents/go-agents/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>go-agents</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Agent :: Golang agents</name>
     <properties>
         <go.workspace.name>go-workspace</go.workspace.name>

--- a/agents/ls-csharp/pom.xml
+++ b/agents/ls-csharp/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-csharp-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server C# Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-csharp/pom.xml
+++ b/agents/ls-csharp/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>ls-csharp-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server C# Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-json/pom.xml
+++ b/agents/ls-json/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>ls-json-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server Json Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-json/pom.xml
+++ b/agents/ls-json/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-json-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server Json Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-php/pom.xml
+++ b/agents/ls-php/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-php-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server PHP Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-php/pom.xml
+++ b/agents/ls-php/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>ls-php-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server PHP Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-python/pom.xml
+++ b/agents/ls-python/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>ls-python-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server python Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-python/pom.xml
+++ b/agents/ls-python/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-python-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server python Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-typescript/pom.xml
+++ b/agents/ls-typescript/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ls-typescript-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server typescript Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ls-typescript/pom.xml
+++ b/agents/ls-typescript/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>ls-typescript-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Language Server typescript Agent</name>
     <dependencies>
         <dependency>

--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -16,12 +16,11 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-agents-parent</artifactId>
-    <version>5.5.0</version>
     <packaging>pom</packaging>
     <name>Che Agents Parent</name>
     <modules>

--- a/agents/ssh/pom.xml
+++ b/agents/ssh/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>ssh-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>SSH Agent</name>
     <dependencies>
         <dependency>

--- a/agents/ssh/pom.xml
+++ b/agents/ssh/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>ssh-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>SSH Agent</name>
     <dependencies>
         <dependency>

--- a/agents/unison/pom.xml
+++ b/agents/unison/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agents-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>unison-agent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Unison Agent</name>
     <dependencies>
         <dependency>

--- a/agents/unison/pom.xml
+++ b/agents/unison/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>unison-agent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Unison Agent</name>
     <dependencies>
         <dependency>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-ide-war</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che IDE :: Compiling GWT Application</name>
     <properties>
@@ -26,6 +27,17 @@
         <gwt.log.enable>false</gwt.log.enable>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -407,7 +419,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-dyna-provider-generator-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-assembly-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>assembly-ide-war</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che IDE :: Compiling GWT Application</name>
     <properties>
@@ -27,17 +26,6 @@
         <gwt.log.enable>false</gwt.log.enable>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-main</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che IDE :: Assemblies Tomcat</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.eclipse.che</groupId>

--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -16,23 +16,11 @@
     <parent>
         <artifactId>che-assembly-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>assembly-main</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che IDE :: Assemblies Tomcat</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.eclipse.che</groupId>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -16,23 +16,11 @@
     <parent>
         <artifactId>che-assembly-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>assembly-wsagent-server</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Assembly Workspace Agent Server</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>log4j</groupId>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-wsagent-server</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Assembly Workspace Agent Server</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>log4j</groupId>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-wsagent-war</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che Workspace Agent War Packaging</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -16,23 +16,11 @@
     <parent>
         <artifactId>che-assembly-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>assembly-wsagent-war</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che Workspace Agent War Packaging</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -19,12 +19,24 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>assembly-wsmaster-war</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che IDE :: Compiling WS Master WAR</name>
     <properties>
         <generated.sources.directory>${project.build.directory}/generated-sources/gen</generated.sources.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>aopalliance</groupId>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -16,27 +16,15 @@
     <parent>
         <artifactId>che-assembly-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>assembly-wsmaster-war</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che IDE :: Compiling WS Master WAR</name>
     <properties>
         <generated.sources.directory>${project.build.directory}/generated-sources/gen</generated.sources.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>aopalliance</groupId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -16,12 +16,12 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-assembly-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che IDE :: Parent</name>
     <modules>

--- a/core/che-core-api-core/pom.xml
+++ b/core/che-core-api-core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-core</artifactId>
     <packaging>jar</packaging>

--- a/core/che-core-api-dto-maven-plugin/pom.xml
+++ b/core/che-core-api-dto-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-dto-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/core/che-core-api-dto/pom.xml
+++ b/core/che-core-api-dto/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-dto</artifactId>
     <packaging>jar</packaging>

--- a/core/che-core-api-model/pom.xml
+++ b/core/che-core-api-model/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-model</artifactId>
     <packaging>jar</packaging>

--- a/core/che-core-db-vendor-h2/pom.xml
+++ b/core/che-core-db-vendor-h2/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-db-vendor-h2</artifactId>
     <name>Che Core :: DB :: Vendor H2</name>

--- a/core/che-core-db-vendor-postgresql/pom.xml
+++ b/core/che-core-db-vendor-postgresql/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-db-vendor-postgresql</artifactId>
     <name>Che Core :: DB :: Vendor PostgreSQL</name>

--- a/core/che-core-db/pom.xml
+++ b/core/che-core-db/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-db</artifactId>
     <name>Che Core :: DB</name>

--- a/core/che-core-typescript-dto-maven-plugin/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-typescript-dto-maven-plugin</artifactId>

--- a/core/commons/che-core-commons-annotations/pom.xml
+++ b/core/commons/che-core-commons-annotations/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-annotations</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-inject/pom.xml
+++ b/core/commons/che-core-commons-inject/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-inject</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-j2ee/pom.xml
+++ b/core/commons/che-core-commons-j2ee/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-j2ee</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-json/pom.xml
+++ b/core/commons/che-core-commons-json/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-json</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-lang/pom.xml
+++ b/core/commons/che-core-commons-lang/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-lang</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-schedule/pom.xml
+++ b/core/commons/che-core-commons-schedule/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-schedule</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-test/pom.xml
+++ b/core/commons/che-core-commons-test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-test</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/che-core-commons-xml/pom.xml
+++ b/core/commons/che-core-commons-xml/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-commons-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-xml</artifactId>
     <packaging>jar</packaging>

--- a/core/commons/pom.xml
+++ b/core/commons/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-core-commons-parent</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,12 +16,12 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Core Parent</name>
     <modules>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -16,12 +16,12 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che.dashboard</groupId>
     <artifactId>che-dashboard-war</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che Dashboard :: Web App</name>
     <inceptionYear>2015</inceptionYear>

--- a/ide/che-core-dyna-provider-generator-maven-plugin/pom.xml
+++ b/ide/che-core-dyna-provider-generator-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-dyna-provider-generator-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/ide/che-core-ide-api/pom.xml
+++ b/ide/che-core-ide-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-api</artifactId>

--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-ide-app</artifactId>
     <packaging>jar</packaging>

--- a/ide/che-core-ide-generators/pom.xml
+++ b/ide/che-core-ide-generators/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-generators</artifactId>

--- a/ide/che-core-ide-stacks/pom.xml
+++ b/ide/che-core-ide-stacks/pom.xml
@@ -20,6 +20,7 @@
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-stacks</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: STACKS</name>
     <build>

--- a/ide/che-core-ide-stacks/pom.xml
+++ b/ide/che-core-ide-stacks/pom.xml
@@ -16,11 +16,10 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-stacks</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: STACKS</name>
     <build>

--- a/ide/che-core-ide-templates/pom.xml
+++ b/ide/che-core-ide-templates/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-templates</artifactId>

--- a/ide/che-core-ide-ui/pom.xml
+++ b/ide/che-core-ide-ui/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-ui</artifactId>

--- a/ide/commons-gwt/pom.xml
+++ b/ide/commons-gwt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-core-ide-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-commons-gwt</artifactId>
     <name>Che Core :: Commons :: GWT</name>

--- a/ide/pom.xml
+++ b/ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-composer/che-plugin-composer-ide/pom.xml
+++ b/plugins/plugin-composer/che-plugin-composer-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-composer-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-composer-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-composer/che-plugin-composer-server/pom.xml
+++ b/plugins/plugin-composer/che-plugin-composer-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-composer-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-composer-server</artifactId>
     <name>Che Plugin :: Composer :: Server</name>

--- a/plugins/plugin-composer/che-plugin-composer-shared/pom.xml
+++ b/plugins/plugin-composer/che-plugin-composer-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-composer-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-composer-shared</artifactId>
     <name>Che Plugin :: Composer :: Shared</name>

--- a/plugins/plugin-composer/pom.xml
+++ b/plugins/plugin-composer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-composer-parent</artifactId>

--- a/plugins/plugin-cpp/che-plugin-cpp-lang-ide/pom.xml
+++ b/plugins/plugin-cpp/che-plugin-cpp-lang-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-cpp-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-cpp-lang-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-cpp/che-plugin-cpp-lang-server/pom.xml
+++ b/plugins/plugin-cpp/che-plugin-cpp-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-cpp-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-cpp-lang-server</artifactId>
     <name>Che Plugin :: C/C++ :: Extension Server</name>

--- a/plugins/plugin-cpp/che-plugin-cpp-lang-shared/pom.xml
+++ b/plugins/plugin-cpp/che-plugin-cpp-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-cpp-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-cpp-lang-shared</artifactId>
     <name>Che Plugin :: C/C++ :: Shared</name>

--- a/plugins/plugin-cpp/pom.xml
+++ b/plugins/plugin-cpp/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-cpp-parent</artifactId>

--- a/plugins/plugin-csharp/che-plugin-csharp-lang-ide/pom.xml
+++ b/plugins/plugin-csharp/che-plugin-csharp-lang-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-csharp-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-csharp-lang-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-csharp/che-plugin-csharp-lang-server/pom.xml
+++ b/plugins/plugin-csharp/che-plugin-csharp-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-csharp-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-csharp-lang-server</artifactId>
     <name>Che Plugin :: C# :: Extension Server</name>

--- a/plugins/plugin-csharp/che-plugin-csharp-lang-shared/pom.xml
+++ b/plugins/plugin-csharp/che-plugin-csharp-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-csharp-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-csharp-lang-shared</artifactId>
     <name>Che Plugin :: C# :: Shared</name>

--- a/plugins/plugin-csharp/pom.xml
+++ b/plugins/plugin-csharp/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-csharp-parent</artifactId>

--- a/plugins/plugin-dashboard/che-plugin-ext-dashboard/pom.xml
+++ b/plugins/plugin-dashboard/che-plugin-ext-dashboard/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-dashboard-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-ext-dashboard-client</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-dashboard/pom.xml
+++ b/plugins/plugin-dashboard/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-dashboard-parent</artifactId>

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/pom.xml
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-debugger-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-debugger/pom.xml
+++ b/plugins/plugin-debugger/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-debugger-parent</artifactId>

--- a/plugins/plugin-docker/che-plugin-docker-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-client/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-plugin-docker-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-docker-client</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: Docker Client</name>
     <properties>
@@ -145,7 +144,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-dto-maven-plugin</artifactId>
-                <version>${che.version}</version>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <id>server</id>

--- a/plugins/plugin-docker/che-plugin-docker-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-client/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-docker-client</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: Docker Client</name>
     <properties>
@@ -144,7 +145,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-dto-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <executions>
                     <execution>
                         <id>server</id>

--- a/plugins/plugin-docker/che-plugin-docker-compose/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-compose/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-docker-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-docker-compose</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/CommandDeserializerTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/CommandDeserializerTest.java
@@ -137,7 +137,7 @@ public class CommandDeserializerTest {
                 {"\"echo ${PWD}\"", asList("echo", "${PWD}"), 2},
                 {"\"(Test)\"", singletonList("(Test)"), 1},
 
-                {"", singletonList(""), 1},
+                {"\"\"", singletonList(""), 1},
         };
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/EnvironmentDeserializerTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/EnvironmentDeserializerTest.java
@@ -73,7 +73,7 @@ public class EnvironmentDeserializerTest {
                  + " dev-machine: \n"
                  + "  image: codenvy/ubuntu_jdk8\n"
                  + "  environment:\n"
-                 + "   MYSQL_ROOT_PASSWORD: ",
+                 + "   MYSQL_ROOT_PASSWORD: \"\"",
                  ImmutableMap.of("MYSQL_ROOT_PASSWORD", "")
                 },
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -16,26 +16,14 @@
     <parent>
         <artifactId>che-plugin-docker-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-docker-machine</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: Machine</name>
     <properties>
         <findbugs.failonerror>false</findbugs.failonerror>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -19,11 +19,23 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-docker-machine</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: Machine</name>
     <properties>
         <findbugs.failonerror>false</findbugs.failonerror>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-plugin-docker-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-openshift-client</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: OpenShift Client</name>
     <properties>
@@ -27,17 +26,6 @@
         <license_copyrightOwner>Red Hat, Inc.</license_copyrightOwner>
         <license_header>license-header.txt</license_header>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-openshift-client</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Docker :: OpenShift Client</name>
     <properties>
@@ -26,6 +27,17 @@
         <license_copyrightOwner>Red Hat, Inc.</license_copyrightOwner>
         <license_header>license-header.txt</license_header>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/plugins/plugin-docker/pom.xml
+++ b/plugins/plugin-docker/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-docker-parent</artifactId>

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/pom.xml
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-gdb-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-gdb-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-gdb/che-plugin-gdb-server/pom.xml
+++ b/plugins/plugin-gdb/che-plugin-gdb-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-gdb-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-gdb-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-gdb/pom.xml
+++ b/plugins/plugin-gdb/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-gdb-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-git/che-plugin-git-ext-git/pom.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-git-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-git-ext-git</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-git/pom.xml
+++ b/plugins/plugin-git/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-git-parent</artifactId>

--- a/plugins/plugin-github/che-plugin-github-ide/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-github-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-github-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-github/che-plugin-github-oauth2/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-oauth2/pom.xml
@@ -19,8 +19,20 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-plugin-github-oauth2</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Github :: OAuth2</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>che-parent</artifactId>
+                <version>5.6.0-openshift-connector-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugins/plugin-github/che-plugin-github-oauth2/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-oauth2/pom.xml
@@ -16,23 +16,11 @@
     <parent>
         <artifactId>che-plugin-github-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-github-oauth2</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Plugin :: Github :: OAuth2</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.che</groupId>
-                <artifactId>che-parent</artifactId>
-                <version>5.6.0-openshift-connector-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugins/plugin-github/che-plugin-github-provider-github/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-provider-github/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-github-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-github-provider-github</artifactId>
     <name>Che Plugin :: Github :: Credential provider</name>

--- a/plugins/plugin-github/che-plugin-github-server/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-github-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-github-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-github/che-plugin-github-shared/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-github-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-github-shared</artifactId>
     <name>Che Plugin :: Github :: Shared</name>

--- a/plugins/plugin-github/pom.xml
+++ b/plugins/plugin-github/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-github-parent</artifactId>

--- a/plugins/plugin-gwt/che-plugin-gwt-ext-gwt/pom.xml
+++ b/plugins/plugin-gwt/che-plugin-gwt-ext-gwt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-gwt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-gwt-ext-gwt</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-gwt/pom.xml
+++ b/plugins/plugin-gwt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-gwt-parent</artifactId>

--- a/plugins/plugin-help/che-plugin-help-ext-client/pom.xml
+++ b/plugins/plugin-help/che-plugin-help-ext-client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-help-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-help-ext-client</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-help/pom.xml
+++ b/plugins/plugin-help/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-help-parent</artifactId>

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/pom.xml
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-debugger-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-debugger-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java-debugger/pom.xml
+++ b/plugins/plugin-java-debugger/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-debugger-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-filebuffers/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-filebuffers/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.core.filebuffers</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-filesystem/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-filesystem/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.core.filesystem</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-resources/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-resources/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.core.resources</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.jdt.ui</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jface-text/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jface-text/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.jface.text</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jface/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jface/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.jface</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-ltk-core-refactoring/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-ltk-core-refactoring/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.ltk.core.refactoring</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.search</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-ui-ide/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-ui-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.ui.ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-ext-jdt-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-ext-lang-client</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-ext-lang-server</artifactId>
     <name>Che Plugin :: Java :: Extension Java Server</name>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-ext-lang-shared</artifactId>
     <name>Che Plugin :: Java :: Extension Java Shared</name>

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-plain</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-plain-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-plain</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-plain-server</artifactId>
     <name>Che Plugin :: Java :: Plain :: Server</name>

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-shared/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-plain</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-plain-shared</artifactId>
     <name>Che Plugin :: Java :: Plain :: Shared</name>

--- a/plugins/plugin-java/che-plugin-java-plain/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-plain/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-java-plain</artifactId>

--- a/plugins/plugin-java/pom.xml
+++ b/plugins/plugin-java/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-java-parent</artifactId>

--- a/plugins/plugin-json/che-plugin-json-server/pom.xml
+++ b/plugins/plugin-json/che-plugin-json-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-json-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-json-server</artifactId>
     <name>Che Plugin :: JSON :: Extension Server</name>

--- a/plugins/plugin-json/pom.xml
+++ b/plugins/plugin-json/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-json-parent</artifactId>

--- a/plugins/plugin-keybinding-eclipse/plugin-keybinding-eclipse-ide/pom.xml
+++ b/plugins/plugin-keybinding-eclipse/plugin-keybinding-eclipse-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-keybinding-eclipse-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-keybinding-eclipse-ide</artifactId>

--- a/plugins/plugin-keybinding-eclipse/pom.xml
+++ b/plugins/plugin-keybinding-eclipse/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-keybinding-eclipse-parent</artifactId>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-languageserver-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>che-plugin-languageserver-ide</artifactId>

--- a/plugins/plugin-languageserver/pom.xml
+++ b/plugins/plugin-languageserver/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-languageserver-parent</artifactId>

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-machine-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-machine-ext-client</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-machine-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-machine-ext-server</artifactId>
     <dependencies>

--- a/plugins/plugin-machine/che-plugin-machine-ssh-client/pom.xml
+++ b/plugins/plugin-machine/che-plugin-machine-ssh-client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-machine-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-machine-ssh-client</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-machine/pom.xml
+++ b/plugins/plugin-machine/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-machine-parent</artifactId>

--- a/plugins/plugin-maven/che-plugin-maven-generator-archetype/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-generator-archetype/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-maven-generator-archetype</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-maven/che-plugin-maven-ide/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-maven-ide</artifactId>
     <name>Che Plugin :: Maven :: Extension Maven Client</name>

--- a/plugins/plugin-maven/che-plugin-maven-server/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-maven-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-maven/che-plugin-maven-shared/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-maven-shared</artifactId>
     <name>Che Plugin :: Maven :: Extension Maven Shared</name>

--- a/plugins/plugin-maven/che-plugin-maven-tools/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-tools/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-java-maven-tools</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-maven/che-plugin-maven-wsmaster/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-wsmaster/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-maven-wsmaster</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-maven/maven-server/maven-server-api/pom.xml
+++ b/plugins/plugin-maven/maven-server/maven-server-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-maven-server</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>maven-server-api</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-maven/maven-server/maven-server-impl/pom.xml
+++ b/plugins/plugin-maven/maven-server/maven-server-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-maven-server</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>maven-server-impl</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-maven/maven-server/pom.xml
+++ b/plugins/plugin-maven/maven-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-maven-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-maven-server</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-maven/pom.xml
+++ b/plugins/plugin-maven/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-maven-parent</artifactId>

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/pom.xml
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-nodejs-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-nodejs-debugger-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/pom.xml
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-nodejs-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-nodejs-debugger-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-nodejs-debugger/pom.xml
+++ b/plugins/plugin-nodejs-debugger/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-nodejs-debugger-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-nodejs/che-plugin-nodejs-lang-ide/pom.xml
+++ b/plugins/plugin-nodejs/che-plugin-nodejs-lang-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-nodejs-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-nodejs-lang-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-nodejs/che-plugin-nodejs-lang-server/pom.xml
+++ b/plugins/plugin-nodejs/che-plugin-nodejs-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-nodejs-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-nodejs-lang-server</artifactId>
     <name>Che Plugin :: NodeJs :: Extension Server</name>

--- a/plugins/plugin-nodejs/che-plugin-nodejs-lang-shared/pom.xml
+++ b/plugins/plugin-nodejs/che-plugin-nodejs-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-nodejs-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-nodejs-lang-shared</artifactId>
     <name>Che Plugin :: NodeJs :: Extension Shared</name>

--- a/plugins/plugin-nodejs/pom.xml
+++ b/plugins/plugin-nodejs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-nodejs-parent</artifactId>

--- a/plugins/plugin-orion/che-plugin-orion-compare/pom.xml
+++ b/plugins/plugin-orion/che-plugin-orion-compare/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-orion-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-orion-compare</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-orion/che-plugin-orion-editor/pom.xml
+++ b/plugins/plugin-orion/che-plugin-orion-editor/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-orion-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-orion-editor</artifactId>

--- a/plugins/plugin-orion/pom.xml
+++ b/plugins/plugin-orion/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-orion-parent</artifactId>

--- a/plugins/plugin-php/che-plugin-php-lang-ide/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-php-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-php-lang-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-php/che-plugin-php-lang-server/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-php-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-php-lang-server</artifactId>
     <name>Che Plugin :: PHP :: Extension Server</name>

--- a/plugins/plugin-php/che-plugin-php-lang-shared/pom.xml
+++ b/plugins/plugin-php/che-plugin-php-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-php-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-php-lang-shared</artifactId>
     <name>Che Plugin :: PHP :: Shared</name>

--- a/plugins/plugin-php/pom.xml
+++ b/plugins/plugin-php/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-php-parent</artifactId>

--- a/plugins/plugin-product-info/pom.xml
+++ b/plugins/plugin-product-info/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-product-info</artifactId>

--- a/plugins/plugin-python/che-plugin-python-lang-ide/pom.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-python-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-python-lang-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-python/che-plugin-python-lang-server/pom.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-python-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-python-lang-server</artifactId>
     <name>Che Plugin :: Python :: Extension Server</name>

--- a/plugins/plugin-python/che-plugin-python-lang-shared/pom.xml
+++ b/plugins/plugin-python/che-plugin-python-lang-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-python-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-python-lang-shared</artifactId>
     <name>che-plugin-python-lang-shared</name>

--- a/plugins/plugin-python/pom.xml
+++ b/plugins/plugin-python/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-python-parent</artifactId>

--- a/plugins/plugin-requirejs/pom.xml
+++ b/plugins/plugin-requirejs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-requirejs</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-sdk/che-plugin-sdk-env-local/pom.xml
+++ b/plugins/plugin-sdk/che-plugin-sdk-env-local/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-sdk-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-sdk-env-local</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-sdk/che-plugin-sdk-ext-plugins/pom.xml
+++ b/plugins/plugin-sdk/che-plugin-sdk-ext-plugins/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-sdk-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-sdk-ext-plugins</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-sdk/che-plugin-sdk-tools/pom.xml
+++ b/plugins/plugin-sdk/che-plugin-sdk-tools/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-sdk-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-sdk-tools</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-sdk/pom.xml
+++ b/plugins/plugin-sdk/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-sdk-parent</artifactId>

--- a/plugins/plugin-ssh-key/che-plugin-ssh-key-ide/pom.xml
+++ b/plugins/plugin-ssh-key/che-plugin-ssh-key-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-ssh-key-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-ssh-key-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-ssh-key/che-plugin-ssh-key-server/pom.xml
+++ b/plugins/plugin-ssh-key/che-plugin-ssh-key-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-ssh-key-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-ssh-key-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-ssh-key/pom.xml
+++ b/plugins/plugin-ssh-key/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-ssh-key-parent</artifactId>

--- a/plugins/plugin-ssh-machine/pom.xml
+++ b/plugins/plugin-ssh-machine/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-ssh-machine</artifactId>

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/pom.xml
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-svn-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-svn-ext-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-svn/che-plugin-svn-ext-server/pom.xml
+++ b/plugins/plugin-svn/che-plugin-svn-ext-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-svn-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-svn-ext-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-svn/che-plugin-svn-ext-shared/pom.xml
+++ b/plugins/plugin-svn/che-plugin-svn-ext-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-svn-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-svn-ext-shared</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-svn/pom.xml
+++ b/plugins/plugin-svn/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-svn-parent</artifactId>

--- a/plugins/plugin-terminal-ui/pom.xml
+++ b/plugins/plugin-terminal-ui/pom.xml
@@ -16,11 +16,10 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>plugin-terminal-ui</artifactId>
-    <version>5.5.0</version>
     <packaging>jar</packaging>
     <name>Terminal UI</name>
     <dependencies>

--- a/plugins/plugin-testing-java/plugin-testing-classpath/che-plugin-testing-classpath-maven-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-classpath/che-plugin-testing-classpath-maven-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-classpath</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-classpath-maven-server</artifactId>
     <name>Che Plugin :: Java Testing :: Maven Classpath</name>

--- a/plugins/plugin-testing-java/plugin-testing-classpath/che-plugin-testing-classpath-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-classpath/che-plugin-testing-classpath-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-classpath</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-classpath-server</artifactId>
     <name>Che Plugin :: Java Testing :: Classpath</name>

--- a/plugins/plugin-testing-java/plugin-testing-classpath/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-classpath/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-classpath</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-junit</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-junit-ide</artifactId>
     <name>Che Plugin :: Java Testing :: JUnit IDE</name>

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-junit</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-junit-server</artifactId>
     <name>Che Plugin :: Java Testing :: JUnit Server</name>

--- a/plugins/plugin-testing-java/plugin-testing-junit/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-junit/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-junit</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-testng</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-testng-ide</artifactId>
     <name>Che Plugin :: Java Testing :: TestNG IDE</name>

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-testng</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-testng-server</artifactId>
     <name>Che Plugin :: Java Testing :: TestNG Server</name>

--- a/plugins/plugin-testing-java/plugin-testing-testng/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-testng/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-java-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-testng</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-testing-java/pom.xml
+++ b/plugins/plugin-testing-java/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-java-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-testing/che-plugin-testing-ide/pom.xml
+++ b/plugins/plugin-testing/che-plugin-testing-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-testing-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-ide</artifactId>
     <name>Che Plugin :: Testing :: IDE</name>

--- a/plugins/plugin-testing/pom.xml
+++ b/plugins/plugin-testing/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-testing-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/plugin-web/che-plugin-web-ext-server/pom.xml
+++ b/plugins/plugin-web/che-plugin-web-ext-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-web-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-web-ext-server</artifactId>
     <dependencies>

--- a/plugins/plugin-web/che-plugin-web-ext-shared/pom.xml
+++ b/plugins/plugin-web/che-plugin-web-ext-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-web-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-web-ext-shared</artifactId>
     <build>

--- a/plugins/plugin-web/che-plugin-web-ext-web/pom.xml
+++ b/plugins/plugin-web/che-plugin-web-ext-web/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-web-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-web-ext-web</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-web/pom.xml
+++ b/plugins/plugin-web/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-web-parent</artifactId>

--- a/plugins/plugin-zend-debugger/che-plugin-zend-debugger-ide/pom.xml
+++ b/plugins/plugin-zend-debugger/che-plugin-zend-debugger-ide/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>che-plugin-zend-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-zend-debugger-ide</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-zend-debugger/che-plugin-zend-debugger-server/pom.xml
+++ b/plugins/plugin-zend-debugger/che-plugin-zend-debugger-server/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>che-plugin-zend-debugger-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-zend-debugger-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/plugin-zend-debugger/pom.xml
+++ b/plugins/plugin-zend-debugger/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>che-plugin-parent</artifactId>
         <groupId>org.eclipse.che.plugin</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-plugin-zend-debugger-parent</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,12 +16,12 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che.plugin</groupId>
     <artifactId>che-plugin-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Plugin :: Parent</name>
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Parent</name>
     <modules>
@@ -31,7 +31,11 @@
         <module>agents</module>
         <module>plugins</module>
         <module>samples</module>
+        <!--
+        We avoid to build/maintain dashboard
+        since we are not going to use it
         <module>dashboard</module>
+        -->
         <module>assembly</module>
     </modules>
     <scm>
@@ -43,6 +47,7 @@
     <properties>
         <che.docs.version>5.5.0</che.docs.version>
         <che.lib.version>5.5.0</che.lib.version>
+        <che.openshift.version>5.6.0-openshift-connector-SNAPSHOT</che.openshift.version>
         <che.version>5.5.0</che.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
@@ -56,96 +61,96 @@
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <classifier>classes</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-main</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsagent-server</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>tar.gz</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsagent-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsmaster-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>tar.gz</type>
                 <classifier>linux_amd64</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
                 <type>tar.gz</type>
                 <classifier>linux_arm7</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-csharp-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-json-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-php-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-python-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-typescript-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ssh-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>unison-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -155,7 +160,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-account</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -171,7 +176,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-auth</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -206,7 +211,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-factory</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -253,7 +258,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-machine</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -325,7 +330,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-user</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
@@ -397,17 +402,17 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-db</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-db-vendor-h2</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-db-vendor-postgresql</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -432,7 +437,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-ide-stacks</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -452,7 +457,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>wsagent</artifactId>
-                <version>${project.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -556,7 +561,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-docker-client</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -566,7 +571,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-docker-machine</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -596,7 +601,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-github-oauth2</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -681,7 +686,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-languageserver-ide</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -751,7 +756,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-openshift-client</artifactId>
-                <version>${che.version}</version>
+                <version>${che.openshift.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -801,7 +806,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-requirejs</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,7 @@
         <module>agents</module>
         <module>plugins</module>
         <module>samples</module>
-        <!--
-        We avoid to build/maintain dashboard
-        since we are not going to use it
         <module>dashboard</module>
-        -->
         <module>assembly</module>
     </modules>
     <scm>
@@ -47,8 +43,7 @@
     <properties>
         <che.docs.version>5.5.0</che.docs.version>
         <che.lib.version>5.5.0</che.lib.version>
-        <che.openshift.version>5.6.0-openshift-connector-SNAPSHOT</che.openshift.version>
-        <che.version>5.5.0</che.version>
+        <che.version>5.6.0-openshift-connector-SNAPSHOT</che.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>
@@ -61,96 +56,96 @@
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-ide-war</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <classifier>classes</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-main</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsagent-server</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <type>tar.gz</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsagent-war</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>assembly-wsmaster-war</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <type>tar.gz</type>
                 <classifier>linux_amd64</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
                 <type>tar.gz</type>
                 <classifier>linux_arm7</classifier>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>go-agents</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-csharp-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-json-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-php-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-python-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ls-typescript-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>ssh-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>unison-agent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -176,7 +171,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-auth</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -437,7 +432,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-ide-stacks</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -457,7 +452,7 @@
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>wsagent</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
@@ -561,7 +556,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-docker-client</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -571,7 +566,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-docker-machine</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -601,7 +596,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-github-oauth2</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
@@ -756,7 +751,7 @@
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-openshift-client</artifactId>
-                <version>${che.openshift.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -16,12 +16,12 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che.sample</groupId>
     <artifactId>che-sample-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Sample :: Parent</name>
     <modules>

--- a/samples/sample-plugin-actions/che-sample-plugin-actions-ide/pom.xml
+++ b/samples/sample-plugin-actions/che-sample-plugin-actions-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-actions-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-actions-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-actions/pom.xml
+++ b/samples/sample-plugin-actions/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-actions-parent</artifactId>

--- a/samples/sample-plugin-embedjs/che-sample-plugin-embedjs-ide/pom.xml
+++ b/samples/sample-plugin-embedjs/che-sample-plugin-embedjs-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-embedjs-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-embedjs-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-embedjs/pom.xml
+++ b/samples/sample-plugin-embedjs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-embedjs-parent</artifactId>

--- a/samples/sample-plugin-filetype/che-sample-plugin-filetype-ide/pom.xml
+++ b/samples/sample-plugin-filetype/che-sample-plugin-filetype-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-filetype-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-filetype-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-filetype/pom.xml
+++ b/samples/sample-plugin-filetype/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-filetype-parent</artifactId>

--- a/samples/sample-plugin-json/che-sample-plugin-json-ide/pom.xml
+++ b/samples/sample-plugin-json/che-sample-plugin-json-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-json-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-json-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-json/che-sample-plugin-json-server/pom.xml
+++ b/samples/sample-plugin-json/che-sample-plugin-json-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-json-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-json-server</artifactId>
     <name>Che Sample :: Plugin JSON :: Server</name>

--- a/samples/sample-plugin-json/che-sample-plugin-json-shared/pom.xml
+++ b/samples/sample-plugin-json/che-sample-plugin-json-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-json-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-json-shared</artifactId>
     <name>Che Sample :: Plugin JSON :: Shared</name>

--- a/samples/sample-plugin-json/pom.xml
+++ b/samples/sample-plugin-json/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-json-parent</artifactId>

--- a/samples/sample-plugin-nativeaccess/che-sample-plugin-nativeaccess-ide/pom.xml
+++ b/samples/sample-plugin-nativeaccess/che-sample-plugin-nativeaccess-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-nativeaccess-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-nativeaccess-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-nativeaccess/pom.xml
+++ b/samples/sample-plugin-nativeaccess/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-nativeaccess-parent</artifactId>

--- a/samples/sample-plugin-parts/che-sample-plugin-parts-ide/pom.xml
+++ b/samples/sample-plugin-parts/che-sample-plugin-parts-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-parts-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-parts-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-parts/pom.xml
+++ b/samples/sample-plugin-parts/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-parts-parent</artifactId>

--- a/samples/sample-plugin-serverservice/che-sample-plugin-serverservice-ide/pom.xml
+++ b/samples/sample-plugin-serverservice/che-sample-plugin-serverservice-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-serverservice-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-serverservice-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-serverservice/che-sample-plugin-serverservice-server/pom.xml
+++ b/samples/sample-plugin-serverservice/che-sample-plugin-serverservice-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-serverservice-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-serverservice-server</artifactId>
     <name>Che Sample :: Plugin ServerService :: Server</name>

--- a/samples/sample-plugin-serverservice/pom.xml
+++ b/samples/sample-plugin-serverservice/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-serverservice-parent</artifactId>

--- a/samples/sample-plugin-wizard/che-sample-plugin-wizard-ide/pom.xml
+++ b/samples/sample-plugin-wizard/che-sample-plugin-wizard-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-wizard-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-wizard-ide</artifactId>
     <packaging>jar</packaging>

--- a/samples/sample-plugin-wizard/che-sample-plugin-wizard-server/pom.xml
+++ b/samples/sample-plugin-wizard/che-sample-plugin-wizard-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-wizard-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-wizard-server</artifactId>
     <name>Che Sample :: Plugin Wizard :: Server</name>

--- a/samples/sample-plugin-wizard/che-sample-plugin-wizard-shared/pom.xml
+++ b/samples/sample-plugin-wizard/che-sample-plugin-wizard-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-plugin-wizard-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-sample-plugin-wizard-shared</artifactId>
     <name>Che Sample :: Plugin Wizard :: Shared</name>

--- a/samples/sample-plugin-wizard/pom.xml
+++ b/samples/sample-plugin-wizard/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-sample-parent</artifactId>
         <groupId>org.eclipse.che.sample</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-sample-plugin-wizard-parent</artifactId>

--- a/wsagent/agent/pom.xml
+++ b/wsagent/agent/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>wsagent</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Workspace Agent</name>
     <dependencies>
         <dependency>

--- a/wsagent/agent/pom.xml
+++ b/wsagent/agent/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>wsagent</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <name>Workspace Agent</name>
     <dependencies>
         <dependency>

--- a/wsagent/che-core-api-debug-shared/pom.xml
+++ b/wsagent/che-core-api-debug-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-debug-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/che-core-api-debug/pom.xml
+++ b/wsagent/che-core-api-debug/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-debug</artifactId>
     <name>Che Core :: API :: Debug</name>

--- a/wsagent/che-core-api-git-shared/pom.xml
+++ b/wsagent/che-core-api-git-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-git-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/che-core-api-git/pom.xml
+++ b/wsagent/che-core-api-git/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-git</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/che-core-api-languageserver-shared/pom.xml
+++ b/wsagent/che-core-api-languageserver-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-languageserver-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/che-core-api-languageserver/pom.xml
+++ b/wsagent/che-core-api-languageserver/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-languageserver</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/che-core-api-project-shared/pom.xml
+++ b/wsagent/che-core-api-project-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-project-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/che-core-api-project/pom.xml
+++ b/wsagent/che-core-api-project/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-project</artifactId>
     <packaging>jar</packaging>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-project-shared</artifactId>
-            <version>5.5.0</version>
+            <version>5.6.0-openshift-connector-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/wsagent/che-core-api-testing-shared/pom.xml
+++ b/wsagent/che-core-api-testing-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-testing-shared</artifactId>
     <name>Che Core :: API :: Testing Shared</name>

--- a/wsagent/che-core-api-testing/pom.xml
+++ b/wsagent/che-core-api-testing/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-testing</artifactId>
     <name>Che Core :: API :: Testing</name>

--- a/wsagent/che-core-git-impl-jgit/pom.xml
+++ b/wsagent/che-core-git-impl-jgit/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-git-impl-jgit</artifactId>
     <packaging>jar</packaging>

--- a/wsagent/pom.xml
+++ b/wsagent/pom.xml
@@ -16,12 +16,11 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../core/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-agent-parent</artifactId>
-    <version>5.5.0</version>
     <packaging>pom</packaging>
     <name>Che Agent Parent</name>
     <modules>

--- a/wsagent/wsagent-local/pom.xml
+++ b/wsagent/wsagent-local/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-agent-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>wsagent-local</artifactId>
     <name>Che Core :: API :: Agent</name>

--- a/wsmaster/che-core-api-account/pom.xml
+++ b/wsmaster/che-core-api-account/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-account</artifactId>
     <name>Che Core :: API :: Account</name>

--- a/wsmaster/che-core-api-auth/pom.xml
+++ b/wsmaster/che-core-api-auth/pom.xml
@@ -16,10 +16,9 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-auth</artifactId>
-    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Core :: API :: Authentication</name>
     <properties>

--- a/wsmaster/che-core-api-auth/pom.xml
+++ b/wsmaster/che-core-api-auth/pom.xml
@@ -19,6 +19,7 @@
         <version>5.5.0</version>
     </parent>
     <artifactId>che-core-api-auth</artifactId>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Che Core :: API :: Authentication</name>
     <properties>
@@ -175,7 +176,7 @@
             <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-dto-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>

--- a/wsmaster/che-core-api-factory-shared/pom.xml
+++ b/wsmaster/che-core-api-factory-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-factory-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-factory/pom.xml
+++ b/wsmaster/che-core-api-factory/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-factory</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-machine-shared/pom.xml
+++ b/wsmaster/che-core-api-machine-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-machine-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-machine/pom.xml
+++ b/wsmaster/che-core-api-machine/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-machine</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-project-templates-shared/pom.xml
+++ b/wsmaster/che-core-api-project-templates-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-project-templates-shared</artifactId>
     <name>Che Core :: API :: Project Templates :: Shared</name>

--- a/wsmaster/che-core-api-project-templates/pom.xml
+++ b/wsmaster/che-core-api-project-templates/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-project-templates</artifactId>
     <name>Che Core :: API :: Project Templates</name>

--- a/wsmaster/che-core-api-ssh-shared/pom.xml
+++ b/wsmaster/che-core-api-ssh-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-ssh-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-ssh/pom.xml
+++ b/wsmaster/che-core-api-ssh/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-ssh</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-system-shared/pom.xml
+++ b/wsmaster/che-core-api-system-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-system-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-system/pom.xml
+++ b/wsmaster/che-core-api-system/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-system</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-user-shared/pom.xml
+++ b/wsmaster/che-core-api-user-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-user-shared</artifactId>
     <name>Che Core :: API :: User :: Shared</name>

--- a/wsmaster/che-core-api-user/pom.xml
+++ b/wsmaster/che-core-api-user/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-user</artifactId>
     <name>Che Core :: API :: User</name>

--- a/wsmaster/che-core-api-workspace-shared/pom.xml
+++ b/wsmaster/che-core-api-workspace-shared/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-workspace-shared</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-api-workspace/pom.xml
+++ b/wsmaster/che-core-api-workspace/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-api-workspace</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/che-core-sql-schema/pom.xml
+++ b/wsmaster/che-core-sql-schema/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>che-core-sql-schema</artifactId>
     <name>Che Core :: SQL :: Schema</name>

--- a/wsmaster/integration-tests/cascade-removal/pom.xml
+++ b/wsmaster/integration-tests/cascade-removal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>integration-tests-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>cascade-removal</artifactId>
     <name>Integration Tests :: Cascade Removal</name>

--- a/wsmaster/integration-tests/pom.xml
+++ b/wsmaster/integration-tests/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>integration-tests-parent</artifactId>

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>integration-tests-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>postgresql-tck</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/pom.xml
+++ b/wsmaster/pom.xml
@@ -16,11 +16,11 @@
     <parent>
         <artifactId>che-core-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
         <relativePath>../core/pom.xml</relativePath>
     </parent>
     <artifactId>che-master-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0-openshift-connector-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Master Parent</name>
     <modules>

--- a/wsmaster/wsmaster-local/pom.xml
+++ b/wsmaster/wsmaster-local/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-master-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>5.5.0</version>
+        <version>5.6.0-openshift-connector-SNAPSHOT</version>
     </parent>
     <artifactId>wsmaster-local</artifactId>
     <name>Che Core :: API :: Impl Local</name>


### PR DESCRIPTION
### What does this PR do?

Updates Che version `5.6.0-openshift-connector-SNAPSHOT` for rest of Che classes, separating OpenShift development from main Che. 

This commit should probably be squashed into the other version change commit, to make the changes a single commit.