### PR TITLE
[MERGE-AFTER-PR-5366] Multi-container workspace Support

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -1458,12 +1458,14 @@ public class OpenShiftConnector extends DockerConnector {
         PersistentVolumeClaim pvc = getClaimCheWorkspace();
         if (pvc != null) {
             String subPath = getWorkspaceSubpath(volumes);
-            VolumeMount vm = new VolumeMountBuilder()
+            if (subPath != null) {
+                VolumeMount vm = new VolumeMountBuilder()
                     .withMountPath(cheWorkspaceProjectsStorage)
                     .withName(workspacesPersistentVolumeClaim)
                     .withSubPath(subPath)
                     .build();
-            vms.add(vm);
+                vms.add(vm);
+            }
         }
         return vms;
     }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
@@ -25,10 +25,11 @@ public class OpenShiftRouteCreator {
     private static final String REDIRECT_INSECURE_EDGE_TERMINATION_POLICY = "Redirect";
 
     public static void createRoute (final String namespace,
-                                    final String workspaceName,
                                     final String openShiftNamespaceExternalAddress,
                                     final String serverRef,
                                     final String serviceName,
+                                    final String deploymentName,
+                                    final String routeId,
                                     final boolean enableTls) {
 
         if (openShiftNamespaceExternalAddress == null) {
@@ -36,7 +37,7 @@ public class OpenShiftRouteCreator {
         }
 
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
-            String routeName = generateRouteName(workspaceName, serverRef);
+            String routeName = generateRouteName(routeId, serverRef);
             String serviceHost = generateRouteHost(routeName, openShiftNamespaceExternalAddress);
     
                SpecNested<DoneableRoute> routeSpec = openShiftClient
@@ -45,7 +46,7 @@ public class OpenShiftRouteCreator {
                     .createNew()
                     .withNewMetadata()
                       .withName(routeName)
-                      .addToLabels(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, serviceName)
+                      .addToLabels(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName)
                     .endMetadata()
                     .withNewSpec()
                       .withHost(serviceHost)
@@ -72,8 +73,8 @@ public class OpenShiftRouteCreator {
         }
     }
 
-    private static String generateRouteName(final String workspaceName, final String serverRef) {
-        return serverRef + "-" + workspaceName;
+    private static String generateRouteName(final String serviceName, final String serverRef) {
+        return serverRef + "-" + serviceName;
     }
 
     private static String generateRouteHost(final String routeName, final String openShiftNamespaceExternalAddress) {

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesLabelConverter.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesLabelConverter.java
@@ -64,6 +64,9 @@ public final class KubernetesLabelConverter {
      */
     public static Map<String, String> labelsToNames(Map<String, String> labels) {
         Map<String, String> names = new HashMap<>();
+        if (labels == null) {
+            return names;
+        }
         for (Map.Entry<String, String> label : labels.entrySet()) {
 
             if (!hasConversionProblems(label)) {
@@ -103,6 +106,9 @@ public final class KubernetesLabelConverter {
      */
     public static Map<String, String> namesToLabels(Map<String, String> names) {
         Map<String, String> labels = new HashMap<>();
+        if (names == null) {
+            return labels;
+        }
         for (Map.Entry<String, String> entry: names.entrySet()){
             String key = entry.getKey();
             String value = entry.getValue();


### PR DESCRIPTION
### What does this PR do?

Fixes the support of multi-container (multi-machine) Che workspaces inside Openshift.

In the current design of the OpenShift connector, each Che machine create is transformed into an OpenShift Pod with a single container. (and not a Pod with many containers).

However, the multi-machine use-case wasn't fully tested and NPEs used to prevent the setup of non-development additional machines. This is now fixed.

Additionally, since machines live in distinct pods, the docker compose internal network feature cannot be used to allow machines communicating with their compose service names.
To fix this, the OpenShift service name, for all non-development Che machines, will be created with the name of the related compose service. This way we can leverage the OpenShift internal Dns server that allows all pods in an OS namespace to communicate through their OS service name.

### What issues does this PR fix or reference?

https://issues.jboss.org/browse/CHE-175
https://issues.jboss.org/browse/CHE-258
https://issues.jboss.org/browse/CHE-259
