### PR TITLE
Add possibility to extend che.env with addon.env if it exist

### DIFF
--- a/dockerfiles/init/entrypoint.sh
+++ b/dockerfiles/init/entrypoint.sh
@@ -13,5 +13,9 @@ cp -rf /files/docs /copy
 
 # do not copy che.env if exist
 if [ ! -f  /copy/che.env ]; then
+    # if exist add addon env values to main env file.
+    if [ -f /etc/puppet/addon.env ]; then
+        cat /etc/puppet/addon.env >> /etc/puppet/manifests/che.env
+    fi
     cp /etc/puppet/manifests/che.env /copy
 fi


### PR DESCRIPTION
### What does this PR do?
this improve allows to have `addon.env` file and inject values from `addon.env` to `che.env` in custom CLI based on CHE CLI. As result user will have che.env with ENV vars from addon.
This merge happens ONLY on first init where che.env not yet generated, to prevent any collisions.

example of usage in openshift assembly: https://github.com/codenvy/plugin-openshift/pull/65

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5117

#### Changelog
Add possibility to extend che.env with addon.env if it exist
