### PR TITLE
Introduce a template-based custom docker server evaluation strategy

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -211,10 +211,27 @@ che.docker.ip.external=NULL
 #   - 'default':      internal address is address of docker host and ephemeral port are used
 #   - 'docker-local': internal address is address of container within docker network, and exposed ports
 #                     are used.
+#   - 'custom': The evaluation strategy may be customized through a template property.
 # The 'docker-local' strategy may be useful if a firewall prevents communication between che-server and
 # workspace containers, but will prevent communication when che-server and workspace containers are not
 # on the same Docker network.
 che.docker.server_evaluation_strategy=default
+
+
+# Here are macros available for the custom server evaluation strategy
+# serverName: name of the server exposing the port (like tomcat8, ws-agent, etc)
+# machineName: name of the machine of the workspace. (like devMachine)
+# workspaceId: id of the workspace
+# internalIp: IP of the internal address of che (che.docker.ip property)
+# externalIP: IP of the external address of che
+# externalAddresss : external address of che (che.docker.ip.external or if null che.docker.ip)
+# chePort : Che listening port number of workspace master
+# wildcardNipDomain : get external address transformed into a nip.io DNS sub-domain
+# wildcardXipDomain : get external address transformed into a xip.io DNS sub-domain
+che.docker.custom.external.template=<serverName>.<machineName>.<workspaceId>.<wildcardNipDomain>:<chePort>
+
+# Protocol to use for http access (for example it can be set to https)
+che.docker.custom.external.protocol=http
 
 # Provides a Docker network where Che server is running.
 # Workspace containers created by Che will be added to this Docker network.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -228,7 +228,7 @@ che.docker.server_evaluation_strategy=default
 # chePort : Che listening port number of workspace master
 # wildcardNipDomain : get external address transformed into a nip.io DNS sub-domain
 # wildcardXipDomain : get external address transformed into a xip.io DNS sub-domain
-che.docker.server_evaluation_strategy.custom.external.template=<serverName>.<machineName>.<workspaceId>.<wildcardNipDomain>:<chePort>
+che.docker.server_evaluation_strategy.custom.template=<serverName>.<machineName>.<workspaceId>.<wildcardNipDomain>:<chePort>
 
 # Protocol to use for http access (for example it can be set to https)
 che.docker.server_evaluation_strategy.custom.external.protocol=http

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -219,7 +219,7 @@ che.docker.server_evaluation_strategy=default
 
 
 # Here are macros available for the custom server evaluation strategy
-# serverName: name of the server exposing the port (like tomcat8, ws-agent, etc)
+# serverName: server reference exposing the port (like tomcat8, ws-agent, etc)
 # machineName: name of the machine of the workspace. (like devMachine)
 # workspaceId: id of the workspace
 # internalIp: IP of the internal address of che (che.docker.ip property)
@@ -228,10 +228,10 @@ che.docker.server_evaluation_strategy=default
 # chePort : Che listening port number of workspace master
 # wildcardNipDomain : get external address transformed into a nip.io DNS sub-domain
 # wildcardXipDomain : get external address transformed into a xip.io DNS sub-domain
-che.docker.custom.external.template=<serverName>.<machineName>.<workspaceId>.<wildcardNipDomain>:<chePort>
+che.docker.server_evaluation_strategy.custom.external.template=<serverName>.<machineName>.<workspaceId>.<wildcardNipDomain>:<chePort>
 
 # Protocol to use for http access (for example it can be set to https)
