### PR TITLE
Ability to register language servers for file names instead of extensions #5107

### DIFF
--- a/plugins/plugin-csharp/che-plugin-csharp-lang-server/src/main/java/org/eclipse/che/plugin/csharp/inject/CSharpModule.java
+++ b/plugins/plugin-csharp/che-plugin-csharp-lang-server/src/main/java/org/eclipse/che/plugin/csharp/inject/CSharpModule.java
@@ -12,8 +12,8 @@ package org.eclipse.che.plugin.csharp.inject;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.project.server.handlers.ProjectHandler;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.inject.DynaModule;
@@ -21,11 +21,17 @@ import org.eclipse.che.plugin.csharp.languageserver.CSharpLanguageServerLauncher
 import org.eclipse.che.plugin.csharp.projecttype.CSharpProjectType;
 import org.eclipse.che.plugin.csharp.projecttype.CreateNetCoreProjectHandler;
 
+import static java.util.Arrays.asList;
+
 /**
  * @author Anatolii Bazko
  */
 @DynaModule
 public class CSharpModule extends AbstractModule {
+    public static final String    LANGUAGE_ID = "csharp";
+    private static final String[] EXTENSIONS  = new String[] { "cs", "csx" };
+    private static final String   MIME_TYPE   = "text/x-csharp";
+
     @Override
     protected void configure() {
         Multibinder<ProjectTypeDef> projectTypeMultibinder = Multibinder.newSetBinder(binder(), ProjectTypeDef.class);
@@ -35,5 +41,13 @@ public class CSharpModule extends AbstractModule {
         projectHandlersMultibinder.addBinding().to(CreateNetCoreProjectHandler.class);
 
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(CSharpLanguageServerLauncher.class);
+
+        LanguageDescription description = new LanguageDescription();
+        description.setFileExtensions(asList(EXTENSIONS));
+        description.setLanguageId(LANGUAGE_ID);
+        description.setMimeType(MIME_TYPE);
+
+        Multibinder.newSetBinder(binder(), LanguageDescription.class).addBinding().toInstance(description);
+
     }
 }

--- a/plugins/plugin-csharp/che-plugin-csharp-lang-server/src/main/java/org/eclipse/che/plugin/csharp/languageserver/CSharpLanguageServerLauncher.java
+++ b/plugins/plugin-csharp/che-plugin-csharp-lang-server/src/main/java/org/eclipse/che/plugin/csharp/languageserver/CSharpLanguageServerLauncher.java
@@ -12,11 +12,10 @@ package org.eclipse.che.plugin.csharp.languageserver;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
-import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.commons.lang.IoUtil;
+import org.eclipse.che.plugin.csharp.inject.CSharpModule;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -26,9 +25,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-
-import static java.util.Arrays.asList;
 
 
 /**
@@ -37,11 +33,7 @@ import static java.util.Arrays.asList;
 @Singleton
 public class CSharpLanguageServerLauncher extends LanguageServerLauncherTemplate {
 
-    private static final String   LANGUAGE_ID = "csharp";
-    private static final String[] EXTENSIONS  = new String[]{"cs", "csx"};
-    private static final String[] MIME_TYPES  = new String[]{"text/x-csharp"};
-    private static final LanguageDescription description;
-
+ 
     private final Path launchScript;
 
     @Inject
@@ -89,8 +81,8 @@ public class CSharpLanguageServerLauncher extends LanguageServerLauncherTemplate
     }
 
     @Override
-    public LanguageDescription getLanguageDescription() {
-        return description;
+    public String getLanguageId() {
+        return CSharpModule.LANGUAGE_ID;
     }
 
     @Override
@@ -98,10 +90,4 @@ public class CSharpLanguageServerLauncher extends LanguageServerLauncherTemplate
         return Files.exists(launchScript);
     }
 
-    static {
-        description = new LanguageDescription();
-        description.setFileExtensions(asList(EXTENSIONS));
-        description.setLanguageId(LANGUAGE_ID);
-        description.setMimeTypes(Arrays.asList(MIME_TYPES));
-    }
-}
+ }

--- a/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/inject/JsonModule.java
+++ b/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/inject/JsonModule.java
@@ -31,9 +31,6 @@ public class JsonModule extends AbstractModule {
                                                              "babelrc"};
     private static final String MIME_TYPE  = "application/json";
 
-
-    static {
-    }
     @Override
     protected void configure() {
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(JsonLanguageServerLauncher.class);

--- a/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/inject/JsonModule.java
+++ b/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/inject/JsonModule.java
@@ -15,15 +15,32 @@ import com.google.inject.multibindings.Multibinder;
 
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.plugin.json.languageserver.JsonLanguageServerLauncher;
+
+import static java.util.Arrays.asList;
+
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 
 /**
  * @author Anatolii Bazko
  */
 @DynaModule
 public class JsonModule extends AbstractModule {
+    public static final String   LANGUAGE_ID = "json";
+    private static final String[] EXTENSIONS  = new String[]{"json", "bowerrc", "jshintrc", "jscsrc", "eslintrc",
+                                                             "babelrc"};
+    private static final String MIME_TYPE  = "application/json";
+
+
+    static {
+    }
     @Override
     protected void configure() {
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(JsonLanguageServerLauncher.class);
+        LanguageDescription description = new LanguageDescription();
+        description.setFileExtensions(asList(EXTENSIONS));
+        description.setLanguageId(LANGUAGE_ID);
+        description.setMimeType(MIME_TYPE);
+        Multibinder.newSetBinder(binder(), LanguageDescription.class).addBinding().toInstance(description);
     }
 }

--- a/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/inject/JsonModule.java
+++ b/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/inject/JsonModule.java
@@ -10,16 +10,14 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.json.inject;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.Multibinder;
-
-import org.eclipse.che.inject.DynaModule;
-import org.eclipse.che.plugin.json.languageserver.JsonLanguageServerLauncher;
-
 import static java.util.Arrays.asList;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.plugin.json.languageserver.JsonLanguageServerLauncher;
 
 /**
  * @author Anatolii Bazko

--- a/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/languageserver/JsonLanguageServerLauncher.java
+++ b/plugins/plugin-json/che-plugin-json-server/src/main/java/org/eclipse/che/plugin/json/languageserver/JsonLanguageServerLauncher.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
 import org.eclipse.che.api.languageserver.registry.ServerInitializerObserver;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+import org.eclipse.che.plugin.json.inject.JsonModule;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -30,8 +31,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
-
 /**
  * @author Evgen Vidolob
  * @author Anatolii Bazko
@@ -39,15 +38,7 @@ import static java.util.Arrays.asList;
 @Singleton
 public class JsonLanguageServerLauncher extends LanguageServerLauncherTemplate implements ServerInitializerObserver {
 
-    private static final String   LANGUAGE_ID = "json";
-    private static final String[] EXTENSIONS  = new String[]{"json", "bowerrc", "jshintrc", "jscsrc", "eslintrc",
-                                                             "babelrc"};
-    private static final String[] MIME_TYPES  = new String[]{"application/json"};
-    private static final LanguageDescription description;
-
     private final Path launchScript;
-
-    private LanguageClient client;
 
     @Inject
     public JsonLanguageServerLauncher() {
@@ -55,8 +46,8 @@ public class JsonLanguageServerLauncher extends LanguageServerLauncherTemplate i
     }
 
     @Override
-    public LanguageDescription getLanguageDescription() {
-        return description;
+    public String getLanguageId() {
+        return JsonModule.LANGUAGE_ID;
     }
 
     @Override
@@ -65,7 +56,6 @@ public class JsonLanguageServerLauncher extends LanguageServerLauncherTemplate i
     }
 
     protected LanguageServer connectToLanguageServer(final Process languageServerProcess, LanguageClient client) {
-        this.client = client;
         Launcher<LanguageServer> launcher = Launcher.createLauncher(client, LanguageServer.class,
                                                                     languageServerProcess.getInputStream(),
                                                                     languageServerProcess.getOutputStream());
@@ -82,13 +72,6 @@ public class JsonLanguageServerLauncher extends LanguageServerLauncherTemplate i
         } catch (IOException e) {
             throw new LanguageServerException("Can't start JSON language server", e);
         }
-    }
-
-    static {
-        description = new LanguageDescription();
-        description.setFileExtensions(asList(EXTENSIONS));
-        description.setLanguageId(LANGUAGE_ID);
-        description.setMimeTypes(asList(MIME_TYPES));
     }
 
     @Override

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -153,7 +153,7 @@
                 <version>${project.version}</version>
                 <executions>
                     <execution>
-                        <phase>process-sources</phase>
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>generate</goal>
                         </goals>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
@@ -13,7 +13,6 @@ package org.eclipse.che.plugin.languageserver.ide;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
-
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.ide.api.action.ActionManager;
@@ -34,6 +33,7 @@ import org.eclipse.che.plugin.languageserver.ide.navigation.declaration.FindDefi
 import org.eclipse.che.plugin.languageserver.ide.navigation.references.FindReferencesAction;
 import org.eclipse.che.plugin.languageserver.ide.navigation.symbol.GoToSymbolAction;
 import org.eclipse.che.plugin.languageserver.ide.navigation.workspace.FindSymbolAction;
+import org.eclipse.che.plugin.languageserver.ide.registry.LanguageServerRegistry;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
@@ -91,20 +91,20 @@ public class LanguageServerExtension {
     protected void registerFileEventHandler(final EventBus eventBus,
                                             final TextDocumentServiceClient serviceClient,
                                             final DtoFactory dtoFactory,
-                                            final LanguageServerFileTypeRegister fileTypeRegister) {
+                                            final LanguageServerRegistry lsRegistry) {
         eventBus.addHandler(FileEvent.TYPE, new FileEvent.FileEventHandler() {
 
             @Override
             public void onFileOperation(final FileEvent event) {
                 Path location = event.getFile().getLocation();
-                if (location.getFileExtension() == null || !fileTypeRegister.hasLSForExtension(location.getFileExtension())) {
+                if (lsRegistry.getLanguageDescription(event.getFile()) == null) {
                     return;
                 }
                 final TextDocumentIdentifier documentId = dtoFactory.createDto(TextDocumentIdentifier.class);
                 documentId.setUri(location.toString());
                 switch (event.getOperationType()) {
                     case OPEN:
-                        onOpen(event, dtoFactory, serviceClient, fileTypeRegister);
+                        onOpen(event, dtoFactory, serviceClient, lsRegistry);
                         break;
                     case CLOSE:
                         onClose(documentId, dtoFactory, serviceClient);
@@ -136,7 +136,7 @@ public class LanguageServerExtension {
     private void onOpen(final FileEvent event,
                         final DtoFactory dtoFactory,
                         final TextDocumentServiceClient serviceClient,
-                        final LanguageServerFileTypeRegister fileTypeRegister) {
+                        final LanguageServerRegistry lsRegistry) {
         event.getFile().getContent().then(new Operation<String>() {
             @Override
             public void apply(String text) throws OperationException {
@@ -144,7 +144,7 @@ public class LanguageServerExtension {
                 documentItem.setUri(event.getFile().getLocation().toString());
                 documentItem.setVersion(LanguageServerEditorConfiguration.INITIAL_DOCUMENT_VERSION);
                 documentItem.setText(text);
-                documentItem.setLanguageId(fileTypeRegister.findLangId(event.getFile().getLocation().getFileExtension()));
+                documentItem.setLanguageId(lsRegistry.getLanguageDescription(event.getFile()).getLanguageId());
 
                 DidOpenTextDocumentParams openEvent = dtoFactory.createDto(DidOpenTextDocumentParams.class);
                 openEvent.setTextDocument(documentItem);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
@@ -56,18 +56,22 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
     private final OccurrencesProvider                 occurrencesProvider;
 
     @Inject
-    public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry, LanguageServerRegistry lsRegistry,
-                                          LanguageServerResources resources, EditorRegistry editorRegistry,
-                                          OrionContentTypeRegistrant contentTypeRegistrant, OrionHoverRegistrant orionHoverRegistrant,
+    public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry, 
+                                          LanguageServerRegistry lsRegistry,
+                                          LanguageServerResources resources, 
+                                          EditorRegistry editorRegistry,
+                                          OrionContentTypeRegistrant contentTypeRegistrant, 
+                                          OrionHoverRegistrant orionHoverRegistrant,
                                           OrionOccurrencesRegistrant orionOccurrencesRegistrant,
-                                          LanguageServerEditorProvider editorProvider, HoverProvider hoverProvider,
+                                          LanguageServerEditorProvider editorProvider, 
+                                          HoverProvider hoverProvider,
                                           OccurrencesProvider occurrencesProvider) { 
         this.serverLanguageRegistry = serverLanguageRegistry;
         this.lsRegistry = lsRegistry;
         this.resources = resources;
         this.editorRegistry = editorRegistry;
         this.contentTypeRegistrant = contentTypeRegistrant;
-        this.orionHoverRegistrant = orionHoverRegistrant; 
+        this.orionHoverRegistrant = orionHoverRegistrant;
         this.orionOccurrencesRegistrant = orionOccurrencesRegistrant;
         this.editorProvider = editorProvider;
         this.hoverProvider = hoverProvider;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  */
 @Singleton
 public class LanguageServerFileTypeRegister implements WsAgentComponent {
-    private static Logger logger = Logger.getLogger(LanguageServerFileTypeRegister.class.getName());
+    private static Logger LOGGER = Logger.getLogger(LanguageServerFileTypeRegister.class.getName());
 
     private final LanguageServerRegistryServiceClient serverLanguageRegistry;
     private final LanguageServerRegistry              lsRegistry;
@@ -80,7 +80,7 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
         registeredLanguages.then(new Operation<List<LanguageDescription>>() {
             @Override
             public void apply(List<LanguageDescription> langs) throws OperationException {
-                logger.info("registering language descriptions");
+                LOGGER.info("registering language descriptions");
                 if (!langs.isEmpty()) {
                     JsArrayString contentTypes = JsArrayString.createArray().cast();
                     for (LanguageDescription lang : langs) {
@@ -112,7 +112,7 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
                         config.setContentTypes(mimeType);
                         config.setPatterns(lang.getHighlightingConfiguration());
                         contentTypeRegistrant.registerFileType(contentType, config);
-                        logger.info("registered language description for " + lang.getLanguageId());
+                        LOGGER.info("registered language description for " + lang.getLanguageId());
                     }
                     orionHoverRegistrant.registerHover(contentTypes, hoverProvider);
                     orionOccurrencesRegistrant.registerOccurrencesHandler(contentTypes, occurrencesProvider);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
@@ -12,9 +12,9 @@ package org.eclipse.che.plugin.languageserver.ide;
 
 import com.google.gwt.core.client.Callback;
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.regexp.shared.RegExp;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
@@ -23,7 +23,6 @@ import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
 import org.eclipse.che.ide.api.editor.EditorRegistry;
 import org.eclipse.che.ide.api.filetypes.FileType;
-import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.editor.orion.client.OrionContentTypeRegistrant;
 import org.eclipse.che.ide.editor.orion.client.OrionHoverRegistrant;
 import org.eclipse.che.ide.editor.orion.client.OrionOccurrencesRegistrant;
@@ -32,24 +31,21 @@ import org.eclipse.che.ide.editor.orion.client.jso.OrionHighlightingConfiguratio
 import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorProvider;
 import org.eclipse.che.plugin.languageserver.ide.highlighting.OccurrencesProvider;
 import org.eclipse.che.plugin.languageserver.ide.hover.HoverProvider;
+import org.eclipse.che.plugin.languageserver.ide.registry.LanguageServerRegistry;
 import org.eclipse.che.plugin.languageserver.ide.service.LanguageServerRegistryServiceClient;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 /**
  * @author Evgen Vidolob
  */
 @Singleton
 public class LanguageServerFileTypeRegister implements WsAgentComponent {
-
+    private static Logger logger = Logger.getLogger(LanguageServerFileTypeRegister.class.getName());
 
     private final LanguageServerRegistryServiceClient serverLanguageRegistry;
-    private final FileTypeRegistry                    fileTypeRegistry;
+    private final LanguageServerRegistry              lsRegistry;
     private final LanguageServerResources             resources;
     private final EditorRegistry                      editorRegistry;
     private final OrionContentTypeRegistrant          contentTypeRegistrant;
@@ -59,25 +55,19 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
     private final HoverProvider                       hoverProvider;
     private final OccurrencesProvider                 occurrencesProvider;
 
-    private final Map<String, String> ext2langId = new HashMap<>();
-
     @Inject
-    public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry,
-                                          FileTypeRegistry fileTypeRegistry,
-                                          LanguageServerResources resources,
-                                          EditorRegistry editorRegistry,
-                                          OrionContentTypeRegistrant contentTypeRegistrant,
-                                          OrionHoverRegistrant orionHoverRegistrant,
+    public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry, LanguageServerRegistry lsRegistry,
+                                          LanguageServerResources resources, EditorRegistry editorRegistry,
+                                          OrionContentTypeRegistrant contentTypeRegistrant, OrionHoverRegistrant orionHoverRegistrant,
                                           OrionOccurrencesRegistrant orionOccurrencesRegistrant,
-                                          LanguageServerEditorProvider editorProvider,
-                                          HoverProvider hoverProvider,
-                                          OccurrencesProvider occurrencesProvider) {
+                                          LanguageServerEditorProvider editorProvider, HoverProvider hoverProvider,
+                                          OccurrencesProvider occurrencesProvider) { 
         this.serverLanguageRegistry = serverLanguageRegistry;
-        this.fileTypeRegistry = fileTypeRegistry;
+        this.lsRegistry = lsRegistry;
         this.resources = resources;
         this.editorRegistry = editorRegistry;
         this.contentTypeRegistrant = contentTypeRegistrant;
-        this.orionHoverRegistrant = orionHoverRegistrant;
+        this.orionHoverRegistrant = orionHoverRegistrant; 
         this.orionOccurrencesRegistrant = orionOccurrencesRegistrant;
         this.editorProvider = editorProvider;
         this.hoverProvider = hoverProvider;
@@ -90,40 +80,43 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
         registeredLanguages.then(new Operation<List<LanguageDescription>>() {
             @Override
             public void apply(List<LanguageDescription> langs) throws OperationException {
+                logger.info("registering language descriptions");
                 if (!langs.isEmpty()) {
                     JsArrayString contentTypes = JsArrayString.createArray().cast();
                     for (LanguageDescription lang : langs) {
-                        String primaryExtension = lang.getFileExtensions().get(0);
-                        for (String ext : lang.getFileExtensions()) {
-                            final FileType fileType = new FileType(resources.file(), ext);
-                            fileTypeRegistry.registerFileType(fileType);
-                            editorRegistry.registerDefaultEditor(fileType, editorProvider);
-                            ext2langId.put(ext, lang.getLanguageId());
+                        if (lang.getFileExtensions() != null) {
+                            for (String ext : lang.getFileExtensions()) {
+                                final FileType fileType = new FileType(resources.file(), ext);
+                                lsRegistry.registerFileType(fileType, lang);
+                                editorRegistry.registerDefaultEditor(fileType, editorProvider);
+                            }
                         }
-                        List<String> mimeTypes = lang.getMimeTypes();
-                        if (mimeTypes.isEmpty()) {
-                            mimeTypes = newArrayList("text/x-" + lang.getLanguageId());
+                        if (lang.getFileNames() != null) {
+                            for (String fileName : lang.getFileNames()) {
+                                final FileType fileType = new FileType(resources.file(), null, RegExp.quote(fileName));
+                                lsRegistry.registerFileType(fileType, lang);
+                                editorRegistry.registerDefaultEditor(fileType, editorProvider);
+                            }
                         }
-                        for (String contentTypeId : mimeTypes) {
-                            contentTypes.push(contentTypeId);
-                            OrionContentTypeOverlay contentType = OrionContentTypeOverlay.create();
-                            contentType.setId(contentTypeId);
-                            contentType.setName(lang.getLanguageId());
-                            contentType.setExtension(primaryExtension);
-                            contentType.setExtends("text/plain");
+                        String mimeType = lang.getMimeType();
+                        contentTypes.push(mimeType);
+                        OrionContentTypeOverlay contentType = OrionContentTypeOverlay.create();
+                        contentType.setId(mimeType);
+                        contentType.setName(lang.getLanguageId());
+                        contentType.setExtension(lang.getFileExtensions().toArray(new String[lang.getFileExtensions().size()]));
+                        contentType.setExtends("text/plain");
 
-                            // highlighting
-                            OrionHighlightingConfigurationOverlay config = OrionHighlightingConfigurationOverlay
-                                    .create();
-                            config.setId(lang.getLanguageId() + ".highlighting");
-                            config.setContentTypes(contentTypeId);
-                            config.setPatterns(lang.getHighlightingConfiguration());
-                            Logger logger = Logger.getLogger(LanguageServerFileTypeRegister.class.getName());
-                            contentTypeRegistrant.registerFileType(contentType, config);
-                        }
+                        // highlighting
+                        OrionHighlightingConfigurationOverlay config = OrionHighlightingConfigurationOverlay.create();
+                        config.setId(lang.getLanguageId() + ".highlighting");
+                        config.setContentTypes(mimeType);
+                        config.setPatterns(lang.getHighlightingConfiguration());
+                        contentTypeRegistrant.registerFileType(contentType, config);
+                        logger.info("registered language description for " + lang.getLanguageId());
                     }
                     orionHoverRegistrant.registerHover(contentTypes, hoverProvider);
                     orionOccurrencesRegistrant.registerOccurrencesHandler(contentTypes, occurrencesProvider);
+
                 }
                 callback.onSuccess(LanguageServerFileTypeRegister.this);
             }
@@ -133,13 +126,5 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
                 callback.onFailure(new Exception(arg.getMessage(), arg.getCause()));
             }
         });
-    }
-
-    boolean hasLSForExtension(String ext) {
-        return ext2langId.containsKey(ext);
-    }
-
-    String findLangId(String ext) {
-        return ext2langId.get(ext);
     }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
@@ -56,16 +56,16 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
     private final OccurrencesProvider                 occurrencesProvider;
 
     @Inject
-    public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry, 
+    public LanguageServerFileTypeRegister(LanguageServerRegistryServiceClient serverLanguageRegistry,
                                           LanguageServerRegistry lsRegistry,
-                                          LanguageServerResources resources, 
+                                          LanguageServerResources resources,
                                           EditorRegistry editorRegistry,
-                                          OrionContentTypeRegistrant contentTypeRegistrant, 
+                                          OrionContentTypeRegistrant contentTypeRegistrant,
                                           OrionHoverRegistrant orionHoverRegistrant,
                                           OrionOccurrencesRegistrant orionOccurrencesRegistrant,
-                                          LanguageServerEditorProvider editorProvider, 
+                                          LanguageServerEditorProvider editorProvider,
                                           HoverProvider hoverProvider,
-                                          OccurrencesProvider occurrencesProvider) { 
+                                          OccurrencesProvider occurrencesProvider) {
         this.serverLanguageRegistry = serverLanguageRegistry;
         this.lsRegistry = lsRegistry;
         this.resources = resources;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerFileTypeRegister.java
@@ -88,25 +88,22 @@ public class LanguageServerFileTypeRegister implements WsAgentComponent {
                 if (!langs.isEmpty()) {
                     JsArrayString contentTypes = JsArrayString.createArray().cast();
                     for (LanguageDescription lang : langs) {
-                        if (lang.getFileExtensions() != null) {
-                            for (String ext : lang.getFileExtensions()) {
-                                final FileType fileType = new FileType(resources.file(), ext);
-                                lsRegistry.registerFileType(fileType, lang);
-                                editorRegistry.registerDefaultEditor(fileType, editorProvider);
-                            }
+                        for (String ext : lang.getFileExtensions()) {
+                            final FileType fileType = new FileType(resources.file(), ext);
+                            lsRegistry.registerFileType(fileType, lang);
+                            editorRegistry.registerDefaultEditor(fileType, editorProvider);
                         }
-                        if (lang.getFileNames() != null) {
-                            for (String fileName : lang.getFileNames()) {
-                                final FileType fileType = new FileType(resources.file(), null, RegExp.quote(fileName));
-                                lsRegistry.registerFileType(fileType, lang);
-                                editorRegistry.registerDefaultEditor(fileType, editorProvider);
-                            }
+                        for (String fileName : lang.getFileNames()) {
+                            final FileType fileType = new FileType(resources.file(), null, RegExp.quote(fileName));
+                            lsRegistry.registerFileType(fileType, lang);
+                            editorRegistry.registerDefaultEditor(fileType, editorProvider);
                         }
                         String mimeType = lang.getMimeType();
                         contentTypes.push(mimeType);
                         OrionContentTypeOverlay contentType = OrionContentTypeOverlay.create();
                         contentType.setId(mimeType);
                         contentType.setName(lang.getLanguageId());
+                        contentType.setFileName(lang.getFileNames().toArray(new String[lang.getFileNames().size()]));
                         contentType.setExtension(lang.getFileExtensions().toArray(new String[lang.getFileExtensions().size()]));
                         contentType.setExtends("text/plain");
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
@@ -13,7 +13,7 @@ package org.eclipse.che.plugin.languageserver.ide.inject;
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
 import com.google.gwt.inject.client.multibindings.GinMapBinder;
-
+import com.google.inject.Singleton;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerFileTypeRegister;
@@ -45,7 +45,8 @@ public class LanguageServerGinModule extends AbstractGinModule {
         install(new GinFactoryModuleBuilder().build(LanguageServerQuickAssistProcessorFactory.class));
         install(new GinFactoryModuleBuilder().build(LanguageServerReconcileStrategyFactory.class));
         install(new GinFactoryModuleBuilder().build(LanguageServerSignatureHelpFactory.class));
-        bind(LanguageServerRegistry.class);
+        // need this to ensure only one instance.
+        bind(LanguageServerRegistry.class).in(Singleton.class);
 
         GinMapBinder<String, WsAgentComponent> wsAgentComponentsBinder =
                 GinMapBinder.newMapBinder(binder(), String.class, WsAgentComponent.class);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
@@ -45,15 +45,10 @@ public class LanguageServerGinModule extends AbstractGinModule {
         install(new GinFactoryModuleBuilder().build(LanguageServerQuickAssistProcessorFactory.class));
         install(new GinFactoryModuleBuilder().build(LanguageServerReconcileStrategyFactory.class));
         install(new GinFactoryModuleBuilder().build(LanguageServerSignatureHelpFactory.class));
-        // need this to ensure only one instance.
-        bind(LanguageServerRegistry.class).in(Singleton.class);
 
         GinMapBinder<String, WsAgentComponent> wsAgentComponentsBinder =
                 GinMapBinder.newMapBinder(binder(), String.class, WsAgentComponent.class);
         wsAgentComponentsBinder.addBinding("Load Language Server file types.").to(LanguageServerFileTypeRegister.class);
-
-        bind(PublishDiagnosticsReceiver.class).asEagerSingleton();
-        bind(ShowMessageJsonRpcReceiver.class).asEagerSingleton();
     }
 
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
@@ -13,7 +13,6 @@ package org.eclipse.che.plugin.languageserver.ide.inject;
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
 import com.google.gwt.inject.client.multibindings.GinMapBinder;
-import com.google.inject.Singleton;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerFileTypeRegister;
@@ -25,7 +24,6 @@ import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerReconcileS
 import org.eclipse.che.plugin.languageserver.ide.editor.quickassist.LanguageServerQuickAssistProcessorFactory;
 import org.eclipse.che.plugin.languageserver.ide.editor.signature.LanguageServerSignatureHelpFactory;
 import org.eclipse.che.plugin.languageserver.ide.location.OpenLocationPresenterFactory;
-import org.eclipse.che.plugin.languageserver.ide.registry.LanguageServerRegistry;
 import org.eclipse.che.plugin.languageserver.ide.service.PublishDiagnosticsReceiver;
 import org.eclipse.che.plugin.languageserver.ide.service.ShowMessageJsonRpcReceiver;
 
@@ -49,6 +47,9 @@ public class LanguageServerGinModule extends AbstractGinModule {
         GinMapBinder<String, WsAgentComponent> wsAgentComponentsBinder =
                 GinMapBinder.newMapBinder(binder(), String.class, WsAgentComponent.class);
         wsAgentComponentsBinder.addBinding("Load Language Server file types.").to(LanguageServerFileTypeRegister.class);
+
+        bind(PublishDiagnosticsReceiver.class).asEagerSingleton();
+        bind(ShowMessageJsonRpcReceiver.class).asEagerSingleton();
     }
 
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
@@ -14,20 +14,22 @@ import com.google.gwt.core.client.Callback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
-
-import org.eclipse.che.api.languageserver.shared.ProjectExtensionKey;
+import org.eclipse.che.api.languageserver.shared.ProjectLangugageKey;
 import org.eclipse.che.api.languageserver.shared.event.LanguageServerInitializeEvent;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedInitializeResult;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.api.promises.client.callback.CallbackPromiseHelper;
-import org.eclipse.che.api.promises.client.js.Promises;
+import org.eclipse.che.ide.api.filetypes.FileType;
+import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.notification.StatusNotification;
+import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
 import org.eclipse.che.ide.ui.loaders.request.MessageLoader;
@@ -44,8 +46,9 @@ import org.eclipse.lsp4j.ServerCapabilities;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static org.eclipse.che.api.languageserver.shared.ProjectExtensionKey.createProjectKey;
+import static org.eclipse.che.api.languageserver.shared.ProjectLangugageKey.createProjectKey;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.WARNING;
@@ -56,27 +59,35 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.WAR
  */
 @Singleton
 public class LanguageServerRegistry {
-    private final EventBus                                                                eventBus;
-    private final LanguageServerRegistryJsonRpcClient                                     jsonRpcClient;
-    private final LanguageServerRegistryServiceClient                                     client;
-    private final Map<ProjectExtensionKey, ExtendedInitializeResult>                      projectToInitResult;
-    private final Map<ProjectExtensionKey, Callback<ExtendedInitializeResult, Throwable>> callbackMap;
-    private       LoaderFactory                                                           loaderFactory;
-    private       NotificationManager                                                     notificationManager;
+    private final EventBus                            eventBus;
+    private final LanguageServerRegistryJsonRpcClient jsonRpcClient;
+    private final LoaderFactory                             loaderFactory;
+    private NotificationManager                       notificationManager;
+    private final LanguageServerRegistryServiceClient client;
+
+    private final Map<ProjectLangugageKey, ExtendedInitializeResult>                      projectToInitResult;
+    private final Map<ProjectLangugageKey, Callback<ExtendedInitializeResult, Throwable>> callbackMap;
+    private final Map<FileType, LanguageDescription>                                      registeredFileTypes = new ConcurrentHashMap<>();
+    private final PromiseProvider                                                         promiseProvider;
+    private final FileTypeRegistry                                                        fileTypeRegistry;
 
     @Inject
     public LanguageServerRegistry(EventBus eventBus,
                                   LoaderFactory loaderFactory,
                                   NotificationManager notificationManager,
                                   LanguageServerRegistryJsonRpcClient jsonRpcClient,
-                                  LanguageServerRegistryServiceClient client) {
+                                  LanguageServerRegistryServiceClient client, 
+                                  PromiseProvider promiseProvider,
+                                  FileTypeRegistry fileTypeRegistry) {
         this.eventBus = eventBus;
         this.loaderFactory = loaderFactory;
         this.notificationManager = notificationManager;
         this.jsonRpcClient = jsonRpcClient;
         this.client = client;
+        this.promiseProvider = promiseProvider;
         this.projectToInitResult = new HashMap<>();
         this.callbackMap = new HashMap<>();
+        this.fileTypeRegistry = fileTypeRegistry;
     }
 
     /**
@@ -84,8 +95,7 @@ public class LanguageServerRegistry {
      */
     protected void register(String projectPath, LanguageDescription languageDescription, ServerCapabilities capabilities) {
         ExtendedInitializeResult initializeResult = new ExtendedInitializeResult(projectPath, capabilities, languageDescription);
-        for (String ext : languageDescription.getFileExtensions()) {
-            ProjectExtensionKey key = createProjectKey(projectPath, ext);
+        ProjectLangugageKey key = createProjectKey(projectPath, languageDescription.getLanguageId());
             projectToInitResult.put(key, initializeResult);
 
             if (callbackMap.containsKey(key)) {
@@ -93,22 +103,22 @@ public class LanguageServerRegistry {
                 callback.onSuccess(initializeResult);
             }
         }
-    }
 
-    public Promise<ExtendedInitializeResult> getOrInitializeServer(String projectPath, String ext, String filePath) {
-        final ProjectExtensionKey key = createProjectKey(projectPath, ext);
+    public Promise<ExtendedInitializeResult> getOrInitializeServer(String projectPath, VirtualFile file) {
+        LanguageDescription languageDescription = getLanguageDescription(file);
+        final ProjectLangugageKey key = createProjectKey(projectPath, languageDescription.getLanguageId());
         if (projectToInitResult.containsKey(key)) {
-            return Promises.resolve(projectToInitResult.get(key));
+            return promiseProvider.resolve(projectToInitResult.get(key));
         } else {
             //call initialize service
-            final MessageLoader loader = loaderFactory.newLoader("Initializing Language Server for " + ext);
+            final MessageLoader loader = loaderFactory.newLoader("Initializing Language Server for " + file.getName());
             loader.show();
 
-            jsonRpcClient.initializeServer(filePath)
+            jsonRpcClient.initializeServer(file.getLocation().toString())
                          .onSuccess(loader::hide)
                          .onFailure((error) -> {
                              notificationManager
-                                     .notify("Failed to initialize language server for " + ext + " : ", error.getMessage(), FAIL,
+                                     .notify("Failed to initialize language server for " + file.getLocation().toString() + " : ", error.getMessage(), FAIL,
                                              EMERGE_MODE);
                              loader.hide();
                          })
@@ -137,9 +147,7 @@ public class LanguageServerRegistry {
                     public void apply(List<ExtendedInitializeResult> initialResults) throws OperationException {
                         for (ExtendedInitializeResult initializeResultDTO : initialResults) {
                             for (LanguageDescription languageDescription : initializeResultDTO.getSupportedLanguages()) {
-                                register(initializeResultDTO.getProject(),
-                                         languageDescription,
-                                         initializeResultDTO.getCapabilities());
+                                register(initializeResultDTO.getProject(), languageDescription, initializeResultDTO.getCapabilities());
                             }
                         }
                     }
@@ -191,4 +199,28 @@ public class LanguageServerRegistry {
             }
         });
     }
+
+    /**
+     * Register file type for a language description
+     * @param type
+     * @param description
+     */
+    public void registerFileType(FileType type, LanguageDescription description) {
+        fileTypeRegistry.registerFileType(type);
+        registeredFileTypes.put(type, description);
+    }
+
+    /**
+     * Get the language that is registered for this file. May return null if none is found.
+     * @param file
+     * @return
+     */
+    public LanguageDescription getLanguageDescription(VirtualFile file) {
+        FileType fileType = fileTypeRegistry.getFileTypeByFile(file);
+        if (fileType == null) {
+            return null;
+        }
+        return registeredFileTypes.get(fileType);
+    }
+
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
@@ -201,9 +201,9 @@ public class LanguageServerRegistry {
     }
 
     /**
-     * Register file type for a language description
-     * @param type
-     * @param description
+     * Register a che file type and associate it with the given language
+     * @param type the che file type
+     * @param description the language description to associate with the file type
      */
     public void registerFileType(FileType type, LanguageDescription description) {
         fileTypeRegistry.registerFileType(type);
@@ -211,9 +211,11 @@ public class LanguageServerRegistry {
     }
 
     /**
-     * Get the language that is registered for this file. May return null if none is found.
-     * @param file
-     * @return
+     * Get the language that is registered for this file. May return null if
+     * none is found.
+     * 
+     * @param file the file in question
+     * @return the langauge that is associated with the given file or <code>null</code> if not found.
      */
     public LanguageDescription getLanguageDescription(VirtualFile file) {
         FileType fileType = fileTypeRegistry.getFileTypeByFile(file);

--- a/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/inject/PhpModule.java
+++ b/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/inject/PhpModule.java
@@ -14,6 +14,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.project.server.handlers.ProjectHandler;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.inject.DynaModule;
@@ -22,12 +23,17 @@ import org.eclipse.che.plugin.php.projecttype.PhpProjectGenerator;
 import org.eclipse.che.plugin.php.projecttype.PhpProjectType;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.util.Arrays.asList;
 
 /**
  * @author Kaloyan Raev
  */
 @DynaModule
 public class PhpModule extends AbstractModule {
+    public static final String   LANGUAGE_ID = "php";
+    private static final String[] EXTENSIONS  = new String[]{"php"};
+    private static final String MIME_TYPE  = "text/x-php";
+
     @Override
     protected void configure() {
         Multibinder<ProjectTypeDef> projectTypeMultibinder = Multibinder.newSetBinder(binder(), ProjectTypeDef.class);
@@ -37,5 +43,10 @@ public class PhpModule extends AbstractModule {
         projectHandlerMultibinder.addBinding().to(PhpProjectGenerator.class);
 
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(PhpLanguageServerLauncher.class);
-    }
+        LanguageDescription description = new LanguageDescription();
+        description.setFileExtensions(asList(EXTENSIONS));
+        description.setLanguageId(LANGUAGE_ID);
+        description.setMimeType(MIME_TYPE);
+        Multibinder.newSetBinder(binder(), LanguageDescription.class).addBinding().toInstance(description);
+   }
 }

--- a/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/languageserver/PhpLanguageServerLauncher.java
+++ b/plugins/plugin-php/che-plugin-php-lang-server/src/main/java/org/eclipse/che/plugin/php/languageserver/PhpLanguageServerLauncher.java
@@ -12,10 +12,9 @@ package org.eclipse.che.plugin.php.languageserver;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
-import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+import org.eclipse.che.plugin.php.inject.PhpModule;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -25,8 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static java.util.Arrays.asList;
-
 /**
  * @author Evgen Vidolob
  * @author Anatolii Bazko
@@ -34,10 +31,6 @@ import static java.util.Arrays.asList;
  */
 @Singleton
 public class PhpLanguageServerLauncher extends LanguageServerLauncherTemplate {
-    private static final String   LANGUAGE_ID = "php";
-    private static final String[] EXTENSIONS  = new String[]{"php"};
-    private static final String[] MIME_TYPES  = new String[]{"text/x-php"};
-    private static final LanguageDescription description;
     private final Path launchScript;
 
     @Inject
@@ -46,8 +39,8 @@ public class PhpLanguageServerLauncher extends LanguageServerLauncherTemplate {
     }
 
     @Override
-    public LanguageDescription getLanguageDescription() {
-        return description;
+    public String getLanguageId() {
+        return PhpModule.LANGUAGE_ID;
     }
 
     @Override
@@ -73,10 +66,4 @@ public class PhpLanguageServerLauncher extends LanguageServerLauncherTemplate {
         }
     }
 
-    static {
-        description = new LanguageDescription();
-        description.setFileExtensions(asList(EXTENSIONS));
-        description.setLanguageId(LANGUAGE_ID);
-        description.setMimeTypes(asList(MIME_TYPES));
-    }
 }

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/inject/PythonModule.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/inject/PythonModule.java
@@ -12,22 +12,29 @@ package org.eclipse.che.plugin.python.inject;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.project.server.handlers.ProjectHandler;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.plugin.python.generator.PythonProjectGenerator;
 import org.eclipse.che.plugin.python.languageserver.PythonLanguageSeverLauncher;
 import org.eclipse.che.plugin.python.projecttype.PythonProjectType;
+import org.eclipse.che.plugin.python.shared.ProjectAttributes;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.util.Arrays.asList;
 
 /**
  * @author Valeriy Svydenko
  */
 @DynaModule
 public class PythonModule extends AbstractModule {
+    private static final String[] EXTENSIONS = new String[]{ProjectAttributes.PYTHON_EXT};
+    private static final String MIME_TYPE = "text/x-python";
+    static {
+    }
+
     @Override
     protected void configure() {
         Multibinder<ProjectTypeDef> projectTypeMultibinder = newSetBinder(binder(), ProjectTypeDef.class);
@@ -37,5 +44,10 @@ public class PythonModule extends AbstractModule {
         projectHandlerMultibinder.addBinding().to(PythonProjectGenerator.class);
 
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(PythonLanguageSeverLauncher.class);
-    }
+        LanguageDescription description = new LanguageDescription();
+        description.setFileExtensions(asList(EXTENSIONS));
+        description.setLanguageId(ProjectAttributes.PYTHON_ID);
+        description.setMimeType(MIME_TYPE);
+        Multibinder.newSetBinder(binder(), LanguageDescription.class).addBinding().toInstance(description);
+   }
 }

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/inject/PythonModule.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/inject/PythonModule.java
@@ -32,8 +32,6 @@ import static java.util.Arrays.asList;
 public class PythonModule extends AbstractModule {
     private static final String[] EXTENSIONS = new String[]{ProjectAttributes.PYTHON_EXT};
     private static final String MIME_TYPE = "text/x-python";
-    static {
-    }
 
     @Override
     protected void configure() {

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
@@ -39,7 +39,7 @@ public class PythonLanguageSeverLauncher extends LanguageServerLauncherTemplate 
     public String getLanguageId() {
         return ProjectAttributes.PYTHON_ID;
     }
-    
+
     @Override
     public boolean isAbleToLaunch() {
         return launchScript.toFile().exists();

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
@@ -12,29 +12,22 @@ package org.eclipse.che.plugin.python.languageserver;
 
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
-import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.plugin.python.shared.ProjectAttributes;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 import javax.inject.Singleton;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-
-import static java.util.Arrays.asList;
 
 /**
  * Launches language server for Python
  */
 @Singleton
 public class PythonLanguageSeverLauncher extends LanguageServerLauncherTemplate {
-
-    private static final String[] EXTENSIONS = new String[]{ProjectAttributes.PYTHON_EXT};
-    private static final String[] MIME_TYPES = new String[]{"text/x-python"};
-    private static final LanguageDescription description;
 
     private final Path launchScript;
 
@@ -43,10 +36,10 @@ public class PythonLanguageSeverLauncher extends LanguageServerLauncherTemplate 
     }
 
     @Override
-    public LanguageDescription getLanguageDescription() {
-        return description;
+    public String getLanguageId() {
+        return ProjectAttributes.PYTHON_ID;
     }
-
+    
     @Override
     public boolean isAbleToLaunch() {
         return launchScript.toFile().exists();
@@ -74,10 +67,4 @@ public class PythonLanguageSeverLauncher extends LanguageServerLauncherTemplate 
         return launcher.getRemoteProxy();
     }
 
-    static {
-        description = new LanguageDescription();
-        description.setFileExtensions(asList(EXTENSIONS));
-        description.setLanguageId(ProjectAttributes.PYTHON_ID);
-        description.setMimeTypes(Arrays.asList(MIME_TYPES));
-    }
-}
+  }

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
@@ -66,5 +66,4 @@ public class PythonLanguageSeverLauncher extends LanguageServerLauncherTemplate 
         launcher.startListening();
         return launcher.getRemoteProxy();
     }
-
   }

--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/java/org/eclipse/che/plugin/python/languageserver/PythonLanguageSeverLauncher.java
@@ -66,4 +66,4 @@ public class PythonLanguageSeverLauncher extends LanguageServerLauncherTemplate 
         launcher.startListening();
         return launcher.getRemoteProxy();
     }
-  }
+}

--- a/plugins/plugin-web/che-plugin-web-ext-server/src/main/java/org/eclipse/che/plugin/web/inject/WebModule.java
+++ b/plugins/plugin-web/che-plugin-web-ext-server/src/main/java/org/eclipse/che/plugin/web/inject/WebModule.java
@@ -12,12 +12,15 @@ package org.eclipse.che.plugin.web.inject;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
 import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.plugin.web.shared.Constants;
 import org.eclipse.che.plugin.web.typescript.TSLSLauncher;
 import org.eclipse.che.plugin.web.typescript.TypeScriptProjectType;
+
+import static java.util.Arrays.asList;
 
 /**
  * The module that contains configuration of the server side part of the Web plugin
@@ -25,11 +28,24 @@ import org.eclipse.che.plugin.web.typescript.TypeScriptProjectType;
 @DynaModule
 public class WebModule extends AbstractModule {
 
-    @Override
+    private static final String[] EXTENSIONS = new String[]{Constants.TS_EXT};
+    private static final String MIME_TYPE = Constants.TS_MIME_TYPE;
+
+   @Override
     protected void configure() {
         Multibinder<ProjectTypeDef> projectTypeMultibinder = Multibinder.newSetBinder(binder(), ProjectTypeDef.class);
         projectTypeMultibinder.addBinding().to(TypeScriptProjectType.class);
 
         Multibinder.newSetBinder(binder(), LanguageServerLauncher.class).addBinding().to(TSLSLauncher.class);
+        LanguageDescription description = new LanguageDescription();
+        description.setFileExtensions(asList(EXTENSIONS));
+        description.setLanguageId(Constants.TS_LANG);
+        description.setMimeType(MIME_TYPE);
+        description.setHighlightingConfiguration("[\n" +
+                                                 "  {\"include\":\"orion.js\"},\n" +
+                                                 "  {\"match\":\"\\\\b(?:constructor|declare|module)\\\\b\",\"name\" :\"keyword.operator.typescript\"},\n" +
+                                                 "  {\"match\":\"\\\\b(?:any|boolean|number|string)\\\\b\",\"name\" : \"storage.type.typescript\"}\n" +
+                                                 "]");
+        Multibinder.newSetBinder(binder(), LanguageDescription.class).addBinding().toInstance(description);
     }
 }

--- a/plugins/plugin-web/che-plugin-web-ext-server/src/main/java/org/eclipse/che/plugin/web/typescript/TSLSLauncher.java
+++ b/plugins/plugin-web/che-plugin-web-ext-server/src/main/java/org/eclipse/che/plugin/web/typescript/TSLSLauncher.java
@@ -60,7 +60,7 @@ public class TSLSLauncher extends LanguageServerLauncherTemplate {
     public String getLanguageId() {
         return Constants.TS_LANG;
     }
-    
+
     @Override
     public boolean isAbleToLaunch() {
         return Files.exists(launchScript);

--- a/plugins/plugin-web/che-plugin-web-ext-server/src/main/java/org/eclipse/che/plugin/web/typescript/TSLSLauncher.java
+++ b/plugins/plugin-web/che-plugin-web-ext-server/src/main/java/org/eclipse/che/plugin/web/typescript/TSLSLauncher.java
@@ -12,19 +12,17 @@ package org.eclipse.che.plugin.web.typescript;
 
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
-import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.plugin.web.shared.Constants;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 import javax.inject.Singleton;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static java.util.Arrays.asList;
 
 
 /**
@@ -32,10 +30,6 @@ import static java.util.Arrays.asList;
  */
 @Singleton
 public class TSLSLauncher extends LanguageServerLauncherTemplate {
-    private static final String[] EXTENSIONS = new String[]{Constants.TS_EXT};
-    private static final String[] MIME_TYPES = new String[]{Constants.TS_MIME_TYPE};
-    private static final LanguageDescription description;
-
     private final Path launchScript;
 
     public TSLSLauncher() {
@@ -63,24 +57,12 @@ public class TSLSLauncher extends LanguageServerLauncherTemplate {
     }
 
     @Override
-    public LanguageDescription getLanguageDescription() {
-        return description;
+    public String getLanguageId() {
+        return Constants.TS_LANG;
     }
-
+    
     @Override
     public boolean isAbleToLaunch() {
         return Files.exists(launchScript);
-    }
-
-    static {
-        description = new LanguageDescription();
-        description.setFileExtensions(asList(EXTENSIONS));
-        description.setLanguageId(Constants.TS_LANG);
-        description.setMimeTypes(asList(MIME_TYPES));
-        description.setHighlightingConfiguration("[\n" +
-                                                 "  {\"include\":\"orion.js\"},\n" +
-                                                 "  {\"match\":\"\\\\b(?:constructor|declare|module)\\\\b\",\"name\" :\"keyword.operator.typescript\"},\n" +
-                                                 "  {\"match\":\"\\\\b(?:any|boolean|number|string)\\\\b\",\"name\" : \"storage.type.typescript\"}\n" +
-                                                 "]");
     }
 }

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/ProjectLangugageKey.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/ProjectLangugageKey.java
@@ -15,26 +15,22 @@ import java.util.Objects;
 /**
  * @author Anatoliy Bazko
  */
-public class ProjectExtensionKey {
+public class ProjectLangugageKey {
     public static final String ALL_PROJECT_MARKER = "*";
 
     private String project;
-    private String extension;
+    private String languageId;
 
-    private ProjectExtensionKey(String project, String extension) {
+    private ProjectLangugageKey(String project, String languageId) {
         this.project = project;
-        this.extension = extension;
+        this.languageId = languageId;
     }
 
-    public ProjectExtensionKey() {
+    public ProjectLangugageKey() {
     }
 
-    public static ProjectExtensionKey createProjectKey(String project, String extension) {
-        return new ProjectExtensionKey(project, extension);
-    }
-
-    public static ProjectExtensionKey createAllProjectKey(String extension) {
-        return new ProjectExtensionKey(ALL_PROJECT_MARKER, extension);
+    public static ProjectLangugageKey createProjectKey(String project, String languageId) {
+        return new ProjectLangugageKey(project, languageId);
     }
 
     public String getProject() {
@@ -45,26 +41,26 @@ public class ProjectExtensionKey {
         this.project = project;
     }
 
-    public String getExtension() {
-        return extension;
+    public String getLanguageId() {
+        return languageId;
     }
 
-    public void setExtension(String extension) {
-        this.extension = extension;
+    public void setLanguageId(String languageId) {
+        this.languageId = languageId;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;
-        if (!(o instanceof ProjectExtensionKey))
+        if (!(o instanceof ProjectLangugageKey))
             return false;
-        ProjectExtensionKey that = (ProjectExtensionKey)o;
-        return Objects.equals(extension, that.extension) && Objects.equals(project, that.project);
+        ProjectLangugageKey that = (ProjectLangugageKey)o;
+        return Objects.equals(languageId, that.languageId) && Objects.equals(project, that.project);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(extension, project);
+        return Objects.hash(languageId, project);
     }
 }

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/LanguageDescription.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/LanguageDescription.java
@@ -25,11 +25,17 @@ public class LanguageDescription {
     /**
      * The optional content types this language is associated with.
      */
-    private List<String> mimeTypes;
+    private String mimeType;
     /**
-     * The fileExtension this language is associated with. At least one extension must be provided.
+     * The fileExtension this language is associated with. 
      */
     private List<String> fileExtensions;
+    
+    /**
+     * The file names this language is associated with. 
+     */
+    private List<String> fileNames;
+
     /**
      * The optional highlighting configuration to support client side syntax highlighting.
      * The format is client (editor) dependent.
@@ -44,12 +50,12 @@ public class LanguageDescription {
         this.languageId = languageId;
     }
 
-    public List<String> getMimeTypes() {
-        return this.mimeTypes;
+    public String getMimeType() {
+        return this.mimeType;
     }
 
-    public void setMimeTypes(final List<String> mimeTypes) {
-        this.mimeTypes = mimeTypes;
+    public void setMimeType(final String mimeType) {
+        this.mimeType = mimeType;
     }
 
     public List<String> getFileExtensions() {
@@ -58,6 +64,14 @@ public class LanguageDescription {
 
     public void setFileExtensions(final List<String> fileExtensions) {
         this.fileExtensions = fileExtensions;
+    }
+    
+    public List<String> getFileNames() {
+        return fileNames;
+    }
+    
+    public void setFileNames(List<String> fileNames) {
+        this.fileNames = fileNames;
     }
 
     public String getHighlightingConfiguration() {
@@ -74,22 +88,24 @@ public class LanguageDescription {
         if (o == null || getClass() != o.getClass()) return false;
         LanguageDescription that = (LanguageDescription)o;
         return Objects.equals(languageId, that.languageId) &&
-               Objects.equals(mimeTypes, that.mimeTypes) &&
+               Objects.equals(mimeType, that.mimeType) &&
                Objects.equals(fileExtensions, that.fileExtensions) &&
+               Objects.equals(fileNames, that.fileNames) &&
                Objects.equals(highlightingConfiguration, that.highlightingConfiguration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(languageId, mimeTypes, fileExtensions, highlightingConfiguration);
+        return Objects.hash(languageId, mimeType, fileExtensions, fileNames, highlightingConfiguration);
     }
 
     @Override
     public String toString() {
         return "LanguageDescriptionImpl{" +
                "languageId='" + languageId + '\'' +
-               ", mimeTypes=" + mimeTypes +
+               ", mimeTypes=" + mimeType +
                ", fileExtensions=" + fileExtensions +
+               ", fileNames=" + fileNames +
                ", highlightingConfiguration='" + highlightingConfiguration + '\'' +
                '}';
     }

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/LanguageDescription.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/LanguageDescription.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.languageserver.shared.model;
 
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,22 +26,22 @@ public class LanguageDescription {
     /**
      * The optional content types this language is associated with.
      */
-    private String mimeType;
+    private String       mimeType;
     /**
-     * The fileExtension this language is associated with. 
+     * The fileExtension this language is associated with.
      */
-    private List<String> fileExtensions= Collections.emptyList();
-    
-    /**
-     * The file names this language is associated with. 
-     */
-    private List<String> fileNames= Collections.emptyList();
+    private List<String> fileExtensions = Collections.emptyList();
 
     /**
-     * The optional highlighting configuration to support client side syntax highlighting.
-     * The format is client (editor) dependent.
+     * The file names this language is associated with.
      */
-    private String       highlightingConfiguration;
+    private List<String> fileNames = Collections.emptyList();
+
+    /**
+     * The optional highlighting configuration to support client side syntax
+     * highlighting. The format is client (editor) dependent.
+     */
+    private String highlightingConfiguration;
 
     public String getLanguageId() {
         return this.languageId;
@@ -65,18 +64,20 @@ public class LanguageDescription {
     }
 
     /**
-     * @param fileExtensions must not be null
+     * @param fileExtensions
+     *            must not be null
      */
     public void setFileExtensions(final List<String> fileExtensions) {
         this.fileExtensions = new ArrayList<>(fileExtensions);
     }
-    
+
     public List<String> getFileNames() {
         return fileNames;
     }
-    
+
     /**
-     * @param fileNames must not be null
+     * @param fileNames
+     *            must not be null
      */
     public void setFileNames(List<String> fileNames) {
         this.fileNames = new ArrayList<>(fileNames);
@@ -92,14 +93,14 @@ public class LanguageDescription {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LanguageDescription that = (LanguageDescription)o;
-        return Objects.equals(languageId, that.languageId) &&
-               Objects.equals(mimeType, that.mimeType) &&
-               Objects.equals(fileExtensions, that.fileExtensions) &&
-               Objects.equals(fileNames, that.fileNames) &&
-               Objects.equals(highlightingConfiguration, that.highlightingConfiguration);
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        LanguageDescription that = (LanguageDescription) o;
+        return Objects.equals(languageId, that.languageId) && Objects.equals(mimeType, that.mimeType)
+                        && Objects.equals(fileExtensions, that.fileExtensions) && Objects.equals(fileNames, that.fileNames)
+                        && Objects.equals(highlightingConfiguration, that.highlightingConfiguration);
     }
 
     @Override
@@ -109,12 +110,8 @@ public class LanguageDescription {
 
     @Override
     public String toString() {
-        return "LanguageDescriptionImpl{" +
-               "languageId='" + languageId + '\'' +
-               ", mimeTypes=" + mimeType +
-               ", fileExtensions=" + fileExtensions +
-               ", fileNames=" + fileNames +
-               ", highlightingConfiguration='" + highlightingConfiguration + '\'' +
-               '}';
+        return "LanguageDescriptionImpl{" + "languageId='" + languageId + '\'' + ", mimeTypes=" + mimeType + ", fileExtensions="
+                        + fileExtensions + ", fileNames=" + fileNames + ", highlightingConfiguration='" + highlightingConfiguration + '\''
+                        + '}';
     }
 }

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/LanguageDescription.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/LanguageDescription.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.api.languageserver.shared.model;
 
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,12 +31,12 @@ public class LanguageDescription {
     /**
      * The fileExtension this language is associated with. 
      */
-    private List<String> fileExtensions;
+    private List<String> fileExtensions= Collections.emptyList();
     
     /**
      * The file names this language is associated with. 
      */
-    private List<String> fileNames;
+    private List<String> fileNames= Collections.emptyList();
 
     /**
      * The optional highlighting configuration to support client side syntax highlighting.
@@ -62,16 +64,22 @@ public class LanguageDescription {
         return this.fileExtensions;
     }
 
+    /**
+     * @param fileExtensions must not be null
+     */
     public void setFileExtensions(final List<String> fileExtensions) {
-        this.fileExtensions = fileExtensions;
+        this.fileExtensions = new ArrayList<>(fileExtensions);
     }
     
     public List<String> getFileNames() {
         return fileNames;
     }
     
+    /**
+     * @param fileNames must not be null
+     */
     public void setFileNames(List<String> fileNames) {
-        this.fileNames = fileNames;
+        this.fileNames = new ArrayList<>(fileNames);
     }
 
     public String getHighlightingConfiguration() {

--- a/wsagent/che-core-api-languageserver/pom.xml
+++ b/wsagent/che-core-api-languageserver/pom.xml
@@ -30,10 +30,6 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
@@ -25,6 +25,7 @@ import org.eclipse.che.api.languageserver.service.LanguageRegistryService;
 import org.eclipse.che.api.languageserver.service.LanguageServerInitializationHandler;
 import org.eclipse.che.api.languageserver.service.TextDocumentService;
 import org.eclipse.che.api.languageserver.service.WorkspaceService;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 
 public class LanguageServerModule extends AbstractModule {
 
@@ -40,7 +41,7 @@ public class LanguageServerModule extends AbstractModule {
         bind(TextDocumentService.class).asEagerSingleton();
         bind(PublishDiagnosticsParamsJsonRpcTransmitter.class).asEagerSingleton();
         bind(ShowMessageJsonRpcTransmitter.class).asEagerSingleton();
-
         bind(LanguageServerInitializationHandler.class).asEagerSingleton();
+        Multibinder.newSetBinder(binder(), LanguageDescription.class);
     }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/launcher/LanguageServerLauncher.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/launcher/LanguageServerLauncher.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.languageserver.launcher;
 
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
-import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 
@@ -26,9 +25,9 @@ public interface LanguageServerLauncher {
     LanguageServer launch(String projectPath, LanguageClient client) throws LanguageServerException;
 
     /**
-     * Gets supported languages.
+     * Gets supported language ID.
      */
-    LanguageDescription getLanguageDescription();
+    String getLanguageId();
 
     boolean isAbleToLaunch();
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistry.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistry.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.api.languageserver.registry;
 
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
-import org.eclipse.che.api.languageserver.shared.ProjectExtensionKey;
+import org.eclipse.che.api.languageserver.shared.ProjectLangugageKey;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -34,5 +34,5 @@ public interface LanguageServerRegistry {
      */
     List<LanguageDescription> getSupportedLanguages();
 
-    Map<ProjectExtensionKey, LanguageServerDescription> getInitializedLanguages();
+    Map<ProjectLangugageKey, LanguageServerDescription> getInitializedLanguages();
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
@@ -13,11 +13,10 @@ package org.eclipse.che.api.languageserver.registry;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
-import org.eclipse.che.api.languageserver.shared.ProjectExtensionKey;
+import org.eclipse.che.api.languageserver.shared.ProjectLangugageKey;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.project.server.FolderEntry;
 import org.eclipse.che.api.project.server.ProjectManager;
@@ -26,99 +25,117 @@ import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageServer;
 
+import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import static com.google.common.io.Files.getFileExtension;
-import static org.eclipse.che.api.languageserver.shared.ProjectExtensionKey.createProjectKey;
+import static org.eclipse.che.api.languageserver.shared.ProjectLangugageKey.createProjectKey;
 
 @Singleton
 public class LanguageServerRegistryImpl implements LanguageServerRegistry, ServerInitializerObserver {
-    public final static String PROJECT_FOLDER_PATH = "/projects";
-
-    /**
-     * Available {@link LanguageServerLauncher} by extension.
-     */
-    private final ConcurrentHashMap<String, List<LanguageServerLauncher>> extensionToLauncher;
+    public final static String                        PROJECT_FOLDER_PATH = "/projects";
+    private final List<LanguageDescription>           languages           = new ArrayList<>();
+    private final Map<String, LanguageServerLauncher> launchers           = new HashMap<>();
 
     /**
      * Started {@link LanguageServer} by project.
      */
-    private final ConcurrentHashMap<ProjectExtensionKey, LanguageServer> projectToServer;
+    private final ConcurrentHashMap<ProjectLangugageKey, LanguageServer> projectToServer;
 
     private final Provider<ProjectManager> projectManagerProvider;
     private final ServerInitializer        initializer;
 
     @Inject
-    public LanguageServerRegistryImpl(Set<LanguageServerLauncher> languageServerLaunchers,
-                                      Provider<ProjectManager> projectManagerProvider,
-                                      ServerInitializer initializer) {
+    public LanguageServerRegistryImpl(Set<LanguageServerLauncher> languageServerLaunchers, Set<LanguageDescription> languages,
+                                      Provider<ProjectManager> projectManagerProvider, ServerInitializer initializer) {
+        this.languages.addAll(languages);
+        this.launchers.putAll(languageServerLaunchers.stream()
+                        .collect(Collectors.toMap(LanguageServerLauncher::getLanguageId, launcher -> launcher)));
         this.projectManagerProvider = projectManagerProvider;
         this.initializer = initializer;
-        this.extensionToLauncher = new ConcurrentHashMap<>();
         this.projectToServer = new ConcurrentHashMap<>();
         this.initializer.addObserver(this);
-
-        for (LanguageServerLauncher launcher : languageServerLaunchers) {
-            for (String extension : launcher.getLanguageDescription().getFileExtensions()) {
-                extensionToLauncher.putIfAbsent(extension, new ArrayList<>());
-                extensionToLauncher.get(extension).add(launcher);
-            }
-        }
     }
 
     @Override
     public LanguageServer findServer(String fileUri) throws LanguageServerException {
         String path = URI.create(fileUri).getPath();
 
-        String extension = getFileExtension(path);
         String projectPath = extractProjectPath(path);
 
-        return findServer(extension, projectPath);
+        return doFindServer(projectPath, findLanguageId(path));
     }
 
-    @Nullable
-    protected LanguageServer findServer(String extension, String projectPath) throws LanguageServerException {
-        ProjectExtensionKey projectKey = createProjectKey(projectPath, extension);
-
-        for (LanguageServerLauncher launcher : extensionToLauncher.get(extension)) {
-            if (!projectToServer.containsKey(projectKey)) {
-                synchronized (launcher) {
-                    if (!projectToServer.containsKey(projectKey)) {
-                        LanguageServer server = initializer.initialize(launcher, projectPath);
-                        projectToServer.put(projectKey, server);
-                    }
-                }
+    private LanguageDescription findLanguageId(String path) {
+        for (LanguageDescription language : languages) {
+            if (matchesFilenames(language, path) || matchesExtensions(language, path)) {
+                return language;
             }
-            return projectToServer.get(projectKey);
         }
-
         return null;
     }
 
+    private boolean matchesExtensions(LanguageDescription language, String path) {
+        if (language.getFileExtensions() != null) {
+            for (String extension : language.getFileExtensions()) {
+                if (path.endsWith(extension)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
-    @Override
-    public List<LanguageDescription> getSupportedLanguages() {
-        return extensionToLauncher.values()
-                                  .stream()
-                                  .flatMap(Collection::stream)
-                                  .filter(LanguageServerLauncher::isAbleToLaunch)
-                                  .map(LanguageServerLauncher::getLanguageDescription)
-                                  .collect(Collectors.toList());
+    private boolean matchesFilenames(LanguageDescription language, String path) {
+        if (language.getFileNames() != null) {
+            for (String name : language.getFileNames()) {
+                if (name.equals(new File(path).getName())) {
+                    return true;
+                }
+            } 
+        }
+        return false;
+    }
+
+    @Nullable
+    protected LanguageServer doFindServer(String projectPath, LanguageDescription language) throws LanguageServerException {
+        if (language == null || projectPath == null) {
+            return null;
+        }
+        ProjectLangugageKey projectKey = createProjectKey(projectPath, language.getLanguageId());
+        LanguageServerLauncher launcher = launchers.get(language.getLanguageId());
+
+        if (language != null && launcher != null) {
+            synchronized (launcher) {
+                // we're relying on the fact that the following if condition
+                // will
+                // not change unless someone else uses the same launcher
+                if (!projectToServer.containsKey(projectKey)) {
+                    LanguageServer server = initializer.initialize(language, launcher, projectPath);
+                    projectToServer.put(projectKey, server);
+                }
+            }
+        }
+        return projectToServer.get(projectKey);
+
     }
 
     @Override
-    public Map<ProjectExtensionKey, LanguageServerDescription> getInitializedLanguages() {
+    public List<LanguageDescription> getSupportedLanguages() {
+        return Collections.unmodifiableList(languages);
+    }
+
+    @Override
+    public Map<ProjectLangugageKey, LanguageServerDescription> getInitializedLanguages() {
         Map<LanguageServer, LanguageServerDescription> initializedServers = initializer.getInitializedServers();
-        return projectToServer.entrySet()
-                              .stream()
-                              .collect(Collectors.toMap(Map.Entry::getKey, e -> initializedServers.get(e.getValue())));
+        return projectToServer.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> initializedServers.get(e.getValue())));
     }
 
     protected String extractProjectPath(String filePath) throws LanguageServerException {
@@ -148,9 +165,7 @@ public class LanguageServerRegistryImpl implements LanguageServerRegistry, Serve
     }
 
     @Override
-    public void onServerInitialized(LanguageServer server,
-                                    ServerCapabilities capabilities,
-                                    LanguageDescription languageDescription,
+    public void onServerInitialized(LanguageServer server, ServerCapabilities capabilities, LanguageDescription languageDescription,
                                     String projectPath) {
         for (String ext : languageDescription.getFileExtensions()) {
             projectToServer.put(createProjectKey(projectPath, ext), server);

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
@@ -82,25 +82,11 @@ public class LanguageServerRegistryImpl implements LanguageServerRegistry, Serve
     }
 
     private boolean matchesExtensions(LanguageDescription language, String path) {
-        if (language.getFileExtensions() != null) {
-            for (String extension : language.getFileExtensions()) {
-                if (path.endsWith(extension)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return language.getFileExtensions().stream().anyMatch(extension->path.endsWith(extension));
     }
 
     private boolean matchesFilenames(LanguageDescription language, String path) {
-        if (language.getFileNames() != null) {
-            for (String name : language.getFileNames()) {
-                if (name.equals(new File(path).getName())) {
-                    return true;
-                }
-            } 
-        }
-        return false;
+        return language.getFileNames().stream().anyMatch(name->path.endsWith(name));
     }
 
     @Nullable

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
@@ -41,13 +41,13 @@ import static org.eclipse.che.api.languageserver.shared.ProjectLangugageKey.crea
 @Singleton
 public class LanguageServerRegistryImpl implements LanguageServerRegistry, ServerInitializerObserver {
     public final static String                        PROJECT_FOLDER_PATH = "/projects";
-    private final List<LanguageDescription>           languages           = new ArrayList<>();
+    private final List<LanguageDescription>           languages;
     private final Map<String, LanguageServerLauncher> launchers           = new HashMap<>();
 
     /**
      * Started {@link LanguageServer} by project.
      */
-    private final ConcurrentHashMap<ProjectLangugageKey, LanguageServer> projectToServer;
+    private final ConcurrentHashMap<ProjectLangugageKey, LanguageServer> projectToServer= new ConcurrentHashMap<>();
 
     private final Provider<ProjectManager> projectManagerProvider;
     private final ServerInitializer        initializer;
@@ -55,12 +55,11 @@ public class LanguageServerRegistryImpl implements LanguageServerRegistry, Serve
     @Inject
     public LanguageServerRegistryImpl(Set<LanguageServerLauncher> languageServerLaunchers, Set<LanguageDescription> languages,
                                       Provider<ProjectManager> projectManagerProvider, ServerInitializer initializer) {
-        this.languages.addAll(languages);
+        this.languages= new ArrayList<>(languages);
         this.launchers.putAll(languageServerLaunchers.stream()
                         .collect(Collectors.toMap(LanguageServerLauncher::getLanguageId, launcher -> launcher)));
         this.projectManagerProvider = projectManagerProvider;
         this.initializer = initializer;
-        this.projectToServer = new ConcurrentHashMap<>();
         this.initializer.addObserver(this);
     }
 

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/ServerInitializer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/ServerInitializer.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.languageserver.registry;
 
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 import java.util.Map;
@@ -25,7 +26,7 @@ public interface ServerInitializer extends ServerInitializerObservable {
     /**
      * Initialize new {@link LanguageServer} with given project path.
      */
-    LanguageServer initialize(LanguageServerLauncher launcher, String projectPath) throws LanguageServerException;
+    LanguageServer initialize(LanguageDescription language, LanguageServerLauncher launcher, String projectPath) throws LanguageServerException;
 
     /**
      * Returns initialized servers.

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageRegistryService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageRegistryService.java
@@ -19,7 +19,7 @@ import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistryImpl;
 import org.eclipse.che.api.languageserver.server.dto.DtoServerImpls;
 import org.eclipse.che.api.languageserver.server.dto.DtoServerImpls.ExtendedInitializeResultDto;
-import org.eclipse.che.api.languageserver.shared.ProjectExtensionKey;
+import org.eclipse.che.api.languageserver.shared.ProjectLangugageKey;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedInitializeResult;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 
@@ -60,7 +60,7 @@ public class LanguageRegistryService {
                        .entrySet()
                        .stream()
                        .map(entry -> {
-                           ProjectExtensionKey projectExtensionKey = entry.getKey();
+                           ProjectLangugageKey projectExtensionKey = entry.getKey();
                            LanguageServerDescription serverDescription = entry.getValue();
 
 

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImplTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImplTest.java
@@ -124,7 +124,7 @@ public class LanguageServerRegistryImplTest {
     void testFindByPattern() throws Exception {
         LanguageServerLauncher xmlLauncher = createLauncher("xml", null);
         LanguageServerLauncher pomLauncher = createLauncher("pom", null);
-        LanguageDescription xmlDesc = createDescription("xml", Arrays.asList("xml"), null);
+        LanguageDescription xmlDesc = createDescription("xml", Arrays.asList("xml"), Collections.emptyList());
         LanguageDescription pomDesc = createDescription("pom", Arrays.asList(), Arrays.asList("pom.xml"));
         LanguageServer xmlServer = mock(LanguageServer.class);
         LanguageServer pomServer = mock(LanguageServer.class);

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImplTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImplTest.java
@@ -67,12 +67,12 @@ public class ServerInitializerImplTest {
         when(server.initialize(any(InitializeParams.class))).thenReturn(completableFuture);
         when(completableFuture.get()).thenReturn(mock(InitializeResult.class));
 
-        when(launcher.getLanguageDescription()).thenReturn(languageDescription);
+        when(launcher.getLanguageId()).thenReturn("languageId");
         when(launcher.launch(anyString(), any())).thenReturn(server);
         doNothing().when(initializer).registerCallbacks(server, launcher);
 
         initializer.addObserver(observer);
-        LanguageServer languageServer = initializer.initialize(launcher, "/path");
+        LanguageServer languageServer = initializer.initialize(languageDescription, launcher, "/path");
 
         assertEquals(server, languageServer);
         verify(observer).onServerInitialized(eq(server), any(ServerCapabilities.class), eq(languageDescription), eq("/path"));


### PR DESCRIPTION
### What does this PR do?

This PR allows language server plugins to register language servers for specific file names (for example pom.xml). Until now, it is only possible to register for filename extension (like *.xml). 
The PR introduces two major changes:
1. Multiple extensions/or and file names can be mapped to a single mime type and language id. This solves the problem that the mime type was only registered for the first extension when multiples were given.
2. Language registration and language server launcher registration are separated. This way, we can still mimic the old behavior and register multiple mime types for the same language id. As an additional advantage, this change will be useful when allowing to register multiple language servers for the same language in the future.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/5107

#### Changelog
Ability to register language servers for file names instead of extensions
#### Release Notes
Language Server Support: Add ability to register language servers for file names instead of extensions

#### Docs PR
https://github.com/eclipse/che-docs/pull/230
