### PR TITLE
Add CentOS based minimal stack with only git to default assembly

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2682,5 +2682,53 @@
       "name": "type-go.svg",
       "mediaType": "image/svg+xml"
     }
+  },
+  {
+  "id": "centos",
+  "creator": "Dharmit Shah",
+  "name": "CentOS blank",
+  "description": "CentOS Blank Stack",
+  "scope": "advanced",
+  "tags": [
+    "Blank",
+    "CentOS",
+    "Git",
+    "Subversion"
+  ],
+  "components": [],
+  "source": {
+    "type": "image",
+    "origin": "registry.centos.org/che-stacks/centos-git"
+  },
+  "workspaceConfig": {
+    "environments": {
+      "default": {
+        "machines": {
+          "dev-machine": {
+            "agents": [
+              "org.eclipse.che.terminal",
+              "org.eclipse.che.ws-agent",
+              "org.eclipse.che.ssh"
+            ],
+            "servers": {},
+            "attributes": {
+              "memoryLimitBytes": "2147483648"
+            }
+          }
+        },
+        "recipe": {
+          "location": "registry.centos.org/che-stacks/centos-git",
+          "type": "dockerimage"
+        }
+      }
+    },
+    "name": "default",
+    "defaultEnv": "default",
+    "description": null
+  },
+  "stackIcon": {
+    "name": "type-blank.svg",
+    "mediaType": "image/svg+xml"
   }
+}
 ]


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add blank stack based on CentOS to the default assembly

#### Changelog
<!-- one line entry to be added to changelog -->
Add CentOS based minimal stack with git to default assembly

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add CentOS based minimal stack with git to default assembly

#### Note
Have rebased this on top of PR #4788 

cc @l0rd 