-che.docker.custom.external.protocol=http
+che.docker.server_evaluation_strategy.custom.external.protocol=http
 
 # Provides a Docker network where Che server is running.
 # Workspace containers created by Che will be added to this Docker network.

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -1,0 +1,396 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.machine;
+
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
+import org.eclipse.che.plugin.docker.client.json.PortBinding;
+import org.stringtemplate.v4.ST;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Represents a server evaluation strategy for the configuration where the strategy can be customized through template properties.
+ *
+ * @author Florent Benoit
+ * @see ServerEvaluationStrategy
+ */
+public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrategy {
+
+    /**
+     * Regexp to extract port (under the form 22/tcp or 4401/tcp, etc.) from label references
+     */
+    public static final String LABEL_CHE_SERVER_REF_KEY = "^che:server:(.*):ref$";
+
+    /**
+     * Name of the property for getting the workspace ID.
+     */
+    public static final String CHE_WORKSPACE_ID_PROPERTY = "CHE_WORKSPACE_ID=";
+
+    /**
+     * Name of the property to get the machine name property
+     */
+    public static final String CHE_MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=";
+
+    /**
+     * The current port of che.
+     */
+    private final String chePort;
+
+    /**
+     * Secured or not ? (for example https vs http)
+     */
+    private final String cheDockerCustomExternalProtocol;
+
+    /**
+     * Template for external addresses.
+     */
+    private String cheDockerCustomExternalTemplate;
+
+
+    /**
+     * Default constructor
+     */
+    @Inject
+    public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String cheDockerIp,
+                                          @Nullable @Named("che.docker.ip.external") String cheDockerIpExternal,
+                                          @Nullable @Named("che.docker.custom.external.template") String cheDockerCustomExternalTemplate,
+                                          @Nullable @Named("che.docker.custom.external.protocol") String cheDockerCustomExternalProtocol,
+                                          @Named("che.port") String chePort) {
+        super(cheDockerIp, cheDockerIpExternal);
+        this.chePort = chePort;
+        this.cheDockerCustomExternalTemplate = cheDockerCustomExternalTemplate;
+        this.cheDockerCustomExternalProtocol = cheDockerCustomExternalProtocol;
+    }
+
+    /**
+     * Override the host for all ports by using the external template.
+     */
+    @Override
+    protected Map<String, String> getExternalAddressesAndPorts(ContainerInfo containerInfo, String internalHost) {
+
+        // create Rendering evaluation
+        RenderingEvaluation renderingEvaluation = getOnlineRenderingEvaluation(containerInfo, internalHost);
+
+        // get current ports
+        Map<String, List<PortBinding>> ports = containerInfo.getNetworkSettings().getPorts();
+
+        return ports.keySet().stream()
+                    .collect(Collectors.toMap(portKey -> portKey,
+                                              portKey -> renderingEvaluation.render(cheDockerCustomExternalTemplate, portKey)));
+    }
+
+
+    /**
+     * Constructs a map of {@link ServerImpl} from provided parameters, using selected strategy
+     * for evaluating addresses and ports.
+     *
+     * <p>Keys consist of port number and transport protocol (tcp or udp) separated by
+     * a forward slash (e.g. 8080/tcp)
+     *
+     * @param containerInfo
+     *         the {@link ContainerInfo} describing the container.
+     * @param internalHost
+     *         alternative hostname to use, if address cannot be obtained from containerInfo
+     * @param serverConfMap
+     *         additional Map of {@link ServerConfImpl}. Configurations here override those found
+     *         in containerInfo.
+     * @return a Map of the servers exposed by the container.
+     */
+    public Map<String, ServerImpl> getServers(ContainerInfo containerInfo,
+                                              String internalHost,
+                                              Map<String, ServerConfImpl> serverConfMap) {
+            Map<String, ServerImpl> servers = super.getServers(containerInfo, internalHost, serverConfMap);
+            return servers.entrySet().stream().collect(Collectors.toMap(map -> map.getKey(), map -> updateServer(map.getValue())));
+    }
+
+
+    /**
+     * Updates the protocol for the given server by using given protocol (like https) for http URLs.
+     * @param server the server to update
+     * @return updated server object
+     */
+    protected ServerImpl updateServer(ServerImpl server) {
+        if (!Strings.isNullOrEmpty(cheDockerCustomExternalProtocol)) {
+            if ("http".equals(server.getProtocol())) {
+                server.setProtocol(cheDockerCustomExternalProtocol);
+                String url = server.getUrl();
+                int length = "http".length();
+                server.setUrl(cheDockerCustomExternalProtocol.concat(url.substring(length)));
+            }
+        }
+        return server;
+    }
+
+
+    /**
+     * Allow to get the rendering outside of the evaluation strategies.
+     * It is called online as in this case we have access to container info
+     */
+    public RenderingEvaluation getOnlineRenderingEvaluation(ContainerInfo containerInfo, String internalHost) {
+        return new OnlineRenderingEvaluation(containerInfo).withInternalHost(internalHost);
+    }
+
+    /**
+     * Allow to get the rendering outside of the evaluation strategies.
+     * It is called offline as without container info, user need to provide merge of container and images data
+     */
+    public RenderingEvaluation getOfflineRenderingEvaluation(Map<String, String> labels, Set<String> exposedPorts, String[] env) {
+        return new OfflineRenderingEvaluation(labels, exposedPorts, env);
+    }
+
+    /**
+     * Simple interface for performing the rendering for a given portby using the given template
+     *
+     * @author Florent Benoit
+     */
+    public interface RenderingEvaluation {
+        /**
+         * Gets the template rendering for the given port and using the given template
+         *
+         * @param template
+         *         which can include <propertyName></propertyName>
+         * @param port
+         *         the port for the mapping
+         * @return the rendering of the template
+         */
+        String render(String template, String port);
+    }
+
+    /**
+     * Online implementation (using the container info)
+     */
+    protected class OnlineRenderingEvaluation extends OfflineRenderingEvaluation implements RenderingEvaluation {
+
+        private String gatewayAddressContainer;
+        private String internalHost;
+
+        protected OnlineRenderingEvaluation(ContainerInfo containerInfo) {
+            super(containerInfo.getConfig().getLabels(), containerInfo.getConfig().getExposedPorts().keySet(),
+                  containerInfo.getConfig().getEnv());
+            this.gatewayAddressContainer = containerInfo.getNetworkSettings().getGateway();
+            this.init();
+        }
+
+        protected OnlineRenderingEvaluation withInternalHost(String internalHost) {
+            this.internalHost = internalHost;
+            return this;
+        }
+
+        @Override
+        protected String getExternalAddress() {
+            return externalAddressProperty != null ?
+                   externalAddressProperty :
+                   !isNullOrEmpty(gatewayAddressContainer) ?
+                   gatewayAddressContainer :
+                   this.internalHost;
+        }
+    }
+
+    /**
+     * Offline implementation (container not yet created)
+     */
+    protected class OfflineRenderingEvaluation extends DefaultRenderingEvaluation implements RenderingEvaluation {
+
+        public OfflineRenderingEvaluation(Map<String, String> labels, Set<String> exposedPorts, String[] env) {
+            super(labels, exposedPorts, env);
+            this.init();
+        }
+    }
+
+    /**
+     * Provides the template.
+     */
+    public String getTemplate() {
+        return this.cheDockerCustomExternalTemplate;
+    }
+
+    /**
+     * Inner class used to perform the rendering
+     */
+    protected abstract class DefaultRenderingEvaluation implements RenderingEvaluation {
+
+        /**
+         * Labels
+         */
+        private Map<String, String> labels;
+
+        /**
+         * Ports
+         */
+        private Set<String> exposedPorts;
+
+        /**
+         * Environment variables
+         */
+        private final String[] env;
+
+        /**
+         * Map with properties for all ports
+         */
+        private Map<String, String> globalPropertiesMap = new HashMap<>();
+
+        /**
+         * Mapping between a port and the server ref name
+         */
+        private Map<String, String> portsToRefName;
+
+        /**
+         * Default constructor.
+         */
+        protected DefaultRenderingEvaluation(Map<String, String> labels, Set<String> exposedPorts, String[] env) {
+            this.labels = labels;
+            this.exposedPorts = exposedPorts;
+            this.env = env;
+        }
+
+        /**
+         * Initialize data
+         */
+        protected void init() {
+            this.initPortMapping();
+            this.populateGlobalProperties();
+        }
+
+        /**
+         * Compute port mapping with server ref name
+         */
+        protected void initPortMapping() {
+            // ok, so now we have a map of labels and a map of exposed ports
+            // need to extract the name of the ref (if defined in a label) or then pickup default name "Server-<port>-<protocol>"
+            Pattern pattern = Pattern.compile(LABEL_CHE_SERVER_REF_KEY);
+            Map<String, String> portsToKnownRefName = labels.entrySet().stream()
+                                                            .filter(map -> pattern.matcher(map.getKey()).matches())
+                                                            .collect(Collectors.toMap(p -> {
+                                                                Matcher matcher = pattern.matcher(p.getKey());
+                                                                matcher.matches();
+                                                                String val = matcher.group(1);
+                                                                return val.contains("/") ? val : val.concat("/tcp");
+                                                            }, p -> p.getValue()));
+
+            // add to this map only port without a known ref name
+            Map<String, String> portsToUnkownRefName =
+                    exposedPorts.stream().filter((port) -> !portsToKnownRefName.containsKey(port))
+                                .collect(Collectors.toMap(p -> p, p -> "Server-" + p.replace('/', '-')));
+
+            // list of all ports with refName (known/unknown)
+            this.portsToRefName = new HashMap(portsToKnownRefName);
+            portsToRefName.putAll(portsToUnkownRefName);
+        }
+
+        /**
+         * Gets default external address.
+         */
+        protected String getExternalAddress() {
+            return externalAddressProperty != null ?
+                   externalAddressProperty : internalAddressProperty;
+        }
+
+        /**
+         * Populate the template properties
+         */
+        protected void populateGlobalProperties() {
+            String externalAddress = getExternalAddress();
+            String externalIP = getExternalIp(externalAddress);
+            globalPropertiesMap.put("internalIp", internalAddressProperty);
+            globalPropertiesMap.put("externalAddress", externalAddress);
+            globalPropertiesMap.put("externalIP", externalIP);
+            globalPropertiesMap.put("workspaceId", getWorkspaceId());
+            globalPropertiesMap.put("machineName", getMachineName());
+            globalPropertiesMap.put("wildcardNipDomain", getWildcardNipDomain(externalAddress));
+            globalPropertiesMap.put("wildcardXipDomain", getWildcardXipDomain(externalAddress));
+            globalPropertiesMap.put("chePort", chePort);
+        }
+
+        /**
+         * Rendering
+         */
+        @Override
+        public String render(String template, String port) {
+            ST stringTemplate = new ST(template);
+            globalPropertiesMap.forEach((key, value) -> stringTemplate.add(key, value));
+            stringTemplate.add("serverName", portsToRefName.get(port));
+            return stringTemplate.render();
+        }
+
+        /**
+         * Gets the workspace ID from the config of the given container
+         *
+         * @return workspace ID
+         */
+        protected String getWorkspaceId() {
+            return Arrays.stream(env).filter(env -> env.startsWith(CHE_WORKSPACE_ID_PROPERTY))
+                         .map(s -> s.substring(CHE_WORKSPACE_ID_PROPERTY.length()))
+                         .findFirst().get();
+        }
+
+        /**
+         * Gets the workspace Machine Name from the config of the given container
+         *
+         * @return machine name of the workspace
+         */
+        protected String getMachineName() {
+            return Arrays.stream(env).filter(env -> env.startsWith(CHE_MACHINE_NAME_PROPERTY))
+                         .map(s -> s.substring(CHE_MACHINE_NAME_PROPERTY.length()))
+                         .findFirst().get();
+        }
+
+        /**
+         * Gets the IP address of the external address
+         *
+         * @return IP Address
+         */
+        protected String getExternalIp(String externalAddress) {
+            try {
+                return InetAddress.getByName(externalAddress).getHostAddress();
+            } catch (UnknownHostException e) {
+                throw new UnsupportedOperationException("Unable to find the IP for the address '" + externalAddress + "'", e);
+            }
+        }
+
+        /**
+         * Gets a Wildcard domain based on the ip using an external provider nip.io
+         *
+         * @return wildcard domain
+         */
+        protected String getWildcardNipDomain(String externalAddress) {
+            return String.format("%s.%s", getExternalIp(externalAddress), "nip.io");
+        }
+
+        /**
+         * Gets a Wildcard domain based on the ip using an external provider xip.io
+         *
+         * @return wildcard domain
+         */
+        protected String getWildcardXipDomain(String externalAddress) {
+            return String.format("%s.%s", getExternalIp(externalAddress), "xip.io");
+        }
+
+    }
+
+}

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -79,7 +79,7 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
     @Inject
     public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String cheDockerIp,
                                           @Nullable @Named("che.docker.ip.external") String cheDockerIpExternal,
