### PR TITLE
Create workspace dir in server instead of workspace pod on Openshift

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -298,6 +298,7 @@ che.openshift.liveness.probe.delay=300
 che.openshift.liveness.probe.timeout=1
 che.openshift.workspaces.pvc.name=claim-che-workspace
 che.openshift.workspaces.pvc.quantity=10Gi
+che.openshift.workspace.pvc.mount.path=/projects
 # Create secure route against HTTPS 
 # NOTE: In order to create routes against HTTPS 
 # Property 'strategy.che.docker.server_evaluation_strategy.secure.external.urls' should be also set to true

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -77,6 +77,7 @@ public class OpenShiftConnectorTest {
                                                     OPENSHIFT_DEFAULT_WORKSPACE_QUANTITY,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_STORAGE,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE,
+                                                    null,
                                                     CHE_WORKSPACE_CPU_LIMIT,
                                                     null,
                                                     SECURE_ROUTES);


### PR DESCRIPTION
### What does this PR do?
Create workspace directory on PVC before launching workspace instead of starting a Pod to create the directory. This step is necessary because if a workspace directory does not exist, it will be created with root permissions when mounted on a subpath.

Assumes that the workspace PVC is mounted in the server pod. In addition to mounting the PVC on che-server, the property `che.openshift.workspace.pvc.mount.path` must match the mount path of the workspace PVC.

See: https://github.com/fabric8io/fabric8-online/pull/140