### PR TITLE
ENTERPRISE-82: truncate stacks description by adding '...'

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.directive.ts
@@ -10,21 +10,28 @@
  */
 'use strict';
 
+interface ISelecterScope extends ng.IScope {
+  stackId: string;
+  select: Function;
+}
 
 /**
  * Defines a directive for the stack library selecter.
  * @author Florent Benoit
  */
-export class CheStackLibrarySelecter {
+export class CheStackLibrarySelecter implements ng.IDirective {
+  restrict: string = 'E';
+  templateUrl: string = 'app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.html';
+
+  scope: {
+    [propName: string]: string;
+  };
 
   /**
    * Default constructor that is using resource
    * @ngInject for Dependency injection
    */
   constructor () {
-    this.restrict='E';
-    this.templateUrl = 'app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.html';
-
     // scope values
     this.scope = {
       title: '@cheTitle',
@@ -36,11 +43,26 @@ export class CheStackLibrarySelecter {
     };
   }
 
-  link($scope) {
-    //select item
+  link($scope: ISelecterScope, element: ng.IAugmentedJQuery) {
+    // select item
     $scope.select = () => {
       $scope.$emit('event:library:selectStackId', $scope.stackId);
     };
+
+    const jqTextWrapper  = element.find('.che-stack-library-selecter-descr'),
+          jqText         = angular.element(jqTextWrapper.find('.che-stack-library-selecter-descr-text')),
+          jqTextEllipsis = angular.element(jqTextWrapper.find('.che-stack-library-selecter-descr-ellipsis'));
+
+    // show ellipsis
+    $scope.$watch(() => {
+      return jqText.get(0).clientHeight;
+    }, (textHeight: number) => {
+      if (textHeight > jqTextWrapper.get(0).clientHeight) {
+        jqTextEllipsis.show();
+      } else {
+        jqTextEllipsis.hide();
+      }
+    });
   }
 
 }

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.html
@@ -5,8 +5,11 @@
     <div class="body">
       <div class="title">{{title}}</div>
     </div>
-    <div class="che-stack-library-selecter-text">{{text}}</div>
-    <div layout="row" layout-align="end end" flex>
+    <div class="che-stack-library-selecter-descr" flex>
+      <div class="che-stack-library-selecter-descr-text">{{text}}</div>
+      <div class="che-stack-library-selecter-descr-ellipsis">&hellip;</div>
+    </div>
+    <div layout="row" layout-align="end end">
       <div class="che-stack-library-selecter-extra-text" tooltip="{{extraText}}">...</div>
     </div>
   </md-card-content>

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.styl
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.styl
@@ -1,4 +1,5 @@
 $che-stack-library-selecter-color = $label-info-color
+$che-stack-library-selecter-bg-color = #EEE
 
 .che-stack-library-selecter
   height 110px
@@ -16,7 +17,7 @@ $che-stack-library-selecter-color = $label-info-color
   color $che-stack-library-selecter-color
 
   &:hover
-    background-color #EEE
+    background-color $che-stack-library-selecter-bg-color
 
 
 .che-stack-library-selecter md-card-content
@@ -42,8 +43,8 @@ $che-stack-library-selecter-color = $label-info-color
   margin-left auto
   margin-right auto
   margin-top 16px
-  margin-bottom 0px
-  padding 0px
+  margin-bottom 0
+  padding 0
   height 74px
   width 74px
 
@@ -54,7 +55,7 @@ $che-stack-library-selecter-color = $label-info-color
 
   &:hover
     color $primary-color
-    background-color #EEE
+    background-color $che-stack-library-selecter-bg-color
 
 .che-stack-library-selecter-active:hover .title
   background-color $primary-color
@@ -90,8 +91,36 @@ che-stack-library-selecter
 .che-stack-library-selecter-extra-text
   cursor pointer
   margin-right 7px
-  margin-bottom 2px
+  margin-bottom 7px
+  line-height 5px
 
-.che-stack-library-selecter-text
+.che-stack-library-selecter-descr
   font-size 12px
   padding-left 10px
+  padding-right 20px
+  text-align justify
+  position relative
+
+  $line-height = 16px
+  $text-height = 3 * $line-height
+
+  overflow hidden
+  height $text-height !important
+  min-height $text-height !important
+  max-height $text-height !important
+  line-height $line-height
+  box-sizing content-box
+
+  .che-stack-library-selecter-descr-ellipsis
+    position absolute
+    bottom 0
+    right 20px
+    width 25px
+    display none
+    text-align right
+
+    background-size 100% 100%
+    background linear-gradient(to right, rgba(255, 255, 255, 0), $background-color 50%, $background-color)
+
+.che-stack-library-selecter:hover .che-stack-library-selecter-descr-ellipsis
+  background linear-gradient(to right, rgba(255, 255, 255, 0), $che-stack-library-selecter-bg-color 50%, $che-stack-library-selecter-bg-color)


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR truncates long stack description in Stack library by adding '...' .

![screenshot-localhost-3000-2017-05-03-12-55-19](https://cloud.githubusercontent.com/assets/16220722/25656235/b7d173da-3000-11e7-8e48-ab11f44f3f6a.png)


### What issues does this PR fix or reference?
https://github.com/codenvy/enterprise/issues/82

#### Changelog
<!-- one line entry to be added to changelog -->
[UD] truncated long stack description in Stack library by adding '...'

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>
