### PR TITLE
Add WildFly Swarm stack to default assembly

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2384,5 +2384,81 @@
       "name": "type-spring-boot.svg",
       "mediaType": "image/svg+xml"
     }
-  }
+  },
+  {
+  "name": "CentOS WildFly Swarm",
+  "id": "WildFly Swarm",
+  "creator": "Dharmit Shah",
+  "description": "Eclipse WildFly Swarm Stack on CentOS.",
+  "scope": "advanced",
+  "source": {
+    "type": "image",
+    "origin": "registry.centos.org/che-stacks/wildfly-swarm"
+  },
+  "tags": [
+    "Java",
+    "JDK",
+    "Maven",
+    "WildFly Swarm",
+    "CentOS",
+    "Git"
+  ],
+  "workspaceConfig": {
+    "name": "default",
+    "environments": {
+      "default": {
+        "recipe": {
+          "location": "registry.centos.org/che-stacks/wildfly-swarm",
+          "type": "dockerimage"
+        },
+        "machines": {
+          "dev-machine": {
+            "attributes": {
+              "memoryLimitBytes": "2147483648"
+            },
+            "agents": [
+              "org.eclipse.che.terminal",
+              "org.eclipse.che.ws-agent",
+              "org.eclipse.che.ssh"
+            ],
+            "servers": {}
+          }
+        }
+      }
+    },
+    "commands": [
+      {
+        "name": "build",
+        "type": "mvn",
+        "attributes": {},
+        "commandLine": "scl enable rh-maven33 'mvn clean install -f ${current.project.path}'"
+      },
+      {
+        "name": "run",
+        "type": "custom",
+        "attributes": {
+          "previewUrl": "http://${server.port.8080}"
+        },
+        "commandLine": "cd ${current.project.path} && scl enable rh-maven33 'java -jar target/*-swarm.jar'"
+      }
+    ],
+    "projects": [],
+    "defaultEnv": "default",
+    "links": []
+  },
+  "components": [
+    {
+      "name": "CentOS",
+      "version": "---"
+    },
+    {
+      "name": "JDK",
+      "version": "1.8.0_45"
+    },
+    {
+      "name": "Maven",
+      "version": "3.3.9"
+    }
+  ]
+}
 ]


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

Adds CentOS based WildFly Swarm stack to default assembly

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->

Add WildFly Swarm stack to default assembly

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

You can now build WildFly Swarm based applications on CentOS Linux by easily creating a workspace from the WildFly Swarm stack.

#### Docs PR
TODO Create tutorial. 

**Recipe PR**: [che-dockerfiles/pull/79](https://github.com/eclipse/che-dockerfiles/pull/79)