### PR TITLE
Add property to control manual workspace dir creation in OpenShift

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -306,6 +306,14 @@ che.openshift.secure.routes=false
 che.openshift.jobs.image=centos:centos7
 che.openshift.jobs.memorylimit=250Mi
 
+# Run job to create workspace subpath directories in persistent volume before launching workspace.
+# Necessary in some versions of OpenShift/Kubernetes as workspace subpath volumemounts are created
+# with root permissions, and thus cannot be modified by workspaces running as user (presents as error
+# importing projects into workspace in Che). Default is "true", but should be set to false if version
+# of Openshift/Kubernetes creates subdirectories with user permissions.
+# Relevant issue: https://github.com/kubernetes/kubernetes/issues/41638
+che.openshift.precreate.workspace.dirs=true
+
 # Specifications of compute resources that can be consumed
 # by the workspace container:
 #

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -197,6 +197,7 @@ public class OpenShiftConnector extends DockerConnector {
     private final String          cheWorkspaceMemoryLimit;
     private final String          cheWorkspaceMemoryRequest;
     private final boolean         secureRoutes;
+    private final boolean         createWorkspaceDirs;
     private final OpenShiftPvcHelper openShiftPvcHelper;
 
     @Inject
@@ -216,7 +217,8 @@ public class OpenShiftConnector extends DockerConnector {
                               @Named("che.workspace.projects.storage") String cheWorkspaceProjectsStorage,
                               @Nullable @Named("che.openshift.workspace.memory.request") String cheWorkspaceMemoryRequest,
                               @Nullable @Named("che.openshift.workspace.memory.override") String cheWorkspaceMemoryLimit,
-                              @Named("che.openshift.secure.routes") boolean secureRoutes) {
+                              @Named("che.openshift.secure.routes") boolean secureRoutes,
+                              @Named("che.openshift.precreate.workspace.dirs") boolean createWorkspaceDirs) {
 
         super(connectorConfiguration, connectionFactory, authResolver, dockerApiVersionPathPrefixProvider);
         this.cheServerExternalAddress = cheServerExternalAddress;
@@ -230,6 +232,7 @@ public class OpenShiftConnector extends DockerConnector {
         this.cheWorkspaceMemoryRequest = cheWorkspaceMemoryRequest;
         this.cheWorkspaceMemoryLimit = cheWorkspaceMemoryLimit;
         this.secureRoutes = secureRoutes;
+        this.createWorkspaceDirs = createWorkspaceDirs;
         this.openShiftPvcHelper = openShiftPvcHelper;
         eventService.subscribe(new EventSubscriber<ServerIdleEvent>() {
 
@@ -1146,7 +1149,9 @@ public class OpenShiftConnector extends DockerConnector {
 
         LOG.info("Adding container {} to OpenShift deployment {}", sanitizedContainerName, deploymentName);
 
-        createWorkspaceDir(volumes);
+        if (createWorkspaceDirs) {
+            createWorkspaceDir(volumes);
+        }
 
         Container container = new ContainerBuilder()
                                     .withName(sanitizedContainerName)

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -41,6 +41,7 @@ public class OpenShiftConnectorTest {
     private static final String   CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS = "che.openshift.mini";
     private static final String   CHE_WORKSPACE_CPU_LIMIT = "1";
     private static final boolean  SECURE_ROUTES = false;
+    private static final boolean  CREATE_WORKSPACE_DIRS = true;
 
 
     @Mock
@@ -86,7 +87,8 @@ public class OpenShiftConnectorTest {
                                                     OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE,
                                                     CHE_WORKSPACE_CPU_LIMIT,
                                                     null,
-                                                    SECURE_ROUTES);
+                                                    SECURE_ROUTES,
+                                                    CREATE_WORKSPACE_DIRS);
         String workspaceID = openShiftConnector.getCheWorkspaceId(createContainerParams);
 
         //Then


### PR DESCRIPTION
### What does this PR do?
Adds property `che.openshift.precreate.workspace.dirs`. If true, Che will run a separate pod to create a subdirectory in the workspaces PV before launching the pod. If false, this step is skipped.

Creating the directory is necessary in some versions as Kubernetes creates the volumemount subpath with root permissions, preventing modification by workspaces. This has been fixed fairly [recently](https://github.com/kubernetes/kubernetes/pull/43775) and should be disabled if OpenShift supports it, as mounting/unmounting PVs can cause issues. 

I've left the property as true by default, as this is the safer option, and minishift does not seem to support a version of OpenShift with this fix at the moment. Once the fix is standard, this property could probably be removed.