### PR TITLE
CODENVY-1734: improve docker client

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/ExecNotFoundException.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/ExecNotFoundException.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.exception;
+
+/**
+ * Occurs when docker exec is not found.
+ *
+ * @author Alexander Garagatyi
+ */
+public class ExecNotFoundException extends DockerException {
+
+    public ExecNotFoundException(String message) {
+        super(message, 404);
+    }
+
+}

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/ExecNotFoundException.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/exception/ExecNotFoundException.java
@@ -20,5 +20,4 @@ public class ExecNotFoundException extends DockerException {
     public ExecNotFoundException(String message) {
         super(message, 404);
     }
-
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ExecInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ExecInfo.java
@@ -94,11 +94,11 @@ public class ExecInfo {
                "id='" + id + '\'' +
                ", container=" + container +
                ", processConfig=" + processConfig +
-               ", openStdout=" + openStdout +
-               ", openStderr=" + openStderr +
-               ", openStdin=" + openStdin +
-               ", running=" + running +
-               ", exitCode=" + exitCode +
+               ", openStdout='" + openStdout + '\'' +
+               ", openStderr='" + openStderr + '\'' +
+               ", openStdin='" + openStdin + '\'' +
+               ", running='" + running + '\'' +
+               ", exitCode='" + exitCode + '\'' +
                '}';
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -28,6 +28,7 @@ import org.eclipse.che.plugin.docker.client.dto.AuthConfig;
 import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
 import org.eclipse.che.plugin.docker.client.exception.ContainerNotFoundException;
 import org.eclipse.che.plugin.docker.client.exception.DockerException;
+import org.eclipse.che.plugin.docker.client.exception.ExecNotFoundException;
 import org.eclipse.che.plugin.docker.client.exception.NetworkNotFoundException;
 import org.eclipse.che.plugin.docker.client.json.ContainerCommitted;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
@@ -749,6 +750,17 @@ public class DockerConnectorTest {
         verify(dockerConnection).request();
         verify(dockerResponse).getStatus();
         verify(dockerResponse).getInputStream();
+    }
+
+    @Test(expectedExceptions = ExecNotFoundException.class,
+          expectedExceptionsMessageRegExp = EXCEPTION_ERROR_MESSAGE)
+    public void execStartShouldThrowExecNotFoundIf404Received() throws IOException {
+        StartExecParams startExecParams = StartExecParams.create(EXEC_ID);
+
+        doReturn(new ByteArrayInputStream(EXCEPTION_ERROR_MESSAGE.getBytes())).when(dockerResponse).getInputStream();
+        when(dockerResponse.getStatus()).thenReturn(RESPONSE_NOT_FOUND_CODE);
+
+        dockerConnector.startExec(startExecParams, logMessageProcessor);
     }
 
     @Test(expectedExceptions = DockerException.class, expectedExceptionsMessageRegExp = EXCEPTION_ERROR_MESSAGE)


### PR DESCRIPTION
### What does this PR do?
Throw specific exception in docker client if exec not found on exec start.

### What issues does this PR fix or reference?
Related to codenvy/codenvy#1734

#### Changelog
Docker client throws specific exception instead of general in case exec is not found on exec start request.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
