### PR TITLE
CODENVY-2129: Add additional info into wsagent start fail log

### DIFF
--- a/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncher.java
+++ b/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncher.java
@@ -150,7 +150,7 @@ public abstract class AbstractAgentLauncher implements AgentLauncher {
                       agentName,
                       machine.getWorkspaceId(),
                       machine.getId(),
-                      machine.getNode(),
+                      machine.getNode().getHost(),
                       logs);
         } else {
             LOG.error("An error occurs while starting '{}' agent in '{}' workspace in '{}' machine on '{}' node. " +
@@ -158,7 +158,7 @@ public abstract class AbstractAgentLauncher implements AgentLauncher {
                       agentName,
                       machine.getWorkspaceId(),
                       machine.getId(),
-                      machine.getNode());
+                      machine.getNode().getHost());
         }
     }
 

--- a/agents/che-core-api-agent/src/test/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncherTest.java
+++ b/agents/che-core-api-agent/src/test/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncherTest.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
+import org.eclipse.che.api.machine.server.spi.InstanceNode;
 import org.eclipse.che.api.machine.server.spi.InstanceProcess;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
@@ -34,6 +35,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -69,6 +71,7 @@ public class AbstractAgentLauncherTest {
         when(agentChecker.isLaunched(any(Agent.class),
                                      any(InstanceProcess.class),
                                      any(Instance.class))).thenReturn(true);
+        when(machine.getNode()).thenReturn(mock(InstanceNode.class));
     }
 
     @Test

--- a/wsagent/agent/src/main/java/org/eclipse/che/api/agent/WsAgentLauncher.java
+++ b/wsagent/agent/src/main/java/org/eclipse/che/api/agent/WsAgentLauncher.java
@@ -124,7 +124,11 @@ public class WsAgentLauncher implements AgentLauncher {
             Thread.currentThread().interrupt();
             throw new ServerException("Ws agent pinging is interrupted");
         }
-        LOG.error("Fail pinging ws agent. Workspace ID:{}. Url:{}. Timestamp:{}", machine.getWorkspaceId(), wsAgentPingUrl);
+        LOG.error("Fail pinging ws agent with {} url in {} workspace in {} machine on {} node.",
+                  wsAgentPingUrl,
+                  machine.getWorkspaceId(),
+                  machine.getId(),
+                  machine.getNode().getHost());
         throw new ServerException(pingTimedOutErrorMessage);
     }
 

--- a/wsagent/agent/src/test/java/org/eclipse/che/api/agent/WsAgentLauncherTest.java
+++ b/wsagent/agent/src/test/java/org/eclipse/che/api/agent/WsAgentLauncherTest.java
@@ -27,6 +27,7 @@ import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
 import org.eclipse.che.api.machine.server.spi.Instance;
+import org.eclipse.che.api.machine.server.spi.InstanceNode;
 import org.eclipse.che.api.machine.shared.Constants;
 import org.eclipse.che.commons.test.mockito.answer.SelfReturningAnswer;
 import org.mockito.Matchers;
@@ -95,6 +96,7 @@ public class WsAgentLauncherTest {
         Mockito.when(machine.getId()).thenReturn(MACHINE_ID);
         Mockito.when(machine.getWorkspaceId()).thenReturn(WORKSPACE_ID);
         Mockito.when(machine.getRuntime()).thenReturn(machineRuntime);
+        Mockito.when(machine.getNode()).thenReturn(Mockito.mock(InstanceNode.class));
         Mockito.doReturn(Collections.<String, Server>singletonMap(WS_AGENT_PORT, SERVER)).when(machineRuntime).getServers();
         Mockito.when(requestFactory.fromUrl(Matchers.anyString())).thenReturn(pingRequest);
         Mockito.when(wsAgentPingRequestFactory.createRequest(machine)).thenReturn(pingRequest);


### PR DESCRIPTION
### What does this PR do?
Adds additional information about workspace into error logs when ws agent failed to start.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2129

#### Changelog
Improve error logging on ws agent start.

#### Release Notes
N/A

#### Docs PR
N/A