### PR TITLE
CHE-5188: fix a bug with showing commands when a ws has started

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandManager.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandManager.java
@@ -24,6 +24,9 @@ public interface CommandManager {
     /** Returns all commands. */
     List<CommandImpl> getCommands();
 
+    /** Fetches all commands related to the workspace. */
+    void fetchCommands();
+
     /** Returns optional command by the specified name or {@link Optional#empty()} if none. */
     Optional<CommandImpl> getCommand(String name);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsExplorerPresenter.java
@@ -78,6 +78,8 @@ public class CommandsExplorerPresenter extends BasePresenter implements Commands
     private final AppContext           appContext;
     private final EventBus             eventBus;
 
+    private boolean isFirstActivation;
+
     @Inject
     public CommandsExplorerPresenter(CommandsExplorerView view,
                                      CommandResources commandResources,
@@ -110,6 +112,17 @@ public class CommandsExplorerPresenter extends BasePresenter implements Commands
     }
 
     @Override
+    public void onOpen() {
+        super.onOpen();
+
+        if (isFirstActivation) {
+            commandManager.fetchCommands();
+            refreshView();
+            isFirstActivation = false;
+        }
+    }
+
+    @Override
     public void start(Callback<WsAgentComponent, Exception> callback) {
         callback.onSuccess(this);
 
@@ -126,6 +139,7 @@ public class CommandsExplorerPresenter extends BasePresenter implements Commands
 
     @Override
     public void go(AcceptsOneWidget container) {
+        isFirstActivation = true;
         refreshView();
 
         container.setWidget(getView());

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/manager/CommandManagerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/manager/CommandManagerImpl.java
@@ -100,28 +100,43 @@ public class CommandManagerImpl implements CommandManager, WsAgentComponent {
             workspaceCommands.forEach(workspaceCommand -> commands.put(workspaceCommand.getName(),
                                                                        new CommandImpl(workspaceCommand, new ApplicableContext())));
 
-            // get all commands related to the projects
-            Arrays.stream(appContext.getProjects())
-                  .forEach(project -> projectCommandManager.getCommands(project).forEach(projectCommand -> {
-                      final CommandImpl existedCommand = commands.get(projectCommand.getName());
-
-                      if (existedCommand == null) {
-                          commands.put(projectCommand.getName(),
-                                       new CommandImpl(projectCommand, new ApplicableContext(project.getPath())));
-                      } else {
-                          if (projectCommand.equalsIgnoreContext(existedCommand)) {
-                              existedCommand.getApplicableContext().addProject(project.getPath());
-                          } else {
-                              // normally, should never happen
-                              Log.error(CommandManagerImpl.this.getClass(), "Different commands with the same names found");
-                          }
-                      }
-                  }));
+            addCommands();
 
             callback.onSuccess(this);
 
             notifyCommandsLoaded();
         });
+    }
+
+    public void fetchCommands() {
+        workspaceCommandManager.getCommands(appContext.getWorkspaceId()).then(workspaceCommands -> {
+            workspaceCommands.forEach(workspaceCommand -> commands.put(workspaceCommand.getName(),
+                    new CommandImpl(workspaceCommand, new ApplicableContext())));
+
+            addCommands();
+
+            notifyCommandsLoaded();
+        });
+    }
+
+    private void addCommands() {
+        // get all commands related to the projects
+        Arrays.stream(appContext.getProjects())
+                .forEach(project -> projectCommandManager.getCommands(project).forEach(projectCommand -> {
+                    final CommandImpl existedCommand = commands.get(projectCommand.getName());
+
+                    if (existedCommand == null) {
+                        commands.put(projectCommand.getName(),
+                                new CommandImpl(projectCommand, new ApplicableContext(project.getPath())));
+                    } else {
+                        if (projectCommand.equalsIgnoreContext(existedCommand)) {
+                            existedCommand.getApplicableContext().addProject(project.getPath());
+                        } else {
+                            // normally, should never happen
+                            Log.error(CommandManagerImpl.this.getClass(), "Different commands with the same names found");
+                        }
+                    }
+                }));
     }
 
     @Override


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes a bug with showing commands when a ws has started. Now when Commands explorer initializes first time then all related to the workspace commands will read and show. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5188

#### Changelog
<!-- one line entry to be added to changelog -->
Display default commands after starting workspace

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Display default commands after starting workspace

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
