### PR TITLE
CHE-4711: fix expanding/collapsing tree with the Enter key in the Commands Palette

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/palette/CommandsPaletteViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/palette/CommandsPaletteViewImpl.java
@@ -177,6 +177,8 @@ public class CommandsPaletteViewImpl extends Window implements CommandsPaletteVi
 
                     if (node instanceof ExecutableCommandNode) {
                         delegate.onCommandExecute(((ExecutableCommandNode)node).getData());
+                    } else if (node instanceof CommandGoalNode) {
+                        tree.setExpanded(node, !tree.isExpanded(node));
                     }
                 }
                 break;


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes expanding/collapsing tree in the Commands Palette when Enter key has been pressed while command goal node is selected

### What issues does this PR fix or reference?
#4711 

#### Changelog
Fixed expanding/collapsing tree in the Commands Palette when Enter key has been pressed while command goal node is selected

#### Release Notes
N/A - bug fix

#### Docs PR
N/A - bug fix
