### PR TITLE
Extend the dashboard stuff that can be re-branded

### DIFF
--- a/dashboard/src/app/navbar/navbar.controller.ts
+++ b/dashboard/src/app/navbar/navbar.controller.ts
@@ -12,10 +12,6 @@
 import {CheAPI} from '../../components/api/che-api.factory';
 
 export class CheNavBarController {
-  links = [{
-    href: '#/create-workspace',
-    name: 'New Workspace'
-  }];
   menuItemUrl = {
     dashboard: '#/',
     workspaces: '#/workspaces',

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -11,6 +11,7 @@
 'use strict';
 import {CheWorkspace} from '../../../components/api/che-workspace.factory';
 import IdeSvc from '../../../app/ide/ide.service';
+import {CheBranding} from '../../../components/branding/che-branding.factory';
 
 const MAX_RECENT_WORKSPACES_ITEMS: number = 5;
 
@@ -33,17 +34,19 @@ export class NavbarRecentWorkspacesController {
   $window: ng.IWindowService;
   $rootScope: ng.IRootScopeService;
   dropdownItems: Object;
+  workspaceCreationLink: string;
 
   /**
    * Default constructor
    * @ngInject for Dependency injection
    */
-  constructor(ideSvc: IdeSvc, cheWorkspace: CheWorkspace, $window: ng.IWindowService, $log: ng.ILogService, $scope: ng.IScope, $rootScope: ng.IRootScopeService) {
+  constructor(ideSvc: IdeSvc, cheWorkspace: CheWorkspace, cheBranding: CheBranding, $window: ng.IWindowService, $log: ng.ILogService, $scope: ng.IScope, $rootScope: ng.IRootScopeService) {
     this.ideSvc = ideSvc;
     this.cheWorkspace = cheWorkspace;
     this.$log = $log;
     this.$window = $window;
     this.$rootScope = $rootScope;
+    this.workspaceCreationLink = cheBranding.getWorkspace().creationLink;
 
     // workspace updated time map by id
     this.workspaceUpdated = new Map();

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.html
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.html
@@ -10,7 +10,7 @@
     <md-list layout="column">
       <md-list-item flex class="navbar-subsection-item">
         <md-button flex che-reload-href
-                   ng-href="#/create-workspace"
+                   ng-href="{{navbarRecentWorkspacesController.workspaceCreationLink}}"
                    layout-align="left">
           <div class="navbar-item" layout="row" layout-align="start center">
             <i class="fa fa-plus navbar-icon navbar-primary"></i>

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
@@ -14,6 +14,7 @@ import {CheNotification} from '../../../components/notification/che-notification
 import {CheWorkspace} from '../../../components/api/che-workspace.factory';
 import {CheNamespaceRegistry, INamespace} from '../../../components/api/namespace/che-namespace-registry.factory';
 import {ConfirmDialogService} from '../../../components/service/confirm-dialog/confirm-dialog.service';
+import {CheBranding} from '../../../components/branding/che-branding.factory';
 
 /**
  * @ngdoc controller
@@ -34,6 +35,7 @@ export class ListWorkspacesCtrl {
   isInfoLoading: boolean;
   workspaceFilter: any;
   userWorkspaces: che.IWorkspace[];
+  workspaceCreationLink: string;
 
   workspacesById: Map<string, che.IWorkspace>;
   workspaceUsedResources: Map<string, string>;
@@ -59,7 +61,7 @@ export class ListWorkspacesCtrl {
    * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService, $mdDialog: ng.material.IDialogService, $q: ng.IQService, lodash: any,
-              $rootScope: che.IRootScopeService, cheAPI: CheAPI, cheNotification: CheNotification,
+              $rootScope: che.IRootScopeService, cheAPI: CheAPI, cheNotification: CheNotification, cheBranding: CheBranding,
               cheWorkspace: CheWorkspace, cheNamespaceRegistry: CheNamespaceRegistry, confirmDialogService: ConfirmDialogService) {
     this.cheAPI = cheAPI;
     this.$q = $q;
@@ -70,6 +72,8 @@ export class ListWorkspacesCtrl {
     this.cheWorkspace = cheWorkspace;
     this.cheNamespaceRegistry = cheNamespaceRegistry;
     this.confirmDialogService = confirmDialogService;
+
+    this.workspaceCreationLink = cheBranding.getWorkspace().creationLink;
 
     this.state = 'loading';
     this.isInfoLoading = true;

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
@@ -20,7 +20,7 @@
                      che-search-model="listWorkspacesCtrl.workspaceFilter.config.name"
                      che-hide-search="listWorkspacesCtrl.userWorkspaces.length === 0"
                      che-add-button-title="Add Workspace"
-                     che-add-button-href="#/create-workspace"
+                     che-add-button-href="{{listWorkspacesCtrl.workspaceCreationLink}}"
                      che-delete-button-title="Delete"
                      che-on-delete="listWorkspacesCtrl.deleteSelectedWorkspaces()"
                      che-filter-values="listWorkspacesCtrl.namespaceLabels"

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
@@ -20,8 +20,7 @@
   </div>
   <div layout="row" layout-wrap>
     <md-card layout="column" class="che-simple-selector"
-             ng-repeat="stack in readyToGoStacksCtrl.generalStacks"
-             ng-init="$first && readyToGoStacksCtrl.setStackSelectionById(stack.id)"
+             ng-repeat="stack in readyToGoStacksCtrl.generalStacks | orderBy:readyToGoStacksCtrl.getPrioritySortPosition"
              ng-click="readyToGoStacksCtrl.setStackSelectionById(stack.id)"
              ng-hide="readyToGoStacksCtrl.filteredStackIds.indexOf(stack.id) === -1"
              ng-class="{'che-simple-selector-active' : '{{stack.id}}' === readyToGoStacksCtrl.selectedStackId}">

--- a/dashboard/src/assets/branding/product.json
+++ b/dashboard/src/assets/branding/product.json
@@ -10,6 +10,10 @@
   "helpTitle": "Community",
   "supportEmail": "wish@codenvy.com",
   "oauthDocs": "Configure OAuth in the che.properties file.",
+  "workspace": {
+    "priorityStacks": ["Java", "Java-MySQL", "Blank"],
+    "defaultStack": "java-mysql"
+  },
   "cli" : {
     "configName" : "che.env",
     "name" : "CHE"

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -31,6 +31,16 @@ interface IBranding {
     stack?: string;
     workspace?: string;
   };
+  workspace?: {
+    priorityStacks?: Array<string>;
+    defaultStack?: string;
+    creationLink?: string;
+  }
+  footer?: {
+    content?: string;
+    links?: Array<{title: string, location: string}>;
+    email?: {title: string, address: string, subject: string};
+  }
 }
 
 const ASSET_PREFIX = 'assets/branding/';
@@ -41,15 +51,14 @@ const DEFAULT_LOADER = 'loader.svg';
 const DEFAULT_PRODUCT_LOGO = 'che-logo.svg';
 const DEFAULT_PRODUCT_LOGO_TEXT = 'che-logo-text.svg';
 const DEFAULT_IDE_RESOURCES_PATH = '/_app/';
-const DEFAULT_HELP_PATH = 'https://www.eclipse.org/che/';
-const DEFAULT_HELP_TITLE = 'Community';
-const DEFAULT_SUPPORT_EMAIL = 'wish@codenvy.com';
 const DEFAULT_OAUTH_DOCS = 'Configure OAuth in the che.properties file.';
 const DEFAULT_CLI_NAME = 'che.env';
 const DEFAULT_CLI_CONFIG_NAME = 'CHE';
 const DEFAULT_DOCS_STACK = '/docs/getting-started/runtime-stacks/index.html';
 const DEFAULT_DOCS_WORKSPACE = '/docs/getting-started/intro/index.html';
-
+const DEFAULT_WORKSPACE_PRIORITY_STACKS = ['Java', 'Java-MySQL', 'Blank'];
+const DEFAULT_WORKSPACE_DEFAULT_STACK = 'java-mysql';
+const DEFAULT_WORKSPACE_CREATION_LINK = '#/create-workspace';
 
 /**
  * This class is handling the branding data in Che.
@@ -105,10 +114,12 @@ export class CheBranding {
         ideResourcesPath: this.getIdeResourcesPath(),
         helpPath: this.getProductHelpPath(),
         helpTitle: this.getProductHelpTitle(),
+        footer: this.getFooter(),
         supportEmail: this.getProductSupportEmail(),
         oauthDocs: this.getOauthDocs(),
         cli: this.getCLI(),
-        docs: this.getDocs()
+        docs: this.getDocs(),
+        workspace: this.getWorkspace()
       };
       this.callbacks.forEach((callback: Function) => {
         if (angular.isFunction(callback)) {
@@ -191,7 +202,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductHelpPath(): string {
-    return this.brandingData.helpPath ? this.brandingData.helpPath : DEFAULT_HELP_PATH;
+    return this.brandingData.helpPath ? this.brandingData.helpPath : null;
   }
 
   /**
@@ -199,7 +210,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductHelpTitle(): string {
-    return this.brandingData.helpTitle ? this.brandingData.helpTitle : DEFAULT_HELP_TITLE;
+    return this.brandingData.helpTitle ? this.brandingData.helpTitle : null
   }
 
   /**
@@ -223,7 +234,20 @@ export class CheBranding {
    * @returns {string}
    */
   getProductSupportEmail(): string {
-    return this.brandingData.supportEmail ? this.brandingData.supportEmail : DEFAULT_SUPPORT_EMAIL;
+    return this.brandingData.supportEmail ? this.brandingData.supportEmail : null;
+  }
+
+  /**
+   * Returns footer additional elements (email button, content, button links).
+   *
+   * @returns {any} additional elements (email button, content, button links).
+   */
+  getFooter():  {content?: string; links?: Array<{title: string, location: string}>; email: {title: string, address: string, subject: string}} {
+    return {
+      content: this.brandingData.footer && this.brandingData.footer.content ? this.brandingData.footer.content : '',
+      links: this.brandingData.footer && this.brandingData.footer.links ? this.brandingData.footer.links : [],
+      email: this.brandingData.footer && this.brandingData.footer.email ? this.brandingData.footer.email : null
+    };
   }
 
   /**
@@ -247,5 +271,16 @@ export class CheBranding {
       workspace: this.brandingData.docs && this.brandingData.docs.workspace ? this.brandingData.docs.workspace : DEFAULT_DOCS_WORKSPACE
     };
   }
-}
 
+  /**
+   * Returns object with workspace dedicated data.
+   * @returns {{stack: string, workspace: string}}
+   */
+  getWorkspace(): { priorityStacks: Array<string>; defaultStack: string, creationLink: string} {
+    return {
+      priorityStacks: this.brandingData.workspace && this.brandingData.workspace.priorityStacks ? this.brandingData.workspace.priorityStacks : DEFAULT_WORKSPACE_PRIORITY_STACKS,
+      defaultStack: this.brandingData.workspace && this.brandingData.workspace.defaultStack ? this.brandingData.workspace.defaultStack : DEFAULT_WORKSPACE_DEFAULT_STACK,
+      creationLink: this.brandingData.workspace && this.brandingData.workspace.creationLink ? this.brandingData.workspace.creationLink : DEFAULT_WORKSPACE_CREATION_LINK
+    };
+  }
+}

--- a/dashboard/src/components/widget/footer/che-footer.controller.ts
+++ b/dashboard/src/components/widget/footer/che-footer.controller.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ */
+'use strict';
+
+
+/**
+ * This class is handling the controller for the footer.
+ *
+ * @author Ann Shumilova
+ */
+export class CheFooterController {
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor() {
+  }
+
+  /**
+   * Returns 'Make a wish' email subject.
+   *
+   * @param productName
+   * @returns {string}
+   */
+  getWishEmailSubject(productName: string): string {
+    return this.getEmailSubject('Wishes for ' + productName);
+  }
+
+  /**
+   * Returns formed subject for email.
+   *
+   * @param subject
+   * @returns {string}
+   */
+  getEmailSubject(subject: string): string {
+    return '?subject=' + encodeURIComponent(subject);
+  }
+}
+
+

--- a/dashboard/src/components/widget/footer/che-footer.directive.ts
+++ b/dashboard/src/components/widget/footer/che-footer.directive.ts
@@ -52,54 +52,39 @@ export class CheFooter {
    * </example>
    * @author Ann Shumilova
    */
-  restrict: string = 'E';
-  replace: boolean = true;
-  transclude: boolean = true;
+  private restrict: string;
+  private replace: boolean;
+  private transclude: boolean;
 
-  /**
-   * Template for the current footer
-   * @param {ng.IAugmentedJQuery} element
-   * @param {any} attrs
-   * @returns {string} the template
-   */
-  template(element: ng.IAugmentedJQuery, attrs: any) {
-    let logo = attrs.cheLogo;
-    let version = attrs.cheVersion;
-    let productName  = attrs.cheProductName;
-    let supportEmail = attrs.cheSupportEmail;
-    let supportHelpPath = attrs.cheSupportHelpPath;
-    let supportHelpTitle = attrs.cheSupportHelpTitle;
+  private bindToController: boolean;
+  private controller: string;
+  private controllerAs: string;
+  private templateUrl: string;
 
-    let template = '<div class=\"che-footer\" layout=\"row\" layout-align=\"start center\">';
-    if (logo) {
-      template += '<img class=\"che-footer-logo\" ng-src=\"' + logo + '\" alt=\"logo\">';
-    }
-    if (version) {
-      template += '<span class=\"che-footer-version\">' + version + '</span>';
-    }
-    template += '<div flex />';
-    template += '<ng-transclude></ng-transclude>';
+  private scope: {
+    [propName: string]: string
+  };
 
-    // email
-    if (supportEmail) {
-      let subject = '?subject=' + encodeURIComponent('Wishes for ' + productName);
-      template += '<a class=\"che-footer-button-blue che-footer-button\" ng-href=\"mailto:' + supportEmail + subject + '\">Make a wish<a/>';
-    }
+  constructor() {
+    this.templateUrl = 'components/widget/footer/che-footer.html';
 
-    // docs
-    template += '<a class=\"che-footer-button-blue che-footer-button\" href=\"/docs\" target=\"_blank\">Docs<a/>';
+    this.restrict = 'E';
+    this.replace = true;
+    this.transclude = true;
+    this.bindToController = true;
+    this.controller = 'CheFooterController';
+    this.controllerAs = 'cheFooterController';
 
-    // help
-    if (supportHelpPath && supportHelpTitle) {
-      template += '<a class=\"che-footer-button-blue che-footer-button\" ng-href=\"' + supportHelpPath + '\" target=\"_blank\">' + supportHelpTitle + '<a/>';
-    }
-
-    // diagnostics
-    template += '<a class=\"che-footer-button-blue che-footer-button\" ng-href=\"#/diagnostic\">Diagnostics<a/>';
-
-    template += '</div>';
-    return template;
+    this.scope = {
+      supportHelpPath: '@cheSupportHelpPath',
+      supportHelpTitle: '@cheSupportHelpTitle',
+      supportEmail: '@cheSupportEmail',
+      logo: '@cheLogo',
+      version: '@cheVersion',
+      productName: '@cheProductName',
+      links: '=cheLinks',
+      email: '=?cheEmail'
+    };
   }
-
 }
 

--- a/dashboard/src/components/widget/footer/che-footer.html
+++ b/dashboard/src/components/widget/footer/che-footer.html
@@ -1,0 +1,17 @@
+<div class="che-footer" layout="row" layout-align="start center">
+  <img class="che-footer-logo" id="footer-logo" ng-if="cheFooterController.logo" ng-src="{{cheFooterController.logo}}" alt="logo">
+  <span class="che-footer-version" id="footer-version" ng-if="cheFooterController.version">{{cheFooterController.version}}</span>
+  <div id="footer-space" flex></div>
+  <ng-transclude id="footer-content"></ng-transclude>
+  <a class="che-footer-button-blue che-footer-button" id="footer-email-wish" ng-if="cheFooterController.supportEmail"
+     ng-href="{{'mailto:' + cheFooterController.supportEmail + cheFooterController.getWishEmailSubject(cheFooterController.productName)}}">Make a wish<a/>
+  <a class="che-footer-button-blue che-footer-button" id="footer-email" ng-if="cheFooterController.email"
+       ng-href="{{'mailto:' + cheFooterController.email.address + cheFooterController.getEmailSubject(cheFooterController.email.subject)}}">{{cheFooterController.email.title}}<a/>
+  <a class="che-footer-button-blue che-footer-button" id="footer-docs" href="/docs" target="_blank">Docs<a/>
+  <a class="che-footer-button-blue che-footer-button" id="footer-support" ng-if="cheFooterController.supportHelpPath && cheFooterController.supportHelpTitle"
+     ng-href="{{cheFooterController.supportHelpPath}}" target="_blank">{{cheFooterController.supportHelpTitle}}<a/>
+
+  <a class="che-footer-button-blue che-footer-button" id="footer-diagnostics" ng-href="#/diagnostic">Diagnostics<a/>
+
+  <a ng-repeat="link in cheFooterController.links" class="che-footer-button-blue che-footer-button" ng-href="{{link.location}}">{{link.title}}<a/>
+</div>

--- a/dashboard/src/components/widget/widget-config.ts
+++ b/dashboard/src/components/widget/widget-config.ts
@@ -31,6 +31,7 @@ import {CheFilterSelector} from './filter-selector/che-filter-selector.directive
 import {CheFilterSelectorController} from './filter-selector/che-filter-selector.controller';
 import {CheFrame} from './frame/che-frame.directive';
 import {CheFooter} from './footer/che-footer.directive';
+import {CheFooterController} from './footer/che-footer.controller';
 import {CheHtmlSource} from './html-source/che-html-source.directive';
 import {CheInput} from './input/che-input.directive';
 import {CheInputBox} from './input/che-input-box.directive';
@@ -106,6 +107,7 @@ export class WidgetConfig {
       .controller('CheFilterSelectorController', CheFilterSelectorController)
       .directive('cheFrame', CheFrame)
       .directive('cheFooter', CheFooter)
+      .controller('CheFooterController', CheFooterController)
       .directive('cheHtmlSource', CheHtmlSource)
       .directive('demoSourceRender', DemoSourceRender)
       .directive('cheInput', CheInput)

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -57,7 +57,12 @@
                 che-support-email="{{branding.supportEmail}}"
                 che-logo="{{branding.logoURL}}"
                 che-version="{{productVersion}}"
-                che-product-name="Eclipse Che" ng-show="waitingLoaded && !showIDE"></che-footer>
+                che-product-name="Eclipse Che"
+                che-links="branding.footer.links"
+                che-email="branding.footer.email"
+                ng-show="waitingLoaded && !showIDE">
+      {{branding.footer.content}}
+    </che-footer>
   </div>
     <!-- Addons are not automatically injected -->
 


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds following elements, that can be re-branded:
- footer (content, style all elements, add additional button links, email button)
- workspace (stacks priority, default stack and workspace creation link)
### What issues does this PR fix or reference?
Is needed for: 
https://github.com/codenvy/silexica/issues/27
https://github.com/codenvy/silexica/issues/19
https://github.com/codenvy/silexica/issues/18

#### Changelog
Extended the dashboard footer and workspace creation that can be re-branded

#### Release Notes
We have extended the capabilities of customization for the dashboard.
It is now possible to customize the footer content to add a button redirecting to a specific link or starting a new email. You can also style all the elements with your own css.
In the creation of a new workspace, you can now customize the list of stacks' order to show your own stack first and be pre-selected too. 


#### Docs PR
N/A
