### PR TITLE
Fix: Add Nullable parameter to che.docker.ip.external in OpenShiftConnector

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -303,4 +303,6 @@ che.openshift.workspace.memory.override=NULL
 # is necessary for deploying Che on OpenShift. Options:
 #     - 'default'   : Use DockerConnector
 #     - 'openshift' : use OpenShiftConnector
+# Note that if 'openshift' connector is used, the property che.docker.ip.external
+# MUST be set.
 che.docker.connector=default

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -178,7 +178,7 @@ public class OpenShiftConnector extends DockerConnector {
                               DockerConnectionFactory connectionFactory,
                               DockerRegistryAuthResolver authResolver,
                               DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider,
-                              @Named("che.docker.ip.external") String cheServerExternalAddress,
+                              @Nullable @Named("che.docker.ip.external") String cheServerExternalAddress,
                               @Named("che.openshift.project") String openShiftCheProjectName,
                               @Named("che.openshift.liveness.probe.delay") int openShiftLivenessProbeDelay,
                               @Named("che.openshift.liveness.probe.timeout") int openShiftLivenessProbeTimeout,
@@ -982,6 +982,9 @@ public class OpenShiftConnector extends DockerConnector {
                                       String workspaceName) {
 
         String routeName = CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceName + "." + serverRef;
+        if (cheServerExternalAddress == null) {
+            throw new IllegalArgumentException("Property che.docker.ip.external must be set when using openshift.");
+        }
         String serviceHost = serverRef + "." + workspaceName + "." + this.cheServerExternalAddress;
 
         Route route = openShiftClient


### PR DESCRIPTION
### What does this PR do?
The property che.docker.ip.external can be null, but OpenShiftConnector does not include the annotation. This prevents Che from initialising if e.g. running on docker without the property set.

#### Changelog
Add Nullable parameter to che.docker.ip.external in OpenShiftConnector
