### PR TITLE
Adding line number property `line` to the `openFile` action.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -416,6 +416,9 @@ public interface CoreLocalizationConstant extends Messages {
     @Key("messages.fileToOpenIsNotSpecified")
     String fileToOpenIsNotSpecified();
 
+    @Key("messages.fileToOpenLineIsNotANumber")
+    String fileToOpenLineIsNotANumber();
+
     @Key("messages.canNotOpenNodeWithoutParams")
     String canNotOpenNodeWithoutParams();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
@@ -107,12 +107,9 @@ public class OpenFileAction extends Action implements PromisableAction {
                             }
 
                             try {
-
                                 int lineNumber = Integer.parseInt(event.getParameters().get(LINE_PARAM_ID)) - 1;
-
                                 ((TextEditor)editor).getDocument()
                                                     .setCursorPosition(new TextPosition(lineNumber, 0));
-
                             } catch (NumberFormatException e) {
                                 Log.error(getClass(), localization.fileToOpenLineIsNotANumber());
                             }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
@@ -30,6 +30,8 @@ import org.eclipse.che.ide.api.action.PromisableAction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.notification.NotificationManager;
@@ -52,6 +54,8 @@ public class OpenFileAction extends Action implements PromisableAction {
 
     /** ID of the parameter to specify file path to open. */
     public static final String FILE_PARAM_ID = "file";
+
+    public static final String LINE_PARAM_ID = "line";
 
     private final EventBus                 eventBus;
     private final CoreLocalizationConstant localization;
@@ -95,7 +99,35 @@ public class OpenFileAction extends Action implements PromisableAction {
                         actionCompletedCallback.onSuccess(null);
                     }
 
-                    editorAgent.openEditor(optionalFile.get());
+                    editorAgent.openEditor(optionalFile.get(), new EditorAgent.OpenEditorCallback() {
+                        @Override
+                        public void onEditorOpened(EditorPartPresenter editor) {
+                            if (!(editor instanceof TextEditor)) {
+                                return;
+                            }
+
+                            try {
+
+                                int lineNumber = Integer.parseInt(event.getParameters().get(LINE_PARAM_ID)) - 1;
+
+                                ((TextEditor)editor).getDocument()
+                                                    .setCursorPosition(new TextPosition(lineNumber, 0));
+
+                            } catch (NumberFormatException e) {
+                                Log.error(getClass(), localization.fileToOpenLineIsNotANumber());
+                            }
+
+                        }
+
+                        @Override
+                        public void onInitializationFailed() {
+                        }
+
+                        @Override
+                        public void onEditorActivated(EditorPartPresenter editor) {
+                        }
+                    });
+
                 } else {
                     if (actionCompletedCallback != null) {
                         actionCompletedCallback.onFailure(null);

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -217,6 +217,7 @@ messages.promptSaveChanges = Some data has been modified. Save changes?
 messages.unableOpenResource = Unable to open {0}.
 messages.canNotOpenFileWithoutParams=Can not open file without parameters
 messages.fileToOpenIsNotSpecified=File to open is not specified
+messages.fileToOpenLineIsNotANumber=Line specified for the file to open is not a number
 messages.canNotOpenNodeWithoutParams=Can not open node without parameters
 messages.nodeToOpenIsNotSpecified=Node to open is not specified
 messages.noOpenedProject=No opened project


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adding line number property `line` to the `openFile` action. When the file is open with `openFile` action, the cursor moves to this line.

Can be tested with the startup actions: https://youtu.be/6GK9oLq1kjc
For instance: <http://localhost:8080/dashboard/#/ide/che/che-gotoline?action=openFile:file=eclipse-che/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/StartUpActionsParser.java;line=50> opens `StartUpActionsParser.java` at the line `50`
The change also works in factory actions:

    "ide" : {  
      "onProjectsLoaded" : {
        "actions" : [{
          "id" : "openFile",
          "properties" : {
            "file" : "/my-project/pom.xml",
            "line" : "50"
          }
        },

#### Changelog
<!-- one line entry to be added to changelog -->
Added ability to automatically open files at specific line number.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add ability to automatically open files at specific line number with `openFile` action in Factory or workspace URL.

#### Docs
eclipse/che-docs#208