### PR TITLE
CHE-4567: Update open in editor files after re-creation

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileTracker.java
@@ -42,7 +42,6 @@ import java.util.function.Consumer;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType.DELETED;
 import static org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType.MODIFIED;
-import static org.eclipse.che.api.vfs.watcher.FileWatcherManager.EMPTY_CONSUMER;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -165,7 +164,8 @@ public class EditorFileTracker {
     }
 
     private Consumer<String> getCreateConsumer(String endpointId, String path) {
-        return EMPTY_CONSUMER;
+        // for case when file is updated through recreation
+        return getModifyConsumer(endpointId, path);
     }
 
     private Consumer<String> getModifyConsumer(String endpointId, String path) {


### PR DESCRIPTION
### What does this PR do?
Adds handler for file creation event in editor file tracker.
Added handler just invokes handler for modify event from file watcher. This is done because file can be changed through re-creation, especially through some software, like jGit.
This is legally for editor file tracker because files are always opened after their creation. This means, that re-creation (not deletion and creation sequentially) is another way to modify a file.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4567

#### Changelog
Fixed bug when editor didn't update opened in editor file after re-creation.

#### Release Notes
N/A

#### Docs PR
N/A