### PR TITLE
Incorrect processing JSON RPC responses

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -92,7 +92,7 @@ public class ResponseDispatcher {
         checkArgument(!endpointId.isEmpty(), "Endpoint ID name must not be empty");
         checkNotNull(response, "Response name must not be null");
 
-        LOGGER.debug("Dispatching a response: " + response + ", from endpoint: " + endpointId);
+        LOGGER.debug("Dispatching a response: {} from endpoint: {}", response, endpointId);
 
         String responseId = response.getId();
         if (responseId == null) {
@@ -102,7 +102,7 @@ public class ResponseDispatcher {
         LOGGER.debug("Fetching response ID: {}", responseId);
 
         String key = combine(endpointId, responseId);
-        LOGGER.debug("Generating key: " + key);
+        LOGGER.debug("Generating key: {} ", key);
 
         if (response.hasResult()) {
             processResult(endpointId, response, key);
@@ -124,7 +124,7 @@ public class ResponseDispatcher {
         JsonRpcError error = response.getError();
 
         JsonRpcPromise<?> promise = promises.remove(key);
-        LOGGER.debug("Fetching promise:" + promise);
+        LOGGER.debug("Fetching promise: {}", promise);
 
         BiConsumer<String, JsonRpcError> consumer = promise.getFailureConsumer();
         if (consumer != null) {
@@ -151,7 +151,7 @@ public class ResponseDispatcher {
         JsonRpcResult result = response.getResult();
 
         Class<?> rClass = rClasses.remove(key);
-        LOGGER.debug("Fetching result class: {}",rClass);
+        LOGGER.debug("Fetching result class: {}", rClass);
 
         JsonRpcPromise promise = promises.remove(key);
         LOGGER.debug("Fetching promise: {}", promise);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -99,7 +99,7 @@ public class ResponseDispatcher {
             LOGGER.debug("Response ID is not defined, skipping...");
             return;
         }
-        LOGGER.debug("Fetching response ID: " + responseId);
+        LOGGER.debug("Fetching response ID: {}", responseId);
 
         String key = combine(endpointId, responseId);
         LOGGER.debug("Generating key: " + key);
@@ -117,7 +117,7 @@ public class ResponseDispatcher {
         LOGGER.debug("Response has error. Proceeding...");
 
         if (!promises.containsKey(key)) {
-            LOGGER.debug("No action is associated for the key: " + key + ", skipping.");
+            LOGGER.debug("No action is associated for the key: {}, skipping.", key);
             return;
         }
 
@@ -139,22 +139,22 @@ public class ResponseDispatcher {
         LOGGER.debug("Response has result. Proceeding...");
 
         if (!promises.containsKey(key)) {
-            LOGGER.debug("No promise is associated with the key: " + key + ", skipping.");
+            LOGGER.debug("No promise is associated with the key: {}, skipping.", key);
             return;
         }
 
         if (!rClasses.containsKey(key)) {
-            LOGGER.debug("No result class is associated for the key: " + key + ", skipping.");
+            LOGGER.debug("No result class is associated for the key: {}, skipping.", key);
             return;
         }
 
         JsonRpcResult result = response.getResult();
 
         Class<?> rClass = rClasses.remove(key);
-        LOGGER.debug("Fetching result class:" + rClass);
+        LOGGER.debug("Fetching result class: {}",rClass);
 
         JsonRpcPromise promise = promises.remove(key);
-        LOGGER.debug("Fetching promise:" + promise);
+        LOGGER.debug("Fetching promise: {}", promise);
 
         if (result.isSingle()) {
             processOne(endpointId, result, rClass, cast(promise.getSuccessConsumer()));


### PR DESCRIPTION
Signed-off-by: Dmitry Kuleshov <dkuleshov@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes situations where we do not define actions for responses when sending requests over Json RPC

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5135

#### Changelog
Fixed response handling if no response action is set
<!-- one line entry to be added to changelog -->

#### Release Notes
Fixed response handling if no response action is set
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
