### PR TITLE
CHE-4721: fix agents install scripts

### DIFF
--- a/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
+++ b/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
@@ -20,6 +20,7 @@ command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
 # no curl, no wget, install curl
 if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
   PACKAGES=${PACKAGES}" curl";
+  CURL_INSTALLED=true
 fi
 
 test "$(id -u)" = 0 || SUDO="sudo -E"

--- a/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
@@ -20,6 +20,7 @@ command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
 # no curl, no wget, install curl
 if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
   PACKAGES=${PACKAGES}" curl";
+  CURL_INSTALLED=true
 fi
 
 test "$(id -u)" = 0 || SUDO="sudo -E"

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -20,6 +20,7 @@ command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
 # no curl, no wget, install curl
 if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
   PACKAGES=${PACKAGES}" curl";
+  CURL_INSTALLED=true
 fi
 
 test "$(id -u)" = 0 || SUDO="sudo -E"


### PR DESCRIPTION
### What does this PR do?
Fixes agents installation scripts in case neither of curl/wget is installed in machine.

### What issues does this PR fix or reference?
Fixes #4721 

#### Changelog
Fix agents installation scripts in case neither of curl/wget is installed in machine.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
