### PR TITLE
Provide error message to UI

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -379,9 +379,9 @@ public final class ResourceManager {
         return findResource(path, true).thenPromise(resource -> {
             if (resource.isPresent()) {
                 if (resource.get().isProject()) {
-                    throw new IllegalStateException("Project already exists");
+                    return promises.reject(new IllegalStateException("Project already exists"));
                 } else if (resource.get().isFile()) {
-                    throw new IllegalStateException("File can not be converted to project");
+                    return promises.reject(new IllegalStateException("File can not be converted to project"));
                 }
 
                 return update(path, createRequest);
@@ -393,7 +393,7 @@ public final class ResourceManager {
             final List<NewProjectConfigDto> configDtoList = asDto(projectConfigList);
 
             return ps.createBatchProjects(configDtoList).thenPromise(
-                    configList -> ps.getProjects().then((Function<List<ProjectConfigDto>, Project>)updatedConfiguration -> {
+                    configList -> ps.getProjects().thenPromise(updatedConfiguration -> {
                         //cache new configs
                         cachedConfigs = updatedConfiguration.toArray(new ProjectConfigDto[updatedConfiguration.size()]);
 
@@ -403,11 +403,11 @@ public final class ResourceManager {
                                 store.register(newResource);
                                 eventBus.fireEvent(new ResourceChangedEvent(new ResourceDeltaImpl(newResource, ADDED | DERIVED)));
 
-                                return newResource;
+                                return promises.resolve(newResource);
                             }
                         }
 
-                        throw new IllegalStateException("Created project is not found");
+                        return promises.reject(new IllegalStateException("Created project is not found"));
                     }));
         });
     }


### PR DESCRIPTION
### What does this PR do?

This changes proposal provide correct routing error message to the UI wizard. If user is trying to create a project with similar name he can't obtain error message in dialog and create project wizard freeze. This PR fix this problem.

### What issues does this PR fix or reference?
#5185 

#### Changelog
Provide error message if duplicate project is trying to be created

#### Release Notes
N/A

#### Docs PR
N/A
