### PR TITLE
CHE-4939: Fix bugs related to processing of read-only files

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -381,6 +381,16 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
         }
     }
 
+    @Override
+    protected void updateDirtyState(boolean dirty) {
+        if (isReadOnly()) {
+            dirtyState = false;
+            return;
+        }
+
+        super.updateDirtyState(dirty);
+    }
+
     private void updateTabReference(File file, Path oldPath) {
         final PartPresenter activePart = editorMultiPartStackPresenter.getActivePart();
         final EditorPartStack activePartStack = editorMultiPartStackPresenter.getPartStackByPart(activePart);
@@ -585,9 +595,10 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
     @Override
     public void doSave(final AsyncCallback<EditorInput> callback) {
         //If the workspace is stopped we shouldn't try to save a file
-        if (appContext.getDevMachine() == null) {
+        if (isReadOnly() || appContext.getDevMachine() == null) {
             return;
         }
+
         this.documentStorage.saveDocument(getEditorInput(), this.document, false, new AsyncCallback<EditorInput>() {
             @Override
             public void onSuccess(EditorInput editorInput) {


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikitenko@codenvy.com>

### What does this PR do?
Fix bugs related to processing of read-only files:
1. Do not try to save a content of read-only files
2. Close read-only files when project is removed
3. Do not display a browser popup with warning "Change you made may not be saved" for read-only files at attempt to refresh page.

### What issues does this PR fix or reference?
#4939

#### Changelog
Fix bugs related to processing of read-only files
