### PR TITLE
CHE-5020. Add ability to cancel rename operation by Escape button

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionLinkedModeOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionLinkedModeOverlay.java
@@ -106,7 +106,7 @@ public class OrionLinkedModeOverlay extends JavaScriptObject implements LinkedMo
         this.annotationListener = annotationListener;
         var func = function (param) {
             listener.@org.eclipse.che.ide.api.editor.link.LinkedMode.LinkedModeListener::onLinkedModeExited(*)(param.isSuccessful,
-                start, end);
+                start || -1, end || -1);
         };
         $wnd.che_handels[listener] = func;
         this.addEventListener("LinkedModeExit", func, true);


### PR DESCRIPTION
### What does this PR do?
Add ability to cancel Refactoring -> Rename action by 'Escape' button

### What issues does this PR fix or reference?
#5020 

#### Changelog
Add ability to cancel rename operation by Escape button
![escaperename](https://cloud.githubusercontent.com/assets/5676062/26685840/e5d38070-46f3-11e7-8773-c2c2ad3d0489.gif)


