### PR TITLE
Fix NPE for junit and testng test actions.

### DIFF
--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunAllTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunAllTestAction.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.junit.ide.action;
 
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,16 +22,8 @@ import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.resources.Container;
-import org.eclipse.che.ide.api.resources.File;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
-import org.eclipse.che.ide.api.resources.VirtualFile;
-import org.eclipse.che.ide.api.selection.Selection;
-import org.eclipse.che.ide.api.selection.SelectionAgent;
-import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
-import org.eclipse.che.ide.resources.tree.ContainerNode;
-import org.eclipse.che.ide.resources.tree.FileNode;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
 import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
@@ -51,24 +43,21 @@ public class RunAllTestAction extends AbstractPerspectiveAction
     private final TestResultPresenter   presenter;
     private final TestServiceClient     service;
     private final AppContext            appContext;
-    private final SelectionAgent        selectionAgent;
     private final RunTestActionDelegate delegate;
 
     @Inject
     public RunAllTestAction(JUnitTestResources resources,
-                                   NotificationManager notificationManager,
-                                   AppContext appContext,
-                                   TestResultPresenter presenter,
-                                   TestServiceClient service,
-                                   SelectionAgent selectionAgent,
-                                   JUnitTestLocalizationConstant localization) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunAllTitle(),
+                            NotificationManager notificationManager,
+                            AppContext appContext,
+                            TestResultPresenter presenter,
+                            TestServiceClient service,
+                            JUnitTestLocalizationConstant localization) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), localization.actionRunAllTitle(),
               localization.actionRunAllDescription(), null, resources.testAllIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
         this.service = service;
         this.appContext = appContext;
-        this.selectionAgent = selectionAgent;
         this.delegate = new RunTestActionDelegate(this);
     }
 
@@ -87,18 +76,14 @@ public class RunAllTestAction extends AbstractPerspectiveAction
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         Resource resource = appContext.getResource();
-        if (resource == null) {
+        if (resource == null || resource.getProject() == null) {
             e.getPresentation().setEnabledAndVisible(false);
+            return;
         }
-        
-        Project project = resource.getProject();
-        if (project == null) {
-            e.getPresentation().setEnabledAndVisible(false);
-        }
-        
+
         e.getPresentation().setVisible(true);
 
-        String projectType = project.getType();
+        String projectType = resource.getProject().getType();
         boolean enable = "maven".equals(projectType);
         e.getPresentation().setEnabled(enable);
     }

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunClassTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/RunClassTestAction.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.junit.ide.action;
 
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +23,6 @@ import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.File;
-import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
@@ -50,12 +49,12 @@ public class RunClassTestAction extends AbstractPerspectiveAction
 
     @Inject
     public RunClassTestAction(JUnitTestResources resources,
-                                     NotificationManager notificationManager,
-                                     AppContext appContext,
-                                     TestResultPresenter presenter,
-                                     TestServiceClient service,
-                                     JUnitTestLocalizationConstant localization) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunClassTitle(),
+                              NotificationManager notificationManager,
+                              AppContext appContext,
+                              TestResultPresenter presenter,
+                              TestServiceClient service,
+                              JUnitTestLocalizationConstant localization) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), localization.actionRunClassTitle(),
               localization.actionRunClassDescription(), null, resources.testIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
@@ -80,20 +79,15 @@ public class RunClassTestAction extends AbstractPerspectiveAction
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         Resource resource = appContext.getResource();
-        if (! (resource instanceof File)) {
+        if (!(resource instanceof File) || resource.getProject() == null) {
             e.getPresentation().setEnabledAndVisible(false);
             return;
         }
-        
-        Project project = resource.getProject();
-        if (project == null) {
-            e.getPresentation().setEnabledAndVisible(false);
-        }
-        
+
         e.getPresentation().setVisible(true);
 
-        String projectType = project.getType();
-        if (! "maven".equals(projectType)) {
+        String projectType = resource.getProject().getType();
+        if (!"maven".equals(projectType)) {
             e.getPresentation().setEnabled(false);
         }
 

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunAllTestAction.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,12 +47,12 @@ public class RunAllTestAction extends AbstractPerspectiveAction
 
     @Inject
     public RunAllTestAction(TestNGResources resources,
-                                   NotificationManager notificationManager,
-                                   AppContext appContext,
-                                   TestResultPresenter presenter,
-                                   TestServiceClient service,
-                                   TestNGLocalizationConstant localization) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunAllTitle(),
+                            NotificationManager notificationManager,
+                            AppContext appContext,
+                            TestResultPresenter presenter,
+                            TestServiceClient service,
+                            TestNGLocalizationConstant localization) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), localization.actionRunAllTitle(),
               localization.actionRunAllDescription(), null, resources.testAllIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
@@ -76,22 +76,18 @@ public class RunAllTestAction extends AbstractPerspectiveAction
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         Resource resource = appContext.getResource();
-        if (resource == null) {
+        if (resource == null || resource.getProject() == null) {
             e.getPresentation().setEnabledAndVisible(false);
+            return;
         }
-        
-        Project project = resource.getProject();
-        if (project == null) {
-            e.getPresentation().setEnabledAndVisible(false);
-        }
-        
+
         e.getPresentation().setVisible(true);
 
-        String projectType = project.getType();
+        String projectType = resource.getProject().getType();
         boolean enable = "maven".equals(projectType);
         e.getPresentation().setEnabled(enable);
     }
