### PR TITLE
Sets CHE_WORKSPACE_ID and CHE_MACHINE_NAME in all machines started by Che

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -59,9 +59,15 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
     public static final String API_ENDPOINT_URL_VARIABLE = "CHE_API";
 
     /**
-     * Environment variable that will be setup in developer machine will contain ID of a workspace for which this machine has been created
+     * Environment variable that will contain ID of a workspace for which this machine has been created
      */
     public static final String CHE_WORKSPACE_ID = "CHE_WORKSPACE_ID";
+
+    /**
+     * Environment variable that will contain Name of the machine
+     */
+    public static final String CHE_MACHINE_NAME = "CHE_MACHINE_NAME";
+
 
     /**
      * Default HOSTNAME that will be added in all docker containers that are started. This host will container the Docker host's ip

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -68,7 +68,6 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
      */
     public static final String CHE_MACHINE_NAME = "CHE_MACHINE_NAME";
 
-
     /**
      * Default HOSTNAME that will be added in all docker containers that are started. This host will container the Docker host's ip
      * reachable inside the container.

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -491,6 +491,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                                  (long)(service.getMemLimit() * memorySwapMultiplier);
 
         addSystemWideContainerSettings(workspaceId,
+                                       machineName,
                                        isDev,
                                        service);
 
@@ -563,6 +564,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
     }
 
     private void addSystemWideContainerSettings(String workspaceId,
+                                                String machineName,
                                                 boolean isDev,
                                                 CheServiceImpl composeService) throws IOException {
         List<String> portsToExpose;
@@ -573,13 +575,16 @@ public class MachineProviderImpl implements MachineInstanceProvider {
             volumes = devMachineSystemVolumes;
 
             env = new HashMap<>(devMachineEnvVariables);
-            env.put(DockerInstanceRuntimeInfo.CHE_WORKSPACE_ID, workspaceId);
             env.put(DockerInstanceRuntimeInfo.USER_TOKEN, getUserToken(workspaceId));
         } else {
             portsToExpose = commonMachinePortsToExpose;
-            env = commonMachineEnvVariables;
+            env = new HashMap<>(commonMachineEnvVariables);
             volumes = commonMachineSystemVolumes;
         }
+        // register workspace ID and Machine Name
+        env.put(DockerInstanceRuntimeInfo.CHE_WORKSPACE_ID, workspaceId);
+        env.put(DockerInstanceRuntimeInfo.CHE_MACHINE_NAME, machineName);
+
         composeService.getExpose().addAll(portsToExpose);
         composeService.getEnvironment().putAll(env);
         composeService.getVolumes().addAll(volumes);

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
@@ -1074,6 +1074,18 @@ public class MachineProviderImplTest {
     }
 
     @Test
+    public void shouldAddMachineNameEnvVariableOnDevInstanceCreationFromRecipe() throws Exception {
+        String wsId = "myWs";
+        createInstanceFromRecipe(true, wsId);
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
+        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
+                           .contains(DockerInstanceRuntimeInfo.CHE_MACHINE_NAME + "=" + MACHINE_NAME),
+                   "Machine Name variable is missing. Required " + DockerInstanceRuntimeInfo.CHE_MACHINE_NAME + "=" +
+                   MACHINE_NAME +
+                   ". Found " + Arrays.toString(argumentCaptor.getValue().getContainerConfig().getEnv()));
+    }
+    @Test
     public void shouldAddWorkspaceIdEnvVariableOnDevInstanceCreationFromSnapshot() throws Exception {
         String wsId = "myWs";
         createInstanceFromSnapshot(true, wsId);
@@ -1087,14 +1099,14 @@ public class MachineProviderImplTest {
     }
 
     @Test
-    public void shouldNotAddWorkspaceIdEnvVariableOnNonDevInstanceCreationFromRecipe() throws Exception {
+    public void shouldAddWorkspaceIdEnvVariableOnNonDevInstanceCreationFromRecipe() throws Exception {
         String wsId = "myWs";
         createInstanceFromRecipe(false, wsId);
         ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
         verify(dockerConnector).createContainer(argumentCaptor.capture());
-        assertFalse(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
+        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
                             .contains(DockerInstanceRuntimeInfo.CHE_WORKSPACE_ID + "=" + wsId),
-                    "Non dev machine should not contains " + DockerInstanceRuntimeInfo.CHE_WORKSPACE_ID);
+                    "Non dev machine should contains " + DockerInstanceRuntimeInfo.CHE_WORKSPACE_ID);
     }
 
     @Test

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
@@ -1085,6 +1085,20 @@ public class MachineProviderImplTest {
                    MACHINE_NAME +
                    ". Found " + Arrays.toString(argumentCaptor.getValue().getContainerConfig().getEnv()));
     }
+
+    @Test
+    public void shouldAddMachineNameEnvVariableOnNonDevInstanceCreationFromRecipe() throws Exception {
+        String wsId = "myWs";
+        createInstanceFromRecipe(false, wsId);
+        ArgumentCaptor<CreateContainerParams> argumentCaptor = ArgumentCaptor.forClass(CreateContainerParams.class);
+        verify(dockerConnector).createContainer(argumentCaptor.capture());
+        assertTrue(asList(argumentCaptor.getValue().getContainerConfig().getEnv())
+                           .contains(DockerInstanceRuntimeInfo.CHE_MACHINE_NAME + "=" + MACHINE_NAME),
+                   "Machine Name variable is missing. Required " + DockerInstanceRuntimeInfo.CHE_MACHINE_NAME + "=" +
+                   MACHINE_NAME +
+                   ". Found " + Arrays.toString(argumentCaptor.getValue().getContainerConfig().getEnv()));
+    }
+
     @Test
     public void shouldAddWorkspaceIdEnvVariableOnDevInstanceCreationFromSnapshot() throws Exception {
         String wsId = "myWs";


### PR DESCRIPTION
it is required for single port /reverse proxy strategy
linked PR : https://github.com/eclipse/che/pull/4440

### What does this PR do?
Sets CHE_WORKSPACE_ID and CHE_MACHINE_NAME env var in all machines started by Che

### What issues does this PR fix or reference?
#4440 
#4361

#### Changelog
Sets CHE_WORKSPACE_ID and CHE_MACHINE_NAME env variables in all machines started by Che

#### Release Notes
Sets CHE_WORKSPACE_ID and CHE_MACHINE_NAME env variables in all machines started by Che


#### Docs PR
N/A

Change-Id: Ib2cb987e594929151de4c26b614b91d788d19869
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
