### PR TITLE
CHE-4623 Hide `Preview` for non-html items

### DIFF
--- a/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/WebExtension.java
+++ b/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/WebExtension.java
@@ -25,7 +25,7 @@ import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.ext.web.css.NewCssFileAction;
 import org.eclipse.che.ide.ext.web.css.NewLessFileAction;
 import org.eclipse.che.ide.ext.web.html.NewHtmlFileAction;
-import org.eclipse.che.ide.ext.web.html.PreviewAction;
+import org.eclipse.che.ide.ext.web.html.PreviewHTMLAction;
 import org.eclipse.che.ide.ext.web.html.editor.HtmlEditorProvider;
 import org.eclipse.che.ide.ext.web.js.NewJavaScriptFileAction;
 import org.eclipse.che.ide.ext.web.js.editor.JsEditorProvider;
@@ -93,13 +93,13 @@ public class WebExtension {
                                 NewLessFileAction newLessFileAction,
                                 NewHtmlFileAction newHtmlFileAction,
                                 NewJavaScriptFileAction newJavaScriptFileAction,
-                                PreviewAction previewAction) {
+                                PreviewHTMLAction previewHTMLAction) {
         // register actions
         actionManager.registerAction("newCssFile", newCssFileAction);
         actionManager.registerAction("newLessFile", newLessFileAction);
         actionManager.registerAction("newHtmlFile", newHtmlFileAction);
         actionManager.registerAction("newJavaScriptFile", newJavaScriptFileAction);
-        actionManager.registerAction("previewHTML", previewAction);
+        actionManager.registerAction("previewHTML", previewHTMLAction);
 
         // set icons
         newCssFileAction.getTemplatePresentation().setSVGResource(resources.cssFile());
@@ -116,10 +116,10 @@ public class WebExtension {
 
         // add actions in context menu
         DefaultActionGroup mainContextMenuGroup = (DefaultActionGroup)actionManager.getAction(GROUP_MAIN_CONTEXT_MENU);
-        mainContextMenuGroup.add(previewAction);
+        mainContextMenuGroup.add(previewHTMLAction);
 
         // add actions in Assistant main menu
         DefaultActionGroup assistantMainMenuGroup = (DefaultActionGroup)actionManager.getAction(GROUP_ASSISTANT);
-        assistantMainMenuGroup.add(previewAction);
+        assistantMainMenuGroup.add(previewHTMLAction);
     }
 }

--- a/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/html/PreviewHTMLAction.java
+++ b/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/html/PreviewHTMLAction.java
@@ -31,15 +31,15 @@ import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspect
  * @author Artem Zatsarynnyi
  */
 @Singleton
-public class PreviewAction extends AbstractPerspectiveAction {
+public class PreviewHTMLAction extends AbstractPerspectiveAction {
 
     private final WsAgentURLModifier wsAgentURLModifier;
     private final AppContext         appContext;
 
     @Inject
-    public PreviewAction(WsAgentURLModifier wsAgentURLModifier,
-                         AppContext appContext,
-                         WebLocalizationConstant localizationConstants) {
+    public PreviewHTMLAction(WsAgentURLModifier wsAgentURLModifier,
+                             AppContext appContext,
+                             WebLocalizationConstant localizationConstants) {
         super(singletonList(PROJECT_PERSPECTIVE_ID),
               localizationConstants.previewHTMLActionTitle(),
               localizationConstants.previewHTMLActionDescription(),
@@ -51,21 +51,19 @@ public class PreviewAction extends AbstractPerspectiveAction {
 
     @Override
     public void updateInPerspective(ActionEvent e) {
-        e.getPresentation().setVisible(true);
-
         final Resource[] resources = appContext.getResources();
         if (resources != null && resources.length == 1) {
             final Resource selectedResource = resources[0];
             if (Resource.FILE == selectedResource.getResourceType()) {
                 final String fileExtension = ((File)selectedResource).getExtension();
                 if ("html".equals(fileExtension)) {
-                    e.getPresentation().setEnabled(true);
+                    e.getPresentation().setEnabledAndVisible(true);
                     return;
                 }
             }
         }
 
-        e.getPresentation().setEnabled(false);
+        e.getPresentation().setEnabledAndVisible(false);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Hides `Preview` context menu item for non-html items

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4623

#### Changelog
`Preview` in context menu is not visible for non-html items.
