### PR TITLE
Use internal IP if specified. Else on Linux it is not matching the expecting interface

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -205,6 +205,8 @@ public class CustomServerEvaluationStrategy extends DefaultServerEvaluationStrat
         protected String getExternalAddress() {
             return externalAddressProperty != null ?
                    externalAddressProperty :
+                   internalAddressProperty != null ?
+                   internalAddressProperty :
                    !isNullOrEmpty(gatewayAddressContainer) ?
                    gatewayAddressContainer :
                    this.internalHost;


### PR DESCRIPTION
### What does this PR do?
Routes created for Traefik were not containing the same ip than the hosts returned by the /api/workspace runtime links, so the routes didn't match and all traffic was routed to the default route : workspace master

### What issues does this PR fix or reference?
#5240

#### Changelog
Use CHE_IP system provoperty if defined.


Change-Id: I62c766a3ef8dd1dac6831a5fbc986e555b14586b
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>

