### PR TITLE
Add support for resource requests/limits when running on Openshift

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -294,6 +294,9 @@ che.openshift.liveness.probe.delay=300
 che.openshift.liveness.probe.timeout=1
 che.openshift.workspaces.pvc.name=claim-che-workspace
 che.openshift.workspaces.pvc.quantity=10Gi
+che.openshift.workspace.cpu.limit=1
+# Override memory limit used for openshift workspaces. String, e.g. 1300Mi
+che.openshift.workspace.memory.override=NULL
 
 # Which implementation of DockerConnector to use in managing containers. In general,
 # the base implementation of DockerConnector is appropriate, but OpenShiftConnector

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -37,8 +37,9 @@ public class OpenShiftConnectorTest {
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_QUANTITY = "10Gi";
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_STORAGE = "/data/workspaces";
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE = "/projects";
-	private static final String   CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS = "che.openshift.mini";
-	
+    private static final String   CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS = "che.openshift.mini";
+    private static final String   CHE_WORKSPACE_CPU_LIMIT = "1";
+
     @Mock
     private DockerConnectorConfiguration       dockerConnectorConfiguration;
     @Mock
@@ -73,7 +74,9 @@ public class OpenShiftConnectorTest {
                                                     OPENSHIFT_DEFAULT_WORKSPACE_PERSISTENT_VOLUME_CLAIM,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_QUANTITY,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_STORAGE,
-                                                    OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE);
+                                                    OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE,
+                                                    CHE_WORKSPACE_CPU_LIMIT,
+                                                    null);
         String workspaceID = openShiftConnector.getCheWorkspaceId(createContainerParams);
 
         //Then


### PR DESCRIPTION
### What does this PR do?
Add resource requests and limits to workspace Pods when running on OpenShift. Workspace memory limit is obtained from the che REST API, while memory request, cpu limit, and cpu request are determined by new che properties

- "che.openshift.workspace.memory.request"
- "che.openshift.workspace.cpu.limit"
- "che.openshift.workspace.cpu.request"