### PR TITLE
In some cases exec agent can fail to start due to the missing permission of current folder

### DIFF
--- a/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
+++ b/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
@@ -45,6 +45,8 @@ MACHINE_TYPE=$(uname -m)
 SHELL_INTERPRETER="/bin/sh"
 
 mkdir -p ${CHE_DIR}
+${SUDO} mkdir -p /projects
+${SUDO} sh -c "chown $(id -u -n) /projects"
 
 ########################
 ### Install packages ###


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
In some cases exec agent can fail to start due to the missing permission of current folder.
We do the same like we do for ws-agent- we update permissions of ```/project``` folder

### What issues does this PR fix or reference?
Fixes https://github.com/codenvy/codenvy/issues/2103

#### Changelog
Fixes problems running exec-agent.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
