### PR TITLE
Fix workspace storage path on Docker Cloud

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -307,10 +307,10 @@ get_che_data_from_host() {
 }
 
 get_che_server_container_id() {
-  # Returning `hostname` doesn't work when running Che on OpenShift/Kubernetes.
+  # Returning `hostname` doesn't work when running Che on OpenShift/Kubernetes/Docker Cloud.
   # In these cases `hostname` correspond to the pod ID that is different from
   # the container ID
-  hostname
+  echo $(basename "$(head /proc/1/cgroup || hostname)");
 }
 
 is_docker_for_mac_or_windows() {


### PR DESCRIPTION
### What does this PR do?
This PR fixes the problem with workspace data directories already fixed for *some* in https://github.com/eclipse/che/issues/3324 but identified as not complete for all users in https://github.com/eclipse/che/blob/master/dockerfiles/che/entrypoint.sh#L310.

By using the cgroup file we can find the container's real ID without relying on the hostname (which can be changed with `--hostname` or by many clustering tools like Docker Cloud). 

#### Changelog
Fix workspace storage path where hostname does not match container name


