### PR TITLE
Delete redundant terminal-client dependency.

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -104,10 +104,6 @@
             <artifactId>che-orion-editor</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.lib</groupId>
-            <artifactId>che-terminal-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-composer-ide</artifactId>
         </dependency>


### PR DESCRIPTION
### What does this PR do?
Delete redundant terminal-client dependency. This dependency is once defined like transitive dependency in the che-plugin-machine-ext-client.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>
