### PR TITLE
CHE-4778; Prevent project params from disappearing from response during update & creation;

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -27,6 +27,7 @@ import javax.persistence.MapKey;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -250,6 +251,15 @@ public class ProjectConfigImpl implements ProjectConfig {
         attributes = dbAttributes.values()
                                  .stream()
                                  .collect(toMap(attr -> attr.name, attr -> attr.values));
+    }
+
+    @PostPersist
+    private void postPersistAttributes() {
+        if (dbAttributes != null) {
+            getAttributes().putAll(dbAttributes.values()
+                                               .stream()
+                                               .collect(toMap(attr -> attr.name, attr -> attr.values)));
+        }
     }
 
     @Entity(name = "ProjectAttribute")


### PR DESCRIPTION
### What does this PR do?
When editing project attributes, response from update command always contains empty map because of  some storage specific logic. This fix allows to return always actual object.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4778

#### Changelog
N/A

#### Release Notes
N/A

#### Docs PR
N/A
