### PR TITLE
CODENVY-2095: Fix Eclipse CHE-logo. Add to the ProductInfoProvider method to get water-mark-logo.

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/ProductInfoDataProvider.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/ProductInfoDataProvider.java
@@ -49,6 +49,11 @@ public interface ProductInfoDataProvider {
     SVGResource getLogo();
 
     /**
+     * @return waterMark logo
+     */
+    SVGResource getWaterMarkLogo();
+
+    /**
      * @return title for support action which displayed in Help menu.
      */
     String getSupportTitle();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/ProductInfoDataProviderImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/ProductInfoDataProviderImpl.java
@@ -43,6 +43,11 @@ public class ProductInfoDataProviderImpl implements ProductInfoDataProvider {
     }
 
     @Override
+    public SVGResource getWaterMarkLogo() {
+        return null;
+    }
+
+    @Override
     public String getSupportTitle() {
         return "";
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
@@ -100,7 +100,7 @@ public class EmptyEditorsPanel extends Composite implements ResourceChangedEvent
 
 
         eventBus.addHandler(ResourceChangedEvent.getType(), this);
-        final SVGResource logo = productInfoDataProvider.getLogo();
+        final SVGResource logo = productInfoDataProvider.getWaterMarkLogo();
         if (nonNull(logo)) {
             this.logo.appendChild(new SVGImage(logo).getSvgElement().getElement());
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.ui.xml
@@ -16,17 +16,25 @@
     <ui:style type='org.eclipse.che.ide.part.editor.EmptyEditorsPanel.Css'>
         @eval lineColor org.eclipse.che.ide.api.theme.Style.theme.iconColor();
         @eval fontColor org.eclipse.che.ide.api.theme.Style.getMainFontColor();
-        .center{
+        @eval logoFill org.eclipse.che.ide.api.theme.Style.getLogoFill();
+
+        .center {
             display: flex;
             justify-content: center;
             align-items: center;
             margin-bottom: 50px;
         }
+
+        .center g {
+            fill: logoFill;
+        }
+
         .parent {
             position: relative;
             width: 100%;
             height: 100%;
         }
+
         .child {
             position: absolute;
             top: 50%;
@@ -34,30 +42,32 @@
             transform: translate(-50%, -50%);
             width: 215px;
         }
+
         .list {
             padding-left: 26px;
             margin: 0;
             margin-top: 5px;
         }
 
-        .listElement{
+        .listElement {
             font-size: 10px;
             margin-bottom: 3px;
         }
 
-        .title{
+        .title {
             padding-left: 8px;
             border-bottom: 1px solid lineColor;
             font-size: 13px;
             width: 138px;
         }
 
-        .hotKey{
+        .hotKey {
             border: 1px solid fontColor;
             color: fontColor;
             border-radius: 2px;
             margin-left: 50px;
         }
+
         .actionLabel {
             display: inline-block;
             width: 77px;

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/Resources.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/Resources.java
@@ -20,6 +20,9 @@ public interface Resources extends com.google.gwt.resources.client.ClientBundle 
     @Source("logo/che-logo.svg")
     SVGResource logo();
 
+    @Source("logo/water-mark-logo.svg")
+    SVGResource waterMarkLogo();
+
     @Source({"Styles.css", "org/eclipse/che/ide/api/ui/style.css"})
     Styles styles();
 }

--- a/ide/che-core-ide-ui/src/main/resources/org/eclipse/che/ide/ui/logo/water-mark-logo.svg
+++ b/ide/che-core-ide-ui/src/main/resources/org/eclipse/che/ide/ui/logo/water-mark-logo.svg
@@ -12,9 +12,9 @@
 
 -->
 <svg id="svg3077" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns="http://www.w3.org/2000/svg" height="100%" width="100%" version="1.1" xmlns:cc="http://creativecommons.org/ns#"
-     xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 225 57">
-    <g fill-rule="evenodd" stroke="none" stroke-width="1" fill="none">
+                                                              xmlns="http://www.w3.org/2000/svg" height="100%" width="100%" version="1.1" xmlns:cc="http://creativecommons.org/ns#"
+                                                              xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 225 57">
+    <g fill-rule="evenodd" stroke="none" stroke-width="1" fill="none" fill-opacity="0.2">
         <g>
             <path d="M0.032227,30.88l-0.032227-17.087,23.853-13.793,23.796,13.784-14.691,8.51-9.062-5.109-23.864,13.695z" fill="#fdb940"/>
             <path d="M0,43.355l23.876,13.622,23.974-13.937v-16.902l-23.974,13.506-23.876-13.506v17.217z" fill="#525c86"/>

--- a/plugins/plugin-product-info/src/main/java/org/eclipse/che/plugin/product/info/client/CheProductInfoDataProvider.java
+++ b/plugins/plugin-product-info/src/main/java/org/eclipse/che/plugin/product/info/client/CheProductInfoDataProvider.java
@@ -41,20 +41,29 @@ public class CheProductInfoDataProvider extends ProductInfoDataProviderImpl {
         return locale.getProductName();
     }
 
+    @Override
     public String getSupportLink() {
         return locale.getSupportLink();
     }
 
+    @Override
     public String getDocumentTitle() {
         return locale.cheTabTitle();
     }
 
+    @Override
     public String getDocumentTitle(String workspaceName) {
         return locale.cheTabTitle(workspaceName);
     }
 
+    @Override
     public SVGResource getLogo() {
         return resources.logo();
+    }
+
+    @Override
+    public SVGResource getWaterMarkLogo() {
+        return resources.waterMarkLogo();
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Fix Eclipse CHE-logo. Add to the ProductInfoProvider method to get water-mark-logo.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2095

#### Changelog
Fix Eclipse CHE-logo. Add to the ProductInfoProvider method to get water-mark-logo.

#### Release Notes
Fixed water-mark-logo displayed in background of the IDE until no file is opened.

![che_logo](https://cloud.githubusercontent.com/assets/6873095/26295829/9bc8077a-3ed4-11e7-9666-7de2a377dca8.png)
![dark_che_logo](https://cloud.githubusercontent.com/assets/6873095/26296577/e289af12-3ed7-11e7-96c4-db6d37e05fd5.png)



Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>
