### PR TITLE
CHE-4514: restore Commands Explorer active state

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsExplorerPresenter.java
@@ -44,6 +44,7 @@ import org.eclipse.che.ide.command.CommandResources;
 import org.eclipse.che.ide.command.CommandUtils;
 import org.eclipse.che.ide.command.node.NodeFactory;
 import org.eclipse.che.ide.command.type.chooser.CommandTypeChooser;
+import org.eclipse.che.providers.DynaObject;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
 import static org.eclipse.che.ide.api.parts.PartStackType.NAVIGATION;
 
 /** Presenter for Commands Explorer. */
+@DynaObject
 @Singleton
 public class CommandsExplorerPresenter extends BasePresenter implements CommandsExplorerView.ActionDelegate,
                                                                         WsAgentComponent {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes restoring Commands Explorer active state on refreshing IDE

### What issues does this PR fix or reference?
#4514 

#### Changelog
Fixed restoring Commands Explorer active state on refreshing IDE

#### Release Notes
bug fix N/A

#### Docs PR
N/A
