### PR TITLE
CHE-3948: fix build of dockerfiles behind a proxy

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/proxy/DockerBuildArgsProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/proxy/DockerBuildArgsProvider.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.machine.proxy;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides docker build arguments with proxy settings.
+ *
+ * @author Alexander Garagatyi
+ */
+@Singleton
+public class DockerBuildArgsProvider implements Provider<Map<String, String>> {
+    private final Map<String, String> buildArgs;
+
+    @Inject
+    public DockerBuildArgsProvider(HttpProxyEnvVariableProvider httpProxy,
+                                   HttpsProxyEnvVariableProvider httpsProxy,
+                                   NoProxyEnvVariableProvider noProxy) {
+        Map<String, String> buildArgs = new HashMap<>();
+        splitVarAndAdd(httpProxy.get(), buildArgs);
+        splitVarAndAdd(httpsProxy.get(), buildArgs);
+        splitVarAndAdd(noProxy.get(), buildArgs);
+        this.buildArgs = Collections.unmodifiableMap(buildArgs);
+    }
+
+    private void splitVarAndAdd(String envVariable, Map<String, String> splitVariables) {
+        if (!envVariable.isEmpty()) {
+            String[] keyValue = envVariable.split("=", 2);
+            splitVariables.put(keyValue[0], keyValue[1]);
+        }
+    }
+
+    @Override
+    public Map<String, String> get() {
+        return buildArgs;
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/proxy/DockerProxyModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/proxy/DockerProxyModule.java
@@ -11,8 +11,11 @@
 package org.eclipse.che.plugin.docker.machine.proxy;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
+
+import java.util.Map;
 
 /**
  * Module that injects components needed to run docker machines behind proxies.
@@ -33,6 +36,8 @@ public class DockerProxyModule extends AbstractModule {
                             .toProvider(org.eclipse.che.plugin.docker.machine.proxy.HttpsProxyEnvVariableProvider.class);
         proxySettingsEnvVars.addBinding()
                             .toProvider(org.eclipse.che.plugin.docker.machine.proxy.NoProxyEnvVariableProvider.class);
+        bind(new TypeLiteral<Map<String, String>>() {}).annotatedWith(Names.named("che.docker.build_args"))
+                                                       .toProvider(DockerBuildArgsProvider.class);
     }
 
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/MachineProviderImplTest.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
@@ -1751,7 +1752,6 @@ public class MachineProviderImplTest {
             return this;
         }
 
-
         MachineProviderImpl build() throws IOException {
             return new MachineProviderImpl(new MockConnectorProvider(),
                                            credentialsReader,
@@ -1778,7 +1778,8 @@ public class MachineProviderImplTest {
                                            cpuQuota,
                                            pathEscaper,
                                            extraHosts,
-                                           dnsResolvers);
+                                           dnsResolvers,
+                                           emptyMap());
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?
Adds possibility to use dockerfile with `apt-get install` like instructions as a source of WS machine.
Note that in case sudo is used in build/inside container user has to use sudo -E to pass proxy variables into root's environment or set these variables himself.

### What issues does this PR fix or reference?
Fixes #3948 

#### Changelog
Add possibility to access external resources in docker image build phase of workspace start if Che is deployed in environment behind the proxy.  

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
