### PR TITLE
Fix catching exception in case invalid POM to prevent fail start workspace 

### DIFF
--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -93,6 +93,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-pullrequest-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-python-lang-server</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -212,10 +212,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-pullrequest-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-ssh-machine</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
@@ -16,17 +16,17 @@ package org.eclipse.che.ide.ext.java.shared;
  */
 public final class Constants {
     // project categories
-    public static String JAVA_CATEGORY               = "Java";
-    public static String JAVA_ID                     = "java";
+    public static final String JAVA_CATEGORY               = "Java";
+    public static final String JAVA_ID                     = "java";
     // project attribute names
-    public static String LANGUAGE                    = "language";
-    public static String LANGUAGE_VERSION            = "languageVersion";
-    public static String FRAMEWORK                   = "framework";
-    public static String CONTAINS_JAVA_FILES         = "containsJavaFiles";
-    public static String SOURCE_FOLDER               = "java.source.folder";
-    public static String OUTPUT_FOLDER               = "java.output.folder";
+    public static final String LANGUAGE                    = "language";
+    public static final String LANGUAGE_VERSION            = "languageVersion";
+    public static final String FRAMEWORK                   = "framework";
+    public static final String CONTAINS_JAVA_FILES         = "containsJavaFiles";
+    public static final String SOURCE_FOLDER               = "java.source.folder";
+    public static final String OUTPUT_FOLDER               = "java.output.folder";
 
-    public static String JAVAC                       = "javac";
+    public static final String JAVAC                       = "javac";
 
     private Constants() {
         throw new UnsupportedOperationException("Unused constructor.");

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenProjectManager.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenProjectManager.java
@@ -360,6 +360,22 @@ public class MavenProjectManager {
         }
     }
 
+
+    public MavenProject getMavenProject(IProject iProject) {
+        readLock.lock();
+        try {
+            return projectToMavenProjectMap.get(iProject);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+
+    public MavenProject getMavenProject(String projectPath) {
+        final IProject project = workspaceProvider.get().getRoot().getProject(projectPath);
+        return getMavenProject(project);
+    }
+
     private void fillMavenKeyMap(MavenProject mavenProject) {
         MavenKey mavenKey = mavenProject.getMavenKey();
         mavenWorkspaceCache.put(mavenKey, mavenProject.getPomFile());

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenModelReader.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenModelReader.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.plugin.maven.server.core.project;
 
 import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.xml.XMLTreeException;
 import org.eclipse.che.ide.maven.tools.Build;
 import org.eclipse.che.ide.maven.tools.Model;
 import org.eclipse.che.ide.maven.tools.Parent;
@@ -116,6 +117,8 @@ public class MavenModelReader {
             model = Model.readFrom(pom);
         } catch (IOException e) {
             problems.add(MavenProjectProblem.newProblem(pom.getPath(), e.getMessage(), MavenProblemType.SYNTAX));
+        }  catch (XMLTreeException xmlExc) {
+            problems.add(MavenProjectProblem.newProblem(pom.getPath(), xmlExc.getMessage(), MavenProblemType.STRUCTURE));
         }
 
         if (model == null) {

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProvider.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProvider.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.maven.server.projecttype;
+
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.project.server.FileEntry;
+import org.eclipse.che.api.project.server.FolderEntry;
+import org.eclipse.che.api.project.server.type.ReadonlyValueProvider;
+import org.eclipse.che.api.project.server.type.ValueStorageException;
+import org.eclipse.che.commons.xml.XMLTreeException;
+import org.eclipse.che.ide.maven.tools.Build;
+import org.eclipse.che.ide.maven.tools.Model;
+import org.eclipse.che.ide.maven.tools.Resource;
+import org.eclipse.che.maven.data.MavenResource;
+import org.eclipse.che.plugin.maven.server.core.MavenProjectManager;
+import org.eclipse.che.plugin.maven.server.core.project.MavenProject;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.eclipse.che.ide.ext.java.shared.Constants.SOURCE_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.ARTIFACT_ID;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_PACKAGING;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_RESOURCES_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_SOURCE_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.GROUP_ID;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PACKAGING;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PARENT_ARTIFACT_ID;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PARENT_GROUP_ID;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PARENT_VERSION;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.RESOURCE_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.TEST_SOURCE_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.VERSION;
+
+/**
+ * @author Vitalii Parfonov
+ */
+public class MavenValueProvider extends ReadonlyValueProvider {
+
+
+    private MavenProjectManager mavenProjectManager;
+    private FolderEntry projectFolder;
+
+    protected MavenValueProvider(MavenProjectManager mavenProjectManager,
+                                 FolderEntry projectFolder) {
+        this.mavenProjectManager = mavenProjectManager;
+        this.projectFolder = projectFolder;
+    }
+
+    @Override
+    public List<String> getValues(String attributeName) throws ValueStorageException {
+        try {
+            final MavenProject mavenProject = mavenProjectManager.getMavenProject(projectFolder.getPath().toString());
+            if (mavenProject != null) {
+                return getFromMavenProject(mavenProject, attributeName);
+            } else {
+                return readFromPom(attributeName);
+            }
+        } catch (ServerException | ForbiddenException | IOException e) {
+            throwReadException(e);
+        } catch (XMLTreeException e) {
+            throw new ValueStorageException("Error parsing pom.xml : " + e.getMessage());
+        }
+        return null;
+    }
+
+    private List<String> getFromMavenProject(MavenProject mavenProject, String attributeName) {
+        String value = "";
+        if (attributeName.equals(ARTIFACT_ID)) {
+            value = mavenProject.getMavenKey().getArtifactId();
+        } else if (attributeName.equals(GROUP_ID)) {
+            value = mavenProject.getMavenKey().getGroupId();
+        } else if (attributeName.equals(PACKAGING)) {
+            final String packaging = mavenProject.getPackaging();
+            value = packaging == null ? DEFAULT_PACKAGING : packaging;
+        } else if (attributeName.equals(VERSION)) {
+            value = mavenProject.getMavenKey().getVersion();
+        } else if (attributeName.equals(PARENT_ARTIFACT_ID) && mavenProject.getParentKey() != null) {
+            value = mavenProject.getParentKey().getArtifactId();
+        } else if (attributeName.equals(PARENT_GROUP_ID) && mavenProject.getParentKey() != null) {
+            value = mavenProject.getParentKey().getGroupId();
+        } else if (attributeName.equals(PARENT_VERSION) && mavenProject.getParentKey() != null) {
+            value = mavenProject.getParentKey().getVersion();
+        } else if (attributeName.equals(SOURCE_FOLDER)) {
+            if (mavenProject.getSources() != null && !mavenProject.getSources().isEmpty()) {
+                return mavenProject.getSources();
+            } else {
+                value = DEFAULT_SOURCE_FOLDER;
+            }
+        } else if (attributeName.equals(TEST_SOURCE_FOLDER)) {
+            if (mavenProject.getTestSources() != null && !mavenProject.getTestSources().isEmpty()) {
+                return mavenProject.getTestSources();
+            } else {
+                value = DEFAULT_TEST_SOURCE_FOLDER;
+            }
+        } else if (attributeName.equals(RESOURCE_FOLDER)) {
+            if (mavenProject.getResources() != null && !mavenProject.getResources().isEmpty()) {
+                return mavenProject.getResources().stream().map(MavenResource::getDirectory).collect(Collectors.toList());
+            } else {
+                return Arrays.asList(DEFAULT_RESOURCES_FOLDER, DEFAULT_TEST_RESOURCES_FOLDER);
+            }
+        }
+        return Collections.singletonList(value);
+    }
+
+
+    private List<String> readFromPom(String attributeName)
+            throws ServerException, ForbiddenException, IOException, XMLTreeException, ValueStorageException {
+        String value = "";
+        final Model model = readModel(projectFolder);
+        if (attributeName.equals(ARTIFACT_ID)) {
+            value = model.getArtifactId();
+        } else if (attributeName.equals(GROUP_ID)) {
+            value = model.getGroupId();
+        } else if (attributeName.equals(PACKAGING)) {
+            final String packaging = model.getPackaging();
+            value = packaging == null ? DEFAULT_PACKAGING : packaging;
+        } else if (attributeName.equals(VERSION)) {
+            value = model.getVersion();
+        } else if (attributeName.equals(PARENT_ARTIFACT_ID) && model.getParent() != null) {
+            value = model.getParent().getArtifactId();
+        } else if (attributeName.equals(PARENT_GROUP_ID) && model.getParent() != null) {
+            value = model.getParent().getGroupId();
+        } else if (attributeName.equals(PARENT_VERSION) && model.getParent() != null) {
+            value = model.getParent().getVersion();
+        } else if (attributeName.equals(SOURCE_FOLDER)) {
+            Build build = model.getBuild();
+            if (build != null && build.getSourceDirectory() != null) {
+                value = build.getSourceDirectory();
+            } else {
+                value = DEFAULT_SOURCE_FOLDER;
+            }
+        } else if (attributeName.equals(TEST_SOURCE_FOLDER)) {
+            Build build = model.getBuild();
+            if (build != null && build.getTestSourceDirectory() != null) {
+                value = build.getTestSourceDirectory();
+            } else {
+                value = DEFAULT_TEST_SOURCE_FOLDER;
+            }
+        } else if (attributeName.equals(RESOURCE_FOLDER)) {
+            Build build = model.getBuild();
+            if (build != null && build.getResources() != null) {
+                return build.getResources().stream().map(Resource::getDirectory).collect(Collectors.toList());
+            } else {
+                return Arrays.asList(DEFAULT_RESOURCES_FOLDER, DEFAULT_TEST_RESOURCES_FOLDER);
+            }
+        }
+
+        return Collections.singletonList(value);
+    }
+
+    protected Model readModel(FolderEntry projectFolder) throws ValueStorageException, ServerException, ForbiddenException, IOException {
+        FileEntry pomFile = (FileEntry)projectFolder.getChild("pom.xml");
+        if (pomFile == null) {
+            throw new ValueStorageException("pom.xml does not exist.");
+        }
+        return Model.readFrom(pomFile.getInputStream());
+    }
+
+    protected void throwReadException(Exception e) throws ValueStorageException {
+        throw new ValueStorageException("Can't read pom.xml : " + e.getMessage());
+    }
+
+}

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProviderFactory.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProviderFactory.java
@@ -10,120 +10,25 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.maven.server.projecttype;
 
-import org.eclipse.che.api.core.ForbiddenException;
-import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.project.server.FileEntry;
 import org.eclipse.che.api.project.server.FolderEntry;
-import org.eclipse.che.api.project.server.type.ReadonlyValueProvider;
 import org.eclipse.che.api.project.server.type.ValueProvider;
 import org.eclipse.che.api.project.server.type.ValueProviderFactory;
-import org.eclipse.che.api.project.server.type.ValueStorageException;
-import org.eclipse.che.commons.xml.XMLTreeException;
-import org.eclipse.che.ide.maven.tools.Build;
-import org.eclipse.che.ide.maven.tools.Model;
-import org.eclipse.che.ide.maven.tools.Resource;
+import org.eclipse.che.plugin.maven.server.core.MavenProjectManager;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.eclipse.che.ide.ext.java.shared.Constants.SOURCE_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.ARTIFACT_ID;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_RESOURCES_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_SOURCE_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.GROUP_ID;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PACKAGING;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PARENT_ARTIFACT_ID;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PARENT_GROUP_ID;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.PARENT_VERSION;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.RESOURCE_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.TEST_SOURCE_FOLDER;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.VERSION;
+import javax.inject.Inject;
 
 /**
  * @author Evgen Vidolob
  */
 public class MavenValueProviderFactory implements ValueProviderFactory {
 
-    protected Model readModel(FolderEntry projectFolder) throws ValueStorageException, ServerException, ForbiddenException, IOException {
-        FileEntry pomFile = (FileEntry)projectFolder.getChild("pom.xml");
-        if (pomFile == null) {
-            throw new ValueStorageException("pom.xml does not exist.");
-        }
-        return Model.readFrom(pomFile.getInputStream());
-    }
+    @Inject
+    MavenProjectManager mavenProjectManager;
 
-    protected void throwReadException(Exception e) throws ValueStorageException {
-        throw new ValueStorageException("Can't read pom.xml : " + e.getMessage());
-    }
 
     @Override
     public ValueProvider newInstance(FolderEntry projectFolder) {
-        return new MavenValueProvider(projectFolder);
+        return new MavenValueProvider(mavenProjectManager, projectFolder);
     }
 
-    protected class MavenValueProvider extends ReadonlyValueProvider {
-
-        protected FolderEntry projectFolder;
-
-        protected MavenValueProvider(FolderEntry projectFolder) {
-            this.projectFolder = projectFolder;
-        }
-
-        @Override
-        public List<String> getValues(String attributeName) throws ValueStorageException {
-            try {
-                String value = "";
-                final Model model = readModel(projectFolder);
-                if (attributeName.equals(ARTIFACT_ID)) {
-                    value = model.getArtifactId();
-                } else if (attributeName.equals(GROUP_ID)) {
-                    value = model.getGroupId();
-                } else if (attributeName.equals(PACKAGING)) {
-                    final String packaging = model.getPackaging();
-                    value = packaging == null ? "" : packaging;
-                } else if (attributeName.equals(VERSION)) {
-                    value = model.getVersion();
-                } else if (attributeName.equals(PARENT_ARTIFACT_ID) && model.getParent() != null) {
-                    value = model.getParent().getArtifactId();
-                } else if (attributeName.equals(PARENT_GROUP_ID) && model.getParent() != null) {
-                    value = model.getParent().getGroupId();
-                } else if (attributeName.equals(PARENT_VERSION) && model.getParent() != null) {
-                    value = model.getParent().getVersion();
-                } else if (attributeName.equals(SOURCE_FOLDER)) {
-                    Build build = model.getBuild();
-                    if (build != null && build.getSourceDirectory() != null) {
-                        value = build.getSourceDirectory();
-                    } else {
-                        value = DEFAULT_SOURCE_FOLDER;
-                    }
-                } else if (attributeName.equals(TEST_SOURCE_FOLDER)) {
-                    Build build = model.getBuild();
-                    if (build != null && build.getTestSourceDirectory() != null) {
-                        value = build.getTestSourceDirectory();
-                    } else {
-                        value = DEFAULT_TEST_SOURCE_FOLDER;
-                    }
-                } else if (attributeName.equals(RESOURCE_FOLDER)) {
-                    Build build = model.getBuild();
-                    if (build != null && build.getResources() != null) {
-                        return build.getResources().stream().map(Resource::getDirectory).collect(Collectors.toList());
-                    } else {
-                        return Arrays.asList(DEFAULT_RESOURCES_FOLDER, DEFAULT_TEST_RESOURCES_FOLDER);
-                    }
-                }
-
-                return Collections.singletonList(value);
-            } catch (ServerException | ForbiddenException | IOException e) {
-                throwReadException(e);
-            } catch (XMLTreeException e) {
-                throw new ValueStorageException("Error parsing pom.xml : " + e.getMessage());
-            }
-            return null;
-        }
-    }
 }

--- a/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProviderTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProviderTest.java
@@ -1,0 +1,404 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.maven.server.projecttype;
+
+import org.eclipse.che.api.project.server.FileEntry;
+import org.eclipse.che.api.project.server.FolderEntry;
+import org.eclipse.che.api.vfs.Path;
+import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.ide.ext.java.shared.Constants;
+import org.eclipse.che.maven.data.MavenKey;
+import org.eclipse.che.plugin.maven.server.core.MavenProjectManager;
+import org.eclipse.che.plugin.maven.server.core.project.MavenProject;
+import org.eclipse.che.plugin.maven.shared.MavenAttributes;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vitalii Parfonov
+ */
+
+@Listeners(value = {MockitoTestNGListener.class})
+public class MavenValueProviderTest {
+
+    String pomContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" +
+                        "    <parent>\n" +
+                        "        <artifactId>che-plugin-parent</artifactId>\n" +
+                        "        <groupId>org.eclipse.che.plugin</groupId>\n" +
+                        "        <version>5.0.0-SNAPSHOT</version>\n" +
+                        "    </parent>" +
+                        "    <modelVersion>4.0.0</modelVersion>\n" +
+                        "    <groupId>my_group</groupId>\n" +
+                        "    <artifactId>my_artifact</artifactId>\n" +
+                        "    <version>1.0-SNAPSHOT</version>\n" +
+                        "    <packaging>jar</packaging>\n" +
+                        "    <build>\n" +
+                        "        <sourceDirectory>src</sourceDirectory>" +
+                        "        <testSourceDirectory>test</testSourceDirectory>" +
+                        "     </build>\n" +
+                        "</project>";
+
+    @Mock
+    private MavenProjectManager mavenProjectManager;
+    @Mock
+    private FolderEntry folderEntry;
+    @Mock
+    private MavenProject mavenProject;
+    @Mock
+    private MavenKey mavenKey;
+    @Mock
+    private MavenKey parentKey;
+
+    private MavenValueProvider mavenValueProvider;
+    private String x;
+
+
+    @BeforeMethod
+    public void setUp() {
+        final String path = getClass().getClassLoader().getResource("").getPath();
+        x = path + "/FirstProject";
+        System.out.println(x);
+        when(folderEntry.getPath()).thenReturn(Path.of(path + "/FirstProject"));
+        when(mavenProject.getMavenKey()).thenReturn(mavenKey);
+        when(mavenProject.getParentKey()).thenReturn(parentKey);
+        mavenValueProvider = new MavenValueProvider(mavenProjectManager, folderEntry);
+    }
+
+
+    @Test
+    public void getArtifactIdFromMavenProject() throws Exception {
+        String artifactId = NameGenerator.generate("artifactId-", 6);
+        when(mavenKey.getArtifactId()).thenReturn(artifactId);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> artifactIds = mavenValueProvider.getValues(MavenAttributes.ARTIFACT_ID);
+        Assert.assertNotNull(artifactIds);
+        Assert.assertFalse(artifactIds.isEmpty());
+        Assert.assertEquals(artifactIds.size(), 1);
+        Assert.assertNotNull(artifactIds.get(0));
+        Assert.assertEquals(artifactIds.get(0), artifactId);
+    }
+
+
+    @Test
+    public void getGroupIdFromMavenProject() throws Exception {
+        String groupId = NameGenerator.generate("groupId-", 6);
+        when(mavenKey.getGroupId()).thenReturn(groupId);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> groupIds = mavenValueProvider.getValues(MavenAttributes.GROUP_ID);
+        Assert.assertNotNull(groupIds);
+        Assert.assertFalse(groupIds.isEmpty());
+        Assert.assertEquals(groupIds.size(), 1);
+        Assert.assertNotNull(groupIds.get(0));
+        Assert.assertEquals(groupIds.get(0), groupId);
+    }
+
+
+    @Test
+    public void getVersionFromMavenProject() throws Exception {
+        String versionId = NameGenerator.generate("version-", 6);
+        when(mavenKey.getVersion()).thenReturn(versionId);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.VERSION);
+        Assert.assertNotNull(versions);
+        Assert.assertFalse(versions.isEmpty());
+        Assert.assertEquals(versions.size(), 1);
+        Assert.assertNotNull(versions.get(0));
+        Assert.assertEquals(versions.get(0), versionId);
+    }
+
+
+    @Test
+    public void getPackagingFromMavenProject() throws Exception {
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        when(mavenProject.getPackaging()).thenReturn("war");
+        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        Assert.assertNotNull(pkgs);
+        Assert.assertFalse(pkgs.isEmpty());
+        Assert.assertEquals(pkgs.size(), 1);
+        Assert.assertNotNull(pkgs.get(0));
+        Assert.assertEquals(pkgs.get(0), "war");
+    }
+
+    @Test
+    public void getPackagingFromMavenProjectIfNotSet() throws Exception {
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        Assert.assertNotNull(pkgs);
+        Assert.assertFalse(pkgs.isEmpty());
+        Assert.assertEquals(pkgs.size(), 1);
+        Assert.assertNotNull(pkgs.get(0));
+        Assert.assertEquals(pkgs.get(0), "jar");
+    }
+
+
+    @Test
+    public void getParentArtifactFromMavenProject() throws Exception {
+        String parentArtifact = NameGenerator.generate("parentArtifact", 6);
+        when(parentKey.getArtifactId()).thenReturn(parentArtifact);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_ARTIFACT_ID);
+        Assert.assertNotNull(values);
+        Assert.assertFalse(values.isEmpty());
+        Assert.assertEquals(values.size(), 1);
+        Assert.assertNotNull(values.get(0));
+        Assert.assertEquals(values.get(0), parentArtifact);
+    }
+
+
+    @Test
+    public void getParentVersionFromMavenProject() throws Exception {
+        String parentVersionId = NameGenerator.generate("parent-version-", 6);
+        when(parentKey.getVersion()).thenReturn(parentVersionId);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.PARENT_VERSION);
+        Assert.assertNotNull(versions);
+        Assert.assertFalse(versions.isEmpty());
+        Assert.assertEquals(versions.size(), 1);
+        Assert.assertNotNull(versions.get(0));
+        Assert.assertEquals(versions.get(0), parentVersionId);
+    }
+
+    @Test
+    public void getParentGroupFromMavenProject() throws Exception {
+        String groupId = NameGenerator.generate("parent-group-", 6);
+        when(parentKey.getGroupId()).thenReturn(groupId);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_GROUP_ID);
+        Assert.assertNotNull(values);
+        Assert.assertFalse(values.isEmpty());
+        Assert.assertEquals(values.size(), 1);
+        Assert.assertNotNull(values.get(0));
+        Assert.assertEquals(values.get(0), groupId);
+    }
+
+    @Test
+    public void getSourceFromMavenProject() throws Exception {
+        final List<String> strings = Collections.singletonList("src");
+        when(mavenProject.getSources()).thenReturn(strings);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, strings);
+    }
+
+    @Test
+    public void getSourceFromMavenProjectIfNotSet() throws Exception {
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, Arrays.asList(MavenAttributes.DEFAULT_SOURCE_FOLDER));
+    }
+
+    @Test
+    public void getTestSourceFromMavenProject() throws Exception {
+        final List<String> strings = Collections.singletonList("src/test");
+        when(mavenProject.getTestSources()).thenReturn(strings);
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, strings);
+    }
+
+    @Test
+    public void getTestSourceFromMavenProjectIfNotSet() throws Exception {
+        when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
+        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        verify(mavenProjectManager).getMavenProject(anyString());
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, Arrays.asList(MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER));
+    }
+
+
+    @Test
+    public void getArtifactIdFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> artifactIds = mavenValueProvider.getValues(MavenAttributes.ARTIFACT_ID);
+        Assert.assertNotNull(artifactIds);
+        Assert.assertFalse(artifactIds.isEmpty());
+        Assert.assertEquals(artifactIds.size(), 1);
+        Assert.assertNotNull(artifactIds.get(0));
+        Assert.assertEquals(artifactIds.get(0), "my_artifact");
+    }
+
+
+    @Test
+    public void getGroupIdFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> groupIds = mavenValueProvider.getValues(MavenAttributes.GROUP_ID);
+        Assert.assertNotNull(groupIds);
+        Assert.assertFalse(groupIds.isEmpty());
+        Assert.assertEquals(groupIds.size(), 1);
+        Assert.assertNotNull(groupIds.get(0));
+        Assert.assertEquals(groupIds.get(0), "my_group");
+    }
+
+
+    @Test
+    public void getVersionFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.VERSION);
+        Assert.assertNotNull(versions);
+        Assert.assertFalse(versions.isEmpty());
+        Assert.assertEquals(versions.size(), 1);
+        Assert.assertNotNull(versions.get(0));
+        Assert.assertEquals(versions.get(0), "1.0-SNAPSHOT");
+    }
+
+
+    @Test
+    public void getPackagingFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        Assert.assertNotNull(pkgs);
+        Assert.assertFalse(pkgs.isEmpty());
+        Assert.assertEquals(pkgs.size(), 1);
+        Assert.assertNotNull(pkgs.get(0));
+        Assert.assertEquals(pkgs.get(0), "jar");
+    }
+
+    @Test
+    public void getPackagingFromPomIfNotSet() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        Assert.assertNotNull(pkgs);
+        Assert.assertFalse(pkgs.isEmpty());
+        Assert.assertEquals(pkgs.size(), 1);
+        Assert.assertNotNull(pkgs.get(0));
+        Assert.assertEquals(pkgs.get(0), "jar");
+    }
+
+
+    @Test
+    public void getParentArtifactFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_ARTIFACT_ID);
+        Assert.assertNotNull(values);
+        Assert.assertFalse(values.isEmpty());
+        Assert.assertEquals(values.size(), 1);
+        Assert.assertNotNull(values.get(0));
+        Assert.assertEquals(values.get(0), "che-plugin-parent");
+    }
+
+
+    @Test
+    public void getParentVersionFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.PARENT_VERSION);
+        Assert.assertNotNull(versions);
+        Assert.assertFalse(versions.isEmpty());
+        Assert.assertEquals(versions.size(), 1);
+        Assert.assertNotNull(versions.get(0));
+        Assert.assertEquals(versions.get(0), "5.0.0-SNAPSHOT");
+    }
+
+    @Test
+    public void getParentGroupFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_GROUP_ID);
+        Assert.assertNotNull(values);
+        Assert.assertFalse(values.isEmpty());
+        Assert.assertEquals(values.size(), 1);
+        Assert.assertNotNull(values.get(0));
+        Assert.assertEquals(values.get(0), "org.eclipse.che.plugin");
+    }
+
+    @Test
+    public void getSourceFromPom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, Collections.singletonList("src"));
+    }
+
+    @Test
+    public void getSourceFromPomIfNotSet() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, Collections.singletonList(MavenAttributes.DEFAULT_SOURCE_FOLDER));
+    }
+
+    @Test
+    public void getTestSourcePom() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, Collections.singletonList("test"));
+    }
+
+    @Test
+    public void getTestSourceFromPomIfNotSet() throws Exception {
+        FileEntry fileEntry = mock(FileEntry.class);
+        final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
+        when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)));
+        when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
+        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        Assert.assertNotNull(sources);
+        Assert.assertFalse(sources.isEmpty());
+        Assert.assertEquals(sources.size(), 1);
+        Assert.assertEquals(sources, Collections.singletonList(MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER));
+    }
+
+}

