### PR TITLE
CHE-4058 Removed usage name of a current user as a namespace

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerContainerNameGenerator.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerContainerNameGenerator.java
@@ -41,14 +41,14 @@ public class DockerContainerNameGenerator implements ContainerNameGenerator {
      *         unique workspace id, see more (@link WorkspaceConfig#getId)
      * @param machineId
      *         unique machine id, see more {@link Machine#getId()}
-     * @param userName
+     * @param ownerName
      *         name of the user who is docker container owner
      * @param machineName
      *         name of the workspace machine, see more {@link MachineConfig#getName()}
      */
     @Override
-    public String generateContainerName(String workspaceId, String machineId, String userName, String machineName) {
-        String containerName = workspaceId + '_' + machineId + '_' + userName + '_' + machineName;
+    public String generateContainerName(String workspaceId, String machineId, String ownerName, String machineName) {
+        String containerName = workspaceId + '_' + machineId + '_' + ownerName + '_' + machineName;
         return containerName.toLowerCase().replaceAll("[^a-z0-9_-]+", "");
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -296,7 +296,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
     }
 
     @Override
-    public Instance startService(String namespace,
+    public Instance startService(String ownerName,
                                  String workspaceId,
                                  String envName,
                                  String machineName,

--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/WorkspaceSshKeys.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/WorkspaceSshKeys.java
@@ -83,8 +83,11 @@ public class WorkspaceSshKeys {
                 try {
                     final User user = userManager.getByName(workspaceCreatedEvent.getWorkspace().getNamespace());
                     userId = user.getId();
-                } catch (NotFoundException | ServerException e) {
-                    LOG.error("Unable to get owner of the workspace {} with namespace {}", workspaceCreatedEvent.getWorkspace().getId(), workspaceCreatedEvent.getWorkspace().getNamespace());
+                } catch (NotFoundException ignored) {
+                    // namespace can be different from username
+                    return;
+                } catch (ServerException e) {
+                    LOG.warn("Unable to get owner of the workspace {} with namespace {}", workspaceCreatedEvent.getWorkspace().getId(), workspaceCreatedEvent.getWorkspace().getNamespace());
                     return;
                 }
 
@@ -94,8 +97,8 @@ public class WorkspaceSshKeys {
                                             workspaceCreatedEvent.getWorkspace().getId());
                 } catch (ServerException | ConflictException e) {
                     // Conflict shouldn't happen as workspace id is new each time.
-                    LOG.error("Unable to generate a default ssh pair for the workspace with ID {}",
-                                            workspaceCreatedEvent.getWorkspace().getId(), e);
+                    LOG.warn("Unable to generate a default ssh pair for the workspace with ID {}",
+                             workspaceCreatedEvent.getWorkspace().getId(), e);
                 }
             }
         });

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/ContainerNameGenerator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/ContainerNameGenerator.java
@@ -27,13 +27,13 @@ public interface ContainerNameGenerator {
      *         unique workspace id, see more (@link WorkspaceConfig#getId)
      * @param machineId
      *         unique machine id, see more {@link Machine#getId()}
-     * @param namespace
+     * @param ownerName
      *         name of the user who is docker container owner
      * @param machineName
      *         name of the workspace machine, see more {@link MachineConfig#getName()}
      */
     String generateContainerName(String workspaceId,
                                  String machineId,
-                                 String namespace,
+                                 String ownerName,
                                  String machineName);
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineInstanceProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/environment/server/MachineInstanceProvider.java
@@ -24,8 +24,8 @@ public interface MachineInstanceProvider {
     /**
      * Create docker container from compose service definition.
      *
-     * @param namespace
-     *         namespace of workspace that owns provided service
+     * @param ownerName
+     *         name of user who starts provided service
      * @param workspaceId
      *         ID of workspace that owns provided service
      * @param envName
@@ -44,7 +44,7 @@ public interface MachineInstanceProvider {
      * @throws ServerException
      *         if any error occurs
      */
-    Instance startService(String namespace,
+    Instance startService(String ownerName,
                           String workspaceId,
                           String envName,
                           String machineName,


### PR DESCRIPTION
### What does this PR do?
A namespace can be different from username so:
- renamed variable `namespace` to `ownerName` where it is needed to propagate name of a user who starts workspace;
- fixed logging cases when there is fail on getting user by name that equals to a namespace.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4058

#### Changelog
Removed usage name of a current user as a namespace.

#### Release Notes
N/A

#### Docs PR
N/A