### PR TITLE
CODENVY-1936: Add alias index.docker.io for docker hub

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolver.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolver.java
@@ -115,6 +115,10 @@ public class DockerRegistryAuthResolver {
             Map<String,AuthConfig> normalizedAuthConfigMap = new HashMap<>(authConfigs);
             normalizedAuthConfigMap.put(DEFAULT_REGISTRY, normalizedAuthConfigMap.remove("docker.io"));
             return normalizedAuthConfigMap;
+        } else if (authConfigs.containsKey("index.docker.io")) {
+            Map<String,AuthConfig> normalizedAuthConfigMap = new HashMap<>(authConfigs);
+            normalizedAuthConfigMap.put(DEFAULT_REGISTRY, normalizedAuthConfigMap.remove("index.docker.io"));
+            return normalizedAuthConfigMap;
         }
         return authConfigs;
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolver.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolver.java
@@ -111,14 +111,12 @@ public class DockerRegistryAuthResolver {
     }
 
     private Map<String, AuthConfig> normalizeDockerHubRegistryUrl(Map<String, AuthConfig> authConfigs) {
-        if (authConfigs.containsKey("docker.io")) {
-            Map<String,AuthConfig> normalizedAuthConfigMap = new HashMap<>(authConfigs);
-            normalizedAuthConfigMap.put(DEFAULT_REGISTRY, normalizedAuthConfigMap.remove("docker.io"));
-            return normalizedAuthConfigMap;
-        } else if (authConfigs.containsKey("index.docker.io")) {
-            Map<String,AuthConfig> normalizedAuthConfigMap = new HashMap<>(authConfigs);
-            normalizedAuthConfigMap.put(DEFAULT_REGISTRY, normalizedAuthConfigMap.remove("index.docker.io"));
-            return normalizedAuthConfigMap;
+        for (String defaultRegistryAlias : DEFAULT_REGISTRY_SYNONYMS) {
+            if (authConfigs.containsKey(defaultRegistryAlias)) {
+                Map<String, AuthConfig> normalizedAuthConfigMap = new HashMap<>(authConfigs);
+                normalizedAuthConfigMap.put(DEFAULT_REGISTRY, normalizedAuthConfigMap.remove(defaultRegistryAlias));
+                return normalizedAuthConfigMap;
+            }
         }
         return authConfigs;
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/InitialAuthConfigTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/InitialAuthConfigTest.java
@@ -186,5 +186,20 @@ public class InitialAuthConfigTest {
 
         new InitialAuthConfig(configurationProperties);
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = "Docker hub registry is configured more than one time")
+    public void shouldThrowExceptionIfUserConfigureDockerHubMoreThanOneTime() {
+        properties.put(CONFIG_PREFIX + "registry3.url", "docker.io");
+        properties.put(CONFIG_PREFIX + "registry3.username", "inattentive");
+        properties.put(CONFIG_PREFIX + "registry3.password", "Be careful");
+
+        properties.put(CONFIG_PREFIX + "registry4.url", "index.docker.io");
+        properties.put(CONFIG_PREFIX + "registry4.username", "duplicate");
+        properties.put(CONFIG_PREFIX + "registry4.password", "config");
+
+        new InitialAuthConfig(configurationProperties);
+    }
+
 }
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -27,7 +27,6 @@ import org.eclipse.che.api.machine.server.spi.InstanceProvider;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.DockerConnectorProvider;
-import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
 import org.eclipse.che.plugin.docker.client.params.RemoveImageParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,15 +71,12 @@ public class DockerInstanceProvider implements InstanceProvider {
     public static final String MACHINE_SNAPSHOT_PREFIX = "machine_snapshot_";
 
     private final DockerConnector                               docker;
-    private final DockerRegistryAuthResolver                    authResolver;
     private final boolean                                       snapshotUseRegistry;
 
     @Inject
     public DockerInstanceProvider(DockerConnectorProvider dockerProvider,
-                                  DockerRegistryAuthResolver authResolver,
                                   @Named("che.docker.registry_for_snapshots") boolean snapshotUseRegistry) throws IOException {
         this.docker = dockerProvider.get();
-        this.authResolver = authResolver;
         this.snapshotUseRegistry = snapshotUseRegistry;
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineSource.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineSource.java
@@ -53,8 +53,6 @@ public class DockerMachineSource extends MachineSourceImpl {
      * @param machineSource the machine source used to parse data.
      */
     public DockerMachineSource(MachineSource machineSource) throws MachineException {
-        super();
-
         // check type
         if (!DOCKER_IMAGE_TYPE.equals(machineSource.getType())) {
             throw new MachineException("Docker machine source can only be built with '" + DOCKER_IMAGE_TYPE + "' type");
@@ -208,6 +206,16 @@ public class DockerMachineSource extends MachineSourceImpl {
             fullRepoId.append('@').append(getDigest());
         }
         return fullRepoId.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "DockerMachineSource{" +
+               "registry='" + registry + '\'' +
+               ", repository='" + repository + '\'' +
+               ", tag='" + tag + '\'' +
+               ", digest='" + digest + '\'' +
+               '}';
     }
 
 }


### PR DESCRIPTION
### What does this PR do?
Adds alias `index.docker.io` for docker hub container registry. This alias can be  used for configuration of `CHE_DOCKER_REGISTRY` and `CHE_DOCKER_REGISTRY_AUTH_<docker-hub-registry-name>_URL` properties.
Adds tests.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1936

#### Changelog
Added alias `index.docker.io` for docker hub.

