### PR TITLE
Add secret to workspaces for bayesian plugin

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -107,6 +107,8 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
@@ -1148,6 +1150,7 @@ public class OpenShiftConnector extends DockerConnector {
                                     .withName(sanitizedContainerName)
                                     .withImage(imageName)
                                     .withEnv(KubernetesEnvVar.getEnvFrom(envVariables))
+                                    .addToEnv(getAdditionalEnvVars())
                                     .withPorts(KubernetesContainer.getContainerPortsFrom(exposedPorts))
                                     .withImagePullPolicy(OPENSHIFT_IMAGE_PULL_POLICY_IFNOTPRESENT)
                                     .withNewSecurityContext()
@@ -1194,6 +1197,27 @@ public class OpenShiftConnector extends DockerConnector {
 
         LOG.info("OpenShift deployment {} created", deploymentName);
         return deployment.getMetadata().getName();
+    }
+
+    private EnvVar[] getAdditionalEnvVars() {
+        try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
+            if (openShiftClient.secrets()
+                               .inNamespace(openShiftCheProjectName)
+                               .withName("che-recommender-api-token")
+                               .get() != null) {
+                EnvVar envVar = new EnvVarBuilder().withName("RECOMMENDER_API_TOKEN")
+                                                   .withNewValueFrom()
+                                                       .withNewSecretKeyRef()
+                                                           .withName("che-recommender-api-token")
+                                                           .withKey("token")
+                                                       .endSecretKeyRef()
+                                                   .endValueFrom()
+                                                   .build();
+                LOG.info("Adding RECOMMENDER_API_TOKEN env var to workspace container");
+                return new EnvVar[] {envVar};
+            }
+            return new EnvVar[0];
+        }
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?
Adds env var to workspace containers to allow the bayesian server to communicate with backend.

This is a bit of a workaround, as currently there doesn't seem to be a good way of figuring out which agents are going to be injected at workspace creation.