### PR TITLE
CHE-3914: Fix launching SSH agent in some cases

### DIFF
--- a/agents/ssh/src/main/java/org/eclipse/che/api/agent/SshAgentLauncher.java
+++ b/agents/ssh/src/main/java/org/eclipse/che/api/agent/SshAgentLauncher.java
@@ -33,8 +33,7 @@ public class SshAgentLauncher extends AbstractAgentLauncher {
                             @Named("che.agent.dev.ping_delay_ms") long agentPingDelayMs) {
         super(agentMaxStartTimeMs,
               agentPingDelayMs,
-              new CompositeAgentLaunchingChecker(new ProcessIsLaunchedChecker("sshd"),
-                                                 new MappedPortIsListeningAgentChecker("22/tcp")));
+              new MappedPortIsListeningAgentChecker("22/tcp"));
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Fixes launching SSH agent error, when according to security setting of host OS, a user in a docker container cannot see processes, which belongs to container's root.

Before this PR, to check whether SSH agent is started successfully we checked two things:
- SSH process is running inside container
- exposed port for SSH connection is opened and has been listening

But the first check is redundant, because if ssh fail to run it won't stand on port and second check will fail. More, that check could prevent workspace start when it shouldn't.
So, this PR just deletes redundant checking of launching ssh process in workspace container. Check that port has been listening is enough here.

### What issues does this PR fix or reference?
#3914 

#### Changelog
Fixed SSH agent launch error when host security prevents a user from seeing container root's processes.

#### Release Notes
N/A

#### Docs PR
N/A
