### PR TITLE
[go-agents] Ged rid of core/process -> core/rpc dependency

### DIFF
--- a/agents/go-agents/core/process/common.go
+++ b/agents/go-agents/core/process/common.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-// LogKind reperesents kind of source of log line - stdout or stderr
+// LogKind represents kind of source of log line - stdout or stderr
 type LogKind int
 
 const (

--- a/agents/go-agents/core/process/common.go
+++ b/agents/go-agents/core/process/common.go
@@ -16,13 +16,13 @@ import (
 	"time"
 )
 
-// LogKind represents kind of source of log line - stdout or stderr
+// LogKind represents kind of source of log line - stdout or stderr.
 type LogKind int
 
 const (
-	// StdoutKind match logs produced by stdout of a process
+	// StdoutKind match logs produced by stdout of a process.
 	StdoutKind LogKind = iota
-	// StderrKind match logs produced by stderr of a process
+	// StderrKind match logs produced by stderr of a process.
 	StderrKind
 )
 
@@ -30,7 +30,7 @@ const (
 // Single date format keeps API consistent
 var DateTimeFormat = time.RFC3339Nano
 
-// LogMessage represents single log entry with timestamp and source of log
+// LogMessage represents single log entry with timestamp and source of log.
 type LogMessage struct {
 	Kind LogKind   `json:"kind"`
 	Time time.Time `json:"time"`
@@ -40,7 +40,7 @@ type LogMessage struct {
 // ParseTime parses string into Time.
 // If time string is empty, then time provided as an argument is returned.
 // If time string is invalid, then appropriate error is returned.
-// If time string is valid then parsed time is returned
+// If time string is valid then parsed time is returned.
 func ParseTime(timeStr string, defTime time.Time) (time.Time, error) {
 	if timeStr == "" {
 		return defTime, nil

--- a/agents/go-agents/core/process/events.go
+++ b/agents/go-agents/core/process/events.go
@@ -13,11 +13,9 @@ package process
 
 import (
 	"time"
-
-	"github.com/eclipse/che/agents/go-agents/core/rpc"
 )
 
-// Types of process events
+// Types of process events.
 const (
 	StartedEventType = "process_started"
 	DiedEventType    = "process_died"
@@ -25,67 +23,85 @@ const (
 	StderrEventType  = "process_stderr"
 )
 
-// StatusEventBody is body of event that informs about process status
-type StatusEventBody struct {
-	rpc.Timed
-	Pid         uint64 `json:"pid"`
-	NativePid   int    `json:"nativePid"`
-	Name        string `json:"name"`
-	CommandLine string `json:"commandLine"`
+// Event is a common interface for all the process events.
+type Event interface {
+	Type() string
 }
 
-// OutputEventBody is body of event that informs about process output
-type OutputEventBody struct {
-	rpc.Timed
-	Pid  uint64 `json:"pid"`
-	Text string `json:"text"`
+// EventConsumer provides ability to handle process events.
+type EventConsumer interface {
+	Accept(event Event)
 }
 
-// DiedEventBody is a body of event that informs about process death
-type DiedEventBody struct {
-	StatusEventBody
-	ExitCode int `json:"exitCode"`
+// StartedEvent published once when process is started.
+type StartedEvent struct {
+	Time        time.Time `json:"time"`
+	Pid         uint64    `json:"pid"`
+	NativePid   int       `json:"nativePid"`
+	Name        string    `json:"name"`
+	CommandLine string    `json:"commandLine"`
 }
 
-func newStderrEvent(pid uint64, text string, when time.Time) *rpc.Event {
-	return rpc.NewEvent(StderrEventType, &OutputEventBody{
-		Timed: rpc.Timed{Time: when},
-		Pid:   pid,
-		Text:  text,
-	})
-}
+func (se *StartedEvent) Type() string { return StartedEventType }
 
-func newStdoutEvent(pid uint64, text string, when time.Time) *rpc.Event {
-	return rpc.NewEvent(StdoutEventType, &OutputEventBody{
-		Timed: rpc.Timed{Time: when},
-		Pid:   pid,
-		Text:  text,
-	})
-}
-
-func newStatusEvent(mp MachineProcess, status string) *rpc.Event {
-	return rpc.NewEvent(status, &StatusEventBody{
-		Timed:       rpc.Timed{Time: time.Now()},
+func newStartedEvent(mp MachineProcess) *StartedEvent {
+	return &StartedEvent{
+		Time:        time.Now(),
 		Pid:         mp.Pid,
 		NativePid:   mp.NativePid,
 		Name:        mp.Name,
 		CommandLine: mp.CommandLine,
-	})
+	}
 }
 
-func newStartedEvent(mp MachineProcess) *rpc.Event {
-	return newStatusEvent(mp, StartedEventType)
+// DiedEvent published once after process death.
+type DiedEvent struct {
+	Time        time.Time `json:"time"`
+	Pid         uint64    `json:"pid"`
+	NativePid   int       `json:"nativePid"`
+	Name        string    `json:"name"`
+	CommandLine string    `json:"commandLine"`
+	ExitCode    int       `json:"exitCode"`
 }
 
-func newDiedEvent(mp MachineProcess) *rpc.Event {
-	return rpc.NewEvent(DiedEventType, &DiedEventBody{
-		StatusEventBody: StatusEventBody{
-			Timed:       rpc.Timed{Time: time.Now()},
-			Pid:         mp.Pid,
-			NativePid:   mp.NativePid,
-			Name:        mp.Name,
-			CommandLine: mp.CommandLine,
-		},
-		ExitCode: mp.ExitCode,
-	})
+func (de *DiedEvent) Type() string { return DiedEventType }
+
+func newDiedEvent(mp MachineProcess) *DiedEvent {
+	return &DiedEvent{
+		Time:        time.Now(),
+		Pid:         mp.Pid,
+		NativePid:   mp.NativePid,
+		Name:        mp.Name,
+		CommandLine: mp.CommandLine,
+		ExitCode:    mp.ExitCode,
+	}
+}
+
+// OutputEvent is published each time when process writes to stdout or stderr.
+type OutputEvent struct {
+	Time time.Time `json:"time"`
+	Pid  uint64    `json:"pid"`
+	Text string    `json:"text"`
+
+	_type string
+}
+
+func (se *OutputEvent) Type() string { return se._type }
+
+func newStderrEvent(pid uint64, text string, when time.Time) Event {
+	return &OutputEvent{
+		Time:  when,
+		Pid:   pid,
+		Text:  text,
+		_type: StderrEventType,
+	}
+}
+
+func newStdoutEvent(pid uint64, text string, when time.Time) Event {
+	return &OutputEvent{
+		Time:  when,
+		Pid:   pid,
+		Text:  text,
+		_type: StdoutEventType,
+	}
 }

--- a/agents/go-agents/core/process/events.go
+++ b/agents/go-agents/core/process/events.go
@@ -28,7 +28,7 @@ type Event interface {
 	Type() string
 }
 
-// EventConsumer provides ability to handle process events.
+// EventConsumer is a process events client.
 type EventConsumer interface {
 	Accept(event Event)
 }
@@ -42,6 +42,7 @@ type StartedEvent struct {
 	CommandLine string    `json:"commandLine"`
 }
 
+// Type returns StartedEventType.
 func (se *StartedEvent) Type() string { return StartedEventType }
 
 func newStartedEvent(mp MachineProcess) *StartedEvent {
@@ -64,6 +65,7 @@ type DiedEvent struct {
 	ExitCode    int       `json:"exitCode"`
 }
 
+// Type returns DiedEventType.
 func (de *DiedEvent) Type() string { return DiedEventType }
 
 func newDiedEvent(mp MachineProcess) *DiedEvent {
@@ -86,6 +88,7 @@ type OutputEvent struct {
 	_type string
 }
 
+// Type returns one of StdoutEventType, StderrEventType.
 func (se *OutputEvent) Type() string { return se._type }
 
 func newStderrEvent(pid uint64, text string, when time.Time) Event {

--- a/agents/go-agents/core/process/process_builder.go
+++ b/agents/go-agents/core/process/process_builder.go
@@ -11,41 +11,37 @@
 
 package process
 
-import (
-	"github.com/eclipse/che/agents/go-agents/core/rpc"
-)
-
-//Builder simplifies creation of MachineProcess
+//Builder simplifies creation of MachineProcess.
 type Builder struct {
 	command          Command
 	beforeEventsHook func(p MachineProcess)
 	subscribers      []*Subscriber
 }
 
-// NewBuilder creates new instance of ProcessBuilder
+// NewBuilder creates new instance of ProcessBuilder.
 func NewBuilder() *Builder {
 	return &Builder{}
 }
 
-// Cmd sets command of process
+// Cmd sets command of process.
 func (pb *Builder) Cmd(command Command) *Builder {
 	pb.command = command
 	return pb
 }
 
-// CmdLine sets command line of process
+// CmdLine sets command line of process.
 func (pb *Builder) CmdLine(cmdLine string) *Builder {
 	pb.command.CommandLine = cmdLine
 	return pb
 }
 
-// CmdType sets type of command that creates a process
+// CmdType sets type of command that creates a process.
 func (pb *Builder) CmdType(cmdType string) *Builder {
 	pb.command.Type = cmdType
 	return pb
 }
 
-// CmdName sets name of command that creates a process
+// CmdName sets name of command that creates a process.
 func (pb *Builder) CmdName(cmdName string) *Builder {
 	pb.command.Name = cmdName
 	return pb
@@ -60,21 +56,21 @@ func (pb *Builder) BeforeEventsHook(hook func(p MachineProcess)) *Builder {
 }
 
 //Subscribe subscribes to the process events.
-func (pb *Builder) Subscribe(id string, mask uint64, channel chan *rpc.Event) *Builder {
+func (pb *Builder) Subscribe(id string, mask uint64, consumer EventConsumer) *Builder {
 	pb.subscribers = append(pb.subscribers, &Subscriber{
-		ID:      id,
-		Mask:    mask,
-		Channel: channel,
+		ID:       id,
+		Mask:     mask,
+		Consumer: consumer,
 	})
 	return pb
 }
 
 //SubscribeDefault subscribes to the process events using process.DefaultMask.
-func (pb *Builder) SubscribeDefault(id string, channel chan *rpc.Event) *Builder {
-	return pb.Subscribe(id, DefaultMask, channel)
+func (pb *Builder) SubscribeDefault(id string, consumer EventConsumer) *Builder {
+	return pb.Subscribe(id, DefaultMask, consumer)
 }
 
-// Build creates MachineProcess from this builder
+// Build creates MachineProcess from this builder.
 func (pb *Builder) Build() MachineProcess {
 	p := MachineProcess{
 		Name:             pb.command.Name,
@@ -86,7 +82,7 @@ func (pb *Builder) Build() MachineProcess {
 	return p
 }
 
-// Start creates MachineProcess from this builder and starts this process
+// Start creates MachineProcess from this builder and starts this process.
 func (pb *Builder) Start() (MachineProcess, error) {
 	return Start(pb.Build())
 }

--- a/agents/go-agents/core/process/process_test.go
+++ b/agents/go-agents/core/process/process_test.go
@@ -21,7 +21,6 @@ import (
 
 	"fmt"
 	"github.com/eclipse/che/agents/go-agents/core/process"
-	"github.com/eclipse/che/agents/go-agents/core/rpc"
 	"sync"
 )
 
@@ -74,8 +73,8 @@ func TestAddSubscriber(t *testing.T) {
 	pb.CmdLine("printf \"" + strings.Join(outputLines, "\n") + "\"")
 
 	// add a new subscriber
-	eventsChan := make(chan *rpc.Event)
-	pb.SubscribeDefault("test", eventsChan)
+	eventsChan := make(chan process.Event)
+	pb.SubscribeDefault("test", &channelEventConsumer{eventsChan})
 
 	// start a new process
 	if _, err := pb.Start(); err != nil {
@@ -87,9 +86,9 @@ func TestAddSubscriber(t *testing.T) {
 	var received []string
 	go func() {
 		event := <-eventsChan
-		for event.EventType != process.DiedEventType {
-			if event.EventType == process.StdoutEventType {
-				out := event.Body.(*process.OutputEventBody)
+		for event.Type() != process.DiedEventType {
+			if event.Type() == process.StdoutEventType {
+				out := event.(*process.OutputEvent)
 				received = append(received, out.Text)
 			}
 			event = <-eventsChan
@@ -117,9 +116,9 @@ func TestRestoreSubscriberForDeadProcess(t *testing.T) {
 	defer process.WipeLogs()
 
 	// Read all the data from channel
-	channel := make(chan *rpc.Event)
+	channel := make(chan process.Event)
 	done := make(chan bool)
-	var received []*rpc.Event
+	var received []process.Event
 	go func() {
 		statusReceived := false
 		timeoutReached := false
@@ -127,7 +126,7 @@ func TestRestoreSubscriberForDeadProcess(t *testing.T) {
 			select {
 			case v := <-channel:
 				received = append(received, v)
-				if v.EventType == process.DiedEventType {
+				if v.Type() == process.DiedEventType {
 					statusReceived = true
 				}
 			case <-time.After(time.Second):
@@ -138,9 +137,9 @@ func TestRestoreSubscriberForDeadProcess(t *testing.T) {
 	}()
 
 	_ = process.RestoreSubscriber(p.Pid, process.Subscriber{
-		ID:      "test",
-		Mask:    process.DefaultMask,
-		Channel: channel,
+		ID:       "test",
+		Mask:     process.DefaultMask,
+		Consumer: &channelEventConsumer{channel: channel},
 	}, beforeStart)
 
 	<-done
@@ -148,14 +147,14 @@ func TestRestoreSubscriberForDeadProcess(t *testing.T) {
 	if len(received) != 2 {
 		t.Fatalf("Expected to recieve 2 events but got %d", len(received))
 	}
-	e1Type := received[0].EventType
-	e1Text := received[0].Body.(*process.OutputEventBody).Text
-	if received[0].EventType != process.StdoutEventType || e1Text != "test" {
+	e1Type := received[0].Type()
+	e1Text := received[0].(*process.OutputEvent).Text
+	if received[0].Type() != process.StdoutEventType || e1Text != "test" {
 		t.Fatalf("Expected to receieve output event with text 'test', but got '%s' event with text %s",
 			e1Type,
 			e1Text)
 	}
-	if received[1].EventType != process.DiedEventType {
+	if received[1].Type() != process.DiedEventType {
 		t.Fatal("Expected to get 'process_died' event")
 	}
 }
@@ -228,11 +227,10 @@ func TestProcessExitCodeIs0IfFinishedOk(t *testing.T) {
 		t.Fatalf("Expected process exit code to be 0, but it is %d", p.ExitCode)
 	}
 
-	diedEvent := captor.events[len(captor.events)-1]
-	if body, ok := diedEvent.Body.(*process.DiedEventBody); !ok {
-		t.Fatalf("Expected last captured event to be process died event, but it is %s", diedEvent.EventType)
-	} else if body.ExitCode != 0 {
-		t.Fatalf("Expected process died event exit code to be 0, but it is %d", body.ExitCode)
+	if diedEvent, ok := captor.events[len(captor.events)-1].(*process.DiedEvent); !ok {
+		t.Fatalf("Expected last captured event to be process died event, but it is %s", diedEvent.Type())
+	} else if diedEvent.ExitCode != 0 {
+		t.Fatalf("Expected process died event exit code to be 0, but it is %d", diedEvent.ExitCode)
 	}
 }
 
@@ -245,15 +243,14 @@ func TestProcessExitCodeIsNot0IfFinishedNotOk(t *testing.T) {
 		t.Fatalf("Expected process exit code to be > 0, but it is %d", p.ExitCode)
 	}
 
-	diedEvent := captor.events[len(captor.events)-1]
-	if body, ok := diedEvent.Body.(*process.DiedEventBody); !ok {
-		t.Fatalf("Expected last captured event to be process died event, but it is %s", diedEvent.EventType)
-	} else if body.ExitCode <= 0 {
-		t.Fatalf("Expected process died event exit code to be > 0, but it is %d", body.ExitCode)
+	if diedEvent, ok := captor.events[len(captor.events)-1].(*process.DiedEvent); !ok {
+		t.Fatalf("Expected last captured event to be process died event, but it is %s", diedEvent.Type())
+	} else if diedEvent.ExitCode <= 0 {
+		t.Fatalf("Expected process died event exit code to be > 0, but it is %d", diedEvent.ExitCode)
 	}
 }
 
-func checkEventsOrder(t *testing.T, events []*rpc.Event, types ...string) {
+func checkEventsOrder(t *testing.T, events []process.Event, types ...string) {
 	if len(types) != len(events) {
 		t.Fatalf("Expected receive %d events while received %d", len(types), len(events))
 	}
@@ -262,9 +259,9 @@ func checkEventsOrder(t *testing.T, events []*rpc.Event, types ...string) {
 	}
 }
 
-func failIfEventTypeIsDifferent(t *testing.T, event *rpc.Event, expectedType string) {
-	if event.EventType != expectedType {
-		t.Fatalf("Expected event type to be '%s' but it is '%s'", expectedType, event.EventType)
+func failIfEventTypeIsDifferent(t *testing.T, event process.Event, expectedType string) {
+	if event.Type() != expectedType {
+		t.Fatalf("Expected event type to be '%s' but it is '%s'", expectedType, event.Type())
 	}
 }
 
@@ -287,7 +284,7 @@ func doStartAndWaitTestProcess(cmd string, logsDir string, eventsCaptor *eventsC
 	pb.CmdName("test")
 	pb.CmdType("test")
 	pb.CmdLine(cmd)
-	pb.SubscribeDefault("events-captor", eventsCaptor.eventsChan)
+	pb.SubscribeDefault("events-captor", eventsCaptor)
 
 	p, err := pb.Start()
 	if err != nil {
@@ -337,11 +334,11 @@ type eventsCaptor struct {
 	sync.Mutex
 
 	// Result events.
-	events []*rpc.Event
+	events []process.Event
 
 	// Events channel. Close of this channel considered as immediate interruption,
 	// to hold until execution completes use captor.wait(timeout) channel.
-	eventsChan chan *rpc.Event
+	eventsChan chan process.Event
 
 	// Channel used as internal approach to interrupt capturing.
 	interruptChan chan bool
@@ -354,22 +351,22 @@ type eventsCaptor struct {
 	deathEventType string
 }
 
-func (ec *eventsCaptor) addEvent(e *rpc.Event) {
+func (ec *eventsCaptor) addEvent(e process.Event) {
 	ec.Lock()
 	defer ec.Unlock()
 	ec.events = append(ec.events, e)
 }
 
-func (ec *eventsCaptor) capturedEvents() []*rpc.Event {
+func (ec *eventsCaptor) capturedEvents() []process.Event {
 	ec.Lock()
 	defer ec.Unlock()
-	cp := make([]*rpc.Event, len(ec.events))
+	cp := make([]process.Event, len(ec.events))
 	copy(cp, ec.events)
 	return cp
 }
 
 func (ec *eventsCaptor) capture() {
-	ec.eventsChan = make(chan *rpc.Event)
+	ec.eventsChan = make(chan process.Event)
 	ec.interruptChan = make(chan bool)
 	ec.done = make(chan bool)
 
@@ -379,7 +376,7 @@ func (ec *eventsCaptor) capture() {
 			case event, ok := <-ec.eventsChan:
 				if ok {
 					ec.addEvent(event)
-					if event.EventType == ec.deathEventType {
+					if event.Type() == ec.deathEventType {
 						// death event reached - capturing is done
 						ec.done <- true
 						return
@@ -404,3 +401,12 @@ func (ec *eventsCaptor) wait(timeout time.Duration) chan bool {
 	}()
 	return ec.done
 }
+
+func (ec *eventsCaptor) Accept(e process.Event) { ec.eventsChan <- e }
+
+// A consumer that redirects all the incoming events to the channel.
+type channelEventConsumer struct {
+	channel chan process.Event
+}
+
+func (c *channelEventConsumer) Accept(e process.Event) { c.channel <- e }

--- a/agents/go-agents/core/process/processtest/test_utils.go
+++ b/agents/go-agents/core/process/processtest/test_utils.go
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2012-2017 Codenvy, S.A.
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// which accompanies this distribution, and is available at
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// Contributors:
+//   Codenvy, S.A. - initial API and implementation
+//
+
+// Package processtest provides utils for process testing.
+package processtest
+
+import (
+	"sync"
+	"time"
+
+	"github.com/eclipse/che/agents/go-agents/core/process"
+)
+
+// NewEventsCaptor create a new instance of events captor
+func NewEventsCaptor(deathEventType string) *EventsCaptor {
+	return &EventsCaptor{DeathEventType: deathEventType}
+}
+
+// EventsCaptor helps to Capture process events and wait for them.
+type EventsCaptor struct {
+	sync.Mutex
+
+	// Result events.
+	events []process.Event
+
+	// Events channel. Close of this channel considered as immediate interruption,
+	// to hold until execution completes use captor.Wait(timeout) channel.
+	eventsChan chan process.Event
+
+	// Channel used as internal approach to interrupt capturing.
+	interruptChan chan bool
+
+	// Captor sends true if finishes reaching DeathEventType
+	// and false if interrupted while waiting for event of DeathEventType.
+	done chan bool
+
+	// The last event after which events capturing stopped.
+	DeathEventType string
+}
+
+func (ec *EventsCaptor) addEvent(e process.Event) {
+	ec.Lock()
+	defer ec.Unlock()
+	ec.events = append(ec.events, e)
+}
+
+// Events returns all the captured events.
+func (ec *EventsCaptor) Events() []process.Event {
+	ec.Lock()
+	defer ec.Unlock()
+	cp := make([]process.Event, len(ec.events))
+	copy(cp, ec.events)
+	return cp
+}
+
+// Capture starts capturing events, until one of the
+// following conditions is met:
+// - event of type EventsCaptor.deathEventType received.
+//   In this case capturing is successful done <- true
+// - events channel closed.
+//   In this case capturing is interrupted done <- false
+func (ec *EventsCaptor) Capture() {
+	ec.eventsChan = make(chan process.Event)
+	ec.interruptChan = make(chan bool)
+	ec.done = make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-ec.eventsChan:
+				if ok {
+					ec.addEvent(event)
+					if event.Type() == ec.DeathEventType {
+						// death event reached - capturing is done
+						ec.done <- true
+						return
+					}
+				} else {
+					// events channel closed interrupt immediately
+					ec.done <- false
+					return
+				}
+			case <-ec.interruptChan:
+				close(ec.eventsChan)
+			}
+		}
+	}()
+}
+
+// Waits a timeout and if deadTypeEvent isn't reached interrupts captor.
+// Returns done channel if the value received from the channel is true
+// then the captor finished capturing successfully catching deathEventType,
+// otherwise it was interrupted.
+func (ec *EventsCaptor) Wait(timeout time.Duration) chan bool {
+	go func() {
+		<-time.NewTimer(timeout).C
+		ec.interruptChan <- true
+	}()
+	return ec.done
+}
+
+// Interrupts capturing immediately, returns done channel.
+func (ec *EventsCaptor) Stop() chan bool {
+	return ec.Wait(0)
+}
+
+// Accept notifies the captor about incoming event.
+func (ec *EventsCaptor) Accept(e process.Event) { ec.eventsChan <- e }

--- a/agents/go-agents/exec-agent/exec/common.go
+++ b/agents/go-agents/exec-agent/exec/common.go
@@ -14,6 +14,7 @@ package exec
 import (
 	"errors"
 	"github.com/eclipse/che/agents/go-agents/core/process"
+	"github.com/eclipse/che/agents/go-agents/core/rpc"
 	"strconv"
 	"strings"
 )
@@ -32,7 +33,7 @@ func maskFromTypes(types string) uint64 {
 		case "stdout":
 			mask |= process.StdoutBit
 		case "process_status":
-			mask |= process.ProcessStatusBit
+			mask |= process.StatusBit
 		}
 	}
 	return mask
@@ -67,4 +68,12 @@ func checkCommand(command *process.Command) error {
 		return errors.New("Command line required")
 	}
 	return nil
+}
+
+type rpcProcessEventConsumer struct {
+	rpcChannel chan *rpc.Event
+}
+
+func (rpcConsumer *rpcProcessEventConsumer) Accept(e process.Event) {
+	rpcConsumer.rpcChannel <- rpc.NewEvent(e.Type(), e)
 }

--- a/agents/go-agents/exec-agent/exec/rest_service.go
+++ b/agents/go-agents/exec-agent/exec/rest_service.go
@@ -85,7 +85,8 @@ func startProcessHF(w http.ResponseWriter, r *http.Request, p rest.Params) error
 			m := fmt.Sprintf("Channel with id '%s' doesn't exist. Process won't be started", channelID)
 			return rest.NotFound(errors.New(m))
 		}
-		pb.Subscribe(channelID, parseTypes(r.URL.Query().Get("types")), channel.Events)
+		eventsConsumer := &rpcProcessEventConsumer{channel.Events}
+		pb.Subscribe(channelID, parseTypes(r.URL.Query().Get("types")), eventsConsumer)
 	}
 
 	proc, err := pb.Start()

--- a/agents/go-agents/exec-agent/exec/rest_service_test.go
+++ b/agents/go-agents/exec-agent/exec/rest_service_test.go
@@ -1,0 +1,288 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eclipse/che/agents/go-agents/core/process"
+	"github.com/eclipse/che/agents/go-agents/core/process/processtest"
+	"github.com/eclipse/che/agents/go-agents/core/rest"
+	"net/url"
+)
+
+func TestStartProcessHandlerFunc(t *testing.T) {
+	command := &process.Command{
+		Name:        "test",
+		CommandLine: "echo hello",
+		Type:        "test",
+	}
+	req, err := http.NewRequest("POST", "/process", asJSONReader(t, command))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	asHTTPHandlerFunc(startProcessHF).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code %d but got %d", http.StatusOK, rr.Code)
+	}
+
+	mp := &process.MachineProcess{}
+	json.Unmarshal(rr.Body.Bytes(), mp)
+	failIfDifferent(t, command.Name, mp.Name, "name")
+	failIfDifferent(t, command.CommandLine, mp.CommandLine, "command-line")
+	failIfDifferent(t, command.Type, mp.Type, "type")
+	failIfDifferent(t, -1, mp.ExitCode, "exit-code")
+	failIfFalse(t, mp.Pid > 0, "Pid > 0")
+}
+
+func TestStartProcessFailsIfCommandIsInvalid(t *testing.T) {
+	invalidCommands := []*process.Command{
+		{
+			Name:        "test",
+			CommandLine: "",
+			Type:        "test",
+		},
+		{
+			Name:        "",
+			CommandLine: "echo test",
+			Type:        "test",
+		},
+	}
+
+	for _, command := range invalidCommands {
+		req, err := http.NewRequest("POST", "/process", asJSONReader(t, command))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rr := httptest.NewRecorder()
+
+		asHTTPHandlerFunc(startProcessHF).ServeHTTP(rr, req)
+
+		failIfDifferent(t, http.StatusBadRequest, rr.Code, "status-code")
+	}
+}
+
+func TestGetsExistingProcess(t *testing.T) {
+	exp := startAndWaitProcess(t, "echo hello")
+
+	strPid := strconv.Itoa(int(exp.Pid))
+	req, err := http.NewRequest("GET", "/process/"+strPid, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	asHTTPHandlerFunc(getProcessHF, "pid", strPid).ServeHTTP(rr, req)
+
+	failIfDifferent(t, 200, rr.Code, "status-code")
+
+	res := &process.MachineProcess{}
+	json.Unmarshal(rr.Body.Bytes(), res)
+	failIfDifferent(t, exp.Pid, res.Pid, "pid")
+	failIfDifferent(t, exp.Name, res.Name, "name")
+	failIfDifferent(t, exp.CommandLine, res.CommandLine, "command-line")
+	failIfDifferent(t, exp.Type, res.Type, "type")
+	failIfDifferent(t, exp.NativePid, res.NativePid, "native-pid")
+	failIfDifferent(t, false, res.Alive, "alive")
+}
+
+func TestReturnsNotFoundWhenNoProcess(t *testing.T) {
+	strPid := "4444"
+	req, err := http.NewRequest("GET", "/process/"+strPid, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	asHTTPHandlerFunc(getProcessHF, "pid", strPid).ServeHTTP(rr, req)
+
+	failIfDifferent(t, 404, rr.Code, "status-code")
+}
+
+func TestGetsNoAliveProcesses(t *testing.T) {
+	startAndWaitProcess(t, "echo test1")
+	startAndWaitProcess(t, "echo test2")
+
+	req, err := http.NewRequest("GET", "/process", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	asHTTPHandlerFunc(getProcessesHF).ServeHTTP(rr, req)
+
+	failIfDifferent(t, 200, rr.Code, "status-code")
+	mps := []process.MachineProcess{}
+	json.Unmarshal(rr.Body.Bytes(), &mps)
+	failIfDifferent(t, 0, len(mps), "processes slice len")
+}
+
+func TestGetsProcessLogs(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "exec-agent-text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	process.SetLogsDir(dir)
+	defer process.WipeLogs()
+
+	outputLines := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
+	mp := startAndWaitProcess(t, "printf \""+strings.Join(outputLines, "\n")+"\"")
+
+	realLogs, err := process.ReadAllLogs(mp.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type TestCase struct {
+		expectedLogs []*process.LogMessage
+		queryString  string
+	}
+
+	cases := []TestCase{
+		{
+			expectedLogs: realLogs[5:],
+			queryString:  "limit=5",
+		},
+		{
+			expectedLogs: realLogs[:5],
+			queryString:  "skip=5",
+		},
+		{
+			expectedLogs: realLogs[3:5],
+			queryString:  "limit=2&skip=5",
+		},
+		{
+			expectedLogs: make([]*process.LogMessage, 0),
+			queryString:  "limit=2&skip=20",
+		},
+		{
+			expectedLogs: realLogs[9:],
+			queryString:  "limit=1",
+		},
+		{
+			expectedLogs: realLogs[6:],
+			queryString:  query("from", realLogs[6].Time.Format(process.DateTimeFormat)),
+		},
+		{
+			expectedLogs: realLogs[6:8],
+			queryString: query(
+				"from", realLogs[6].Time.Format(process.DateTimeFormat),
+				"till", realLogs[7].Time.Format(process.DateTimeFormat),
+			),
+		},
+	}
+
+	strPid := strconv.Itoa(int(mp.Pid))
+	baseURL := "/process/" + strconv.Itoa(int(mp.Pid)) + "/logs?"
+
+	for _, theCase := range cases {
+		// fetch logs
+		req, err := http.NewRequest("GET", baseURL+theCase.queryString, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rr := httptest.NewRecorder()
+		asHTTPHandlerFunc(getProcessLogsHF, "pid", strPid).ServeHTTP(rr, req)
+
+		// must be 200ok
+		failIfDifferent(t, http.StatusOK, rr.Code, "status code")
+
+		// check logs are the same to expected
+		logs := []*process.LogMessage{}
+		json.Unmarshal(rr.Body.Bytes(), &logs)
+		failIfDifferent(t, len(theCase.expectedLogs), len(logs), "logs len")
+		for i := 0; i < len(theCase.expectedLogs); i++ {
+			failIfDifferent(t, *theCase.expectedLogs[i], *logs[i], "log messages")
+		}
+	}
+}
+
+func query(kv ...string) string {
+	if len(kv) == 0 {
+		return ""
+	}
+	values := url.Values{}
+	for i := 0; i < len(kv); i += 2 {
+		values.Add(kv[i], kv[i+1])
+	}
+	return values.Encode()
+}
+
+func asJSONReader(t *testing.T, v interface{}) *bytes.Reader {
+	body, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewReader(body)
+}
+
+func startAndWaitProcess(t *testing.T, cmd string) process.MachineProcess {
+	captor := processtest.NewEventsCaptor(process.DiedEventType)
+	captor.Capture()
+
+	pb := process.NewBuilder()
+	pb.CmdLine(cmd)
+	pb.SubscribeDefault("test", captor)
+
+	mp, err := pb.Start()
+	if err != nil {
+		captor.Stop()
+		t.Fatal(err)
+	}
+
+	if ok := <-captor.Wait(2 * time.Second); !ok {
+		t.Errorf("Waited 2 seconds for process to finish, killing the process %d", mp.Pid)
+		if err := process.Kill(mp.Pid); err != nil {
+			t.Error(err)
+		}
+		t.FailNow()
+	}
+
+	return mp
+}
+
+func failIfDifferent(t *testing.T, expected interface{}, actual interface{}, context string) {
+	if expected != actual {
+		t.Fatalf("Expected to receive '%v' %s but received '%v'", expected, context, actual)
+	}
+}
+
+func failIfFalse(t *testing.T, condition bool, context string) {
+	if !condition {
+		t.Fatalf("%s: false", context)
+	}
+}
+
+func asHTTPHandlerFunc(f rest.HTTPRouteHandlerFunc, params ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := f(w, r, newFakeParams(params...)); err != nil {
+			rest.WriteError(w, err)
+		}
+	}
+}
+
+func newFakeParams(kv ...string) *fakeParams {
+	params := &fakeParams{make(map[string]string)}
+	for i := 0; i < len(kv); i += 2 {
+		params.items[kv[i]] = kv[i+1]
+	}
+	return params
+}
+
+type fakeParams struct {
+	items map[string]string
+}
+
+func (p *fakeParams) Get(key string) string {
+	return p.items[key]
+}

--- a/agents/go-agents/exec-agent/exec/ws_service.go
+++ b/agents/go-agents/exec-agent/exec/ws_service.go
@@ -145,7 +145,7 @@ func startProcessReqHF(params interface{}, t *rpc.Transmitter) error {
 
 	pb := process.NewBuilder()
 	pb.Cmd(command)
-	pb.Subscribe(t.Channel.ID, parseTypes(startParams.EventTypes), t.Channel.Events)
+	pb.Subscribe(t.Channel.ID, parseTypes(startParams.EventTypes), &rpcProcessEventConsumer{t.Channel.Events})
 	pb.BeforeEventsHook(func(process process.MachineProcess) {
 		t.Send(process)
 	})
@@ -194,9 +194,9 @@ func subscribeReqHF(params interface{}, t *rpc.Transmitter) error {
 	}
 
 	subscriber := process.Subscriber{
-		ID:      t.Channel.ID,
-		Mask:    mask,
-		Channel: t.Channel.Events,
+		ID:       t.Channel.ID,
+		Mask:     mask,
+		Consumer: &rpcProcessEventConsumer{t.Channel.Events},
 	}
 	// Check whether subscriber should see previous logs or not
 	if subscribeParams.After == "" {
@@ -295,7 +295,7 @@ func getProcessLogsReqHF(params interface{}, t *rpc.Transmitter) error {
 
 	limit := DefaultLogsPerPageLimit
 	if getLogsParams.Limit != 0 {
-		if limit < 1 {
+		if getLogsParams.Limit < 1 {
 			return rpc.NewArgsError(errors.New("Required 'limit' to be > 0"))
 		}
 		limit = getLogsParams.Limit
@@ -303,7 +303,7 @@ func getProcessLogsReqHF(params interface{}, t *rpc.Transmitter) error {
 
 	skip := 0
 	if getLogsParams.Skip != 0 {
-		if skip < 0 {
+		if getLogsParams.Skip < 0 {
 			return rpc.NewArgsError(errors.New("Required 'skip' to be >= 0"))
 		}
 		skip = getLogsParams.Skip


### PR DESCRIPTION
### What does this PR do?
Decuples core/process and core/rpc.

`rpc.Event` is replaced with `process.Event`
```go
type Event interface {
	Type() string
}
```

`chan *rpc.Event` is replaced with `process.EventsConsumer`
```go
type EventConsumer interface {
	Accept(event Event)
}
```

Also added exec-agent REST service tests.

### What issues does this PR fix or reference?
Resolves #5149 

#### Changelog
The package _core/process_ doesn't depend on _core/rpc_ anymore instead it provides
its own routines for events publication
