### PR TITLE
CHE-158 Using '-' instead of '.' for generating OpenShift route Urls

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
  * This server evaluation strategy will return a completed {@link ServerImpl} with internal addresses set
  * as {@link LocalDockerServerEvaluationStrategy} does. Contrary external addresses will have the following format:
  *
- *       serverName.workspaceID.cheExternalAddress (e.g. terminal.79rfwhqaztq2ru2k.che.local)
+ *       serverName-workspaceID-cheExternalAddress (e.g. terminal-79rfwhqaztq2ru2k-che.local)
  *
  * <p>cheExternalAddress can be set using property {@code che.docker.ip.external}.
  * This strategy is useful when Che and the workspace servers need to be exposed on the same single TCP port
@@ -71,7 +71,7 @@ public class LocalDockerSinglePortServerEvaluationStrategy extends LocalDockerSe
         Map<String, String> addressesAndPorts = new HashMap<>();
         for (String serverKey : portBindings.keySet()) {
             String serverName = getWorkspaceServerName(labels, serverKey);
-            String serverURL = serverName + "." + workspaceID + "." + cheExternalAddress;
+            String serverURL = serverName + "-" + workspaceID + "-" + cheExternalAddress;
             addressesAndPorts.put(serverKey, serverURL);
         }
 

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
@@ -69,11 +69,11 @@ public class OpenShiftRouteCreator {
     }
 
     private static String generateRouteName(final String workspaceName, final String serverRef) {
-        return OpenShiftConnector.CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceName + "." + serverRef;
+        return OpenShiftConnector.CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceName + "-" + serverRef;
     }
 
     private static String generateRouteHost(final String workspaceName, final String serverRef, final String cheServerExternalAddress) {
-        return serverRef + "." + workspaceName + "." + cheServerExternalAddress;
+        return serverRef + "-" + workspaceName + "-" + cheServerExternalAddress;
     }
 
 }


### PR DESCRIPTION
### What does this PR do?
Changes the way of generation OpenShift Route URLs. Instead of wsagent.8mh25c0c2zao1xya.che-mario-loriedo-che.d800.free-int.openshiftapps.com we need to use wsagent-8mh25c0c2zao1xya-che-mario-loriedo-che.d800.free-int.openshiftapps.com in order to avoid certificate errors:

```
wsagent.8mh25c0c2zao1xya.che-mario-loriedo-che.d800.free-int.openshiftapps.com uses an invalid security certificate. 
The certificate is only valid for the following names: *.d800.free-int.openshiftapps.com, d800.free-int.openshiftapps.com 

```
Error code: SSL_ERROR_BAD_CERT_DOMAIN

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-158

#### Changelog
Using '-' instead of '.' for generating OpenShift route Urls