### PR TITLE
CHE-4593: Use JSON RPC for the debugger functionality

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -84,9 +84,9 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  * @author Anatoliy Bazko
  */
 public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
-    private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:message:breakpoint";
-    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:message:disconnect";
-    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND    = "event:debugger:message:suspend";
+    private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:breakpoint";
+    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:disconnect";
+    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND    = "event:debugger:suspend";
     private static final String EVENT_DEBUGGER_UN_SUBSCRIBE       = "event:debugger:un-subscribe";
     private static final String EVENT_DEBUGGER_SUBSCRIBE          = "event:debugger:subscribe";
 

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -85,10 +85,10 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  */
 public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
     private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:message:breakpoint";
-    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT  = "event:debugger:message:disconnect";
-    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND     = "event:debugger:message:suspend";
-    private static final String EVENT_DEBUGGER_UN_SUBSCRIBE        = "event:debugger:un-subscribe";
-    private static final String EVENT_DEBUGGER_SUBSCRIBE           = "event:debugger:subscribe";
+    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:message:disconnect";
+    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND    = "event:debugger:message:suspend";
+    private static final String EVENT_DEBUGGER_UN_SUBSCRIBE       = "event:debugger:un-subscribe";
+    private static final String EVENT_DEBUGGER_SUBSCRIBE          = "event:debugger:subscribe";
 
     public static final String LOCAL_STORAGE_DEBUGGER_SESSION_KEY = "che-debugger-session";
     public static final String LOCAL_STORAGE_DEBUGGER_STATE_KEY   = "che-debugger-state";

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.debug.shared.dto.action.StepOverActionDto;
 import org.eclipse.che.api.debug.shared.dto.action.SuspendActionDto;
 import org.eclipse.che.api.debug.shared.dto.event.BreakpointActivatedEventDto;
 import org.eclipse.che.api.debug.shared.dto.event.DebuggerEventDto;
+import org.eclipse.che.api.debug.shared.dto.event.DisconnectEventDto;
 import org.eclipse.che.api.debug.shared.dto.event.SuspendEventDto;
 import org.eclipse.che.api.debug.shared.model.DebuggerInfo;
 import org.eclipse.che.api.debug.shared.model.Location;
@@ -40,7 +41,6 @@ import org.eclipse.che.api.debug.shared.model.action.Action;
 import org.eclipse.che.api.debug.shared.model.impl.SimpleValueImpl;
 import org.eclipse.che.api.debug.shared.model.impl.StackFrameDumpImpl;
 import org.eclipse.che.api.promises.client.Function;
-import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
@@ -64,15 +64,11 @@ import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.debug.DebuggerObservable;
 import org.eclipse.che.ide.debug.DebuggerObserver;
 import org.eclipse.che.ide.dto.DtoFactory;
-import org.eclipse.che.ide.rest.HTTPStatus;
+import org.eclipse.che.ide.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.ide.jsonrpc.RequestTransmitter;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.ide.util.storage.LocalStorage;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
-import org.eclipse.che.ide.websocket.MessageBus;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
-import org.eclipse.che.ide.websocket.WebSocketException;
-import org.eclipse.che.ide.websocket.rest.SubscriptionHandler;
-import org.eclipse.che.ide.websocket.rest.exceptions.ServerException;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -88,33 +84,39 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
  * @author Anatoliy Bazko
  */
 public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
+    private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:message:breakpoint";
+    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT  = "event:debugger:message:disconnect";
+    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND     = "event:debugger:message:suspend";
+    private static final String EVENT_DEBUGGER_UN_SUBSCRIBE        = "event:debugger:un-subscribe";
+    private static final String EVENT_DEBUGGER_SUBSCRIBE           = "event:debugger:subscribe";
 
     public static final String LOCAL_STORAGE_DEBUGGER_SESSION_KEY = "che-debugger-session";
     public static final String LOCAL_STORAGE_DEBUGGER_STATE_KEY   = "che-debugger-state";
+    public static final String WS_AGENT_ENDPOINT                  = "ws-agent";
 
-    protected final DtoFactory          dtoFactory;
-    protected final NotificationManager notificationManager;
+    protected final DtoFactory             dtoFactory;
+    protected final NotificationManager    notificationManager;
+    private final   List<DebuggerObserver> observers;
 
-    private final List<DebuggerObserver> observers;
-    private final DebuggerServiceClient  service;
-    private final LocalStorageProvider   localStorageProvider;
-    private final EventBus               eventBus;
-    private final ActiveFileHandler      activeFileHandler;
-    private final DebuggerManager        debuggerManager;
-    private final BreakpointManager      breakpointManager;
-    private final String                 debuggerType;
-    private final String                 eventChannel;
+    private final RequestTransmitter         transmitter;
+    private final RequestHandlerConfigurator configurator;
+    private final DebuggerServiceClient      service;
+    private final LocalStorageProvider       localStorageProvider;
+    private final EventBus                   eventBus;
+    private final ActiveFileHandler          activeFileHandler;
+    private final DebuggerManager            debuggerManager;
+    private final BreakpointManager          breakpointManager;
+    private final String                     debuggerType;
 
-    private DebugSessionDto                       debugSessionDto;
-    private Location                              currentLocation;
-    private SubscriptionHandler<DebuggerEventDto> debuggerEventsHandler;
+    private DebugSessionDto debugSessionDto;
+    private Location        currentLocation;
 
