### PR TITLE
CHE-4826: Do not display external operation event for opened files at remove resource

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -587,7 +587,7 @@ public final class ResourceManager {
 
             if (descToRemove != null) {
                 for (Resource toRemove : descToRemove) {
-                    if (isResourceOpened(resource)) {
+                    if (isResourceOpened(toRemove)) {
                         deletedFilesController.add(toRemove.getLocation().toString());
                     }
 


### PR DESCRIPTION
### What does this PR do?
Correctly handle list of opened files at remove resource to avoid displaying external operation event 

### What issues does this PR fix or reference?
#4826

#### Changelog
Do not display external operation event for opened files at remove resource
