### PR TITLE
Add Alpine support to ls-php

### DIFF
--- a/agents/ls-php/src/main/resources/org.eclipse.che.ls.php.script.sh
+++ b/agents/ls-php/src/main/resources/org.eclipse.che.ls.php.script.sh
@@ -94,6 +94,14 @@ elif echo ${LINUX_TYPE} | grep -qi "opensuse"; then
     test "${PACKAGES}" = "" || {
         ${SUDO} zypper install -y ${PACKAGES};
     }
+    
+# Alpine 3.3
+############
+elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apk update
+        ${SUDO} apk add ${PACKAGES};
+    }
 
 else
     >&2 echo "Unrecognized Linux Type"


### PR DESCRIPTION
### What does this PR do?
Add's Alpine support to ls-php (the same as other agents)

#### Changelog
<!-- one line entry to be added to changelog -->
Fixed Alpine support for ls-php (the same as other agents)

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fixed Alpine support for ls-php (the same as other agents)

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->


