### PR TITLE
Remove generating of outdated analitycs rel for factories

### DIFF
--- a/wsmaster/che-core-api-factory-shared/src/main/java/org/eclipse/che/api/factory/shared/Constants.java
+++ b/wsmaster/che-core-api-factory-shared/src/main/java/org/eclipse/che/api/factory/shared/Constants.java
@@ -23,7 +23,6 @@ public final class Constants {
     public static final String SNIPPET_REL_ATT                  = "snippet";
     public static final String FACTORY_ACCEPTANCE_REL_ATT       = "accept";
     public static final String NAMED_FACTORY_ACCEPTANCE_REL_ATT = "accept-named";
-    public static final String ACCEPTED_REL_ATT                 = "accepted";
 
     // factory snippet types
     public static final String MARKDOWN_SNIPPET_TYPE = "markdown";

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryLinksHelper.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryLinksHelper.java
@@ -28,7 +28,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.eclipse.che.api.core.util.LinksHelper.createLink;
-import static org.eclipse.che.api.factory.shared.Constants.ACCEPTED_REL_ATT;
 import static org.eclipse.che.api.factory.shared.Constants.FACTORY_ACCEPTANCE_REL_ATT;
 import static org.eclipse.che.api.factory.shared.Constants.IMAGE_REL_ATT;
 import static org.eclipse.che.api.factory.shared.Constants.NAMED_FACTORY_ACCEPTANCE_REL_ATT;
@@ -127,16 +126,6 @@ public class FactoryLinksHelper {
                                                     TEXT_HTML,
                                                     FACTORY_ACCEPTANCE_REL_ATT);
             links.add(createWorkspace);
-            // creation of links for analytics
-            links.add(createLink(HttpMethod.GET,
-                                 uriBuilder.clone()
-                                           .path("analytics")
-                                           .path("public-metric/factory_used")
-                                           .queryParam("factory", createWorkspace.getHref())
-                                           .toString(),
-                                 null,
-                                 TEXT_PLAIN,
-                                 ACCEPTED_REL_ATT));
         }
 
         if (!Strings.isNullOrEmpty(factory.getName()) && !Strings.isNullOrEmpty(userName)) {


### PR DESCRIPTION
### What does this PR do?
Removes generating of outdated analitycs rel for factories that breaks using of caching with etags 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4907

#### Changelog
Removed generating of outdated analitycs rel for factories.

#### Release Notes
N/A

#### Docs PR
N/A