### PR TITLE
CHE-4540: prevent Duplicate/Remove command buttons from hiding when width of the Commands Explorer is too small

### DIFF
--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/explorer/styles.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/command/explorer/styles.css
@@ -26,7 +26,7 @@
 }
 
 .commandNodeText {
-    max-width: 65%;
+    max-width: literal("calc(100% - 100px)");
 }
 
 .commandGoalNode span:last-child svg,


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes disappearing Duplicate/Remove Command buttons when width of the Commands Explorer is too small

### What issues does this PR fix or reference?
#4540 

#### Changelog
Fixed disappearing Duplicate/Remove Command buttons when width of the Commands Explorer is too small

#### Release Notes
bug fix N/A

#### Docs PR
N/A
