### PR TITLE
Fix failing tests on build.

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/CommandDeserializerTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/CommandDeserializerTest.java
@@ -69,8 +69,7 @@ public class CommandDeserializerTest {
         assertEquals(environment.get("MYSQL_PASSWORD"), "password");
         assertTrue(service.getExpose().containsAll(asList("4403", "5502")));
 
-        assertTrue(service.getCommand().containsAll(commandWords));
-        assertEquals(service.getCommand().size(), commandNumberOfWords);
+        assertEquals(service.getCommand(), commandWords);
     }
 
     @DataProvider(name = "validCommand")
@@ -137,7 +136,7 @@ public class CommandDeserializerTest {
                 {"\"echo ${PWD}\"", asList("echo", "${PWD}"), 2},
                 {"\"(Test)\"", singletonList("(Test)"), 1},
 
-                {"", singletonList(""), 1},
+                {"", null, 1},
         };
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/EnvironmentDeserializerTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-compose/src/test/java/org/eclipse/che/plugin/docker/compose/yaml/EnvironmentDeserializerTest.java
@@ -13,11 +13,9 @@ package org.eclipse.che.plugin.docker.compose.yaml;
 import com.google.common.collect.ImmutableMap;
 
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.machine.server.util.RecipeDownloader;
 import org.eclipse.che.plugin.docker.compose.ComposeEnvironment;
 import org.eclipse.che.plugin.docker.compose.ComposeServiceImpl;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -39,9 +37,6 @@ import static org.testng.Assert.fail;
  */
 @Listeners(MockitoTestNGListener.class)
 public class EnvironmentDeserializerTest {
-
-    @Mock
-    private RecipeDownloader recipeDownloader;
 
     @InjectMocks
     private ComposeEnvironmentParser parser;
@@ -74,7 +69,7 @@ public class EnvironmentDeserializerTest {
                  + "  image: codenvy/ubuntu_jdk8\n"
                  + "  environment:\n"
                  + "   MYSQL_ROOT_PASSWORD: ",
-                 ImmutableMap.of("MYSQL_ROOT_PASSWORD", "")
+                 ImmutableMap.of("MYSQL_ROOT_PASSWORD", null)
                 },
 
                 // dictionary format, value of variable contains colon sign


### PR DESCRIPTION
After update lib jackson-core from version 2.5.0 to 2.7.0 some tests fails on build. Our yaml parser uses inside jackson.databind library and this library has the same version property like jackson-core, so this lib was updated from 2.5.0 to 2.7.0 too. In newer version library changed behavior for parser and tests fails.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>