### PR TITLE
Do not set debug log level when debug flag is used

### DIFF
--- a/dockerfiles/init/modules/che/templates/che.env.erb
+++ b/dockerfiles/init/modules/che/templates/che.env.erb
@@ -19,7 +19,6 @@ CATALINA_OPTS=-Dcom.sun.management.jmxremote=true -Djava.rmi.server.hostname=loc
 CHE_DEBUG_SERVER=true
 JPDA=jpda
 CHE_ASSEMBLY=<%= scope.lookupvar('che::che_assembly') %>
-CHE_LOG_LEVEL=debug
 JPDA_ADDRESS=<%= scope.lookupvar('che::che_debug_port') %>
 <% if scope.lookupvar('che::che_debug_suspend') == "true" %>JPDA_SUSPEND=y<% end %>
 <% end -%>


### PR DESCRIPTION
### What does this PR do?
Unset debug level when --debug is used to not use it as default behavior.
To set debug log level use env variable from CLI help.
Also not setting CHE_LOG_LEVEL doesn't work because of the default issue, so this PR fixes this behavior.

#### Changelog
Do not use debug log level as default when master debug mode is enabled.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
