### PR TITLE
CHE-5237 fix state for 'create workspace' button

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.controller.ts
@@ -131,6 +131,10 @@ export class WorkspaceRecipeAuthoringController {
     }
   }
 
+  isRecipeValid(): boolean {
+    return this.recipeValidationError.length === 0;
+  }
+
   onRecipeChange(): void {
     this.$timeout(() => {
       this.detectFormat(this.recipeScriptCopy);

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.html
@@ -10,16 +10,14 @@
                  che-name="recipe"
                  type="hidden"
                  ng-model="workspaceRecipeAuthoringController.recipeScriptCopy"
+                 custom-validator="workspaceRecipeAuthoringController.isRecipeValid()"
                  ng-required>
         <che-error-messages che-message-scope="workspace-details-environment"
                             che-message-name="Recipe content">
           <div ng-message="required">The recipe is required.</div>
+          <div ng-message="customValidator">{{workspaceRecipeAuthoringController.recipeValidationError}}</div>
         </che-error-messages>
       </che-input>
-      <div class="errors-container"
-           ng-if="workspaceRecipeAuthoringController.recipeValidationError">
-        {{workspaceRecipeAuthoringController.recipeValidationError}}
-      </div>
       <div class="recipe-docs-link">
         <a ng-href="{{workspaceRecipeAuthoringController.stackDocsUrl}}" target="_blank">Custom stack documentation</a>
       </div>


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@codenvy.com>

### What does this PR do?
Disable 'create' button in a case when the recipe is invalid.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5237

#### Changelog
- disable 'create' button in a case when the recipe is invalid.

#### Release Notes
N/A

#### Docs PR
N/A

![selection_001](https://user-images.githubusercontent.com/6310786/26930293-9ceb0118-4c65-11e7-93c1-2d794b455ac7.png)