### PR TITLE
CHE-4132: Fix clean up map after widget deletion from ProcessPanel.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java
@@ -45,7 +45,6 @@ public class WsConnectionListener implements ConnectionClosedHandler, Connection
             public void onWorkspaceStarted(WorkspaceStartedEvent workspace) {
                 messageBus = messageBusProvider.getMessageBus();
 
-                Log.info(getClass(), "ws started add on close handler");
                 messageBus.addOnCloseHandler(WsConnectionListener.this);
             }
         });
@@ -65,7 +64,6 @@ public class WsConnectionListener implements ConnectionClosedHandler, Connection
 
     @Override
     public void onOpen() {
-        Log.info(getClass(), "open");
         messageBus.addOnCloseHandler(this);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java
@@ -45,6 +45,7 @@ public class WsConnectionListener implements ConnectionClosedHandler, Connection
             public void onWorkspaceStarted(WorkspaceStartedEvent workspace) {
                 messageBus = messageBusProvider.getMessageBus();
 
+                Log.info(getClass(), "ws started add on close handler");
                 messageBus.addOnCloseHandler(WsConnectionListener.this);
             }
         });
@@ -64,6 +65,7 @@ public class WsConnectionListener implements ConnectionClosedHandler, Connection
 
     @Override
     public void onOpen() {
+        Log.info(getClass(), "open");
         messageBus.addOnCloseHandler(this);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -337,7 +337,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
     @Override
     public void onCloseTerminal(ProcessTreeNode node) {
         closeTerminal(node);
-        view.hideProcessOutput(node.getId());
+        view.removeWidget(node.getId());
     }
 
     @Override
@@ -455,17 +455,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
 
         newTerminal.setVisible(true);
         newTerminal.connect();
-        newTerminal.setListener(new TerminalPresenter.TerminalStateListener() {
-            @Override
-            public void onExit() {
-                String terminalId = terminalNode.getId();
-                if (terminals.containsKey(terminalId)) {
-                    onStopProcess(terminalNode);
-                    terminals.remove(terminalId);
-                }
-                view.hideProcessOutput(terminalId);
-            }
-        });
+        newTerminal.setListener(() -> onCloseTerminal(terminalNode));
     }
 
     @Override
@@ -677,7 +667,8 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         closeCommandOutput(node, new SubPanel.RemoveCallback() {
             @Override
             public void remove() {
-                view.hideProcessOutput(node.getId());
+                Log.info(getClass(), "remove Command output");
+                view.removeWidget(node.getId());
             }
         });
     }
@@ -685,6 +676,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
     @Override
     public void onCommandTabClosing(ProcessTreeNode node, SubPanel.RemoveCallback removeCallback) {
         closeCommandOutput(node, removeCallback);
+        Log.info(getClass(), "Log " + node.getId());
     }
 
     private void closeCommandOutput(ProcessTreeNode node, SubPanel.RemoveCallback removeCallback) {
@@ -735,6 +727,7 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
                 if (console instanceof CommandOutputConsole) {
                     eventBus.fireEvent(new ProcessOutputClosedEvent(((CommandOutputConsole)console).getPid()));
                 }
+                view.removeWidget(node.getId());
             }
         };
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -326,8 +326,8 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
             if (TERMINAL_NODE.equals(child.getType()) && terminals.containsKey(child.getId())) {
                 onCloseTerminal(child);
             } else if (COMMAND_NODE.equals(child.getType()) && consoles.containsKey(child.getId())) {
-                onStopCommandProcess(child);
-                view.hideProcessOutput(child.getId());
+                OutputConsole console = consoles.get(child.getId());
+                removeConsole(console, child, () -> {});
             }
         }
 
