### PR TITLE
[cli] Use of version_lt function instead of less_than function

### DIFF
--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -287,8 +287,8 @@ compare_versions() {
     TAG=$(echo $VERSION_LIST_JSON | jq ".results[$COUNTER].name")
     TAG=${TAG//\"}
 
-    if [ "$TAG" != "nightly" ] && [ "$TAG" != "latest" ]; then
-      if less_than $BASE_VERSION $TAG; then
+    if [ "$TAG" != "nightly" ] && [ "$TAG" != "latest" ] && [ "$TAG" != "${BASE_VERSION}" ]; then
+      if version_lt $BASE_VERSION $TAG; then
         RETURN_VERSION=$TAG
         break;
       fi


### PR DESCRIPTION
### What does this PR do?

less_than is not working with for example “5.9.1” and “5.10.0”, 5.9.0 being said to be a greater version

bash-4.3# version_lt "5.9.0" "5.10.1"
—> 0

bash-4.3# less_than "5.9.0" "5.10.1"
—> 1

bash-4.3# less_than "5.6" "5.8"
—> 0

note: version_lt is a less and equals method, so we need to exclude the condition : tag == base version

### What issues does this PR fix or reference?
#5140

#### Changelog
Fix comparing versions in the check of newer docker CLI versions.

#### Release Notes
CLI: Fixed comparing versions in the check of newer docker CLI versions.


#### Docs PR
N/A (bug)

Change-Id: I33417f012c193416bfb746df125c19e92a868b4e
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
