### PR TITLE
Deprecate DevMachine and ActiveRuntime classes

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/app/AppContext.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/app/AppContext.java
@@ -123,7 +123,9 @@ public interface AppContext {
      * @return the object which describes developer machine
      * @see DevMachine
      * @since 4.2.0
+     * @deprecated use {@link org.eclipse.che.ide.api.workspace.model.RuntimeImpl#getDevMachine()}
      */
+    @Deprecated
     DevMachine getDevMachine();
 
     /**

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandTypeRegistry.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandTypeRegistry.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public interface CommandTypeRegistry {
 
     /**
-     * Returns {@code Optional} {@link CommandType} with the specified ID or {@code Optional.absent()} if none.
+     * Returns {@code Optional} {@link CommandType} with the specified ID or {@code Optional.empty()} if none.
      *
      * @param id
      *         the ID of the command type

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
@@ -157,13 +157,8 @@ public class JsonRpcWebSocketAgentEventListener implements WsAgentStateHandler {
     @Override
     public void onWsAgentStopped(WsAgentStateEvent event) {
         final WorkspaceImpl workspace = appContext.getWorkspace();
-        final RuntimeImpl runtime = workspace.getRuntime();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
 
-        if (runtime == null) {
-            return;
-        }
-
-        final Optional<MachineImpl> devMachine = runtime.getDevMachine();
         if (!devMachine.isPresent()) {
             return;
         }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
@@ -18,7 +18,6 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.api.machine.shared.dto.execagent.event.DtoWithPid;
 import org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto;
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
@@ -157,12 +156,23 @@ public class JsonRpcWebSocketAgentEventListener implements WsAgentStateHandler {
 
     @Override
     public void onWsAgentStopped(WsAgentStateEvent event) {
-        DevMachine devMachine = appContext.getDevMachine();
-        String devMachineId = devMachine.getId();
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final RuntimeImpl runtime = workspace.getRuntime();
+
+        if (runtime == null) {
+            return;
+        }
+
+        final Optional<MachineImpl> devMachine = runtime.getDevMachine();
+        if (!devMachine.isPresent()) {
+            return;
+        }
+
+        final String devMachineName = devMachine.get().getName();
 
         Log.debug(JsonRpcWebSocketAgentEventListener.class, "Web socket agent stopped event caught.");
 
         initializer.terminate("ws-agent");
-        initializer.terminate(devMachineId);
+        initializer.terminate(devMachineName);
     }
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/ActiveRuntime.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/ActiveRuntime.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.api.machine;
 import org.eclipse.che.api.core.model.workspace.Runtime;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
 import org.eclipse.che.ide.util.loging.Log;
 
 import java.util.ArrayList;
@@ -26,7 +27,9 @@ import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
 
 /**
  * @author Vitalii Parfonov
+ * @deprecated use {@link org.eclipse.che.ide.api.workspace.model.RuntimeImpl}
  */
+@Deprecated
 public class ActiveRuntime {
 
     private DevMachine                 devMachine;
@@ -62,14 +65,18 @@ public class ActiveRuntime {
 
     }
 
+    @Deprecated
     public DevMachine getDevMachine() {
         return devMachine;
     }
 
+    @Deprecated
+    /** @deprecated use {@link RuntimeImpl#getMachines()} */
     public List<MachineEntity> getMachines() {
         return new ArrayList<>(machines.values());
     }
 
+    @Deprecated
     public Optional<MachineEntity> getMachineByName(String name) {
         return Optional.ofNullable(machines.get(name));
     }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/ActiveRuntime.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/ActiveRuntime.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
 
@@ -74,10 +73,5 @@ public class ActiveRuntime {
     /** @deprecated use {@link RuntimeImpl#getMachines()} */
     public List<MachineEntity> getMachines() {
         return new ArrayList<>(machines.values());
-    }
-
-    @Deprecated
-    public Optional<MachineEntity> getMachineByName(String name) {
-        return Optional.ofNullable(machines.get(name));
     }
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/CheWsAgentLinksModifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/CheWsAgentLinksModifier.java
@@ -12,6 +12,8 @@ package org.eclipse.che.ide.api.machine;
 
 import com.google.inject.Singleton;
 
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+
 /**
  * Dummy implementation.
  *
@@ -21,7 +23,7 @@ import com.google.inject.Singleton;
 public class CheWsAgentLinksModifier implements WsAgentURLModifier {
 
     @Override
-    public void initialize(DevMachine devMachine) {
+    public void initialize(MachineImpl devMachine) {
     }
 
     @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachine.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/DevMachine.java
@@ -22,7 +22,9 @@ import javax.validation.constraints.NotNull;
  * Must contains all information that need to communicate with dev machine such as links, type, environment variable and etc.
  *
  * @author Vitalii Parfonov
+ * @deprecated use {@link org.eclipse.che.ide.api.workspace.model.RuntimeImpl#getDevMachine()}
  */
+@Deprecated
 public class DevMachine extends MachineEntityImpl {
 
     public DevMachine(String name, @NotNull Machine devMachineDescriptor) {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentStateController.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentStateController.java
@@ -23,9 +23,9 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.ui.loaders.LoaderPresenter;
-import org.eclipse.che.ide.util.browser.BrowserUtils;
 import org.eclipse.che.ide.websocket.MessageBus;
 import org.eclipse.che.ide.websocket.MessageBusProvider;
 import org.eclipse.che.ide.websocket.events.ConnectionClosedHandler;
@@ -57,11 +57,11 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
     private final AppContext             appContext;
     private final AsyncRequestFactory    asyncRequestFactory;
     private final LoaderPresenter        loader;
-    private       DevMachine             devMachine;
+    private       MachineImpl             devMachine;
     private       MessageBus             messageBus;
     private       WsAgentState           state;
     private List<AsyncCallback<MessageBus>> messageBusCallbacks = newArrayList();
-    private List<AsyncCallback<DevMachine>> devMachineCallbacks = newArrayList();
+    private List<AsyncCallback<MachineImpl>> devMachineCallbacks = newArrayList();
 
     @Inject
     public WsAgentStateController(EventBus eventBus,
@@ -78,7 +78,7 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
         this.appContext = appContext;
     }
 
-    public void initialize(DevMachine devMachine) {
+    public void initialize(MachineImpl devMachine) {
         checkNotNull(devMachine, "Developer machine should not be a null");
 
         this.devMachine = devMachine;
@@ -161,7 +161,7 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
         }
         messageBusCallbacks.clear();
 
-        for (AsyncCallback<DevMachine> callback : devMachineCallbacks) {
+        for (AsyncCallback<MachineImpl> callback : devMachineCallbacks) {
             callback.onSuccess(devMachine);
         }
         devMachineCallbacks.clear();
@@ -202,7 +202,10 @@ public class WsAgentStateController implements ConnectionOpenedHandler, Connecti
         if (messageBus != null) {
             messageBus.cancelReconnection();
         }
-        messageBus = messageBusProvider.createMachineMessageBus(devMachine.getWsAgentWebSocketUrl());
+
+        // FIXME: spi
+        final String wsAgentWebSocketURL = appContext.getDevAgentEndpoint().replaceFirst("http", "ws") + "/ws";
+        messageBus = messageBusProvider.createMachineMessageBus(wsAgentWebSocketURL);
         messageBus.addOnCloseHandler(this);
         messageBus.addOnErrorHandler(this);
         messageBus.addOnOpenHandler(this);

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentURLModifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/WsAgentURLModifier.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.ide.api.machine;
 
 
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+
 /**
  * Modify the URL to the workspace agent.
  * <p>Note that for che assembly it's return the source url.
@@ -25,7 +27,7 @@ public interface WsAgentURLModifier {
      * @param devMachine
      *         runtime information of dev machine instance, such as link
      */
-    void initialize(DevMachine devMachine);
+    void initialize(MachineImpl devMachine);
 
     /**
      * Change source url in accordance with the requirements of the assembly

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/RuntimeImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/RuntimeImpl.java
@@ -28,10 +28,10 @@ import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
 /** Data object for {@link Runtime}. */
 public class RuntimeImpl implements Runtime {
 
-    private final String                             activeEnv;
-    private final String                             owner;
-    private       Map<String, ? extends MachineImpl> machines;
-    private       List<Warning>                      warnings;
+    private final String                   activeEnv;
+    private final String                   owner;
+    private       Map<String, MachineImpl> machines;
+    private       List<Warning>            warnings;
 
     public RuntimeImpl(String activeEnv,
                        Map<String, ? extends Machine> machines,
@@ -60,11 +60,19 @@ public class RuntimeImpl implements Runtime {
     }
 
     @Override
-    public Map<String, ? extends MachineImpl> getMachines() {
+    public Map<String, MachineImpl> getMachines() {
         if (machines == null) {
             machines = new HashMap<>();
         }
         return machines;
+    }
+
+    /** Returns development machine or an empty {@code Optional} if none. */
+    public Optional<MachineImpl> getDevMachine() {
+        return getMachines().values()
+                            .stream()
+                            .filter(m -> m.getServerByName(WSAGENT_REFERENCE).isPresent())
+                            .findAny();
     }
 
     /** Returns ws-agent server. */

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.che.commons.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /** Data object for {@link Workspace}. */
 public class WorkspaceImpl implements Workspace {
@@ -103,6 +104,18 @@ public class WorkspaceImpl implements Workspace {
     @Override
     public RuntimeImpl getRuntime() {
         return runtime;
+    }
+
+    /**
+     * Shorthand for {@link RuntimeImpl#getDevMachine()}.
+     * Returns an empty {@code Optional} if workspace doesn't have a runtime.
+     */
+    public Optional<MachineImpl> getDevMachine() {
+        if (getRuntime() != null) {
+            return getRuntime().getDevMachine();
+        }
+
+        return Optional.empty();
     }
 
     @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceImpl.java
@@ -111,11 +111,7 @@ public class WorkspaceImpl implements Workspace {
      * Returns an empty {@code Optional} if workspace doesn't have a runtime.
      */
     public Optional<MachineImpl> getDevMachine() {
-        if (getRuntime() != null) {
-            return getRuntime().getDevMachine();
-        }
-
-        return Optional.empty();
+        return getRuntime() != null ? getRuntime().getDevMachine() : Optional.empty();
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
@@ -18,7 +18,6 @@ import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandExecutor;
 import org.eclipse.che.ide.api.command.CommandManager;
-import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -61,10 +60,7 @@ public class RunCommandAction extends Action {
         }
 
         final WorkspaceImpl workspace = appContext.getWorkspace();
-        final RuntimeImpl runtime = workspace.getRuntime();
-        if (runtime != null) {
-            runtime.getDevMachine().ifPresent(m -> commandManager.getCommand(name)
-                                                                 .ifPresent(command -> commandExecutor.executeCommand(command, m)));
-        }
+        workspace.getDevMachine().ifPresent(m -> commandManager.getCommand(name)
+                                                               .ifPresent(command -> commandExecutor.executeCommand(command, m)));
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
@@ -18,9 +18,9 @@ import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandExecutor;
 import org.eclipse.che.ide.api.command.CommandManager;
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.util.loging.Log;
-
 
 /**
  * Allows to run predefined command without UI.
@@ -60,9 +60,11 @@ public class RunCommandAction extends Action {
             return;
         }
 
-        commandManager.getCommand(name)
-                      .ifPresent(command -> commandExecutor.executeCommand(command,
-                                                                           new MachineImpl(appContext.getDevMachine().getName(),
-                                                                                           appContext.getDevMachine())));
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final RuntimeImpl runtime = workspace.getRuntime();
+        if (runtime != null) {
+            runtime.getDevMachine().ifPresent(m -> commandManager.getCommand(name)
+                                                                 .ifPresent(command -> commandExecutor.executeCommand(command, m)));
+        }
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/StopWorkspaceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/StopWorkspaceAction.java
@@ -46,7 +46,7 @@ public class StopWorkspaceAction extends AbstractPerspectiveAction {
     @Override
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
-        event.getPresentation().setEnabled(appContext.getDevMachine() != null);
+        event.getPresentation().setEnabled(appContext.getWorkspace().getRuntime() != null);
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/previews/PreviewUrl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/previews/PreviewUrl.java
@@ -12,10 +12,13 @@ package org.eclipse.che.ide.command.toolbar.previews;
 
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 
 /** Represents an item for displaying in the 'Previews' list. */
 class PreviewUrl {
@@ -45,13 +48,19 @@ class PreviewUrl {
     }
 
     private String getDisplayNameForPreviewUrl(String previewUrl) {
-        final DevMachine devMachine = appContext.getDevMachine();
-
-        if (devMachine == null) {
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final RuntimeImpl runtime = workspace.getRuntime();
+        if(runtime == null) {
             return previewUrl;
         }
 
-        for (Entry<String, ? extends Server> entry : devMachine.getServers().entrySet()) {
+        final Optional<? extends MachineImpl> devMachine = runtime.getDevMachine();
+
+        if (!devMachine.isPresent()) {
+            return previewUrl;
+        }
+
+        for (Entry<String, ? extends Server> entry : devMachine.get().getServers().entrySet()) {
             Server server = entry.getValue();
             String serverUrl = server.getUrl();
 
@@ -68,7 +77,7 @@ class PreviewUrl {
                     port = port.substring(0, slashIndex);
                 }
 
-                return previewUrl.replace(serverUrl, devMachine.getDisplayName() + ':' + port);
+                return previewUrl.replace(serverUrl, devMachine.get().getName() + ':' + port);
             }
         }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/previews/PreviewUrl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/previews/PreviewUrl.java
@@ -13,7 +13,6 @@ package org.eclipse.che.ide.command.toolbar.previews;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 
 import java.util.Map.Entry;
@@ -49,12 +48,7 @@ class PreviewUrl {
 
     private String getDisplayNameForPreviewUrl(String previewUrl) {
         final WorkspaceImpl workspace = appContext.getWorkspace();
-        final RuntimeImpl runtime = workspace.getRuntime();
-        if(runtime == null) {
-            return previewUrl;
-        }
-
-        final Optional<? extends MachineImpl> devMachine = runtime.getDevMachine();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
 
         if (!devMachine.isPresent()) {
             return previewUrl;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -92,13 +92,13 @@ public class AppContextImpl implements AppContext,
      * Can be processed after IDE initialization as usual after starting ws-agent.
      */
     private final List<StartUpAction> startAppActions;
-    private CurrentUser currentUser;
-    private WorkspaceImpl       workspace;
-    private FactoryImpl         factory;
-    private Path                projectsRoot;
-    private ActiveRuntime       runtime;
-    private ResourceManager     resourceManager;
-    private Map<String, String> properties;
+    private       CurrentUser         currentUser;
+    private       WorkspaceImpl       workspace;
+    private       FactoryImpl         factory;
+    private       Path                projectsRoot;
+    private       ActiveRuntime       runtime;
+    private       ResourceManager     resourceManager;
+    private       Map<String, String> properties;
 
     @Inject
     public AppContextImpl(EventBus eventBus,
@@ -200,6 +200,7 @@ public class AppContextImpl implements AppContext,
         this.factory = new FactoryImpl(factory);
     }
 
+    @Deprecated
     @Override
     public DevMachine getDevMachine() {
         return runtime.getDevMachine();
@@ -412,20 +413,24 @@ public class AppContextImpl implements AppContext,
 
     @Override
     public String getMasterEndpoint() {
-        String fromUrl = queryParameters.getByName("master");
-        if (fromUrl == null || fromUrl.isEmpty())
+        final String fromUrl = queryParameters.getByName("master");
+
+        if (fromUrl == null || fromUrl.isEmpty()) {
             return masterFromIDEConfig();
-        else
+        } else {
             return fromUrl;
+        }
     }
 
     @Override
     public String getDevAgentEndpoint() {
-        String fromUrl = queryParameters.getByName("agent");
-        if (fromUrl == null || fromUrl.isEmpty())
+        final String fromUrl = queryParameters.getByName("agent");
+
+        if (fromUrl == null || fromUrl.isEmpty()) {
             return getDevMachine().getWsAgentBaseUrl();
-        else
+        } else {
             return fromUrl;
+        }
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/AbstractServerMacro.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/AbstractServerMacro.java
@@ -14,12 +14,14 @@ import com.google.common.annotations.Beta;
 import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
 import org.eclipse.che.ide.api.macro.Macro;
 import org.eclipse.che.ide.api.macro.MacroRegistry;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -53,17 +55,18 @@ public abstract class AbstractServerMacro implements WsAgentStateHandler {
     /**
      * Register macro providers which returns the implementation.
      *
-     * @see AbstractServerMacro#getMacros(DevMachine)
+     * @see AbstractServerMacro#getMacros(MachineImpl)
      * @since 4.7.0
      */
     private void registerMacros() {
-        final DevMachine devMachine = appContext.getDevMachine();
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
 
-        if (devMachine == null) {
+        if (!devMachine.isPresent()) {
             return;
         }
 
-        final Set<Macro> macros = getMacros(devMachine);
+        final Set<Macro> macros = getMacros(devMachine.get());
         checkNotNull(macros);
 
         if (macros.isEmpty()) {
@@ -76,17 +79,18 @@ public abstract class AbstractServerMacro implements WsAgentStateHandler {
     /**
      * Unregister macro providers which the implementation returns.
      *
-     * @see AbstractServerMacro#getMacros(DevMachine)
+     * @see AbstractServerMacro#getMacros(MachineImpl)
      * @since 4.7.0
      */
     private void unregisterMacros() {
-        final DevMachine devMachine = appContext.getDevMachine();
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
 
-        if (devMachine == null) {
+        if (!devMachine.isPresent()) {
             return;
         }
 
-        for (Macro provider : getMacros(devMachine)) {
+        for (Macro provider : getMacros(devMachine.get())) {
             macroRegistry.unregister(provider);
         }
     }
@@ -97,11 +101,10 @@ public abstract class AbstractServerMacro implements WsAgentStateHandler {
      * @param devMachine
      *         current developer machine
      * @return set of unique macro providers
-     * @see DevMachine
      * @see Macro
      * @since 4.7.0
      */
-    public abstract Set<Macro> getMacros(DevMachine devMachine);
+    public abstract Set<Macro> getMacros(MachineImpl devMachine);
 
     /** {@inheritDoc} */
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/DevMachineHostNameMacro.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/DevMachineHostNameMacro.java
@@ -21,8 +21,11 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
 import org.eclipse.che.ide.api.macro.Macro;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 /**
  * Provides dev-machine's host name.
@@ -66,9 +69,15 @@ public class DevMachineHostNameMacro implements Macro, WsAgentStateHandler {
 
     @Override
     public void onWsAgentStarted(WsAgentStateEvent event) {
-        String hostName = appContext.getDevMachine().getProperties().get("config.hostname");
-        if (hostName != null) {
-            value = hostName;
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
+
+        if (devMachine.isPresent()) {
+            final String hostName = devMachine.get().getProperties().get("config.hostname");
+
+            if (hostName != null) {
+                value = hostName;
+            }
         }
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/ServerAddressMacroRegistrar.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/ServerAddressMacroRegistrar.java
@@ -23,8 +23,11 @@ import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
 import org.eclipse.che.ide.api.macro.BaseMacro;
 import org.eclipse.che.ide.api.macro.Macro;
 import org.eclipse.che.ide.api.macro.MacroRegistry;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -56,9 +59,11 @@ public class ServerAddressMacroRegistrar implements WsAgentStateHandler {
     }
 
     private void registerMacros() {
-        Machine devMachine = appContext.getDevMachine();
-        if (devMachine != null) {
-            macros = getMacros(devMachine);
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
+
+        if (devMachine.isPresent()) {
+            macros = getMacros(devMachine.get());
             macroRegistry.register(macros);
         }
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -40,11 +40,10 @@ import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandTypeRegistry;
 import org.eclipse.che.ide.api.dialogs.ConfirmCallback;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.events.ActivateProcessOutputEvent;
-import org.eclipse.che.ide.api.machine.events.MachineStartingEvent;
 import org.eclipse.che.ide.api.machine.events.MachineRunningEvent;
+import org.eclipse.che.ide.api.machine.events.MachineStartingEvent;
 import org.eclipse.che.ide.api.machine.events.ProcessFinishedEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
@@ -87,6 +86,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -310,9 +310,12 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
     /** Opens new terminal for the selected machine. */
     public void newTerminal(Object source) {
         final ProcessTreeNode selectedTreeNode = view.getSelectedTreeNode();
-        final DevMachine devMachine = appContext.getDevMachine();
-        if (selectedTreeNode == null && devMachine != null) {
-            onAddTerminal(devMachine.getName(), source);
+
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
+
+        if (selectedTreeNode == null && devMachine.isPresent()) {
+            onAddTerminal(devMachine.get().getName(), source);
             return;
         }
 
@@ -516,7 +519,10 @@ public class ProcessesPanelPresenter extends BasePresenter implements ProcessesP
     }
 
     public void addCommandOutput(OutputConsole outputConsole) {
-        addCommandOutput(appContext.getDevMachine().getName(), outputConsole);
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
+
+        devMachine.ifPresent(machine -> addCommandOutput(machine.getName(), outputConsole));
     }
 
     /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceStatusHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceStatusHandler.java
@@ -25,10 +25,13 @@ import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStartedEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStartingEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 import org.eclipse.che.ide.context.AppContextImpl;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.ui.loaders.LoaderPresenter;
 import org.eclipse.che.ide.workspace.start.StartWorkspaceNotification;
+
+import java.util.Optional;
 
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
@@ -94,8 +97,12 @@ public class WorkspaceStatusHandler {
 
             if (workspace.getStatus() == RUNNING) {
                 wsStatusNotification.setSuccess(STARTING_WORKSPACE_RUNTIME);
-                wsAgentStateController.initialize(appContext.getDevMachine());
-                wsAgentURLModifier.initialize(appContext.getDevMachine());
+
+                final Optional<MachineImpl> devMachine = appContext.getWorkspace().getDevMachine();
+                devMachine.ifPresent(machine -> {
+                    wsAgentStateController.initialize(machine);
+                    wsAgentURLModifier.initialize(machine);
+                });
 
                 eventBus.fireEvent(new WorkspaceStartedEvent(workspace));
             } else if (workspace.getStatus() == STARTING) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/WorkspaceAgentOutputHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/WorkspaceAgentOutputHandler.java
@@ -17,6 +17,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.workspace.event.EnvironmentOutputEvent;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.util.loging.Log;
 
 import java.util.List;
@@ -30,7 +31,9 @@ class WorkspaceAgentOutputHandler {
         BiConsumer<String, List<String>> operation = (String endpointId, List<String> messages) -> {
             Log.debug(getClass(), "Received notification from endpoint: " + endpointId);
 
-            if (appContext.getWorkspace().getRuntime() == null || appContext.getDevMachine() == null) {
+            final WorkspaceImpl workspace = appContext.getWorkspace();
+
+            if (!workspace.getDevMachine().isPresent()) {
                 Log.error(getClass(), "Runtime or dev machine is not properly initialized for this action");
                 return;
             }
@@ -40,7 +43,7 @@ class WorkspaceAgentOutputHandler {
                 return;
             }
 
-            eventBus.fireEvent(new EnvironmentOutputEvent(messages.get(0), appContext.getDevMachine().getName()));
+            eventBus.fireEvent(new EnvironmentOutputEvent(messages.get(0), workspace.getDevMachine().get().getName()));
         };
 
         configurator.newConfiguration()

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/DownloadWsActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/DownloadWsActionTest.java
@@ -17,7 +17,6 @@ import org.eclipse.che.ide.Resources;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.WsAgentURLModifier;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.download.DownloadContainer;
@@ -66,9 +65,7 @@ public class DownloadWsActionTest {
     public void actionShouldBePerformed() throws Exception {
         String baseUrl = "baseUrl";
 
-        DevMachine devMachine = mock(DevMachine.class);
-        when(appContext.getDevMachine()).thenReturn(devMachine);
-        when(devMachine.getWsAgentBaseUrl()).thenReturn(baseUrl);
+        when(appContext.getDevAgentEndpoint()).thenReturn(baseUrl);
         when(wsAgentURLModifier.modify(anyString())).thenReturn(baseUrl);
 
         action.actionPerformed(actionEvent);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/RunCommandActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/RunCommandActionTest.java
@@ -17,7 +17,6 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandExecutor;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandManager;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,10 +76,10 @@ public class RunCommandActionTest {
     @Test
     public void actionShouldBePerformed() {
         when(event.getParameters()).thenReturn(Collections.singletonMap(NAME_PROPERTY, "MCI"));
-        final DevMachine devMachine = mock(DevMachine.class);
+//        final DevMachine devMachine = mock(DevMachine.class);
         final Machine machine = mock(Machine.class);
-        when(devMachine.getDescriptor()).thenReturn(machine);
-        when(appContext.getDevMachine()).thenReturn(devMachine);
+//        when(devMachine.getDescriptor()).thenReturn(machine);
+//        when(appContext.getDevMachine()).thenReturn(devMachine);
 
         action.actionPerformed(event);
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/toolbar/previews/PreviewUrlTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/toolbar/previews/PreviewUrlTest.java
@@ -10,10 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.ide.command.toolbar.previews;
 
-import org.eclipse.che.api.machine.shared.dto.MachineRuntimeInfoDto;
-import org.eclipse.che.api.workspace.shared.dto.ServerDto;
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.ServerImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,20 +41,17 @@ public class PreviewUrlTest {
 
     @Before
     public void setUp() {
-        ServerDto server = mock(ServerDto.class);
+        ServerImpl server = mock(ServerImpl.class);
         when(server.getUrl()).thenReturn("http://preview.com");
 
-        Map<String, ServerDto> servers = new HashMap<>();
+        Map<String, ServerImpl> servers = new HashMap<>();
         servers.put(SERVER_PORT + "/tcp", server);
 
-        MachineRuntimeInfoDto machineRuntimeInfo = mock(MachineRuntimeInfoDto.class);
-        when(machineRuntimeInfo.getServers()).thenReturn(servers);
+        MachineImpl devMachine = mock(MachineImpl.class);
+        when(devMachine.getName()).thenReturn(MACHINE_NAME);
+        when(devMachine.getServers()).thenReturn(servers);
 
-        DevMachine devMachine = mock(DevMachine.class);
-        when(devMachine.getDisplayName()).thenReturn(MACHINE_NAME);
-        when(devMachine.getRuntime()).thenReturn(machineRuntimeInfo);
-
-        when(appContext.getDevMachine()).thenReturn(devMachine);
+//        when(appContext.getDevMachine()).thenReturn(devMachine);
 
         previewUrl = new PreviewUrl(PREVIEW_URL, appContext);
     }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/navigation/NavigateToFilePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/navigation/NavigateToFilePresenterTest.java
@@ -13,11 +13,10 @@ package org.eclipse.che.ide.navigation;
 import com.google.common.base.Optional;
 import com.google.web.bindery.event.shared.EventBus;
 
+import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
-import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.resources.Container;
 import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.resource.Path;
@@ -32,7 +31,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,9 +69,6 @@ public class NavigateToFilePresenterTest {
 
     @Before
     public void setUp() {
-        DevMachine devMachine = mock(DevMachine.class);
-        when(devMachine.getId()).thenReturn("id");
-        when(appContext.getDevMachine()).thenReturn(devMachine);
         when(appContext.getWorkspaceRoot()).thenReturn(container);
         when(container.getFile(any(Path.class))).thenReturn(optFilePromise);
         when(messageBusProvider.getMachineMessageBus()).thenReturn(messageBus);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/project/ProjectServiceClientTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/project/ProjectServiceClientTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.ide.project;
 
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.WsAgentStateController;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.resource.Path;
@@ -64,10 +63,7 @@ public class ProjectServiceClientTest {
                                                         dtoFactory,
                                                         dtoUnmarshallerFactory,
                                                         appContext);
-        DevMachine devMachine = mock(DevMachine.class);
-        when(devMachine.getWsAgentBaseUrl()).thenReturn("");
-
-        when(appContext.getDevMachine()).thenReturn(devMachine);
+        when(appContext.getDevAgentEndpoint()).thenReturn("");
     }
 
     @Test

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -133,6 +133,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.Boolean.parseBoolean;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.ADDED;
@@ -597,7 +598,7 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
     @Override
     public void doSave(final AsyncCallback<EditorInput> callback) {
         //If the workspace is stopped we shouldn't try to save a file
-        if (isReadOnly() || appContext.getDevMachine() == null) {
+        if (isReadOnly() || appContext.getWorkspace().getStatus() != RUNNING) {
             return;
         }
 

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/configuration/JavaDebugConfigurationPagePresenter.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/main/java/org/eclipse/che/plugin/jdb/ide/configuration/JavaDebugConfigurationPagePresenter.java
@@ -18,7 +18,8 @@ import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
 import org.eclipse.che.ide.api.debug.DebugConfigurationPage;
-import org.eclipse.che.ide.api.machine.MachineEntity;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.util.Pair;
 
 import javax.validation.constraints.NotNull;
@@ -74,12 +75,12 @@ public class JavaDebugConfigurationPagePresenter implements JavaDebugConfigurati
     }
 
     private void setPortsList() {
-        List<Pair<String, String>> ports = extractPortsList(appContext.getDevMachine());
-        view.setPortsList(ports);
+        WorkspaceImpl workspace = appContext.getWorkspace();
+        workspace.getDevMachine().ifPresent(machine -> view.setPortsList(extractPortsList(machine)));
     }
 
     /** Extracts list of ports available for connecting to the remote debugger. */
-    private List<Pair<String, String>> extractPortsList(final MachineEntity machine) {
+    private List<Pair<String, String>> extractPortsList(final MachineImpl machine) {
         List<Pair<String, String>> ports = new ArrayList<>();
         if (machine == null) {
             return ports;

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/test/java/org/eclipse/che/plugin/jdb/ide/configuration/JavaDebugConfigurationPagePresenterTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-ide/src/test/java/org/eclipse/che/plugin/jdb/ide/configuration/JavaDebugConfigurationPagePresenterTest.java
@@ -15,7 +15,7 @@ import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
 import org.eclipse.che.ide.api.debug.DebugConfigurationPage;
-import org.eclipse.che.ide.api.machine.DevMachine;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -43,7 +43,7 @@ public class JavaDebugConfigurationPagePresenterTest {
     @Mock
     private AppContext                     appContext;
     @Mock
-    private DevMachine                     devMachine;
+    private MachineImpl                    devMachine;
 
     @Mock
     private DebugConfiguration configuration;
@@ -55,8 +55,8 @@ public class JavaDebugConfigurationPagePresenterTest {
     public void setUp() {
         when(configuration.getHost()).thenReturn(HOST);
         when(configuration.getPort()).thenReturn(PORT);
-        when(appContext.getDevMachine()).thenReturn(devMachine);
-        when(devMachine.getId()).thenReturn("devMachine");
+//        when(appContext.getDevMachine()).thenReturn(devMachine);
+        when(devMachine.getName()).thenReturn("devMachine");
 
 
         pagePresenter.resetFrom(configuration);

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/export/ExportPresenter.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/export/ExportPresenter.java
@@ -23,6 +23,9 @@ import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.user.AskCredentialsDialog;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.util.Arrays;
@@ -34,6 +37,7 @@ import org.eclipse.che.plugin.svn.ide.common.SubversionOutputConsoleFactory;
 import org.eclipse.che.plugin.svn.shared.GetRevisionsResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -155,8 +159,18 @@ public class ExportPresenter extends SubversionActionPresenter implements Export
     }
 
     private void openExportPopup(Path project, Path exportPath, String revision, StatusNotification notification) {
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final RuntimeImpl runtime = workspace.getRuntime();
+        if (runtime == null) {
+            return;
+        }
+        final Optional<? extends MachineImpl> devMachine = runtime.getDevMachine();
+        if (!devMachine.isPresent()) {
+            return;
+        }
+
         final StringBuilder url = new StringBuilder(appContext.getDevAgentEndpoint() + "/svn/"
-                                                    + appContext.getDevMachine().getId() + "/export" + project.toString());
+                                                    + devMachine.get().getName() + "/export" + project.toString());
         char separator = '?';
         if (!".".equals(exportPath.toString())) {
             url.append(separator).append("path").append('=').append(exportPath);

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/export/ExportPresenter.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/export/ExportPresenter.java
@@ -24,7 +24,6 @@ import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.user.AskCredentialsDialog;
 import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
 import org.eclipse.che.ide.resource.Path;
@@ -160,11 +159,8 @@ public class ExportPresenter extends SubversionActionPresenter implements Export
 
     private void openExportPopup(Path project, Path exportPath, String revision, StatusNotification notification) {
         final WorkspaceImpl workspace = appContext.getWorkspace();
-        final RuntimeImpl runtime = workspace.getRuntime();
-        if (runtime == null) {
-            return;
-        }
-        final Optional<? extends MachineImpl> devMachine = runtime.getDevMachine();
+        final Optional<MachineImpl> devMachine = workspace.getDevMachine();
+
         if (!devMachine.isPresent()) {
             return;
         }

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -37,7 +37,6 @@ import org.eclipse.che.ide.api.machine.execagent.ExecAgentConsumer;
 import org.eclipse.che.ide.api.macro.MacroProcessor;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.command.goal.TestGoal;
 import org.eclipse.che.ide.console.CommandConsoleFactory;
@@ -153,13 +152,8 @@ public class TestServiceClient {
                                                  Promise<CommandImpl> compileCommand) {
         return compileCommand.thenPromise(command -> {
             final WorkspaceImpl workspace = appContext.getWorkspace();
-            final RuntimeImpl runtime = workspace.getRuntime();
-            final MachineImpl machine;
-            if (runtime == null) {
-                machine = null;
-            } else {
-                machine = runtime.getDevMachine().orElse(null);
-            }
+            final MachineImpl machine = workspace.getDevMachine().orElse(null);
+
             if (machine == null) {
                 if (statusNotification != null) {
                     statusNotification.setContent("Executing the tests without preliminary compilation.");

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.ide;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.gwt.http.client.URL;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 import org.eclipse.che.api.machine.shared.dto.execagent.ProcessStartResponseDto;
 import org.eclipse.che.api.promises.client.Operation;
@@ -31,24 +33,24 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandManager;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
-import org.eclipse.che.ide.api.machine.MachineEntity;
 import org.eclipse.che.ide.api.machine.execagent.ExecAgentConsumer;
 import org.eclipse.che.ide.api.macro.MacroProcessor;
 import org.eclipse.che.ide.api.notification.StatusNotification;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.command.goal.TestGoal;
-import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.console.CommandConsoleFactory;
 import org.eclipse.che.ide.console.CommandOutputConsole;
+import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.rest.HTTPHeader;
 
-import com.google.gwt.http.client.URL;
-import com.google.gwt.regexp.shared.MatchResult;
-import com.google.gwt.regexp.shared.RegExp;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.eclipse.che.api.workspace.shared.Constants.COMMAND_PREVIEW_URL_ATTRIBUTE_NAME;
 
@@ -150,11 +152,13 @@ public class TestServiceClient {
                                                  StatusNotification statusNotification,
                                                  Promise<CommandImpl> compileCommand) {
         return compileCommand.thenPromise(command -> {
-            final MachineEntity machine;
-            if (command == null) {
+            final WorkspaceImpl workspace = appContext.getWorkspace();
+            final RuntimeImpl runtime = workspace.getRuntime();
+            final MachineImpl machine;
+            if (runtime == null) {
                 machine = null;
             } else {
-                machine = appContext.getDevMachine();
+                machine = runtime.getDevMachine().orElse(null);
             }
             if (machine == null) {
                 if (statusNotification != null) {
@@ -182,7 +186,7 @@ public class TestServiceClient {
                                                                           command.getType(), attributes);
 
                             final CommandOutputConsole console = commandConsoleFactory.create(expandedCommand, machine);
-                            final String machineId = machine.getId();
+                            final String machineId = machine.getName();
 
                             processesPanelPresenter.addCommandOutput(console);
                             ExecAgentConsumer<ProcessStartResponseDto> processPromise = execAgentCommandManager.startProcess(machineId,

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/test/java/org/eclipse/che/plugin/testing/ide/TestServiceClientTest.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/test/java/org/eclipse/che/plugin/testing/ide/TestServiceClientTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.plugin.testing.ide;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
 import org.eclipse.che.api.core.model.machine.Command;
-import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.machine.shared.dto.execagent.ProcessStartResponseDto;
 import org.eclipse.che.api.machine.shared.dto.execagent.event.DtoWithPid;
 import org.eclipse.che.api.machine.shared.dto.execagent.event.ProcessDiedEventDto;
@@ -30,15 +29,15 @@ import org.eclipse.che.api.testing.shared.TestResult;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandManager;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.execagent.ExecAgentConsumer;
 import org.eclipse.che.ide.api.macro.MacroProcessor;
 import org.eclipse.che.ide.api.notification.StatusNotification;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 import org.eclipse.che.ide.command.goal.TestGoal;
-import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.console.CommandConsoleFactory;
 import org.eclipse.che.ide.console.CommandOutputConsole;
+import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
@@ -107,9 +106,9 @@ public class TestServiceClientTest implements MockitoPrinter {
     @Mock
     private StatusNotification         statusNotification;
     @Mock
-    private DevMachine                 devMachine;
+    private MachineImpl                 devMachine;
     @Mock
-    private Machine                    machine;
+    private MachineImpl                    machine;
     @Mock
     private CommandOutputConsole       commandOutputConsole;
 
@@ -158,15 +157,15 @@ public class TestServiceClientTest implements MockitoPrinter {
             return promiseError;
         })).when(testServiceClient).promiseFromThrowable(any(Throwable.class));
 
-        when(appContext.getDevMachine()).thenReturn(devMachine);
-        when(machine.getId()).thenReturn("DevMachineId");
+//        when(appContext.getDevMachine()).thenReturn(devMachine);
+        when(machine.getName()).thenReturn("DevMachineId");
 
         doAnswer(new FunctionAnswer<String, Promise<String>>(commandLine -> {
             String processedCommandLine = commandLine.replace("${current.project.path}", rootOfProjects + "/" + projectPath);
             return new PromiseMocker<String>().applyOnThenOperation(processedCommandLine).getPromise();
         })).when(macroProcessor).expandMacros(anyString());
 
-        when(commandConsoleFactory.create(any(CommandImpl.class), any(Machine.class))).then(createCall -> {
+        when(commandConsoleFactory.create(any(CommandImpl.class), any(MachineImpl.class))).then(createCall -> {
             CommandOutputConsole commandOutputConsole = mock(CommandOutputConsole.class);
             when(commandOutputConsole.getProcessStartedConsumer()).thenReturn(processStartedEvent -> {
                 consoleEvents.add(processStartedEvent);

--- a/samples/sample-plugin-nativeaccess/che-sample-plugin-nativeaccess-ide/src/main/java/org/eclipse/che/plugin/nativeaccessexample/machine/client/command/CommandManager.java
+++ b/samples/sample-plugin-nativeaccess/che-sample-plugin-nativeaccess-ide/src/main/java/org/eclipse/che/plugin/nativeaccessexample/machine/client/command/CommandManager.java
@@ -19,7 +19,6 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.execagent.ExecAgentConsumer;
 import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.dto.DtoFactory;
 
@@ -54,12 +53,8 @@ public class CommandManager {
      */
     public void execute(String commandLine) {
         final WorkspaceImpl workspace = appContext.getWorkspace();
-        final RuntimeImpl runtime = workspace.getRuntime();
-        if (runtime == null) {
-            return;
-        }
+        final Optional<MachineImpl> machine = workspace.getDevMachine();
 
-        final Optional<? extends MachineImpl> machine = runtime.getDevMachine();
         if (!machine.isPresent()) {
             return;
         }

--- a/samples/sample-plugin-nativeaccess/che-sample-plugin-nativeaccess-ide/src/main/java/org/eclipse/che/plugin/nativeaccessexample/machine/client/command/CommandManager.java
+++ b/samples/sample-plugin-nativeaccess/che-sample-plugin-nativeaccess-ide/src/main/java/org/eclipse/che/plugin/nativeaccessexample/machine/client/command/CommandManager.java
@@ -16,12 +16,15 @@ import com.google.inject.Singleton;
 import org.eclipse.che.api.machine.shared.dto.execagent.ProcessStartResponseDto;
 import org.eclipse.che.api.workspace.shared.dto.CommandDto;
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.execagent.ExecAgentConsumer;
+import org.eclipse.che.ide.api.workspace.model.MachineImpl;
+import org.eclipse.che.ide.api.workspace.model.RuntimeImpl;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.dto.DtoFactory;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -50,11 +53,18 @@ public class CommandManager {
      * Execute the the given command command within the workspace Docker container.
      */
     public void execute(String commandLine) {
-        final DevMachine machine = appContext.getDevMachine();
-        if (machine == null) {
+        final WorkspaceImpl workspace = appContext.getWorkspace();
+        final RuntimeImpl runtime = workspace.getRuntime();
+        if (runtime == null) {
             return;
         }
-        String machineID = machine.getName();
+
+        final Optional<? extends MachineImpl> machine = runtime.getDevMachine();
+        if (!machine.isPresent()) {
+            return;
+        }
+
+        String machineID = machine.get().getName();
         final CommandDto command = dtoFactory.createDto(CommandDto.class)
                 .withName("some-command")
                 .withCommandLine(commandLine)


### PR DESCRIPTION

### What does this PR do?
Deprecates `org.eclipse.che.ide.api.machine.DevMachine` and `org.eclipse.che.ide.api.machine.ActiveRuntime` classes

### What issues does this PR fix or reference?
N/A

#### Changelog
 `org.eclipse.che.ide.api.machine.DevMachine` and `org.eclipse.che.ide.api.machine.ActiveRuntime` are deprecarted. `org.eclipse.che.ide.api.workspace.model.MachineImpl` and `org.eclipse.che.ide.api.workspace.model.RuntimeImpl` respectively should be used instead.

#### Release Notes
N/A

#### Docs PR
N/A
