### PR TITLE
Add CentOS based Golang stack to default assembly

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2618,5 +2618,69 @@
       }
     ],
     "creator": "Dharmit Shah"
+},
+{
+    "id": "centos-go",
+    "creator": "Dharmit Shah",
+    "name": "CentOS Go",
+    "description": "CentOS based Go Stack",
+    "scope": "advanced",
+    "tags": [
+      "CentOS",
+      "Go"
+    ],
+    "components": [
+      {
+        "name": "CentOS",
+        "version": "7.3"
+      },
+      {
+        "name": "Go",
+        "version": "1.6.2"
+      }
+    ],
+    "source": {
+      "type": "image",
+      "origin": "registry.centos.org/che-stacks/centos-go"
+    },
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "agents": [
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+              ],
+              "servers": {},
+              "attributes" : {
+                "memoryLimitBytes": "2147483648"
+              }
+            }
+          },
+          "recipe": {
+            "location": "registry.centos.org/che-stacks/centos-go",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": [
+        {
+          "name": "run",
+          "type": "custom",
+          "commandLine": "cd ${current.project.path} && go get -d && go run main.go",
+          "attributes": {
+            "previewUrl": "http://${server.port.8080}",
+            "goal": "Run"
+          }
+        }
+      ]
+    },
+    "stackIcon": {
+      "name": "type-go.svg",
+      "mediaType": "image/svg+xml"
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <dshah@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds CentOS based Golang stacks to default assembly

#### Changelog
<!-- one line entry to be added to changelog -->
Golang stack based on CentOS added to the default assembly

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Added Golang stack based on CentOS added to the default assembly

cc: @l0rd 