### PR TITLE
CHE-4590: adopt the commands toolbar and command editor for the light theme

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Style.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Style.java
@@ -43,8 +43,76 @@ public class Style {
         return theme.getDisabledMenuColor();
     }
 
+    public static String getCommandsToolbarBackgroundColor() {
+        return theme.getCommandsToolbarBackgroundColor();
+    }
+
+    public static String getCommandsToolbarProcessesLabelBackground() {
+        return theme.getCommandsToolbarProcessesLabelBackground();
+    }
+
+    public static String getCommandsToolbarProcessesLabelBorder() {
+        return theme.getCommandsToolbarProcessesLabelBorder();
+    }
+
+    public static String getCommandsToolbarMachineNameColor() {
+        return theme.getCommandsToolbarMachineNameColor();
+    }
+
+    public static String getCommandsToolbarCommandNameColor() {
+        return theme.getCommandsToolbarCommandNameColor();
+    }
+
+    public static String getCommandEditorProjectsTableHeaderColor() {
+        return theme.getCommandEditorProjectsTableHeaderColor();
+    }
+
+    public static String getCommandEditorProjectsTableRowColor() {
+        return theme.getCommandEditorProjectsTableRowColor();
+    }
+
+    public static String getCommandEditorProjectSwitcherBorder() {
+        return theme.getCommandEditorProjectSwitcherBorder();
+    }
+
     public static String getDialogContentBackground() {
         return theme.getDialogContentBackground();
+    }
+
+    public static String getDropdownListBackground() {
+        return theme.getDropdownListBackground();
+    }
+
+    public static String getHoveredDropdownListBackground() {
+        return theme.getHoveredDropdownListBackground();
+    }
+
+    public static String getActiveDropdownListBackground() {
+        return theme.getActiveDropdownListBackground();
+    }
+
+    public static String getDropdownListBorder() {
+        return theme.getDropdownListBorder();
+    }
+
+    public static String getDropdownListButtonColor() {
+        return theme.getDropdownListButtonColor();
+    }
+
+    public static String getMenuButtonBackground() {
+        return theme.getMenuButtonBackground();
+    }
+
+    public static String getHoveredMenuButtonBackground() {
+        return theme.getHoveredMenuButtonBackground();
+    }
+
+    public static String getActiveMenuButtonBackground() {
+        return theme.getActiveMenuButtonBackground();
+    }
+
+    public static String getActiveMenuButtonBorder() {
+        return theme.getMenuButtonBorder();
     }
 
     public static String getButtonBackground() {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Theme.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Theme.java
@@ -265,12 +265,63 @@ public interface Theme {
      */
     String getDisabledMenuColor();
 
+    /** Background color of the Commands toolbar. */
+    String getCommandsToolbarBackgroundColor();
+
+    /** Background of the Processes list's label on the Commands toolbar. */
+    String getCommandsToolbarProcessesLabelBackground();
+
+    /** Border of the Processes list's label on the Commands toolbar. */
+    String getCommandsToolbarProcessesLabelBorder();
+
+    /** Color of the machine name label on the Commands toolbar. */
+    String getCommandsToolbarMachineNameColor();
+
+    /** Color of the command name label on the Commands toolbar. */
+    String getCommandsToolbarCommandNameColor();
+
+    /** Color of the projects table's header in the command editor. */
+    String getCommandEditorProjectsTableHeaderColor();
+
+    /** Color of the projects table's row in the command editor. */
+    String getCommandEditorProjectsTableRowColor();
+
+    /** Border of the project switcher in the command editor. */
+    String getCommandEditorProjectSwitcherBorder();
+
     /**
      * Background color of the {@link com.google.gwt.user.client.ui.DialogBox}
      *
      * @return the color
      */
     String getDialogContentBackground();
+
+    /** Background of the DropdownList widget. */
+    String getDropdownListBackground();
+
+    /** Background of the hovered DropdownList widget. */
+    String getHoveredDropdownListBackground();
+
+    /** Background of the active DropdownList widget. */
+    String getActiveDropdownListBackground();
+
+    /** Border of the DropdownList widget. */
+    String getDropdownListBorder();
+
+    /** Color of the button for opening DropdownList. */
+    String getDropdownListButtonColor();
+
+    /** Background of the MenuButton widget. */
+    String getMenuButtonBackground();
+
+    /** Background of the hovered MenuButton widget. */
+    String getHoveredMenuButtonBackground();
+
+    /** Background of the active MenuButton widget. */
+    String getActiveMenuButtonBackground();
+
+    /** Border of the MenuButton widget. */
+    String getMenuButtonBorder();
 
     /**
      * Background color of default button.

--- a/ide/che-core-ide-api/src/main/resources/org/eclipse/che/ide/api/ui/style.css
+++ b/ide/che-core-ide-api/src/main/resources/org/eclipse/che/ide/api/ui/style.css
@@ -232,6 +232,18 @@
 @eval radioButtonBackgroundColor org.eclipse.che.ide.api.theme.Style.getRadioButtonBackgroundColor();
 @eval disabledMenuItemColor org.eclipse.che.ide.api.theme.Style.getDeisabledMenuColor();
 
+/*Commands toolbar*/
+@eval commandsToolbarBackgroundColor org.eclipse.che.ide.api.theme.Style.getCommandsToolbarBackgroundColor();
+@eval commandsToolbarProcessesLabelBackground org.eclipse.che.ide.api.theme.Style.getCommandsToolbarProcessesLabelBackground();
+@eval commandsToolbarProcessesLabelBorder org.eclipse.che.ide.api.theme.Style.getCommandsToolbarProcessesLabelBorder();
+@eval commandsToolbarMachineNameColor org.eclipse.che.ide.api.theme.Style.getCommandsToolbarMachineNameColor();
+@eval commandsToolbarCommandNameColor org.eclipse.che.ide.api.theme.Style.getCommandsToolbarCommandNameColor();
+
+/*Commands editor*/
+@eval commandEditorProjectsTableHeaderColor org.eclipse.che.ide.api.theme.Style.getCommandEditorProjectsTableHeaderColor();
+@eval commandEditorProjectsTableRowColor org.eclipse.che.ide.api.theme.Style.getCommandEditorProjectsTableRowColor();
+@eval commandEditorProjectSwitcherBorder org.eclipse.che.ide.api.theme.Style.getCommandEditorProjectSwitcherBorder();
+
 /*Icons colors*/
 @eval blueIconColor org.eclipse.che.ide.api.theme.Style.theme.getBlueIconColor();
 @eval redIconColor org.eclipse.che.ide.api.theme.Style.theme.getRedIconColor();
@@ -269,6 +281,19 @@
 @eval dialogBottomCenter org.eclipse.che.ide.api.theme.Style.theme.tabBorderColor();
 @eval dialogBottomRight org.eclipse.che.ide.api.theme.Style.theme.tabBorderColor();
 @eval dialogContentBackground org.eclipse.che.ide.api.theme.Style.getDialogContentBackground();
+
+/*DropdownList*/
+@eval dropdownListBackground org.eclipse.che.ide.api.theme.Style.getDropdownListBackground();
+@eval hoveredDropdownListBackground org.eclipse.che.ide.api.theme.Style.getHoveredDropdownListBackground();
+@eval activeDropdownListBackground org.eclipse.che.ide.api.theme.Style.getActiveDropdownListBackground();
+@eval dropdownListBorder org.eclipse.che.ide.api.theme.Style.getDropdownListBorder();
+@eval dropdownListButtonColor org.eclipse.che.ide.api.theme.Style.getDropdownListButtonColor();
+
+/*MenuButton*/
+@eval menuButtonBackground org.eclipse.che.ide.api.theme.Style.getMenuButtonBackground();
+@eval hoveredMenuButtonBackground org.eclipse.che.ide.api.theme.Style.getHoveredMenuButtonBackground();
+@eval activeMenuButtonBackground org.eclipse.che.ide.api.theme.Style.getActiveMenuButtonBackground();
+@eval menuButtonBorder org.eclipse.che.ide.api.theme.Style.getActiveMenuButtonBorder();
 
 /*Window*/
 @eval windowContentBackground org.eclipse.che.ide.api.theme.Style.getWindowContentBackground();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/project/ProjectSwitcher.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/project/ProjectSwitcher.ui.xml
@@ -17,8 +17,11 @@
              xmlns:che='urn:import:org.eclipse.che.ide.ui.switcher'>
 
     <ui:style>
+        @eval commandEditorProjectsTableRowColor org.eclipse.che.ide.api.theme.Style.getCommandEditorProjectsTableRowColor();
+        @eval commandEditorProjectSwitcherBorder org.eclipse.che.ide.api.theme.Style.getCommandEditorProjectSwitcherBorder();
+
         .panel {
-            background-color: #3D4650;
+            background-color: commandEditorProjectsTableRowColor;
             padding: 5px 0 5px 0;
         }
 
@@ -32,6 +35,7 @@
             display: inline-block;
             margin-left: 10px;
             vertical-align: middle;
+            border: commandEditorProjectSwitcherBorder;
         }
     </ui:style>
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/project/ProjectsPageViewImpl.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/project/ProjectsPageViewImpl.ui.xml
@@ -17,13 +17,14 @@
     <ui:with field='messages' type='org.eclipse.che.ide.command.editor.EditorMessages'/>
     <ui:style>
         @eval textFieldBorderColor org.eclipse.che.ide.api.theme.Style.theme.toolButtonActiveBorder();
+        @eval commandEditorProjectsTableHeaderColor org.eclipse.che.ide.api.theme.Style.getCommandEditorProjectsTableHeaderColor();
 
         .table {
             border: textFieldBorderColor;
         }
 
         .table-header {
-            background-color: #2E353B;
+            background-color: commandEditorProjectsTableHeaderColor;
         }
 
         .column-header {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MainMenuViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MainMenuViewImpl.java
@@ -108,6 +108,7 @@ public class MainMenuViewImpl extends Composite implements MainMenuView, CloseMe
         final DivElement triangleSeparator = Elements.createDivElement(resources.menuCss().triangleSeparator());
 
         rightPanel.addStyleName(resources.menuCss().rightPanel());
+        rightPanel.addStyleName(resources.menuCss().commandToolbar());
 
         rootPanel.add(leftPanel);
         rootPanel.add(table);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MenuResources.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MenuResources.java
@@ -37,6 +37,8 @@ public interface MenuResources extends ClientBundle {
 
         String rightPanel();
 
+        String commandToolbar();
+
         String customComponent();
 
         String panelSeparator();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
@@ -222,8 +222,93 @@ public class DarkTheme implements Theme {
     }
 
     @Override
+    public String getCommandsToolbarBackgroundColor() {
+        return "#000000";
+    }
+
+    @Override
+    public String getCommandsToolbarProcessesLabelBackground() {
+        return "linear-gradient(to bottom, #292929, #131313)";
+    }
+
+    @Override
+    public String getCommandsToolbarProcessesLabelBorder() {
+        return "solid 0.6px #454545";
+    }
+
+    @Override
+    public String getCommandsToolbarMachineNameColor() {
+        return "#a3a3a3";
+    }
+
+    @Override
+    public String getCommandsToolbarCommandNameColor() {
+        return "#e3e3e3";
+    }
+
+    @Override
+    public String getCommandEditorProjectsTableHeaderColor() {
+        return "#2E353B";
+    }
+
+    @Override
+    public String getCommandEditorProjectsTableRowColor() {
+        return "#3D4650";
+    }
+
+    @Override
+    public String getCommandEditorProjectSwitcherBorder() {
+        return "none";
+    }
+
+    @Override
     public String getDialogContentBackground() {
         return "#656565";
+    }
+
+    @Override
+    public String getDropdownListBackground() {
+        return "linear-gradient(to bottom, #444444, #343434 98%)";
+    }
+
+    @Override
+    public String getHoveredDropdownListBackground() {
+        return "linear-gradient(to bottom, #3d3d3d, #1d1d1d 98%)";
+    }
+
+    @Override
+    public String getActiveDropdownListBackground() {
+        return "linear-gradient(to bottom, #3d3d3d, #1d1d1d)";
+    }
+
+    @Override
+    public String getDropdownListBorder() {
+        return "solid 0.6px #454545";
+    }
+
+    @Override
+    public String getDropdownListButtonColor() {
+        return "#e4e4e4";
+    }
+
+    @Override
+    public String getMenuButtonBackground() {
+        return "linear-gradient(to bottom, #444444, #343434 98%)";
+    }
+
+    @Override
+    public String getHoveredMenuButtonBackground() {
+        return "linear-gradient(to bottom, #3d3d3d, #1d1d1d 98%)";
+    }
+
+    @Override
+    public String getActiveMenuButtonBackground() {
+        return "linear-gradient(to bottom, #3d3d3d, #1d1d1d)";
+    }
+
+    @Override
+    public String getMenuButtonBorder() {
+        return "solid 0.6px #454545";
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/LightTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/LightTheme.java
@@ -203,8 +203,93 @@ public class LightTheme implements Theme {
     }
 
     @Override
+    public String getCommandsToolbarBackgroundColor() {
+        return "#bcbdbf";
+    }
+
+    @Override
+    public String getCommandsToolbarProcessesLabelBackground() {
+        return "#d0d0d0";
+    }
+
+    @Override
+    public String getCommandsToolbarProcessesLabelBorder() {
+        return "solid 0.6px #818181";
+    }
+
+    @Override
+    public String getCommandsToolbarMachineNameColor() {
+        return "#737373";
+    }
+
+    @Override
+    public String getCommandsToolbarCommandNameColor() {
+        return "#737373";
+    }
+
+    @Override
+    public String getCommandEditorProjectsTableHeaderColor() {
+        return "#ddd";
+    }
+
+    @Override
+    public String getCommandEditorProjectsTableRowColor() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getCommandEditorProjectSwitcherBorder() {
+        return "solid 1px #979797";
+    }
+
+    @Override
     public String getDialogContentBackground() {
         return "#FFFFFF";
+    }
+
+    @Override
+    public String getDropdownListBackground() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getHoveredDropdownListBackground() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getActiveDropdownListBackground() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getDropdownListBorder() {
+        return "solid 0.6px #818181";
+    }
+
+    @Override
+    public String getDropdownListButtonColor() {
+        return "#737373";
+    }
+
+    @Override
+    public String getMenuButtonBackground() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getHoveredMenuButtonBackground() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getActiveMenuButtonBackground() {
+        return "#ffffff";
+    }
+
+    @Override
+    public String getMenuButtonBorder() {
+        return "solid 0.6px #818181";
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/toolbar/processes/styles.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/toolbar/processes/styles.css
@@ -16,10 +16,9 @@
 
 .processesListLabel {
     float: left;
-    background-color: #1d1d1d;
-    border-left: solid 0.6px #454545;
-    border-top: solid 0.6px #454545;
-    border-bottom: solid 0.6px #454545;
+    border-left: commandsToolbarProcessesLabelBorder;
+    border-top: commandsToolbarProcessesLabelBorder;
+    border-bottom: commandsToolbarProcessesLabelBorder;
     border-right: 0;
     font-family: mainFontFamily;
     font-size: 9px;
@@ -31,7 +30,7 @@
     width: 44px;
     height: 22px;
     line-height: 22px;
-    background-image: linear-gradient(to bottom, #292929, #131313);
+    background: commandsToolbarProcessesLabelBackground;
     cursor: default;
 }
 
@@ -44,7 +43,7 @@
 
 .processWidgetMachineNameLabel {
     float: left;
-    color: #a3a3a3;
+    color: commandsToolbarMachineNameColor;
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: literal("calc(100% - 50px)");
@@ -52,7 +51,7 @@
 
 .processWidgetCommandNameLabel {
     float: left;
-    color: #e3e3e3;
+    color: commandsToolbarCommandNameColor;
     font-weight: bold;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/menu/menu.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/menu/menu.css
@@ -77,7 +77,7 @@
     width: 0;
     height: 0;
     border-bottom: 34px solid mainMenuBkgColor;
-    border-right: 25px solid transparent;
+    border-right: 25px solid commandsToolbarBackgroundColor;
 }
 
 .rightPanel {
@@ -86,6 +86,10 @@
     float: left;
     height: inherit;
     white-space: nowrap;
+}
+
+.commandToolbar {
+    background-color: commandsToolbarBackgroundColor;
 }
 
 .customComponent {

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dropdown/DropdownList.ui.xml
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dropdown/DropdownList.ui.xml
@@ -14,26 +14,28 @@
              xmlns:g='urn:import:com.google.gwt.user.client.ui'>
 
     <ui:style>
-        @eval selectCommandActionColor org.eclipse.che.ide.api.theme.Style.getSelectCommandActionColor();
-        @eval selectCommandActionHoverColor org.eclipse.che.ide.api.theme.Style.getSelectCommandActionHoverColor();
+        @eval dropdownListBackground org.eclipse.che.ide.api.theme.Style.getDropdownListBackground();
+        @eval hoveredDropdownListBackground org.eclipse.che.ide.api.theme.Style.getHoveredDropdownListBackground();
+        @eval activeDropdownListBackground org.eclipse.che.ide.api.theme.Style.getActiveDropdownListBackground();
+        @eval dropdownListBorder org.eclipse.che.ide.api.theme.Style.getDropdownListBorder();
+        @eval dropdownListButtonColor org.eclipse.che.ide.api.theme.Style.getDropdownListButtonColor();
 
         .widget {
             height: 22px;
             display: inline-block;
             cursor: pointer;
-            background-color: #33373b;
-            background-image: linear-gradient(to bottom, #444444, #343434 98%);
-            border: solid 0.6px #454545;
+            background: dropdownListBackground;
+            border: dropdownListBorder;
         }
 
         .widget:hover {
             color: #53a2ff;
-            background-image: linear-gradient(to bottom, #3d3d3d, #1d1d1d 98%);
+            background: hoveredDropdownListBackground;
         }
 
         .widget:active {
             color: #235c9e;
-            background-image: linear-gradient(to bottom, #3d3d3d, #1d1d1d);
+            background: activeDropdownListBackground;
         }
 
         .selectedItemPanel {
@@ -57,11 +59,7 @@
         .dropButton svg {
             width: 10px;
             height: 7px;
-            fill: selectCommandActionColor;
-        }
-
-        .dropButton:hover svg {
-            fill: selectCommandActionHoverColor;
+            fill: dropdownListButtonColor;
         }
     </ui:style>
 

--- a/ide/che-core-ide-ui/src/main/resources/org/eclipse/che/ide/ui/menubutton/button.css
+++ b/ide/che-core-ide-ui/src/main/resources/org/eclipse/che/ide/ui/menubutton/button.css
@@ -12,8 +12,8 @@
     width: 32px;
     height: 22px;
     color: #4990e2;
-    background-image: linear-gradient(to bottom, #444444, #343434 98%);
-    border: solid 0.6px #454545;
+    background: menuButtonBackground;
+    border: menuButtonBorder;
     font-size: 17px;
     font-weight: normal;
     font-style: normal;
@@ -28,18 +28,19 @@
 
 .button:hover {
     color: #53a2ff;
-    background-image: linear-gradient(to bottom, #3d3d3d, #1d1d1d 98%);
+    background: hoveredMenuButtonBackground;
 }
 
 .button:active {
     color: #235c9e;
-    background-image: linear-gradient(to bottom, #3d3d3d, #1d1d1d);
+    background: activeMenuButtonBackground;
 }
 
 .popupPanel {
-    background-color: #212325;
-    box-shadow: 0 1px 3px 0 #202020;
-    border: solid 1px #161819;
+    background-color: openedFilesDropdownListBackgroundColor;
+    border: 1px solid openedFilesDropdownListBorderColor;
+    box-shadow: 0 2px 2px 0 openedFilesDropdownListShadowColor;
+    border-radius: 0 0 3px 3px;
     font-size: 10px;
     font-weight: normal;
     font-style: normal;
@@ -59,11 +60,7 @@
 .expandedImage svg {
     width: 9px;
     height: 9px;
-    fill: selectCommandActionColor;
-}
-
-.expandedImage:hover svg {
-    fill: selectCommandActionHoverColor;
+    fill: dropdownListButtonColor;
 }
 
 .popupItem {
@@ -71,10 +68,11 @@
     line-height: 20px;
     padding: 0 10px;
     cursor: default;
+    color: selectCommandActionColor;
 }
 
 .popupItemOver {
-    background-color: #2e3945;
+    background-color: hoverBackgroundColor;
     color: #4eabff;
 }
 

--- a/ide/che-core-ide-ui/src/main/resources/org/eclipse/che/ide/ui/switcher/switcher.css
+++ b/ide/che-core-ide-ui/src/main/resources/org/eclipse/che/ide/ui/switcher/switcher.css
@@ -29,7 +29,7 @@
     display: block;
     overflow: hidden;
     cursor: pointer;
-    width: 55px;
+    width: 50px;
     height: 18px;
     background-color: outputBackgroundColor;
 }
@@ -84,6 +84,6 @@
 }
 
 .onoffswitchCheckbox:checked + .onoffswitchLabel .onoffswitchSwitch {
-    right: 0px;
+    right: 4px;
     background: primaryButtonBackground;
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes appearance of the commands toolbar and command editor for the light theme

before bugfix
![dark](https://cloud.githubusercontent.com/assets/1636395/24663265/145922fe-1960-11e7-8074-070265047623.png)

after bugfix
![white](https://cloud.githubusercontent.com/assets/1636395/24663274/1af5d83c-1960-11e7-8457-f683b6264e91.png)

### What issues does this PR fix or reference?
#4590 

#### Changelog
Fixed appearance of the commands toolbar and command editor for the light theme

#### Release Notes
bugfix N/A

#### Docs PR
bugfix N/A
