### PR TITLE
CHE-4516: Check command goal name uniqueness ignoring string case considerations on new goal creation

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/EditorMessages.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/EditorMessages.java
@@ -52,6 +52,9 @@ public interface EditorMessages extends Messages {
     @Key("page.goal.new_goal.button.create")
     String pageGoalNewGoalButtonCreate();
 
+    @Key("page.goal.new_goal.already_exists.message")
+    String pageGoalNewGoalAlreadyExistsMessage(String newGoalName);
+
     @Key("page.projects.title")
     String pageProjectsTitle();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/AbstractCommandEditorPage.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/AbstractCommandEditorPage.java
@@ -44,7 +44,7 @@ public abstract class AbstractCommandEditorPage implements CommandEditorPage {
     }
 
     /**
-     * This method is called every time when command is opening in the editor.
+     * Called every time when command is opening in the editor.
      * Typically, implementor should do initial setup of the page with the {@link #editedCommand}.
      */
     protected abstract void initialize();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/goal/GoalPage.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/goal/GoalPage.java
@@ -21,6 +21,7 @@ import org.eclipse.che.ide.command.editor.EditorMessages;
 import org.eclipse.che.ide.command.editor.page.AbstractCommandEditorPage;
 import org.eclipse.che.ide.command.editor.page.CommandEditorPage;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -60,13 +61,10 @@ public class GoalPage extends AbstractCommandEditorPage implements GoalPageView.
 
     @Override
     protected void initialize() {
-        final String goalId = editedCommand.getGoal();
-        final CommandGoal goal = goalRegistry.getGoalForId(goalId);
-
-        goalInitial = goal.getId();
+        goalInitial = editedCommand.getGoal();
 
         view.setAvailableGoals(goalRegistry.getAllGoals());
-        view.setGoal(goal.getId());
+        view.setGoal(goalInitial);
     }
 
     @Override
@@ -75,9 +73,7 @@ public class GoalPage extends AbstractCommandEditorPage implements GoalPageView.
             return false;
         }
 
-        CommandGoal goal = goalRegistry.getGoalForId(editedCommand.getGoal());
-
-        return !(goalInitial.equals(goal.getId()));
+        return !(goalInitial.equals(editedCommand.getGoal()));
     }
 
     @Override
