### PR TITLE
CHE-194 Need to hide buttons from Workspace to dashboard

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -137,10 +137,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-ext-dashboard-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-gdb-ide</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-dashboard/pom.xml
+++ b/plugins/plugin-dashboard/pom.xml
@@ -22,7 +22,4 @@
     <artifactId>che-plugin-dashboard-parent</artifactId>
     <packaging>pom</packaging>
     <name>Che Plugin :: Dashboard :: Parent</name>
-    <modules>
-        <module>che-plugin-ext-dashboard</module>
-    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -590,11 +590,6 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.plugin</groupId>
-                <artifactId>che-plugin-ext-dashboard-client</artifactId>
-                <version>${che.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.che.plugin</groupId>
                 <artifactId>che-plugin-factory-ide</artifactId>
                 <version>${che.version}</version>
             </dependency>


### PR DESCRIPTION
che-plugin-ext-dashboard-client plug-in extension is removed from the build

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

PR removes che-plugin-ext-dashboard-client plug-in extension from the build

### What issues does this PR fix or reference?

CHE-194 Need to hide buttons from Workspace to dashboard

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