@@ -664,19 +664,12 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
 
     @Override
     public void onCloseCommandOutputClick(final ProcessTreeNode node) {
-        closeCommandOutput(node, new SubPanel.RemoveCallback() {
-            @Override
-            public void remove() {
-                Log.info(getClass(), "remove Command output");
-                view.removeWidget(node.getId());
-            }
-        });
+        closeCommandOutput(node, () -> {});
     }
 
     @Override
     public void onCommandTabClosing(ProcessTreeNode node, SubPanel.RemoveCallback removeCallback) {
         closeCommandOutput(node, removeCallback);
-        Log.info(getClass(), "Log " + node.getId());
     }
 
     private void closeCommandOutput(ProcessTreeNode node, SubPanel.RemoveCallback removeCallback) {
@@ -689,47 +682,39 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
         }
 
         if (console.isFinished()) {
-            console.close();
-            onStopProcess(node);
-            consoles.remove(commandId);
-            consoleCommands.remove(console);
-
-            removeCallback.remove();
-
-            if (console instanceof CommandOutputConsole) {
-                eventBus.fireEvent(new ProcessOutputClosedEvent(((CommandOutputConsole)console).getPid()));
-            }
-
-            return;
+            removeConsole(console, node, removeCallback);
+        } else {
+            dialogFactory.createConfirmDialog("",
+                                              localizationConstant.outputsConsoleViewStopProcessConfirmation(console.getTitle()),
+                                              getConfirmCloseConsoleCallback(console, node, removeCallback),
+                                              null).show();
         }
