### PR TITLE
Add Alpine support to ls-json

### DIFF
--- a/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
+++ b/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
@@ -139,6 +139,14 @@ elif echo ${LINUX_TYPE} | grep -qi "opensuse"; then
         ${SUDO} zypper in nodejs
     }
 
+# Alpine 3.3
+############
+elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apk update
+        ${SUDO} apk add ${PACKAGES};
+    }
+
 else
     >&2 echo "Unrecognized Linux Type"
     >&2 cat $FILE

--- a/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
+++ b/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
@@ -147,6 +147,11 @@ elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
         ${SUDO} apk add ${PACKAGES};
     }
 
+    command -v nodejs >/dev/null 2>&1 || {
+        ${SUDO} apk update
+        ${SUDO} apk add nodejs;
+    }
+
 else
     >&2 echo "Unrecognized Linux Type"
     >&2 cat $FILE


### PR DESCRIPTION
### What does this PR do?
Add's Alpine support to ls-json (the same as other agents)

#### Changelog
<!-- one line entry to be added to changelog -->
Fixed Alpine support for ls-json (the same as other agents)

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fixed Alpine support for ls-json (the same as other agents)


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->