### PR TITLE
Fix OpenShiftConnectorTest

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
@@ -52,7 +52,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
  *
  * @author amisevsk
  */
-final class OpenShiftPvcHelper {
+public class OpenShiftPvcHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenShiftPvcHelper.class);
 


### PR DESCRIPTION
### What does this PR do?
Makes class `OpenShiftPvcHelper` not`final` 

### What issues does this PR fix or reference?
`OpenShiftConnectorTest` was failing:

> [INFO] Tests run: 25, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.031 sec <<< FAILURE! - in TestSuite
[INFO] shouldGetWorkspaceIDWhenAValidOneIsProvidedInCreateContainerParams(org.eclipse.che.plugin.openshift.client.OpenShiftConnectorTest)  Time elapsed: 0.222 sec  <<< FAILURE!
[INFO] org.mockito.exceptions.base.MockitoException: 
[INFO] Cannot mock/spy class org.eclipse.che.plugin.openshift.client.OpenShiftPvcHelper
[INFO] Mockito cannot mock/spy following:
[INFO]   - final classes
[INFO]   - anonymous classes
[INFO]   - primitive types
[INFO]     at org.testng.internal.invokers.InvokedMethodListenerInvoker$InvokeBeforeInvocationWithoutContextStrategy.callMethod(InvokedMethodListenerInvoker.java:84)
[INFO]     at org.testng.internal.invokers.InvokedMethodListenerInvoker.invokeListener(InvokedMethodListenerInvoker.java:62)
[INFO]     at org.testng.internal.Invoker.runInvokedMethodListeners(Invoker.java:619)
[INFO]     at org.testng.internal.Invoker.invokeMethod(Invoker.java:687)
[INFO]     at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:901)
[INFO]     at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1231)
[INFO]     at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:127)
[INFO]     at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:111)
[INFO]     at org.testng.TestRunner.privateRun(TestRunner.java:767)
[INFO]     at org.testng.TestRunner.run(TestRunner.java:617)
[INFO]     at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
[INFO]     at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:343)
[INFO]     at org.testng.SuiteRunner.privateRun(SuiteRunner.java:305)
[INFO]     at org.testng.SuiteRunner.run(SuiteRunner.java:254)
[INFO]     at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
[INFO]     at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
[INFO]     at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
[INFO]     at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
[INFO]     at org.testng.TestNG.run(TestNG.java:1057)
[INFO]     at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:115)
[INFO]     at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeMulti(TestNGDirectoryTestSuite.java:205)
[INFO]     at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:108)
[INFO]     at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:111)
[INFO]     at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
[INFO]     at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
[INFO]     at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
[INFO] 
[INFO] 
[INFO] Results :
[INFO] 
[INFO] Failed tests: 
[INFO]   OpenShiftConnectorTest.shouldGetWorkspaceIDWhenAValidOneIsProvidedInCreateContainerParams » Mockito
[INFO] 
[INFO] Tests run: 25, Failures: 1, Errors: 0, Skipped: 0