### PR TITLE
CHE-4778; Prevent project params from disappearing from response during update & creation;

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -27,6 +27,8 @@ import javax.persistence.MapKey;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
+import javax.persistence.PostUpdate;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -246,10 +248,14 @@ public class ProjectConfigImpl implements ProjectConfig {
     }
 
     @PostLoad
+    @PostUpdate
+    @PostPersist
     private void postLoadAttributes() {
-        attributes = dbAttributes.values()
-                                 .stream()
-                                 .collect(toMap(attr -> attr.name, attr -> attr.values));
+        if (dbAttributes != null) {
+            attributes = dbAttributes.values()
+                                     .stream()
+                                     .collect(toMap(attr -> attr.name, attr -> attr.values));
+        }
     }
 
     @Entity(name = "ProjectAttribute")

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDaoTest.java
@@ -144,11 +144,11 @@ public class JpaWorkspaceDaoTest {
         manager.clear();
 
         // check it's okay
-        assertEquals(result  .getConfig()
-                             .getProjects()
-                             .get(0)
-                             .getAttributes()
-                             .size(), 3);
+        assertEquals(result.getConfig()
+                           .getProjects()
+                           .get(0)
+                           .getAttributes()
+                           .size(), 3);
     }
 
     private long asLong(String query) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDaoTest.java
@@ -14,6 +14,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 
 import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.commons.test.db.H2JpaCleaner;
 import org.eclipse.che.commons.test.tck.JpaCleaner;
 import org.eclipse.che.core.db.jpa.DuplicateKeyException;
@@ -122,7 +123,9 @@ public class JpaWorkspaceDaoTest {
     public void shouldSyncDbAttributesWhileUpdatingWorkspace() throws Exception {
         final AccountImpl account = new AccountImpl("accountId", "namespace", "test");
         final WorkspaceImpl workspace = createWorkspace("id", account, "name");
-
+        if (workspace.getConfig() != null) {
+            workspace.getConfig().getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
+        }
         // persist the workspace
         manager.getTransaction().begin();
         manager.persist(account);
@@ -136,17 +139,16 @@ public class JpaWorkspaceDaoTest {
                  .get(0)
                  .getAttributes()
                  .put("new-attr", singletonList("value"));
-        workspaceDao.update(workspace);
+        WorkspaceImpl result = workspaceDao.update(workspace);
 
         manager.clear();
 
         // check it's okay
-        assertEquals(workspaceDao.get(workspace.getId())
-                                 .getConfig()
-                                 .getProjects()
-                                 .get(0)
-                                 .getAttributes()
-                                 .size(), 3);
+        assertEquals(result  .getConfig()
+                             .getProjects()
+                             .get(0)
+                             .getAttributes()
+                             .size(), 3);
     }
 
     private long asLong(String query) {


### PR DESCRIPTION
### What does this PR do?
When editing project attributes, response from update command always contains empty map because of  some storage specific logic. This fix allows to return always actual object.

Since it is impossible to store `Map<String, List<String>>` in the DB directly, for attributes we use another map with synthetic objects, like `Map<String, Attribute>`. So, after each DB read we should shift those attributes from 
utility map to the model one. `@PostLoad` does well for reads, but we also need to return correct objects after create/update, so `@PostPersist` and `@PostUpdate` annotations are added.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4778

#### Changelog
Fixed error with empty project attributes in response after update.

#### Release Notes
N/A

#### Docs PR
N/A