-    
+
     @Override
     public NotificationManager getNotificationManager() {
         return notificationManager;

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunClassTestAction.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,14 +21,11 @@ import javax.validation.constraints.NotNull;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.resources.File;
-import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.ext.java.client.util.JavaUtil;
-import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.plugin.testing.ide.TestServiceClient;
 import org.eclipse.che.plugin.testing.ide.action.RunTestActionDelegate;
 import org.eclipse.che.plugin.testing.ide.view.TestResultPresenter;
@@ -51,14 +48,12 @@ public class RunClassTestAction extends AbstractPerspectiveAction
 
     @Inject
     public RunClassTestAction(TestNGResources resources,
-                                     NotificationManager notificationManager,
-                                     EditorAgent editorAgent,
-                                     AppContext appContext,
-                                     TestResultPresenter presenter,
-                                     TestServiceClient service,
-                                     DtoUnmarshallerFactory dtoUnmarshallerFactory,
-                                     TestNGLocalizationConstant localization) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunClassTitle(),
+                              NotificationManager notificationManager,
+                              AppContext appContext,
+                              TestResultPresenter presenter,
+                              TestServiceClient service,
+                              TestNGLocalizationConstant localization) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), localization.actionRunClassTitle(),
               localization.actionRunClassDescription(), null, resources.testIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
@@ -83,20 +78,15 @@ public class RunClassTestAction extends AbstractPerspectiveAction
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         Resource resource = appContext.getResource();
-        if (! (resource instanceof File)) {
+        if (!(resource instanceof File) || resource.getProject() == null) {
             e.getPresentation().setEnabledAndVisible(false);
             return;
         }
-        
-        Project project = resource.getProject();
-        if (project == null) {
-            e.getPresentation().setEnabledAndVisible(false);
-        }
-        
+
         e.getPresentation().setVisible(true);
 
-        String projectType = project.getType();
-        if (! "maven".equals(projectType)) {
+        String projectType = resource.getProject().getType();
+        if (!"maven".equals(projectType)) {
             e.getPresentation().setEnabled(false);
         }
 

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunTestXMLAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/action/RunTestXMLAction.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.testng.ide.action;
 
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,12 +49,12 @@ public class RunTestXMLAction extends AbstractPerspectiveAction
 
     @Inject
     public RunTestXMLAction(TestNGResources resources,
-                                   NotificationManager notificationManager,
-                                   AppContext appContext,
-                                   TestResultPresenter presenter,
-                                   TestServiceClient service,
-                                   TestNGLocalizationConstant localization) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), localization.actionRunXMLTitle(),
+                            NotificationManager notificationManager,
+                            AppContext appContext,
+                            TestResultPresenter presenter,
+                            TestServiceClient service,
+                            TestNGLocalizationConstant localization) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), localization.actionRunXMLTitle(),
               localization.actionRunXMLDescription(), null, resources.testAllIcon());
         this.notificationManager = notificationManager;
         this.presenter = presenter;
@@ -80,32 +80,27 @@ public class RunTestXMLAction extends AbstractPerspectiveAction
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         Resource resource = appContext.getResource();
-        if (resource == null) {
+        if (resource == null || resource.getProject() == null) {
             e.getPresentation().setEnabledAndVisible(false);
             return;
         }
-        
-        Project project = resource.getProject();
-        if (project == null) {
-            e.getPresentation().setEnabledAndVisible(false);
-        }
-        
+
         e.getPresentation().setVisible(true);
 
-        String projectType = project.getType();
-        if (! "maven".equals(projectType)) {
+        String projectType = resource.getProject().getType();
+        if (!"maven".equals(projectType)) {
             e.getPresentation().setEnabled(false);
         }
 
-        String expectedXmlFile = MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER + "/testng.xml";
         if (resource instanceof File) {
             File file = (File)resource;
+            String expectedXmlFile = MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER + "/testng.xml";
             e.getPresentation().setEnabled(file.getLocation().toString().endsWith(expectedXmlFile));
         } else {
             e.getPresentation().setEnabled(true);
         }
     }
-    
+
     @Override
     public NotificationManager getNotificationManager() {
         return notificationManager;


### PR DESCRIPTION
### What does this PR do?
Detail:
Fix NPE in case if user open context menu in the jar nodes in the ProjectExplorer.
Fix NPE when user click to RUN menu in the main toolbar in the workspace without projects.
Fix NPE when user launch step into action in the java debugger which should open java files from some jar and click Run menu.
Clean up unused injections and imports.
Main goal of this pull request: fix NPE and nothing to break :)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5270

#### Changelog
Fix NPE for junit and testng test actions.

#### Release Notes
Fix NPE for junit and testng test actions.

#### Docs PR
Don't need. It's only bugfix.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>
