### PR TITLE
[OpenShift] Adding property to set workspaces memory request on OpenShift

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -294,9 +294,21 @@ che.openshift.liveness.probe.delay=300
 che.openshift.liveness.probe.timeout=1
 che.openshift.workspaces.pvc.name=claim-che-workspace
 che.openshift.workspaces.pvc.quantity=10Gi
-che.openshift.workspace.cpu.limit=1
-# Override memory limit used for openshift workspaces. String, e.g. 1300Mi
+
+# Specifications of compute resources that can be consumed
+# by the workspace container:
+#
+# - Amount of memory required for a workspace container to run e.g. 512Mi
+che.openshift.workspace.memory.request=NULL
+#
+# - Maximum amount of memory a workspace container can use e.g. 1.3Gi
 che.openshift.workspace.memory.override=NULL
+#
+# Be aware that setting che.openshift.workspace.memory.override
+# will override Che memory limits
+#
+# More information about setting Compute Resources in OpenShift can be
+# found here: https://docs.openshift.org/latest/dev_guide/compute_resources.html#dev-compute-resources
 
 # Which implementation of DockerConnector to use in managing containers. In general,
 # the base implementation of DockerConnector is appropriate, but OpenShiftConnector

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -170,8 +170,8 @@ public class OpenShiftConnector extends DockerConnector {
     private final String          cheWorkspaceStorage;
     private final String          cheWorkspaceProjectsStorage;
     private final String          cheServerExternalAddress;
-    private final String          cheWorkspaceCpuLimit;
-    private final String          cheWorkspaceMemory;
+    private final String          cheWorkspaceMemoryLimit;
+    private final String          cheWorkspaceMemoryRequest;
 
     @Inject
     public OpenShiftConnector(DockerConnectorConfiguration connectorConfiguration,
@@ -186,8 +186,8 @@ public class OpenShiftConnector extends DockerConnector {
                               @Named("che.openshift.workspaces.pvc.quantity") String workspacesPvcQuantity,
                               @Named("che.workspace.storage") String cheWorkspaceStorage,
                               @Named("che.workspace.projects.storage") String cheWorkspaceProjectsStorage,
-                              @Named("che.openshift.workspace.cpu.limit") String cheWorkspaceCpuLimit,
-                              @Nullable @Named("che.openshift.workspace.memory.override") String cheWorkspaceMemory) {
+                              @Nullable @Named("che.openshift.workspace.memory.request") String cheWorkspaceMemoryRequest,
+                              @Nullable @Named("che.openshift.workspace.memory.override") String cheWorkspaceMemoryLimit) {
 
 
         super(connectorConfiguration, connectionFactory, authResolver, dockerApiVersionPathPrefixProvider);
@@ -199,8 +199,8 @@ public class OpenShiftConnector extends DockerConnector {
         this.workspacesPvcQuantity = workspacesPvcQuantity;
         this.cheWorkspaceStorage = cheWorkspaceStorage;
         this.cheWorkspaceProjectsStorage = cheWorkspaceProjectsStorage;
-        this.cheWorkspaceCpuLimit = cheWorkspaceCpuLimit;
-        this.cheWorkspaceMemory = cheWorkspaceMemory;
+        this.cheWorkspaceMemoryRequest = cheWorkspaceMemoryRequest;
+        this.cheWorkspaceMemoryLimit = cheWorkspaceMemoryLimit;
 
         this.openShiftClient = new DefaultOpenShiftClient();
     }
@@ -260,19 +260,22 @@ public class OpenShiftConnector extends DockerConnector {
 
         Map<String, String> additionalLabels = createContainerParams.getContainerConfig().getLabels();
 
-        String memoryLimit;
-        if (!isNullOrEmpty(cheWorkspaceMemory)) {
+        Map<String, Quantity> resourceLimits = new HashMap<>();
+        if (!isNullOrEmpty(cheWorkspaceMemoryLimit)) {
             LOG.info("Che property 'che.openshift.workspace.memory.override' "
-                   + "used to override workspace memory limit to {}.", cheWorkspaceMemory);
-            memoryLimit = cheWorkspaceMemory;
+                   + "used to override workspace memory limit to {}.", cheWorkspaceMemoryLimit);
+            resourceLimits.put("memory", new Quantity(cheWorkspaceMemoryLimit));
         } else {
             long memoryLimitBytes = createContainerParams.getContainerConfig().getHostConfig().getMemory();
-            memoryLimit = Long.toString(memoryLimitBytes / 1048576) + "Mi";
+            String memoryLimit = Long.toString(memoryLimitBytes / 1048576) + "Mi";
             LOG.info("Creating workspace pod with memory limit of {}.", memoryLimit);
+            resourceLimits.put("memory", new Quantity(cheWorkspaceMemoryLimit));
         }
-        Map<String, Quantity> resourceLimits = new HashMap<>();
-        resourceLimits.put("memory", new Quantity(memoryLimit));
-        resourceLimits.put("cpu", new Quantity(cheWorkspaceCpuLimit));
+
+        Map<String, Quantity> resourceRequests = new HashMap<>();
+        if (!isNullOrEmpty(cheWorkspaceMemoryRequest)) {
+            resourceRequests.put("memory", new Quantity(cheWorkspaceMemoryRequest));
+        }
 
         String containerID;
         try {
@@ -283,7 +286,8 @@ public class OpenShiftConnector extends DockerConnector {
                                                               exposedPorts,
                                                               envVariables,
                                                               volumes,
-                                                              resourceLimits);
+                                                              resourceLimits,
+                                                              resourceRequests);
 
             containerID = waitAndRetrieveContainerID(deploymentName);
             if (containerID == null) {
@@ -1015,7 +1019,8 @@ public class OpenShiftConnector extends DockerConnector {
                                              Set<String> exposedPorts,
                                              String[] envVariables,
                                              String[] volumes,
-                                             Map<String, Quantity> resourceLimits) {
+                                             Map<String, Quantity> resourceLimits,
+                                             Map<String, Quantity> resourceRequests) {
 
         String deploymentName = CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceID;
         LOG.info("Creating OpenShift deployment {}", deploymentName);
@@ -1044,8 +1049,8 @@ public class OpenShiftConnector extends DockerConnector {
                                                                       selector,
                                                                       command,
                                                                       false,
-                                                                      resourceLimits);
-
+                                                                      resourceLimits,
+                                                                      resourceRequests);
             try {
                 waitAndRetrieveContainerID(deploymentName);
             } catch (IOException e) {
@@ -1070,7 +1075,8 @@ public class OpenShiftConnector extends DockerConnector {
                                                        selector,
                                                        null,
                                                        true,
-                                                       resourceLimits);
+                                                       resourceLimits,
+                                                       resourceRequests);
         LOG.info("OpenShift deployment {} created", deploymentName);
         return deployment.getMetadata().getName();
     }
@@ -1107,7 +1113,8 @@ public class OpenShiftConnector extends DockerConnector {
                                                          String> selector,
                                                          String[] command,
                                                          boolean withSubpath,
-                                                         Map<String, Quantity> resourceLimits) {
+                                                         Map<String, Quantity> resourceLimits,
+                                                         Map<String, Quantity> resourceRequests) {
 
         Container container = new ContainerBuilder()
                                     .withName(sanitizedContainerName)
@@ -1123,6 +1130,7 @@ public class OpenShiftConnector extends DockerConnector {
                                     .withVolumeMounts(getVolumeMountsFrom(volumes, workspaceID, withSubpath))
                                     .withNewResources()
                                         .withLimits(resourceLimits)
+                                        .withRequests(resourceRequests)
                                     .endResources()
                                     .build();
 


### PR DESCRIPTION
Adding a new property `che.openshift.workspace.memory.request`. If this property is set it will be used in the spec of the workspace containers ([c.f. OpenShift documentation on memory requests](https://docs.openshift.com/enterprise/3.2/dev_guide/compute_resources.html#dev-memory-requests)).

This fixes "Insufficient memory" problem we currently have on Minishift.

#### Changelog
Adding property to set workspaces memory request on OpenShift 