-                                          @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.template") String cheDockerCustomExternalTemplate,
+                                          @Nullable @Named("che.docker.server_evaluation_strategy.custom.template") String cheDockerCustomExternalTemplate,
                                           @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.protocol") String cheDockerCustomExternalProtocol,
                                           @Named("che.port") String chePort) {
         super(cheDockerIp, cheDockerIpExternal);

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -79,8 +79,8 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
     @Inject
     public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String cheDockerIp,
                                           @Nullable @Named("che.docker.ip.external") String cheDockerIpExternal,
-                                          @Nullable @Named("che.docker.custom.external.template") String cheDockerCustomExternalTemplate,
-                                          @Nullable @Named("che.docker.custom.external.protocol") String cheDockerCustomExternalProtocol,
+                                          @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.template") String cheDockerCustomExternalTemplate,
+                                          @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.protocol") String cheDockerCustomExternalProtocol,
                                           @Named("che.port") String chePort) {
         super(cheDockerIp, cheDockerIpExternal);
         this.chePort = chePort;

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -194,7 +194,6 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
             super(containerInfo.getConfig().getLabels(), containerInfo.getConfig().getExposedPorts().keySet(),
                   containerInfo.getConfig().getEnv());
             this.gatewayAddressContainer = containerInfo.getNetworkSettings().getGateway();
-            this.init();
         }
 
         protected OnlineRenderingEvaluation withInternalHost(String internalHost) {
@@ -219,15 +218,7 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
 
         public OfflineRenderingEvaluation(Map<String, String> labels, Set<String> exposedPorts, String[] env) {
             super(labels, exposedPorts, env);
-            this.init();
         }
-    }
-
-    /**
-     * Provides the template.
-     */
-    public String getTemplate() {
-        return this.cheDockerCustomExternalTemplate;
     }
 
     /**
@@ -259,6 +250,11 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
          * Mapping between a port and the server ref name
          */
         private Map<String, String> portsToRefName;