-
-        dialogFactory.createConfirmDialog("",
-                                          localizationConstant.outputsConsoleViewStopProcessConfirmation(console.getTitle()),
-                                          getConfirmCloseConsoleCallback(console, node, removeCallback),
-                                          null).show();
     }
 
     private ConfirmCallback getConfirmCloseConsoleCallback(final OutputConsole console,
                                                            final ProcessTreeNode node,
                                                            final SubPanel.RemoveCallback removeCallback) {
-        return new ConfirmCallback() {
-            @Override
-            public void accepted() {
-                console.stop();
-                onStopProcess(node);
-
-                console.close();
-                consoles.remove(node.getId());
-                consoleCommands.remove(console);
-
-                removeCallback.remove();
-
-                if (console instanceof CommandOutputConsole) {
-                    eventBus.fireEvent(new ProcessOutputClosedEvent(((CommandOutputConsole)console).getPid()));
-                }
-                view.removeWidget(node.getId());
-            }
+        return () -> {
+            console.stop();
+            removeConsole(console, node, removeCallback);
         };
+    }
+
+    private void removeConsole(final OutputConsole console,
+                               final ProcessTreeNode node,
+                               final SubPanel.RemoveCallback removeCallback) {
+        console.close();
+        onStopProcess(node);
+
+        consoles.remove(node.getId());
+        consoleCommands.remove(console);
+        view.removeWidget(node.getId());
+
+        removeCallback.remove();
+
+        if (console instanceof CommandOutputConsole) {
+            eventBus.fireEvent(new ProcessOutputClosedEvent(((CommandOutputConsole)console).getPid()));
+        }
     }
 
     private void onStopProcess(ProcessTreeNode node) {
@@ -1011,13 +996,10 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
 
                     for (ProcessTreeNode child : children) {
                         if (COMMAND_NODE == child.getType()) {
-                            closeCommandOutput(child, new SubPanel.RemoveCallback() {
-                                @Override
-                                public void remove() {
-                                }
-                            });
+                            OutputConsole console = consoles.get(child.getId());
+                            removeConsole(console, child, () -> {});
                         } else if (TERMINAL_NODE == child.getType()) {
-                            closeTerminal(child);
+                            onCloseTerminal(child);
                         }
 
                         view.hideProcessOutput(child.getId());

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelView.java
@@ -84,6 +84,9 @@ public interface ProcessesPanelView extends View<ProcessesPanelView.ActionDelega
     /** Hides output for process with given ID */
     void hideProcessOutput(String processId);
 
+    /** Removes widget for process with given ID */
+    void removeWidget(String processId);
+
     /** Marks process with a badge in process tree */
     void markProcessHasOutput(String processId);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
@@ -113,7 +113,6 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
         processWidgets = new HashMap<>();
         widget2TreeNodes = new HashMap<>();
 
-
         renderer.setAddTerminalClickHandler(new AddTerminalClickHandler() {
             @Override
             public void onAddTerminalClick(@NotNull String machineId) {
@@ -136,7 +135,6 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
             @Override
             public void onCloseProcessOutputClick(ProcessTreeNode node) {
-                Log.info(getClass(), "close by click close button in the machine tree");
                 switch (node.getType()) {
                     case COMMAND_NODE:
                         delegate.onCloseCommandOutputClick(node);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
@@ -48,7 +48,6 @@ import org.eclipse.che.ide.ui.tree.SelectionModel;
 import org.eclipse.che.ide.ui.tree.Tree;
 import org.eclipse.che.ide.ui.tree.TreeNodeElement;
 import org.eclipse.che.ide.util.input.SignalEvent;
-import org.eclipse.che.ide.util.loging.Log;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.validation.constraints.NotNull;
@@ -510,15 +509,12 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
     @Override
     public void onResize() {
-        Log.info(getClass(), "***********Begin resize.*********");
         for (WidgetToShow widgetToShow : widget2Panels.keySet()) {
-            Log.info(getClass(), widgetToShow.getTitle());
             final IsWidget widget = widgetToShow.getWidget();
             if (widget instanceof RequiresResize) {
                 ((RequiresResize)widget).onResize();
             }
         }
-        Log.info(getClass(), "********End resize.************");
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
@@ -157,7 +157,6 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
             @Override
             public void onNodeClosed(TreeNodeElement<ProcessTreeNode> node) {
-                //todo and what ?
             }
 
             @Override
@@ -513,6 +512,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
     @Override
     public void onResize() {
+        Log.info(getClass(), "***********Begin resize.*********");
         for (WidgetToShow widgetToShow : widget2Panels.keySet()) {
             Log.info(getClass(), widgetToShow.getTitle());
             final IsWidget widget = widgetToShow.getWidget();
@@ -520,6 +520,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
                 ((RequiresResize)widget).onResize();
             }
         }
+        Log.info(getClass(), "********End resize.************");
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
@@ -48,6 +48,7 @@ import org.eclipse.che.ide.ui.tree.SelectionModel;
 import org.eclipse.che.ide.ui.tree.Tree;
 import org.eclipse.che.ide.ui.tree.TreeNodeElement;
 import org.eclipse.che.ide.util.input.SignalEvent;
+import org.eclipse.che.ide.util.loging.Log;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.validation.constraints.NotNull;
@@ -112,6 +113,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
         processWidgets = new HashMap<>();
         widget2TreeNodes = new HashMap<>();
 
+
         renderer.setAddTerminalClickHandler(new AddTerminalClickHandler() {
             @Override
             public void onAddTerminalClick(@NotNull String machineId) {
@@ -134,6 +136,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
             @Override
             public void onCloseProcessOutputClick(ProcessTreeNode node) {
+                Log.info(getClass(), "close by click close button in the machine tree");
                 switch (node.getType()) {
                     case COMMAND_NODE:
                         delegate.onCloseCommandOutputClick(node);
@@ -154,6 +157,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
 
             @Override
             public void onNodeClosed(TreeNodeElement<ProcessTreeNode> node) {
+                //todo and what ?
             }
 
             @Override
@@ -453,6 +457,13 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
     }
 
     @Override
+    public void removeWidget(String processId) {
+        WidgetToShow widget = processWidgets.get(processId);
+        hideProcessOutput(processId);
+        widget2Panels.remove(widget);
+    }
+
+    @Override
     public void markProcessHasOutput(String processId) {
         if (processId.equals(activeProcessId)) {
             return;
@@ -503,6 +514,7 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
     @Override
     public void onResize() {
         for (WidgetToShow widgetToShow : widget2Panels.keySet()) {
+            Log.info(getClass(), widgetToShow.getTitle());
             final IsWidget widget = widgetToShow.getWidget();
             if (widget instanceof RequiresResize) {
                 ((RequiresResize)widget).onResize();


### PR DESCRIPTION
### What does this PR do?
Clean up map on deleting widget from Process Panel. 
Don't show "Stop command" window if workspace has already stopped.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4132

#### Changelog
Clean up map on deleting widget from Process Panel. 
Don't show "Stop command" window if workspace has already stopped.

#### Release Notes
Clean up map on deleting widget from Process Panel. 
Don't show "Stop command" window if workspace has already stopped.


