### PR TITLE
CHE-5154: use another implementation of the Language Server Protocol for python

### DIFF
--- a/agents/ls-python/src/main/resources/org.eclipse.che.ls.python.script.sh
+++ b/agents/ls-python/src/main/resources/org.eclipse.che.ls.python.script.sh
@@ -188,8 +188,8 @@ fi
 
 curl -s ${AGENT_BINARIES_URI} | tar xzf - -C ${LS_DIR}
 
-cd ${LS_DIR} && ${SUDO} pip3 install -r ${LS_DIR}/requirements.txt
+cd ${LS_DIR} && ${SUDO} pip3 install --process-dependency-links .
 
 touch ${LS_LAUNCHER}
 chmod +x ${LS_LAUNCHER}
-echo "python3.5 ${LS_DIR}/python-langserver.py --fs=local --mode=stdio" > ${LS_LAUNCHER}
+echo "pyls" > ${LS_LAUNCHER}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -36,6 +36,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
 
 import java.util.List;
 
@@ -47,6 +48,7 @@ import static org.eclipse.che.ide.api.theme.Style.theme;
  */
 public class CompletionItemBasedCompletionProposal implements CompletionProposal {
 
+    private final String                    currentWord;
     private final TextDocumentServiceClient documentServiceClient;
     private final TextDocumentIdentifier    documentId;
     private final LanguageServerResources   resources;
@@ -58,6 +60,7 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
     private       boolean                   resolved;
 
     CompletionItemBasedCompletionProposal(ExtendedCompletionItem completionItem,
+                                          String currentWord,
                                           TextDocumentServiceClient documentServiceClient,
                                           TextDocumentIdentifier documentId,
                                           LanguageServerResources resources,
@@ -66,6 +69,7 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
                                           List<Match> highlights,
                                           int offset) {
         this.completionItem = completionItem;
+        this.currentWord = currentWord;
         this.documentServiceClient = documentServiceClient;
         this.documentId = documentId;
         this.resources = resources;
@@ -167,7 +171,7 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
 
     @Override
     public void getCompletion(final CompletionCallback callback) {
-        callback.onCompletion(new CompletionImpl(completionItem, offset));
+        callback.onCompletion(new CompletionImpl(completionItem, currentWord, offset));
     }
 
     private boolean canResolve() {
@@ -184,11 +188,13 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
 
     private static class CompletionImpl implements Completion {
 
-        private CompletionItem completionItem;
-        private int            offset;
+        private       CompletionItem completionItem;
+        private final String         currentWord;
+        private       int            offset;
 
-        public CompletionImpl(CompletionItem completionItem, int offset) {
+        public CompletionImpl(CompletionItem completionItem, String currentWord, int offset) {
             this.completionItem = completionItem;
+            this.currentWord = currentWord;
             this.offset = offset;
         }
 
@@ -202,17 +208,22 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
                         new TextPosition(range.getEnd().getLine(), range.getEnd().getCharacter()));
                 document.replace(startOffset, endOffset - startOffset, completionItem.getTextEdit().getNewText());
             } else {
+                final int currentWordLength = currentWord.length();
                 String insertText = completionItem.getInsertText() == null ? completionItem.getLabel() : completionItem.getInsertText();
-                document.replace(document.getCursorOffset() - offset, offset, insertText);
+                final int cursorOffset = document.getCursorOffset();
+                document.replace(cursorOffset - currentWordLength, currentWordLength, insertText);
             }
         }
 
         @Override
         public LinearRange getSelection(Document document) {
-            Range range = completionItem.getTextEdit().getRange();
-            int startOffset = document
-                                      .getIndexFromPosition(new TextPosition(range.getStart().getLine(), range.getStart().getCharacter()))
-                              + completionItem.getTextEdit().getNewText().length();
+            final TextEdit textEdit = completionItem.getTextEdit();
+            if (textEdit == null) {
+                return LinearRange.createWithStart(document.getCursorOffset()).andLength(0);
+            }
+            Range range = textEdit.getRange();
+            int startOffset = document.getIndexFromPosition(new TextPosition(range.getStart().getLine(), range.getStart().getCharacter()))
+                              + textEdit.getNewText().length();
             return LinearRange.createWithStart(startOffset).andLength(0);
         }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -188,9 +188,9 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
 
     private static class CompletionImpl implements Completion {
 
-        private       CompletionItem completionItem;
-        private final String         currentWord;
-        private       int            offset;
+        private CompletionItem completionItem;
+        private String         currentWord;
+        private int            offset;
 
         public CompletionImpl(CompletionItem completionItem, String currentWord, int offset) {
             this.completionItem = completionItem;
@@ -208,9 +208,9 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
                         new TextPosition(range.getEnd().getLine(), range.getEnd().getCharacter()));
                 document.replace(startOffset, endOffset - startOffset, completionItem.getTextEdit().getNewText());
             } else {
-                final int currentWordLength = currentWord.length();
+                int currentWordLength = currentWord.length();
+                int cursorOffset = document.getCursorOffset();
                 String insertText = completionItem.getInsertText() == null ? completionItem.getLabel() : completionItem.getInsertText();
-                final int cursorOffset = document.getCursorOffset();
                 document.replace(cursorOffset - currentWordLength, currentWordLength, insertText);
             }
         }
@@ -222,8 +222,8 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
                 return LinearRange.createWithStart(document.getCursorOffset()).andLength(0);
             }
             Range range = textEdit.getRange();
