### PR TITLE
Setting rwx permissions for all on /data/ in case it's not mounted

### DIFF
--- a/dockerfiles/che/Dockerfile.centos
+++ b/dockerfiles/che/Dockerfile.centos
@@ -50,3 +50,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 ADD eclipse-che.tar.gz /home/user/
 RUN mkdir /logs && chmod 0777 /logs
 RUN chmod -R 0777 /home/user/
+RUN mkdir /data && chmod 0777 /data


### PR DESCRIPTION
If /data/ is not bind mounted from the host and if the container is started as an arbitrary user, a permission error will occur.

Creating the folder and chmod it solves the problem.

#### Changelog
Setting rwx permissions for all on /data/ in case it's not mounted