### PR TITLE
CHE-4664: update restriction in UD for port range to be 0-65535.

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.controller.ts
@@ -33,7 +33,7 @@ export class EditServerDialogController {
   usedReferences: string[];
 
   port: number;
-  portMin: number = 1024;
+  portMin: number = 0;
   portMax: number = 65535;
   protocol: string;
   reference: string;

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.html
@@ -35,7 +35,7 @@
                    che-place-holder="Port number"
                    ng-model="editServerDialogController.port"
                    type="number"
-                   min="1024"
+                   min="0"
                    max="65535"
                    custom-validator="editServerDialogController.isUniquePort($value)"
                    aria-label="Server port number"


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR updates restriction in UD for port range to be 0-65535.

### What issues does this PR fix or reference?
#4664 

#### Changelog
<!-- one line entry to be added to changelog -->
[UD] updated restriction in UD for port range to be 0-65535.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>