-    private MessageBus messageBus;
 
     public AbstractDebugger(DebuggerServiceClient service,
+                            RequestTransmitter transmitter,
+                            RequestHandlerConfigurator configurator,
                             DtoFactory dtoFactory,
                             LocalStorageProvider localStorageProvider,
-                            MessageBusProvider messageBusProvider,
                             EventBus eventBus,
                             ActiveFileHandler activeFileHandler,
                             DebuggerManager debuggerManager,
@@ -122,6 +124,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
                             BreakpointManager breakpointManager,
                             String type) {
         this.service = service;
+        this.transmitter = transmitter;
+        this.configurator = configurator;
         this.dtoFactory = dtoFactory;
         this.localStorageProvider = localStorageProvider;
         this.eventBus = eventBus;
@@ -131,47 +135,40 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         this.breakpointManager = breakpointManager;
         this.observers = new ArrayList<>();
         this.debuggerType = type;
-        this.eventChannel = debuggerType + ":events:";
 
         restoreDebuggerState();
-        addHandlers(messageBusProvider);
+        addHandlers();
     }
 
 
-    private void addHandlers(final MessageBusProvider messageBusProvider) {
+    private void addHandlers() {
         eventBus.addHandler(WsAgentStateEvent.TYPE, new WsAgentStateHandler() {
             @Override
             public void onWsAgentStarted(WsAgentStateEvent event) {
-                messageBus = messageBusProvider.getMachineMessageBus();
+                transmitter.transmitNoneToNone(WS_AGENT_ENDPOINT, EVENT_DEBUGGER_SUBSCRIBE);
 
                 if (!isConnected()) {
                     return;
                 }
                 Promise<DebugSessionDto> promise = service.getSessionInfo(debugSessionDto.getId());
-                promise.then(new Operation<DebugSessionDto>() {
-                    @Override
-                    public void apply(DebugSessionDto arg) throws OperationException {
-                        debuggerManager.setActiveDebugger(AbstractDebugger.this);
-                        setDebugSession(arg);
+                promise.then(debugSessionDto -> {
+                    debuggerManager.setActiveDebugger(AbstractDebugger.this);
+                    setDebugSession(debugSessionDto);
 
-                        DebuggerInfo debuggerInfo = arg.getDebuggerInfo();
-                        String info = debuggerInfo.getName() + " " + debuggerInfo.getVersion();
-                        String address = debuggerInfo.getHost() + ":" + debuggerInfo.getPort();
-                        DebuggerDescriptor debuggerDescriptor = new DebuggerDescriptor(info, address);
-                        JsPromise<Void> promise = Promises.resolve(null);
+                    DebuggerInfo debuggerInfo = debugSessionDto.getDebuggerInfo();
+                    String info = debuggerInfo.getName() + " " + debuggerInfo.getVersion();
+                    String address = debuggerInfo.getHost() + ":" + debuggerInfo.getPort();
+                    DebuggerDescriptor debuggerDescriptor = new DebuggerDescriptor(info, address);
+                    JsPromise<Void> promise1 = Promises.resolve(null);
 
-                        for (DebuggerObserver observer : observers) {
-                            observer.onDebuggerAttached(debuggerDescriptor, promise);
-                        }
-
-                        startCheckingEvents();
+                    for (DebuggerObserver observer : observers) {
+                        observer.onDebuggerAttached(debuggerDescriptor, promise1);
                     }
-                }).catchError(new Operation<PromiseError>() {
-                    @Override
-                    public void apply(PromiseError arg) throws OperationException {
-                        if (!isConnected()) {
-                            invalidateDebugSession();
-                        }
+
+                    startCheckingEvents();
+                }).catchError(error -> {
+                    if (!isConnected()) {
+                        invalidateDebugSession();
                     }
                 });
             }
@@ -180,38 +177,6 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             public void onWsAgentStopped(WsAgentStateEvent event) {
             }
         });
-
-        this.debuggerEventsHandler = new SubscriptionHandler<DebuggerEventDto>(new DebuggerEventUnmarshaller(dtoFactory)) {
-            @Override
-            public void onMessageReceived(DebuggerEventDto result) {
-                if (!isConnected()) {
-                    return;
-                }
-                onEventListReceived(result);
-            }
-
-            @Override
-            public void onErrorReceived(Throwable exception) {
-                if (!isConnected()) {
-                    return;
-                }
-                try {
-                    messageBus.unsubscribe(eventChannel, this);
-                } catch (WebSocketException e) {
-                    Log.error(AbstractDebugger.class, e);
-                }
-
-                if (exception instanceof ServerException) {
-                    ServerException serverException = (ServerException)exception;
-                    if (HTTPStatus.INTERNAL_ERROR == serverException.getHTTPStatus()
-                        && serverException.getMessage() != null
-                        && serverException.getMessage().contains("not found")) {
-
-                        disconnect();
-                    }
-                }
-            }
-        };
     }
 
     private void onEventListReceived(@NotNull DebuggerEventDto event) {
@@ -279,21 +244,36 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
     }
 
     private void startCheckingEvents() {
-        try {
-            messageBus.subscribe(eventChannel, debuggerEventsHandler);
-        } catch (WebSocketException e) {
-            Log.error(DebuggerPresenter.class, e);
-        }
+        configurator.newConfiguration()
+                    .methodName(EVENT_DEBUGGER_MESSAGE_SUSPEND)
+                    .paramsAsDto(SuspendEventDto.class)
+                    .noResult()
+                    .withOperation((endpointId, event) -> {
+                        Log.debug(getClass(), "Received suspend message from endpoint: " + endpointId);
+                        onEventListReceived(event);
+                    });
+
+        configurator.newConfiguration()
+                    .methodName(EVENT_DEBUGGER_MESSAGE_DISCONNECT)
+                    .paramsAsDto(DisconnectEventDto.class)
+                    .noResult()
+                    .withOperation((endpointId, event) -> {
+                        Log.debug(getClass(), "Received disconnect message from endpoint: " + endpointId);
+                        onEventListReceived(event);
+                    });
+
+        configurator.newConfiguration()
+                    .methodName(EVENT_DEBUGGER_MESSAGE_BREAKPOINT)
+                    .paramsAsDto(BreakpointActivatedEventDto.class)
+                    .noResult()
+                    .withOperation((endpointId, event) -> {
+                        Log.debug(getClass(), "Received breakpoint activated message from endpoint: " + endpointId);
+                        onEventListReceived(event);
+                    });
     }
 
     private void stopCheckingDebugEvents() {
-        try {
-            if (messageBus.isHandlerSubscribed(debuggerEventsHandler, eventChannel)) {
-                messageBus.unsubscribe(eventChannel, debuggerEventsHandler);
-            }
-        } catch (WebSocketException e) {
-            Log.error(AbstractDebugger.class, e);
-        }
+        transmitter.transmitNoneToNone(WS_AGENT_ENDPOINT, EVENT_DEBUGGER_UN_SUBSCRIBE);
     }
 
     @Override
@@ -303,12 +283,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         }
 
         Promise<SimpleValueDto> promise = service.getValue(debugSessionDto.getId(), asDto(variable));
-        return promise.then(new Function<SimpleValueDto, SimpleValue>() {
-            @Override
-            public SimpleValue apply(SimpleValueDto arg) throws FunctionException {
-                return new SimpleValueImpl(arg);
-            }
-        });
+        return promise.then((Function<SimpleValueDto, SimpleValue>)SimpleValueImpl::new);
     }
 
     @Override
@@ -318,12 +293,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         }
 
         Promise<StackFrameDumpDto> stackFrameDump = service.getStackFrameDump(debugSessionDto.getId());
-        return stackFrameDump.then(new Function<StackFrameDumpDto, StackFrameDump>() {
-            @Override
-            public StackFrameDump apply(StackFrameDumpDto arg) throws FunctionException {
-                return new StackFrameDumpImpl(arg);
-            }
-        });
+        return stackFrameDump.then((Function<StackFrameDumpDto, StackFrameDump>)StackFrameDumpImpl::new);
     }
 
     @Override
@@ -344,19 +314,13 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             BreakpointDto breakpointDto = dtoFactory.createDto(BreakpointDto.class).withLocation(locationDto).withEnabled(true);
 
             Promise<Void> promise = service.addBreakpoint(debugSessionDto.getId(), breakpointDto);
-            promise.then(new Operation<Void>() {
-                @Override
-                public void apply(Void arg) throws OperationException {
-                    Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, filePath, file, true);
-                    for (DebuggerObserver observer : observers) {
-                        observer.onBreakpointAdded(breakpoint);
-                    }
+            promise.then(it -> {
+                Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, filePath, file, true);
+                for (DebuggerObserver observer : observers) {
+                    observer.onBreakpointAdded(breakpoint);
                 }
-            }).catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    Log.error(AbstractDebugger.class, arg.getMessage());
-                }
+            }).catchError(error -> {
+                Log.error(AbstractDebugger.class, error.getMessage());
             });
         } else {
             Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getLocation().toString(), file, false);
