### PR TITLE
CHE-4626: prevent Processes dropdown list from opening/closing when Stop/Rerun button has been clicked

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessWidget.java
@@ -120,7 +120,10 @@ class ProcessWidget extends FlowPanel {
         safeHtmlBuilder.appendHtmlConstant(FontAwesome.STOP);
 
         final ActionButton button = new ActionButton(safeHtmlBuilder.toSafeHtml());
-        button.addClickHandler(event -> handler.onStopProcess(process));
+        button.addClickHandler(event -> {
+            event.stopPropagation(); // prevent dropdown list from opening/closing
+            handler.onStopProcess(process);
+        });
         button.ensureDebugId("dropdown-processes-stop");
 
         Tooltip.create((Element)button.getElement(), BOTTOM, MIDDLE, "Stop");
@@ -133,7 +136,10 @@ class ProcessWidget extends FlowPanel {
         safeHtmlBuilder.appendHtmlConstant(FontAwesome.REPEAT);
 
         final ActionButton button = new ActionButton(safeHtmlBuilder.toSafeHtml());
-        button.addClickHandler(event -> handler.onRerunProcess(process));
+        button.addClickHandler(event -> {
+            event.stopPropagation(); // prevent dropdown list from opening/closing
+            handler.onRerunProcess(process);
+        });
         button.ensureDebugId("dropdown-processes-rerun");
 
         Tooltip.create((Element)button.getElement(), BOTTOM, MIDDLE, "Re-run");


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Prevents _Processes_ dropdown list from opening/closing when _Stop/Rerun_ button has been clicked

### What issues does this PR fix or reference?
#4626 

#### Changelog
Fixed bug with opening/closing Processes dropdown list when Stop/Rerun button has been clicked

#### Release Notes
bug fix N/A

#### Docs PR
N/A
