### PR TITLE
CHE-158 Adding TLS support for Workspace routes

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -220,6 +220,10 @@ che.docker.ip.external=NULL
 # same single TCP port.
 che.docker.server_evaluation_strategy=default
 
+# NOTE: Property works only with 'single-port' strategy.
+# Specifies if external addresses need to be exposed against HTTPS
+che.docker.server_evaluation_strategy.secure.external.urls=false
+
 # Provides a Docker network where Che server is running.
 # Workspace containers created by Che will be added to this Docker network.
 # Communications between the Che server and container occur over this network.
@@ -294,6 +298,10 @@ che.openshift.liveness.probe.delay=300
 che.openshift.liveness.probe.timeout=1
 che.openshift.workspaces.pvc.name=claim-che-workspace
 che.openshift.workspaces.pvc.quantity=10Gi
+# Create secure route against HTTPS 
+# NOTE: In order to create routes against HTTPS 
+# Property 'strategy.che.docker.server_evaluation_strategy.secure.external.urls' should be also set to true
+che.openshift.secure.routes=false
 
 # Specifications of compute resources that can be consumed
 # by the workspace container:

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategy.java
@@ -70,4 +70,9 @@ public class DefaultServerEvaluationStrategy extends ServerEvaluationStrategy {
 
         return super.getExposedPortsToAddressPorts(externalAddress, containerInfo.getNetworkSettings().getPorts());
     }
+
+    @Override
+    protected boolean useHttpsForExternalUrls() {
+        return false;
+    }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
@@ -99,4 +99,9 @@ public class LocalDockerServerEvaluationStrategy extends ServerEvaluationStrateg
                         internalHost;
     }
 
+    @Override
+    protected boolean useHttpsForExternalUrls() {
+        return false;
+    }
+
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  * containers are running on the same Docker network and are exposed through the same single port.
  *
  * This server evaluation strategy will return a completed {@link ServerImpl} with internal addresses set
- * as {@link LocalDockerServerEvaluationStrategy} does. Contrarily external addresses will have the following format:
+ * as {@link LocalDockerServerEvaluationStrategy} does. Contrary external addresses will have the following format:
  *
  *       serverName.workspaceID.cheExternalAddress (e.g. terminal.79rfwhqaztq2ru2k.che.local)
  *
@@ -45,10 +45,19 @@ public class LocalDockerSinglePortServerEvaluationStrategy extends LocalDockerSe
 
     private static final String CHE_WORKSPACE_ID_ENV_VAR = "CHE_WORKSPACE_ID";
 
+    private boolean secureExternalUrls;
+
     @Inject
     public LocalDockerSinglePortServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
