### PR TITLE
CHE-4541: Avoid NPE if UI element not attached to the parent

### DIFF
--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/ContentAssistWidget.java
@@ -530,7 +530,9 @@ public class ContentAssistWidget implements EventListener {
             @Override
             public void run() {
                 // detach assist popup
-                popupElement.getParentNode().removeChild(popupElement);
+                if (popupElement.getParentNode() != null) {
+                    popupElement.getParentNode().removeChild(popupElement);
+                }
                 // remove all items from popup element
                 listElement.setInnerHTML("");
             }

--- a/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewOverlay.java
+++ b/plugins/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewOverlay.java
@@ -322,8 +322,11 @@ public class OrionTextViewOverlay extends JavaScriptObject {
     }-*/;
 
     public final native <T extends OrionEventOverlay> void removeEventListener(String eventType, EventHandler<T> handler,
+
                                                                                boolean useCapture) /*-{
-        this.removeEventListener(eventType, $wnd.che_handels[handler], useCapture)
+        if ($wnd.che_handels) {
+            this.removeEventListener(eventType, $wnd.che_handels[handler], useCapture);
+        }
     }-*/;
 
     /**


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>

### What does this PR do?
Avoid NPE if UI element not attached to the parent

### What issues does this PR fix or reference?
#4541 

#### Changelog
Avoid NPE if UI element not attached to the parent

#### Release Notes
N/A


