### PR TITLE
Deprecate some FactoryService methods related to factory button 

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -139,6 +139,10 @@ public class FactoryService extends Service {
         this.factoryParametersResolvers = factoryParametersResolverHolder.getFactoryParametersResolvers();
     }
 
+    /**
+     * @deprecated this is a legacy method for functionality that is no longer exists.
+     * use {@link #saveFactory(FactoryDto)}
+     */
     @POST
     @Consumes(MULTIPART_FORM_DATA)
     @Produces(APPLICATION_JSON)
@@ -149,6 +153,7 @@ public class FactoryService extends Service {
                    @ApiResponse(code = 403, message = "The user does not have rights to create factory"),
                    @ApiResponse(code = 409, message = "When factory with given name and creator already exists"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
+    @Deprecated
     public FactoryDto saveFactory(Iterator<FileItem> formData) throws ForbiddenException,
                                                                       ConflictException,
                                                                       BadRequestException,
@@ -327,6 +332,10 @@ public class FactoryService extends Service {
         factoryManager.removeFactory(id);
     }
 
+    /**
+     * @deprecated this is a legacy method for functionality that is no longer exists.
+     * There is no alternative for this method.
+     */
     @GET
     @Path("/{id}/image")
     @Produces("image/*")
@@ -336,6 +345,7 @@ public class FactoryService extends Service {
                    @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
                    @ApiResponse(code = 404, message = "Factory or factory image not found"),
                    @ApiResponse(code = 500, message = "Internal server error")})
+    @Deprecated
     public Response getImage(@ApiParam(value = "Factory identifier")
                              @PathParam("id")
                              String factoryId,
@@ -360,6 +370,10 @@ public class FactoryService extends Service {
         return Response.ok(image.getImageData(), image.getMediaType()).build();
     }
 
+    /**
+     * @deprecated this is a legacy method for functionality that is no longer exists.
+     * There is no alternative for this method.
+     */
     @GET
     @Path("/{id}/snippet")
     @Produces(TEXT_PLAIN)
@@ -369,6 +383,7 @@ public class FactoryService extends Service {
                    @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
                    @ApiResponse(code = 404, message = "Factory or factory snippet not found"),
                    @ApiResponse(code = 500, message = "Internal server error")})
+    @Deprecated
     public String getFactorySnippet(@ApiParam(value = "Factory identifier")
                                     @PathParam("id")
                                     String factoryId,


### PR DESCRIPTION
### What does this PR do?
Deprecate FactoryService methods related to factory button 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4501

#### Changelog
Methods related to factory button functionality in FactoryService become deprecated
#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
