### PR TITLE
Fix path in sample to be the same as project name

### DIFF
--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -908,7 +908,7 @@
   {
     "name": "aspnet-web-simple",
     "displayName": "aspnet-web-simple",
-    "path": "/aspnet-mvc-simple",
+    "path": "/aspnet-web-simple",
     "description": "A simple ASP.net web sample.",
     "projectType": "blank",
     "mixins": [],


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix sample path in aspnet-web-simple project.

#### Changelog
Fixed path for aspnet-web-simple project to be the same as project name.

#### Release Notes
N/A


#### Docs PR
N/A
