### PR TITLE
Remove opacity style for emptyEditorsPanel logo div.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.ui.xml
@@ -20,7 +20,6 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            opacity: 0.2;
             margin-bottom: 50px;
         }
         .parent {


### PR DESCRIPTION
Remove opacity style for emptyEditorsPanel logo div because this style can does logo invisible if svg logo dark styled. If we need opacity style I think it would be better to set fill-opacity style in the logo svg and we will get the same style effect.
Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>
