### PR TITLE
che-5209: add ability to stop starting workspace

### DIFF
--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -251,8 +251,8 @@ export class NavbarRecentWorkspacesController {
     }
 
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId),
-      disabled = workspace && (workspace.status === 'STARTING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING'),
-      visibleScope = (workspace && (workspace.status === 'RUNNING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING')) ? 'RUNNING' : 'STOPPED';
+      disabled = workspace && (workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING'),
+      visibleScope = (workspace && (workspace.status === 'RUNNING' || workspace.status === 'STOPPING' || workspace.status === 'SNAPSHOTTING' || workspace.status === 'STARTING')) ? 'RUNNING' : 'STOPPED';
 
     if (!this.dropdownItems[workspaceId]) {
       this.dropdownItems[workspaceId] = [];

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.controller.ts
@@ -53,7 +53,7 @@ export class WorkspaceStatusController {
   }
 
   stopWorkspace(): void {
-    if (this.isLoading || !this.workspace || this.workspace.status !== 'RUNNING') {
+    if (this.isLoading || !this.workspace || (this.workspace.status !== 'RUNNING' && this.workspace.status !== 'STARTING')) {
       return;
     }
 

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
@@ -10,15 +10,15 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<div class="workspaces-status" ng-class="{'workspaces-busy' : workspaceStatusController.workspace.status === 'STARTING'}">
+<div class="workspaces-status">
   <span class="fa fa-play"
         data-ng-click="workspaceStatusController.startWorkspace()"
-        ng-show="(workspaceStatusController.workspace.status !== 'RUNNING' && workspaceStatusController.workspace.status !== 'STOPPING' && workspaceStatusController.workspace.status !== 'SNAPSHOTTING')"
+        ng-show="(workspaceStatusController.workspace.status !== 'RUNNING' && workspaceStatusController.workspace.status !== 'STOPPING' && workspaceStatusController.workspace.status !== 'SNAPSHOTTING' && workspaceStatusController.workspace.status !== 'STARTING')"
         ng-class="{'disabled' : workspaceStatusController.workspace.status === 'STARTING'}"
         tooltip="Run workspace"></span>
   <span class="fa fa-stop"
-        data-ng-click="workspaceStatusController.stopWorkspace()"
-        ng-show="(workspaceStatusController.workspace.status === 'RUNNING' || workspaceStatusController.workspace.status === 'STOPPING' || workspaceStatusController.workspace.status === 'SNAPSHOTTING')"
+        ng-click="workspaceStatusController.stopWorkspace()"
+        ng-show="(workspaceStatusController.workspace.status === 'RUNNING' || workspaceStatusController.workspace.status === 'STOPPING' || workspaceStatusController.workspace.status === 'SNAPSHOTTING' || workspaceStatusController.workspace.status === 'STARTING')"
         ng-class="{'disabled' : workspaceStatusController.workspace.status === 'STOPPING' || workspaceDetailsController.workspace.status === 'SNAPSHOTTING'}"
         tooltip="Stop workspace"></span>
 </div>


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilova@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds abiity to stop starting workspace in the workspace list and recent workspace on navigation bar. Previously was possible only from workspace details.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5209

#### Changelog
[dashboard] Fixed ability to stop workspace from recent worskpaces section and general list of workspaces.

#### Release Notes
N/A


#### Docs PR
N/A
