### PR TITLE
slx-49: consider only sample name on project creation

### DIFF
--- a/dashboard/src/app/projects/create-project/create-project.controller.ts
+++ b/dashboard/src/app/projects/create-project/create-project.controller.ts
@@ -315,8 +315,6 @@ export class CreateProjectController {
           return workspace.id === preselectWorkspaceId;
         });
       }
-      // generate project name
-      this.generateProjectName(true);
     }
   }
 
@@ -963,30 +961,6 @@ export class CreateProjectController {
   }
 
   /**
-   * Generates a default project name only if user has not entered any data
-   * @param firstInit on first init, user do not have yet initialized something
-   */
-  generateProjectName(firstInit: boolean): void {
-    // name has not been modified by the user
-    if (firstInit || (this.projectInformationForm.deskname.$pristine && this.projectInformationForm.name.$pristine)) {
-      // generate a name
-
-      // starts with project
-      let name = 'project';
-
-      // type selected
-      if (this.importProjectData.project.type) {
-        name = this.importProjectData.project.type.replace(/\s/g, '_');
-      }
-
-      name = name + '-' + this.generateRandomStr();
-
-      this.setProjectName(name);
-    }
-
-  }
-
-  /**
    * Generates a default workspace name
    */
   generateWorkspaceName(): void {
@@ -1020,12 +994,6 @@ export class CreateProjectController {
       this.$location.path('/workspaces');
     }
     this.createProjectSvc.resetCreateProgress();
-  }
-
-  resetCreateNewProject(): void {
-    this.resetCreateProgress();
-    this.generateWorkspaceName();
-    this.generateProjectName(true);
   }
 
   showIDE(): void {
@@ -1209,7 +1177,7 @@ export class CreateProjectController {
     }
 
     this.templatesChoice = 'templates-samples';
-    this.generateProjectName(true);
+
     // enable wizard only if
     // - ready-to-go-stack with PT
     // - custom stack

--- a/dashboard/src/app/projects/create-project/create-project.html
+++ b/dashboard/src/app/projects/create-project/create-project.html
@@ -51,32 +51,6 @@
           <div class="main-page" layout="row" layout-align="center stretch">
             <div flex="50" layout="column" layout-align="end start">
             </div>
-            <div flex="50" layout="column" layout-align="start end">
-              <div layout="row"
-                   ng-show="createProjectCtrl.getCurrentProgressStep() === (createProjectCtrl.getCreationSteps().length - 1)">
-                <div layout="column" flex layout-align="start start">
-                  <che-button-notice che-button-title="Add another project"
-                                     ng-click="createProjectCtrl.resetCreateNewProject()"></che-button-notice>
-                </div>
-                &nbsp;
-                <div layout="column" flex layout-align="start end">
-                  <che-button-primary ng-href="{{createProjectCtrl.getIDELink()}}"
-                                      ng-click="createProjectCtrl.resetCreateNewProject()"
-                                      class="che-hover create-project-details-arrow"
-                                      che-button-icon="fa fa-chevron-circle-right"
-                                      che-button-title="Open project in IDE"></che-button-primary>
-                </div>
-              </div>
-              <div layout="column" layout-align="end end"
-                   ng-show="createProjectCtrl.getCreationSteps()[createProjectCtrl.getCurrentProgressStep()].hasError">
-                <che-button-danger
-                        che-button-title="{{createProjectCtrl.isResourceProblem() ? 'Stop running workspaces' :  'Retry'}}"
-                        ng-click="createProjectCtrl.resetCreateProgress()"></che-button-danger>
-                <che-link class="create-project-download-logs-link"
-                          ng-click="createProjectCtrl.downloadLogs()"
-                          che-link-text="Problem? download logs"></che-link>
-              </div>
-            </div>
           </div>
         </div>
       </che-loader>

--- a/dashboard/src/app/projects/create-project/samples/create-project-samples.controller.ts
+++ b/dashboard/src/app/projects/create-project/samples/create-project-samples.controller.ts
@@ -91,7 +91,6 @@ export class CreateProjectSamplesController {
 
     // set selected item
     this.selectedTemplateName = template.name;
-
     this.projectSampleOnSelect({template: template});
   }
 


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removes unused parts of project creation flow and generation of project name - only sample name will be considered, cause now sometimes sample is selected and then project name is overwritten by generated name.

### What issues does this PR fix or reference?
https://github.com/codenvy/silexica/issues/49

#### Changelog
Use only project sample name on project creation - avoid name generation

#### Release Notes
N/A


#### Docs PR
N/A
