### PR TITLE
CHE-4497: Delete snapshots from docker hub

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolverTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerRegistryAuthResolverTest.java
@@ -548,6 +548,34 @@ public class DockerRegistryAuthResolverTest {
                                           jsonToAuthConfigs(REGISTRY_WITH_DYNAMIC_PASSWORD_X_AUTH_CONFIG_VALUE));
     }
 
+    @Test
+    public void shouldGetBasicAuthHeaderValueFromInitialConfig() {
+        assertEquals(authResolver.getBasicAuthHeaderValue(INITIAL_REGISTRY2_URL, null),
+                     "Basic " + Base64.getEncoder()
+                                      .encodeToString((INITIAL_REGISTRY2_USERNAME + ':' + INITIAL_REGISTRY2_PASSWORD).getBytes()));
+    }
+
+    @Test
+    public void shouldGetBasicAuthHeaderValueFromCustomConfig() {
+        assertEquals(authResolver.getBasicAuthHeaderValue(REGISTRY2_URL, customAuthConfigs),
+                     "Basic " + Base64.getEncoder().encodeToString((REGISTRY2_USERNAME + ':' + REGISTRY2_PASSWORD).getBytes()));
+    }
+
+    @Test
+    public void shouldGetBasicAuthHeaderValueFromDynamicConfig() {
+        when(dynamicAuthResolver.getXRegistryAuth(REGISTRY_WITH_DYNAMIC_PASSWORD_URL))
+                .thenReturn(dynamicAuthConfigs.getConfigs().get(REGISTRY_WITH_DYNAMIC_PASSWORD_URL));
+
+        assertEquals(authResolver.getBasicAuthHeaderValue(REGISTRY_WITH_DYNAMIC_PASSWORD_URL, customAuthConfigs),
+                     "Basic " + Base64.getEncoder().encodeToString((REGISTRY_WITH_DYNAMIC_PASSWORD_USERNAME + ':' +
+                                                                    REGISTRY_WITH_DYNAMIC_PASSWORD_PASSWORD).getBytes()));
+    }
+
+    @Test
+    public void shouldReturnEmptyStringIfRegistryNotConfigured() {
+        assertEquals(authResolver.getBasicAuthHeaderValue("unconfigured.registry.com:5000", customAuthConfigs), "");
+    }
+
     private AuthConfig base64ToAuthConfig(String base64decodedJson) {
         return jsonToAuthConfig(new String(Base64.getDecoder().decode(base64decodedJson.getBytes())));
     }


### PR DESCRIPTION
### What does this PR do?
Distinguish Docker Hub as special registry on snapshot deletion operation and adds corresponding authorization header to the request. This adds ability to automatically deletion of workspace snapshots from Docker Hub.
This implementation uses v1 registry API because Docker Hub doesn't expose corresponding API method of v2 registry API.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4497

#### Changelog
Added ability to delete workspace snapshots from Docker Hub.

#### Release Notes
N/A

#### Docs PR
N/A
