### PR TITLE
Fix few warn during GWT compilation

### DIFF
--- a/ide/che-core-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/orion-codenvy-theme.css
+++ b/ide/che-core-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/orion-codenvy-theme.css
@@ -134,7 +134,7 @@
     margin-left: 0px;
     border: 1px solid rgba(188, 195, 199, 0.2);
     position: absolute;
-    width: literal(calc(100% - 0px));
+    width: literal("calc(100% - 0px)");
     border-radius: 3px;
     z-index: 100;
     box-sizing: border-box;


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>

### What does this PR do?
During compilation got warning in console output:
```
Computing all possible rebind results for 'org.eclipse.che.ide.editor.orion.client.OrionResource'
       Rebinding org.eclipse.che.ide.editor.orion.client.OrionResource
          Invoking generator com.google.gwt.resources.rebind.context.InlineClientBundleGenerator
             Preparing method editorStyle
                The following problems were detected
                   [WARN] Line 137 column 30: encountered " ". Was expecting one of: <NUMBER> <PERCENTAGE> <PT> <MM> <CM> <PC> <IN> <PX> <EMS> <EXS> <DEG> <RAD> <GRAD> <MS> <SECOND> <HZ> <KHZ> <DIMEN> <FUNCTION>

```

this PR fix it

#### Changelog
Fix few warn during GWT compilation

#### Release Notes
N/A


