### PR TITLE
CODENVY-1834: allow docker node throw environment exception on WS bind

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/node/DockerNode.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/node/DockerNode.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.plugin.docker.machine.node;
 
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.environment.server.exception.EnvironmentException;
 import org.eclipse.che.api.machine.server.spi.InstanceNode;
 
 /**
@@ -22,10 +23,12 @@ public interface DockerNode extends InstanceNode {
     /**
      * Bind the whole workspace on the Node.
      *
+     * @throws EnvironmentException
+     *         if environment in abnormal state because of problem with machines
      * @throws ServerException
-     *         if error occurs on binding
+     *         if other error occurs on binding
      */
-    void bindWorkspace() throws ServerException;
+    void bindWorkspace() throws ServerException, EnvironmentException;
 
     /**
      * Unbind the workspace on Node.


### PR DESCRIPTION
### What does this PR do?
Allow docker machine implementation throw exception that indicates that container is in abnormal state and start of workspace should be interrupted.

### What issues does this PR fix or reference?
Related to codenvy/codenvy#1834

#### Changelog
Allow to identify container problems on bind node phase of docker machine start.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
