### PR TITLE
Add user search methods by email/name fragment

### DIFF
--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserManager.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserManager.java
@@ -50,6 +50,7 @@ import static org.eclipse.che.commons.lang.NameGenerator.generate;
  *
  * @author Max Shaposhnik (mshaposhnik@codenvy.com)
  * @author Yevhenii Voevodin
+ * @author Anton Korneta
  */
 @Singleton
 public class UserManager {
@@ -218,6 +219,58 @@ public class UserManager {
         checkArgument(maxItems >= 0, "The number of items to return can't be negative.");
         checkArgument(skipCount >= 0, "The number of items to skip can't be negative.");
         return userDao.getAll(maxItems, skipCount);
+    }
+
+    /**
+     * Returns all users whose email address contains specified {@code emailPart}.
+     *
+     * @param emailPart
+     *         fragment of user's email
+     * @param maxItems
+     *         the maximum number of users to return
+     * @param skipCount
+     *         the number of users to skip
+     * @return list of matched users
+     * @throws NullPointerException
+     *         when {@code emailPart} is null
+     * @throws IllegalArgumentException
+     *         when {@code maxItems} or {@code skipCount} is negative or
+     *         when {@code skipCount} more than {@value Integer#MAX_VALUE}
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    public Page<? extends User> getByEmailPart(String emailPart, int maxItems, long skipCount) throws ServerException {
+        requireNonNull(emailPart, "Required non-null email part");
+        checkArgument(maxItems >= 0, "The number of items to return can't be negative");
+        checkArgument(skipCount >= 0 && skipCount <= Integer.MAX_VALUE,
+                      "The number of items to skip can't be negative or greater than " + Integer.MAX_VALUE);
+        return userDao.getByEmailPart(emailPart, maxItems, skipCount);
+    }
+
+    /**
+     * Returns all users whose name contains specified {@code namePart}.
+     *
+     * @param namePart
+     *         fragment of user's name
+     * @param maxItems
+     *         the maximum number of users to return
+     * @param skipCount
+     *         the number of users to skip
+     * @return list of matched users
+     * @throws NullPointerException
+     *         when {@code namePart} is null
+     * @throws IllegalArgumentException
+     *         when {@code maxItems} or {@code skipCount} is negative or
+     *         when {@code skipCount} more than {@value Integer#MAX_VALUE}
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    public Page<? extends User> getByNamePart(String namePart, int maxItems, long skipCount) throws ServerException {
+        requireNonNull(namePart, "Required non-null name part");
+        checkArgument(maxItems >= 0, "The number of items to return can't be negative");
+        checkArgument(skipCount >= 0 && skipCount <= Integer.MAX_VALUE,
+                      "The number of items to skip can't be negative or greater than " + Integer.MAX_VALUE);
+        return userDao.getByNamePart(namePart, maxItems, skipCount);
     }
 
     /**

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/JpaUserDao.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/JpaUserDao.java
@@ -195,6 +195,60 @@ public class JpaUserDao implements UserDao {
 
     @Override
     @Transactional
+    public Page<UserImpl> getByNamePart(String namePart, int maxItems, long skipCount) throws ServerException {
+        requireNonNull(namePart, "Required non-null name part");
+        checkArgument(maxItems >= 0, "The number of items to return can't be negative");
+        checkArgument(skipCount >= 0 && skipCount <= Integer.MAX_VALUE,
+                      "The number of items to skip can't be negative or greater than " + Integer.MAX_VALUE);
+        try {
+            final List<UserImpl> list = managerProvider.get()
+                                                       .createNamedQuery("User.getByNamePart", UserImpl.class)
+                                                       .setParameter("name", namePart.toLowerCase())
+                                                       .setMaxResults(maxItems)
+                                                       .setFirstResult((int)skipCount)
+                                                       .getResultList()
+                                                       .stream()
+                                                       .map(JpaUserDao::erasePassword)
+                                                       .collect(toList());
+            final long count = managerProvider.get()
+                                              .createNamedQuery("User.getByNamePartCount", Long.class)
+                                              .setParameter("name", namePart.toLowerCase())
+                                              .getSingleResult();
+            return new Page<>(list, skipCount, maxItems, count);
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        }
+    }
+
+    @Override
+    @Transactional
+    public Page<UserImpl> getByEmailPart(String emailPart, int maxItems, long skipCount) throws ServerException {
+        requireNonNull(emailPart, "Required non-null email part");
+        checkArgument(maxItems >= 0, "The number of items to return can't be negative");
+        checkArgument(skipCount >= 0 && skipCount <= Integer.MAX_VALUE,
+                      "The number of items to skip can't be negative or greater than " + Integer.MAX_VALUE);
+        try {
+            final List<UserImpl> list = managerProvider.get()
+                                                       .createNamedQuery("User.getByEmailPart", UserImpl.class)
+                                                       .setParameter("email", emailPart.toLowerCase())
+                                                       .setMaxResults(maxItems)
+                                                       .setFirstResult((int)skipCount)
+                                                       .getResultList()
+                                                       .stream()
+                                                       .map(JpaUserDao::erasePassword)
+                                                       .collect(toList());
+            final long count = managerProvider.get()
+                                              .createNamedQuery("User.getByEmailPartCount", Long.class)
+                                              .setParameter("email", emailPart.toLowerCase())
+                                              .getSingleResult();
+            return new Page<>(list, skipCount, maxItems, count);
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        }
+    }
+
+    @Override
+    @Transactional
     public long getTotalCount() throws ServerException {
         try {
             return managerProvider.get().createNamedQuery("User.getTotalCount", Long.class).getSingleResult();

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/model/impl/UserImpl.java
@@ -49,8 +49,15 @@ import java.util.Objects;
                 @NamedQuery(name = "User.getAll",
                             query = "SELECT u FROM Usr u"),
                 @NamedQuery(name = "User.getTotalCount",
-                            query = "SELECT COUNT(u) FROM Usr u")
-
+                            query = "SELECT COUNT(u) FROM Usr u"),
+                @NamedQuery(name = "User.getByEmailPart",
+                            query = "SELECT u FROM Usr u WHERE LOWER(u.email) LIKE CONCAT('%', :email, '%')"),
+                @NamedQuery(name = "User.getByEmailPartCount",
+                            query = "SELECT COUNT(u) FROM Usr u WHERE LOWER(u.email) LIKE CONCAT('%', :email, '%')"),
+                @NamedQuery(name = "User.getByNamePart",
+                            query = "SELECT u FROM Usr u WHERE LOWER(u.name) LIKE CONCAT('%', :name, '%')"),
+                @NamedQuery(name = "User.getByNamePartCount",
+                            query = "SELECT COUNT(u) FROM Usr u WHERE LOWER(u.name) LIKE CONCAT('%', :name, '%')")
         }
 )
 @Table(name = "usr")

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/spi/UserDao.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/spi/UserDao.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.user.server.model.impl.UserImpl;
  * such kind of inconsistencies are expected by design and may be treated further.
  *
  * @author Yevhenii Voevodin
+ * @author Anton Korneta
  */
 public interface UserDao {
 
@@ -175,6 +176,56 @@ public interface UserDao {
      *         when any other error occurs
      */
     Page<UserImpl> getAll(int maxItems, long skipCount) throws ServerException;
+
+    /**
+     * Returns all users whose name contains(case insensitively) specified {@code namePart}.
+     *
+     * @param namePart
+     *         fragment of user's name
+     * @param maxItems
+     *         the maximum number of users to return
+     * @param skipCount
+     *         the number of users to skip
+     * @return list of matched users
+     * @throws NullPointerException
+     *         when {@code namePart} is null
+     * @throws IllegalArgumentException
+     *         when {@code maxItems} or {@code skipCount} is negative or
+     *         when {@code skipCount} more than {@value Integer#MAX_VALUE}
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    Page<UserImpl> getByNamePart(String namePart, int maxItems, long skipCount) throws ServerException;
+
+    /**
+     * Returns all users whose email address contains(case insensitively) specified {@code emailPart}.
+     *
+     * <p>For example if email fragment would be 'CHE' then result of search will include the following:
+     * <pre>
+     *  |        emails          |  result  |
+     *  | Cherkassy@example.com  |    +     |
+     *  | preacher@example.com   |    +     |
+     *  | user@ukr.che           |    +     |
+     *  | johny@example.com      |    -     |
+     *  | CoachEddie@example.com |    +     |
+     * </pre>
+     *
+     * @param emailPart
+     *         fragment of user's email
+     * @param maxItems
+     *         the maximum number of users to return
+     * @param skipCount
+     *         the number of users to skip
+     * @return list of matched users
+     * @throws NullPointerException
+     *         when {@code emailPart} is null
+     * @throws IllegalArgumentException
+     *         when {@code maxItems} or {@code skipCount} is negative or
+     *         when {@code skipCount} more than {@value Integer#MAX_VALUE}
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    Page<UserImpl> getByEmailPart(String emailPart, int maxItems, long skipCount) throws ServerException;
 
     /**
      * Get count of all users from persistent layer.

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.11.0/1__optimize_user_search.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.11.0/1__optimize_user_search.sql
@@ -1,0 +1,15 @@
+--
+--  [2012] - [2017] Codenvy, S.A.
+--  All Rights Reserved.
+--
+-- NOTICE:  All information contained herein is, and remains
+-- the property of Codenvy S.A. and its suppliers,
+-- if any.  The intellectual and technical concepts contained
+-- herein are proprietary to Codenvy S.A.
+-- and its suppliers and may be covered by U.S. and Foreign Patents,
+-- patents in process, and are protected by trade secret or copyright law.
+-- Dissemination of this information or reproduction of this material
+-- is strictly forbidden unless prior written permission is obtained
+-- from Codenvy S.A..
+--
+

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.11.0/postgresql/1__optimize_user_search.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/5.11.0/postgresql/1__optimize_user_search.sql
@@ -1,0 +1,17 @@
+--
+--  [2012] - [2017] Codenvy, S.A.
+--  All Rights Reserved.
+--
+-- NOTICE:  All information contained herein is, and remains
+-- the property of Codenvy S.A. and its suppliers,
+-- if any.  The intellectual and technical concepts contained
+-- herein are proprietary to Codenvy S.A.
+-- and its suppliers and may be covered by U.S. and Foreign Patents,
+-- patents in process, and are protected by trade secret or copyright law.
+-- Dissemination of this information or reproduction of this material
+-- is strictly forbidden unless prior written permission is obtained
+-- from Codenvy S.A..
+--
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX index_user_lower_email ON usr USING GIN (LOWER(email) gin_trgm_ops);
+CREATE INDEX index_user_lower_name ON usr USING GIN (LOWER(name) gin_trgm_ops);


### PR DESCRIPTION
### What does this PR do?
Adds user search methods by email/name part.
Adds pattern index on email for `postgresql`.

### What issues does this PR fix or reference?
is needed for: [issue](https://github.com/codenvy/codenvy/issues/2164)

#### Changelog
add user search methods by email/name fragment

#### Release Notes
n/a

#### Docs PR
n/a