### PR TITLE
che-4604: fix erasing projects source info and influence on template's projects

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.controller.ts
+++ b/dashboard/src/app/projects/create-project/create-project.controller.ts
@@ -832,7 +832,6 @@ export class CreateProjectController {
    * Call the create operation that may create or import a project
    */
   create(): void {
-    this.importProjectData = this.getDefaultProjectJson();
     this.importProjectData.project.description = this.projectDescription;
     this.importProjectData.project.name = this.projectName;
     this.createProjectSvc.setProject(this.projectName);
@@ -1359,7 +1358,7 @@ export class CreateProjectController {
     this.importProjectData.project.commands = template.commands;
     this.importProjectData.project.attributes = template.attributes;
     this.importProjectData.project.options = template.options;
-    this.importProjectData.projects = template.projects;
+    this.importProjectData.projects = angular.copy(template.projects);
 
     let name: string = template.displayName;
     // strip space


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

### What does this PR do?
It's the fix for https://github.com/eclipse/che/issues/4239. The bug was in referencing projects from templates, modifying them by reference. Thus on next project creation from the very same template - the projects list had wrong value.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4604
https://github.com/eclipse/che/issues/4239

#### Changelog
[UD] Fixed the project creation when reusing the same project template several times which was erasing source data during import.

#### Release Notes
Fixed the project creation when reusing a project template several times which was erasing source data during import.


#### Docs PR
N/A
