### PR TITLE
CHE-4590: hide info panel in command line and preview URL editors

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorPartView.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditorPartView.java
@@ -69,6 +69,14 @@ public interface TextEditorPartView extends RequiresResize, IsWidget, HasNotific
     void showPlaceHolder(Widget placeHolder);
 
     /**
+     * Sets whether the info panel is visible.
+     *
+     * @param visible
+     *         {@code true} to show the info panel, {@code false} to hide it
+     */
+    void setInfoPanelVisible(boolean visible);
+
+    /**
      * Sets the initial state of the info panel.
      *
      * @param mode

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/text/AbstractPageWithTextEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/text/AbstractPageWithTextEditor.java
@@ -79,6 +79,7 @@ public abstract class AbstractPageWithTextEditor extends AbstractCommandEditorPa
                     editor.getEditorWidget().setFoldingRulerVisible(false);
                     editor.getEditorWidget().setZoomRulerVisible(false);
                     editor.getEditorWidget().setOverviewRulerVisible(false);
+                    editor.getView().setInfoPanelVisible(false);
 
                     break;
                 case PROP_DIRTY:

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/texteditor/TextEditorPartViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/texteditor/TextEditorPartViewImpl.java
@@ -144,6 +144,11 @@ public class TextEditorPartViewImpl extends Composite implements TextEditorPartV
     }
 
     @Override
+    public void setInfoPanelVisible(boolean visible) {
+        infoPanel.setVisible(visible);
+    }
+
+    @Override
     public void initInfoPanel(final String mode, final Keymap keymap,
                               final int lineCount, final int tabSize) {
         this.infoPanel.createDefaultState(mode, lineCount, tabSize);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds possibility to show/hide info panel in text editors.
Hides info panel in command line and preview URL editors.

### What issues does this PR fix or reference?
#4590 

#### Changelog
Added possibility to show/hide info panel in text editors.
Info panels in command line and preview URL editors are hidden now.

#### Release Notes
N/A

#### Docs PR
N/A