### PR TITLE
Support for multiple highlights

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
@@ -204,10 +204,9 @@ public class TextDocumentServiceClient {
      * @param params
      * @return a {@link Promise} of an array of {@link DocumentHighlight} which will be computed by the language server.
      */
-    public Promise<DocumentHighlight> documentHighlight(TextDocumentPositionParams params) {
-        return transmitDtoAndReceiveDto(params, "textDocument/documentHighlight", DocumentHighlight.class);
+    public Promise<List<DocumentHighlight>> documentHighlight(TextDocumentPositionParams params) {
+        return transmitDtoAndReceiveDtoList(params, "textDocument/documentHighlight", DocumentHighlight.class);
     }
-
 
     public Promise<List<Command>> codeAction(CodeActionParams params) {
         return transmitDtoAndReceiveDtoList(params, "textDocument/codeAction", Command.class);


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>
### What does this PR do?
This PR adds support for multiple document highlights in LSP based editors. It also fixes incorrect handling of line/char based text positions. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4343

#### Changelog
Added support for showing multiple document highlights in LSP based editors.

#### Release Notes
N/A

#### Docs PR
N/A
