### PR TITLE
Fix LSP didChange parameters #4978

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/annotation/AnnotationModel.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/annotation/AnnotationModel.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import org.eclipse.che.ide.api.editor.text.Position;
 import org.eclipse.che.ide.api.editor.text.annotation.Annotation;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.document.UseDocumentHandle;
 
 /**
@@ -33,7 +33,7 @@ import org.eclipse.che.ide.api.editor.document.UseDocumentHandle;
  * using the callback.</li>
  * </ul>
  */
-public interface AnnotationModel extends UseDocumentHandle, DocumentChangeHandler, QueryAnnotationsHandler {
+public interface AnnotationModel extends UseDocumentHandle, DocumentChangedHandler, QueryAnnotationsHandler {
 
 
     /**

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/annotation/AnnotationModelImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/annotation/AnnotationModelImpl.java
@@ -13,7 +13,7 @@ package org.eclipse.che.ide.api.editor.annotation;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.partition.DocumentPositionMap;
 import org.eclipse.che.ide.api.editor.text.BadLocationException;
 import org.eclipse.che.ide.api.editor.text.BadPositionCategoryException;
@@ -261,7 +261,7 @@ public class AnnotationModelImpl implements AnnotationModel {
     }
 
     @Override
-    public void onDocumentChange(final DocumentChangeEvent event) {
+    public void onDocumentChanged(final DocumentChangedEvent event) {
         this.documentChanged = true;
     }
 

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/autosave/AutoSaveMode.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/autosave/AutoSaveMode.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.ide.api.editor.autosave;
 
 import org.eclipse.che.ide.api.editor.document.UseDocumentHandle;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 
 /**
@@ -19,7 +19,7 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
  *
  * @author Roman Nikitenko
  */
-public interface AutoSaveMode extends DocumentChangeHandler, UseDocumentHandle {
+public interface AutoSaveMode extends DocumentChangedHandler, UseDocumentHandle {
 
     /**
      * Installs auto save mode on the given editor.

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangedEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangedEvent.java
@@ -13,10 +13,10 @@ package org.eclipse.che.ide.api.editor.events;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
 import com.google.gwt.event.shared.GwtEvent;
 
-public class DocumentChangeEvent extends GwtEvent<DocumentChangeHandler> {
+public class DocumentChangedEvent extends GwtEvent<DocumentChangedHandler> {
 
     /** The type instance for this event. */
-    public static final Type<DocumentChangeHandler> TYPE = new Type<>();
+    public static final Type<DocumentChangedHandler> TYPE = new Type<>();
 
     /** The document handle */
     private final DocumentHandle document;
@@ -32,7 +32,7 @@ public class DocumentChangeEvent extends GwtEvent<DocumentChangeHandler> {
 
     private final int removedCharCount;
 
-    public DocumentChangeEvent(final DocumentHandle document, final int offset, final int length, final String text, int removedCharCount) {
+    public DocumentChangedEvent(final DocumentHandle document, final int offset, final int length, final String text, int removedCharCount) {
         this.offset = offset;
         this.length = length;
         this.text = text;
@@ -41,13 +41,13 @@ public class DocumentChangeEvent extends GwtEvent<DocumentChangeHandler> {
     }
 
     @Override
-    public Type<DocumentChangeHandler> getAssociatedType() {
+    public Type<DocumentChangedHandler> getAssociatedType() {
         return TYPE;
     }
 
     @Override
-    protected void dispatch(final DocumentChangeHandler handler) {
-        handler.onDocumentChange(this);
+    protected void dispatch(final DocumentChangedHandler handler) {
+        handler.onDocumentChanged(this);
     }
 
     public int getOffset() {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangedHandler.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangedHandler.java
@@ -12,7 +12,7 @@ package org.eclipse.che.ide.api.editor.events;
 
 import com.google.gwt.event.shared.EventHandler;
 
-public interface DocumentChangeHandler extends EventHandler {
+public interface DocumentChangedHandler extends EventHandler {
 
-    void onDocumentChange(DocumentChangeEvent event);
+    void onDocumentChanged(DocumentChangedEvent event);
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangingEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangingEvent.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.editor.events;
+
+import com.google.gwt.event.shared.GwtEvent;
+import org.eclipse.che.ide.api.editor.document.DocumentHandle;
+
+public class DocumentChangingEvent extends GwtEvent<DocumentChangingHandler> {
+
+    /** The type instance for this event. */
+    public static final Type<DocumentChangingHandler> TYPE = new Type<>();
+
+    /** The document handle */
+    private final DocumentHandle document;
+
+    /** The document offset */
+    private final int offset;
+
+    /** Length of the replaced document text */
+    private final int length;
+
+    /** Text inserted into the document */
+    private final String text;
+
+    private final int removedCharCount;
+
+    public DocumentChangingEvent(final DocumentHandle document, final int offset, final int length, final String text, int removedCharCount) {
+        this.offset = offset;
+        this.length = length;
+        this.text = text;
+        this.document = document;
+        this.removedCharCount = removedCharCount;
+    }
+
+    @Override
+    public Type<DocumentChangingHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(final DocumentChangingHandler handler) {
+        handler.onDocumentChanging(this);
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public DocumentHandle getDocument() {
+        return document;
+    }
+
+    public int getRemoveCharCount() {
+        return removedCharCount;
+    }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangingHandler.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/events/DocumentChangingHandler.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.editor.events;
+
+import com.google.gwt.event.shared.EventHandler;
+
+public interface DocumentChangingHandler extends EventHandler {
+
+    void onDocumentChanging(DocumentChangingEvent event);
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/partition/ConstantPartitioner.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/partition/ConstantPartitioner.java
@@ -13,7 +13,7 @@ package org.eclipse.che.ide.api.editor.partition;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.text.TypedRegion;
 import org.eclipse.che.ide.api.editor.text.TypedRegionImpl;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
@@ -53,7 +53,7 @@ public class ConstantPartitioner implements DocumentPartitioner {
     }
 
     @Override
-    public void onDocumentChange(final DocumentChangeEvent event) {
+    public void onDocumentChanged(final DocumentChangedEvent event) {
         final int removed = event.getLength();
         int added = 0;
         if (event.getText() != null) {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/partition/DefaultPartitioner.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/partition/DefaultPartitioner.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.text.BadLocationException;
 import org.eclipse.che.ide.api.editor.text.BadPositionCategoryException;
 import org.eclipse.che.ide.api.editor.text.Position;
@@ -87,7 +87,7 @@ public class DefaultPartitioner implements DocumentPartitioner {
     }
 
     @Override
-    public void onDocumentChange(final DocumentChangeEvent event) {
+    public void onDocumentChanged(final DocumentChangedEvent event) {
         this.scanner.setScannedString(event.getDocument().getDocument().getContents());
         updatePositions();
     }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/partition/DocumentPartitioner.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/partition/DocumentPartitioner.java
@@ -12,7 +12,7 @@ package org.eclipse.che.ide.api.editor.partition;
 
 import java.util.List;
 
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.text.TypedRegion;
 import org.eclipse.che.ide.api.editor.document.UseDocumentHandle;
 
@@ -21,7 +21,7 @@ import org.eclipse.che.ide.api.editor.document.UseDocumentHandle;
  * Partitioners parse a document and splits it in partitions, which are contiguous zones of text
  * of a specific type (for example comment, literal string, code etc.).
  */
-public interface DocumentPartitioner extends DocumentChangeHandler, UseDocumentHandle {
+public interface DocumentPartitioner extends DocumentChangedHandler, UseDocumentHandle {
 
     /** The identifier of the default partition content type. */
     String DEFAULT_CONTENT_TYPE = "__dftl_partition_content_type";

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/reconciler/DefaultReconciler.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/reconciler/DefaultReconciler.java
@@ -15,7 +15,7 @@ import com.google.inject.assistedinject.AssistedInject;
 
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.partition.DocumentPartitioner;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 
@@ -72,7 +72,7 @@ public class DefaultReconciler implements Reconciler {
     }
 
     @Override
-    public void onDocumentChange(final DocumentChangeEvent event) {
+    public void onDocumentChanged(final DocumentChangedEvent event) {
     }
 
     @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/reconciler/Reconciler.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/reconciler/Reconciler.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.ide.api.editor.reconciler;
 
 import org.eclipse.che.ide.api.editor.document.UseDocumentHandle;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
  * 
  * @author Evgen Vidolob
  */
-public interface Reconciler extends UseDocumentHandle, DocumentChangeHandler {
+public interface Reconciler extends UseDocumentHandle, DocumentChangedHandler {
 
     /**
      * Installs the reconciler on the given text view. After this method has been finished, the reconciler is operational, i.e., it works

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/reconciler/ReconcilerWithAutoSave.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/reconciler/ReconcilerWithAutoSave.java
@@ -18,7 +18,7 @@ import com.google.inject.assistedinject.AssistedInject;
 import org.eclipse.che.ide.api.editor.EditorInput;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.partition.DocumentPartitioner;
 import org.eclipse.che.ide.api.editor.text.Region;
 import org.eclipse.che.ide.api.editor.text.RegionImpl;
@@ -177,7 +177,7 @@ public class ReconcilerWithAutoSave implements Reconciler {
      *
      * @param event the document event for which to create a dirty region
      */
-    private void createDirtyRegion(final DocumentChangeEvent event) {
+    private void createDirtyRegion(final DocumentChangedEvent event) {
         if (event.getLength() == 0 && event.getText() != null) {
             // Insert
             dirtyRegionQueue.addDirtyRegion(new DirtyRegion(event.getOffset(),
@@ -221,7 +221,7 @@ public class ReconcilerWithAutoSave implements Reconciler {
     }
 
     @Override
-    public void onDocumentChange(final DocumentChangeEvent event) {
+    public void onDocumentChanged(final DocumentChangedEvent event) {
         if (documentHandle == null || !documentHandle.isSameAs(event.getDocument())) {
             return;
         }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/EditorWidget.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/EditorWidget.java
@@ -17,7 +17,7 @@ import com.google.gwt.event.dom.client.HasFocusHandlers;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.RequiresResize;
 
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.text.Region;
 import org.eclipse.che.ide.api.hotkeys.HotKeyItem;
 import org.eclipse.che.ide.api.editor.codeassist.AdditionalInfoCallback;
@@ -56,7 +56,7 @@ public interface EditorWidget extends IsWidget,
 
     /**
      * Sets the content of the editor.<br>
-     * The operation <em>must</em> send a {@link DocumentChangeEvent} on the document private event bus.
+     * The operation <em>must</em> send a {@link DocumentChangedEvent} on the document private event bus.
      *
      * @param newValue
      *         the new contents

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/autosave/AutoSaveModeImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/autosave/AutoSaveModeImpl.java
@@ -20,7 +20,7 @@ import org.eclipse.che.ide.api.editor.EditorOpenedEventHandler;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.autosave.AutoSaveMode;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.reconciler.DirtyRegion;
 import org.eclipse.che.ide.api.editor.reconciler.DirtyRegionQueue;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
@@ -156,13 +156,13 @@ public class AutoSaveModeImpl implements AutoSaveMode, EditorSettingsChangedHand
     public void onEditorOpened(EditorOpenedEvent editorOpenedEvent) {
         if (documentHandle != null && editor == editorOpenedEvent.getEditor()) {
             HandlerRegistration documentChangeHandlerRegistration =
-                    documentHandle.getDocEventBus().addHandler(DocumentChangeEvent.TYPE, this);
+                    documentHandle.getDocEventBus().addHandler(DocumentChangedEvent.TYPE, this);
             handlerRegistrations.add(documentChangeHandlerRegistration);
         }
     }
 
     @Override
-    public void onDocumentChange(final DocumentChangeEvent event) {
+    public void onDocumentChanged(final DocumentChangedEvent event) {
         if (documentHandle == null || !event.getDocument().isSameAs(documentHandle)) {
             return;
         }
@@ -184,7 +184,7 @@ public class AutoSaveModeImpl implements AutoSaveMode, EditorSettingsChangedHand
      * @param event
      *         the document event for which to create a dirty region
      */
-    private void createDirtyRegion(final DocumentChangeEvent event) {
+    private void createDirtyRegion(final DocumentChangedEvent event) {
         if (event.getRemoveCharCount() == 0 && event.getText() != null && !event.getText().isEmpty()) {
             // Insert
             dirtyRegionQueue.addDirtyRegion(new DirtyRegion(event.getOffset(),

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronization.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronization.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.ide.editor.synchronization;
 
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
 import org.eclipse.che.ide.resource.Path;
 
@@ -19,7 +19,7 @@ import javax.validation.constraints.NotNull;
 import java.util.Set;
 
 /**
- * Contains list of opened files with the same {@link Path} and listens to {@link DocumentChangeEvent} and {@link FileContentUpdateEvent}
+ * Contains list of opened files with the same {@link Path} and listens to {@link DocumentChangedEvent} and {@link FileContentUpdateEvent}
  * to provide the synchronization of the content for them.
  *
  * @author Roman Nikitenko

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
@@ -20,8 +20,8 @@ import org.eclipse.che.ide.api.editor.EditorWithAutoSave;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
 import org.eclipse.che.ide.api.editor.document.DocumentStorage;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
@@ -41,7 +41,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMod
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 
-public class EditorGroupSynchronizationImpl implements EditorGroupSynchronization, DocumentChangeHandler, FileContentUpdateHandler {
+public class EditorGroupSynchronizationImpl implements EditorGroupSynchronization, DocumentChangedHandler, FileContentUpdateHandler {
     private final DocumentStorage     documentStorage;
     private final NotificationManager notificationManager;
     private final HandlerRegistration fileContentUpdateHandlerRegistration;
@@ -66,7 +66,7 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
         }
 
         if (synchronizedEditors.isEmpty()) {
-            HandlerRegistration handlerRegistration = documentHandle.getDocEventBus().addHandler(DocumentChangeEvent.TYPE, this);
+            HandlerRegistration handlerRegistration = documentHandle.getDocEventBus().addHandler(DocumentChangedEvent.TYPE, this);
             synchronizedEditors.put(editor, handlerRegistration);
             return;
         }
@@ -83,7 +83,7 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
             editorDocument.replace(0, oldContent.length(), groupMemberContent);
         }
 
-        HandlerRegistration handlerRegistration = documentHandle.getDocEventBus().addHandler(DocumentChangeEvent.TYPE, this);
+        HandlerRegistration handlerRegistration = documentHandle.getDocEventBus().addHandler(DocumentChangedEvent.TYPE, this);
         synchronizedEditors.put(editor, handlerRegistration);
     }
 
@@ -121,7 +121,7 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
     }
 
     @Override
-    public void onDocumentChange(DocumentChangeEvent event) {
+    public void onDocumentChanged(DocumentChangedEvent event) {
         DocumentHandle activeEditorDocumentHandle = getDocumentHandleFor(groupLeaderEditor);
         if (activeEditorDocumentHandle == null || !event.getDocument().isSameAs(activeEditorDocumentHandle)) {
             return;

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImplTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImplTest.java
@@ -21,7 +21,7 @@ import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.document.DocumentEventBus;
 import org.eclipse.che.ide.api.editor.document.DocumentHandle;
 import org.eclipse.che.ide.api.editor.document.DocumentStorage;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.junit.Before;
@@ -64,7 +64,7 @@ public class EditorGroupSynchronizationImplTest {
     @Mock
     private HandlerRegistration handlerRegistration;
     @Mock
-    private DocumentChangeEvent documentChangeEvent;
+    private DocumentChangedEvent documentChangeEvent;
 
     private EditorPartPresenter            activeEditor;
     private EditorPartPresenter            openedEditor1;
@@ -102,7 +102,7 @@ public class EditorGroupSynchronizationImplTest {
 
         editorGroupSynchronization.addEditor(activeEditor);
 
-        verify(documentEventBus).addHandler(Matchers.<DocumentChangeEvent.Type>anyObject(), eq(editorGroupSynchronization));
+        verify(documentEventBus).addHandler(Matchers.<DocumentChangedEvent.Type>anyObject(), eq(editorGroupSynchronization));
     }
 
     @Test
@@ -118,7 +118,7 @@ public class EditorGroupSynchronizationImplTest {
         verify((EditorWithAutoSave)openedEditor1).isAutoSaveEnabled();
         verify(document, times(2)).getContents();
         verify(document).replace(anyInt(), anyInt(), anyString());
-        verify(documentEventBus).addHandler(Matchers.<DocumentChangeEvent.Type>anyObject(), eq(editorGroupSynchronization));
+        verify(documentEventBus).addHandler(Matchers.<DocumentChangedEvent.Type>anyObject(), eq(editorGroupSynchronization));
     }
 
     @Test
@@ -145,7 +145,7 @@ public class EditorGroupSynchronizationImplTest {
         when(documentChangeEvent.getDocument()).thenReturn(documentHandle1);
         when(documentHandle1.isSameAs(documentHandle)).thenReturn(false);
 
-        editorGroupSynchronization.onDocumentChange(documentChangeEvent);
+        editorGroupSynchronization.onDocumentChanged(documentChangeEvent);
 
         verify(document, never()).replace(anyInt(), anyInt(), anyString());
     }
@@ -163,7 +163,7 @@ public class EditorGroupSynchronizationImplTest {
         when(documentHandle1.isSameAs(documentHandle)).thenReturn(true);
 
         addEditorsToGroup();
-        editorGroupSynchronization.onDocumentChange(documentChangeEvent);
+        editorGroupSynchronization.onDocumentChanged(documentChangeEvent);
 
         verify(document, times(2)).replace(eq(offset), eq(removeCharCount), eq(text));
     }

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -14,7 +14,7 @@ import com.google.web.bindery.event.shared.HandlerRegistration;
 import org.eclipse.che.ide.api.editor.document.AbstractDocument;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.events.CursorActivityHandler;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.events.DocumentChangingEvent;
 import org.eclipse.che.ide.api.editor.events.HasCursorActivityHandlers;
 import org.eclipse.che.ide.api.editor.position.PositionConverter;
@@ -78,7 +78,7 @@ public class OrionDocument extends AbstractDocument {
 
         String text = editorOverlay.getModel().getText(startOffset, startOffset + addedCharCount);
 
-        final DocumentChangeEvent event = new DocumentChangeEvent(this,
+        final DocumentChangedEvent event = new DocumentChangedEvent(this,
                                                                   startOffset,
                                                                   addedCharCount,
                                                                   text,

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -11,7 +11,16 @@
 package org.eclipse.che.ide.editor.orion.client;
 
 import com.google.web.bindery.event.shared.HandlerRegistration;
-
+import org.eclipse.che.ide.api.editor.document.AbstractDocument;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.events.CursorActivityHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangingEvent;
+import org.eclipse.che.ide.api.editor.events.HasCursorActivityHandlers;
+import org.eclipse.che.ide.api.editor.position.PositionConverter;
+import org.eclipse.che.ide.api.editor.text.LinearRange;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
+import org.eclipse.che.ide.api.editor.text.TextRange;
 import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.editor.orion.client.jso.ModelChangedEventOverlay;
@@ -21,15 +30,6 @@ import org.eclipse.che.ide.editor.orion.client.jso.OrionSelectionOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextModelOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextModelOverlay.EventHandler;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewOverlay;
-import org.eclipse.che.ide.api.editor.document.AbstractDocument;
-import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.events.CursorActivityHandler;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
-import org.eclipse.che.ide.api.editor.events.HasCursorActivityHandlers;
-import org.eclipse.che.ide.api.editor.position.PositionConverter;
-import org.eclipse.che.ide.api.editor.text.LinearRange;
-import org.eclipse.che.ide.api.editor.text.TextPosition;
-import org.eclipse.che.ide.api.editor.text.TextRange;
 
 /**
  * The implementation of {@link Document} for Orion.
@@ -60,6 +60,14 @@ public class OrionDocument extends AbstractDocument {
                 fireDocumentChangeEvent(parameter);
             }
         }, true);
+        
+        this.editorOverlay.getModel().addEventListener("Changing", new EventHandler<ModelChangedEventOverlay>() {
+            @Override
+            public void onEvent(ModelChangedEventOverlay parameter) {
+                fireDocumentChangingEvent(parameter);
+            }
+        }, true);
+
     }
 
     private void fireDocumentChangeEvent(final ModelChangedEventOverlay param) {
@@ -78,6 +86,24 @@ public class OrionDocument extends AbstractDocument {
         // according to https://github.com/codenvy/che-core/pull/122
         getDocEventBus().fireEvent(event);
     }
+    
+    private void fireDocumentChangingEvent(final ModelChangedEventOverlay param) {
+        int startOffset = param.start();
+        int addedCharCount = param.addedCharCount();
+        int removedCharCount = param.removedCharCount();
+
+
+        String text = editorOverlay.getModel().getText(startOffset, startOffset + addedCharCount);
+
+        final DocumentChangingEvent event = new DocumentChangingEvent(this,
+                                                                  startOffset,
+                                                                  addedCharCount,
+                                                                  text,
+                                                                  removedCharCount);
+        // according to https://github.com/codenvy/che-core/pull/122
+        getDocEventBus().fireEvent(event);
+    }
+
 
     @Override
     public TextPosition getPositionFromIndex(final int index) {

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorInit.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorInit.java
@@ -31,7 +31,7 @@ import org.eclipse.che.ide.api.editor.document.DocumentHandle;
 import org.eclipse.che.ide.api.editor.editorconfig.TextEditorConfiguration;
 import org.eclipse.che.ide.api.editor.events.CompletionRequestEvent;
 import org.eclipse.che.ide.api.editor.events.CompletionRequestHandler;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
 import org.eclipse.che.ide.api.editor.events.TextChangeEvent;
 import org.eclipse.che.ide.api.editor.events.TextChangeHandler;
 import org.eclipse.che.ide.api.editor.formatter.ContentFormatter;
@@ -143,7 +143,7 @@ public class OrionEditorInit {
         final DocumentPartitioner partitioner = configuration.getPartitioner();
         if (partitioner != null) {
             partitioner.setDocumentHandle(documentHandle);
-            documentHandle.getDocEventBus().addHandler(DocumentChangeEvent.TYPE, partitioner);
+            documentHandle.getDocEventBus().addHandler(DocumentChangedEvent.TYPE, partitioner);
             partitioner.initialize();
         }
     }
@@ -156,7 +156,7 @@ public class OrionEditorInit {
         final Reconciler reconciler = configuration.getReconciler();
         if (reconciler != null) {
             reconciler.setDocumentHandle(documentHandle);
-            documentHandle.getDocEventBus().addHandler(DocumentChangeEvent.TYPE, reconciler);
+            documentHandle.getDocEventBus().addHandler(DocumentChangedEvent.TYPE, reconciler);
             reconciler.install(textEditor);
         }
     }
@@ -175,7 +175,7 @@ public class OrionEditorInit {
             ((HasAnnotationRendering)textEditor).configure(annotationModel, documentHandle);
         }
         annotationModel.setDocumentHandle(documentHandle);
-        documentHandle.getDocEventBus().addHandler(DocumentChangeEvent.TYPE, annotationModel);
+        documentHandle.getDocEventBus().addHandler(DocumentChangedEvent.TYPE, annotationModel);
 
         // the model listens to QueryAnnotation events
         documentHandle.getDocEventBus().addHandler(QueryAnnotationsEvent.TYPE, annotationModel);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -18,8 +18,8 @@ import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.formatter.ContentFormatter;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.editor.text.TextRange;
@@ -89,9 +89,9 @@ public class LanguageServerFormatter implements ContentFormatter {
         this.editor = editor;
         if (capabilities.getDocumentOnTypeFormattingProvider() != null &&
             capabilities.getDocumentOnTypeFormattingProvider().getFirstTriggerCharacter() != null) {
-            editor.getDocument().getDocumentHandle().getDocEventBus().addHandler(DocumentChangeEvent.TYPE, new DocumentChangeHandler() {
+            editor.getDocument().getDocumentHandle().getDocEventBus().addHandler(DocumentChangedEvent.TYPE, new DocumentChangedHandler() {
                 @Override
-                public void onDocumentChange(DocumentChangeEvent event) {
+                public void onDocumentChanged(DocumentChangedEvent event) {
                     if (capabilities.getDocumentOnTypeFormattingProvider().getFirstTriggerCharacter().equals(event.getText())) {
                         Document document = event.getDocument().getDocument();
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerReconcileStrategy.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerReconcileStrategy.java
@@ -13,8 +13,8 @@ package org.eclipse.che.plugin.languageserver.ide.editor;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.events.DocumentChangingEvent;
 import org.eclipse.che.ide.api.editor.events.DocumentChangingHandler;
 import org.eclipse.che.ide.api.editor.reconciler.DirtyRegion;
@@ -57,9 +57,9 @@ public class LanguageServerReconcileStrategy implements ReconcilingStrategy {
 
     @Override
     public void setDocument(Document document) {
-        document.getDocumentHandle().getDocEventBus().addHandler(DocumentChangeEvent.TYPE, new DocumentChangeHandler() {
+        document.getDocumentHandle().getDocEventBus().addHandler(DocumentChangedEvent.TYPE, new DocumentChangedHandler() {
             @Override
-            public void onDocumentChange(DocumentChangeEvent event) {
+            public void onDocumentChanged(DocumentChangedEvent event) {
                 synchronize.syncTextDocument(event.getDocument().getDocument(), lastEventStart, lastEventEnd, event.getText(), ++version);
             }
         });

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerReconcileStrategy.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerReconcileStrategy.java
@@ -60,14 +60,14 @@ public class LanguageServerReconcileStrategy implements ReconcilingStrategy {
         document.getDocumentHandle().getDocEventBus().addHandler(DocumentChangeEvent.TYPE, new DocumentChangeHandler() {
             @Override
             public void onDocumentChange(DocumentChangeEvent event) {
-                synchronize.syncTextDocument(document, lastEventStart, lastEventEnd, event.getText(), ++version);
+                synchronize.syncTextDocument(event.getDocument().getDocument(), lastEventStart, lastEventEnd, event.getText(), ++version);
             }
         });
         document.getDocumentHandle().getDocEventBus().addHandler(DocumentChangingEvent.TYPE, new DocumentChangingHandler() {
             @Override
             public void onDocumentChanging(DocumentChangingEvent event) {
-                lastEventStart= document.getPositionFromIndex(event.getOffset());
-                lastEventEnd= document.getPositionFromIndex(event.getOffset()+event.getRemoveCharCount());
+                lastEventStart= event.getDocument().getDocument().getPositionFromIndex(event.getOffset());
+                lastEventEnd= event.getDocument().getDocument().getPositionFromIndex(event.getOffset()+event.getRemoveCharCount());
             }
         });
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/LanguageServerSignatureHelp.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/LanguageServerSignatureHelp.java
@@ -20,8 +20,8 @@ import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeHandler;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
+import org.eclipse.che.ide.api.editor.events.DocumentChangedHandler;
 import org.eclipse.che.ide.api.editor.signature.SignatureHelp;
 import org.eclipse.che.ide.api.editor.signature.SignatureHelpProvider;
 import org.eclipse.che.ide.api.editor.texteditor.HandlesTextOperations;
@@ -87,9 +87,9 @@ public class LanguageServerSignatureHelp implements SignatureHelpProvider {
         if (capabilities.getSignatureHelpProvider() != null && capabilities.getSignatureHelpProvider().getTriggerCharacters() != null) {
             final List<String> triggerCharacters = capabilities.getSignatureHelpProvider().getTriggerCharacters();
             handlerRegistration = editor.getDocument().getDocumentHandle().getDocEventBus()
-                                        .addHandler(DocumentChangeEvent.TYPE, new DocumentChangeHandler() {
+                                        .addHandler(DocumentChangedEvent.TYPE, new DocumentChangedHandler() {
                                             @Override
-                                            public void onDocumentChange(DocumentChangeEvent event) {
+                                            public void onDocumentChanged(DocumentChangedEvent event) {
                                                 if (triggerCharacters.contains(event.getText())) {
                                                     ((HandlesTextOperations)editor)
                                                             .doOperation(TextEditorOperations.SIGNATURE_HELP);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/FullTextDocumentSynchronize.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/FullTextDocumentSynchronize.java
@@ -12,9 +12,8 @@ package org.eclipse.che.plugin.languageserver.ide.editor.sync;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
 import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
@@ -41,8 +40,7 @@ class FullTextDocumentSynchronize implements TextDocumentSynchronize {
     }
 
     @Override
-    public void syncTextDocument(DocumentChangeEvent event, int version) {
-        Document document = event.getDocument().getDocument();
+    public void syncTextDocument(Document document, TextPosition start, TextPosition end, String insertedText, int version) {
 
         DidChangeTextDocumentParams changeDTO = dtoFactory.createDto(DidChangeTextDocumentParams.class);
         String uri = document.getFile().getLocation().toString();
@@ -53,7 +51,7 @@ class FullTextDocumentSynchronize implements TextDocumentSynchronize {
         changeDTO.setTextDocument(versionedDocId);
         TextDocumentContentChangeEvent actualChange = dtoFactory.createDto(TextDocumentContentChangeEvent.class);
 
-        actualChange.setText(event.getDocument().getDocument().getContents());
+        actualChange.setText(document.getContents());
         changeDTO.setContentChanges(Collections.singletonList(actualChange));
         textDocumentService.didChange(changeDTO);
     }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/IncrementalTextDocumentSynchronize.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/IncrementalTextDocumentSynchronize.java
@@ -12,9 +12,7 @@ package org.eclipse.che.plugin.languageserver.ide.editor.sync;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
 import org.eclipse.che.ide.api.editor.document.Document;
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
@@ -44,16 +42,7 @@ class IncrementalTextDocumentSynchronize implements TextDocumentSynchronize {
     }
 
     @Override
-    public void syncTextDocument(DocumentChangeEvent event, int version) {
-        Document document = event.getDocument().getDocument();
-        TextPosition startPosition = document.getPositionFromIndex(event.getOffset());
-        TextPosition endPosition;
-        if (event.getRemoveCharCount() != 0) {
-            endPosition = new TextPosition(startPosition.getLine(), startPosition.getCharacter() + event.getRemoveCharCount());
-        } else {
-            endPosition = new TextPosition(startPosition.getLine(), startPosition.getCharacter());
-        }
-
+    public void syncTextDocument(Document document, TextPosition startPosition, TextPosition endPosition, String insertedText, int version) {
         DidChangeTextDocumentParams changeDTO = dtoFactory.createDto(DidChangeTextDocumentParams.class);
         String uri = document.getFile().getLocation().toString();
         changeDTO.setUri(uri);
@@ -74,7 +63,7 @@ class IncrementalTextDocumentSynchronize implements TextDocumentSynchronize {
 
         TextDocumentContentChangeEvent actualChange = dtoFactory.createDto(TextDocumentContentChangeEvent.class);
         actualChange.setRange(range);
-        actualChange.setText(event.getText());
+        actualChange.setText(insertedText);
 
         changeDTO.setContentChanges(Collections.singletonList(actualChange));
         textDocumentService.didChange(changeDTO);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/TextDocumentSynchronize.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/TextDocumentSynchronize.java
@@ -10,7 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.languageserver.ide.editor.sync;
 
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
 
 /**
  * Handle TextDocument synchronization
@@ -18,5 +19,5 @@ import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
  * @author Evgen Vidolob
  */
 public interface TextDocumentSynchronize {
-    void syncTextDocument(DocumentChangeEvent event, int version);
+    void syncTextDocument(Document document, TextPosition start, TextPosition end, String insertedText, int version);
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/TextDocumentSynchronizeFactory.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/TextDocumentSynchronizeFactory.java
@@ -12,8 +12,8 @@ package org.eclipse.che.plugin.languageserver.ide.editor.sync;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
-import org.eclipse.che.ide.api.editor.events.DocumentChangeEvent;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 
 /**
@@ -56,8 +56,8 @@ public class TextDocumentSynchronizeFactory {
 
     private static class NoneSynchronize implements TextDocumentSynchronize {
         @Override
-        public void syncTextDocument(DocumentChangeEvent event, int version) {
-            //no implementation
+        public void syncTextDocument(Document document, TextPosition start, TextPosition end, String insertedText, int version) {
+            // no-op implementation
         }
     }
 }


### PR DESCRIPTION
This PR adds support for "documentChanging" events and uses the event to properly compute line numbers in "textDocument/didChange" notifications to LSP language servers. This only affects language servers that request incremental "didChange" messages. The language servers currently in use in Che use full text changes.

This is a fix for https://github.com/eclipse/che/issues/4978

#### Changelog
Fix didChange notification line numbers for incremental update policy.

This is a bugfix only.