### PR TITLE
#5311: Update JSON LS to VSCode 1.13.0

### DIFF
--- a/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
+++ b/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
@@ -154,4 +154,4 @@ curl -s ${AGENT_BINARIES_URI} | tar xzf - -C ${LS_DIR}
 
 touch ${LS_LAUNCHER}
 chmod +x ${LS_LAUNCHER}
-echo "nodejs ${LS_DIR}/vscode-json-server/server.js" > ${LS_LAUNCHER}
+echo "nodejs ${LS_DIR}/vscode-json-server/out/jsonServerMain.js --stdio" > ${LS_LAUNCHER}


### PR DESCRIPTION
Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>

### What does this PR do?

This is the first step of resolving #5311.

The following attachment must be uploaded to https://codenvy.com/update/repository/public/download/org.eclipse.che.ls.json.binaries:
[vscode-json-server.tar.gz](https://github.com/eclipse/che/files/1064193/vscode-json-server.tar.gz)

The language server integration in Che was updated to use LSP4J 0.1.2, which supports newer version of the Language Server Protocol. The aging version of the JSON language server included in Che supported an older version of the protocol.

Updating the JSON language server to a newer version resolves some of the issues:
- document symbols (Ctrl+F12) now works
- after adding a `$schema` key I have also hovering works.

There are still many issues remaining that needs to be investigated somewhere in the LS integration code.

### What issues does this PR fix or reference?

Regression: JSON intellisense is broken #5311 

#### Changelog

JSON Language Server update to VSCode 1.13.0

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

