### PR TITLE
Allow to use single hyphen in the middle of account name

### DIFF
--- a/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/spi/AccountValidator.java
+++ b/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/spi/AccountValidator.java
@@ -31,8 +31,11 @@ import java.util.regex.Pattern;
 public class AccountValidator {
     private static final Logger LOG = LoggerFactory.getLogger(AccountValidator.class);
 
-    private static final Pattern ILLEGAL_ACCOUNT_NAME_CHARACTERS = Pattern.compile("[^a-zA-Z0-9]");
-    private static final Pattern VALID_ACCOUNT_NAME              = Pattern.compile("^[a-zA-Z0-9]*");
+    private static final Pattern ILLEGAL_ACCOUNT_NAME_CHARACTERS = Pattern.compile("[^a-zA-Z0-9-]" + // all character except allowed
+                                                                                   "|(?<=-)-+" +     // non single hyphens
+                                                                                   "|^-+" +          // hyphens at the beginning
+                                                                                   "|-+$");          // hyphens at the end
+    private static final Pattern VALID_ACCOUNT_NAME              = Pattern.compile("^(?:[a-zA-Z0-9]-?)*[a-zA-Z0-9]+");
 
     private final AccountManager accountManager;
 

--- a/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/AccountValidatorTest.java
+++ b/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/AccountValidatorTest.java
@@ -39,7 +39,7 @@ public class AccountValidatorTest {
     @InjectMocks
     private AccountValidator accountValidator;
 
-    @Test(dataProvider = "normalizeNames")
+    @Test(dataProvider = "namesToNormalize")
     public void testNormalizeAccountName(String input, String expected) throws Exception {
         doThrow(NotFoundException.class).when(accountManager).getByName(anyString());
 
@@ -53,40 +53,48 @@ public class AccountValidatorTest {
         Assert.assertTrue(accountValidator.normalizeAccountName("#", "name").startsWith("name"));
     }
 
-    @Test(dataProvider = "validNames")
+    @Test(dataProvider = "namesToValidate")
     public void testValidUserName(String input, boolean expected) throws Exception {
         doThrow(NotFoundException.class).when(accountManager).getByName(anyString());
 
         Assert.assertEquals(accountValidator.isValidName(input), expected);
     }
 
-    @DataProvider(name = "normalizeNames")
-    public Object[][] normalizeNames() {
+    @DataProvider
+    public Object[][] namesToNormalize() {
         return new Object[][] {{"test", "test"},
                                {"test123", "test123"},
                                {"test 123", "test123"},
                                {"test@gmail.com", "testgmailcom"},
                                {"TEST", "TEST"},
                                {"test-", "test"},
-                               {"te-st", "test"},
                                {"-test", "test"},
                                {"te_st", "test"},
-                               {"te#st", "test"}
+                               {"te#st", "test"},
+                               {"-test", "test"},
+                               {"test-", "test"},
+                               {"--test--", "test"},
+                               {"t-----e--s-t", "t-e-s-t"}
         };
     }
 
-    @DataProvider(name = "validNames")
-    public Object[][] validNames() {
+    @DataProvider
+    public Object[][] namesToValidate() {
         return new Object[][] {{"test", true},
+                               {"t-e-s-t", true},
                                {"test123", true},
+                               {"TEST", true},
+                               {"te-st", true},
                                {"test 123", false},
                                {"test@gmail.com", false},
-                               {"TEST", true},
                                {"test-", false},
-                               {"te-st", false},
                                {"-test", false},
                                {"te_st", false},
-                               {"te#st", false}
+                               {"te#st", false},
+                               {"-test", false},
+                               {"test-", false},
+                               {"--test--", false},
+                               {"te--st", false}
         };
     }
 }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserValidator.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserValidator.java
@@ -55,7 +55,7 @@ public class UserValidator {
             throw new BadRequestException("User name required");
         }
         if (!isValidName(user.getName())) {
-            throw new BadRequestException("Username must contain only letters and digits");
+            throw new BadRequestException("Username may only contain alphanumeric characters or single hyphens inside");
         }
         if (isNullOrEmpty(user.getEmail())) {
             throw new BadRequestException("User email required");


### PR DESCRIPTION
### What does this PR do?
Allows to use single hyphen in the middle of account name

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1610

#### Changelog
Allowed to use single hyphen in the middle of account name.

#### Release Notes
Allowing use of a single hyphen in the account name.

#### Docs PR
N/A
