### PR TITLE
CHE-102 - Idle detection of che-server and workspaces

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -340,6 +340,12 @@ che.openshift.workspace.memory.request=NULL
 #
 # - Maximum amount of memory a workspace container can use e.g. 1.3Gi
 che.openshift.workspace.memory.override=NULL
+
+# The Openshift will idle the server if no workspace is run for
+# this length of time.
+che.openshift.server.inactive.stop.timeout.ms=1800000
+
+#
 #
 # Be aware that setting che.openshift.workspace.memory.override
 # will override Che memory limits

--- a/core/che-core-api-core/pom.xml
+++ b/core/che-core-api-core/pom.xml
@@ -255,6 +255,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- Exclude files until #3281 is resolved -->
+                        <exclude>**/ServerIdleEvent.java</exclude>
+                        <!-- End excluded files -->
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/event/ServerIdleEvent.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/event/ServerIdleEvent.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.event;
+/**
+ * Event informing about idling the che server.
+ */
+public class ServerIdleEvent {
+    private long timeout;
+
+    /**
+     * Implements the handler to handle idling.
+     */
+    public ServerIdleEvent(long timeout) {
+        super();
+        this.timeout = timeout;
+    }
+
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -169,6 +169,7 @@
                         <exclude>**/LocalDockerSinglePortServerEvaluationStrategyTest.java</exclude>
                         <exclude>**/DockerInstanceRuntimeInfo.java</exclude>
                         <exclude>**/DockerInstanceRuntimeInfoTest.java</exclude>
+                        <exclude>**/ServerIdleDetector.java</exclude>
                         <!-- End excluded files -->
                     </excludes>
                 </configuration>

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
@@ -33,6 +33,7 @@ public class DockerMachineModule extends AbstractModule {
     protected void configure() {
         bind(org.eclipse.che.plugin.docker.machine.cleaner.DockerAbandonedResourcesCleaner.class);
         bind(org.eclipse.che.plugin.docker.machine.cleaner.RemoveWorkspaceFilesAfterRemoveWorkspaceEventSubscriber.class);
+        bind(org.eclipse.che.plugin.docker.machine.idle.ServerIdleDetector.class);
 
         @SuppressWarnings("unused") Multibinder<String> devMachineEnvVars =
                 Multibinder.newSetBinder(binder(),

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/idle/ServerIdleDetector.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/idle/ServerIdleDetector.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.machine.idle;
+
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.event.ServerIdleEvent;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+/**
+ * Notifies about idling the che server
+ * Fires {@link org.eclipse.che.api.core.event.ServerIdleEvent} if no workspace
+ * is run for <b>che.openshift.server.inactive.stop.timeout.ms</b> milliseconds
+ */
+@Singleton
+public class ServerIdleDetector implements EventSubscriber<WorkspaceStatusEvent> {
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIdleDetector.class);
+    private static final String IDLING_CHE_SERVER_SCHEDULED = "Idling che server scheduled [timeout=%s] seconds]";
+
+    private final long               timeout;
+    private ScheduledFuture<?>       future;
+    private ScheduledExecutorService executor;
+    private WorkspaceManager         workspaceManager;
+    private final EventService       eventService;
+
+    @Inject
+    public ServerIdleDetector(WorkspaceManager workspaceManager,
+                                 EventService eventService,
+                                 @Named("che.openshift.server.inactive.stop.timeout.ms") long timeout) {
+        this.timeout = timeout;
+        this.eventService = eventService;
+        this.workspaceManager = workspaceManager;
+        if (timeout > 0) {
+            this.executor = Executors.newSingleThreadScheduledExecutor();
+            this.future = executor.schedule(this::run, timeout, TimeUnit.MILLISECONDS);
+            LOG.info(String.format(IDLING_CHE_SERVER_SCHEDULED, timeout/1000));
+        }
+    }
+
+    @Override
+    public void onEvent(WorkspaceStatusEvent event) {
+        if (future != null) {
+            String workspaceId = event.getWorkspaceId();
+            switch (event.getEventType()) {
+            case RUNNING:
+                if (!future.isCancelled()) {
+                    future.cancel(true);
+                    LOG.info("Idling che server canceled");
+                }
+                break;
+            case STOPPED:
+                Set<String> ids = workspaceManager.getRunningWorkspacesIds();
+                ids.remove(workspaceId);
+                if (ids.size() <= 0) {
+                    if (!future.isCancelled()) {
+                        future.cancel(true);
+                    }
+                    future = executor.schedule(this::run, timeout, TimeUnit.MILLISECONDS);
+                    LOG.info(String.format(IDLING_CHE_SERVER_SCHEDULED, timeout/1000));
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    private void run() {
+        Set<String> ids = workspaceManager.getRunningWorkspacesIds();
+        if (ids.size() <= 0) {
+            eventService.publish(new ServerIdleEvent(timeout));
+        }
+    }
+
+    @PostConstruct
+    private void subscribe() {
+        eventService.subscribe(this);
+    }
+
+    @PreDestroy
+    private void unsubscribe() {
+        eventService.unsubscribe(this);
+        if (future != null && !future.isCancelled()) {
+            future.cancel(true);
+        }
+        if (executor != null && !executor.isShutdown()) {
+            executor.shutdown();
+        }
+    }
+
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -55,7 +55,11 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
-	<dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-model</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -18,14 +18,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,6 +41,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.eclipse.che.api.core.event.ServerIdleEvent;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
@@ -98,6 +105,8 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.DoneableEndpoints;
+import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
@@ -124,7 +133,10 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.InputStreamPumper;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DoneableDeploymentConfig;
 import io.fabric8.openshift.api.model.Image;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamTag;
@@ -132,6 +144,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.dsl.DeployableScalableResource;
 
 /**
  * Client for OpenShift API.
@@ -161,6 +174,13 @@ public class OpenShiftConnector extends DockerConnector {
     private static final String OPENSHIFT_VOLUME_STORAGE_CLASS_NAME      = "che-workspace";
     private static final String OPENSHIFT_IMAGE_PULL_POLICY_IFNOTPRESENT = "IfNotPresent";
 
+    private static final String IDLING_ALPHA_OPENSHIFT_IO_IDLED_AT       = "idling.alpha.openshift.io/idled-at";
+    private static final String IDLING_ALPHA_OPENSHIFT_IO_PREVIOUS_SCALE = "idling.alpha.openshift.io/previous-scale";
+    private static final String OPENSHIFT_CHE_SERVER_DEPLOYMENT_NAME     = "che";
+    private static final String OPENSHIFT_CHE_SERVER_SERVICE_NAME        = "che-host";
+    private static final String IDLING_ALPHA_OPENSHIFT_IO_UNIDLE_TARGETS = "idling.alpha.openshift.io/unidle-targets";
+    private static final String ISO_8601_DATE_FORMAT                     = "yyyy-MM-dd'T'HH:mm:ssX";
+
     private Map<String, KubernetesExecHolder> execMap = new HashMap<>();
 
     private final String          openShiftCheProjectName;
@@ -183,6 +203,7 @@ public class OpenShiftConnector extends DockerConnector {
                               DockerRegistryAuthResolver authResolver,
                               DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider,
                               OpenShiftPvcHelper openShiftPvcHelper,
+                              EventService eventService,
                               @Nullable @Named("che.docker.ip.external") String cheServerExternalAddress,
                               @Named("che.openshift.project") String openShiftCheProjectName,
                               @Named("che.openshift.liveness.probe.delay") int openShiftLivenessProbeDelay,
@@ -210,6 +231,61 @@ public class OpenShiftConnector extends DockerConnector {
         this.secureRoutes = secureRoutes;
         this.createWorkspaceDirs = createWorkspaceDirs;
         this.openShiftPvcHelper = openShiftPvcHelper;
+        eventService.subscribe(new EventSubscriber<ServerIdleEvent>() {
+
+            @Override
+            public void onEvent(ServerIdleEvent event) {
+                idleCheServer(event);
+            }
+        });
+    }
+
+    private void idleCheServer(ServerIdleEvent event) {
+        try (DefaultOpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
+            DeployableScalableResource<DeploymentConfig, DoneableDeploymentConfig> deploymentConfigResource = openShiftClient.deploymentConfigs()
+                                                                                                                             .inNamespace(openShiftCheProjectName)
+                                                                                                                             .withName(OPENSHIFT_CHE_SERVER_DEPLOYMENT_NAME);
+            DeploymentConfig deploymentConfig = deploymentConfigResource.get();
+            if (deploymentConfig == null) {
+                LOG.warn(String.format("Deployment config %s not found", OPENSHIFT_CHE_SERVER_DEPLOYMENT_NAME));
+                return;
+            }
+            Integer replicas = deploymentConfig.getSpec().getReplicas();
+            if (replicas != null && replicas > 0) {
+                Resource<Endpoints, DoneableEndpoints> endpointResource = openShiftClient.endpoints()
+                                                                                         .inNamespace(openShiftCheProjectName)
+                                                                                         .withName(OPENSHIFT_CHE_SERVER_SERVICE_NAME);
+                Endpoints endpoint = endpointResource.get();
+                if (endpoint == null) {
+                    LOG.warn(String.format("Endpoint %s not found", OPENSHIFT_CHE_SERVER_SERVICE_NAME));
+                    return;
+                }
+                Map<String, String> annotations = deploymentConfig.getMetadata().getAnnotations();
+                if (annotations == null) {
+                    annotations = new HashMap<>();
+                    deploymentConfig.getMetadata().setAnnotations(annotations);
+                }
+                TimeZone tz = TimeZone.getTimeZone("UTC");
+                DateFormat df = new SimpleDateFormat(ISO_8601_DATE_FORMAT);
+                df.setTimeZone(tz);
+                String idle = df.format(new Date());
+                annotations.put(IDLING_ALPHA_OPENSHIFT_IO_IDLED_AT, idle);
+                annotations.put(IDLING_ALPHA_OPENSHIFT_IO_PREVIOUS_SCALE, "1");
+                deploymentConfig.getSpec().setReplicas(0);
+                deploymentConfigResource.patch(deploymentConfig);
+                Map<String, String> endpointAnnotations = endpoint.getMetadata().getAnnotations();
+                if (endpointAnnotations == null) {
+                    endpointAnnotations = new HashMap<>();
+                    endpoint.getMetadata().setAnnotations(endpointAnnotations);
+                }
+                endpointAnnotations.put(IDLING_ALPHA_OPENSHIFT_IO_IDLED_AT, idle);
+                endpointAnnotations.put(IDLING_ALPHA_OPENSHIFT_IO_UNIDLE_TARGETS,
+                            "[{\"kind\":\"DeploymentConfig\",\"name\":\"" + OPENSHIFT_CHE_SERVER_DEPLOYMENT_NAME
+                            + "\",\"replicas\":1}]");
+                endpointResource.patch(endpoint);
+                LOG.info("Che server has been idled");
+            }
+        }
     }
 
     /**

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 
+import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
 import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
@@ -54,6 +55,8 @@ public class OpenShiftConnectorTest {
     @Mock
     private CreateContainerParams              createContainerParams;
     @Mock
+    private EventService                       eventService;
+    @Mock
     private OpenShiftPvcHelper                 openShiftPvcHelper;
 
     private OpenShiftConnector                 openShiftConnector;
@@ -73,6 +76,7 @@ public class OpenShiftConnectorTest {
                                                     authManager,
                                                     dockerApiVersionPathPrefixProvider,
                                                     openShiftPvcHelper,
+                                                    eventService,
                                                     CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS,
                                                     CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,
                                                     OPENSHIFT_LIVENESS_PROBE_DELAY,


### PR DESCRIPTION
https://github.com/eclipse/che/pull/4732 has been removed from the openshift-connector-rebased branch. I suppose we will port the code from the codenvy project. However, part of the PR related to idling the che server is openshift specific and doesn't exist in the codenvy project.
Since the PR is being used in OpenShiftWorkspaceFilesCleaner, the branch contains compile errors. This PR fixes them.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>

