### PR TITLE
Codenvy-1612: Apply possibility copy and paste text in the terminal by "Ctrl + C" / "Ctrl + V"

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/CustomKeyDownTerminalHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/CustomKeyDownTerminalHandler.java
@@ -25,7 +25,7 @@ public class CustomKeyDownTerminalHandler extends JavaScriptObject {
         return function(ev) {
             var C = 67;
             var V = 86;
-            if (ev.ctrlKey) {
+            if (ev.ctrlKey && !(ev.shiftKey || ev.metaKey || ev.altKey)) {
 
                 //handle Ctrl + V
                 if (ev.keyCode === V) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/CustomKeyDownTerminalHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/CustomKeyDownTerminalHandler.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.terminal;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Custom keyDown handler for {@link TerminalJso}
+ *
+ * @author Alexander Andrienko
+ */
+public class CustomKeyDownTerminalHandler extends JavaScriptObject {
+    protected CustomKeyDownTerminalHandler() {
+    }
+
+    public static native CustomKeyDownTerminalHandler create() /*-{
+        return function(ev) {
+            var C = 67;
+            var V = 86;
+            if (ev.ctrlKey) {
+
+                //handle Ctrl + V
+                if (ev.keyCode === V) {
+                    return false;
+                }
+
+                var selection = this.document.getSelection(),
+                    collapsed = selection.isCollapsed,
+                    isRange = typeof collapsed === 'boolean' ? !collapsed : selection.type === 'Range';
+
+                //handle Ctrl + C
+                if (ev.keyCode === C && isRange) {
+                    return false;
+                }
+            }
+        }
+    }-*/;
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalJso.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalJso.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.promises.client.Operation;
  * GWT binding to term.js script
  *
  * @author Evgen Vidolob
+ * @author Alexander Andrienko
  */
 class TerminalJso extends JavaScriptObject {
     protected TerminalJso() {
@@ -30,6 +31,28 @@ class TerminalJso extends JavaScriptObject {
 
     public final native void open(Element element) /*-{
         this.open(element);
+    }-*/;
+
+    public final native void attachCustomKeydownHandler() /*-{
+        this.attachCustomKeydownHandler(function (ev) {
+            var C = 67;
+            var V = 86;
+            if (ev.ctrlKey) {//todo handle not shift, alt, meta and so on maybe.
+                var selection = this.document.getSelection(),
+                    collapsed = selection.isCollapsed,
+                    isRange = typeof collapsed === 'boolean' ? !collapsed : selection.type === 'Range';
+
+                    //Ctrl + C
+                    if (ev.keyCode === C && isRange) {
+                        return false;
+                    }
+
+                //Ctrl + V
+                if (ev.keyCode === V) {
+                    return false;
+                }
+            }
+        });
     }-*/;
 
     public final native Element getElement() /*-{

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalJso.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalJso.java
@@ -33,26 +33,8 @@ class TerminalJso extends JavaScriptObject {
         this.open(element);
     }-*/;
 
-    public final native void attachCustomKeydownHandler() /*-{
-        this.attachCustomKeydownHandler(function (ev) {
-            var C = 67;
-            var V = 86;
-            if (ev.ctrlKey) {//todo handle not shift, alt, meta and so on maybe.
-                var selection = this.document.getSelection(),
-                    collapsed = selection.isCollapsed,
-                    isRange = typeof collapsed === 'boolean' ? !collapsed : selection.type === 'Range';
-
-                    //Ctrl + C
-                    if (ev.keyCode === C && isRange) {
-                        return false;
-                    }
-
-                //Ctrl + V
-                if (ev.keyCode === V) {
-                    return false;
-                }
-            }
-        });
+    public final native void attachCustomKeyDownHandler(JavaScriptObject customKeyDownHandler) /*-{
+        this.attachCustomKeydownHandler(customKeyDownHandler);
     }-*/;
 
     public final native Element getElement() /*-{

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalViewImpl.java
@@ -66,6 +66,7 @@ final class TerminalViewImpl extends Composite implements TerminalView, Requires
         terminalElement.getStyle().setProperty("opacity", "0");
 
         terminal.open(terminalPanel.getElement());
+        terminal.attachCustomKeydownHandler();
 
         terminalElement.getFirstChildElement().getStyle().clearProperty("backgroundColor");
         terminalElement.getFirstChildElement().getStyle().clearProperty("color");

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalViewImpl.java
@@ -66,7 +66,7 @@ final class TerminalViewImpl extends Composite implements TerminalView, Requires
         terminalElement.getStyle().setProperty("opacity", "0");
 
         terminal.open(terminalPanel.getElement());
-        terminal.attachCustomKeydownHandler();
+        terminal.attachCustomKeyDownHandler(CustomKeyDownTerminalHandler.create());
 
         terminalElement.getFirstChildElement().getStyle().clearProperty("backgroundColor");
         terminalElement.getFirstChildElement().getStyle().clearProperty("color");


### PR DESCRIPTION
### What does this PR do?
Apply possibility copy and paste text in the terminal by "Ctrl + C" and "Ctrl + V".

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1612

#### Changelog
Apply possibility copy and paste in the terminal by "Ctrl + C" and "Ctrl + V". Combination "Ctrl + C" works to copy only in case if you selected some text in the terminal, otherwise it sends stop signal for current running process in the terminal.

#### Release Notes
Apply possibility copy and paste text in the terminal by "Ctrl + C" and "Ctrl + V".
