### PR TITLE
Fix the buggy `build` command of the RH `spring-boot` stack (https://issues.jboss.org/browse/CHE-237)

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2195,11 +2195,7 @@
         {
           "commandLine": "scl enable rh-maven33 'mvn clean install -f ${current.project.path}'",
           "name": "build",
-          "type": "custom",
-          "attributes": {
-            "previewUrl": "",
-            "goal": "Build"
-          }
+          "type": "mvn"
         },
         {
           "commandLine": "java -jar ${current.project.path}/target/*.jar",


### PR DESCRIPTION
The `build` command of the RH `spring-boot` stack is a `custom` command
with preview, instead of being simply a `mvn` command.
This prevents on-the-fly compilation of test classes to happen during testing sessions.

Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

It fixes the wrong definition of the `build` command in the `spring-boot` stack

### What issues does this PR fix or reference?

https://issues.jboss.org/browse/CHE-237

