### PR TITLE
CHE-4670: make copy file operation more informative

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -544,7 +544,9 @@ public final class ResourceManager {
         checkArgument(!source.getLocation().isRoot(), "Workspace root is not allowed to be copied");
 
         return findResource(destination, true).thenPromise(resource -> {
-            checkState(!resource.isPresent() || force, "Cannot create '" + destination.toString() + "'. Resource already exists.");
+            if (resource.isPresent() && !force){
+                return promises.reject(new IllegalStateException("Cannot create '" + destination.toString() + "'. Resource already exists."));
+            }
 
             return ps.copy(source.getLocation(), destination.parent(), destination.lastSegment(), force)
                      .thenPromise(ignored -> findResource(destination, false)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Makes copy file operation more informative.
If a file with its name already exists the window will be shown:
![selection_003](https://cloud.githubusercontent.com/assets/1271546/25438128/2a80a9ec-2aa1-11e7-8a2b-c9e8252e4df4.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4670

#### Changelog
<!-- one line entry to be added to changelog -->
Make copy file operation more informative
