### PR TITLE
CHE-4670: update an editor tab after changing command name

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
@@ -231,7 +231,6 @@ public class CommandEditor extends AbstractEditorPresenter implements CommandEdi
                 input.setFile(nodeFactory.newCommandFileNode(editedCommand));
             }
 
-
             final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
             if (activeEditor != null) {
                 activeEditor.onFileChanged();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
@@ -31,7 +31,6 @@ import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.editor.AbstractEditorPresenter;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorInput;
-import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
@@ -220,8 +219,6 @@ public class CommandEditor extends AbstractEditorPresenter implements CommandEdi
     @Override
     public void doSave(AsyncCallback<EditorInput> callback) {
         commandManager.updateCommand(initialCommandName, editedCommand).then(arg -> {
-            updateDirtyState(false);
-
             // according to the CommandManager#updateCommand contract
             // command's name after updating may differ from the proposed name
             // in order to prevent name duplication
@@ -229,12 +226,10 @@ public class CommandEditor extends AbstractEditorPresenter implements CommandEdi
 
             if (!initialCommandName.equals(editedCommand.getName())) {
                 input.setFile(nodeFactory.newCommandFileNode(editedCommand));
+                initialCommandName = editedCommand.getName();
             }
 
-            final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
-            if (activeEditor != null) {
-                activeEditor.onFileChanged();
-            }
+            updateDirtyState(false);
 
             view.setSaveEnabled(false);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
@@ -230,6 +230,9 @@ public class CommandEditor extends AbstractEditorPresenter implements CommandEdi
                 input.setFile(nodeFactory.newCommandFileNode(editedCommand));
             }
 
+
+            editorAgent.getActiveEditor().onFileChanged();
+
             view.setSaveEnabled(false);
 
             callback.onSuccess(getEditorInput());

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
@@ -31,6 +31,7 @@ import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.editor.AbstractEditorPresenter;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorInput;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
@@ -231,7 +232,10 @@ public class CommandEditor extends AbstractEditorPresenter implements CommandEdi
             }
 
 
-            editorAgent.getActiveEditor().onFileChanged();
+            final EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+            if (activeEditor != null) {
+                activeEditor.onFileChanged();
+            }
 
             view.setSaveEnabled(false);
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/CommandEditorTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/CommandEditorTest.java
@@ -26,7 +26,6 @@ import org.eclipse.che.ide.api.command.CommandRemovedEvent;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorInput;
-import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
@@ -45,7 +44,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
@@ -176,8 +174,6 @@ public class CommandEditorTest {
     public void shouldSaveCommand() throws Exception {
         when(commandManager.updateCommand(anyString(), eq(editor.editedCommand))).thenReturn(commandPromise);
         when(commandPromise.then(any(Operation.class))).thenReturn(commandPromise);
-        EditorPartPresenter editorPartPresenter = Mockito.mock(EditorPartPresenter.class);
-        when(editorAgent.getActiveEditor()).thenReturn(editorPartPresenter);
 
         editor.doSave();
 
@@ -186,7 +182,6 @@ public class CommandEditorTest {
         operationCaptor.getValue().apply(editedCommand);
 
         verify(view).setSaveEnabled(false);
-        verify(editorPartPresenter).onFileChanged();
     }
 
     @Test(expected = OperationException.class)

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/CommandEditorTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/CommandEditorTest.java
@@ -26,6 +26,7 @@ import org.eclipse.che.ide.api.command.CommandRemovedEvent;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorInput;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
@@ -44,6 +45,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
@@ -174,6 +176,8 @@ public class CommandEditorTest {
     public void shouldSaveCommand() throws Exception {
         when(commandManager.updateCommand(anyString(), eq(editor.editedCommand))).thenReturn(commandPromise);
         when(commandPromise.then(any(Operation.class))).thenReturn(commandPromise);
+        EditorPartPresenter editorPartPresenter = Mockito.mock(EditorPartPresenter.class);
+        when(editorAgent.getActiveEditor()).thenReturn(editorPartPresenter);
 
         editor.doSave();
 
@@ -182,6 +186,7 @@ public class CommandEditorTest {
         operationCaptor.getValue().apply(editedCommand);
 
         verify(view).setSaveEnabled(false);
+        verify(editorPartPresenter).onFileChanged();
     }
 
     @Test(expected = OperationException.class)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes a problem with updating an editor tab after updating command name

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5145

