### PR TITLE
Fix retrieving autosnapshot property value from boolean to string

### DIFF
--- a/dashboard/src/components/api/che-workspace.factory.ts
+++ b/dashboard/src/components/api/che-workspace.factory.ts
@@ -632,7 +632,7 @@ export class CheWorkspace {
    * @returns {boolean} 'che.workspace.auto_snapshot' property value
    */
   getAutoSnapshotSettings(): boolean {
-    return this.workspaceSettings ? this.workspaceSettings['che.workspace.auto_snapshot'] : true;
+    return this.workspaceSettings ? this.workspaceSettings['che.workspace.auto_snapshot'] === 'true' : true;
   }
 
   private updateWorkspacesList(workspace: che.IWorkspace): void {


### PR DESCRIPTION

Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The value of autosnapshot property was checked as string one - not boolean, so one case was working wrong, when property had been set to false.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5105

#### Changelog
Fix using autosnapshot property retrieval by considering it's type as boolean. 

#### Release Notes
N/A


#### Docs PR
N/A
