### PR TITLE
Depend on ls-shared, not ls-ide when generating dtos.

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -189,8 +189,8 @@
                 </executions> 
                 <dependencies>
                     <dependency>
-                        <groupId>${project.groupId}</groupId>
-                        <artifactId>${project.artifactId}</artifactId>
+                        <groupId>org.eclipse.che.core</groupId>
+                        <artifactId>che-core-api-languageserver-shared</artifactId>
                         <version>${project.version}</version>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
This should fix a build problem in the openshift-connector branch.
