### PR TITLE
CLI fix offline command save stacks to tars

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_offline.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_offline.sh
@@ -71,7 +71,9 @@ cmd_offline() {
     info "offline" "Optional: (repeat --image:<name> for stack, --all-stacks, or --no-stacks)"
     for STACK in $(seq 0 $((${#STACK_IMAGE_LIST[@]}-1)))
     do
-      info "offline" "  STACK: ${STACK_IMAGE_LIST[$STACK]}"
+      if [ ! -z ${STACK_IMAGE_LIST[$STACK]} ]; then
+          info "offline" "  STACK: ${STACK_IMAGE_LIST[$STACK]}"
+      fi
     done
 
     return 1
@@ -111,7 +113,9 @@ cmd_offline() {
       --all-stacks)
         for STACK in $(seq 0 $((${#STACK_IMAGE_LIST[@]}-1)))
         do
-          download_and_save_image ${STACK_IMAGE_LIST[$STACK]}
+          if [ ! -z ${STACK_IMAGE_LIST[$STACK]} ]; then
+              download_and_save_image ${STACK_IMAGE_LIST[$STACK]}
+          fi
         done
         break
         shift ;;
@@ -135,7 +139,7 @@ download_and_save_image() {
 }
 
 save_image(){
-  TAR_NAME=$(echo $1 | sed "s|\/|_|")
+  TAR_NAME=$(echo $1 | sed "s|\/|_|g")
 
   if [ ! -f $CHE_CONTAINER_OFFLINE_FOLDER/$TAR_NAME.tar ]; then
     info "offline" "Saving $CHE_HOST_OFFLINE_FOLDER/$TAR_NAME.tar..."


### PR DESCRIPTION
### What does this PR do?
fixes two issues related to CLI offline mode during stack images saving

**first issue**:
if image name has more than 1 `/` symbol like `registry.centos.org/che-stacks/vertx` save to tar will fail:

```
...
INFO: (che offline): Saving /Users/roman/development/codenvy_projects/.che/backup/eclipse_ubuntu_jre.tar...
INFO: (che offline): Saving /Users/roman/development/codenvy_projects/.che/backup/eclipse_ubuntu_python.tar...
INFO: (che offline): Saving /Users/roman/development/codenvy_projects/.che/backup/eclipse_ubuntu_wildfly8.tar...
INFO: (che offline): Saving /Users/roman/development/codenvy_projects/.che/backup/registry.centos.org_che-stacks/vertx.tar...
/scripts/base/commands/cmd_offline.sh: line 142: /data/backup/registry.centos.org_che-stacks/vertx.tar: No such file or directory
ERROR: Docker was interrupted while saving /data/backup/registry.centos.org_che-stacks/vertx.tar
```
to fix this I;ve updated `sed` pattern to replace all `/` symbols with `_`

**second issue**:
if `images-stacks` file has any empty line like this https://github.com/eclipse/che/blob/master/dockerfiles/cli/version/5.11.2/images-stacks#L24 
that will cause an error during iterating over array which is made from that file:

```
...
INFO: (che offline):   Image eclipse/ubuntu_wildfly8 already saved...skipping
INFO: (che offline):   Image registry.centos.org/che-stacks/vertx already saved...skipping
/scripts/base/commands/cmd_offline.sh: line 133: 1: unbound variable
```
to fix this I;ve added check on empty strings:


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5268

#### Changelog
CLI fix offline command save stacks to tars