### PR TITLE
Nocmdimage

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerConfig.java
@@ -309,11 +309,11 @@ public class ContainerConfig {
         return entrypoint;
     }
 
-    public void setEntrypoint(String[] entrypoint) {
+    public void setEntrypoint(String... entrypoint) {
         this.entrypoint = entrypoint;
     }
 
-    public ContainerConfig withEntrypoint(String[] entrypoint) {
+    public ContainerConfig withEntrypoint(String... entrypoint) {
         this.entrypoint = entrypoint;
         return this;
     }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerState.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerState.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.client.json;
 
+import java.util.Objects;
+
 /** @author andrew00x */
 public class ContainerState {
     private boolean running;
@@ -23,6 +25,7 @@ public class ContainerState {
     private boolean dead;
     private boolean oOMKilled;
     private String  error;
+    private String  status;
 
     public boolean isRunning() {
         return running;
@@ -102,6 +105,39 @@ public class ContainerState {
 
     public void setError(String error) {
         this.error = error;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ContainerState)) return false;
+        ContainerState that = (ContainerState)o;
+        return isRunning() == that.isRunning() &&
+               getPid() == that.getPid() &&
+               getExitCode() == that.getExitCode() &&
+               isPaused() == that.isPaused() &&
+               isRestarting() == that.isRestarting() &&
+               isDead() == that.isDead() &&
+               oOMKilled == that.oOMKilled &&
+               Objects.equals(getStartedAt(), that.getStartedAt()) &&
+               Objects.equals(getFinishedAt(), that.getFinishedAt()) &&
+               Objects.equals(getError(), that.getError()) &&
+               Objects.equals(getStatus(), that.getStatus());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects
+                .hash(isRunning(), getPid(), getExitCode(), getStartedAt(), getFinishedAt(), isPaused(), isRestarting(),
+                      isDead(), oOMKilled, getError(), getStatus());
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -29,6 +29,7 @@ import org.eclipse.che.plugin.docker.client.dto.AuthConfigs;
 import org.eclipse.che.plugin.docker.client.exception.ContainerNotFoundException;
 import org.eclipse.che.plugin.docker.client.exception.DockerException;
 import org.eclipse.che.plugin.docker.client.exception.ExecNotFoundException;
+import org.eclipse.che.plugin.docker.client.exception.ImageNotFoundException;
 import org.eclipse.che.plugin.docker.client.exception.NetworkNotFoundException;
 import org.eclipse.che.plugin.docker.client.json.ContainerCommitted;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
@@ -441,6 +442,17 @@ public class DockerConnectorTest {
         verify(dockerResponse).getStatus();
     }
 
+    @Test(expectedExceptions = ImageNotFoundException.class, expectedExceptionsMessageRegExp = ERROR_MESSAGE)
+    public void shouldThrowImageNotFoundExceptionOnGettingImageInfoIfResponseCodeIs404() throws IOException {
+        InspectImageParams inspectImageParams = InspectImageParams.create(IMAGE);
+
+        when(dockerResponse.getStatus()).thenReturn(RESPONSE_NOT_FOUND_CODE);
+
+        dockerConnector.inspectImage(inspectImageParams);
+
+        verify(dockerResponse).getStatus();
+    }
+
     @Test
     public void shouldBeAbleToStopContainer() throws IOException {
         StopContainerParams stopContainerParams = StopContainerParams.create(CONTAINER);
@@ -621,6 +633,17 @@ public class DockerConnectorTest {
         InspectContainerParams inspectContainerParams = InspectContainerParams.create(CONTAINER);
 
         when(dockerResponse.getStatus()).thenReturn(RESPONSE_ERROR_CODE);
+
+        dockerConnector.inspectContainer(inspectContainerParams);
+
+        verify(dockerResponse).getStatus();
+    }
+
+    @Test(expectedExceptions = ContainerNotFoundException.class, expectedExceptionsMessageRegExp = ERROR_MESSAGE)
+    public void shouldThrowContainerNotFoundExceptionOnInspectingContainerIfResponseCodeIs404() throws IOException {
+        InspectContainerParams inspectContainerParams = InspectContainerParams.create(CONTAINER);
+
+        when(dockerResponse.getStatus()).thenReturn(RESPONSE_NOT_FOUND_CODE);
 
         dockerConnector.inspectContainer(inspectContainerParams);
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -12,6 +12,7 @@ package org.eclipse.che.plugin.docker.machine;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.eclipse.che.api.core.NotFoundException;
@@ -51,7 +52,9 @@ import org.eclipse.che.plugin.docker.client.exception.ContainerNotFoundException
 import org.eclipse.che.plugin.docker.client.exception.ImageNotFoundException;
 import org.eclipse.che.plugin.docker.client.exception.NetworkNotFoundException;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 import org.eclipse.che.plugin.docker.client.json.HostConfig;
+import org.eclipse.che.plugin.docker.client.json.ImageConfig;
 import org.eclipse.che.plugin.docker.client.json.PortBinding;
 import org.eclipse.che.plugin.docker.client.json.Volume;
 import org.eclipse.che.plugin.docker.client.json.container.NetworkingConfig;
@@ -93,6 +96,7 @@ import java.util.regex.Pattern;
 import static java.lang.String.format;
 import static java.lang.Thread.sleep;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -113,6 +117,28 @@ public class MachineProviderImpl implements MachineInstanceProvider {
     public static final String MACHINE_SNAPSHOT_PREFIX = "machine_snapshot_";
 
     public static final Pattern SNAPSHOT_LOCATION_PATTERN = Pattern.compile("(.+/)?" + MACHINE_SNAPSHOT_PREFIX + ".+");
+
+    static final String CONTAINER_EXITED_ERROR = "We detected that a machine exited unexpectedly. " +
+                                                 "This may be caused by a container in interactive mode " +
+                                                 "or a container that requires additional arguments to start. " +
+                                                 "Please check the container recipe.";
+
+    // CMDs and entrypoints that lead to exiting of container right after start
+    private Set<List<String>> badCMDs        = ImmutableSet.of(singletonList("/bin/bash"),
+                                                               singletonList("/bin/sh"),
+                                                               singletonList("bash"),
+                                                               singletonList("sh"),
+                                                               Arrays.asList("/bin/sh", "-c", "/bin/sh"),
+                                                               Arrays.asList("/bin/sh", "-c", "/bin/bash"),
+                                                               Arrays.asList("/bin/sh", "-c", "bash"),
+                                                               Arrays.asList("/bin/sh", "-c", "sh"));
+    private Set<List<String>> badEntrypoints =
+            ImmutableSet.<List<String>>builder().addAll(badCMDs)
+                                                .add(Arrays.asList("/bin/sh", "-c"))
+                                                .add(Arrays.asList("/bin/bash", "-c"))
+                                                .add(Arrays.asList("sh", "-c"))
+                                                .add(Arrays.asList("bash", "-c"))
+                                                .build();
 
     private final DockerConnector                               docker;
     private final UserSpecificDockerRegistryCredentialsProvider dockerCredentials;
@@ -314,6 +340,8 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                                                  service);
 
             docker.startContainer(StartContainerParams.create(container));
+
+            checkContainerIsRunning(container);
 
             readContainerLogsInSeparateThread(container,
                                               workspaceId,
@@ -568,6 +596,8 @@ public class MachineProviderImpl implements MachineInstanceProvider {
 
         addStaticDockerConfiguration(config);
 
+        setNonExitingContainerCommandIfNeeded(config);
+
         return docker.createContainer(CreateContainerParams.create(config)
                                                            .withContainerName(service.getContainerName()))
                      .getId();
@@ -615,6 +645,36 @@ public class MachineProviderImpl implements MachineInstanceProvider {
         composeService.getEnvironment().putAll(env);
         composeService.getVolumes().addAll(volumes);
         composeService.getNetworks().addAll(additionalNetworks);
+    }
+
+    // We can detect certain situation when container exited right after start.
+    // We can detect
+    //  - when no command/entrypoint is set
+    //  - when most common shell interpreters are used and require additional arguments
+    //  - when most common shell interpreters are used and they require interactive mode which we don't support
+    // When we identify such situation we change CMD/entrypoint in such a way that it runs "tail -f /dev/null".
+    // This command does nothing and lasts until workspace is stopped.
+    // Images such as "ubuntu" or "openjdk" fits this situation.
+    protected void setNonExitingContainerCommandIfNeeded(ContainerConfig containerConfig) throws IOException {
+        ImageConfig imageConfig = docker.inspectImage(containerConfig.getImage()).getConfig();
+        List<String> cmd = imageConfig.getCmd() == null ?
+                           null : Arrays.asList(imageConfig.getCmd());
+        List<String> entrypoint = imageConfig.getEntrypoint() == null ?
+                                  null : Arrays.asList(imageConfig.getEntrypoint());
+
+        if ((entrypoint == null || badEntrypoints.contains(entrypoint)) && (cmd == null || badCMDs.contains(cmd))) {
+            containerConfig.setCmd("tail", "-f", "/dev/null");
+            containerConfig.setEntrypoint((String[])null);
+        }
+    }
+
+    // Inspect container right after start to check if it is running,
+    // otherwise throw error that command should not exit right after container start
+    protected void checkContainerIsRunning(String container) throws IOException, ServerException {
+        ContainerInfo containerInfo = docker.inspectContainer(container);
+        if ("exited".equals(containerInfo.getState().getStatus())) {
+            throw new ServerException(CONTAINER_EXITED_ERROR);
+        }
     }
 
     private void connectContainerToAdditionalNetworks(String container,


### PR DESCRIPTION
### What does this PR do?
Improves UX when user used docker image that needs additional command or use interactive command/entrypoint by default. E.g. ubuntu, openjdk, etc.
In some cases we can recognize this situation and change command to fix it.
When we can't recognize this situation but container stops right after start we send custom error message that explains why that error happens. 
Here are a few screenshots on how it looks:
<details>

![selection_051](https://cloud.githubusercontent.com/assets/1851863/24666261/82216064-1968-11e7-9aac-fba12fe13c45.png)

![selection_050](https://cloud.githubusercontent.com/assets/1851863/24666325/acb2034c-1968-11e7-9306-b53f242e0e55.png)

![selection_047](https://cloud.githubusercontent.com/assets/1851863/24666329/b107b8ec-1968-11e7-80cd-448181c2961e.png)

</details>



### What issues does this PR fix or reference?
Fixes #4310 

#### Changelog
<!-- one line entry to be added to changelog -->
Adds guidance for user when containers exit unexpectedly in certain situations.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
**Improved UX For Unexpected Container Exits**
We have created additional guidance for users when machines exit immediately after startup. This is often caused because the machine recipe requires interaction or additional arguments to start. Although we can't prevent the machine from stopping we now display a popup notification to the user asking them to check the machine recipe for commands that would require interaction or additional arguments.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A