+
+        /**
+         * Data initialized ?
+         */
+        private boolean initialized;
 
         /**
          * Default constructor.
@@ -332,6 +328,10 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
          */
         @Override
         public String render(String template, String port) {
+            if (!this.initialized) {
+                init();
+                this.initialized = true;
+            }
             ST stringTemplate = new ST(template);
             globalPropertiesMap.forEach((key, value) -> stringTemplate.add(key, value));
             stringTemplate.add("serverName", portsToRefName.get(port));

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
@@ -56,6 +56,8 @@ public class LocalDockerModule extends AbstractModule {
                   .to(org.eclipse.che.plugin.docker.machine.DefaultServerEvaluationStrategy.class);
         strategies.addBinding("docker-local")
                   .to(org.eclipse.che.plugin.docker.machine.LocalDockerServerEvaluationStrategy.class);
+        strategies.addBinding("custom")
+                  .to(org.eclipse.che.plugin.docker.machine.CustomServerEvaluationStrategy.class);
 
         bind(org.eclipse.che.plugin.docker.machine.node.WorkspaceFolderPathProvider.class)
                 .to(org.eclipse.che.plugin.docker.machine.local.node.provider.LocalWorkspaceFolderPathProvider.class);

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.machine;
+
+import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
+import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
+import org.eclipse.che.plugin.docker.client.json.PortBinding;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@Link CustomServerEvaluationStrategy}
+ *
+ * @author Florent Benoit
+ */
+@Listeners(MockitoTestNGListener.class)
+public class CustomServerEvaluationStrategyTest {
+
+    private static final String ALL_IP_ADDRESS           = "0.0.0.0";
+
+    private static final String WORKSPACE_ID_VALUE    = "work123";
+    private static final String WORKSPACE_ID_PROPERTY = "CHE_WORKSPACE_ID=" + WORKSPACE_ID_VALUE;
+
+    private static final String MACHINE_NAME_VALUE    = "myMachine";
+    private static final String MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=" + MACHINE_NAME_VALUE;
+
+    @Mock
+    private ContainerConfig containerConfig;
+
+    @Mock
+    private ContainerInfo containerInfo;
+
+    @Mock
+    private NetworkSettings networkSettings;
+
+
+    private CustomServerEvaluationStrategy customServerEvaluationStrategy;
+
+    private Map<String, Map<String, String>> containerExposedPorts;
+    private Map<String, String>              containerLabels;
+    private String[]                         envContainerConfig;
+    private Map<String, List<PortBinding>>   networkExposedPorts;
+
+
+    @BeforeMethod
+    protected void setup() throws Exception {
+        containerLabels = new HashMap<>();
+        containerExposedPorts = new HashMap<>();
+        networkExposedPorts = new HashMap<>();
+        when(containerInfo.getConfig()).thenReturn(containerConfig);
+        when(containerConfig.getLabels()).thenReturn(containerLabels);
+        when(containerConfig.getExposedPorts()).thenReturn(containerExposedPorts);
+
+        envContainerConfig = new String[]{WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY};
+        when(containerConfig.getEnv()).thenReturn(envContainerConfig);
+
+        when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
+        when(networkSettings.getGateway()).thenReturn("gateway");
+        when(networkSettings.getPorts()).thenReturn(networkExposedPorts);
+
+        containerLabels.put("foo1", "bar");
+        containerLabels.put("foo1/dummy", "bar");
+        containerLabels.put("che:server:4401/tcp:protocol", "http");
+        containerLabels.put("che:server:4401/tcp:ref", "wsagent");
+        containerLabels.put("che:server:22/tcp:protocol", "ssh");
+        containerLabels.put("che:server:22/tcp:ref", "ssh");
+        containerLabels.put("che:server:22/tcp:path", "/api");
+        containerLabels.put("che:server:4411/tcp:ref", "terminal");
+        containerLabels.put("che:server:4411/tcp:protocol", "http");
+        containerLabels.put("che:server:8080:protocol", "http");
+        containerLabels.put("che:server:8080:ref", "tomcat8");
+        containerLabels.put("anotherfoo1", "bar2");
+        containerLabels.put("anotherfoo1/dummy", "bar2");
+
+        containerExposedPorts.put("22/tcp", Collections.emptyMap());
+        networkExposedPorts.put("22/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+                                                                                     .withHostPort("3222")));
+        containerExposedPorts.put("4401/tcp", Collections.emptyMap());
+        networkExposedPorts.put("4401/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+                                                                                       .withHostPort("324401")));
+        containerExposedPorts.put("4411/tcp", Collections.emptyMap());
+        networkExposedPorts.put("4411/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+                                                                                       .withHostPort("324411")));
+        containerExposedPorts.put("8080/tcp", Collections.emptyMap());
+        networkExposedPorts.put("8080/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+                                                                                       .withHostPort("328080")));
+    }
+
+
+    /**
+     * Check workspace Id template
+     */
+    @Test
+    public void testWorkspaceIdRule() throws Throwable {
+        this.customServerEvaluationStrategy = new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceId>", "http", "8080");
+
+        Map<String, String> portMapping = this.customServerEvaluationStrategy.getExternalAddressesAndPorts(containerInfo, "localhost");
+
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        Assert.assertEquals(portMapping.get("4401/tcp"), WORKSPACE_ID_VALUE);
+    }
+
+
+    /**
+     * Check workspace Id template
+     */
+    @Test
+    public void testMachineNameRule() throws Throwable {
+        this.customServerEvaluationStrategy = new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<machineName>", "http", "8080");
+
+        Map<String, String> portMapping = this.customServerEvaluationStrategy.getExternalAddressesAndPorts(containerInfo, "localhost");
+
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        Assert.assertEquals(portMapping.get("4401/tcp"), MACHINE_NAME_VALUE);
+    }
+
+    /**
+     * Check updates of protocols
+     */
+    @Test
+    public void testProtocolUpdate() throws Throwable {
+
+
+        HashMap<String, ServerConfImpl> serverConfs = new HashMap<>();
+
+        this.customServerEvaluationStrategy = new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceId>", "https", "8080");
+
+        Map<String, ServerImpl> portMapping = this.customServerEvaluationStrategy.getServers(containerInfo, "localhost", serverConfs);
+
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        ServerImpl server = portMapping.get("4401/tcp");
+        Assert.assertNotNull(server);
+        Assert.assertEquals(server.getUrl(), "https://" + WORKSPACE_ID_VALUE);
+        Assert.assertEquals(server.getProtocol(), "https");
+        Assert.assertEquals(server.getAddress(), WORKSPACE_ID_VALUE);
+        Assert.assertEquals(server.getRef(), "wsagent");
+    }
+
+
+
+}
+

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
@@ -23,10 +23,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.Mockito.when;
 
@@ -38,7 +41,7 @@ import static org.mockito.Mockito.when;
 @Listeners(MockitoTestNGListener.class)
 public class CustomServerEvaluationStrategyTest {
 
-    private static final String ALL_IP_ADDRESS           = "0.0.0.0";
+    private static final String ALL_IP_ADDRESS = "0.0.0.0";
 
     private static final String WORKSPACE_ID_VALUE    = "work123";
     private static final String WORKSPACE_ID_PROPERTY = "CHE_WORKSPACE_ID=" + WORKSPACE_ID_VALUE;
@@ -77,7 +80,7 @@ public class CustomServerEvaluationStrategyTest {
         when(containerConfig.getEnv()).thenReturn(envContainerConfig);
 
         when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
-        when(networkSettings.getGateway()).thenReturn("gateway");
+        when(networkSettings.getGateway()).thenReturn("127.0.0.1");
         when(networkSettings.getPorts()).thenReturn(networkExposedPorts);
 
         containerLabels.put("foo1", "bar");
@@ -95,16 +98,16 @@ public class CustomServerEvaluationStrategyTest {
         containerLabels.put("anotherfoo1/dummy", "bar2");
 
         containerExposedPorts.put("22/tcp", Collections.emptyMap());
-        networkExposedPorts.put("22/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+        networkExposedPorts.put("22/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS)
                                                                                      .withHostPort("3222")));
         containerExposedPorts.put("4401/tcp", Collections.emptyMap());
-        networkExposedPorts.put("4401/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+        networkExposedPorts.put("4401/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS)
                                                                                        .withHostPort("324401")));
         containerExposedPorts.put("4411/tcp", Collections.emptyMap());
-        networkExposedPorts.put("4411/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+        networkExposedPorts.put("4411/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS)
                                                                                        .withHostPort("324411")));
         containerExposedPorts.put("8080/tcp", Collections.emptyMap());
-        networkExposedPorts.put("8080/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS )
+        networkExposedPorts.put("8080/tcp", Collections.singletonList(new PortBinding().withHostIp(ALL_IP_ADDRESS)
                                                                                        .withHostPort("328080")));
     }
 
@@ -114,7 +117,8 @@ public class CustomServerEvaluationStrategyTest {
      */
     @Test
     public void testWorkspaceIdRule() throws Throwable {
-        this.customServerEvaluationStrategy = new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceId>", "http", "8080");
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceId>", "http", "8080");
 
         Map<String, String> portMapping = this.customServerEvaluationStrategy.getExternalAddressesAndPorts(containerInfo, "localhost");
 
@@ -128,7 +132,8 @@ public class CustomServerEvaluationStrategyTest {
      */
     @Test
     public void testMachineNameRule() throws Throwable {
-        this.customServerEvaluationStrategy = new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<machineName>", "http", "8080");
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<machineName>", "http", "8080");
 
         Map<String, String> portMapping = this.customServerEvaluationStrategy.getExternalAddressesAndPorts(containerInfo, "localhost");
 
@@ -141,12 +146,9 @@ public class CustomServerEvaluationStrategyTest {
      */
     @Test
     public void testProtocolUpdate() throws Throwable {
-
-
         HashMap<String, ServerConfImpl> serverConfs = new HashMap<>();
-
-        this.customServerEvaluationStrategy = new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceId>", "https", "8080");
-
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceId>", "https", "8080");
         Map<String, ServerImpl> portMapping = this.customServerEvaluationStrategy.getServers(containerInfo, "localhost", serverConfs);
 
         Assert.assertTrue(portMapping.containsKey("4401/tcp"));
@@ -158,6 +160,107 @@ public class CustomServerEvaluationStrategyTest {
         Assert.assertEquals(server.getRef(), "wsagent");
     }
 
+    /**
+     * Check defaults values
+     */
+    @Test
+    public void testDefaults() throws Throwable {
+        HashMap<String, ServerConfImpl> serverConfs = new HashMap<>();
+
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("127.0.0.1", null, "<externalAddress>-<workspaceId>", "https", "8080");
+
+        Map<String, ServerImpl> portMapping = this.customServerEvaluationStrategy.getServers(containerInfo, "localhost", serverConfs);
+
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        ServerImpl server = portMapping.get("4401/tcp");
+        Assert.assertNotNull(server);
+        Assert.assertEquals(server.getUrl(), "https://127.0.0.1-" + WORKSPACE_ID_VALUE);
+        Assert.assertEquals(server.getProtocol(), "https");
+        Assert.assertEquals(server.getAddress(), "127.0.0.1-" + WORKSPACE_ID_VALUE);
+        Assert.assertEquals(server.getRef(), "wsagent");
+        Assert.assertEquals(server.getRef(), "wsagent");
+    }
+
+    /**
+     * Check defaults values
+     */
+    @Test
+    public void testDefaultsNoGateway() throws Throwable {
+        when(networkSettings.getGateway()).thenReturn(null);
+        HashMap<String, ServerConfImpl> serverConfs = new HashMap<>();
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("127.0.0.1", null, "<externalAddress>-<workspaceId>", "https", "8080");
+        Map<String, ServerImpl> portMapping = this.customServerEvaluationStrategy.getServers(containerInfo, "127.0.0.1", serverConfs);
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        ServerImpl server = portMapping.get("4401/tcp");
+        Assert.assertNotNull(server);
+        Assert.assertEquals(server.getUrl(), "https://127.0.0.1-" + WORKSPACE_ID_VALUE);
+        Assert.assertEquals(server.getProtocol(), "https");
+        Assert.assertEquals(server.getAddress(), "127.0.0.1-" + WORKSPACE_ID_VALUE);
+        Assert.assertEquals(server.getRef(), "wsagent");
+        Assert.assertEquals(server.getRef(), "wsagent");
+    }
+
+
+    /**
+     * Check offline mode
+     */
+    @Test
+    public void testOffline() throws Throwable {
+        Set<String> exposedPorts = new HashSet<>();
+        exposedPorts.add("22/tcp");
+        exposedPorts.add("4401/tcp");
+        exposedPorts.add("4411/tcp");
+        exposedPorts.add("8080/tcp");
+        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY);
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("127.0.0.1", null, "<externalAddress>-<workspaceId>", "https", "8080");
+        CustomServerEvaluationStrategy.RenderingEvaluation renderingEvaluation = this.customServerEvaluationStrategy
+                .getOfflineRenderingEvaluation(containerLabels, exposedPorts, env.stream().toArray(String[]::new));
+        String eval = renderingEvaluation.render("<workspaceId>", "4401/tcp");
+        Assert.assertEquals(eval, WORKSPACE_ID_VALUE);
+    }
+
+
+    /**
+     * Check offline mode with external ip
+     */
+    @Test
+    public void testOfflineExternal() throws Throwable {
+        Set<String> exposedPorts = new HashSet<>();
+        exposedPorts.add("22/tcp");
+        exposedPorts.add("4401/tcp");
+        exposedPorts.add("4411/tcp");
+        exposedPorts.add("8080/tcp");
+        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY);
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("127.0.0.1", "127.0.0.1", "<externalAddress>-<workspaceId>", "https", "8080");
+        CustomServerEvaluationStrategy.RenderingEvaluation renderingEvaluation = this.customServerEvaluationStrategy
+                .getOfflineRenderingEvaluation(containerLabels, exposedPorts, env.stream().toArray(String[]::new));
+        String eval = renderingEvaluation.render("<workspaceId>", "4401/tcp");
+        Assert.assertEquals(eval, WORKSPACE_ID_VALUE);
+    }
+
+
+    /**
+     * Check offline mode with external ip
+     */
+    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "Unable to find the IP for the address .*")
+    public void testOfflineInvalidExternal() throws Throwable {
+        Set<String> exposedPorts = new HashSet<>();
+        exposedPorts.add("22/tcp");
+        exposedPorts.add("4401/tcp");
+        exposedPorts.add("4411/tcp");
+        exposedPorts.add("8080/tcp");
+        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY);
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("127.0.0.1", "300.300.300.300", "<externalAddress>-<workspaceId>", "https", "8080");
+        CustomServerEvaluationStrategy.RenderingEvaluation renderingEvaluation = this.customServerEvaluationStrategy
+                .getOfflineRenderingEvaluation(containerLabels, exposedPorts, env.stream().toArray(String[]::new));
+        String eval = renderingEvaluation.render("<workspaceId>", "4401/tcp");
+        Assert.assertEquals(eval, WORKSPACE_ID_VALUE);
+    }
 
 
 }


### PR DESCRIPTION
### What does this PR do?
This custom server evaluation strategy allows to configure the links by providing a set of macro/templates.
It avoids to create one strategy class file for each needs, as template/macros can be used independently.

### What issues does this PR fix or reference?
#1560 
#4361 

#### Changelog
Introduce a template-based docker server evaluation stategy

#### Release Notes
Introduce a template-based docker server evaluation stategy

#### Docs PR
https://github.com/eclipse/che-docs/pull/227

Change-Id: I3d941e0e786bdbfec037ba59e3f790f890bf9eb0
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
