### PR TITLE
Add process exit code to MachineProcess & process_died event

### DIFF
--- a/agents/go-agents/core/process/process_test.go
+++ b/agents/go-agents/core/process/process_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/eclipse/che/agents/go-agents/core/process"
 	"github.com/eclipse/che/agents/go-agents/core/rpc"
+	"sync"
 )
 
 const (
@@ -67,18 +68,14 @@ func TestAddSubscriber(t *testing.T) {
 	outputLines := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 
 	// create and start a process
-	pb := process.NewBuilder().
-		CmdName("test").
-		CmdType("test").
-		CmdLine("printf \"" + strings.Join(outputLines, "\n") + "\"")
+	pb := process.NewBuilder()
+	pb.CmdName("test")
+	pb.CmdType("test")
+	pb.CmdLine("printf \"" + strings.Join(outputLines, "\n") + "\"")
 
 	// add a new subscriber
 	eventsChan := make(chan *rpc.Event)
-	pb.FirstSubscriber(process.Subscriber{
-		ID:      "test",
-		Mask:    process.DefaultMask,
-		Channel: eventsChan,
-	})
+	pb.SubscribeDefault("test", eventsChan)
 
 	// start a new process
 	if _, err := pb.Start(); err != nil {
@@ -92,7 +89,7 @@ func TestAddSubscriber(t *testing.T) {
 		event := <-eventsChan
 		for event.EventType != process.DiedEventType {
 			if event.EventType == process.StdoutEventType {
-				out := event.Body.(*process.ProcessOutputEventBody)
+				out := event.Body.(*process.OutputEventBody)
 				received = append(received, out.Text)
 			}
 			event = <-eventsChan
@@ -152,7 +149,7 @@ func TestRestoreSubscriberForDeadProcess(t *testing.T) {
 		t.Fatalf("Expected to recieve 2 events but got %d", len(received))
 	}
 	e1Type := received[0].EventType
-	e1Text := received[0].Body.(*process.ProcessOutputEventBody).Text
+	e1Text := received[0].Body.(*process.OutputEventBody).Text
 	if received[0].EventType != process.StdoutEventType || e1Text != "test" {
 		t.Fatalf("Expected to receieve output event with text 'test', but got '%s' event with text %s",
 			e1Type,
@@ -197,7 +194,7 @@ func TestReadProcessLogs(t *testing.T) {
 }
 
 func TestLogsAreNotWrittenIfLogsDirIsNotSet(t *testing.T) {
-	p := doStartAndWaitTestProcess(testCmd, "", t)
+	p := doStartAndWaitTestProcess(testCmd, "", &eventsCaptor{deathEventType: process.DiedEventType}, t)
 
 	_, err := process.ReadAllLogs(p.Pid)
 	if err == nil {
@@ -210,79 +207,110 @@ func TestLogsAreNotWrittenIfLogsDirIsNotSet(t *testing.T) {
 	}
 }
 
+func TestAllProcessLifeCycleEventsArePublished(t *testing.T) {
+	eventsCaptor := &eventsCaptor{deathEventType: process.DiedEventType}
+	doStartAndWaitTestProcess("printf \"first_line\nsecond_line\"", "", eventsCaptor, t)
+
+	expected := []string{
+		process.StartedEventType,
+		process.StdoutEventType,
+		process.StdoutEventType,
+		process.DiedEventType,
+	}
+	checkEventsOrder(t, eventsCaptor.events, expected...)
+}
+
+func TestProcessExitCodeIs0IfFinishedOk(t *testing.T) {
+	captor := &eventsCaptor{deathEventType: process.DiedEventType}
+	p := doStartAndWaitTestProcess("echo test", "", captor, t)
+
+	if p.ExitCode != 0 {
+		t.Fatalf("Expected process exit code to be 0, but it is %d", p.ExitCode)
+	}
+
+	diedEvent := captor.events[len(captor.events)-1]
+	if body, ok := diedEvent.Body.(*process.DiedEventBody); !ok {
+		t.Fatalf("Expected last captured event to be process died event, but it is %s", diedEvent.EventType)
+	} else if body.ExitCode != 0 {
+		t.Fatalf("Expected process died event exit code to be 0, but it is %d", body.ExitCode)
+	}
+}
+
+func TestProcessExitCodeIsNot0IfFinishedNotOk(t *testing.T) {
+	captor := &eventsCaptor{deathEventType: process.DiedEventType}
+	// starting non-existing command(hopefully)
+	p := doStartAndWaitTestProcess("test-process-cmd-"+randomName(10), "", captor, t)
+
+	if p.ExitCode <= 0 {
+		t.Fatalf("Expected process exit code to be > 0, but it is %d", p.ExitCode)
+	}
+
+	diedEvent := captor.events[len(captor.events)-1]
+	if body, ok := diedEvent.Body.(*process.DiedEventBody); !ok {
+		t.Fatalf("Expected last captured event to be process died event, but it is %s", diedEvent.EventType)
+	} else if body.ExitCode <= 0 {
+		t.Fatalf("Expected process died event exit code to be > 0, but it is %d", body.ExitCode)
+	}
+}
+
+func checkEventsOrder(t *testing.T, events []*rpc.Event, types ...string) {
+	if len(types) != len(events) {
+		t.Fatalf("Expected receive %d events while received %d", len(types), len(events))
+	}
+	for idx := range types {
+		failIfEventTypeIsDifferent(t, events[idx], types[idx])
+	}
+}
+
+func failIfEventTypeIsDifferent(t *testing.T, event *rpc.Event, expectedType string) {
+	if event.EventType != expectedType {
+		t.Fatalf("Expected event type to be '%s' but it is '%s'", expectedType, event.EventType)
+	}
+}
+
 func startAndWaitTestProcess(cmd string, t *testing.T) process.MachineProcess {
-	return doStartAndWaitTestProcess(cmd, "", t);
+	p := doStartAndWaitTestProcess(cmd, "", &eventsCaptor{deathEventType: process.DiedEventType}, t)
+	return p
 }
 
 func startAndWaitTestProcessWritingLogsToTmpDir(cmd string, t *testing.T) process.MachineProcess {
-	return doStartAndWaitTestProcess(cmd, tmpFile(), t);
+	p := doStartAndWaitTestProcess(cmd, tmpFile(), &eventsCaptor{deathEventType: process.DiedEventType}, t)
+	return p
 }
 
-func doStartAndWaitTestProcess(cmd string, logsDir string, t *testing.T) process.MachineProcess {
+func doStartAndWaitTestProcess(cmd string, logsDir string, eventsCaptor *eventsCaptor, t *testing.T) process.MachineProcess {
 	process.SetLogsDir(logsDir)
-	p, err := process.NewBuilder().
-		CmdName("test").
-		CmdType("test").
-		CmdLine(cmd).
-		Start()
+
+	eventsCaptor.capture()
+
+	pb := process.NewBuilder()
+	pb.CmdName("test")
+	pb.CmdType("test")
+	pb.CmdLine(cmd)
+	pb.SubscribeDefault("events-captor", eventsCaptor.eventsChan)
+
+	p, err := pb.Start()
 	if err != nil {
+		eventsCaptor.wait(0)
 		t.Fatal(err)
 	}
-	waitProcessDied(p, t)
 
-	// Check process state after it is finished
+	// wait process for a little while
+	if ok := <-eventsCaptor.wait(time.Second * 2); !ok {
+		t.Log("The process doesn't finish its execution in 2 seconds. Trying to kill it")
+		if err := process.Kill(p.Pid); err != nil {
+			t.Logf("Failed to kill process, native pid = %d", p.NativePid)
+		}
+		t.FailNow()
+	}
+
+	// check process state after it is finished
 	result, err := process.Get(p.Pid)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return result
-}
-
-func waitProcessDiedOrFailIfTimeoutReached(mp process.MachineProcess, timeout time.Duration) error {
-	events := make(chan *rpc.Event)
-	subscriber := process.Subscriber{
-		ID:      "test",
-		Mask:    process.DefaultMask,
-		Channel: events,
-	}
-	if err := process.RestoreSubscriber(mp.Pid, subscriber, time.Now()); err != nil {
-		return err
-	}
-
-	// wait process.DiedEventType
-	processDied := make(chan bool)
-	go func() {
-		for {
-			event, ok := <-events
-			if !ok {
-				return
-			}
-			if event.EventType == process.DiedEventType {
-				processDied <- true
-				return
-			}
-		}
-	}()
-
-	// wait either process died or timeout reached
-	select {
-	case <-processDied:
-		return nil
-	case <-time.After(timeout):
-		close(processDied)
-		return fmt.Errorf(
-			"Process pid='%d' cmd='%s' didn't publish '%s' event before timeout was reached",
-			mp.Pid,
-			mp.CommandLine,
-			process.DiedEventType,
-		)
-	}
-}
-
-func waitProcessDied(mp process.MachineProcess, t *testing.T) {
-	if err := waitProcessDiedOrFailIfTimeoutReached(mp, time.Second*5); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func tmpFile() string {
@@ -302,4 +330,77 @@ func randomName(length int) string {
 		bytes[i] = alphabet[rand.Intn(len(alphabet))]
 	}
 	return string(bytes)
+}
+
+// Helps to capture process events and wait for them.
+type eventsCaptor struct {
+	sync.Mutex
+
+	// Result events.
+	events []*rpc.Event
+
+	// Events channel. Close of this channel considered as immediate interruption,
+	// to hold until execution completes use captor.wait(timeout) channel.
+	eventsChan chan *rpc.Event
+
+	// Channel used as internal approach to interrupt capturing.
+	interruptChan chan bool
+
+	// Captor sends true if finishes reaching deathEventType
+	// and false if interrupted while waiting for event of deathEventType.
+	done chan bool
+
+	// The last event after which events capturing stopped.
+	deathEventType string
+}
+
+func (ec *eventsCaptor) addEvent(e *rpc.Event) {
+	ec.Lock()
+	defer ec.Unlock()
+	ec.events = append(ec.events, e)
+}
+
+func (ec *eventsCaptor) capturedEvents() []*rpc.Event {
+	ec.Lock()
+	defer ec.Unlock()
+	cp := make([]*rpc.Event, len(ec.events))
+	copy(cp, ec.events)
+	return cp
+}
+
+func (ec *eventsCaptor) capture() {
+	ec.eventsChan = make(chan *rpc.Event)
+	ec.interruptChan = make(chan bool)
+	ec.done = make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-ec.eventsChan:
+				if ok {
+					ec.addEvent(event)
+					if event.EventType == ec.deathEventType {
+						// death event reached - capturing is done
+						ec.done <- true
+						return
+					}
+				} else {
+					// events channel closed interrupt immediately
+					ec.done <- false
+					return
+				}
+			case <-ec.interruptChan:
+				close(ec.eventsChan)
+			}
+		}
+	}()
+}
+
+// Waits a timeout and if deadTypeEvent wasn't reached interrupts captor.
+func (ec *eventsCaptor) wait(timeout time.Duration) chan bool {
+	go func() {
+		<-time.NewTimer(timeout).C
+		ec.interruptChan <- true
+	}()
+	return ec.done
 }

--- a/agents/go-agents/docs/events.md
+++ b/agents/go-agents/docs/events.md
@@ -92,7 +92,8 @@ it appears only once for one process
     "pid": 1,
     "nativePid": 22164,
     "name": "print",
-    "commandLine": "printf \"\n1\n2\n3\""
+    "commandLine": "printf \"\n1\n2\n3\"",
+    "exitCode" : 0
   }
 }
 ```

--- a/agents/go-agents/docs/rest_api.md
+++ b/agents/go-agents/docs/rest_api.md
@@ -13,7 +13,7 @@ _POST /process_
 - `channel`(optional) - the id of the channel which should be subscribed to the process events
 - `types`(optional) - comma separated types works only in couple with specified `channel`, defines
 the events which will be sent by the process to the `channel`. Several values may be specified,
-e.g. `channel=channel-1&types=stderr,stdout`. By default channel will be subscribed to 
+e.g. `channel=channel-1&types=stderr,stdout`. By default channel will be subscribed to
 all the existing types(listed below). Possible type values:
     - `stderr` - output from the process stderr
     - `stdout` - output from the process stdout
@@ -37,7 +37,8 @@ all the existing types(listed below). Possible type values:
     "commandLine": "mvn clean install",
     "type" : "maven",
     "alive": true,
-    "nativePid": 9186
+    "nativePid": 9186,
+    "exitCode" : -1
 }
 ```
 - `200` if successfully started
@@ -64,6 +65,7 @@ _GET /process/{pid}_
     "type" : "maven",
     "alive": false,
     "nativePid": 9186,
+    "exitCode" : 0
 }
 ```
 
@@ -90,6 +92,7 @@ _DELETE /process/{pid}_
     "type" : "maven",
     "alive": true,
     "nativePid": 9186,
+    "exitCode" : -1
 }
 ```
 - `200` if successfully killed
@@ -110,7 +113,7 @@ don't forget to encode this query parameter
 - `till`(optional) - time to get logs till e.g. _2016-07-12T01:49:04.097980475+03:00_ the format is _RFC3339Nano_
 don't forget to encode this query parameter
 - `format`(optional) - the format of the response, default is `json`, possible values are: `text`, `json`
-- `limit`(optional) - the limit of logs in result, the default value is _50_, logs are limited from the 
+- `limit`(optional) - the limit of logs in result, the default value is _50_, logs are limited from the
 latest to the earliest
 - `skip` (optional) - the logs to skip, default value is `0`
 
@@ -151,7 +154,7 @@ Json:
 
 _GET /process_
 
-- `all`(optional) - if `true` then all the processes including _dead_ ones will be returned(respecting paging ofc), 
+- `all`(optional) - if `true` then all the processes including _dead_ ones will be returned(respecting paging ofc),
 otherwise only _alive_ processes will be returnedg
 
 #### Response
@@ -166,13 +169,15 @@ The result of the request _GET /process?all=true_
         "type" : "maven",
         "alive": true,
         "nativePid": 9186,
+        "exitCode" : -1
     },
     {
         "pid": 2,
         "name": "build",
         "commandLine": "printf \"Hello World\"",
         "alive": false,
-        "nativePid": 9588
+        "nativePid": 9588,
+        "exitCode" : 0
     }
 ]
 ```

--- a/agents/go-agents/docs/ws_api.md
+++ b/agents/go-agents/docs/ws_api.md
@@ -497,7 +497,8 @@ When everything is okay
     "commandLine": "printf \n1\n2\n3\"",
     "type": "test",
     "alive": false,
-    "nativePid": 13158
+    "nativePid": 13158,
+    "exitCode": 0
   }
 }    
 ```
@@ -549,7 +550,8 @@ otherwise only _alive_ processes will be returned
       "commandLine": "printf \"1\n2\n3\"",
       "type": "test",
       "alive": false,
-      "nativePid": 13553
+      "nativePid": 13553,
+      "exitCode": 0
     },
     {
       "pid": 2,
@@ -557,7 +559,8 @@ otherwise only _alive_ processes will be returned
       "commandLine": "printf \"\n3\n2\n1\"",
       "type": "test2",
       "alive": false,
-      "nativePid": 13561
+      "nativePid": 13561,
+      "exitCode": 0
     }
   ]
 }

--- a/agents/go-agents/exec-agent/exec/common.go
+++ b/agents/go-agents/exec-agent/exec/common.go
@@ -13,9 +13,9 @@ package exec
 
 import (
 	"errors"
+	"github.com/eclipse/che/agents/go-agents/core/process"
 	"strconv"
 	"strings"
-	"github.com/eclipse/che/agents/go-agents/core/process"
 )
 
 const (


### PR DESCRIPTION
### What does this PR do?

Adds exit code to the process struct & process_died event. 
Example of REST API response when getting a dead process _GET /process/1_
```json
{
  "pid": 1,
  "name": "test",
  "commandLine": "echo hello",
  "type": "test",
  "alive": false,
  "nativePid": 1833,
  "exitCode": 0
}
```

Example of _process_died_ jsonrpc event:
```json
{
  "jsonrpc": "2.0",
  "method": "process_died",
  "params": {
    "time": "2017-05-26T10:19:09.056360416+03:00",
    "pid": 2,
    "nativePid": 2524,
    "name": "print",
    "commandLine": "printf \"1\n2\n3\"",
    "exitCode": 0
  }
}
```

### What issues does this PR fix or reference?
Resolves #5147 

#### Changelog
Added exit code to the response of process REST/WS API and to the _process_died_ event body