@@ -381,19 +345,14 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         locationDto.setTarget(fqn);
 
         Promise<Void> promise = service.deleteBreakpoint(debugSessionDto.getId(), locationDto);
-        promise.then(new Operation<Void>() {
-            @Override
-            public void apply(Void arg) throws OperationException {
-                for (DebuggerObserver observer : observers) {
-                    Breakpoint breakpoint = new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getLocation().toString(), file, false);
-                    observer.onBreakpointDeleted(breakpoint);
-                }
+        promise.then(it -> {
+            for (DebuggerObserver observer : observers) {
+                Breakpoint breakpoint =
+                        new Breakpoint(Breakpoint.Type.BREAKPOINT, lineNumber, file.getLocation().toString(), file, false);
+                observer.onBreakpointDeleted(breakpoint);
             }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError arg) throws OperationException {
-                Log.error(AbstractDebugger.class, arg.getMessage());
-            }
+        }).catchError(error -> {
+            Log.error(AbstractDebugger.class, error.getMessage());
         });
     }
 
@@ -404,18 +363,12 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         }
         Promise<Void> promise = service.deleteAllBreakpoints(debugSessionDto.getId());
 
-        promise.then(new Operation<Void>() {
-            @Override
-            public void apply(Void arg) throws OperationException {
-                for (DebuggerObserver observer : observers) {
-                    observer.onAllBreakpointsDeleted();
-                }
+        promise.then(it -> {
+            for (DebuggerObserver observer : observers) {
+                observer.onAllBreakpointsDeleted();
             }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError arg) throws OperationException {
-                Log.error(AbstractDebugger.class, arg.getMessage());
-            }
+        }).catchError(error -> {
+            Log.error(AbstractDebugger.class, error.getMessage());
         });
     }
 
@@ -428,25 +381,19 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         Promise<DebugSessionDto> connect = service.connect(debuggerType, connectionProperties);
         final DebuggerDescriptor debuggerDescriptor = toDescriptor(connectionProperties);
 
-        Promise<Void> promise = connect.then(new Function<DebugSessionDto, Void>() {
-            @Override
-            public Void apply(final DebugSessionDto arg) throws FunctionException {
-                DebuggerInfo debuggerInfo = arg.getDebuggerInfo();
-                debuggerDescriptor.setInfo(debuggerInfo.getName() + " " + debuggerInfo.getVersion());
+        Promise<Void> promise = connect.then((Function<DebugSessionDto, Void>)debugSession -> {
+            DebuggerInfo debuggerInfo = debugSession.getDebuggerInfo();
+            debuggerDescriptor.setInfo(debuggerInfo.getName() + " " + debuggerInfo.getVersion());
 
-                setDebugSession(arg);
-                preserveDebuggerState();
-                startCheckingEvents();
-                startDebugger(arg);
+            setDebugSession(debugSession);
+            preserveDebuggerState();
+            startCheckingEvents();
+            startDebugger(debugSession);
 
-                return null;
-            }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError arg) throws OperationException {
-                Log.error(AbstractDebugger.class, arg.getMessage());
-                throw new OperationException(arg.getCause());
-            }
+            return null;
+        }).catchError((Operation<PromiseError>)error -> {
+            Log.error(AbstractDebugger.class, error.getMessage());
+            throw new OperationException(error.getCause());
         });
 
         for (DebuggerObserver observer : observers) {
@@ -497,22 +444,16 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         invalidateDebugSession();
         preserveDebuggerState();
 
-        disconnect.then(new Operation<Void>() {
-            @Override
-            public void apply(Void arg) throws OperationException {
-                for (DebuggerObserver observer : observers) {
-                    observer.onDebuggerDisconnected();
-                }
-                debuggerManager.setActiveDebugger(null);
+        disconnect.then(it -> {
+            for (DebuggerObserver observer : observers) {
+                observer.onDebuggerDisconnected();
             }
-        }).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError arg) throws OperationException {
-                for (DebuggerObserver observer : observers) {
-                    observer.onDebuggerDisconnected();
-                }
-                debuggerManager.setActiveDebugger(null);
+            debuggerManager.setActiveDebugger(null);
+        }).catchError(error -> {
+            for (DebuggerObserver observer : observers) {
+                observer.onDebuggerDisconnected();
             }
+            debuggerManager.setActiveDebugger(null);
         });
     }
 
@@ -529,11 +470,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             action.setType(Action.TYPE.STEP_INTO);
 
             Promise<Void> promise = service.stepInto(debugSessionDto.getId(), action);
-            promise.catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    Log.error(AbstractDebugger.class, arg.getCause());
-                }
+            promise.catchError(error -> {
+                Log.error(AbstractDebugger.class, error.getCause());
             });
         }
     }
