### PR TITLE
Use Authorization header instead of session-access-key cookie

### DIFF
--- a/dockerfiles/lib/src/spi/http/default-http-json-request.ts
+++ b/dockerfiles/lib/src/spi/http/default-http-json-request.ts
@@ -42,7 +42,7 @@ export class DefaultHttpJsonRequest implements HttpJsonRequest {
             headers: {
                 'Accept': 'application/json, text/plain, */*',
                 'Content-Type': 'application/json;charset=UTF-8',
-                'Cookie': 'session-access-key=' + this.authData.getToken()
+                'Authorization': this.authData.getToken()
             }
         };
 


### PR DESCRIPTION
CSRF protection https://github.com/codenvy/codenvy/pull/2213 affected CLI.
CLI or any other client different from web-browser SHOULD NOT use cookies for authorization but SHOULD use either _Authorization_ header or query parameter.
