### PR TITLE
Revert WorkspaceFilesCleaner binding

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -174,8 +174,7 @@ public class WsMasterModule extends AbstractModule {
         requestInjection(interceptor);
         bindInterceptor(subclassesOf(CheJsonProvider.class), names("readFrom"), interceptor);
         bind(org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner.class)
-                  .to(org.eclipse.che.plugin.openshift.client.OpenShiftWorkspaceFilesCleaner.class);
-//                .to(org.eclipse.che.plugin.docker.machine.cleaner.LocalWorkspaceFilesCleaner.class);
+                .to(org.eclipse.che.plugin.docker.machine.cleaner.LocalWorkspaceFilesCleaner.class);
 
         bind(org.eclipse.che.api.environment.server.InfrastructureProvisioner.class)
                 .to(org.eclipse.che.plugin.docker.machine.local.LocalCheInfrastructureProvisioner.class);


### PR DESCRIPTION
### What does this PR do?

Binds `WorkspaceFilesCleaner` to `LocalWorkspaceFilesCleaner` instead of `OpenShiftWorkspaceFilesCleaner.class` (the same as `master` branch).
We are reverting what was done in f3a9123be9f3e963635392a70cd4e01628913633 since that has been superseded by https://github.com/redhat-developer/rh-che/pull/57