-            int startOffset = document.getIndexFromPosition(new TextPosition(range.getStart().getLine(), range.getStart().getCharacter()))
-                              + textEdit.getNewText().length();
+            TextPosition textPosition = new TextPosition(range.getStart().getLine(), range.getStart().getCharacter());
+            int startOffset = document.getIndexFromPosition(textPosition) + textEdit.getNewText().length();
             return LinearRange.createWithStart(startOffset).andLength(0);
         }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -171,7 +171,13 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
 
     @Override
     public void getCompletion(final CompletionCallback callback) {
-        callback.onCompletion(new CompletionImpl(completionItem, currentWord, offset));
+        if (canResolve()) {
+            resolve().then(completionItem -> {
+                callback.onCompletion(new CompletionImpl(completionItem, currentWord, offset));
+            });
+        } else {
+            callback.onCompletion(new CompletionImpl(completionItem, currentWord, offset));
+        }
     }
 
     private boolean canResolve() {
@@ -210,8 +216,11 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
             } else {
                 int currentWordLength = currentWord.length();
                 int cursorOffset = document.getCursorOffset();
-                String insertText = completionItem.getInsertText() == null ? completionItem.getLabel() : completionItem.getInsertText();
-                document.replace(cursorOffset - currentWordLength, currentWordLength, insertText);
+                if (completionItem.getInsertText() == null) {
+                    document.replace(cursorOffset - currentWordLength, currentWordLength, completionItem.getLabel());
+                } else {
+                    document.replace(cursorOffset - offset, offset, completionItem.getInsertText());
+                }
             }
         }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
@@ -145,6 +145,7 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
             List<Match> highlights = filter(currentWord, item);
             if (highlights != null) {
                 proposals.add(new CompletionItemBasedCompletionProposal(item,
+                                                                        currentWord,
                                                                         documentServiceClient,
                                                                         latestCompletionResult.getDocumentId(),
                                                                         resources,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Changes an implementation of the LSP for python and adopts plugin-languageserver for using this one. The new implementation is from https://github.com/palantir/python-language-server.

New Features:
1. Error/warning markers and messages
![f5](https://user-images.githubusercontent.com/1271546/26920040-5f8870dc-4c40-11e7-9d03-41f33898fb57.gif)
2. Auto Completition
![f1](https://user-images.githubusercontent.com/1271546/26920054-68113130-4c40-11e7-989e-ebefb9dd1b04.gif)
3. Find References
![f4](https://user-images.githubusercontent.com/1271546/26920074-7798a930-4c40-11e7-82a4-dbe7d629af74.gif)
4. Find Definition
![f3](https://user-images.githubusercontent.com/1271546/26920097-82452ffc-4c40-11e7-82f1-5be23615c04a.gif)
5. Hover
![f2](https://user-images.githubusercontent.com/1271546/26920117-8c71dc6e-4c40-11e7-8865-ff1f95306308.gif)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5154
https://github.com/eclipse/che/issues/4976

#### Changelog
<!-- one line entry to be added to changelog -->
Change an implementation of the LSP for python

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
We have updated the LS used for Python by the Palayton one. This new Python LS is providing a better support and analyzis of the language which allows:
1. Error/warning markers and messages
2. Auto Completion
3. Find References
4. Find Definition
5. Hover

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
