### PR TITLE
Various fixes to the PR panel

### DIFF
--- a/plugins/plugin-github/che-plugin-github-pullrequest/src/main/java/org/eclipse/che/plugin/pullrequest/client/GitHubContributionWorkflow.java
+++ b/plugins/plugin-github/che-plugin-github-pullrequest/src/main/java/org/eclipse/che/plugin/pullrequest/client/GitHubContributionWorkflow.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.pullrequest.client;
 
+import org.eclipse.che.plugin.pullrequest.client.steps.AddHttpForkRemoteStep;
 import org.eclipse.che.plugin.pullrequest.client.steps.AddReviewFactoryLinkStep;
-import org.eclipse.che.plugin.pullrequest.client.steps.AddSshForkRemoteStep;
 import org.eclipse.che.plugin.pullrequest.client.steps.AuthorizeCodenvyOnVCSHostStep;
 import org.eclipse.che.plugin.pullrequest.client.steps.CommitWorkingTreeStep;
 import org.eclipse.che.plugin.pullrequest.client.steps.CreateForkStep;
@@ -47,7 +47,7 @@ public class GitHubContributionWorkflow implements ContributionWorkflow {
     private final DefineExecutionConfiguration    defineExecutionConfiguration;
     private final DetermineUpstreamRepositoryStep determineUpstreamRepositoryStep;
     private final CreateForkStep                  createForkStep;
-    private final AddSshForkRemoteStep            addSshForkRemoteStep;
+    private final AddHttpForkRemoteStep           addHttpForkRemoteStep;
     private final PushBranchOnForkStep            pushBranchOnForkStep;
     private final PushBranchOnOriginStep          pushBranchOnOriginStep;
     private final GenerateReviewFactoryStep       generateReviewFactoryStep;
@@ -64,7 +64,7 @@ public class GitHubContributionWorkflow implements ContributionWorkflow {
                                       DefineExecutionConfiguration defineExecutionConfiguration,
                                       DetermineUpstreamRepositoryStep determineUpstreamRepositoryStep,
                                       CreateForkStep createForkStep,
-                                      AddSshForkRemoteStep addSshForkRemoteStep,
+                                      AddHttpForkRemoteStep addHttpForkRemoteStep,
                                       PushBranchOnForkStep pushBranchOnForkStep,
                                       PushBranchOnOriginStep pushBranchOnOriginStep,
                                       GenerateReviewFactoryStep generateReviewFactoryStep,
@@ -79,7 +79,7 @@ public class GitHubContributionWorkflow implements ContributionWorkflow {
         this.defineExecutionConfiguration = defineExecutionConfiguration;
         this.determineUpstreamRepositoryStep = determineUpstreamRepositoryStep;
         this.createForkStep = createForkStep;
-        this.addSshForkRemoteStep = addSshForkRemoteStep;
+        this.addHttpForkRemoteStep = addHttpForkRemoteStep;
         this.pushBranchOnForkStep = pushBranchOnForkStep;
         this.pushBranchOnOriginStep = pushBranchOnOriginStep;
         this.generateReviewFactoryStep = generateReviewFactoryStep;
@@ -109,7 +109,7 @@ public class GitHubContributionWorkflow implements ContributionWorkflow {
                                           }
                                       },
                                       StepsChain.first(createForkStep)
-                                                .then(addSshForkRemoteStep)
+                                                .then(addHttpForkRemoteStep)
                                                 .then(pushBranchOnForkStep),
                                       StepsChain.first(pushBranchOnOriginStep))
                          .then(generateReviewFactoryStep)
@@ -129,7 +129,7 @@ public class GitHubContributionWorkflow implements ContributionWorkflow {
             public Boolean get() {
                 return context.getForkedRemoteName() == null;
             }
-        }, addSshForkRemoteStep).then(pushBranchOnForkStep);
+        }, addHttpForkRemoteStep).then(pushBranchOnForkStep);
 
         final StepsChain originChain = StepsChain.first(pushBranchOnOriginStep);
 

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/steps/InitializeWorkflowContextStep.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/steps/InitializeWorkflowContextStep.java
@@ -108,9 +108,9 @@ public class InitializeWorkflowContextStep implements Step {
             return;
         }
 
-        vcsServiceProvider.getVcsService(context.getProject()) //
-                          .getBranchName(context.getProject()) //
-                          .then( //
+        vcsServiceProvider.getVcsService(context.getProject())
+                          .getBranchName(context.getProject())
+                          .then(
                           (String branchName) -> {
                               context.setContributeToBranchName(branchName);
                               context.getProject().getSource().getParameters().put("branch", branchName);


### PR DESCRIPTION
1. The user already using the oauth Github token to create the fork, upload the ssh key and create the PR so it makes sense to git push with GH token. Changing AddSshForkRemoteStep with AddHttpForkRemoteStep in GitHubContributionWorkflow.java
2. It doesn't work if we change the local branch to use. Base upstream branch to merge into will change. This is because the panel is supposed to work from a Factory where attribute "base upstream branch to merge to" is set. We should fix it somehow: user should be able to choose the upstream branch to merge into. Also, We shouldn't update this branch when selecting another local branch. https://www.youtube.com/watch?v=H4_cJJWQ5DY

https://issues.jboss.org/browse/CHE-106

#### Changelog
Various fixes to the PR panel 