### PR TITLE
Add CentOS based nodejs4 stack to default assembly

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2387,7 +2387,7 @@
   },
   {
   "name": "CentOS WildFly Swarm",
-  "id": "WildFly Swarm",
+  "id": "wildfly-swarm",
   "creator": "Dharmit Shah",
   "description": "Eclipse WildFly Swarm Stack on CentOS.",
   "scope": "advanced",
@@ -2416,6 +2416,7 @@
             "attributes": {
               "memoryLimitBytes": "2147483648"
             },
+
             "agents": [
               "org.eclipse.che.terminal",
               "org.eclipse.che.ws-agent",
@@ -2460,5 +2461,92 @@
       "version": "3.3.9"
     }
   ]
+},
+{
+  "name": "CentOS nodejs",
+  "id": "nodejs4",
+  "scope": "advanced",
+  "source": {
+    "type": "image",
+    "origin": "registry.centos.org/che-stacks/centos-nodejs"
+  },
+  "description": "CentOS Node Stack",
+  "tags": [
+    "CentOS",
+    "Git",
+    "Node.JS",
+    "NPM",
+    "Gulp",
+    "Bower",
+    "Grunt",
+    "Yeoman",
+    "Angular",
+    "Karma"
+  ],
+  "workspaceConfig": {
+    "name": "default",
+    "environments": {
+      "default": {
+        "recipe": {
+          "location": "registry.centos.org/che-stacks/centos-nodejs",
+          "type": "dockerimage"
+        },
+        "machines": {
+          "dev-machine": {
+            "attributes": {
+              "memoryLimitBytes": "2147483648"
+            },
+            "agents": [
+              "org.eclipse.che.terminal",
+              "org.eclipse.che.ws-agent",
+              "org.eclipse.che.ssh"
+            ],
+            "servers": {}
+          }
+        }
+      }
+    },
+    "commands": [
+      {
+        "name": "run",
+        "type": "custom",
+        "attributes": {
+          "goal": "Run",
+          "previewUrl": "http://${server.port.8080}"
+        },
+        "commandLine": "cd ${current.project.path} && scl enable rh-nodejs4 'node app.js'"
+      }
+    ],
+    "projects": [],
+    "defaultEnv": "default",
+    "links": []
+  },
+  "components": [
+    {
+      "name": "Node.JS",
+      "version": "---"
+    },
+    {
+      "name": "NPM",
+      "version": "---"
+    },
+    {
+      "name": "Gulp",
+      "version": "---"
+    },
+    {
+      "name": "Bower",
+      "version": "---"
+    },
+    {
+      "name": "Grunt",
+      "version": "---"
+    },
+    {
+      "name": "Yeoman",
+      "version": "---"
+    }
+  ],
+  "creator": "Dharmit Shah"
 }
 ]


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <dshah@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add NodeJS stack based on CentOS to the default assembly

#### Changelog
<!-- one line entry to be added to changelog -->
Add CentOS based nodejs4 stack to default assembly

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add CentOS based nodejs4 stack to default assembly

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

cc @l0rd 