### PR TITLE
CHE-4768. Fix receiving file tracking operation calls from client at refactoring

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventService.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventService.java
@@ -10,56 +10,53 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.event.ng;
 
-import com.google.web.bindery.event.shared.EventBus;
-
-import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
-import org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto;
-import org.eclipse.che.ide.dto.DtoFactory;
-import org.eclipse.che.ide.util.loging.Log;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import org.eclipse.che.api.promises.client.Promise;
 
 /**
- * @author Dmitry Kuleshov
+ * Send file tracking operation calls on server side. There are several types of such calls:
+ * <ul>
+ *     <li>
+ *         START/STOP - tells to start/stop tracking specific file
+ *     </li>
+ *     <li>
+ *         SUSPEND/RESUME - tells to start/stop tracking all files registered for specific endpoint
+ *     </li>
+ *     <li>
+ *         MOVE - tells that file that is being tracked should be moved (renamed)
+ *     </li>
+ * </ul>
  */
-@Singleton
-public class ClientServerEventService {
-    private final DtoFactory         dtoFactory;
-    private final RequestTransmitter requestTransmitter;
+public interface ClientServerEventService {
 
-    @Inject
-    public ClientServerEventService(EventBus eventBus, DtoFactory dtoFactory, RequestTransmitter requestTransmitter) {
-        this.dtoFactory = dtoFactory;
-        this.requestTransmitter = requestTransmitter;
+    /**
+     * Sends event on server side which tells to start tracking specific file
+     *
+     * @param path
+     *         the path to the specific file
+     */
+    Promise<Void> sendFileTrackingStartEvent(String path);
 
-        Log.debug(getClass(), "Adding file event listener");
-        eventBus.addHandler(FileTrackingEvent.TYPE, new FileTrackingEvent.FileTrackingEventHandler() {
-            @Override
-            public void onEvent(FileTrackingEvent event) {
-                final FileTrackingOperationDto.Type type = event.getType();
-                final String path = event.getPath();
-                final String oldPath = event.getOldPath();
+    /**
+     * Sends event on server side which tells to stop tracking specific file
+     *
+     * @param path
+     *         the path to the specific file
+     */
+    Promise<Void> sendFileTrackingStopEvent(String path);
 
-                transmit(path, oldPath, type);
-            }
-        });
-    }
+    /** Sends event on server side which tells to suspend tracking all files registered for specific endpoint */
+    Promise<Void> sendFileTrackingSuspendEvent();
 
-    private void transmit(String path, String oldPath, FileTrackingOperationDto.Type type) {
-        final String endpointId = "ws-agent";
-        final String method = "track:editor-file";
-        final FileTrackingOperationDto dto = dtoFactory.createDto(FileTrackingOperationDto.class)
-                                                       .withPath(path)
-                                                       .withType(type)
-                                                       .withOldPath(oldPath);
+    /** Sends event on server side which tells to resume tracking all files registered for specific endpoint */
+    Promise<Void> sendFileTrackingResumeEvent();
 
-
-        requestTransmitter.newRequest()
-                          .endpointId(endpointId)
-                          .methodName(method)
-                          .paramsAsDto(dto)
-                          .sendAndSkipResult();
-
-    }
+    /**
+     * Sends event on server side which tells file that is being tracked should be moved (renamed)
+     *
+     * @param oldPath
+     *         the old path to the specific file
+     * @param newPath
+     *         the new path to the specific file
+     */
+    Promise<Void> sendFileTrackingMoveEvent(String oldPath, String newPath);
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventServiceImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventServiceImpl.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.event.ng;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.dto.DtoFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.MOVE;
+import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.RESUME;
+import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.START;
+import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.STOP;
+import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.SUSPEND;
+
+/**
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class ClientServerEventServiceImpl implements ClientServerEventService {
+    private static final String ENDPOINT_ID      = "ws-agent";
+    private static final String OUTCOMING_METHOD = "track:editor-file";
+
+    private final DtoFactory         dtoFactory;
+    private final RequestTransmitter requestTransmitter;
+    private final PromiseProvider    promises;
+
+    @Inject
+    public ClientServerEventServiceImpl(DtoFactory dtoFactory,
+                                        RequestTransmitter requestTransmitter,
+                                        PromiseProvider promises) {
+        this.dtoFactory = dtoFactory;
+        this.requestTransmitter = requestTransmitter;
+        this.promises = promises;
+    }
+
+    @Override
+    public Promise<Void> sendFileTrackingStartEvent(String path) {
+        return transmit(path, "", START);
+    }
+
+    @Override
+    public Promise<Void> sendFileTrackingStopEvent(String path) {
+        return transmit(path, "", STOP);
+    }
+
+    @Override
+    public Promise<Void> sendFileTrackingSuspendEvent() {
+        return transmit("", "", SUSPEND);
+    }
+
+    @Override
+    public Promise<Void> sendFileTrackingResumeEvent() {
+        return transmit("", "", RESUME);
+    }
+
+    @Override
+    public Promise<Void> sendFileTrackingMoveEvent(String oldPath, String newPath) {
+        return transmit(oldPath, newPath, MOVE);
+    }
+
+    private Promise<Void> transmit(String path, String oldPath, FileTrackingOperationDto.Type type) {
+        final FileTrackingOperationDto dto = dtoFactory.createDto(FileTrackingOperationDto.class)
+                                                       .withPath(path)
+                                                       .withType(type)
+                                                       .withOldPath(oldPath);
+        return promises.create((AsyncCallback<Void> callback) -> {
+            JsonRpcPromise<Void> jsonRpcPromise = requestTransmitter.newRequest()
+                                                                    .endpointId(ENDPOINT_ID)
+                                                                    .methodName(OUTCOMING_METHOD)
+                                                                    .paramsAsDto(dto)
+                                                                    .sendAndReceiveResultAsEmpty();
+            jsonRpcPromise.onSuccess(aVoid -> {
+                callback.onSuccess(null);
+            });
+
+            jsonRpcPromise.onFailure(jsonRpcError -> {
+                callback.onFailure(new Throwable(jsonRpcError.getMessage()));
+            });
+        });
+    }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileOpenCloseEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileOpenCloseEventListener.java
@@ -24,9 +24,6 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.Objects;
 
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingStartEvent;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingStopEvent;
-
 /**
  * File open/close event listener aimed to wrap {@link FileEvent} into {@link FileTrackingEvent}
  * which is consumed by {@link ClientServerEventService} and sent to server side for further
@@ -39,8 +36,8 @@ public class FileOpenCloseEventListener {
 
     @Inject
     public FileOpenCloseEventListener(final Provider<EditorAgent> editorAgentProvider,
-                                      final DeletedFilesController deletedFilesController,
-                                      final EventBus eventBus) {
+                                      final EventBus eventBus,
+                                      final ClientServerEventService clientServerEventService) {
 
         Log.debug(getClass(), "Adding file event listener");
         eventBus.addHandler(FileEvent.TYPE, new FileEvent.FileEventHandler() {
@@ -66,7 +63,7 @@ public class FileOpenCloseEventListener {
             }
 
             private void processFileOpen(Path path) {
-                eventBus.fireEvent(newFileTrackingStartEvent(path.toString()));
+                clientServerEventService.sendFileTrackingStartEvent(path.toString());
             }
 
             private void processFileClose(EditorPartPresenter closingEditor, List<EditorPartPresenter> openedEditors, Path path) {
@@ -77,8 +74,7 @@ public class FileOpenCloseEventListener {
                     }
                 }
 
-                eventBus.fireEvent(newFileTrackingStopEvent(path.toString()));
-
+                clientServerEventService.sendFileTrackingStopEvent(path.toString());
             }
         });
     }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileTrackingEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileTrackingEvent.java
@@ -26,7 +26,9 @@ import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperation
  * server side VFS file watching from client.
  *
  * @author Dmitry Kuleshov
+ * @deprecated use {@link ClientServerEventService} directly
  */
+@Deprecated
 public class FileTrackingEvent extends GwtEvent<FileTrackingEvent.FileTrackingEventHandler> {
 
     public static Type<FileTrackingEventHandler> TYPE = new Type<>();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ClientServerEventModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ClientServerEventModule.java
@@ -11,8 +11,10 @@
 package org.eclipse.che.ide.core;
 
 import com.google.gwt.inject.client.AbstractGinModule;
+import com.google.inject.Singleton;
 
 import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
+import org.eclipse.che.ide.api.event.ng.ClientServerEventServiceImpl;
 import org.eclipse.che.ide.api.event.ng.EditorFileStatusNotificationOperation;
 import org.eclipse.che.ide.api.event.ng.FileOpenCloseEventListener;
 import org.eclipse.che.ide.api.event.ng.ProjectTreeStateNotificationOperation;
@@ -27,7 +29,7 @@ public class ClientServerEventModule extends AbstractGinModule {
     @Override
     protected void configure() {
         bind(FileOpenCloseEventListener.class).asEagerSingleton();
-        bind(ClientServerEventService.class).asEagerSingleton();
+        bind(ClientServerEventService.class).to(ClientServerEventServiceImpl.class).in(Singleton.class);
 
         notificationOperations();
         requestFunctions();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.workspace.shared.dto.SourceStorageDto;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
 import org.eclipse.che.ide.api.event.ng.DeletedFilesController;
 import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.WsAgentURLModifier;
@@ -71,8 +72,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.copyOf;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingResumeEvent;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingSuspendEvent;
 import static org.eclipse.che.ide.api.resources.Resource.FILE;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.ADDED;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.COPIED_FROM;
@@ -130,24 +129,25 @@ public final class ResourceManager {
 
     private static final Resource[] NO_RESOURCES = new Resource[0];
 
-    private final ProjectServiceClient   ps;
-    private final EventBus               eventBus;
-    private final EditorAgent            editorAgent;
-    private final DeletedFilesController deletedFilesController;
-    private final ResourceFactory        resourceFactory;
-    private final PromiseProvider        promises;
-    private final DtoFactory             dtoFactory;
-    private final ProjectTypeRegistry    typeRegistry;
+    private final ProjectServiceClient     ps;
+    private final EventBus                 eventBus;
+    private final EditorAgent              editorAgent;
+    private final DeletedFilesController   deletedFilesController;
+    private final ResourceFactory          resourceFactory;
+    private final PromiseProvider          promises;
+    private final DtoFactory               dtoFactory;
+    private final ProjectTypeRegistry      typeRegistry;
     /**
      * Link to the workspace content root. Immutable among the workspace life.
      */
-    private final Container              workspaceRoot;
-    private final WsAgentURLModifier     urlModifier;
-    private       DevMachine             devMachine;
+    private final Container                workspaceRoot;
+    private final WsAgentURLModifier       urlModifier;
+    private final ClientServerEventService clientServerEventService;
+    private       DevMachine               devMachine;
     /**
      * Internal store, which caches requested resources from the server.
      */
-    private       ResourceStore          store;
+    private       ResourceStore            store;
 
     /**
      * Cached dto project configuration.
@@ -165,7 +165,8 @@ public final class ResourceManager {
                            DtoFactory dtoFactory,
                            ProjectTypeRegistry typeRegistry,
                            ResourceStore store,
-                           WsAgentURLModifier urlModifier) {
+                           WsAgentURLModifier urlModifier,
+                           ClientServerEventService clientServerEventService) {
         this.devMachine = devMachine;
         this.ps = ps;
         this.eventBus = eventBus;
@@ -177,6 +178,7 @@ public final class ResourceManager {
         this.typeRegistry = typeRegistry;
         this.store = store;
         this.urlModifier = urlModifier;
+        this.clientServerEventService = clientServerEventService;
 
         this.workspaceRoot = resourceFactory.newFolderImpl(Path.ROOT, this);
     }
@@ -492,51 +494,54 @@ public final class ResourceManager {
                 deletedFilesController.add(source.getLocation().toString());
             }
 
-            eventBus.fireEvent(newFileTrackingSuspendEvent());
+            return clientServerEventService.sendFileTrackingSuspendEvent().thenPromise(success -> {
+                store.dispose(source.getLocation(), !source.isFile()); //TODO: need to be tested
 
-            store.dispose(source.getLocation(), !source.isFile()); //TODO: need to be tested
+                return ps.move(source.getLocation(), destination.parent(), destination.lastSegment(), force)
+                         .thenPromise(ignored -> {
+                             if (source.isProject() && source.getLocation().segmentCount() == 1) {
+                                 return ps.getProjects().then((Function<List<ProjectConfigDto>, Resource>)updatedConfigs -> {
+                                     clientServerEventService.sendFileTrackingResumeEvent();
 
-            return ps.move(source.getLocation(), destination.parent(), destination.lastSegment(), force)
-                     .thenPromise(ignored -> {
-                         if (source.isProject() && source.getLocation().segmentCount() == 1) {
-                             return ps.getProjects().then((Function<List<ProjectConfigDto>, Resource>)updatedConfigs -> {
-                                 eventBus.fireEvent(newFileTrackingResumeEvent());
+                                     //cache new configs
+                                     cachedConfigs = updatedConfigs.toArray(new ProjectConfigDto[updatedConfigs.size()]);
+                                     store.dispose(source.getLocation(), true);
 
-                                 //cache new configs
-                                 cachedConfigs = updatedConfigs.toArray(new ProjectConfigDto[updatedConfigs.size()]);
-                                 store.dispose(source.getLocation(), true);
+                                     for (ProjectConfigDto projectConfigDto : cachedConfigs) {
+                                         if (projectConfigDto.getPath().equals(destination.toString())) {
+                                             final Project newResource =
+                                                     resourceFactory.newProjectImpl(projectConfigDto, ResourceManager.this);
+                                             store.register(newResource);
+                                             eventBus.fireEvent(new ResourceChangedEvent(new ResourceDeltaImpl(newResource, source,
+                                                                                                               ADDED | MOVED_FROM |
+                                                                                                               MOVED_TO |
+                                                                                                               DERIVED)));
 
-                                 for (ProjectConfigDto projectConfigDto : cachedConfigs) {
-                                     if (projectConfigDto.getPath().equals(destination.toString())) {
-                                         final Project newResource =
-                                                 resourceFactory.newProjectImpl(projectConfigDto, ResourceManager.this);
-                                         store.register(newResource);
-                                         eventBus.fireEvent(new ResourceChangedEvent(new ResourceDeltaImpl(newResource, source,
-                                                                                                           ADDED | MOVED_FROM |
-                                                                                                           MOVED_TO |
-                                                                                                           DERIVED)));
-
-                                         return newResource;
+                                             return newResource;
+                                         }
                                      }
+
+                                     throw new IllegalStateException("Resource not found");
+                                 });
+                             }
+
+                             return findResource(destination, false).then((Function<Optional<Resource>, Resource>)movedResource -> {
+                                 if (movedResource.isPresent()) {
+                                     eventBus.fireEvent(new ResourceChangedEvent(new ResourceDeltaImpl(movedResource.get(), source,
+                                                                                                       ADDED | MOVED_FROM |
+                                                                                                       MOVED_TO | DERIVED)));
+
+                                     clientServerEventService.sendFileTrackingResumeEvent();
+
+                                     return movedResource.get();
                                  }
+
+                                 clientServerEventService.sendFileTrackingResumeEvent();
 
                                  throw new IllegalStateException("Resource not found");
                              });
-                         }
-
-                         return findResource(destination, false).then((Function<Optional<Resource>, Resource>)movedResource -> {
-                             if (movedResource.isPresent()) {
-                                 eventBus.fireEvent(new ResourceChangedEvent(new ResourceDeltaImpl(movedResource.get(), source,
-                                                                                                   ADDED | MOVED_FROM |
-                                                                                                   MOVED_TO | DERIVED)));
-                                 eventBus.fireEvent(newFileTrackingResumeEvent());
-                                 return movedResource.get();
-                             }
-                             eventBus.fireEvent(newFileTrackingResumeEvent());
-
-                             throw new IllegalStateException("Resource not found");
                          });
-                     });
+            });
         });
     }
 

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -102,6 +102,7 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditorOperations;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditorPartView;
 import org.eclipse.che.ide.api.editor.texteditor.UndoableEditor;
 import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
+import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
 import org.eclipse.che.ide.api.event.ng.DeletedFilesController;
 import org.eclipse.che.ide.api.hotkeys.HasHotKeyItems;
 import org.eclipse.che.ide.api.hotkeys.HotKeyItem;
@@ -132,7 +133,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.Boolean.parseBoolean;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingStartEvent;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.ADDED;
@@ -175,16 +175,17 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
     private final EditorMultiPartStackPresenter          editorMultiPartStackPresenter;
     private final EditorLocalizationConstants            constant;
     private final EditorWidgetFactory<OrionEditorWidget> editorWidgetFactory;
-    private final EditorInitializePromiseHolder editorModule;
-    private final TextEditorPartView            editorView;
-    private final EventBus                      generalEventBus;
-    private final FileTypeIdentifier            fileTypeIdentifier;
-    private final QuickAssistantFactory         quickAssistantFactory;
-    private final WorkspaceAgent                workspaceAgent;
-    private final NotificationManager           notificationManager;
-    private final AppContext                    appContext;
-    private final SignatureHelpView             signatureHelpView;
-    private final EditorContextMenu             contextMenu;
+    private final EditorInitializePromiseHolder          editorModule;
+    private final TextEditorPartView                     editorView;
+    private final EventBus                               generalEventBus;
+    private final FileTypeIdentifier                     fileTypeIdentifier;
+    private final QuickAssistantFactory                  quickAssistantFactory;
+    private final WorkspaceAgent                         workspaceAgent;
+    private final NotificationManager                    notificationManager;
+    private final AppContext                             appContext;
+    private final SignatureHelpView                      signatureHelpView;
+    private final EditorContextMenu                      contextMenu;
+    private final ClientServerEventService               clientServerEventService;
 
     private final AnnotationRendering rendering = new AnnotationRendering();
     private HasKeyBindings           keyBindingsManager;
@@ -224,7 +225,8 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
                                 final NotificationManager notificationManager,
                                 final AppContext appContext,
                                 final SignatureHelpView signatureHelpView,
-                                final EditorContextMenu contextMenu) {
+                                final EditorContextMenu contextMenu,
+                                final ClientServerEventService clientServerEventService) {
         this.codeAssistantFactory = codeAssistantFactory;
         this.deletedFilesController = deletedFilesController;
         this.breakpointManager = breakpointManager;
@@ -245,6 +247,7 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
         this.appContext = appContext;
         this.signatureHelpView = signatureHelpView;
         this.contextMenu = contextMenu;
+        this.clientServerEventService = clientServerEventService;
 
         keyBindingsManager = new TemporaryKeyBindingsManager();
 
@@ -362,20 +365,19 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
             final Path relPath = document.getFile().getLocation().removeFirstSegments(movedFrom.segmentCount());
             final Path newPath = delta.getToPath().append(relPath);
 
-            appContext.getWorkspaceRoot().getFile(newPath).then(new Operation<Optional<File>>() {
-                @Override
-                public void apply(Optional<File> file) throws OperationException {
-                    if (file.isPresent()) {
-                        final Path location = document.getFile().getLocation();
-                        deletedFilesController.add(location.toString());
-                        generalEventBus.fireEvent(newFileTrackingStartEvent(file.get().getLocation().toString()));
+            appContext.getWorkspaceRoot().getFile(newPath).then(optional -> {
+                if (optional.isPresent()) {
+                    final Path location = document.getFile().getLocation();
+                    deletedFilesController.add(location.toString());
 
-                        document.setFile(file.get());
-                        input.setFile(file.get());
-                        updateTabReference(file.get(), location);
-
-                        updateContent();
-                    }
+                    File file = optional.get();
+                    clientServerEventService.sendFileTrackingStartEvent(file.getLocation().toString())
+                                            .then(aVoid -> {
+                                                document.setFile(file);
+                                                input.setFile(file);
+                                                updateTabReference(file, location);
+                                                updateContent();
+                                            });
                 }
             });
         }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MovePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MovePresenter.java
@@ -12,7 +12,6 @@ package org.eclipse.che.ide.ext.java.client.refactoring.move.wizard;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
@@ -23,6 +22,7 @@ import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
+import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.notification.StatusNotification.Status;
 import org.eclipse.che.ide.api.resources.Container;
@@ -42,7 +42,6 @@ import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ChangeInfo;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.CreateMoveRefactoring;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ElementToMove;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.MoveSettings;
-import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringResult;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringSession;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ReorgDestination;
@@ -50,9 +49,6 @@ import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ReorgDestination;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingMoveEvent;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingResumeEvent;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingSuspendEvent;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.ERROR;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.FATAL;
@@ -77,7 +73,7 @@ public class MovePresenter implements MoveView.ActionDelegate {
     private final JavaNavigationService    navigationService;
     private final JavaLocalizationConstant locale;
     private final NotificationManager      notificationManager;
-    private final EventBus                 eventBus;
+    private final ClientServerEventService clientServerEventService;
 
     protected RefactorInfo refactorInfo;
     private   String       refactoringSessionId;
@@ -91,11 +87,12 @@ public class MovePresenter implements MoveView.ActionDelegate {
                          JavaNavigationService navigationService,
                          DtoFactory dtoFactory,
                          JavaLocalizationConstant locale,
-                         NotificationManager notificationManager, EventBus eventBus) {
+                         NotificationManager notificationManager,
+                         ClientServerEventService clientServerEventService) {
         this.view = view;
         this.refactoringUpdater = refactoringUpdater;
         this.editorAgent = editorAgent;
-        this.eventBus = eventBus;
+        this.clientServerEventService = clientServerEventService;
         this.view.setDelegate(this);
 
         this.previewPresenter = previewPresenter;
@@ -225,33 +222,8 @@ public class MovePresenter implements MoveView.ActionDelegate {
             @Override
             public void apply(ChangeCreationResult arg) throws OperationException {
                 if (arg.isCanShowPreviewPage()) {
-                    eventBus.fireEvent(newFileTrackingSuspendEvent());
-
-                    refactorService.applyRefactoring(session).then(new Operation<RefactoringResult>() {
-                        @Override
-                        public void apply(RefactoringResult arg) throws OperationException {
-                            if (arg.getSeverity() == OK) {
-                                view.hide();
-                                refactoringUpdater.updateAfterRefactoring(arg.getChanges());
-
-                                final Resource[] resources = refactorInfo.getResources();
-
-                                if (resources != null && resources.length == 1) {
-                                    refactorService.reindexProject(resources[0].getRelatedProject().get().getLocation().toString());
-                                }
-
-                            } else {
-                                view.showErrorMessage(arg);
-                            }
-
-                            for (ChangeInfo change : arg.getChanges()) {
-                                final String path = change.getPath();
-                                final String oldPath = change.getOldPath();
-
-                                eventBus.fireEvent(newFileTrackingMoveEvent(path, oldPath));
-                            }
-                            eventBus.fireEvent(newFileTrackingResumeEvent());
-                        }
+                    clientServerEventService.sendFileTrackingSuspendEvent().then(success -> {
+                        applyRefactoring(session);
                     });
                 } else {
                     view.showErrorMessage(arg.getStatus());
@@ -261,6 +233,31 @@ public class MovePresenter implements MoveView.ActionDelegate {
             @Override
             public void apply(PromiseError error) throws OperationException {
                 notificationManager.notify(locale.applyMoveError(), error.getMessage(), Status.FAIL, FLOAT_MODE);
+            }
+        });
+    }
+
+    private void applyRefactoring(RefactoringSession session) {
+        refactorService.applyRefactoring(session).then(refactoringResult -> {
+            List<ChangeInfo> changes = refactoringResult.getChanges();
+            if (refactoringResult.getSeverity() == OK) {
+                view.hide();
+                refactoringUpdater.updateAfterRefactoring(changes).then(arg -> {
+                    Project project = null;
+                    Resource[] resources = refactorInfo.getResources();
+                    if (resources != null && resources.length == 1) {
+                        project = resources[0].getProject();
+                    }
+
+                    if (project != null) {
+                        refactorService.reindexProject(project.getPath());
+                    }
+
+                    refactoringUpdater.handleMovingFiles(changes).then(clientServerEventService.sendFileTrackingResumeEvent());
+                });
+            } else {
+                view.showErrorMessage(refactoringResult);
+                refactoringUpdater.handleMovingFiles(changes).then(clientServerEventService.sendFileTrackingResumeEvent());
             }
         });
     }
@@ -333,5 +330,4 @@ public class MovePresenter implements MoveView.ActionDelegate {
         view.setEnableAcceptButton(false);
         view.setEnablePreviewButton(false);
     }
-
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/preview/PreviewPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/preview/PreviewPresenter.java
@@ -13,7 +13,6 @@ package org.eclipse.che.ide.ext.java.client.refactoring.preview;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
@@ -21,6 +20,7 @@ import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
+import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.java.client.refactoring.RefactorInfo;
 import org.eclipse.che.ide.ext.java.client.refactoring.RefactoringUpdater;
@@ -32,12 +32,10 @@ import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ChangeInfo;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ChangePreview;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringChange;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringPreview;
-import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringResult;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringSession;
 
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingMoveEvent;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingResumeEvent;
-import static org.eclipse.che.ide.api.event.ng.FileTrackingEvent.newFileTrackingSuspendEvent;
+import java.util.List;
+
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.OK;
 
 /**
@@ -54,7 +52,7 @@ public class PreviewPresenter implements PreviewView.ActionDelegate {
     private final RefactoringUpdater        refactoringUpdater;
     private final RefactoringServiceClient  refactoringService;
     private final Provider<MovePresenter>   movePresenterProvider;
-    private final EventBus eventBus;
+    private final ClientServerEventService  clientServerEventService;
 
     private RefactorInfo       refactorInfo;
     private RefactoringSession session;
@@ -67,14 +65,14 @@ public class PreviewPresenter implements PreviewView.ActionDelegate {
                             EditorAgent editorAgent,
                             RefactoringUpdater refactoringUpdater,
                             RefactoringServiceClient refactoringService,
-                            EventBus eventBus) {
+                            ClientServerEventService clientServerEventService) {
         this.view = view;
         this.renamePresenterProvider = renamePresenterProvider;
         this.dtoFactory = dtoFactory;
         this.editorAgent = editorAgent;
         this.refactoringUpdater = refactoringUpdater;
         this.refactoringService = refactoringService;
-        this.eventBus = eventBus;
+        this.clientServerEventService = clientServerEventService;
         this.view.setDelegate(this);
 
         this.movePresenterProvider = movePresenterProvider;
@@ -118,24 +116,24 @@ public class PreviewPresenter implements PreviewView.ActionDelegate {
     /** {@inheritDoc} */
     @Override
     public void onAcceptButtonClicked() {
-        eventBus.fireEvent(newFileTrackingSuspendEvent());
+        clientServerEventService.sendFileTrackingSuspendEvent().then(success -> {
+            applyRefactoring();
+        });
 
-        refactoringService.applyRefactoring(session).then(new Operation<RefactoringResult>() {
-            @Override
-            public void apply(RefactoringResult result) throws OperationException {
-                if (result.getSeverity() == OK) {
-                    view.hide();
-                    refactoringUpdater.updateAfterRefactoring(result.getChanges());
-                } else {
-                    view.showErrorMessage(result);
-                }
-                for (ChangeInfo change : result.getChanges()) {
-                    final String path = change.getPath();
-                    final String oldPath = change.getOldPath();
+    }
 
-                    eventBus.fireEvent(newFileTrackingMoveEvent(path, oldPath));
-                }
-                eventBus.fireEvent(newFileTrackingResumeEvent());
+    private void applyRefactoring() {
+        refactoringService.applyRefactoring(session).then(refactoringResult -> {
+            List<ChangeInfo> changes = refactoringResult.getChanges();
+            if (refactoringResult.getSeverity() == OK) {
+                view.hide();
+                refactoringUpdater.updateAfterRefactoring(changes)
+                                  .then(refactoringUpdater.handleMovingFiles(changes)
+                                                          .then(clientServerEventService.sendFileTrackingResumeEvent()));
+            } else {
+                view.showErrorMessage(refactoringResult);
+                refactoringUpdater.handleMovingFiles(changes)
+                                  .then(clientServerEventService.sendFileTrackingResumeEvent());
             }
         });
     }
@@ -185,5 +183,4 @@ public class PreviewPresenter implements PreviewView.ActionDelegate {
             }
         });
     }
-
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.vfs.VirtualFileSystemProvider;
 import org.eclipse.che.api.vfs.impl.file.DefaultFileWatcherNotificationHandler;
 import org.eclipse.che.api.vfs.impl.file.FileWatcherNotificationHandler;
 import org.eclipse.che.api.vfs.impl.file.LocalVirtualFileSystemProvider;
+import org.eclipse.che.api.vfs.impl.file.event.detectors.EditorFileOperationHandler;
 import org.eclipse.che.api.vfs.impl.file.event.detectors.EditorFileTracker;
 import org.eclipse.che.api.vfs.impl.file.event.detectors.ProjectTreeTracker;
 import org.eclipse.che.api.vfs.search.MediaTypeFilter;
@@ -147,6 +148,7 @@ public class ProjectApiModule extends AbstractModule {
 
     private void configureVfsEvent() {
         bind(EditorFileTracker.class).asEagerSingleton();
+        bind(EditorFileOperationHandler.class).asEagerSingleton();
         bind(ProjectTreeTracker.class).asEagerSingleton();
     }
 

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileOperationHandler.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileOperationHandler.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
+
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/** Receive a file tracking operation call from client and notify server side about it by {@link FileTrackingOperationEvent}. */
+@Singleton
+public class EditorFileOperationHandler {
+    private static final String INCOMING_METHOD = "track:editor-file";
+
+    private final EventService      eventService;
+
+    @Inject
+    public EditorFileOperationHandler(EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    @Inject
+    public void configureHandler(RequestHandlerConfigurator configurator) {
+        configurator.newConfiguration()
+                    .methodName(INCOMING_METHOD)
+                    .paramsAsDto(FileTrackingOperationDto.class)
+                    .resultAsEmpty()
+                    .withFunction(this::handleFileTrackingOperation);
+    }
+
+    private Void handleFileTrackingOperation(String endpointId, FileTrackingOperationDto operation) {
+        try {
+            eventService.publish(new FileTrackingOperationEvent(endpointId, operation));
+            return null;
+        } catch (Exception e) {
+            throw new JsonRpcException(500, e.getLocalizedMessage());
+        }
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileTracker.java
@@ -14,7 +14,8 @@ import com.google.common.hash.Hashing;
 
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
-import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.project.shared.dto.event.FileStateUpdateDto;
 import org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto;
 import org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type;
@@ -25,6 +26,7 @@ import org.eclipse.che.api.vfs.watcher.FileWatcherManager;
 import org.eclipse.che.api.vfs.watcher.FileWatcherUtils;
 import org.slf4j.Logger;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -36,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static com.google.common.io.Files.hash;
@@ -67,101 +68,107 @@ public class EditorFileTracker {
     private static final Logger LOG = getLogger(EditorFileTracker.class);
 
     private static final String OUTGOING_METHOD = "event:file-state-changed";
-    private static final String INCOMING_METHOD = "track:editor-file";
 
     private final Map<String, String>  hashRegistry    = new HashMap<>();
     private final Map<String, Integer> watchIdRegistry = new HashMap<>();
 
-    private final RequestTransmitter        transmitter;
-    private final FileWatcherManager        fileWatcherManager;
-    private final VirtualFileSystemProvider vfsProvider;
-    private       File                      root;
+    private final RequestTransmitter                          transmitter;
+    private final FileWatcherManager                          fileWatcherManager;
+    private final VirtualFileSystemProvider                   vfsProvider;
+    private       File                                        root;
+    private final EventService                                eventService;
+    private final EventSubscriber<FileTrackingOperationEvent> fileOperationEventSubscriber;
 
 
     @Inject
-    public EditorFileTracker(@Named("che.user.workspaces.storage") File root, FileWatcherManager fileWatcherManager,
+    public EditorFileTracker(@Named("che.user.workspaces.storage") File root,
+                             FileWatcherManager fileWatcherManager,
                              RequestTransmitter transmitter,
-                             VirtualFileSystemProvider vfsProvider) {
+                             VirtualFileSystemProvider vfsProvider,
+                             EventService eventService) {
         this.root = root;
         this.fileWatcherManager = fileWatcherManager;
         this.transmitter = transmitter;
         this.vfsProvider = vfsProvider;
-    }
+        this.eventService = eventService;
 
-    @Inject
-    public void configureHandler(RequestHandlerConfigurator configurator) {
-        configurator.newConfiguration()
-                    .methodName(INCOMING_METHOD)
-                    .paramsAsDto(FileTrackingOperationDto.class)
-                    .noResult()
-                    .withConsumer(getFileTrackingOperationConsumer());
-    }
-
-    private BiConsumer<String, FileTrackingOperationDto> getFileTrackingOperationConsumer() {
-        return (String endpointId, FileTrackingOperationDto operation) -> {
-            Type type = operation.getType();
-            String path = operation.getPath();
-            String oldPath = operation.getOldPath();
-
-            switch (type) {
-                case START: {
-                    String key = path + endpointId;
-                    LOG.debug("Received file tracking operation START trigger key : {}", key);
-                    if (watchIdRegistry.containsKey(key)) {
-                        LOG.debug("Already registered {}", key);
-                        return;
-                    }
-                    int id = fileWatcherManager.registerByPath(path,
-                                                               getCreateConsumer(endpointId, path),
-                                                               getModifyConsumer(endpointId, path),
-                                                               getDeleteConsumer(endpointId, path));
-                    watchIdRegistry.put(key, id);
-                    break;
-                }
-                case STOP: {
-                    LOG.debug("Received file tracking operation STOP trigger.");
-
-                    int id = watchIdRegistry.remove(path + endpointId);
-                    fileWatcherManager.unRegisterByPath(id);
-
-                    break;
-                }
-                case SUSPEND: {
-                    LOG.debug("Received file tracking operation SUSPEND trigger.");
-
-                    fileWatcherManager.suspend();
-
-                    break;
-                }
-                case RESUME: {
-                    LOG.debug("Received file tracking operation RESUME trigger.");
-
-                    fileWatcherManager.resume();
-
-                    break;
-                }
-                case MOVE: {
-                    LOG.debug("Received file tracking operation MOVE trigger.");
-
-                    int oldId = watchIdRegistry.remove(oldPath + endpointId);
-                    fileWatcherManager.unRegisterByPath(oldId);
-
-                    int newId = fileWatcherManager.registerByPath(path,
-                                                                  getCreateConsumer(endpointId, path),
-                                                                  getModifyConsumer(endpointId, path),
-                                                                  getDeleteConsumer(endpointId, path));
-                    watchIdRegistry.put(path + endpointId, newId);
-
-
-                    break;
-                }
-                default: {
-                    LOG.error("Received file tracking operation UNKNOWN trigger.");
-
-                    break;
-                }
+        fileOperationEventSubscriber = new EventSubscriber<FileTrackingOperationEvent>() {
+            @Override
+            public void onEvent(FileTrackingOperationEvent event) {
+                onFileTrackingOperationReceived(event.getEndpointId(), event.getFileTrackingOperation());
             }
         };
+        eventService.subscribe(fileOperationEventSubscriber);
+    }
+
+    private void onFileTrackingOperationReceived(String endpointId, FileTrackingOperationDto operation) {
+        Type type = operation.getType();
+        String path = operation.getPath();
+        String oldPath = operation.getOldPath();
+
+        switch (type) {
+            case START: {
+                String key = path + endpointId;
+                LOG.debug("Received file tracking operation START trigger key : {}", key);
+                if (watchIdRegistry.containsKey(key)) {
+                    LOG.debug("Already registered {}", key);
+                    return;
+                }
+                int id = fileWatcherManager.registerByPath(path,
+                                                           getCreateConsumer(endpointId, path),
+                                                           getModifyConsumer(endpointId, path),
+                                                           getDeleteConsumer(endpointId, path));
+                watchIdRegistry.put(key, id);
+
+                break;
+            }
+            case STOP: {
+                LOG.debug("Received file tracking operation STOP trigger.");
+
+                Integer id = watchIdRegistry.remove(path + endpointId);
+                if (id != null) {
+                    fileWatcherManager.unRegisterByPath(id);
+                }
+
+                break;
+            }
+            case SUSPEND: {
+                LOG.debug("Received file tracking operation SUSPEND trigger.");
+
+                fileWatcherManager.suspend();
+
+                break;
+            }
+            case RESUME: {
+                LOG.debug("Received file tracking operation RESUME trigger.");
+
+                fileWatcherManager.resume();
+
+                break;
+            }
+            case MOVE: {
+                LOG.debug("Received file tracking operation MOVE trigger.");
+
+
+                Integer oldId = watchIdRegistry.remove(oldPath + endpointId);
+                if (oldId != null) {
+                    fileWatcherManager.unRegisterByPath(oldId);
+                }
+
+                int newId = fileWatcherManager.registerByPath(path,
+                                                              getCreateConsumer(endpointId, path),
+                                                              getModifyConsumer(endpointId, path),
+                                                              getDeleteConsumer(endpointId, path));
+                watchIdRegistry.put(path + endpointId, newId);
+
+                break;
+            }
+            default: {
+                LOG.error("Received file tracking operation UNKNOWN trigger.");
+
+                break;
+            }
+        }
     }
 
     private Consumer<String> getCreateConsumer(String endpointId, String path) {
@@ -217,5 +224,10 @@ public class EditorFileTracker {
             LOG.error("Error trying to read {} file and broadcast it", path, e);
         }
         return null;
+    }
+
+    @PreDestroy
+    private void unsubscribe() {
+        eventService.unsubscribe(fileOperationEventSubscriber);
     }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/FileTrackingOperationEvent.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/FileTrackingOperationEvent.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.impl.file.event.detectors;
+
+import org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto;
+
+/**
+ * Describes file tracking operation call from client. There are several types of such calls:
+ * <ul>
+ *     <li>
+ *         START/STOP - tells to start/stop tracking specific file
+ *     </li>
+ *     <li>
+ *         SUSPEND/RESUME - tells to start/stop tracking all files registered for specific endpoint
+ *     </li>
+ *     <li>
+ *         MOVE - tells that file that is being tracked should be moved (renamed)
+ *     </li>
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+public class FileTrackingOperationEvent {
+    private final String endpointId;
+    private final FileTrackingOperationDto fileTrackingOperation;
+
+    FileTrackingOperationEvent(String endpointId, FileTrackingOperationDto fileTrackingOperation) {
+        this.endpointId = endpointId;
+        this.fileTrackingOperation = fileTrackingOperation;
+    }
+
+    public String getEndpointId() {
+        return endpointId;
+    }
+
+    public FileTrackingOperationDto getFileTrackingOperation() {
+        return fileTrackingOperation;
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherService.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherService.java
@@ -31,6 +31,7 @@ import java.nio.file.WatchEvent.Kind;
 import java.nio.file.WatchEvent.Modifier;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -278,6 +279,8 @@ public class FileWatcherService {
                 WatchKey watchKey = service.take();
                 Path dir = keys.get(watchKey);
 
+                List<WatchEvent<?>> watchEvents = watchKey.pollEvents();
+
                 if (suspended.get()) {
                     resetAndRemove(watchKey, dir);
 
@@ -285,7 +288,7 @@ public class FileWatcherService {
                     continue;
                 }
 
-                for (WatchEvent<?> event : watchKey.pollEvents()) {
+                for (WatchEvent<?> event : watchEvents) {
                     Kind<?> kind = event.kind();
 
                     if (kind == OVERFLOW) {


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikitenko@codenvy.com>

### What does this PR do?
1. Fix receiving file tracking operation calls on server side at refactoring.
2. Send file tracking operation calls on server side asynchronously to avoid incorrect "External operation" events 

### What issues does this PR fix or reference?
#4768

#### Changelog
Fix receiving file tracking operation calls from client at refactoring
