### PR TITLE
Wait and check LS process

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerEditorProvider.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerEditorProvider.java
@@ -25,7 +25,6 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
-import org.eclipse.che.ide.ui.loaders.request.MessageLoader;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.plugin.languageserver.ide.registry.LanguageServerRegistry;
 
@@ -82,12 +81,9 @@ public class LanguageServerEditorProvider implements AsyncEditorProvider, Editor
             Promise<ExtendedInitializeResult> promise =
                     registry.getOrInitializeServer(resource.getRelatedProject().get().getPath(), resource.getExtension(),
                                                    resource.getLocation().toString());
-            final MessageLoader loader = loaderFactory.newLoader("Initializing Language Server for " + resource.getExtension());
-            loader.show();
             return promise.thenPromise(new Function<ExtendedInitializeResult, Promise<EditorPartPresenter>>() {
                 @Override
                 public Promise<EditorPartPresenter> apply(ExtendedInitializeResult arg) throws FunctionException {
-                    loader.hide();
                     if (editorBuilder == null) {
                         Log.debug(AbstractTextEditorProvider.class, "No builder registered for default editor type - giving up.");
                         return Promises.<EditorPartPresenter>resolve(null);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryServiceClient.java
@@ -65,9 +65,9 @@ public class LanguageServerRegistryServiceClient {
                                   .send(unmarshallerFactory.newListUnmarshaller(ExtendedInitializeResult.class));
     }
 
-    public void initializeServer(String path) {
+    public Promise<Void> initializeServer(String path) {
         String requestUrl = appContext.getDevMachine().getWsAgentBaseUrl() + BASE_URI + "/initialize?path=" + path;
-        asyncRequestFactory.createPostRequest(requestUrl, null).send();
+        return asyncRequestFactory.createPostRequest(requestUrl, null).send();
     }
 
 }

--- a/wsagent/che-core-api-languageserver/pom.xml
+++ b/wsagent/che-core-api-languageserver/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.lsp4j</groupId>
             <artifactId>org.eclipse.lsp4j</artifactId>
         </dependency>

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/launcher/LanguageServerLauncherTemplate.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/launcher/LanguageServerLauncherTemplate.java
@@ -11,22 +11,63 @@
 package org.eclipse.che.api.languageserver.launcher;
 
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
+import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Anatolii Bazko
  */
 public abstract class LanguageServerLauncherTemplate implements LanguageServerLauncher {
 
+    private static Logger LOGGER = LoggerFactory.getLogger(LanguageServerLauncherTemplate.class);
+
     @Override
     public final LanguageServer launch(String projectPath, LanguageClient client) throws LanguageServerException {
         Process languageServerProcess = startLanguageServerProcess(projectPath);
+        waitCheckProcess(languageServerProcess);
         return connectToLanguageServer(languageServerProcess, client);
+    }
+
+    /**
+     * Temporary solution, in future need to provide some service that can watch for LS process and notify user in case in some reason it
+     * stopped.
+     * For now we just check it once start it before connect to it.
+     * Ask with delay in 5 seconds this delay chose empirical in normal state should be enough for start or fail process.
+     * If after 5 seconds process not alive we notify client about problem.
+     * @param languageServerProcess
+     * @throws LanguageServerException
+     */
+    private void waitCheckProcess(Process languageServerProcess)  throws LanguageServerException {
+        try {
+            TimeUnit.SECONDS.sleep(5);
+        } catch (InterruptedException e) {
+            //ignore
+        }
+        if(!languageServerProcess.isAlive()) {
+            final String error;
+            try {
+                error = IoUtil.readStream(languageServerProcess.getErrorStream());
+            } catch (IOException e) {
+                LOGGER.error(e.getMessage());
+                throw new LanguageServerException("Can't start language server process");
+            }
+            LOGGER.error("Can't start language server process. Got error: {}", error);
+            throw new LanguageServerException(error);
+        }
+
     }
 
     abstract protected Process startLanguageServerProcess(String projectPath) throws LanguageServerException;
 
     abstract protected LanguageServer connectToLanguageServer(Process languageServerProcess, LanguageClient client)
             throws LanguageServerException;
+
+
+
 }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>

### What does this PR do?
_Temporary solution until 5.12 or 5.13 (version)_

In future need to provide some service that can watch for LS process and notify user in case in some reason it  stopped.
For now we just check it once start it before connect to it.  Ask with delay in 5 seconds this delay chose empirical in normal state should be enough for start or fail process. If after 5 seconds process not alive we notify client about problem.
