### PR TITLE
Do not prevent developers to use instance and config folder in package names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ target/
 bin/
 test-output/
 maven-eclipse.xml
-instance/
-config/
 
 # Idea #
 ##################


### PR DESCRIPTION

### What does this PR do?
Removes ```instance``` and  ```config``` folders from gitignore section.
This ignore section was added in the time of che in docker development and it's not longer relevant.


### What issues does this PR fix or reference?
 blocking developers to use words ```instance``` and  ```config``` as package names


#### Changelog
Allow developers to use words ```instance``` and  ```config``` as package names

#### Release Notes
not needed

#### Docs PR
not needed