--- a/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProviderTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/projecttype/MavenValueProviderTest.java
@@ -28,10 +28,9 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -74,15 +73,11 @@ public class MavenValueProviderTest {
     private MavenKey parentKey;
 
     private MavenValueProvider mavenValueProvider;
-    private String x;
 
 
     @BeforeMethod
     public void setUp() {
-        final String path = getClass().getClassLoader().getResource("").getPath();
-        x = path + "/FirstProject";
-        System.out.println(x);
-        when(folderEntry.getPath()).thenReturn(Path.of(path + "/FirstProject"));
+        when(folderEntry.getPath()).thenReturn(Path.of(""));
         when(mavenProject.getMavenKey()).thenReturn(mavenKey);
         when(mavenProject.getParentKey()).thenReturn(parentKey);
         mavenValueProvider = new MavenValueProvider(mavenProjectManager, folderEntry);
@@ -94,7 +89,7 @@ public class MavenValueProviderTest {
         String artifactId = NameGenerator.generate("artifactId-", 6);
         when(mavenKey.getArtifactId()).thenReturn(artifactId);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> artifactIds = mavenValueProvider.getValues(MavenAttributes.ARTIFACT_ID);
+        List<String> artifactIds = mavenValueProvider.getValues(MavenAttributes.ARTIFACT_ID);
         Assert.assertNotNull(artifactIds);
         Assert.assertFalse(artifactIds.isEmpty());
         Assert.assertEquals(artifactIds.size(), 1);
@@ -108,7 +103,7 @@ public class MavenValueProviderTest {
         String groupId = NameGenerator.generate("groupId-", 6);
         when(mavenKey.getGroupId()).thenReturn(groupId);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> groupIds = mavenValueProvider.getValues(MavenAttributes.GROUP_ID);
+        List<String> groupIds = mavenValueProvider.getValues(MavenAttributes.GROUP_ID);
         Assert.assertNotNull(groupIds);
         Assert.assertFalse(groupIds.isEmpty());
         Assert.assertEquals(groupIds.size(), 1);
@@ -122,7 +117,7 @@ public class MavenValueProviderTest {
         String versionId = NameGenerator.generate("version-", 6);
         when(mavenKey.getVersion()).thenReturn(versionId);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.VERSION);
+        List<String> versions = mavenValueProvider.getValues(MavenAttributes.VERSION);
         Assert.assertNotNull(versions);
         Assert.assertFalse(versions.isEmpty());
         Assert.assertEquals(versions.size(), 1);
@@ -135,7 +130,7 @@ public class MavenValueProviderTest {
     public void getPackagingFromMavenProject() throws Exception {
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
         when(mavenProject.getPackaging()).thenReturn("war");
-        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
         Assert.assertNotNull(pkgs);
         Assert.assertFalse(pkgs.isEmpty());
         Assert.assertEquals(pkgs.size(), 1);
@@ -146,7 +141,7 @@ public class MavenValueProviderTest {
     @Test
     public void getPackagingFromMavenProjectIfNotSet() throws Exception {
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
         Assert.assertNotNull(pkgs);
         Assert.assertFalse(pkgs.isEmpty());
         Assert.assertEquals(pkgs.size(), 1);
@@ -160,7 +155,7 @@ public class MavenValueProviderTest {
         String parentArtifact = NameGenerator.generate("parentArtifact", 6);
         when(parentKey.getArtifactId()).thenReturn(parentArtifact);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_ARTIFACT_ID);
+        List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_ARTIFACT_ID);
         Assert.assertNotNull(values);
         Assert.assertFalse(values.isEmpty());
         Assert.assertEquals(values.size(), 1);
@@ -174,7 +169,7 @@ public class MavenValueProviderTest {
         String parentVersionId = NameGenerator.generate("parent-version-", 6);
         when(parentKey.getVersion()).thenReturn(parentVersionId);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.PARENT_VERSION);
+        List<String> versions = mavenValueProvider.getValues(MavenAttributes.PARENT_VERSION);
         Assert.assertNotNull(versions);
         Assert.assertFalse(versions.isEmpty());
         Assert.assertEquals(versions.size(), 1);
@@ -187,7 +182,7 @@ public class MavenValueProviderTest {
         String groupId = NameGenerator.generate("parent-group-", 6);
         when(parentKey.getGroupId()).thenReturn(groupId);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_GROUP_ID);
+        List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_GROUP_ID);
         Assert.assertNotNull(values);
         Assert.assertFalse(values.isEmpty());
         Assert.assertEquals(values.size(), 1);
@@ -197,10 +192,10 @@ public class MavenValueProviderTest {
 
     @Test
     public void getSourceFromMavenProject() throws Exception {
-        final List<String> strings = Collections.singletonList("src");
+        final List<String> strings = singletonList("src");
         when(mavenProject.getSources()).thenReturn(strings);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
@@ -210,19 +205,19 @@ public class MavenValueProviderTest {
     @Test
     public void getSourceFromMavenProjectIfNotSet() throws Exception {
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
-        Assert.assertEquals(sources, Arrays.asList(MavenAttributes.DEFAULT_SOURCE_FOLDER));
+        Assert.assertEquals(sources, singletonList(MavenAttributes.DEFAULT_SOURCE_FOLDER));
     }
 
     @Test
     public void getTestSourceFromMavenProject() throws Exception {
-        final List<String> strings = Collections.singletonList("src/test");
+        List<String> strings = singletonList("src/test");
         when(mavenProject.getTestSources()).thenReturn(strings);
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
@@ -232,12 +227,12 @@ public class MavenValueProviderTest {
     @Test
     public void getTestSourceFromMavenProjectIfNotSet() throws Exception {
         when(mavenProjectManager.getMavenProject(anyString())).thenReturn(mavenProject);
-        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
         verify(mavenProjectManager).getMavenProject(anyString());
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
-        Assert.assertEquals(sources, Arrays.asList(MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER));
+        Assert.assertEquals(sources, singletonList(MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER));
     }
 
 
@@ -246,7 +241,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> artifactIds = mavenValueProvider.getValues(MavenAttributes.ARTIFACT_ID);
+        List<String> artifactIds = mavenValueProvider.getValues(MavenAttributes.ARTIFACT_ID);
         Assert.assertNotNull(artifactIds);
         Assert.assertFalse(artifactIds.isEmpty());
         Assert.assertEquals(artifactIds.size(), 1);
@@ -260,7 +255,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> groupIds = mavenValueProvider.getValues(MavenAttributes.GROUP_ID);
+        List<String> groupIds = mavenValueProvider.getValues(MavenAttributes.GROUP_ID);
         Assert.assertNotNull(groupIds);
         Assert.assertFalse(groupIds.isEmpty());
         Assert.assertEquals(groupIds.size(), 1);
@@ -274,7 +269,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.VERSION);
+        List<String> versions = mavenValueProvider.getValues(MavenAttributes.VERSION);
         Assert.assertNotNull(versions);
         Assert.assertFalse(versions.isEmpty());
         Assert.assertEquals(versions.size(), 1);
@@ -288,7 +283,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
         Assert.assertNotNull(pkgs);
         Assert.assertFalse(pkgs.isEmpty());
         Assert.assertEquals(pkgs.size(), 1);
@@ -299,10 +294,10 @@ public class MavenValueProviderTest {
     @Test
     public void getPackagingFromPomIfNotSet() throws Exception {
         FileEntry fileEntry = mock(FileEntry.class);
-        final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
+        String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
+        List<String> pkgs = mavenValueProvider.getValues(MavenAttributes.PACKAGING);
         Assert.assertNotNull(pkgs);
         Assert.assertFalse(pkgs.isEmpty());
         Assert.assertEquals(pkgs.size(), 1);
@@ -316,7 +311,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_ARTIFACT_ID);
+        List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_ARTIFACT_ID);
         Assert.assertNotNull(values);
         Assert.assertFalse(values.isEmpty());
         Assert.assertEquals(values.size(), 1);
@@ -330,7 +325,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> versions = mavenValueProvider.getValues(MavenAttributes.PARENT_VERSION);
+        List<String> versions = mavenValueProvider.getValues(MavenAttributes.PARENT_VERSION);
         Assert.assertNotNull(versions);
         Assert.assertFalse(versions.isEmpty());
         Assert.assertEquals(versions.size(), 1);
@@ -343,7 +338,7 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_GROUP_ID);
+        List<String> values = mavenValueProvider.getValues(MavenAttributes.PARENT_GROUP_ID);
         Assert.assertNotNull(values);
         Assert.assertFalse(values.isEmpty());
         Assert.assertEquals(values.size(), 1);
@@ -356,24 +351,24 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
-        Assert.assertEquals(sources, Collections.singletonList("src"));
+        Assert.assertEquals(sources, singletonList("src"));
     }
 
     @Test
     public void getSourceFromPomIfNotSet() throws Exception {
         FileEntry fileEntry = mock(FileEntry.class);
-        final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
+        String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(Constants.SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
-        Assert.assertEquals(sources, Collections.singletonList(MavenAttributes.DEFAULT_SOURCE_FOLDER));
+        Assert.assertEquals(sources, singletonList(MavenAttributes.DEFAULT_SOURCE_FOLDER));
     }
 
     @Test
@@ -381,24 +376,24 @@ public class MavenValueProviderTest {
         FileEntry fileEntry = mock(FileEntry.class);
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pomContent.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
-        Assert.assertEquals(sources, Collections.singletonList("test"));
+        Assert.assertEquals(sources, singletonList("test"));
     }
 
     @Test
     public void getTestSourceFromPomIfNotSet() throws Exception {
         FileEntry fileEntry = mock(FileEntry.class);
-        final String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
+        String pom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><project></project>";
         when(fileEntry.getInputStream()).thenReturn(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)));
         when(folderEntry.getChild(anyString())).thenReturn(fileEntry);
-        final List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
+        List<String> sources = mavenValueProvider.getValues(MavenAttributes.TEST_SOURCE_FOLDER);
         Assert.assertNotNull(sources);
         Assert.assertFalse(sources.isEmpty());
         Assert.assertEquals(sources.size(), 1);
-        Assert.assertEquals(sources, Collections.singletonList(MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER));
+        Assert.assertEquals(sources, singletonList(MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER));
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>

### What does this PR do?
Fix dependency  on che-plugin-pullrequest-server in should be only in ws-agent.
Improve maven attribute resolving previous we always read them from pom.xml but MavenProjectManager already has all information about registered projects, in case we not found given project we still goto parse pom.xml
### What issues does this PR fix or reference?
#4910 

#### Changelog
Fix catching exception in case invalid POM to prevent fail start workspace 

#### Release Notes
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