@@ -551,11 +489,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             action.setType(Action.TYPE.STEP_OVER);
 
             Promise<Void> promise = service.stepOver(debugSessionDto.getId(), action);
-            promise.catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    Log.error(AbstractDebugger.class, arg.getCause());
-                }
+            promise.catchError(error -> {
+                Log.error(AbstractDebugger.class, error.getCause());
             });
         }
     }
@@ -573,11 +508,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             action.setType(Action.TYPE.STEP_OUT);
 
             Promise<Void> promise = service.stepOut(debugSessionDto.getId(), action);
-            promise.catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    Log.error(AbstractDebugger.class, arg.getCause());
-                }
+            promise.catchError(error -> {
+                Log.error(AbstractDebugger.class, error.getCause());
             });
         }
     }
@@ -595,11 +527,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
             action.setType(Action.TYPE.RESUME);
 
             Promise<Void> promise = service.resume(debugSessionDto.getId(), action);
-            promise.catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    Log.error(AbstractDebugger.class, arg.getCause());
-                }
+            promise.catchError(error -> {
+                Log.error(AbstractDebugger.class, error.getCause());
             });
         }
     }
@@ -613,11 +542,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         SuspendActionDto suspendAction = dtoFactory.createDto(SuspendActionDto.class);
         suspendAction.setType(Action.TYPE.SUSPEND);
 
