### PR TITLE
Fix primitive parameters support for Json RPC

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcFactory.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcFactory.java
@@ -187,15 +187,4 @@ public interface JsonRpcFactory {
      * @return JSON RPC params
      */
     JsonRpcParams createParams(@Assisted("params") Object params);
-
-    /**
-     * Create a JSON RPC params instance by passing corresponding values.
-     * Params should be represented by a list of objects.
-     *
-     * @param params
-     *         params list
-     *
-     * @return JSON RPC params
-     */
-    JsonRpcParams createParamsList(@Assisted("params") List<?> params);
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcParams.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/JsonRpcParams.java
@@ -21,88 +21,185 @@ import com.google.inject.assistedinject.AssistedInject;
 import org.eclipse.che.dto.server.DtoFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.eclipse.che.api.core.jsonrpc.JsonRpcUtils.cast;
 
 /**
  * Represents JSON RPC params object. Can be constructed out of
  * stringified json object or by passing specific parameters.
  * Use {@link JsonRpcFactory#createParams(Object)},
- * {@link JsonRpcFactory#createParamsList(List)} or
  * {@link JsonRpcFactory#createParams(String)} to get an instance.
  */
 public class JsonRpcParams {
-    private final static JsonObject EMPTY_OBJECT = new JsonObject();
+    private final JsonParser jsonParser;
 
-    private List<JsonElement> paramsList;
-    private JsonElement       params;
+    private List<Param<?>> params;
+    private Param<?>       param;
 
     @AssistedInject
     public JsonRpcParams(@Assisted("message") String message, JsonParser jsonParser) {
+        this.jsonParser = jsonParser;
+
         checkNotNull(message, "Message must not be null");
         checkArgument(!message.isEmpty(), "Message must not be empty");
 
         JsonElement jsonElement = jsonParser.parse(message);
         if (jsonElement.isJsonArray()) {
             JsonArray jsonArray = jsonParser.parse(message).getAsJsonArray();
-            paramsList = new ArrayList<>(jsonArray.size());
-            jsonArray.forEach(it -> paramsList.add(it));
+            this.params = new ArrayList<>(jsonArray.size());
+            for (JsonElement element : jsonArray) {
+                if (element.isJsonPrimitive()) {
+                    JsonPrimitive primitiveElement = element.getAsJsonPrimitive();
+                    Param<?> paramCandidate;
+                    if (primitiveElement.isBoolean()) {
+                        paramCandidate = new Param<>(Boolean.class, primitiveElement.getAsBoolean());
+                    } else if (primitiveElement.isNumber()) {
+                        paramCandidate = new Param<>(Double.class, primitiveElement.getAsDouble());
+                    } else {
+                        paramCandidate = new Param<>(String.class, primitiveElement.getAsString());
+                    }
+                    this.params.add(paramCandidate);
+                } else {
+                    this.params.add(new Param<>(Object.class, element.getAsJsonObject()));
+                }
+            }
+
+            this.param = null;
+        } else if (jsonElement.isJsonPrimitive()) {
+            JsonPrimitive primitiveElement = jsonElement.getAsJsonPrimitive();
+            if (primitiveElement.isBoolean()) {
+                this.param = new Param<>(Boolean.class, primitiveElement.getAsBoolean());
+            } else if (primitiveElement.isNumber()) {
+                this.param = new Param<>(Double.class, primitiveElement.getAsDouble());
+            } else {
+                this.param = new Param<>(String.class, primitiveElement.getAsString());
+            }
+
+            this.params = null;
+        } else if (jsonElement.isJsonObject()) {
+            this.param = new Param<>(Object.class, jsonElement.getAsJsonObject());
+
+            this.params = null;
         } else {
-            params = jsonParser.parse(message);
+            this.params = null;
+            this.param = null;
         }
     }
 
-    @AssistedInject
-    public JsonRpcParams(@Assisted("params") Object params, JsonParser jsonParser) {
-        this.params = params == null ? EMPTY_OBJECT : jsonParser.parse(params.toString());
-    }
 
     @AssistedInject
-    public JsonRpcParams(JsonParser jsonParser, @Assisted("params") List<?> params) {
-        if (params == null || params.isEmpty()) {
-            this.paramsList = Collections.emptyList();
+    public JsonRpcParams(JsonParser jsonParser, @Assisted("params") Object params) {
+        this.jsonParser = jsonParser;
+
+        if (params == null) {
+            this.params = null;
+            this.param = null;
         } else {
-            // ugly workaround will be fixed in next release
-            if (params.get(0) instanceof String) {
-                this.paramsList = params.stream().map(it -> new JsonPrimitive(it.toString())).collect(Collectors.toList());
+            if (params instanceof List) {
+                List<?> listParams = (List<?>)params;
+                this.params = new ArrayList<>(listParams.size());
+
+                for (Object param : listParams) {
+                    Param<?> paramCandidate;
+                    if (param instanceof Boolean) {
+                        paramCandidate = new Param<>(Boolean.class, (Boolean)param);
+                    } else if (param instanceof String) {
+                        paramCandidate = new Param<>(String.class, (String)param);
+                    } else if (param instanceof Double) {
+                        paramCandidate = new Param<>(Double.class, (Double)param);
+                    } else {
+                        paramCandidate = new Param<>(Object.class, param);
+                    }
+                    this.params.add(paramCandidate);
+                }
+
+                this.param = null;
             } else {
-                this.paramsList = params.stream().map(Object::toString).map(jsonParser::parse).collect(Collectors.toList());
+                Param<?> paramCandidate;
+                if (params instanceof Boolean) {
+                    this.param = new Param<>(Boolean.class, (Boolean)params);
+                } else if (params instanceof String) {
+                    this.param = new Param<>(String.class, (String)params);
+                } else if (params instanceof Double) {
+                    this.param = new Param<>(Double.class, (Double)params);
+                } else {
+                    this.param = new Param<>(Object.class, params);
+                }
+
+                this.params = null;
             }
         }
     }
 
     public boolean emptyOrAbsent() {
-        return (paramsList == null || paramsList.isEmpty()) && (params == null || EMPTY_OBJECT.equals(params));
+        return (params == null || params.isEmpty()) && (param == null || jsonParser.parse("{}").equals(param.value));
     }
 
     public JsonElement toJsonElement() {
-        if (params != null) {
-            return params;
+        if (param != null) {
+            if (param.type.equals(Object.class)) {
+                return jsonParser.parse(param.value.toString());
+            } else if (param.type.equals(String.class)) {
+                return new JsonPrimitive((String)param.value);
+            } else if (param.type.equals(Boolean.class)) {
+                return new JsonPrimitive((Boolean)param.value);
+            } else if (param.type.equals(Double.class)) {
+                return new JsonPrimitive((Double)param.value);
+            }
         }
 
         JsonArray array = new JsonArray();
-        paramsList.forEach(array::add);
+        for (Param<?> paramCandidate : params) {
+            JsonElement element;
+            if (paramCandidate.type.equals(Object.class)) {
+                element = jsonParser.parse(paramCandidate.value.toString());
+            } else if (paramCandidate.type.equals(String.class)) {
+                element = new JsonPrimitive((String)paramCandidate.value);
+            } else if (paramCandidate.type.equals(Boolean.class)) {
+                element = new JsonPrimitive((Boolean)paramCandidate.value);
+            } else {
+                element = new JsonPrimitive((Double)paramCandidate.value);
+            }
+            array.add(element);
+        }
         return array;
     }
 
     public <T> T getAs(Class<T> type) {
-        checkNotNull(params, "Type must not be null");
+        checkNotNull(type, "Type must not be null");
+        checkNotNull(param, "Param must not be null");
+        checkState(type.equals(param.type), "Types should match");
 
-        return JsonRpcUtils.getAs(params, type);
+        if (param.type.equals(Object.class)) {
+            return DtoFactory.getInstance().createDtoFromJson(param.value.toString(), type);
+        } else {
+            return cast(param.value);
+        }
     }
 
     public <T> List<T> getAsListOf(Class<T> type) {
         checkNotNull(type, "Type must not be null");
 
-        return JsonRpcUtils.getAsListOf(paramsList, type);
+        return params.stream().map(it -> it.value).collect(cast(Collectors.toList()));
     }
 
     @Override
     public String toString() {
         return toJsonElement().toString();
+    }
+
+    private class Param<T> {
+        final private Class<T> type;
+        final private T        value;
+
+        private Param(Class<T> type, T value) {
+            this.type = type;
+            this.value = value;
+        }
     }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/RequestHandlerOneToMany.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/RequestHandlerOneToMany.java
@@ -53,7 +53,11 @@ public class RequestHandlerOneToMany<P, R> implements RequestHandler {
 
         LOG.debug("Handling request from: {}, with params: {}", endpointId, params);
 
-        P paramsObject = params.getAs(pClass);
+        P paramsObject = pClass.equals(String.class) ||
+                         pClass.equals(Boolean.class) ||
+                         pClass.equals(Double.class) ? params.getAsListOf(pClass).get(0)
+                                                     : params.getAs(pClass);
+
         LOG.debug("Created raw params object: {}", paramsObject);
         List<R> resultList = function.apply(endpointId, paramsObject);
         LOG.debug("Received result list: {}", resultList);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/RequestHandlerOneToOne.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/RequestHandlerOneToOne.java
@@ -52,7 +52,11 @@ public class RequestHandlerOneToOne<P, R> implements RequestHandler {
 
         LOG.debug("Handling request from: {}, with params: {}", endpointId, params);
 
-        P paramsObject = params.getAs(pClass);
+        P paramsObject = pClass.equals(String.class) ||
+                         pClass.equals(Boolean.class) ||
+                         pClass.equals(Double.class) ? params.getAsListOf(pClass).get(0)
+                                                     : params.getAs(pClass);
+
         LOG.debug("Created raw params object: {}", paramsObject);
         R result = function.apply(endpointId, paramsObject);
         LOG.debug("Received result: {}", result);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/transmission/SendConfiguratorFromMany.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/transmission/SendConfiguratorFromMany.java
@@ -167,7 +167,7 @@ public class SendConfiguratorFromMany<P> {
     }
 
     private void transmitNotification() {
-        JsonRpcParams params = factory.createParamsList(pListValue);
+        JsonRpcParams params = factory.createParams(pListValue);
         JsonRpcRequest request = factory.createRequest(method, params);
         transmitter.transmit(endpointId, request.toString());
     }
@@ -176,7 +176,7 @@ public class SendConfiguratorFromMany<P> {
         Integer id = MethodNameConfigurator.id.incrementAndGet();
         String requestId = id.toString();
 
-        JsonRpcParams params = factory.createParamsList(pListValue);
+        JsonRpcParams params = factory.createParams(pListValue);
         JsonRpcRequest request = factory.createRequest(requestId, method, params);
         transmitter.transmit(endpointId, request.toString());
         return requestId;

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/JsonRpcParamsTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/JsonRpcParamsTest.java
@@ -168,12 +168,11 @@ public class JsonRpcParamsTest {
         JsonArray expected = new JsonArray();
         expected.add(new JsonPrimitive(value));
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(singletonList(value), jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, singletonList(value));
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, actual);
     }
-
 
     @Test
     public void shouldToStringCreatedListStringParams() throws Exception {
@@ -182,7 +181,7 @@ public class JsonRpcParamsTest {
         array.add(new JsonPrimitive(value));
         String expected = array.toString();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(singletonList(value), jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, singletonList(value));
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -225,7 +224,7 @@ public class JsonRpcParamsTest {
         JsonRpcParams jsonRpcParams = new JsonRpcParams("[\"" + expected + "\"]", jsonParser);
         List<Double> actual = jsonRpcParams.getAsListOf(Double.class);
 
-        assertEquals(singletonList(expected), actual);
+        assertEquals(singletonList(expected).toString(), actual.toString());
     }
 
     @Test
@@ -257,7 +256,7 @@ public class JsonRpcParamsTest {
     public void shouldGetAsForCreatedSingleDoubleParams() throws Exception {
         Double expected = 0D;
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, expected);
         Double actual = jsonRpcParams.getAs(Double.class);
 
         assertEquals(expected, actual);
@@ -267,7 +266,7 @@ public class JsonRpcParamsTest {
     public void shouldToJsonForCreatedSingleDoubleParams() throws Exception {
         Double expected = 0D;
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, expected);
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, Double.valueOf(actual.toString()));
@@ -277,7 +276,7 @@ public class JsonRpcParamsTest {
     public void shouldToStringCreatedSingleDoubleParams() throws Exception {
         Double expected = 0D;
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, expected);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, Double.valueOf(actual));
@@ -290,7 +289,7 @@ public class JsonRpcParamsTest {
         JsonArray expected = new JsonArray();
         expected.add(new JsonPrimitive(value));
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, list);
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, actual);
@@ -305,7 +304,7 @@ public class JsonRpcParamsTest {
         jsonArray.add(new JsonPrimitive(value));
         String expected = jsonArray.toString();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, list);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -390,7 +389,7 @@ public class JsonRpcParamsTest {
     public void shouldToJsonForCreatedSingleBooleanParams() throws Exception {
         Boolean expected = false;
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, expected);
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, Boolean.valueOf(actual.toString()));
@@ -400,7 +399,7 @@ public class JsonRpcParamsTest {
     public void shouldToStringCreatedSingleBooleanParams() throws Exception {
         Boolean expected = false;
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, expected);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, Boolean.valueOf(actual));
@@ -413,7 +412,7 @@ public class JsonRpcParamsTest {
         JsonArray expected = new JsonArray();
         expected.add(new JsonPrimitive(value));
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, list);
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, actual);
@@ -427,7 +426,7 @@ public class JsonRpcParamsTest {
         jsonArray.add(new JsonPrimitive(value));
         String expected = jsonArray.toString();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, list);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -481,7 +480,7 @@ public class JsonRpcParamsTest {
     @Test
     public void shouldToJsonForCreatedSingleDtoParams() throws Exception {
         JsonObject expected = jsonParser.parse(dto.toString()).getAsJsonObject();
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(dto, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, dto);
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, actual);
@@ -491,7 +490,7 @@ public class JsonRpcParamsTest {
     public void shouldToStringCreatedSingleDtoParams() throws Exception {
         String expected = jsonParser.parse(dto.toString()).toString();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(dto, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, dto);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -505,7 +504,7 @@ public class JsonRpcParamsTest {
         JsonElement element = jsonParser.parse(dto.toString());
         expected.add(element);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, list);
         JsonElement actual = jsonRpcParams.toJsonElement();
 
         assertEquals(expected, actual);
@@ -520,7 +519,7 @@ public class JsonRpcParamsTest {
         jsonArray.add(jsonValue);
         String expected = jsonArray.toString();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, list);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -571,21 +570,21 @@ public class JsonRpcParamsTest {
 
     @Test
     public void shouldNotBeEmptyOrAbsentForBooleanCreatedParams() throws Exception {
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(false, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, false);
 
         assertFalse(jsonRpcParams.emptyOrAbsent());
     }
 
     @Test
     public void shouldNotBeEmptyOrAbsentForNumberCreatedParams() throws Exception {
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(0D, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, 0D);
 
         assertFalse(jsonRpcParams.emptyOrAbsent());
     }
 
     @Test
     public void shouldNotBeEmptyOrAbsentForDtoCreatedParams() throws Exception {
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(dto, jsonParser);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(jsonParser, dto);
 
         assertFalse(jsonRpcParams.emptyOrAbsent());
     }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcFactory.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcFactory.java
@@ -175,15 +175,4 @@ public interface JsonRpcFactory {
      * @return JSON RPC params
      */
     JsonRpcParams createParams(@Assisted("params") Object params);
-
-    /**
-     * Create a JSON RPC params instance by passing corresponding values.
-     * Params should be represented by a list of objects.
-     *
-     * @param params
-     *         params list
-     *
-     * @return JSON RPC params
-     */
-    JsonRpcParams createParamsList(@Assisted("params") List<?> params);
 }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/RequestHandlerOneToList.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/RequestHandlerOneToList.java
@@ -49,7 +49,11 @@ public class RequestHandlerOneToList<P, R> implements RequestHandler {
 
         Log.debug(getClass(), "Handling request from: " + endpointId + ", with params: " + params);
 
-        P paramsObject = params.getAs(pClass);
+        P paramsObject = pClass.equals(String.class) ||
+                         pClass.equals(Boolean.class) ||
+                         pClass.equals(Double.class) ? params.getAsListOf(pClass).get(0)
+                                                     : params.getAs(pClass);
+
         Log.debug(getClass(), "Created raw params object: " + paramsObject);
         List<R> resultList = biFunction.apply(endpointId, paramsObject);
         Log.debug(getClass(), "Received result list: " + resultList);

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/RequestHandlerOneToOne.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/RequestHandlerOneToOne.java
@@ -47,7 +47,11 @@ public class RequestHandlerOneToOne<P, R> implements RequestHandler {
 
         Log.debug(getClass(), "Handling request from: " + endpointId + ", with params: " + params);
 
-        P paramsObject = params.getAs(pClass);
+        P paramsObject = pClass.equals(String.class) ||
+                         pClass.equals(Boolean.class) ||
+                         pClass.equals(Double.class) ? params.getAsListOf(pClass).get(0)
+                                                     : params.getAs(pClass);
+        
         Log.debug(getClass(), "Created raw params object: " + paramsObject);
         R result = biFunction.apply(endpointId, paramsObject);
         Log.debug(getClass(), "Received result: " + result);

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/transmission/SendConfiguratorFromList.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/transmission/SendConfiguratorFromList.java
@@ -201,15 +201,14 @@ public class SendConfiguratorFromList<P> {
     }
 
     private void transmitNotification() {
-        JsonRpcParams params = factory.createParamsList(pListValue);
+        JsonRpcParams params = factory.createParams(pListValue);
         JsonRpcRequest request = factory.createRequest(method, params);
         transmitter.transmit(endpointId, request.toString());
     }
 
     private String transmitRequest() {
+        JsonRpcParams params = factory.createParams(pListValue);
         String requestId = Integer.valueOf(MethodNameConfigurator.id.incrementAndGet()).toString();
-
-        JsonRpcParams params = factory.createParamsList(pListValue);
         JsonRpcRequest request = factory.createRequest(requestId, method, params);
         transmitter.transmit(endpointId, request.toString());
         return requestId;

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/JsonRpcParamsTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/jsonrpc/JsonRpcParamsTest.java
@@ -157,7 +157,7 @@ public class JsonRpcParamsTest {
     public void shouldGetAsListForCreatedListStringParams() throws Exception {
         List<String> expected = singletonList("value");
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, dtoFactory, jsonFactory);
         List<String> actual = jsonRpcParams.getAsListOf(String.class);
 
         assertEquals(expected, actual);
@@ -169,7 +169,7 @@ public class JsonRpcParamsTest {
         JsonArray expected = jsonFactory.createArray();
         expected.set(0, value);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(singletonList(value), jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(singletonList(value), dtoFactory, jsonFactory);
         JsonValue actual = jsonRpcParams.toJsonValue();
 
         assertTrue(expected.jsEquals(actual));
@@ -182,7 +182,7 @@ public class JsonRpcParamsTest {
         JsonArray expected = jsonFactory.createArray();
         expected.set(0, value);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(singletonList(value), jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(singletonList(value), dtoFactory, jsonFactory);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected.toJson(), actual);
@@ -225,7 +225,7 @@ public class JsonRpcParamsTest {
         JsonRpcParams jsonRpcParams = new JsonRpcParams("[" + expected + "]", jsonFactory, dtoFactory);
         List<Double> actual = jsonRpcParams.getAsListOf(Double.class);
 
-        assertEquals(singletonList(expected), actual);
+        assertEquals(singletonList(expected).toString(), actual.toString());
     }
 
     @Test
@@ -287,7 +287,7 @@ public class JsonRpcParamsTest {
     public void shouldGetAsListForCreatedListDoubleParams() throws Exception {
         List<Double> expected = singletonList(0D);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, dtoFactory, jsonFactory);
         List<Double> actual = jsonRpcParams.getAsListOf(Double.class);
 
         assertEquals(expected, actual);
@@ -300,7 +300,7 @@ public class JsonRpcParamsTest {
         JsonArray expected = jsonFactory.createArray();
         expected.set(0, value);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         JsonValue actual = jsonRpcParams.toJsonValue();
 
         assertTrue(expected.jsEquals(actual));
@@ -315,7 +315,7 @@ public class JsonRpcParamsTest {
         jsonArray.set(0, value);
         String expected = jsonArray.toJson();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -420,7 +420,7 @@ public class JsonRpcParamsTest {
     public void shouldGetAsListForCreatedListBooleanParams() throws Exception {
         List<Boolean> expected = singletonList(false);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(expected, dtoFactory, jsonFactory);
         List<Boolean> actual = jsonRpcParams.getAsListOf(Boolean.class);
 
         assertEquals(expected, actual);
@@ -433,7 +433,7 @@ public class JsonRpcParamsTest {
         JsonArray expected = jsonFactory.createArray();
         expected.set(0, value);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         JsonValue actual = jsonRpcParams.toJsonValue();
 
         assertTrue(expected.jsEquals(actual));
@@ -447,7 +447,7 @@ public class JsonRpcParamsTest {
         jsonArray.set(0, value);
         String expected = jsonArray.toJson();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);
@@ -457,7 +457,7 @@ public class JsonRpcParamsTest {
     public void shouldGetAsForParsedSingleDtoParams() throws Exception {
         String expected = DTO_JSON;
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(DTO_JSON, dtoFactory, jsonFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(DTO_JSON, jsonFactory, dtoFactory);
         String actual = jsonRpcParams.getAs(Dto.class).toString();
 
         assertEquals(expected, actual);
@@ -487,8 +487,9 @@ public class JsonRpcParamsTest {
     public void shouldGetAsListForParsedListDtoParams() throws Exception {
         JsonRpcParams jsonRpcParams = new JsonRpcParams("[" + DTO_JSON + "]", jsonFactory, dtoFactory);
         List<Dto> actual = jsonRpcParams.getAsListOf(Dto.class);
+        List<Dto> expected = singletonList(dto);
 
-        assertEquals(singletonList(dto), actual);
+        assertEquals(expected.toString(), actual.toString());
     }
 
     @Test
@@ -548,7 +549,7 @@ public class JsonRpcParamsTest {
     public void shouldGetAsListForCreatedListDtoParams() throws Exception {
         List<Dto> list = singletonList(dto);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         List<Dto> actual = jsonRpcParams.getAsListOf(Dto.class);
 
         assertEquals(list, actual);
@@ -562,7 +563,7 @@ public class JsonRpcParamsTest {
         JsonValue jsonValue = jsonFactory.parse(dto.toString());
         expected.set(0, jsonValue);
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         JsonValue actual = jsonRpcParams.toJsonValue();
 
         assertTrue(expected.jsEquals(actual));
@@ -577,7 +578,7 @@ public class JsonRpcParamsTest {
         jsonArray.set(0, jsonValue);
         String expected = jsonArray.toJson();
 
-        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, jsonFactory, dtoFactory);
+        JsonRpcParams jsonRpcParams = new JsonRpcParams(list, dtoFactory, jsonFactory);
         String actual = jsonRpcParams.toString();
 
         assertEquals(expected, actual);


### PR DESCRIPTION
Signed-off-by: Dmitry Kuleshov <dkuleshov@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes cases where we send primitive values over Json RPC. This includes parsing of json messages and also more accurate support of Json RPC 2.0 spec.

Please note that though the code has several things to be improved or refactored it is intentionally done in this simple way to ease client and server code merge (json rpc related stuff), that is planned for near future.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4615

#### Changelog
Fixed primitive parameters support in Json RPC
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
