### PR TITLE
CHE-4942: fix text overlapping on Configure Actions on Factory details page.

### DIFF
--- a/dashboard/src/app/factories/create-factory/action/factory-action-box.html
+++ b/dashboard/src/app/factories/create-factory/action/factory-action-box.html
@@ -14,8 +14,10 @@
                    che-place-holder="Enter value"
                    aria-label="Enter value"
                    required
+                   ng-maxlength="255"
                    ng-model="factoryActionBoxCtrl.selectedParam">
           <div ng-message="required">Param is required.</div>
+          <div ng-message="maxlength">The value has to be less than 255 characters long.</div>
         </che-input>
       </div>
       <che-button-primary che-button-title="Add"
@@ -23,34 +25,35 @@
                           ng-disabled="actionsForm.$invalid"></che-button-primary>
     </div>
 
-    <div ng-if="factoryActionBoxCtrl.factoryObject.ide.onProjectsLoaded.actions.length > 0"
-         class="factory-actions-list">
-      <che-list>
-        <che-list-item ng-repeat="action in factoryActionBoxCtrl.factoryObject.ide.onProjectsLoaded.actions"
-                       flex-gt-sm="100" flex-sm="33">
-          <div layout="row" flex>
-            <div layout="column"
-                 layout-align="start start"
-                 class="factory-actions-row-action-name">
-              <span>{{action.id}}</span>
-            </div>
-            <div flex layout-align="start start"
-                 class="factory-actions-row-action-param"
-                 ng-click="factoryActionBoxCtrl.editAction($event, $index)">
-              {{action.properties.name ? action.properties.name : action.properties.file}}
-            </div>
-            <div flex="10" layout="row" layout-align="center start"
-                 class="che-list-actions">
-              <div ng-click="factoryActionBoxCtrl.removeAction($index)" class="factory-commands-widget-actions">
-                <span class="fa fa-times-circle"></span>
+    <md-content md-scroll-y flex class="factory-actions-list">
+      <div ng-if="factoryActionBoxCtrl.factoryObject.ide.onProjectsLoaded.actions.length > 0">
+        <che-list>
+          <che-list-item ng-repeat="action in factoryActionBoxCtrl.factoryObject.ide.onProjectsLoaded.actions"
+                         flex-gt-sm="100" flex-sm="33">
+            <div layout="row" flex>
+              <div layout="column"
+                   layout-align="start start"
+                   class="factory-actions-row-action-name">
+                <span>{{action.id}}</span>
               </div>
-              <div ng-click="factoryActionBoxCtrl.editAction($event, $index)" class="factory-commands-widget-actions">
-                <span class="fa fa-edit"></span>
+              <div flex layout-align="start start"
+                   class="factory-actions-row-action-param"
+                   ng-click="factoryActionBoxCtrl.editAction($event, $index)">
+                {{action.properties.name ? action.properties.name : action.properties.file}}
+              </div>
+              <div flex="10" layout="row" layout-align="center start"
+                   class="che-list-actions">
+                <div ng-click="factoryActionBoxCtrl.removeAction($index)" class="factory-commands-widget-actions">
+                  <span class="fa fa-times-circle"></span>
+                </div>
+                <div ng-click="factoryActionBoxCtrl.editAction($event, $index)" class="factory-commands-widget-actions">
+                  <span class="fa fa-edit"></span>
+                </div>
               </div>
             </div>
-          </div>
-        </che-list-item>
-      </che-list>
-    </div>
+          </che-list-item>
+        </che-list>
+      </div>
+    </md-content>
   </div>
 </form>

--- a/dashboard/src/app/factories/create-factory/action/factory-action-box.styl
+++ b/dashboard/src/app/factories/create-factory/action/factory-action-box.styl
@@ -13,6 +13,7 @@
     margin-right 20px
 
   .factory-actions-list
+    max-height 500px
     max-width 600px
 
     md-list
@@ -34,6 +35,8 @@
       min-height 100%
       cursor pointer
       outline none
+      margin-right 0
+      margin-left 10px
 
       span
         line-height inherit

--- a/dashboard/src/app/factories/create-factory/action/factory-action-edit.html
+++ b/dashboard/src/app/factories/create-factory/action/factory-action-edit.html
@@ -24,7 +24,7 @@
                        ng-click="factoryActionDialogEditCtrl.abort()">
     </che-button-notice>
     <che-button-primary
-      che-button-title="Edit" ng-disabled="editActionForm.$invalid"
+      che-button-title="Save" ng-disabled="editActionForm.$invalid"
       ng-click="factoryActionDialogEditCtrl.edit()"></che-button-primary>
   </form>
 </che-popup>

