### PR TITLE
NPE in FileWatcherService

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileTreeWalker.java
@@ -21,6 +21,7 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
@@ -126,6 +127,8 @@ public class FileTreeWalker {
                 }
             });
             LOG.debug("Tree walk finished");
+        } catch (NoSuchFileException e) {
+            LOG.debug("Trying to process a file, however seems like it is already not present: {}", e.getMessage());
         } catch (Exception e) {
             LOG.error("Error while walking file tree", e);
         }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixed NPE in file watcher service and tree file walker. Exceptions happen because of processing of stale file descriptors, in other words in this case we try to process already removed files. This mostly happens on massive file move/remove operations and normally should be ignored.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4507

#### Changelog
Fixed NPE in file watcher service that appeared to happen in some rare cases
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
