### PR TITLE
Remove outline from the Stop/Rerun buttons

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessWidget.java
@@ -30,7 +30,6 @@ import org.eclipse.che.ide.command.toolbar.processes.ProcessItemRenderer.StopPro
 import org.eclipse.che.ide.ui.Tooltip;
 import org.eclipse.che.ide.ui.dropdown.BaseListItem;
 
-import static com.google.gwt.dom.client.Style.Float.RIGHT;
 import static org.eclipse.che.ide.ui.menu.PositionController.HorizontalAlign.MIDDLE;
 import static org.eclipse.che.ide.ui.menu.PositionController.VerticalAlign.BOTTOM;
 
@@ -165,7 +164,6 @@ class ProcessWidget extends FlowPanel {
         ActionButton(SafeHtml content) {
             super(Document.get().createDivElement());
 
-            getElement().getStyle().setFloat(RIGHT);
             getElement().setInnerSafeHtml(content);
             asWidget().addStyleName(RESOURCES.commandToolbarCss().processWidgetActionButton());
         }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/toolbar/processes/styles.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/toolbar/processes/styles.css
@@ -64,6 +64,8 @@
 }
 
 .processWidgetActionButton {
+    float: right;
+    outline: none;
     color: #4eabff;
 }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removes outline from the Stop/Rerun buttons on the Commands toolbar.

With outline:
![outline](https://cloud.githubusercontent.com/assets/1636395/24903947/a8b11d9c-1eb7-11e7-8db1-d4bd09a91294.gif)

Without outline:
![none](https://cloud.githubusercontent.com/assets/1636395/24903951/abd4a624-1eb7-11e7-949a-669249ca170f.gif)


#### Changelog
Removed outline from the Stop/Rerun buttons on the Commands toolbar

#### Release Notes
N/A

#### Docs PR
N/A
