### PR TITLE
CHE-4663: Change wrong button text on "Edit the command" popup.

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.html
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.html
@@ -48,7 +48,7 @@
         <div ng-message="maxlength">Command's preview URL should be less than 256 characters long.</div>
       </che-input>
     </div>
-    <che-button-primary che-button-title="{{editCommandDialogController.index === -1 ? 'Add' : 'Edit'}}"
+    <che-button-primary che-button-title="{{editCommandDialogController.index === -1 ? 'Add' : 'Save'}}"
                         ng-click="editCommandDialogController.updateCommand()"
                         ng-disabled="commandForm.$invalid">
     </che-button-primary>


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR changes wrong button text on "Edit the command" popup.
![screenshot-localhost-3000-2017-04-24-09-18-22](https://cloud.githubusercontent.com/assets/16220722/25324735/1f4436f2-28d0-11e7-8065-6980337a63ab.png)


### What issues does this PR fix or reference?
#4663 

#### Changelog
<!-- one line entry to be added to changelog -->
[UD] changed wrong button text on "Edit the command" popup.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>
