### PR TITLE
che-5230: avoid watching stack tag changes when section is hidden

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.html
+++ b/dashboard/src/app/projects/create-project/create-project.html
@@ -24,7 +24,7 @@
 <md-content id="create-project-content-page"
             md-scroll-y flex
             class="projects-create-project">
-  <div ng-show="createProjectCtrl.isCreateProjectInProgress()">
+  <div ng-if="createProjectCtrl.isCreateProjectInProgress()">
     <div id="create-project-panel" class="create-project-progress-panel">
       <che-loader class="che-loader-panel" layout="column">
         <!--crane and terminals-->
@@ -83,7 +83,7 @@
     </div>
   </div>
 
-  <div ng-hide="createProjectCtrl.isCreateProjectInProgress()">
+  <div ng-if="!createProjectCtrl.isCreateProjectInProgress()">
 
     <!-- Select source -->
     <che-label-container id="create-project-source-id"


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Avoid watching stack tag changes and selecting project samples, when section is hidden (workspace is loading).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5230

#### Changelog
[dashboard] Fixed reacting on stack changes inside of the hidden aria.

#### Release Notes
N/A

#### Docs PR
N/A
