### PR TITLE
Temporary fix for https://issues.jboss.org/browse/CHE-214

### DIFF
--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/pom.xml
@@ -22,6 +22,10 @@
     <name>Che Plugin :: Java Testing :: JUnit Server</name>
     <dependencies>
         <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-posix</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/src/main/java/org/eclipse/che/plugin/testing/junit/server/JUnitTestRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-server/src/main/java/org/eclipse/che/plugin/testing/junit/server/JUnitTestRunner.java
@@ -39,6 +39,8 @@ import org.eclipse.che.plugin.testing.classpath.server.TestClasspathRegistry;
 import javassist.util.proxy.MethodFilter;
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
 
 /**
  * JUnit implementation for the test runner service.
@@ -125,8 +127,12 @@ public class JUnitTestRunner implements TestRunner {
         }
 
         String currentWorkingDir = System.getProperty("user.dir");
+        POSIX posix = POSIXFactory.getPOSIX();
+        String posixCwd = posix.getcwd();
         try {
+            
             System.setProperty("user.dir", projectAbsolutePath);
+            posix.chdir(projectAbsolutePath);
             TestResult testResult;
             if (runClass) {
                 String fqn = testParameters.get("fqn");
@@ -138,6 +144,7 @@ public class JUnitTestRunner implements TestRunner {
             return testResult;
         } finally {
             System.setProperty("user.dir", currentWorkingDir);
+            posix.chdir(posixCwd);
         }
     }
 

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/pom.xml
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/pom.xml
@@ -22,6 +22,10 @@
     <name>Che Plugin :: Java Testing :: TestNG Server</name>
     <dependencies>
         <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-posix</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>


### PR DESCRIPTION
Wildfly Swarm / Arquillian tests cannot be run successfully.

Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

It correctly changes the OS current working directory to the tested project root directory during the execution of the tests. This is necessary for various test framework that assume the tests to be started in the project root directory.

However the true long-term solution for these problems is to refactor the Testing feature to run tests in their own process (see https://issues.jboss.org/browse/CHE-192 and https://github.com/eclipse/che/issues/4679)
