### PR TITLE
CHE-4689: improve dockerfile parser

### DIFF
--- a/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
+++ b/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
@@ -9,6 +9,8 @@
  *   Codenvy, S.A. - initial API and implementation
  */
 'use strict';
+import {DockerfileParser} from '../../../components/api/environment/docker-file-parser';
+
 
 const COMPOSE = 'compose';
 const DOCKERFILE = 'dockerfile';
@@ -20,6 +22,12 @@ const DOCKERIMAGE = 'dockerimage';
  * @author Oleksii Orel
  */
 export class StackValidationService {
+
+  dockerfileParser: DockerfileParser;
+
+  constructor() {
+    this.dockerfileParser = new DockerfileParser();
+  }
 
   /**
    * Return result of recipe validation.
@@ -247,9 +255,13 @@ export class StackValidationService {
         if (!recipe.content) {
           isValid = false;
           errors.push('Unknown recipe content.');
-        } else if (!/^FROM\s+\w+/m.test(recipe.content)) {
-          isValid = false;
-          errors.push('The dockerfile is invalid.');
+        } else {
+          try {
+            this.dockerfileParser.parse(recipe.content);
+          } catch (e) {
+            isValid = false;
+            errors.push(e.message);
+          }
         }
       }
       if (!recipe.contentType) {

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.controller.ts
@@ -9,6 +9,7 @@
  *   Codenvy, S.A. - initial API and implementation
  */
 'use strict';
+import {DockerfileParser} from '../../../../../components/api/environment/docker-file-parser';
 
 /**
  * @ngdoc controller
@@ -19,6 +20,9 @@
  */
 export class WorkspaceRecipeAuthoringController {
   $timeout: ng.ITimeoutService;
+
+  dockerfileParser: DockerfileParser;
+  recipeValidationError: string;
 
   editingTimeoutPromise: ng.IPromise<any>;
 
@@ -42,6 +46,8 @@ export class WorkspaceRecipeAuthoringController {
    */
   constructor($scope: ng.IScope, $timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;
+
+    this.dockerfileParser = new DockerfileParser();
 
     this.editorOptions = {
       lineWrapping: true,
@@ -81,6 +87,7 @@ export class WorkspaceRecipeAuthoringController {
 
     this.editingTimeoutPromise = this.$timeout(() => {
       this.detectFormat(content);
+      this.validateRecipe(content);
     }, 100);
   }
 
@@ -98,7 +105,16 @@ export class WorkspaceRecipeAuthoringController {
     }
   }
 
-  onRecipeChange() {
+  validateRecipe(content: string): void {
+    this.recipeValidationError = '';
+    try {
+      this.dockerfileParser.parse(content);
+    } catch (e) {
+      this.recipeValidationError = e.message;
+    }
+  }
+
+  onRecipeChange(): void {
     this.$timeout(() => {
       this.detectFormat(this.recipeScriptCopy);
       this.recipeChange({

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.html
@@ -16,6 +16,10 @@
           <div ng-message="required">The recipe is required.</div>
         </che-error-messages>
       </che-input>
+      <div class="errors-container"
+           ng-if="workspaceRecipeAuthoringController.recipeValidationError">
+        {{workspaceRecipeAuthoringController.recipeValidationError}}
+      </div>
       <div class="recipe-docs-link">
         <a href="https://www.eclipse.org/che/docs/workspace/stacks/index.html#stack-administration" target="_blank">Custom stack documentation</a>
       </div>

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.styl
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.styl
@@ -17,3 +17,11 @@
 
   .che-label-container-row
     align-items center
+
+  .errors-container
+    color $error-color
+    min-height 20px
+    margin-right 2px
+
+    span
+      margin-right 2px

--- a/dashboard/src/components/api/environment/docker-file-environment-manager.spec.ts
+++ b/dashboard/src/components/api/environment/docker-file-environment-manager.spec.ts
@@ -34,7 +34,7 @@ describe('If recipe has content', () => {
       },
       'recipe': {
         'type': 'dockerfile',
-        'content': 'FROM codenvy/ubuntu_jdk8\nENV myName=\"John Doe\" myDog=Rex\\ The\\ Dog \\\n    myCat=fluffy',
+        'content': 'FROM codenvy/ubuntu_jdk8\nENV myName="John Doe" myDog=Rex\\ The\\ Dog \\\n    myCat=fluffy',
         'contentType': 'text/x-dockerfile'
       }
     };

--- a/dashboard/src/components/api/environment/docker-file-parser.spec.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.spec.ts
@@ -17,84 +17,311 @@ import {DockerfileParser} from './docker-file-parser';
  * @author Oleksii Kurinnyi
  */
 
-describe('Simper dockerfile parser', () => {
+describe('Simple dockerfile parser >', () => {
   let parser;
 
   beforeEach(() => {
     parser = new DockerfileParser();
   });
 
-  describe('method _parseArgument()', () => {
-    it('should parse ENV argument as single variable form #1', () => {
-      let instruction = 'ENV',
-          argument = 'name environment variable value';
+  describe('parsing directives >', () => {
 
-      let result = parser._parseArgument(instruction, argument);
+    it(`should know 'escape' directive`, () => {
+      const dockerfile = `# escape=\\
+FROM codenvy/ubuntu_jdk8`;
 
-      let expectedResult = [{
-        instruction: 'ENV',
-        argument: ['name', 'environment variable value']
-      }];
-      expect(result).toEqual(expectedResult);
-    });
+      const result = parser.parse(dockerfile);
 
-    it('should parse ENV argument as single variable form #2', () => {
-      let instruction = 'ENV',
-          argument = 'SBT_OPTS \'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'';
-
-      let result = parser._parseArgument(instruction, argument);
-
-      let expectedResult = [{
-        instruction: 'ENV',
-        argument: ['SBT_OPTS', '\'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'']
-      }];
-      expect(result).toEqual(expectedResult);
-    });
-
-    it('should parse ENV argument as multiple variables form #1', () => {
-      let instruction = 'ENV',
-          argument = 'key=value';
-      let result = parser._parseArgument(instruction, argument);
-
-      let expectedResult = [{
-        instruction: 'ENV',
-        argument: ['key', 'value']
-      }];
-      expect(result).toEqual(expectedResult);
-    });
-
-    it('should parse ENV argument as multiple variables form #2', () => {
-      let instruction = 'ENV',
-          argument = 'myName="John Doe" myDog=Rex\ The\ Dog myCat=fluffy';
-
-      let result = parser._parseArgument(instruction, argument);
-
-      let expectedResult = [{
-        instruction: 'ENV',
-        argument: ['myName', 'John Doe']
+      const expectedResult = [{
+        directive: '# escape=\\'
       }, {
-        instruction: 'ENV',
-        argument: ['myDog', 'Rex The Dog']
-      }, {
-        instruction: 'ENV',
-        argument: ['myCat', 'fluffy']
+        instruction: 'FROM',
+        argument: 'codenvy/ubuntu_jdk8'
       }];
+
       expect(result).toEqual(expectedResult);
+    });
+
+    it(`should treat unknown directive as a comment`, () => {
+      const dockerfile = `# directive=value
+FROM codenvy/ubuntu_jdk8`;
+
+      const result = parser.parse(dockerfile);
+
+      const expectedResult = [{
+        comment: '# directive=value'
+      }, {
+        instruction: 'FROM',
+        argument: 'codenvy/ubuntu_jdk8'
+      }];
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it(`should throw an error if there are two identical directives`, () => {
+      const dockerfile = `# escape=\\
+# escape=\`
+FROM codenvy/ubuntu_jdk8`;
+      const parse =  () => {
+        parser.parse(dockerfile);
+      };
+
+      expect(parse).toThrowError(TypeError);
+    });
+
+    it(`should treat known directive as a comment after an empty line`, () => {
+      const dockerfile = `
+# escape=\\
+FROM codenvy/ubuntu_jdk8`;
+
+      const result = parser.parse(dockerfile);
+
+      const expectedResult = [{
+        comment: '# escape=\\'
+      }, {
+        instruction: 'FROM',
+        argument: 'codenvy/ubuntu_jdk8'
+      }];
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it(`should treat known directive as a comment after a comment`, () => {
+      const dockerfile = `# comment line
+# escape=\\
+FROM codenvy/ubuntu_jdk8`;
+
+      const result = parser.parse(dockerfile);
+
+      const expectedResult = [{
+        comment: '# comment line'
+      }, {
+        comment: '# escape=\\'
+      }, {
+        instruction: 'FROM',
+        argument: 'codenvy/ubuntu_jdk8'
+      }];
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it(`should treat known directive as a comment after a builder instruction`, () => {
+      const dockerfile = `FROM codenvy/ubuntu_jdk8
+# escape=\\`;
+
+      const result = parser.parse(dockerfile);
+
+      const expectedResult = [{
+        instruction: 'FROM',
+        argument: 'codenvy/ubuntu_jdk8'
+      }, {
+        comment: '# escape=\\'
+      }];
+
+      expect(result).toEqual(expectedResult);
+    });
+
+  });
+
+  describe('method parseArgument()', () => {
+
+    describe('ENV argument as single variable form >', () => {
+
+      it('should parse environment variable #1', () => {
+        const instruction = 'ENV',
+              argument = 'name environment variable value';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['name', 'environment variable value']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should parse environment variable #2', () => {
+        const instruction = 'ENV',
+              argument = 'SBT_OPTS \'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['SBT_OPTS', '\'-Dhttp.proxyHost=proxy.wdf.sap.corp -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.wdf.sap.corp -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=nexus.wdf.sap.corp\'']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it(`should throw an error if incorrect ENV argument is written in single variable form`, () => {
+        const instruction = 'ENV',
+              argument = 'myNameJohnDoe'; // space between name and value is missed
+
+        const parse =  () => {
+          parser.parseArgument(instruction, argument);
+        };
+
+        expect(parse).toThrowError(TypeError);
+      });
+
+    });
+
+    describe('ENV argument as multiple variables form >', () => {
+
+      it('should parse single environment variable with backslashes', () => {
+        const dockerfile = `# escape=\\
+FROM codenvy/ubuntu_jdk8
+ENV myDog=Rex\\ The\\ Dog`;
+
+        const result = parser.parse(dockerfile);
+
+        const expectedResult = [{
+          directive: '# escape=\\'
+        }, {
+          instruction: 'FROM',
+          argument: 'codenvy/ubuntu_jdk8'
+        }, {
+          instruction: 'ENV',
+          argument: ['myDog', 'Rex The Dog']
+        }];
+
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should parse single environment variable with backtick', () => {
+        const dockerfile = `# escape=\`
+FROM codenvy/ubuntu_jdk8
+ENV myDog=Rex\` The\` Dog`;
+
+        const result = parser.parse(dockerfile);
+
+        const expectedResult = [{
+          directive: '# escape=\`'
+        }, {
+          instruction: 'FROM',
+          argument: 'codenvy/ubuntu_jdk8'
+        }, {
+          instruction: 'ENV',
+          argument: ['myDog', 'Rex The Dog']
+        }];
+
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should parse ENV argument as multiple variables form #1', () => {
+        const instruction = 'ENV',
+              argument = 'key=value';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['key', 'value']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should parse ENV argument as multiple variables form #2', () => {
+        const instruction = 'ENV',
+              argument = 'myName="John Doe" myDog=Rex\\ The\\ Dog myCat=fluffy';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['myName', 'John Doe']
+        }, {
+          instruction: 'ENV',
+          argument: ['myDog', 'Rex The Dog']
+        }, {
+          instruction: 'ENV',
+          argument: ['myCat', 'fluffy']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should parse ENV argument as multiple variables form #3', () => {
+        const instruction = 'ENV',
+              argument = 'myName="John Doe" myDog=Rex\\ The\\ Dog \\\n    myCat=fluffy';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['myName', 'John Doe']
+        }, {
+          instruction: 'ENV',
+          argument: ['myDog', 'Rex The Dog']
+        }, {
+          instruction: 'ENV',
+          argument: ['myCat', 'fluffy']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it(`should parse ENV argument as multiple variables form #4`, () => {
+        const instruction = 'ENV',
+              argument = 'myName="John Doe" myDog=Rex\\ The\\ Dog\\ myCat=fluffy';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['myName', 'John Doe']
+        }, {
+          instruction: 'ENV',
+          argument: ['myDog', 'Rex The Dog myCat=fluffy']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it(`should parse ENV argument as multiple variables form #5`, () => {
+        const instruction = 'ENV',
+              argument = 'myVar=\\\\\\ \\\\\\\\';
+
+        const result = parser.parseArgument(instruction, argument);
+
+        const expectedResult = [{
+          instruction: 'ENV',
+          argument: ['myVar', '\\ \\\\']
+        }];
+        expect(result).toEqual(expectedResult);
+      });
+
+      it(`should throw an error if incorrect ENV argument is written in multiple variables form`, () => {
+        const instruction = 'ENV',
+              argument = 'myName="John Doe" myDog=Rex\\ The\\ Dog myCat fluffy'; // the 'equal' symbol is missed
+
+        const parse =  () => {
+          parser.parseArgument(instruction, argument);
+        };
+
+        expect(parse).toThrowError(TypeError);
+      });
+
     });
 
   });
 
   it('should parse a dockerfile', () => {
-    let dockerfile = 'FROM codenvy/ubuntu_jdk8ENV'
-      + '\n#ENV myCat fluffy'
-      + '\nENV myDog Rex The Dog'
-      + '\nENV myName="John Doe"';
+    const dockerfile = `# escape=\\
 
-    let result = parser.parse(dockerfile);
+FROM codenvy/ubuntu_jdk8
+#ENV myCat fluffy
+ENV myDog Rex The Dog
+ENV myName="John Doe"
+ENV myText long \\
+multiline \\
+value
+ENV myVal=\\\\\\ \\\\\\\\`;
 
-    let expectedResult = [{
+    const result = parser.parse(dockerfile);
+
+    const expectedResult = [{
+      directive: '# escape=\\'
+    }, {
       instruction: 'FROM',
-      argument: 'codenvy/ubuntu_jdk8ENV'
+      argument: 'codenvy/ubuntu_jdk8'
     }, {
       comment: '#ENV myCat fluffy'
     }, {
@@ -103,14 +330,22 @@ describe('Simper dockerfile parser', () => {
     }, {
       instruction: 'ENV',
       argument: ['myName', 'John Doe']
+    }, {
+      instruction: 'ENV',
+      argument: ['myText', 'long \nmultiline \nvalue']
+    }, {
+      instruction: 'ENV',
+      argument: ['myVal', '\\ \\\\']
     }];
     expect(result).toEqual(expectedResult);
   });
 
   it('should stringify an object into a dockerfile', () => {
-    let instructions = [{
+    const instructions = [{
+      directive: '# escape=\\'
+    }, {
       instruction: 'FROM',
-      argument: 'codenvy/ubuntu_jdk8ENV'
+      argument: 'codenvy/ubuntu_jdk8'
     }, {
       comment: '#ENV myCat fluffy'
     }, {
@@ -119,14 +354,26 @@ describe('Simper dockerfile parser', () => {
     }, {
       instruction: 'ENV',
       argument: ['myName', 'John Doe']
+    }, {
+      instruction: 'ENV',
+      argument: ['myText', 'long \nmultiline \nvalue']
+    }, {
+      instruction: 'ENV',
+      argument: ['myVal', '\\ \\\\']
     }];
 
-    let result = parser.dump(instructions);
+    const result = parser.dump(instructions);
 
-    let expectedResult = 'FROM codenvy/ubuntu_jdk8ENV'
-      + '\n#ENV myCat fluffy'
-      + '\nENV myDog Rex The Dog'
-      + '\nENV myName John Doe';
+    const expectedResult = `# escape=\\
+
+FROM codenvy/ubuntu_jdk8
+#ENV myCat fluffy
+ENV myDog Rex The Dog
+ENV myName John Doe
+ENV myText long \\
+multiline \\
+value
+ENV myVal \\\\\ \\\\\\\\`;
     expect(result.trim()).toEqual(expectedResult);
   });
 

--- a/dashboard/src/components/api/environment/docker-file-parser.spec.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.spec.ts
@@ -77,6 +77,8 @@ FROM codenvy/ubuntu_jdk8`;
       const result = parser.parse(dockerfile);
 
       const expectedResult = [{
+        emptyLine: true
+      }, {
         comment: '# escape=\\'
       }, {
         instruction: 'FROM',
@@ -320,6 +322,8 @@ ENV myVal=\\\\\\ \\\\\\\\`;
     const expectedResult = [{
       directive: '# escape=\\'
     }, {
+      emptyLine: true
+    }, {
       instruction: 'FROM',
       argument: 'codenvy/ubuntu_jdk8'
     }, {
@@ -343,6 +347,8 @@ ENV myVal=\\\\\\ \\\\\\\\`;
   it('should stringify an object into a dockerfile', () => {
     const instructions = [{
       directive: '# escape=\\'
+    }, {
+      emptyLine: true
     }, {
       instruction: 'FROM',
       argument: 'codenvy/ubuntu_jdk8'

--- a/dashboard/src/components/api/environment/docker-file-parser.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.ts
@@ -19,36 +19,104 @@ interface IRecipeLine {
   instruction?: string;
   argument?: string | string[];
   comment?: string;
+  directive?: string;
 }
 
 export class DockerfileParser {
+  /**
+   * RegExp to match the very first instruction to be 'FROM'.
+   */
   fromRE: RegExp;
-  backslashLineBreakRE: RegExp;
-  lineBreakRE: RegExp;
-  commentLineRE: RegExp;
+  /**
+   * RegExp to match an empty line.
+   */
+  emptyLineRE: RegExp;
+  /**
+   * RegExp to match a comment line.
+   */
+  commentRE: RegExp;
+  /**
+   * RegExp to match a single dockerfile instruction.
+   */
   instructionRE: RegExp;
-  envVariablesRE: RegExp;
-  quotesTestRE: RegExp;
-  quoteAtStartReplaceRE: RegExp;
-  quoteAtEndReplaceRE: RegExp;
-  backslashSpaceRE: RegExp;
+  /**
+   * RegExp to match leading and trailing quotes.
+   */
+  quotesRE: RegExp;
+  /**
+   * RegExp to match a dockerfile parsing directive.
+   */
+  directiveRE: RegExp;
+  /**
+   * RegExp to match an environment variable in form <code>name="quoted value"</code>.
+   */
+  envVariableQuotedValueRE: RegExp;
+  /**
+   * RegExp to match any line break.
+   */
+  linebreaksRE: RegExp;
+  /**
+   * RegExp to match any escaped whitespace or line break.
+   */
+  escapedWhitespacesAndLinebreaksRE: RegExp;
+  /**
+   * RegExp to match any escaped escape symbol.
+   */
+  escapedEscapeSymbolsRE: RegExp;
+  /**
+   * RegExp to match escaped line break at start of the line.
+   */
+  escapedLineBreakAtStartRE: RegExp;
+  /**
+   * RegExp to match environment variable name.
+   */
+  variableNameRE: RegExp;
+  /**
+   * RegExp to match first unescaped whitespace or line break.
+   */
+  unEscapedWhitespaceRE: RegExp;
+
+  /**
+   * Allowed values for parsing directives.
+   */
+  directiveValues: {
+    escape: string[],
+    [name: string]: string[]
+  };
+  /**
+   * Parsing directives with default values.
+   */
+  directives: {
+    escape?: string,
+    [name: string]: string
+  };
+  /**
+   * Current escape to be used as part of a RegExp
+   */
+  escape: string;
+  /**
+   * RegExp to match any escape symbol.
+   */
+  escapeRE: RegExp;
 
   constructor() {
-    this.fromRE = /^FROM\s+\w+/m;
-    this.backslashLineBreakRE = /\\\r?\n(\s+)?/;
-    this.lineBreakRE = /\r?\n/;
-    this.commentLineRE = /^#/;
-    this.instructionRE = /(\w+)\s+?(.+)/;
-    this.envVariablesRE = /(?:^|(?:\s+))([^\s=]+?)=([^=]+?)(?:(?=\s+\w+=)|$)/g;
-    //                     |            |          |       |
-    //                     |            |          |       \- start of next variable name or end of line
-    //                     |            |          \- variable value
-    //                     |            \-  variable name
-    //                     \- start of line or spaces before variable name
-    this.quotesTestRE = /^(["']).+(\1)$/;
-    this.quoteAtStartReplaceRE = /^["']/g;
-    this.quoteAtEndReplaceRE = /["']$/g;
-    this.backslashSpaceRE = /\\\s/g;
+    this.fromRE = /^FROM$/i;
+    this.emptyLineRE = /^\s*\r?\n/;
+    this.commentRE = /^\s*#/;
+    this.quotesRE = /^["']|['"]$/g;
+    this.envVariableQuotedValueRE = /^([^\s=]+?)=['"]([^'"]+?)['"]\s*/;
+    this.linebreaksRE = /(\r?\n)/g;
+    this.variableNameRE = /^([a-z_][a-z0-9_]*)=/i;
+
+    this.directiveValues = {
+      escape: ['\\', '`']
+    };
+    this.directives = {};
+    const knownDirectives = 'escape';
+    this.directiveRE = new RegExp('^\\s*#\\s*(' + knownDirectives + ')\\s*=\\s*([^\\s]+)', 'i');
+
+    // set default parsing directive
+    this.updateDirectives('escape', this.directiveValues.escape[0]);
   }
 
   /**
@@ -58,105 +126,98 @@ export class DockerfileParser {
    * @returns {IRecipeLine[]}
    */
   parse(content: string): IRecipeLine[] {
-    if (!this.fromRE.test(content)) {
-      throw new TypeError('Dockerfile should start with \'FROM\' instruction. Cannot parse this recipe.');
-    }
+    let recipeContent = content;
 
-    // join multiline instructions
-    content = this._joinMultilineInstructions(content);
+    const instructions: IRecipeLine[] = [];
+    const uniqueDirectives: string[] = [];
+    let counter = 1000;
+    let lookingForDirectives = true;
+    let firstInstruction = true;
 
-    // split dockerfile into separate instruction lines
-    let instructionLines: string[] = content.split(this.lineBreakRE);
+    // set default parsing directive
+    this.updateDirectives('escape', this.directiveValues.escape[0]);
 
-    // split instruction line into instruction and argument
-    let instructions: IRecipeLine[] = [];
-    instructionLines.forEach((line: string) => {
-      line = line.trim();
+    while (recipeContent.length && counter) {
+      counter--;
 
-      // check for comment line
-      if (this.commentLineRE.test(line)) {
-        instructions.push({comment: line});
-        return;
+      // process parsing directive
+      if (lookingForDirectives) {
+        if (!this.emptyLineRE.test(recipeContent) && this.directiveRE.test(recipeContent)) {
+          const parts = this.splitBySymbolAtIndex(recipeContent, this.getSplitIndex(recipeContent, '\n')),
+                directiveStr = parts[0];
+          recipeContent = parts[1];
+
+          let [ , name, value] = this.directiveRE.exec(directiveStr);
+
+          if (this.directiveValues[name].indexOf(value) === -1) {
+            // directive value is not allowed
+            // hence this line should be treated as comment
+            instructions.push({comment: directiveStr});
+            lookingForDirectives = false;
+            continue;
+          }
+
+          name = name.toLowerCase();
+          if (uniqueDirectives.indexOf(name) !== -1) {
+            throw new TypeError(`Directive "${name}" is invalid due to appearing twice.`);
+          }
+          uniqueDirectives.push(name);
+
+          this.updateDirectives(name, value);
+          instructions.push({
+            directive: directiveStr
+          });
+          continue;
+        }
+        lookingForDirectives = false;
       }
 
-      let m = line.match(this.instructionRE);
-      if (m) {
-        let instruction = m[1],
-            argument = m[2];
+      // process empty line
+      if (this.emptyLineRE.test(recipeContent)) {
+        const parts = this.splitBySymbolAtIndex(recipeContent, this.getSplitIndex(recipeContent, '\n'));
+        recipeContent = parts[1];
+
+        continue;
+      }
+
+      // process comment
+      if (this.commentRE.test(recipeContent)) {
+        const parts = this.splitBySymbolAtIndex(recipeContent, this.getSplitIndex(recipeContent, '\n')),
+              commentStr = parts[0];
+        recipeContent = parts[1];
+
+        instructions.push({comment: commentStr});
+
+        continue;
+      }
+
+      // process instruction
+      if (this.instructionRE.test(recipeContent)) {
+        const [fullMatch, instruction, argument] = this.instructionRE.exec(recipeContent);
+
+        if (firstInstruction && !this.fromRE.test(instruction)) {
+          throw new TypeError('Dockerfile should start with \'FROM\' instruction.');
+        }
+        firstInstruction = false;
 
         // parse argument
-        let results: IRecipeLine[] = this._parseArgument(instruction, argument);
-
+        let results: IRecipeLine[] = this.parseArgument(instruction, argument);
         results.forEach((result: IRecipeLine) => {
           instructions.push(result);
         });
+
+        const parts = this.splitBySymbolAtIndex(recipeContent, fullMatch.length);
+        recipeContent = parts[1];
+
+        continue;
       }
-    });
 
-    return instructions;
-  }
-
-  /**
-   * Remove line breaks from lines which end with backslash
-   *
-   * @param content {string}
-   * @returns {string}
-   * @private
-   */
-  _joinMultilineInstructions(content: string): string {
-    return content.replace(this.backslashLineBreakRE, '');
-  }
-
-  /**
-   * Parses an argument string depending on instruction
-   *
-   * @param instruction {string}
-   * @param argumentStr {string}
-   * @returns {IRecipeLine[]}
-   * @private
-   */
-  _parseArgument(instruction: string, argumentStr: string): IRecipeLine[] {
-    let results: IRecipeLine[] = [];
-
-    switch (instruction) {
-      case 'ENV':
-        let firstSpaceIndex = argumentStr.indexOf(' '),
-            firstEqualIndex = argumentStr.indexOf('=');
-        if (firstEqualIndex > -1 && (firstSpaceIndex === -1 || firstEqualIndex < firstSpaceIndex)) {
-          // this argument string contains one or more environment variables
-          let match;
-          while (match = this.envVariablesRE.exec(argumentStr)) {
-            let name: string  = match[1],
-                value: string = match[2];
-            if (this.quotesTestRE.test(value)) {
-              value = value.replace(this.quoteAtStartReplaceRE, '');
-              value = value.replace(this.quoteAtEndReplaceRE, '');
-            }
-            if (this.backslashSpaceRE.test(value)) {
-              value = value.replace(this.backslashSpaceRE, ' ');
-            }
-
-            results.push({
-              instruction: instruction,
-              argument: [name, value]
-            });
-          }
-        } else {
-          // this argument string contains only one environment variable
-          results.push({
-            instruction: instruction,
-            argument: [argumentStr.slice(0, firstSpaceIndex), argumentStr.slice(firstSpaceIndex + 1)]
-          });
-        }
-        break;
-      default:
-        results.push({
-          instruction: instruction,
-          argument: argumentStr
-        });
+      // got weird line
+      const [line, ] = this.splitBySymbolAtIndex(recipeContent, this.getSplitIndex(recipeContent, '\n'));
+      throw new TypeError(`Cannot parse recipe from line: ${line}`);
     }
 
-    return results;
+    return instructions;
   }
 
   /**
@@ -169,10 +230,15 @@ export class DockerfileParser {
     let content = '';
 
     instructions.forEach((line: IRecipeLine) => {
-      if (line.comment) {
+      if (line.directive) {
+        content += line.directive + '\n';
+      } else if (line.comment) {
         content += line.comment + '\n';
       } else {
-        content += line.instruction + ' ' + this._stringifyArgument(line) + '\n';
+        if (line.instruction === 'FROM') {
+          content += '\n';
+        }
+        content += line.instruction + ' ' + this.stringifyArgument(line) + '\n';
       }
     });
 
@@ -180,18 +246,224 @@ export class DockerfileParser {
   }
 
   /**
+   * Returns index of given symbol in the string.
+   *
+   * @param {string} content a string
+   * @param {string} delimiter a substring, position of which has to be found.
+   * @return {number}
+   */
+  private getSplitIndex(content: string, delimiter: string): number {
+    return content.indexOf(delimiter) === -1 ? content.length : content.indexOf(delimiter);
+  }
+
+  /**
+   * Builds a RegExp to match any escape symbol.
+   * Builds a RegExp to match a dockerfile instruction.
+   * Builds a RegExp to match any escaped whitespace or line break.
+   * Builds a RegExp to match any escaped whitespace or line break.
+   * Builds a RegExp to match escaped line break at line start.
+   * Builds a RegExp to match first unescaped whitespace or line break.
+   */
+  private buildParsingDirectiveSpecificRegExps(): void {
+    this.escapeRE = new RegExp('(' + this.escape + ')', 'g');
+
+    const instructions = 'FROM|RUN|CMD|LABEL|MAINTAINER|EXPOSE|ENV|ADD|COPY|ENTRYPOINT|VOLUME|USER|WORKDIR|ARG|ONBUILD|STOPSIGNAL|HEALTHCHECK|SHELL';
+    this.instructionRE = new RegExp('^\\s*(' + instructions + ')\\s+((?:.|' + this.escape + '\\r?\\n)+(?!\\r?\\n).)', 'i');
+
+    this.escapedWhitespacesAndLinebreaksRE = new RegExp('([^' + this.escape + ']?(?:' + this.escape + '{2})*)' + this.escape + '(\\s|\\r?\\n|' + this.escape + ')', 'g');
+
+    this.escapedEscapeSymbolsRE = new RegExp('' + this.escape + '(' + this.escape + ')', 'g');
+
+    this.escapedLineBreakAtStartRE = new RegExp('^' + this.escape + '\\r?\\n');
+
+    this.unEscapedWhitespaceRE = new RegExp('[^' + this.escape + '](?:' + this.escape + '{2})*(\\s|\\r?\\n)');
+  }
+
+  /**
+   * Updates parsing directives object and rebuilds appropriate RegExp.
+   *
+   * @param {string} directive a directive's name
+   * @param {string} value a directive's value
+   */
+  private updateDirectives(directive: string, value: string): void {
+    this.escape = value === '\\' ? '\\\\' : value;
+    this.directives[directive] = value;
+
+    switch (directive) {
+      case 'escape':
+        this.buildParsingDirectiveSpecificRegExps();
+        break;
+    }
+  }
+
+  /**
+   * Splits a string by symbol at an index.
+   *
+   * @param {string} what a string to be split.
+   * @param {number} where an index to split the string.
+   * @return {[string,string]}
+   */
+  private splitBySymbolAtIndex(what: string, where: number): string[] {
+    if (where < 0 || where >= what.length) {
+      where = what.length;
+      return [what, ''];
+    }
+
+    return [what.slice(0, where), what.slice(where + 1)];
+  }
+
+  /**
+   * Parses an argument string depending on instruction
+   *
+   * @param instruction {string}
+   * @param argumentStr {string}
+   * @returns {IRecipeLine[]}
+   */
+  private parseArgument(instruction: string, argumentStr: string): IRecipeLine[] {
+    const results: IRecipeLine[] = [];
+
+    switch (instruction) {
+      case 'ENV':
+        const variables: string[][] = this.parseENVInstruction(argumentStr);
+        variables.forEach((variable: string[]) => {
+          results.push({
+            instruction: instruction,
+            argument: variable
+          });
+        });
+        break;
+      default:
+        results.push({
+          instruction: instruction,
+          argument: argumentStr
+        });
+    }
+
+    return results;
+  }
+
+  private parseENVInstruction(content: string): string[][] {
+    const results: string[][] = [];
+
+    const firstSpaceIndex = content.indexOf(' '),
+          firstEqualIndex = content.indexOf('=');
+
+    if (firstEqualIndex === -1 && firstSpaceIndex === -1) {
+      throw new TypeError(`Cannot parse environment variable name and value from string "${content}"`);
+    }
+
+    if (firstSpaceIndex > -1 && (firstEqualIndex === -1 || firstSpaceIndex < firstEqualIndex)) {
+
+      // this argument string contains only one environment variable
+      let [name, value] = [content.slice(0, firstSpaceIndex), content.slice(firstSpaceIndex + 1)];
+
+      value = this.unEscapeString(value);
+
+      results.push([name, value]);
+
+    } else {
+
+      // this argument string contains one or more environment variables
+      let count = 100;
+      while (content.length && count) {
+        count--;
+
+        // remove a linebreak at the start of string
+        content = content.replace(this.escapedLineBreakAtStartRE, '');
+
+        // remove a whitespace at the start of string
+        content = content.replace(/^\s+/, '');
+
+        // check if string begins with variable name
+        if (!this.variableNameRE.test(content)) {
+          throw new TypeError(`Cannot parse environment variable name and value from string "${content}"`);
+        }
+
+        if (this.envVariableQuotedValueRE.test(content)) {
+
+          /* variable with quoted value */
+
+          let [fullMatch, name, value] = this.envVariableQuotedValueRE.exec(content);
+
+          value = value.replace(this.quotesRE, '');
+
+          results.push([name, value]);
+
+          const parts = this.splitBySymbolAtIndex(content, fullMatch.length - 1);
+          // cut processed variable from the string
+          content = parts[1];
+        } else {
+
+          /* variable with escaped value */
+
+          // look for the point where the variable ends
+          const unEscapedWhitespaceMatch = this.unEscapedWhitespaceRE.exec(content);
+
+          let variableLength: number;
+          if (!unEscapedWhitespaceMatch) {
+            // the rest of string is a single variable
+            variableLength = content.length;
+          } else {
+            variableLength = unEscapedWhitespaceMatch.index + unEscapedWhitespaceMatch.length - 1;
+          }
+
+          const parts = this.splitBySymbolAtIndex(content, variableLength);
+          const variableStr = parts[0];
+          // cut processed variable from the string
+          content = parts[1];
+
+          const equalIndex = variableStr.indexOf('=');
+
+          const varParts = this.splitBySymbolAtIndex(variableStr, equalIndex);
+          let name = varParts[0],
+              value = varParts[1];
+
+          value = this.unEscapeString(value);
+
+          results.push([name, value]);
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /**
    * Dumps argument object depending on instruction.
    *
-   * @param line {IRecipeLine}
+   * @param {IRecipeLine} line
    * @returns {string}
-   * @private
    */
-  _stringifyArgument(line: IRecipeLine): string {
+  private stringifyArgument(line: IRecipeLine): string {
     switch (line.instruction) {
       case 'ENV':
-        return (line.argument as string[]).join(' ');
+        const [name, value] = line.argument as string[];
+        return name + ' ' + this.escapeString(value);
       default:
         return line.argument as string;
     }
+  }
+
+  private escapeString(content: string): string {
+    // this replace should be the very first
+    content = content.replace(this.escapeRE, this.directives.escape + '$1');
+
+    content = content.replace(this.linebreaksRE, this.directives.escape + '$1');
+
+    return content;
+  }
+
+  /**
+   * Unescapes whitespaces and escape symbols.
+   *
+   * @param {string} content a string to process.
+   */
+  private unEscapeString(content: string): string {
+    content = content.replace(this.escapedWhitespacesAndLinebreaksRE, '$1$2');
+
+    // this replace should be the very last
+    content = content.replace(this.escapedEscapeSymbolsRE, '$1');
+
+    return content;
   }
 }

--- a/dashboard/src/components/api/environment/docker-file-parser.ts
+++ b/dashboard/src/components/api/environment/docker-file-parser.ts
@@ -20,6 +20,7 @@ interface IRecipeLine {
   argument?: string | string[];
   comment?: string;
   directive?: string;
+  emptyLine?: boolean;
 }
 
 export class DockerfileParser {
@@ -177,6 +178,8 @@ export class DockerfileParser {
         const parts = this.splitBySymbolAtIndex(recipeContent, this.getSplitIndex(recipeContent, '\n'));
         recipeContent = parts[1];
 
+        instructions.push({emptyLine: true});
+
         continue;
       }
 
@@ -230,14 +233,13 @@ export class DockerfileParser {
     let content = '';
 
     instructions.forEach((line: IRecipeLine) => {
-      if (line.directive) {
+      if (line.emptyLine) {
+        content += '\n';
+      } else if (line.directive) {
         content += line.directive + '\n';
       } else if (line.comment) {
         content += line.comment + '\n';
       } else {
-        if (line.instruction === 'FROM') {
-          content += '\n';
-        }
         content += line.instruction + ' ' + this.stringifyArgument(line) + '\n';
       }
     });


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR fixes the bug when some dockerfile instructions which contain line breaks and ampersands were not parsed correctly.

### What issues does this PR fix or reference?
#4689 

#### Changelog
<!-- one line entry to be added to changelog -->
Fixed dockerfile parser in order to correctly parse instructions which contain line breaks and ampersands.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>