-                                                         @Nullable @Named("che.docker.ip.external") String externalAddress) {
+                                                         @Nullable @Named("che.docker.ip.external") String externalAddress,
+                                                         @Named("che.docker.server_evaluation_strategy.secure.external.urls") boolean secureExternalUrls) {
         super(internalAddress, externalAddress);
+        this.secureExternalUrls = secureExternalUrls;
+    }
+
+    @Override
+    protected boolean useHttpsForExternalUrls() {
+        return this.secureExternalUrls;
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
@@ -10,18 +10,18 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.machine;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.eclipse.che.api.core.model.machine.ServerProperties;
 import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.PortBinding;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a strategy for resolving Servers associated with workspace containers.
@@ -30,13 +30,22 @@ import java.util.Map;
  *
  * @author Angel Misevski <amisevsk@redhat.com>
  * @author Alexander Garagatyi
+ * @author Ilya Buziuk
  * @see ServerEvaluationStrategyProvider
  */
 public abstract class ServerEvaluationStrategy {
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
 
     protected static final String SERVER_CONF_LABEL_REF_KEY      = "che:server:%s:ref";
     protected static final String SERVER_CONF_LABEL_PROTOCOL_KEY = "che:server:%s:protocol";
     protected static final String SERVER_CONF_LABEL_PATH_KEY     = "che:server:%s:path";
+
+    
+    /**
+     * @return true if <strong>external</strong> addresses need to be exposed against https, false otherwise
+     */
+    protected abstract boolean useHttpsForExternalUrls();
 
     /**
      * Gets a map of all <strong>internal</strong> addresses exposed by the container in the form of
@@ -112,7 +121,11 @@ public abstract class ServerEvaluationStrategy {
             // Add protocol and path to internal/external address, if applicable
             String internalUrl = null;
             String externalUrl = null;
-            if (serverConf.getProtocol() != null) {
+
+            String internalProtocol = serverConf.getProtocol();
+            String externalProtocol = getProtocolForExternalUrl(internalProtocol);
+
+            if (internalProtocol != null) {
                 String pathSuffix = serverConf.getPath();
                 if (pathSuffix != null && !pathSuffix.isEmpty()) {
                     if (pathSuffix.charAt(0) != '/') {
@@ -121,8 +134,9 @@ public abstract class ServerEvaluationStrategy {
                 } else {
                     pathSuffix = "";
                 }
-                internalUrl = serverConf.getProtocol() + "://" + internalAddressAndPort + pathSuffix;
-                externalUrl = serverConf.getProtocol() + "://" + externalAddressAndPort + pathSuffix;
+
+                internalUrl = internalProtocol + "://" + internalAddressAndPort + pathSuffix;
+                externalUrl = externalProtocol + "://" + externalAddressAndPort + pathSuffix;
             }
 
             ServerProperties properties = new ServerPropertiesImpl(serverConf.getPath(),
@@ -130,7 +144,7 @@ public abstract class ServerEvaluationStrategy {
                                                                    internalUrl);
 
             servers.put(portProtocol, new ServerImpl(serverConf.getRef(),
-                                                     serverConf.getProtocol(),
+                                                     externalProtocol,
                                                      externalAddressAndPort,
                                                      externalUrl,
                                                      properties));
@@ -236,4 +250,16 @@ public abstract class ServerEvaluationStrategy {
         }
         return addressesAndPorts;
     }
+
+    /**
+     * @param protocolForInternalUrl
+     * @return https, if {@link #useHttpsForExternalUrls()} method in sub-class returns true and protocol for internal Url is http
+     */
+    private String getProtocolForExternalUrl(final String protocolForInternalUrl) {
+        if (useHttpsForExternalUrls() && HTTP.equals(protocolForInternalUrl)) {
+            return HTTPS;
+        }
+        return protocolForInternalUrl;
+    }
+
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategyTest.java
@@ -93,7 +93,7 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
     @Test
     public void shouldUseServerRefToBuildAddressWhenAvailable() throws Exception {
         // given
-        strategy = new LocalDockerSinglePortServerEvaluationStrategy(null, null);
+        strategy = new LocalDockerSinglePortServerEvaluationStrategy(null, null, false);
 
         final Map<String, ServerImpl> expectedServers = getExpectedServers(CHE_DOCKER_IP_EXTERNAL,
                                                                            CONTAINERCONFIG_HOSTNAME,

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategyTest.java
@@ -396,5 +396,10 @@ public class ServerEvaluationStrategyTest {
                                                                    String internalAddress) {
             return null;
         }
+
+        @Override
+        protected boolean useHttpsForExternalUrls() {
+            return false;
+        }
     }
 }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.openshift.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.openshift.api.model.DoneableRoute;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteFluent.SpecNested;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+public class OpenShiftRouteCreator {
+    private static final Logger LOG = LoggerFactory.getLogger(OpenShiftRouteCreator.class);
+    private static final String TLS_TERMINATION_EDGE = "edge";
+
+    public static void createRoute (final OpenShiftClient openShiftClient,
+                                    final String namespace,
+                                    final String workspaceName,
+                                    final String cheServerExternalAddress,
+                                    final String serverRef, 
+                                    final String serviceName,
+                                    final boolean enableTls) {
+
+        if (cheServerExternalAddress == null) {
+            throw new IllegalArgumentException("Property che.docker.ip.external must be set when using openshift.");
+        }
+
+        String routeName = generateRouteName(workspaceName, serverRef);
+        String serviceHost = generateRouteHost(workspaceName, serverRef, cheServerExternalAddress);
+
+           SpecNested<DoneableRoute> routeSpec = openShiftClient
+                .routes()
+                .inNamespace(namespace)
+                .createNew()
+                .withNewMetadata()
+                .withName(routeName)
+                .addToLabels(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, serviceName)
+                .endMetadata()
+                .withNewSpec()
+                .withHost(serviceHost)
+                .withNewTo()
+                    .withKind("Service")
+                    .withName(serviceName)
+                .endTo()
+                .withNewPort()
+                    .withNewTargetPort()
+                        .withStrVal(serverRef)
+                    .endTargetPort()
+                .endPort();
+
+        if (enableTls) {
+            routeSpec.withNewTls()
+                         .withTermination(TLS_TERMINATION_EDGE)
+                     .endTls();
+        }
+
+        Route route = routeSpec.endSpec().done();
+
+        LOG.info("OpenShift route {} created", route.getMetadata().getName());
+    }
+
+    private static String generateRouteName(final String workspaceName, final String serverRef) {
+        return OpenShiftConnector.CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceName + "." + serverRef;
+    }
+
+    private static String generateRouteHost(final String workspaceName, final String serverRef, final String cheServerExternalAddress) {
+        return serverRef + "." + workspaceName + "." + cheServerExternalAddress;
+    }
+
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -39,6 +39,8 @@ public class OpenShiftConnectorTest {
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE = "/projects";
     private static final String   CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS = "che.openshift.mini";
     private static final String   CHE_WORKSPACE_CPU_LIMIT = "1";
+    private static final boolean  SECURE_ROUTES = false;
+
 
     @Mock
     private DockerConnectorConfiguration       dockerConnectorConfiguration;
@@ -76,7 +78,8 @@ public class OpenShiftConnectorTest {
                                                     OPENSHIFT_DEFAULT_WORKSPACE_STORAGE,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE,
                                                     CHE_WORKSPACE_CPU_LIMIT,
-                                                    null);
+                                                    null,
+                                                    SECURE_ROUTES);
         String workspaceID = openShiftConnector.getCheWorkspaceId(createContainerParams);
 
         //Then


### PR DESCRIPTION
### What does this PR do?
Adding properties for possibility enabling secure external urls & OpenShift routes

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-158

## Steps to verify

1. Build che-server image and set `che.openshift.secure.routes` & `che.docker.server_evaluation_strategy.secure.external.urls` to true

2. Deploy che on minishift 

3. Make che-server route secure (enable https)
```

oc edit route/che-host

# Add the following line to the route description

tls:
    termination: edge 
```
4. Open Chrome / Chromium with `--ignore-certificate-errors` flag in order to avoid certificate issues - 
https://snag.gy/Ut6jrE.jpg
5. Create 'java' workspace (rhche/ubuntu_jdk8) 

Demo video - https://youtu.be/kr6paQgf5Wc
