### PR TITLE
Openshift pvc refactor

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -174,7 +174,9 @@ public class WsMasterModule extends AbstractModule {
         requestInjection(interceptor);
         bindInterceptor(subclassesOf(CheJsonProvider.class), names("readFrom"), interceptor);
         bind(org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner.class)
-                .to(org.eclipse.che.plugin.docker.machine.cleaner.LocalWorkspaceFilesCleaner.class);
+                  .to(org.eclipse.che.plugin.openshift.client.OpenShiftWorkspaceFilesCleaner.class);
+//                .to(org.eclipse.che.plugin.docker.machine.cleaner.LocalWorkspaceFilesCleaner.class);
+
         bind(org.eclipse.che.api.environment.server.InfrastructureProvisioner.class)
                 .to(org.eclipse.che.plugin.docker.machine.local.LocalCheInfrastructureProvisioner.class);
 

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -302,6 +302,9 @@ che.openshift.workspaces.pvc.quantity=10Gi
 # NOTE: In order to create routes against HTTPS 
 # Property 'strategy.che.docker.server_evaluation_strategy.secure.external.urls' should be also set to true
 che.openshift.secure.routes=false
+# Pod that is launched when performing persistent volume claim maintenance jobs on OpenShift
+che.openshift.jobs.image=centos:centos7
+che.openshift.jobs.memorylimit=250Mi
 
 # Specifications of compute resources that can be consumed
 # by the workspace container:

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -59,6 +59,14 @@
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
+	<dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -193,6 +193,7 @@ public class OpenShiftConnector extends DockerConnector {
     private final String          cheWorkspaceMemoryLimit;
     private final String          cheWorkspaceMemoryRequest;
     private final boolean         secureRoutes;
+    private final OpenShiftPvcHelper openShiftPvcHelper;
 
     @Inject
     public OpenShiftConnector(DockerConnectorConfiguration connectorConfiguration,
@@ -200,6 +201,7 @@ public class OpenShiftConnector extends DockerConnector {
                               DockerRegistryAuthResolver authResolver,
                               DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider,
                               EventService eventService,
+                              OpenShiftPvcHelper openShiftPvcHelper,
                               @Nullable @Named("che.docker.ip.external") String cheServerExternalAddress,
                               @Named("che.openshift.project") String openShiftCheProjectName,
                               @Named("che.openshift.liveness.probe.delay") int openShiftLivenessProbeDelay,
@@ -224,6 +226,7 @@ public class OpenShiftConnector extends DockerConnector {
         this.cheWorkspaceMemoryRequest = cheWorkspaceMemoryRequest;
         this.cheWorkspaceMemoryLimit = cheWorkspaceMemoryLimit;
         this.secureRoutes = secureRoutes;
+        this.openShiftPvcHelper = openShiftPvcHelper;
         eventService.subscribe(new EventSubscriber<ServerIdleEvent>() {
 
             @Override
@@ -288,7 +291,6 @@ public class OpenShiftConnector extends DockerConnector {
      */
     @Override
     public ContainerCreated createContainer(CreateContainerParams createContainerParams) throws IOException {
-        OpenShiftClient openShiftClient = new DefaultOpenShiftClient();
         String containerName = KubernetesStringUtils.convertToContainerName(createContainerParams.getContainerName());
         String workspaceID = getCheWorkspaceId(createContainerParams);
 
@@ -311,13 +313,15 @@ public class OpenShiftConnector extends DockerConnector {
         // Next we need to get the address of the registry where the ImageStreamTag is stored
         String imageStreamName = KubernetesStringUtils.getImageStreamNameFromPullSpec(imageStreamTagPullSpec);
 
-        ImageStream imageStream = openShiftClient.imageStreams()
-                                                 .inNamespace(openShiftCheProjectName)
-                                                 .withName(imageStreamName)
-                                                 .get();
-        if (imageStream == null) {
-            openShiftClient.close();
-            throw new OpenShiftException("ImageStream not found");
+        ImageStream imageStream;
+        try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
+            imageStream = openShiftClient.imageStreams()
+                                         .inNamespace(openShiftCheProjectName)
+                                         .withName(imageStreamName)
+                                         .get();
+            if (imageStream == null) {
+                throw new OpenShiftException("ImageStream not found");
+            }
         }
         String registryAddress = imageStream.getStatus()
                                             .getDockerImageRepository()
@@ -356,6 +360,7 @@ public class OpenShiftConnector extends DockerConnector {
         }
 
         String containerID;
+        OpenShiftClient openShiftClient = new DefaultOpenShiftClient();
         try {
             createOpenShiftService(workspaceID, exposedPorts, additionalLabels);
             String deploymentName = createOpenShiftDeployment(workspaceID,
@@ -1009,13 +1014,12 @@ public class OpenShiftConnector extends DockerConnector {
     }
 
     private List<ReplicaSet> getReplicaSetByLabel(String key, String value) {
-        List<ReplicaSet> replicaSets;
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
-            replicaSets = openShiftClient.extensions()
-                                         .replicaSets()
-                                         .inNamespace(openShiftCheProjectName)
-                                         .withLabel(key, value)
-                                         .list().getItems();
+            List<ReplicaSet> replicaSets = openShiftClient.extensions()
+                                                          .replicaSets()
+                                                          .inNamespace(openShiftCheProjectName)
+                                                          .withLabel(key, value)
+                                                          .list().getItems();
             return replicaSets;
         }
     }
@@ -1129,7 +1133,7 @@ public class OpenShiftConnector extends DockerConnector {
                                              String[] envVariables,
                                              String[] volumes,
                                              Map<String, Quantity> resourceLimits,
-                                             Map<String, Quantity> resourceRequests) {
+                                             Map<String, Quantity> resourceRequests) throws OpenShiftException {
 
         String deploymentName = CHE_OPENSHIFT_RESOURCES_PREFIX + workspaceID;
         LOG.info("Creating OpenShift deployment {}", deploymentName);
@@ -1137,97 +1141,8 @@ public class OpenShiftConnector extends DockerConnector {
         Map<String, String> selector = Collections.singletonMap(OPENSHIFT_DEPLOYMENT_LABEL, deploymentName);
 
         LOG.info("Adding container {} to OpenShift deployment {}", sanitizedContainerName, deploymentName);
-//        String[] command;
-//        String workspaceDir = getWorkspaceDir(volumes);
-//        if (workspaceDir != null) {
-//            command = new String[3];
-//            command[0] = "sh";
-//            command[1] = "-c";
-//            command[2] = "mkdir -p " + workspaceDir + ";tail -f /dev/null";
-//        } else {
-//            command = null;
-//        }
-//        if (command != null) {
-//            Deployment deployment = createOpenShiftDeploymentInternal(workspaceID,
-//                                                                      imageName,
-//                                                                      sanitizedContainerName,
-//                                                                      exposedPorts,
-//                                                                      envVariables,
-//                                                                      volumes,
-//                                                                      deploymentName,
-//                                                                      selector,
-//                                                                      command,
-//                                                                      false,
-//                                                                      resourceLimits,
-//                                                                      resourceRequests);
-//            try {
-//                waitAndRetrieveContainerID(deploymentName);
-//            } catch (IOException e) {
-//                LOG.error(e.getMessage(), e);
-//            }
-//
-//            try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
-//                openShiftClient.extensions()
-//                               .deployments()
-//                               .inNamespace(this.openShiftCheProjectName)
-//                               .delete(deployment);
-//                if (!isDeleted(deploymentName)) {
-//                    LOG.warn("OpenShift deployment {} hasn't been deleted", deploymentName);
-//                }
-//            }
-//        }
-        Deployment deployment = createOpenShiftDeploymentInternal(workspaceID,
-                                                       imageName,
-                                                       sanitizedContainerName,
-                                                       exposedPorts,
-                                                       envVariables,
-                                                       volumes,
-                                                       deploymentName,
-                                                       selector,
-                                                       null,
-                                                       true,
-                                                       resourceLimits,
-                                                       resourceRequests);
-        LOG.info("OpenShift deployment {} created", deploymentName);
-        return deployment.getMetadata().getName();
-    }
 
-    private boolean isDeleted(String deploymentName) {
-        for (int i = 0; i < OPENSHIFT_WAIT_POD_TIMEOUT; i++) {
-            try {
-                Thread.sleep(OPENSHIFT_WAIT_POD_DELAY);
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-            }
-
-            try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
-                List<Pod> pods = openShiftClient.pods()
-                                    .inNamespace(this.openShiftCheProjectName)
-                                    .withLabel(OPENSHIFT_DEPLOYMENT_LABEL, deploymentName)
-                                    .list()
-                                    .getItems();
-    
-                if (pods.size() < 1) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private Deployment createOpenShiftDeploymentInternal(String workspaceID,
-                                                         String imageName,
-                                                         String sanitizedContainerName,
-                                                         Set<String> exposedPorts,
-                                                         String[] envVariables,
-                                                         String[] volumes,
-                                                         String deploymentName,
-                                                         Map<String,
-                                                         String> selector,
-                                                         String[] command,
-                                                         boolean withSubpath,
-                                                         Map<String, Quantity> resourceLimits,
-                                                         Map<String, Quantity> resourceRequests) {
+        createWorkspaceDir(volumes);
 
         Container container = new ContainerBuilder()
                                     .withName(sanitizedContainerName)
@@ -1239,8 +1154,7 @@ public class OpenShiftConnector extends DockerConnector {
                                         .withPrivileged(false)
                                     .endSecurityContext()
                                     .withLivenessProbe(getLivenessProbeFrom(exposedPorts))
-                                    .withCommand(command)
-//                                    .withVolumeMounts(getVolumeMountsFrom(volumes, workspaceID, withSubpath))
+                                    .withVolumeMounts(getVolumeMountsFrom(volumes, workspaceID))
                                     .withNewResources()
                                         .withLimits(resourceLimits)
                                         .withRequests(resourceRequests)
@@ -1249,27 +1163,27 @@ public class OpenShiftConnector extends DockerConnector {
 
         PodSpec podSpec = new PodSpecBuilder()
                                  .withContainers(container)
-//                               .withVolumes(getVolumesFrom(volumes, workspaceID))
+                                 .withVolumes(getVolumesFrom(volumes, workspaceID))
                                  .build();
 
         Deployment deployment = new DeploymentBuilder()
-                .withNewMetadata()
-                    .withName(deploymentName)
-                    .withNamespace(this.openShiftCheProjectName)
-                .endMetadata()
-                .withNewSpec()
-                    .withReplicas(1)
-                    .withNewSelector()
-                        .withMatchLabels(selector)
-                    .endSelector()
-                    .withNewTemplate()
-                        .withNewMetadata()
-                            .withLabels(selector)
-                        .endMetadata()
-                        .withSpec(podSpec)
-                    .endTemplate()
-                .endSpec()
-                .build();
+                                        .withNewMetadata()
+                                            .withName(deploymentName)
+                                            .withNamespace(this.openShiftCheProjectName)
+                                        .endMetadata()
+                                        .withNewSpec()
+                                            .withReplicas(1)
+                                            .withNewSelector()
+                                                .withMatchLabels(selector)
+                                            .endSelector()
+                                            .withNewTemplate()
+                                                .withNewMetadata()
+                                                    .withLabels(selector)
+                                                .endMetadata()
+                                                .withSpec(podSpec)
+                                            .endTemplate()
+                                        .endSpec()
+                                        .build();
 
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
             deployment = openShiftClient.extensions()
@@ -1278,7 +1192,8 @@ public class OpenShiftConnector extends DockerConnector {
                                         .create(deployment);
         }
 
-        return deployment;
+        LOG.info("OpenShift deployment {} created", deploymentName);
+        return deployment.getMetadata().getName();
     }
 
     /**
@@ -1427,7 +1342,7 @@ public class OpenShiftConnector extends DockerConnector {
             }
 
             if (replicaSets != null && replicaSets.size() > 0) {
-                LOG.info("Removing OpenShift ReplicaSets for deploymnet {}", deploymentName);
+                LOG.info("Removing OpenShift ReplicaSets for deployment {}", deploymentName);
                 replicaSets.forEach(rs -> openShiftClient.resource(rs).delete());
             }
 
@@ -1451,57 +1366,64 @@ public class OpenShiftConnector extends DockerConnector {
         throw new OpenShiftException("Timeout while waiting for pods to terminate");
     }
 
-    private String getWorkspaceDir(String[] volumes) {
+    private void createWorkspaceDir(String[] volumes) throws OpenShiftException {
         PersistentVolumeClaim pvc = getClaimCheWorkspace();
-        if (pvc != null) {
-            for (String volume : volumes) {
-                String mountPath = volume.split(":",3)[1];
-                if (cheWorkspaceProjectsStorage.equals(mountPath)) {
-                    String hostPath = volume.split(":",3)[0];
-                    String subPath = hostPath.replace(cheWorkspaceStorage, "");
-                    if (subPath.startsWith("/")) {
-                        subPath = subPath.substring(1);
-                    }
-                    return mountPath + "/" + subPath;
+        String workspaceSubpath = getWorkspaceSubpath(volumes);
+        if (pvc != null && !isNullOrEmpty(workspaceSubpath)) {
+            LOG.info("Making sure directory exists for workspace {}", workspaceSubpath);
+            boolean succeeded = openShiftPvcHelper.createJobPod(workspacesPersistentVolumeClaim,
+                                                                openShiftCheProjectName,
+                                                                "create-",
+                                                                OpenShiftPvcHelper.Command.MAKE,
+                                                                workspaceSubpath);
+            if (!succeeded) {
+                LOG.error("Failed to create workspace directory {} in PVC {}", workspaceSubpath,
+                                                                               workspacesPersistentVolumeClaim);
+                throw new OpenShiftException("Failed to create workspace directory in PVC");
+            }
+        }
+    }
+
+    /**
+     * Gets the workspace subpath from an array of volumes. Since volumes provided are
+     * those used when running Che in Docker, most of the volume spec is ignored; this
+     * method returns the subpath within the hostpath that refers to the workspace.
+     * <p>
+     * E.g. for a volume {@code /data/workspaces/wksp-8z00:/projects:Z}, this method will return
+     * "wksp-8z00".
+     *
+     * @param volumes
+     * @return
+     */
+    private String getWorkspaceSubpath(String[] volumes) {
+        String workspaceSubpath = null;
+        for (String volume : volumes) {
+            // Volumes are structured <hostpath>:<mountpath>:<options>.
+            // We first check that <mountpath> matches the mount path for projects
+            // and then extract the hostpath directory. The first part of the volume
+            // String will be structured <cheWorkspaceStorage>/workspaceName.
+            String mountPath = volume.split(":", 3)[1];
+            if (cheWorkspaceProjectsStorage.equals(mountPath)) {
+                workspaceSubpath = volume.split(":", 3)[0].replaceAll(cheWorkspaceStorage, "");
+                if (workspaceSubpath.startsWith("/")) {
+                    workspaceSubpath = workspaceSubpath.substring(1);
                 }
             }
         }
-        return null;
+        return workspaceSubpath;
     }
 
-    private List<VolumeMount> getVolumeMountsFrom(String[] volumes, String workspaceID, boolean withSubPath) {
+    private List<VolumeMount> getVolumeMountsFrom(String[] volumes, String workspaceID) {
         List<VolumeMount> vms = new ArrayList<>();
         PersistentVolumeClaim pvc = getClaimCheWorkspace();
         if (pvc != null) {
-            for (String volume : volumes) {
-                String mountPath = volume.split(":",3)[1];
-                if (cheWorkspaceProjectsStorage.equals(mountPath)) {
-                    String hostPath = volume.split(":",3)[0];
-                    String subPath = null;
-                    if (withSubPath) {
-                        subPath = hostPath.replace(cheWorkspaceStorage, "");
-                        if (subPath.startsWith("/")) {
-                            subPath = subPath.substring(1);
-                        }
-                    }
-                    VolumeMount vm = new VolumeMountBuilder()
-                            .withMountPath(mountPath)
-                            .withName(workspacesPersistentVolumeClaim)
-                            .withSubPath(subPath)
-                            .build();
-                        vms.add(vm);
-                }
-            }
-        } else {
-            for (String volume : volumes) {
-                String mountPath = volume.split(":",3)[1];
-                String volumeName = getVolumeName(volume);
-                VolumeMount vm = new VolumeMountBuilder()
-                    .withMountPath(mountPath)
-                    .withName("ws-" + workspaceID + "-" + volumeName)
+            String subPath = getWorkspaceSubpath(volumes);
+            VolumeMount vm = new VolumeMountBuilder()
+                    .withMountPath(cheWorkspaceProjectsStorage)
+                    .withName(workspacesPersistentVolumeClaim)
+                    .withSubPath(subPath)
                     .build();
-                vms.add(vm);
-            }
+            vms.add(vm);
         }
         return vms;
     }
@@ -1522,17 +1444,6 @@ public class OpenShiftConnector extends DockerConnector {
                         .build();
                     vs.add(v);
                 }
-            }
-        } else {
-            for (String volume : volumes) {
-                String hostPath = volume.split(":",3)[0];
-                String volumeName = getVolumeName(volume);
-
-                Volume v = new VolumeBuilder()
-                    .withNewHostPath(hostPath)
-                    .withName("ws-" + workspaceID + "-" + volumeName)
-                    .build();
-                vs.add(v);
             }
         }
         return vs;
@@ -1567,22 +1478,6 @@ public class OpenShiftConnector extends DockerConnector {
         }
     }
 
-    private String getVolumeName(String volume) {
-        if (volume.contains("ws-agent")) {
-            return "wsagent-lib";
-        }
-
-        if (volume.contains("terminal")) {
-            return "terminal";
-        }
-
-        if (volume.contains("workspaces")) {
-            return "project";
-        }
-
-        return "unknown-volume";
-    }
-
     private String waitAndRetrieveContainerID(String deploymentName) throws IOException {
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
             for (int i = 0; i < OPENSHIFT_WAIT_POD_TIMEOUT; i++) {
@@ -1591,13 +1486,13 @@ public class OpenShiftConnector extends DockerConnector {
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
                 }
-    
+
                 List<Pod> pods = openShiftClient.pods()
                                     .inNamespace(this.openShiftCheProjectName)
                                     .withLabel(OPENSHIFT_DEPLOYMENT_LABEL, deploymentName)
                                     .list()
                                     .getItems();
-    
+
                 if (pods.size() < 1) {
                     throw new OpenShiftException(String.format("Pod with deployment name %s not found",
                                                                deploymentName));

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * Helper class for executing simple commands in a Persistent Volume on Openshift.
+ * <p>
+ * Creates a short-lived Pod using a CentOS image which mounts a specified PVC and
+ * executes a command (either {@code mkdir -p <path>} or {@code rm -rf <path}). Reports
+ * back whether the pod succeeded or failed. Supports multiple paths for one command.
+ * <p>
+ * For mkdir commands, an in-memory list of created workspaces is stored and used to avoid
+ * calling mkdir unnecessarily. However, this list is not persisted, so dir creation is
+ * not tracked between restarts.
+ *
+ * @author amisevsk
+ */
+final class OpenShiftPvcHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenShiftPvcHelper.class);
+
+    private static final String POD_PHASE_SUCCEEDED        = "Succeeded";
+    private static final String POD_PHASE_FAILED           = "Failed";
+    private static final String[] MKDIR_WORKSPACE_COMMAND  = new String[] {"mkdir", "-p"};
+    private static final String[] RMDIR_WORKSPACE_COMMAND  = new String[] {"rm", "-rf"};
+
+    private static final Set<String> createdWorkspaces = ConcurrentHashMap.newKeySet();
+
+    private final String jobImage;
+    private final String jobMemoryLimit;
+
+    protected enum Command {REMOVE, MAKE}
+
+    @Inject
+    protected OpenShiftPvcHelper(@Named("che.openshift.jobs.image") String jobImage,
+                                 @Named("che.openshift.jobs.memorylimit") String jobMemoryLimit) {
+        this.jobImage = jobImage;
+        this.jobMemoryLimit = jobMemoryLimit;
+    }
+
+    /**
+     * Creates a pod with {@code command} and reports whether it succeeded
+     * @param workspacesPvcName
+     *            name of the PVC to mount
+     * @param projectNamespace
+     *            OpenShift namespace
+     * @param jobNamePrefix
+     *            prefix used for pod metadata name. Name structure will normally
+     *            be {@code <prefix><workspaceDirs>} if only one path is passed, or
+     *            {@code <prefix>batch} if multiple paths are provided
+     * @param command
+     *            command to execute in PVC.
+     * @param workspaceDirs
+     *            list of arguments attached to command. A list of directories to
+     *            create/delete.
+     * @return true if Pod terminates with phase "Succeeded" or mkdir command issued
+     *            for already created worksapce, false otherwise.
+     *
+     * @see Command
+     */
+    protected boolean createJobPod(String workspacesPvcName,
+                                   String projectNamespace,
+                                   String jobNamePrefix,
+                                   Command command,
+                                   String... workspaceDirs) {
+
+        if (workspaceDirs.length == 0) {
+            return true;
+        }
+
+        if (Command.MAKE.equals(command)) {
+            String[] dirsToCreate = filterDirsToCreate(workspaceDirs);
+            if (dirsToCreate.length == 0) {
+                return true;
+            }
+            workspaceDirs = dirsToCreate;
+        }
+
+        VolumeMount vm = new VolumeMountBuilder()
+                .withMountPath("/projects")
+                .withName(workspacesPvcName)
+                .build();
+
+        PersistentVolumeClaimVolumeSource pvcs = new PersistentVolumeClaimVolumeSourceBuilder()
+                .withClaimName(workspacesPvcName)
+                .build();
+
+        Volume volume = new VolumeBuilder()
+                .withPersistentVolumeClaim(pvcs)
+                .withName(workspacesPvcName)
+                .build();
+
+        String[] jobCommand = getCommand(command, "/projects/", workspaceDirs);
+        LOG.info("Executing command {} in PVC {} for {} dirs", jobCommand[0], workspacesPvcName, workspaceDirs.length);
+
+        Map<String, Quantity> limit = Collections.singletonMap("memory", new Quantity(jobMemoryLimit));
+
+        String podName = workspaceDirs.length > 1 ? jobNamePrefix + "batch"
+                                                  : jobNamePrefix + workspaceDirs[0];
+
+        Container container = new ContainerBuilder().withName(podName)
+                                                    .withImage(jobImage)
+                                                    .withImagePullPolicy("IfNotPresent")
+                                                    .withNewSecurityContext()
+                                                        .withPrivileged(false)
+                                                    .endSecurityContext()
+                                                    .withCommand(jobCommand)
+                                                    .withVolumeMounts(vm)
+                                                    .withNewResources()
+                                                        .withLimits(limit)
+                                                    .endResources()
+                                                    .build();
+
+        Pod podSpec = new PodBuilder().withNewMetadata()
+                                       .withName(podName)
+                                   .endMetadata()
+                                   .withNewSpec()
+                                       .withContainers(container)
+                                       .withVolumes(volume)
+                                       .withRestartPolicy("Never")
+                                   .endSpec()
+                                   .build();
+
+
+        try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()){
+            openShiftClient.pods().inNamespace(projectNamespace).create(podSpec);
+            boolean completed = false;
+            while(!completed) {
+                Pod pod = openShiftClient.pods().inNamespace(projectNamespace).withName(podName).get();
+                String phase = pod.getStatus().getPhase();
+                switch (phase) {
+                    case POD_PHASE_FAILED:
+                        LOG.info("Pod command {} failed", Arrays.toString(jobCommand));
+                    case POD_PHASE_SUCCEEDED:
+                        openShiftClient.resource(pod).delete();
+                        updateCreatedDirs(command, phase, workspaceDirs);
+                        return POD_PHASE_SUCCEEDED.equals(phase);
+                    default:
+                        Thread.sleep(1000);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return false;
+    }
+
+    private String[] getCommand(Command commandType, String mountPath, String... dirs) {
+        String[] command = new String[0];
+        switch (commandType) {
+            case MAKE :
+                command = MKDIR_WORKSPACE_COMMAND;
+                break;
+            case REMOVE :
+                command = RMDIR_WORKSPACE_COMMAND;
+                break;
+        }
+
+        String[] dirsWithPath = Arrays.asList(dirs).stream()
+                .map(dir -> mountPath + dir)
+                .toArray(String[]::new);
+
+        String[] fullCommand = new String[command.length + dirsWithPath.length];
+
+        System.arraycopy(command, 0, fullCommand, 0, command.length);
+        System.arraycopy(dirsWithPath, 0, fullCommand, command.length, dirsWithPath.length);
+        return fullCommand;
+    }
+
+    private void updateCreatedDirs(Command command, String phase, String... workspaceDirs) {
+        if (!POD_PHASE_SUCCEEDED.equals(phase)) {
+            return;
+        }
+        List<String> dirs = Arrays.asList(workspaceDirs);
+        switch (command) {
+            case MAKE:
+                createdWorkspaces.addAll(dirs);
+                break;
+            case REMOVE:
+                createdWorkspaces.removeAll(dirs);
+                break;
+        }
+    }
+
+    private String[] filterDirsToCreate(String[] allDirs) {
+        List<String> dirs = Arrays.asList(allDirs);
+        List<String> dirsToCreate = new ArrayList<>();
+        for(String dir : dirs) {
+            if (!createdWorkspaces.contains(dir)) {
+                dirsToCreate.add(dir);
+            }
+        }
+        return dirsToCreate.toArray(new String[dirsToCreate.size()]);
+    }
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleaner.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleaner.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.event.ServerIdleEvent;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class used to remove workspace directories in Persistent Volume when a workspace
+ * is delete while running on OpenShift. Deleted workspace directories are stored
+ * in a list. Upon Che server idling, all of these workspaces are deleted simultaneously
+ * from the PVC using a {@link OpenShiftPvcHelper} job.
+ * <p>
+ * Since deleting a workspace does not immediately remove its files, re-creating a workspace
+ * with a previously used name can result in files from the previous workspace still being
+ * present.
+ *
+ * @see WorkspaceFilesCleaner
+ * @author amisevsk
+ */
+@Singleton
+public class OpenShiftWorkspaceFilesCleaner implements WorkspaceFilesCleaner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenShiftConnector.class);
+    private static final Set<String> deleteQueue = ConcurrentHashMap.newKeySet();
+    private final String projectNamespace;
+    private final String workspacesPvcName;
+    private final OpenShiftPvcHelper openShiftPvcHelper;
+
+    @Inject
+    public OpenShiftWorkspaceFilesCleaner(EventService eventService,
+                                          OpenShiftPvcHelper openShiftPvcHelper,
+                                          @Named("che.openshift.project") String projectNamespace,
+                                          @Named("che.openshift.workspaces.pvc.name") String workspacesPvcName) {
+        this.projectNamespace = projectNamespace;
+        this.workspacesPvcName = workspacesPvcName;
+        this.openShiftPvcHelper = openShiftPvcHelper;
+        eventService.subscribe(new EventSubscriber<ServerIdleEvent>() {
+            @Override
+            public void onEvent(ServerIdleEvent event) {
+                deleteWorkspacesInQueue(event);
+            }
+        });
+    }
+
+    @Override
+    public void clear(Workspace workspace) throws IOException, ServerException {
+        String workspaceName = workspace.getConfig().getName();
+        if (isNullOrEmpty(workspaceName)) {
+            LOG.error("Could not get workspace name for files removal.");
+            return;
+        }
+        deleteQueue.add(workspaceName);
+    }
+
+    private void deleteWorkspacesInQueue(ServerIdleEvent event) {
+        List<String> deleteQueueCopy = new ArrayList<>(deleteQueue);
+        String[] dirsToDelete = deleteQueueCopy.toArray(new String[deleteQueueCopy.size()]);
+
+        LOG.info("Deleting {} workspaces on PVC {}", deleteQueueCopy.size(), workspacesPvcName);
+        boolean successful = openShiftPvcHelper.createJobPod(workspacesPvcName,
+                                                             projectNamespace,
+                                                             "delete-",
+                                                             OpenShiftPvcHelper.Command.REMOVE,
+                                                             dirsToDelete);
+        if (successful) {
+            deleteQueue.removeAll(deleteQueueCopy);
+        }
+    }
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -55,6 +55,8 @@ public class OpenShiftConnectorTest {
     private CreateContainerParams              createContainerParams;
     @Mock
     private EventService                       eventService;
+    @Mock
+    private OpenShiftPvcHelper                 openShiftPvcHelper;
 
     private OpenShiftConnector                 openShiftConnector;
 
@@ -73,6 +75,7 @@ public class OpenShiftConnectorTest {
                                                     authManager,
                                                     dockerApiVersionPathPrefixProvider,
                                                     eventService,
+                                                    openShiftPvcHelper,
                                                     CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS,
                                                     CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
                                                     OPENSHIFT_LIVENESS_PROBE_DELAY,


### PR DESCRIPTION
### What does this PR do?
1. Deletes Replica Sets while deleting other workspace resources, since OpenShift does not clean them automatically.
2. Deletes workspace directories on the workspace PVC when workspaces are deleted. To avoid unnecessary mounting of the PVC, waits until Che server is idled, and all directories simultaneously
    - To override `workspaceFilesCleaner`, the binding in `WsMasterModule` has been changed to suit OpenShift. This is not an ideal solution (not compatible with docker distribution).
    - Since we're not removing the directory immediately, re-creating a workspace with a previously-deleted name before the server idles will result in the previous workspace's files being already present and cause an issue if the same project is imported.
3. Creates directories for workspaces in PVC in a short-lived job pod instead of a full deployment. This makes workspace launch much faster. Additionally, some effort is made to avoid attempting to create directories when they are already there. 

### What issues does this PR fix or reference?
- Removing workspace causes NPE
- Cleanup workspaces resources in PVC on workspace deletion
- Improve PVC set up when creating workspace
- Clean up replica sets when stopping workspace

### Testing
To test creation, creating a workspace, stopping it, and then restarting it is sufficient. The first launch should log `Executing command mkdir in PVC claim-che-workspace for 1 dirs`, whereas the second should not.

To test pvc cleanup, set `che.openshift.server.inactive.stop.timeout.ms` to a small number (e.g. 60 seconds) and delete a created workspace. On idle the workspace folder should be deleted on the PVC.

To test replica set cleanup, `oc get rs` should return no resources when no workspace is running.