### PR TITLE
CHE-3408: fix problem with getting subpackages from the project root

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/main/java/org/eclipse/che/plugin/java/server/JavaNavigation.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/main/java/org/eclipse/che/plugin/java/server/JavaNavigation.java
@@ -843,7 +843,7 @@ public class JavaNavigation {
     }
 
     private List<PackageFragmentRoot> toPackageRoots(IJavaProject javaProject, boolean includePackages) throws JavaModelException {
-        IPackageFragmentRoot[] packageFragmentRoots = javaProject.getPackageFragmentRoots();
+        IPackageFragmentRoot[] packageFragmentRoots = javaProject.getAllPackageFragmentRoots();
         List<PackageFragmentRoot> result = new ArrayList<>();
         for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
             if (packageFragmentRoot.getKind() == IPackageFragmentRoot.K_SOURCE &&


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix a problem with getting subpackages from the project root for building project structure by using classpath.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3408

#### Changelog
Fix a problem with getting subpackages for java projects

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
