### PR TITLE
CHE-4820: fix environment cleanup on env start error

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentEngine.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/CheEnvironmentEngine.java
@@ -764,7 +764,7 @@ public class CheEnvironmentEngine {
                 try (@SuppressWarnings("unused") Unlocker u = stripedLocks.readLock(workspaceId)) {
                     EnvironmentHolder environmentHolder = environments.get(workspaceId);
                     if (environmentHolder == null) {
-                        throw new ServerException("Environment start is interrupted.");
+                        throw new EnvironmentStartInterruptedException(workspaceId, envName);
                     }
                     service = environmentHolder.environment.getServices().get(machineName);
                     extendedMachine = environmentHolder.environmentConfig.getMachines().get(machineName);
@@ -868,7 +868,7 @@ public class CheEnvironmentEngine {
 
                 machineName = queuePeekOrFail(workspaceId);
             }
-        } catch (RuntimeException | ServerException | EnvironmentStartInterruptedException e) {
+        } catch (Exception e) {
             boolean interrupted = Thread.interrupted();
             EnvironmentHolder env;
             try (@SuppressWarnings("unused") Unlocker u = stripedLocks.writeLock(workspaceId)) {
@@ -886,7 +886,7 @@ public class CheEnvironmentEngine {
             }
             try {
                 throw e;
-            } catch (ServerException | EnvironmentStartInterruptedException rethrow) {
+            } catch (ServerException | EnvironmentException | AgentException rethrow) {
                 throw rethrow;
             } catch (Exception wrap) {
                 throw new ServerException(wrap.getMessage(), wrap);


### PR DESCRIPTION
### What does this PR do?
Fixes environment cleanup when environment start fails due to agent/environment/runtime error.

### What issues does this PR fix or reference?
Fixes #4820 

#### Changelog
Fix restart of a workspace when it previously failed to start due to agent error. 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
