### PR TITLE
CHE-3844: Show 'Add terminal button' in the machine node when WsAgent started.

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessTreeNode.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessTreeNode.java
@@ -39,6 +39,7 @@ public class ProcessTreeNode {
     private boolean hasTerminalAgent;
     private boolean hasSSHAgent;
     private boolean running;
+    private boolean showAddTerminalBtn;
 
     public ProcessTreeNode(ProcessNodeType type,
                            ProcessTreeNode parent,
@@ -154,6 +155,14 @@ public class ProcessTreeNode {
 
     public void setRunning(boolean running) {
         this.running = running;
+    }
+
+    public boolean isShowAddTerminalBtn() {
+        return showAddTerminalBtn;
+    }
+
+    public void setShowAddTerminalBtn(boolean showAddTerminalBtn) {
+        this.showAddTerminalBtn = showAddTerminalBtn;
     }
 
     @Override

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessTreeRenderer.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessTreeRenderer.java
@@ -18,6 +18,7 @@ import elemental.html.DivElement;
 import elemental.html.SpanElement;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.ide.api.machine.MachineEntity;
@@ -44,6 +45,7 @@ import static org.eclipse.che.ide.ui.menu.PositionController.VerticalAlign.BOTTO
  * @author Anna Shumilova
  * @author Roman Nikitenko
  */
+@Singleton
 public class ProcessTreeRenderer implements NodeRenderer<ProcessTreeNode> {
 
     public static final Map<String, String> LABELS = new HashMap<String, String>() {
@@ -141,7 +143,7 @@ public class ProcessTreeRenderer implements NodeRenderer<ProcessTreeNode> {
          * New terminal button
          *
          ***************************************************************************/
-        if (node.isRunning() && node.hasTerminalAgent()) {
+        if (node.isShowAddTerminalBtn()) {
             SpanElement newTerminalButton = Elements.createSpanElement(resources.getCss().newTerminalButton());
             newTerminalButton.appendChild((Node)new SVGImage(resources.addTerminalIcon()).getElement());
             root.appendChild(newTerminalButton);

--- a/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessTreeRenderer.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ProcessTreeRenderer.java
@@ -143,7 +143,7 @@ public class ProcessTreeRenderer implements NodeRenderer<ProcessTreeNode> {
          * New terminal button
          *
          ***************************************************************************/
-        if (node.isShowAddTerminalBtn()) {
+        if (node.isShowAddTerminalBtn() && node.hasTerminalAgent()) {
             SpanElement newTerminalButton = Elements.createSpanElement(resources.getCss().newTerminalButton());
             newTerminalButton.appendChild((Node)new SVGImage(resources.addTerminalIcon()).getElement());
             root.appendChild(newTerminalButton);


### PR DESCRIPTION
### What does this PR do?
Show 'Add terminal button' in the machine node when WsAgent started. Earlier We shown this button when machine had got status "running", but on this phase start IDE terminal agent was not installed yet.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3844

#### Changelog
Show 'Add terminal button' in the machine node when WsAgent started.

#### Release Notes
Show 'Add terminal button' in the machine node when WsAgent started.

#### Docs PR
Not needed, this is bug fix.