@@ -88,24 +84,49 @@ public class GoalPage extends AbstractCommandEditorPage implements GoalPageView.
 
     @Override
     public void onCreateGoal() {
-        InputCallback inputCallback = value -> {
-            Set<CommandGoal> goals = goalRegistry.getAllGoals();
-            goals.add(goalRegistry.getGoalForId(value));
+        createGoal("");
+    }
 
-            view.setAvailableGoals(goals);
-            view.setGoal(value);
+    /** Asks user for the the new goal name nad creates it if another one with the same name doesn't exists. */
+    private void createGoal(String initialName) {
+        final InputCallback inputCallback = value -> {
+            final String newGoalName = value.trim();
 
-            editedCommand.setGoal(value);
-            notifyDirtyStateChanged();
+            final Set<CommandGoal> allGoals = goalRegistry.getAllGoals();
+
+            final Optional<CommandGoal> existingGoal = allGoals.stream()
+                                                               .filter(goal -> goal.getId().equalsIgnoreCase(newGoalName))
+                                                               .findAny();
+
+            if (existingGoal.isPresent()) {
+                dialogFactory.createMessageDialog(messages.pageGoalNewGoalTitle(),
+                                                  messages.pageGoalNewGoalAlreadyExistsMessage(existingGoal.get().getId()),
+                                                  () -> createGoal(newGoalName)).show();
+            } else {
+                setGoal(newGoalName);
+            }
         };
 
         dialogFactory.createInputDialog(messages.pageGoalNewGoalTitle(),
                                         messages.pageGoalNewGoalLabel(),
-                                        "",
+                                        initialName,
                                         0,
-                                        0,
+                                        initialName.length(),
                                         messages.pageGoalNewGoalButtonCreate(),
                                         inputCallback,
                                         null).show();
+    }
+
+    /** Set the specified goal name for the currently edited command. */
+    private void setGoal(String goalName) {
+        editedCommand.setGoal(goalName);
+
+        Set<CommandGoal> allGoals = goalRegistry.getAllGoals();
+        allGoals.add(goalRegistry.getGoalForId(goalName));
+
+        view.setAvailableGoals(allGoals);
+        view.setGoal(goalName);
+
+        notifyDirtyStateChanged();
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/goal/GoalPage.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/goal/GoalPage.java
@@ -37,7 +37,7 @@ public class GoalPage extends AbstractCommandEditorPage implements GoalPageView.
     private final DialogFactory       dialogFactory;
 
     /** Initial value of the command's goal. */
-    private String goalInitial;
+    private String initialGoal;
 
     @Inject
     public GoalPage(GoalPageView view,
@@ -61,10 +61,10 @@ public class GoalPage extends AbstractCommandEditorPage implements GoalPageView.
 
     @Override
     protected void initialize() {
-        goalInitial = editedCommand.getGoal();
+        initialGoal = editedCommand.getGoal();
 
         view.setAvailableGoals(goalRegistry.getAllGoals());
-        view.setGoal(goalInitial);
+        view.setGoal(initialGoal);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class GoalPage extends AbstractCommandEditorPage implements GoalPageView.
             return false;
         }
 
-        return !(goalInitial.equals(editedCommand.getGoal()));
+        return !(initialGoal.equals(editedCommand.getGoal()));
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/editor/EditorMessages.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/editor/EditorMessages.properties
@@ -23,6 +23,7 @@ page.goal.title=Goal
 page.goal.new_goal.title=New command goal
 page.goal.new_goal.label=Goal name:
 page.goal.new_goal.button.create=Create
+page.goal.new_goal.already_exists.message=Goal with name \"{0}\" already exists.
 
 page.projects.title=Apply to
 page.projects.table.header.project.label=Project

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/page/goal/GoalPageTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/page/goal/GoalPageTest.java
@@ -29,10 +29,6 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.eclipse.che.api.workspace.shared.Constants.COMMAND_GOAL_ATTRIBUTE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -75,10 +71,7 @@ public class GoalPageTest {
         when(goalRegistry.getGoalForId(anyString())).thenReturn(goal);
 
         when(editedCommand.getApplicableContext()).thenReturn(editedCommandApplicableContext);
-
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(COMMAND_GOAL_ATTRIBUTE_NAME, COMMAND_GOAL_ID);
-        when(editedCommand.getAttributes()).thenReturn(attributes);
+        when(editedCommand.getGoal()).thenReturn(COMMAND_GOAL_ID);
 
         page.setDirtyStateListener(dirtyStateListener);
         page.edit(editedCommand);
@@ -110,6 +103,7 @@ public class GoalPageTest {
 
     @Test
     public void shouldCreateGoal() throws Exception {
+        // given
         InputDialog inputDialog = mock(InputDialog.class);
         when(dialogFactory.createInputDialog(anyString(),
                                              anyString(),
@@ -121,8 +115,10 @@ public class GoalPageTest {
                                              any(CancelCallback.class))).thenReturn(inputDialog);
         String newGoalId = "new goal";
 
+        // when
         page.onCreateGoal();
 
+        // then
         ArgumentCaptor<InputCallback> inputCaptor = ArgumentCaptor.forClass(InputCallback.class);
         verify(dialogFactory).createInputDialog(anyString(),
                                                 anyString(),


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Since Commands Explorer displays all goals names in uppercase we need to check newly created goal name for uniqueness ignoring string case considerations in order to avoid situations like on this screenshot:
![image](https://cloud.githubusercontent.com/assets/1636395/24544851/89865f16-160d-11e7-8d72-9154e62bcbd4.png)

So this PR adds checking goal name uniqueness ignoring string case considerations on new goal creation.

Now user will be proposed to enter another goal's name:
![goal](https://cloud.githubusercontent.com/assets/1636395/24545626/87850cb4-1610-11e7-84fc-2b35148002ee.gif)

### What issues does this PR fix or reference?
#4516 

#### Changelog
Now all command goals names must be unique ignoring string case considerations.

#### Release Notes
N/A

#### Docs PR
N/A