### PR TITLE
CHE-272: Making 'AuthorizationCodeFlow' field from OAuthAuthenticator protected

### DIFF
--- a/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
+++ b/wsmaster/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth/OAuthAuthenticator.java
@@ -50,7 +50,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 public abstract class OAuthAuthenticator {
     private static final Logger LOG = LoggerFactory.getLogger(OAuthAuthenticator.class);
 
-    private   AuthorizationCodeFlow flow;
+    protected AuthorizationCodeFlow flow;
     protected Map<Pattern, String>  redirectUrisMap;
 
     /**


### PR DESCRIPTION
### What does this PR do?
Makes 'AuthorizationCodeFlow' field from OAuthAuthenticator protected

This change is required for creating custom OAuthAuthenticator with possibility of setting GitHub access token. PR https://github.com/eclipse/che/pull/4444 has been rejected. It was recommended to move the logic of setting access token to rh-che assembly and provide a separate service for it.

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-272
 
#### Changelog
Make 'AuthorizationCodeFlow' field from OAuthAuthenticator protected

#### Release Notes
N/A 

#### Docs PR
N/A