--- a/dashboard/src/app/factories/create-factory/command/factory-command-edit.html
+++ b/dashboard/src/app/factories/create-factory/command/factory-command-edit.html
@@ -12,7 +12,7 @@
                        ng-click="factoryCommandDialogEditCtrl.abort()">
     </che-button-notice>
     <che-button-primary
-      che-button-title="Edit" ng-disabled="editActionForm.$invalid"
+      che-button-title="Save" ng-disabled="editActionForm.$invalid"
       ng-click="factoryCommandDialogEditCtrl.edit()"></che-button-primary>
   </form>
 </che-popup>

--- a/dashboard/src/app/factories/create-factory/command/factory-command.html
+++ b/dashboard/src/app/factories/create-factory/command/factory-command.html
@@ -39,36 +39,37 @@
                           ng-disabled="commandsForm.$invalid"></che-button-primary>
     </div>
 
-    <div ng-if="factoryCommandCtrl.factoryObject.workspace.commands.length > 0"
-         class="factory-commands-list">
-      <che-list>
-        <che-list-item ng-repeat="command in factoryCommandCtrl.factoryObject.workspace.commands"
-                       flex="100">
-          <div layout="row" flex>
-            <div layout="column"
-                 layout-align="start start"
-                 class="factory-commands-row-command-name">
-              <span>{{command.name}}</span>
-            </div>
-            <div flex
-                 layout="column"
-                 layout-align="start start"
-                 ng-click="factoryCommandCtrl.editCommand($event, $index)"
-                 class="factory-commands-row-command">
-              {{command.commandLine}}
-            </div>
-            <div flex="10" layout="row" layout-align="center start"
-                 class="che-list-actions">
-              <div ng-click="factoryCommandCtrl.removeCommand($index)" class="factory-commands-widget-actions">
-                <span class="fa fa-times-circle"></span>
+    <md-content md-scroll-y flex class="factory-commands-list">
+      <div ng-if="factoryCommandCtrl.factoryObject.workspace.commands.length > 0">
+        <che-list>
+          <che-list-item ng-repeat="command in factoryCommandCtrl.factoryObject.workspace.commands"
+                         flex="100">
+            <div layout="row" flex>
+              <div layout="column"
+                   layout-align="start start"
+                   class="factory-commands-row-command-name">
+                <span>{{command.name}}</span>
               </div>
-              <div ng-click="factoryCommandCtrl.editCommand($event, $index)" class="factory-commands-widget-actions">
-                <span class="fa fa-edit"></span>
+              <div flex
+                   layout="column"
+                   layout-align="start start"
+                   ng-click="factoryCommandCtrl.editCommand($event, $index)"
+                   class="factory-commands-row-command">
+                {{command.commandLine}}
+              </div>
+              <div flex="10" layout="row" layout-align="center start"
+                   class="che-list-actions">
+                <div ng-click="factoryCommandCtrl.removeCommand($index)" class="factory-commands-widget-actions">
+                  <span class="fa fa-times-circle"></span>
+                </div>
+                <div ng-click="factoryCommandCtrl.editCommand($event, $index)" class="factory-commands-widget-actions">
+                  <span class="fa fa-edit"></span>
+                </div>
               </div>
             </div>
-          </div>
-        </che-list-item>
-      </che-list>
-    </div>
+          </che-list-item>
+        </che-list>
+      </div>
+    </md-content>
   </div>
 </form>

--- a/dashboard/src/app/factories/create-factory/command/factory-command.styl
+++ b/dashboard/src/app/factories/create-factory/command/factory-command.styl
@@ -12,6 +12,7 @@
     margin-right 20px
 
   .factory-commands-list
+    max-height 500px
     max-width 600px
 
     md-list
@@ -33,6 +34,8 @@
       min-height 100%
       cursor pointer
       outline none
+      margin-right 0
+      margin-left 10px
 
       span
         line-height inherit


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- fixes bug when Configure Commands section overlaps on Configure Actions;
- sets max height for Configure Commands an Configure Actions sections;
- changes button text on "Edit command" and "Edit action" popups to be "Save" instead of "Edit".

### What issues does this PR fix or reference?
#4942 
![screenshot-localhost-3000-2017-04-27-17-48-50](https://cloud.githubusercontent.com/assets/16220722/25490168/b27be37e-2b74-11e7-8e60-b1b1cb4efdc2.png)
![screenshot-localhost-3000-2017-04-27-17-49-41](https://cloud.githubusercontent.com/assets/16220722/25490171/b55e3de4-2b74-11e7-83c4-aa8e7bf18acf.png)



#### Changelog
<!-- one line entry to be added to changelog -->
[UD] fixed text overlapping on Configure Actions on Factory details page.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>
