### PR TITLE
Avoid System.exit calls that kills the whole Maven jvm or IDE running it

### DIFF
--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/DtoFactoryVisitorRegistryGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/DtoFactoryVisitorRegistryGenerator.java
@@ -44,22 +44,17 @@ public class DtoFactoryVisitorRegistryGenerator {
      * Entry point. --rootDir is the optional parameter.
      *
      * @param args
+     * @throws IOException 
      */
-    public static void main(String[] args) {
-        try {
-            File rootFolder = GeneratorUtils.getRootFolder(args);
-            System.out.println(" ------------------------------------------------------------------------ ");
-            System.out.println("Searching for DTO");
-            System.out.println(" ------------------------------------------------------------------------ ");
+    public static void main(String[] args) throws IOException {
+        File rootFolder = GeneratorUtils.getRootFolder(args);
+        System.out.println(" ------------------------------------------------------------------------ ");
+        System.out.println("Searching for DTO");
+        System.out.println(" ------------------------------------------------------------------------ ");
 
-            // find all DtoFactoryVisitors
-            findDtoFactoryVisitors();
-            generateExtensionManager(rootFolder);
-        } catch (IOException e) {
-            System.err.println(e.getMessage());
-            // error
-            System.exit(1);//NOSONAR
-        }
+        // find all DtoFactoryVisitors
+        findDtoFactoryVisitors();
+        generateExtensionManager(rootFolder);
     }
 
     /**

--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/ExtensionManagerGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/ExtensionManagerGenerator.java
@@ -52,21 +52,16 @@ public class ExtensionManagerGenerator {
      * Entry point. --rootDir is the optional parameter.
      *
      * @param args
+     * @throws IOException 
      */
-    public static void main(String[] args) {
-        try {
-            File rootFolder = GeneratorUtils.getRootFolder(args);
-            System.out.println(" ------------------------------------------------------------------------ ");
-            System.out.println(String.format("Searching for Extensions in %s", rootFolder.getAbsolutePath()));
-            System.out.println(" ------------------------------------------------------------------------ ");
-            // find all Extension FQNs
-            findExtensions();
-            generateExtensionManager(rootFolder);
-        } catch (IOException e) {
-            System.err.println(e.getMessage());
-            // error
-            System.exit(1);//NOSONAR
-        }
+    public static void main(String[] args) throws IOException {
+        File rootFolder = GeneratorUtils.getRootFolder(args);
+        System.out.println(" ------------------------------------------------------------------------ ");
+        System.out.println(String.format("Searching for Extensions in %s", rootFolder.getAbsolutePath()));
+        System.out.println(" ------------------------------------------------------------------------ ");
+        // find all Extension FQNs
+        findExtensions();
+        generateExtensionManager(rootFolder);
     }
 
     /**

--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/GwtXmlGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/GwtXmlGenerator.java
@@ -97,44 +97,40 @@ public class GwtXmlGenerator {
      *         --loggingEnabled - Enable or disable gwt logging, default "false"
      *         --includePackages - Include only specific packages where *.gwt.xml can be found, default "No value. Means all packages"
      *         --excludePackages - Exclude packages from *.gwt.xml scanning	, default "com.google", "elemental","java.util","java.lang"
+     * @throws IOException 
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
 
-        try {
-            System.out.println(" ------------------------------------------------------------------------ ");
-            System.out.println("Searching for GWT");
-            System.out.println(" ------------------------------------------------------------------------ ");
-            Map<String, Set<String>> parsedArgs = GeneratorUtils.parseArgs(args);
+        System.out.println(" ------------------------------------------------------------------------ ");
+        System.out.println("Searching for GWT");
+        System.out.println(" ------------------------------------------------------------------------ ");
+        Map<String, Set<String>> parsedArgs = GeneratorUtils.parseArgs(args);
 
-            GwtXmlModuleSearcher searcher = new GwtXmlModuleSearcher(parsedArgs.getOrDefault("excludePackages",
-                                                                                             ImmutableSet.of("com.google",
-                                                                                                             "elemental",
-                                                                                                             "java.util",
-                                                                                                             "java.lang"
-                                                                                                            )),
-                                                                     parsedArgs.getOrDefault("includePackages", Collections.emptySet()),
-                                                                     Collections.emptySet());
-            Set<String> gwtModules = searcher.getGwtModulesFromClassPath();
-            gwtModules.forEach(System.out::println);
-            System.out.println("Found " + gwtModules.size() + " gwt modules");
+        GwtXmlModuleSearcher searcher = new GwtXmlModuleSearcher(parsedArgs.getOrDefault("excludePackages",
+                                                                                         ImmutableSet.of("com.google",
+                                                                                                         "elemental",
+                                                                                                         "java.util",
+                                                                                                         "java.lang"
+                                                                                                        )),
+                                                                 parsedArgs.getOrDefault("includePackages", Collections.emptySet()),
+                                                                 Collections.emptySet());
+        Set<String> gwtModules = searcher.getGwtModulesFromClassPath();
+        gwtModules.forEach(System.out::println);
+        System.out.println("Found " + gwtModules.size() + " gwt modules");
 
 
-            GwtXmlGeneratorConfig gwtXmlGeneratorConfig =
-                    new GwtXmlGeneratorConfig(gwtModules,
-                                              new File(getSingleValueOrDefault(parsedArgs, "rootDir", ".")),
-                                              getSingleValueOrDefault(parsedArgs, "gwtFileName", DEFAULT_GWT_XML_PATH),
-                                              getSingleValueOrDefault(parsedArgs, "entryPoint", DEFAULT_GWT_ETNRY_POINT),
-                                              getSingleValueOrDefault(parsedArgs, "styleSheet", DEFAULT_STYLE_SHEET),
-                                              parseBoolean(
-                                                      getSingleValueOrDefault(parsedArgs, "loggingEnabled", DEFAULT_LOGGING.toString()))
-                    );
-            GwtXmlGenerator gwtXmlGenerator = new GwtXmlGenerator(gwtXmlGeneratorConfig);
-            gwtXmlGenerator.generateGwtXml();
-        } catch (IOException e) {
-            System.err.println(e.getMessage());
-            // error
-            System.exit(1);//NOSONAR
-        }
+        GwtXmlGeneratorConfig gwtXmlGeneratorConfig =
+                new GwtXmlGeneratorConfig(gwtModules,
+                                          new File(getSingleValueOrDefault(parsedArgs, "rootDir", ".")),
+                                          getSingleValueOrDefault(parsedArgs, "gwtFileName", DEFAULT_GWT_XML_PATH),
+                                          getSingleValueOrDefault(parsedArgs, "entryPoint", DEFAULT_GWT_ETNRY_POINT),
+                                          getSingleValueOrDefault(parsedArgs, "styleSheet", DEFAULT_STYLE_SHEET),
+                                          parseBoolean(
+                                                  getSingleValueOrDefault(parsedArgs, "loggingEnabled", DEFAULT_LOGGING.toString()))
+            );
+        GwtXmlGenerator gwtXmlGenerator = new GwtXmlGenerator(gwtXmlGeneratorConfig);
+        gwtXmlGenerator.generateGwtXml();
+
     }
 
     private static String getSingleValueOrDefault(Map<String, Set<String>> parsedArgs, String key, String defaultValue) {

--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IDEInjectorGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IDEInjectorGenerator.java
@@ -47,22 +47,17 @@ public class IDEInjectorGenerator {
      * Entry point. --rootDir is the optional parameter.
      *
      * @param args
+     * @throws IOException 
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
 
-        try {
-            File rootFolder = GeneratorUtils.getRootFolder(args);
-            System.out.println(" ------------------------------------------------------------------------ ");
-            System.out.println(String.format("Searching for GinModules in %s", rootFolder.getAbsolutePath()));
-            System.out.println(" ------------------------------------------------------------------------ ");
-            // find all Extension FQNs
-            findGinModules(rootFolder);
-            generateExtensionManager(rootFolder);
-        } catch (IOException e) {
-            System.err.println(e.getMessage());
-            // error
-            System.exit(1);//NOSONAR
-        }
+        File rootFolder = GeneratorUtils.getRootFolder(args);
+        System.out.println(" ------------------------------------------------------------------------ ");
+        System.out.println(String.format("Searching for GinModules in %s", rootFolder.getAbsolutePath()));
+        System.out.println(" ------------------------------------------------------------------------ ");
+        // find all Extension FQNs
+        findGinModules(rootFolder);
+        generateExtensionManager(rootFolder);
 
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removing System.exit calls that kill the whole Maven jvm or IDE running them.

### What issues does this PR fix or reference?
Fix #4458

#### Changelog
Fix maven build execution that kills Eclipse IDE when building Che

