### PR TITLE
CHE-4898: check existing of path before register watcher

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherService.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherService.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.WatchEvent;
@@ -190,13 +191,15 @@ public class FileWatcherService {
             LOG.debug("Directory is already being watched, increasing watch counter, previous value: {}", previous);
             registrations.put(dir, previous + 1);
         } else {
-            try {
-                LOG.debug("Starting watching directory '{}'", dir);
-                WatchKey watchKey = dir.register(service, eventKinds, eventModifiers);
-                keys.put(watchKey, dir);
-                registrations.put(dir, 1);
-            } catch (IOException e) {
-                LOG.error("Can't register dir {} in file watch service", dir, e);
+            if (Files.exists(dir)) {
+                try {
+                    LOG.debug("Starting watching directory '{}'", dir);
+                    WatchKey watchKey = dir.register(service, eventKinds, eventModifiers);
+                    keys.put(watchKey, dir);
+                    registrations.put(dir, 1);
+                } catch (IOException e) {
+                    LOG.error("Can't register dir {} in file watch service", dir, e);
+                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>

### What does this PR do?
Check existing of path before register watcher

### What issues does this PR fix or reference?
#4898 


#### Changelog
Check existing of path before register watcher

#### Release Notes
N/A 