-        service.suspend(debugSessionDto.getId(), suspendAction).catchError(new Operation<PromiseError>() {
-            @Override
-            public void apply(PromiseError arg) throws OperationException {
-                notificationManager.notify(arg.getMessage(), FAIL, FLOAT_MODE);
-            }
+        service.suspend(debugSessionDto.getId(), suspendAction).catchError(error -> {
+            notificationManager.notify(error.getMessage(), FAIL, FLOAT_MODE);
         });
     }
 
@@ -635,18 +561,12 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
         if (isConnected()) {
             Promise<Void> promise = service.setValue(debugSessionDto.getId(), asDto(variable));
 
-            promise.then(new Operation<Void>() {
-                @Override
-                public void apply(Void arg) throws OperationException {
-                    for (DebuggerObserver observer : observers) {
-                        observer.onValueChanged(variable.getVariablePath().getPath(), variable.getValue());
-                    }
+            promise.then(it -> {
+                for (DebuggerObserver observer : observers) {
+                    observer.onValueChanged(variable.getVariablePath().getPath(), variable.getValue());
                 }
-            }).catchError(new Operation<PromiseError>() {
-                @Override
-                public void apply(PromiseError arg) throws OperationException {
-                    Log.error(AbstractDebugger.class, arg.getMessage());
-                }
+            }).catchError(error -> {
+                Log.error(AbstractDebugger.class, error.getMessage());
             });
         }
     }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
@@ -52,11 +52,15 @@ import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.debug.DebuggerObserver;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.ide.jsonrpc.RequestTransmitter;
+import org.eclipse.che.ide.jsonrpc.reception.MethodNameConfigurator;
+import org.eclipse.che.ide.jsonrpc.reception.OperationConfiguratorOneToNone;
+import org.eclipse.che.ide.jsonrpc.reception.ParamsConfigurator;
+import org.eclipse.che.ide.jsonrpc.reception.ResultConfiguratorFromOne;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.util.storage.LocalStorage;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
-import org.eclipse.che.ide.websocket.rest.SubscriptionHandler;
 import org.eclipse.che.plugin.debugger.ide.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,6 +81,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_SMART_NULLS;
@@ -104,23 +109,25 @@ public class DebuggerTest extends BaseTest {
     public static final String PATH        = "test/src/main/java/Test.java";
 
     @Mock
-    private DebuggerServiceClient service;
+    private DebuggerServiceClient      service;
     @Mock
-    private DtoFactory            dtoFactory;
+    private DtoFactory                 dtoFactory;
     @Mock
-    private LocalStorageProvider  localStorageProvider;
+    private LocalStorageProvider       localStorageProvider;
     @Mock
-    private MessageBusProvider    messageBusProvider;
+    private EventBus                   eventBus;
     @Mock
-    private EventBus              eventBus;
+    private ActiveFileHandler          activeFileHandler;
     @Mock
-    private ActiveFileHandler     activeFileHandler;
+    private DebuggerManager            debuggerManager;
     @Mock
-    private DebuggerManager       debuggerManager;
+    private NotificationManager        notificationManager;
     @Mock
-    private NotificationManager   notificationManager;
+    private BreakpointManager          breakpointManager;
     @Mock
-    private BreakpointManager     breakpointManager;
+    private RequestTransmitter         transmitter;
+    @Mock
+    private RequestHandlerConfigurator configurator;
 
     @Mock
     private Promise<Void>         promiseVoid;
@@ -173,20 +180,17 @@ public class DebuggerTest extends BaseTest {
         doReturn(breakpointDto).when(dtoFactory).createDto(BreakpointDto.class);
         doReturn(locationDto).when(breakpointDto).getLocation();
 
-        doReturn(messageBus).when(messageBusProvider).getMachineMessageBus();
-
         doReturn(localStorage).when(localStorageProvider).get();
         doReturn(DEBUG_INFO).when(localStorage).getItem(AbstractDebugger.LOCAL_STORAGE_DEBUGGER_SESSION_KEY);
         doReturn(debugSessionDto).when(dtoFactory).createDtoFromJson(anyString(), eq(DebugSessionDto.class));
 
         doReturn(Path.valueOf(PATH)).when(file).getLocation();
 
-        debugger = new TestDebugger(service, dtoFactory, localStorageProvider, messageBusProvider, eventBus,
+        debugger = new TestDebugger(service, transmitter, configurator, dtoFactory, localStorageProvider, eventBus,
                                     activeFileHandler, debuggerManager, notificationManager, "id");
         doReturn(promiseInfo).when(service).getSessionInfo(SESSION_ID);
         doReturn(promiseInfo).when(promiseInfo).then(any(Operation.class));
 
-        // setup messageBus
         verify(eventBus).addHandler(eq(WsAgentStateEvent.TYPE), extServerStateHandlerCaptor.capture());
         extServerStateHandlerCaptor.getValue().onWsAgentStarted(WsAgentStateEvent.createWsAgentStartedEvent());
 
@@ -206,6 +210,17 @@ public class DebuggerTest extends BaseTest {
 
         Map<String, String> connectionProperties = mock(Map.class);
         Promise<DebugSessionDto> promiseDebuggerInfo = mock(Promise.class);
+
+        MethodNameConfigurator methodNameConfigurator = mock(MethodNameConfigurator.class);
+        ParamsConfigurator paramsConfigurator = mock(ParamsConfigurator.class);
+        ResultConfiguratorFromOne resultConfiguratorFromOne = mock(ResultConfiguratorFromOne.class);
+        OperationConfiguratorOneToNone operationConfiguratorOneToNone = mock(OperationConfiguratorOneToNone.class);
+
+        doReturn(methodNameConfigurator).when(configurator).newConfiguration();
+        doReturn(methodNameConfigurator).when(configurator).newConfiguration();
+        doReturn(paramsConfigurator).when(methodNameConfigurator).methodName(anyString());
+        doReturn(resultConfiguratorFromOne).when(paramsConfigurator).paramsAsDto(anyObject());
+        doReturn(operationConfiguratorOneToNone).when(resultConfiguratorFromOne).noResult();
 
         doReturn(promiseDebuggerInfo).when(service).connect("id", connectionProperties);
         doReturn(promiseVoid).when(promiseDebuggerInfo).then((Function<DebugSessionDto, Void>)any());
@@ -230,7 +245,6 @@ public class DebuggerTest extends BaseTest {
 
         assertTrue(debugger.isConnected());
         verify(localStorage).setItem(eq(AbstractDebugger.LOCAL_STORAGE_DEBUGGER_SESSION_KEY), eq(debugSessionJson));
-        verify(messageBus).subscribe(eq("id:events:"), any(SubscriptionHandler.class));
     }
 
     @Test
@@ -247,13 +261,10 @@ public class DebuggerTest extends BaseTest {
         doReturn(promiseVoid).when(service).disconnect(SESSION_ID);
         doReturn(promiseVoid).when(promiseVoid).then((Operation<Void>)any());
 
-        doReturn(true).when(messageBus).isHandlerSubscribed(any(), any());
-
         debugger.disconnect();
 
         assertFalse(debugger.isConnected());
         verify(localStorage).setItem(eq(AbstractDebugger.LOCAL_STORAGE_DEBUGGER_SESSION_KEY), eq(""));
-        verify(messageBus, times(1)).unsubscribe(anyString(), any());
 
         verify(promiseVoid).then(operationVoidCaptor.capture());
         verify(promiseVoid).catchError(operationPromiseErrorCaptor.capture());
@@ -583,18 +594,20 @@ public class DebuggerTest extends BaseTest {
     private class TestDebugger extends AbstractDebugger {
 
         public TestDebugger(DebuggerServiceClient service,
+                            RequestTransmitter transmitter,
+                            RequestHandlerConfigurator configurator,
                             DtoFactory dtoFactory,
                             LocalStorageProvider localStorageProvider,
-                            MessageBusProvider messageBusProvider,
                             EventBus eventBus,
                             ActiveFileHandler activeFileHandler,
                             DebuggerManager debuggerManager,
                             NotificationManager notificationManager,
                             String id) {
             super(service,
+                  transmitter,
+                  configurator,
                   dtoFactory,
                   localStorageProvider,
-                  messageBusProvider,
                   eventBus,
                   activeFileHandler,
                   debuggerManager,

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
@@ -217,7 +217,6 @@ public class DebuggerTest extends BaseTest {
         OperationConfiguratorOneToNone operationConfiguratorOneToNone = mock(OperationConfiguratorOneToNone.class);
 
         doReturn(methodNameConfigurator).when(configurator).newConfiguration();
-        doReturn(methodNameConfigurator).when(configurator).newConfiguration();
         doReturn(paramsConfigurator).when(methodNameConfigurator).methodName(anyString());
         doReturn(resultConfiguratorFromOne).when(paramsConfigurator).paramsAsDto(anyObject());
         doReturn(operationConfiguratorOneToNone).when(resultConfiguratorFromOne).noResult();

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbDebugger.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/GdbDebugger.java
@@ -26,8 +26,9 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.ide.jsonrpc.RequestTransmitter;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.plugin.debugger.ide.debug.AbstractDebugger;
 import org.eclipse.che.plugin.debugger.ide.debug.BasicActiveFileHandler;
 
@@ -53,10 +54,11 @@ public class GdbDebugger extends AbstractDebugger {
 
     @Inject
     public GdbDebugger(DebuggerServiceClient service,
+                       RequestTransmitter transmitter,
+                       RequestHandlerConfigurator configurator,
                        GdbLocalizationConstant locale,
                        DtoFactory dtoFactory,
                        LocalStorageProvider localStorageProvider,
-                       MessageBusProvider messageBusProvider,
                        EventBus eventBus,
                        BasicActiveFileHandler activeFileHandler,
                        DebuggerManager debuggerManager,
@@ -65,9 +67,10 @@ public class GdbDebugger extends AbstractDebugger {
                        AppContext appContext) {
 
         super(service,
+              transmitter,
+              configurator,
               dtoFactory,
               localStorageProvider,
-              messageBusProvider,
               eventBus,
               activeFileHandler,
               debuggerManager,

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebugger.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/debug/JavaDebugger.java
@@ -22,8 +22,9 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.ide.jsonrpc.RequestTransmitter;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.plugin.debugger.ide.debug.AbstractDebugger;
 import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolver;
 import org.eclipse.che.plugin.debugger.ide.fqn.FqnResolverFactory;
@@ -49,9 +50,10 @@ public class JavaDebugger extends AbstractDebugger {
 
     @Inject
     public JavaDebugger(DebuggerServiceClient service,
+                        RequestTransmitter transmitter,
                         DtoFactory dtoFactory,
+                        RequestHandlerConfigurator configurator,
                         LocalStorageProvider localStorageProvider,
-                        MessageBusProvider messageBusProvider,
                         EventBus eventBus,
                         FqnResolverFactory fqnResolverFactory,
                         JavaDebuggerFileHandler javaDebuggerFileHandler,
@@ -60,9 +62,10 @@ public class JavaDebugger extends AbstractDebugger {
                         FileTypeRegistry fileTypeRegistry,
                         BreakpointManager breakpointManager) {
         super(service,
+              transmitter,
+              configurator,
               dtoFactory,
               localStorageProvider,
-              messageBusProvider,
               eventBus,
               javaDebuggerFileHandler,
               debuggerManager,
@@ -76,7 +79,7 @@ public class JavaDebugger extends AbstractDebugger {
     @Override
     protected String fqnToPath(@NotNull Location location) {
         String resourcePath = location.getResourcePath();
-        return  resourcePath != null ? resourcePath : location.getTarget();
+        return resourcePath != null ? resourcePath : location.getTarget();
     }
 
     @Override

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/src/main/java/org/eclipse/che/plugin/nodejsdbg/ide/NodeJsDebugger.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/src/main/java/org/eclipse/che/plugin/nodejsdbg/ide/NodeJsDebugger.java
@@ -21,8 +21,9 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.ide.jsonrpc.RequestTransmitter;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.plugin.debugger.ide.debug.AbstractDebugger;
 import org.eclipse.che.plugin.debugger.ide.debug.BasicActiveFileHandler;
 
@@ -40,9 +41,10 @@ public class NodeJsDebugger extends AbstractDebugger {
 
     @Inject
     public NodeJsDebugger(DebuggerServiceClient service,
+                          RequestTransmitter transmitter,
+                          RequestHandlerConfigurator configurator,
                           DtoFactory dtoFactory,
                           LocalStorageProvider localStorageProvider,
-                          MessageBusProvider messageBusProvider,
                           EventBus eventBus,
                           BasicActiveFileHandler activeFileHandler,
                           DebuggerManager debuggerManager,
@@ -50,9 +52,10 @@ public class NodeJsDebugger extends AbstractDebugger {
                           BreakpointManager breakpointManager) {
 
         super(service,
+              transmitter,
+              configurator,
               dtoFactory,
               localStorageProvider,
-              messageBusProvider,
               eventBus,
               activeFileHandler,
               debuggerManager,

--- a/plugins/plugin-zend-debugger/che-plugin-zend-debugger-ide/src/main/java/org/eclipse/che/plugin/zdb/ide/ZendDebugger.java
+++ b/plugins/plugin-zend-debugger/che-plugin-zend-debugger-ide/src/main/java/org/eclipse/che/plugin/zdb/ide/ZendDebugger.java
@@ -21,8 +21,9 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.ide.jsonrpc.RequestTransmitter;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.plugin.debugger.ide.debug.AbstractDebugger;
 import org.eclipse.che.plugin.debugger.ide.debug.BasicActiveFileHandler;
 import org.eclipse.che.plugin.zdb.ide.configuration.ZendDbgConfigurationType;
@@ -41,18 +42,20 @@ public class ZendDebugger extends AbstractDebugger {
 
     @Inject
     public ZendDebugger(DebuggerServiceClient service,
+                        RequestTransmitter transmitter,
+                        RequestHandlerConfigurator configurator,
                         DtoFactory dtoFactory,
                         LocalStorageProvider localStorageProvider,
-                        MessageBusProvider messageBusProvider,
                         EventBus eventBus,
                         BasicActiveFileHandler activeFileHandler,
                         NotificationManager notificationManager,
                         DebuggerManager debuggerManager,
                         BreakpointManager breakpointManager) {
         super(service,
+              transmitter,
+              configurator,
               dtoFactory,
               localStorageProvider,
-              messageBusProvider,
               eventBus,
               activeFileHandler,
               debuggerManager,
@@ -75,7 +78,7 @@ public class ZendDebugger extends AbstractDebugger {
     @Override
     protected DebuggerDescriptor toDescriptor(Map<String, String> connectionProperties) {
         return new DebuggerDescriptor("Zend Debugger",
-                "Zend Debugger, port: " + connectionProperties.get(ZendDbgConfigurationType.ATTR_DEBUG_PORT));
+                                      "Zend Debugger, port: " + connectionProperties.get(ZendDbgConfigurationType.ATTR_DEBUG_PORT));
     }
 
 }

--- a/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerJsonRpcMessenger.java
+++ b/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerJsonRpcMessenger.java
@@ -39,9 +39,9 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
  */
 @Singleton
 public class DebuggerJsonRpcMessenger implements EventSubscriber<DebuggerMessage> {
-    private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:message:breakpoint";
-    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:message:disconnect";
-    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND    = "event:debugger:message:suspend";
+    private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:breakpoint";
+    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:disconnect";
+    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND    = "event:debugger:suspend";
     private static final String EVENT_DEBUGGER_UN_SUBSCRIBE       = "event:debugger:un-subscribe";
     private static final String EVENT_DEBUGGER_SUBSCRIBE          = "event:debugger:subscribe";
 

--- a/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerJsonRpcMessenger.java
+++ b/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerJsonRpcMessenger.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.debugger.server;
+
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.core.jsonrpc.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.RequestTransmitter;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.debug.shared.dto.BreakpointDto;
+import org.eclipse.che.api.debug.shared.dto.LocationDto;
+import org.eclipse.che.api.debug.shared.dto.event.BreakpointActivatedEventDto;
+import org.eclipse.che.api.debug.shared.dto.event.DisconnectEventDto;
+import org.eclipse.che.api.debug.shared.dto.event.SuspendEventDto;
+import org.eclipse.che.api.debug.shared.model.event.BreakpointActivatedEvent;
+import org.eclipse.che.api.debug.shared.model.event.DebuggerEvent;
+import org.eclipse.che.api.debug.shared.model.event.SuspendEvent;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static org.eclipse.che.api.debugger.server.DtoConverter.asDto;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
+/**
+ * Send debugger events using JSON RPC to the clients
+ */
+@Singleton
+public class DebuggerJsonRpcMessenger implements EventSubscriber<DebuggerMessage> {
+    private static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:message:breakpoint";
+    private static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:message:disconnect";
+    private static final String EVENT_DEBUGGER_MESSAGE_SUSPEND    = "event:debugger:message:suspend";
+    private static final String EVENT_DEBUGGER_UN_SUBSCRIBE       = "event:debugger:un-subscribe";
+    private static final String EVENT_DEBUGGER_SUBSCRIBE          = "event:debugger:subscribe";
+
+    private final EventService       eventService;
+    private final RequestTransmitter transmitter;
+
+    private final Set<String> endpointIds = newConcurrentHashSet();
+
+    @Inject
+    public DebuggerJsonRpcMessenger(EventService eventService, RequestTransmitter transmitter) {
+        this.eventService = eventService;
+        this.transmitter = transmitter;
+    }
+
+    @PostConstruct
+    private void subscribe() {
+        eventService.subscribe(this);
+    }
+
+    @PreDestroy
+    private void unsubscribe() {
+        eventService.unsubscribe(this);
+    }
+
+    @Override
+    public void onEvent(DebuggerMessage event) {
+        switch (event.getDebuggerEvent().getType()) {
+            case SUSPEND:
+                final LocationDto location = asDto(((SuspendEvent)event.getDebuggerEvent()).getLocation());
+                final SuspendEventDto suspendEvent = newDto(SuspendEventDto.class).withType(DebuggerEvent.TYPE.SUSPEND)
+                                                                                  .withLocation(location);
+                endpointIds.forEach(it -> transmitter.transmitOneToNone(it, EVENT_DEBUGGER_MESSAGE_SUSPEND, suspendEvent));
+                break;
+            case BREAKPOINT_ACTIVATED:
+                final BreakpointDto breakpointDto = asDto(((BreakpointActivatedEvent)event.getDebuggerEvent()).getBreakpoint());
+                final BreakpointActivatedEventDto breakpointActivatedEvent = newDto(BreakpointActivatedEventDto.class)
+                        .withType(DebuggerEvent.TYPE.BREAKPOINT_ACTIVATED)
+                        .withBreakpoint(breakpointDto);
+                endpointIds.forEach(it -> transmitter.transmitOneToNone(it, EVENT_DEBUGGER_MESSAGE_BREAKPOINT, breakpointActivatedEvent));
+                break;
+            case DISCONNECT:
+                final DisconnectEventDto disconnectEvent = newDto(DisconnectEventDto.class).withType(DebuggerEvent.TYPE.DISCONNECT);
+                endpointIds.forEach(it -> transmitter.transmitOneToNone(it, EVENT_DEBUGGER_MESSAGE_DISCONNECT, disconnectEvent));
+                break;
+            default:
+        }
+    }
+
+    @Inject
+    private void configureSubscribeHandler(RequestHandlerConfigurator configurator) {
+        configurator.newConfiguration()
+                    .methodName(EVENT_DEBUGGER_SUBSCRIBE)
+                    .paramsAsEmpty()
+                    .noResult()
+                    .withConsumer((endpointId, aVoid) -> endpointIds.add(endpointId));
+    }
+
+    @Inject
+    private void configureUnSubscribeHandler(RequestHandlerConfigurator configurator) {
+        configurator.newConfiguration()
+                    .methodName(EVENT_DEBUGGER_UN_SUBSCRIBE)
+                    .paramsAsString()
+                    .noResult()
+                    .withConsumer((endpointId, aVoid) -> endpointIds.remove(endpointId));
+    }
+}

--- a/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerModule.java
+++ b/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerModule.java
@@ -28,6 +28,7 @@ public class DebuggerModule extends AbstractModule {
         bind(DebuggerManager.class);
         bind(DebuggerService.class);
         bind(DebuggerWebSocketMessenger.class);
+        bind(DebuggerJsonRpcMessenger.class);
 
         bind(DebuggerActionProvider.class);
         final Multibinder<Class> ignoredClasses = Multibinder.newSetBinder(binder(), Class.class, Names.named("che.json.ignored_classes"));

--- a/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerWebSocketMessenger.java
+++ b/wsagent/che-core-api-debug/src/main/java/org/eclipse/che/api/debugger/server/DebuggerWebSocketMessenger.java
@@ -26,9 +26,10 @@ import javax.inject.Singleton;
 import static org.eclipse.che.api.debugger.server.DtoConverter.asDto;
 
 /**
- * @author Anatoliy Bazko
+ * @deprecated As of release 5.8.0, replaced by {@link DebuggerJsonRpcMessenger}
  */
 @Singleton
+@Deprecated
 public class DebuggerWebSocketMessenger implements EventSubscriber<DebuggerMessage> {
     private static final Logger LOG     = LoggerFactory.getLogger(DebuggerWebSocketMessenger.class);
     private static final String CHANNEL = "%s:events:";


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds JSON RPC connection via websocket between debugger server and IDE client and replaces previous message bus based IDE client services to JSON RPC based 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4593

#### Changelog
<!-- one line entry to be added to changelog -->
Replaced IDE client message bus based services to JSON RPC based for the debugger functionality

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
