### PR TITLE
CHE-4628: shrink machine and command names in processes list when text is too long

### DIFF
--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/toolbar/processes/styles.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/toolbar/processes/styles.css
@@ -45,12 +45,18 @@
 .processWidgetMachineNameLabel {
     float: left;
     color: #a3a3a3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: literal("calc(100% - 50px)");
 }
 
 .processWidgetCommandNameLabel {
     float: left;
     color: #e3e3e3;
     font-weight: bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: literal("calc(100% - 200px)");
 }
 
 .processWidgetPidLabel {

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/menu/menu.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/menu/menu.css
@@ -81,6 +81,7 @@
 }
 
 .rightPanel {
+    min-width: 0;
     width: 100%;
     float: left;
     height: inherit;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes bug with displaying command's name in Processes list when text is too long.

Before bugfix:
![1](https://cloud.githubusercontent.com/assets/1636395/24615820/0309503c-1898-11e7-8560-a88b9a1ec262.png)

After bugfix:
![2](https://cloud.githubusercontent.com/assets/1636395/24615825/058caee4-1898-11e7-953d-f60357305a4a.png)

### What issues does this PR fix or reference?
#4628 

#### Changelog
Fixed bug with displaying command's name in Processes list when text is too long

#### Release Notes
bugfix N/A

#### Docs PR
bugfix N/A