### PR TITLE
Fixed freezing of IDE in case of LS initialization timeout or failure

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcPromise.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcPromise.java
@@ -51,7 +51,7 @@ public class JsonRpcPromise<R> {
      */
     public JsonRpcPromise<R> onTimeout(Runnable runnable) {
         checkNotNull(runnable, "JSON RPC timeout runnable argument must not be null");
-        checkState(this.successConsumer == null, "JSON RPC timeout runnable field must not be set");
+        checkState(this.timeoutRunnable == null, "JSON RPC timeout runnable field must not be set");
         this.timeoutRunnable = runnable;
         return this;
     }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcPromise.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcPromise.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.jsonrpc.commons;
 
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -27,13 +28,32 @@ import static com.google.common.base.Preconditions.checkState;
 public class JsonRpcPromise<R> {
     private BiConsumer<String, R>            successConsumer;
     private BiConsumer<String, JsonRpcError> failureConsumer;
+    private Runnable                         timeoutRunnable;
 
-    BiConsumer<String, R> getSuccessConsumer() {
-        return successConsumer;
+    Optional<BiConsumer<String, R>> getSuccessConsumer() {
+        return Optional.ofNullable(successConsumer);
     }
 
-    BiConsumer<String, JsonRpcError> getFailureConsumer() {
-        return failureConsumer;
+    Optional<BiConsumer<String, JsonRpcError>> getFailureConsumer() {
+        return Optional.ofNullable(failureConsumer);
+    }
+
+    Optional<Runnable> getTimeoutRunnable() {
+        return Optional.ofNullable(timeoutRunnable);
+    }
+
+    /**
+     * Set timeout runnable to be called on this promise timeout.
+     *
+     * @param runnable
+     *         timeout runnable
+     * @return the instance of this very promise
+     */
+    public JsonRpcPromise<R> onTimeout(Runnable runnable) {
+        checkNotNull(runnable, "JSON RPC timeout runnable argument must not be null");
+        checkState(this.successConsumer == null, "JSON RPC timeout runnable field must not be set");
+        this.timeoutRunnable = runnable;
+        return this;
     }
 
     /**

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -16,8 +16,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -30,17 +30,19 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class ResponseDispatcher {
     private final static Logger LOGGER = getLogger(ResponseDispatcher.class);
 
-    private final JsonRpcComposer composer;
+    private final JsonRpcComposer     composer;
+    private final TimeoutActionRunner timeoutActionRunner;
 
-    private final Map<String, JsonRpcPromise> promises = new ConcurrentHashMap<>();
-    private final Map<String, Class<?>>       rClasses = new ConcurrentHashMap<>();
+    private final Map<String, SingleTypedPromise<?>> singleTypedPromises = new ConcurrentHashMap<>();
+    private final Map<String, ListTypedPromise<?>>   listTypedPromises   = new ConcurrentHashMap<>();
 
     @Inject
-    public ResponseDispatcher(JsonRpcComposer composer) {
+    public ResponseDispatcher(JsonRpcComposer composer, TimeoutActionRunner timeoutActionRunner) {
         this.composer = composer;
+        this.timeoutActionRunner = timeoutActionRunner;
     }
 
-    private static void checkArguments(String endpointId, String requestId, Class<?> rClass, JsonRpcPromise success) {
+    private static void checkArguments(String endpointId, String requestId, Class<?> rClass) {
         checkNotNull(endpointId, "Endpoint ID must not be null");
         checkArgument(!endpointId.isEmpty(), "Endpoint ID must not be empty");
 
@@ -48,43 +50,10 @@ public class ResponseDispatcher {
         checkArgument(!requestId.isEmpty(), "Request ID must not be empty");
 
         checkNotNull(rClass, "Result class must not be null");
-
-        checkNotNull(success, "Json rpc promise must not be null");
     }
 
-    private static String combine(String endpointId, String requestId) {
+    private static String generateKey(String endpointId, String requestId) {
         return endpointId + '@' + requestId;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> T cast(Object object) {
-        return (T)object;
-    }
-
-    private <R> void processOne(String endpointId, JsonRpcResult jsonRpcResult, Class<R> resultClass, BiConsumer<String, R> consumer) {
-        LOGGER.debug("Result is a single object - processing single object...");
-
-        R result = composer.composeOne(jsonRpcResult, resultClass);
-        if (consumer == null) {
-            LOGGER.debug("No consumer is not found, skipping.");
-        } else {
-            LOGGER.debug("Consumer is found, processing.");
-
-            consumer.accept(endpointId, result);
-        }
-    }
-
-    private <R> void processMany(String endpointId, JsonRpcResult jsonRpcResult, Class<R> resultClass, BiConsumer<String, List> consumer) {
-        LOGGER.debug("Result is an array - processing array...");
-
-        List<R> result = composer.composeMany(jsonRpcResult, resultClass);
-        if (consumer == null) {
-            LOGGER.debug("No consumer is not found, skipping.");
-        } else {
-            LOGGER.debug("Consumer is found, processing.");
-
-            consumer.accept(endpointId, result);
-        }
     }
 
     public void dispatch(String endpointId, JsonRpcResponse response) {
@@ -92,93 +61,97 @@ public class ResponseDispatcher {
         checkArgument(!endpointId.isEmpty(), "Endpoint ID name must not be empty");
         checkNotNull(response, "Response name must not be null");
 
-        LOGGER.debug("Dispatching a response: {} from endpoint: {}", response, endpointId);
-
         String responseId = response.getId();
         if (responseId == null) {
-            LOGGER.debug("Response ID is not defined, skipping...");
             return;
         }
-        LOGGER.debug("Fetching response ID: {}", responseId);
 
-        String key = combine(endpointId, responseId);
-        LOGGER.debug("Generating key: {} ", key);
+        String key = generateKey(endpointId, responseId);
 
         if (response.hasResult()) {
-            processResult(endpointId, response, key);
+            dispatchResult(endpointId, response, key);
         } else if (response.hasError()) {
-            processError(endpointId, response, key);
+            dispatchError(endpointId, response, key);
         } else {
             LOGGER.error("Received incorrect response: no error, no result");
         }
     }
 
-    private void processError(String endpointId, JsonRpcResponse response, String key) {
-        LOGGER.debug("Response has error. Proceeding...");
+    public synchronized <R> JsonRpcPromise<R> registerPromiseForSingleObject(String endpointId, String requestId, Class<R> rClass,
+                                                                             int timeoutInMillis) {
+        checkArguments(endpointId, requestId, rClass);
 
-        if (!promises.containsKey(key)) {
-            LOGGER.debug("No action is associated for the key: {}, skipping.", key);
-            return;
+        SingleTypedPromise<R> promise = new SingleTypedPromise<>(rClass);
+        String key = generateKey(endpointId, requestId);
+        singleTypedPromises.put(key, promise);
+        if (timeoutInMillis > 0) {
+            timeoutActionRunner.schedule(timeoutInMillis, () -> runTimeoutConsumer(singleTypedPromises.remove(key)));
         }
-
-        JsonRpcError error = response.getError();
-
-        JsonRpcPromise<?> promise = promises.remove(key);
-        LOGGER.debug("Fetching promise: {}", promise);
-
-        BiConsumer<String, JsonRpcError> consumer = promise.getFailureConsumer();
-        if (consumer != null) {
-            LOGGER.debug("Failure consumer is found, accepting...");
-            consumer.accept(endpointId, error);
-        } else {
-            LOGGER.debug("Reject function is not found, skipping");
-        }
-    }
-
-    private void processResult(String endpointId, JsonRpcResponse response, String key) {
-        LOGGER.debug("Response has result. Proceeding...");
-
-        if (!promises.containsKey(key)) {
-            LOGGER.debug("No promise is associated with the key: {}, skipping.", key);
-            return;
-        }
-
-        if (!rClasses.containsKey(key)) {
-            LOGGER.debug("No result class is associated for the key: {}, skipping.", key);
-            return;
-        }
-
-        JsonRpcResult result = response.getResult();
-
-        Class<?> rClass = rClasses.remove(key);
-        LOGGER.debug("Fetching result class: {}", rClass);
-
-        JsonRpcPromise promise = promises.remove(key);
-        LOGGER.debug("Fetching promise: {}", promise);
-
-        if (result.isSingle()) {
-            processOne(endpointId, result, rClass, cast(promise.getSuccessConsumer()));
-        } else {
-            processMany(endpointId, result, rClass, cast(promise.getSuccessConsumer()));
-        }
-    }
-
-    public synchronized <R> JsonRpcPromise<R> registerPromiseOfOne(String endpointId, String requestId, Class<R> rClass) {
-        return cast(registerInternal(endpointId, requestId, rClass, new JsonRpcPromise<R>()));
-    }
-
-    public synchronized <R> JsonRpcPromise<List<R>> registerPromiseOfMany(String endpointId, String requestId, Class<R> rClass) {
-        return cast(registerInternal(endpointId, requestId, rClass, new JsonRpcPromise<List<R>>()));
-    }
-
-    private <R> JsonRpcPromise registerInternal(String endpointId, String requestId, Class<R> rClass, JsonRpcPromise promise) {
-        checkArguments(endpointId, requestId, rClass, promise);
-
-        String key = combine(endpointId, requestId);
-
-        promises.put(key, promise);
-        rClasses.put(key, rClass);
-
         return promise;
+    }
+
+    public synchronized <R> JsonRpcPromise<List<R>> registerPromiseForListOfObjects(String endpointId, String requestId, Class<R> rClass,
+                                                                                    int timeoutInMillis) {
+        checkArguments(endpointId, requestId, rClass);
+
+        ListTypedPromise<R> promise = new ListTypedPromise<>(rClass);
+        String key = generateKey(endpointId, requestId);
+        listTypedPromises.put(key, promise);
+        if (timeoutInMillis > 0) {
+            timeoutActionRunner.schedule(timeoutInMillis, () -> runTimeoutConsumer(listTypedPromises.remove(key)));
+        }
+        return promise;
+    }
+
+    private void runTimeoutConsumer(JsonRpcPromise<?> promise) {
+        Optional.ofNullable(promise)
+                .flatMap(JsonRpcPromise::getTimeoutRunnable)
+                .ifPresent(Runnable::run);
+    }
+
+    private void dispatchResult(String endpointId, JsonRpcResponse response, String key) {
+        JsonRpcResult result = response.getResult();
+        if (result.isSingle()) {
+            Optional.ofNullable(singleTypedPromises.remove(key)).ifPresent(
+                    promise -> promise.getSuccessConsumer().ifPresent(
+                            consumer -> promise.getType().ifPresent(
+                                    type -> consumer.accept(endpointId, composer.composeOne(result, type)))));
+        } else {
+            Optional.ofNullable(listTypedPromises.remove(key)).ifPresent(
+                    promise -> promise.getSuccessConsumer().ifPresent(
+                            consumer -> promise.getType().ifPresent(
+                                    type -> consumer.accept(endpointId, composer.composeMany(result, type)))));
+        }
+    }
+
+    private void dispatchError(String endpointId, JsonRpcResponse response, String key) {
+        SingleTypedPromise<?> singlePromise = singleTypedPromises.remove(key);
+        ListTypedPromise<?> listPromise = listTypedPromises.remove(key);
+        JsonRpcPromise<?> promise = singlePromise != null ? singlePromise : listPromise;
+        promise.getFailureConsumer().ifPresent(it -> it.accept(endpointId, response.getError()));
+    }
+
+    private class ListTypedPromise<R> extends JsonRpcPromise<List<R>> {
+        private final Class<R> type;
+
+        private ListTypedPromise(Class<R> type) {
+            this.type = type;
+        }
+
+        private Optional<Class<R>> getType() {
+            return Optional.ofNullable(type);
+        }
+    }
+
+    private class SingleTypedPromise<R> extends JsonRpcPromise<R> {
+        private final Class<R> type;
+
+        private SingleTypedPromise(Class<R> type) {
+            this.type = type;
+        }
+
+        public Optional<Class<R>> getType() {
+            return Optional.ofNullable(type);
+        }
     }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -92,7 +92,7 @@ public class ResponseDispatcher {
         checkArgument(!endpointId.isEmpty(), "Endpoint ID name must not be empty");
         checkNotNull(response, "Response name must not be null");
 
-        LOGGER.debug("Dispatching a response: " + response + ", from endpoint: " + endpointId);
+        LOGGER.debug("Dispatching a response: {} from endpoint: {}", response, endpointId);
 
         String responseId = response.getId();
         if (responseId == null) {
@@ -102,7 +102,7 @@ public class ResponseDispatcher {
         LOGGER.debug("Fetching response ID: {}", responseId);
 
         String key = combine(endpointId, responseId);
-        LOGGER.debug("Generating key: " + key);
+        LOGGER.debug("Generating key: {} ", key);
 
         if (response.hasResult()) {
             processResult(endpointId, response, key);
@@ -124,7 +124,7 @@ public class ResponseDispatcher {
         JsonRpcError error = response.getError();
 
         JsonRpcPromise<?> promise = promises.remove(key);
-        LOGGER.debug("Fetching promise:" + promise);
+        LOGGER.debug("Fetching promise: {}", promise);
 
         BiConsumer<String, JsonRpcError> consumer = promise.getFailureConsumer();
         if (consumer != null) {
@@ -151,7 +151,7 @@ public class ResponseDispatcher {
         JsonRpcResult result = response.getResult();
 
         Class<?> rClass = rClasses.remove(key);
-        LOGGER.debug("Fetching result class: {}",rClass);
+        LOGGER.debug("Fetching result class: {}", rClass);
 
         JsonRpcPromise promise = promises.remove(key);
         LOGGER.debug("Fetching promise: {}", promise);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -99,7 +99,7 @@ public class ResponseDispatcher {
             LOGGER.debug("Response ID is not defined, skipping...");
             return;
         }
-        LOGGER.debug("Fetching response ID: " + responseId);
+        LOGGER.debug("Fetching response ID: {}", responseId);
 
         String key = combine(endpointId, responseId);
         LOGGER.debug("Generating key: " + key);
@@ -117,7 +117,7 @@ public class ResponseDispatcher {
         LOGGER.debug("Response has error. Proceeding...");
 
         if (!promises.containsKey(key)) {
-            LOGGER.debug("No action is associated for the key: " + key + ", skipping.");
+            LOGGER.debug("No action is associated for the key: {}, skipping.", key);
             return;
         }
 
@@ -139,22 +139,22 @@ public class ResponseDispatcher {
         LOGGER.debug("Response has result. Proceeding...");
 
         if (!promises.containsKey(key)) {
-            LOGGER.debug("No promise is associated with the key: " + key + ", skipping.");
+            LOGGER.debug("No promise is associated with the key: {}, skipping.", key);
             return;
         }
 
         if (!rClasses.containsKey(key)) {
-            LOGGER.debug("No result class is associated for the key: " + key + ", skipping.");
+            LOGGER.debug("No result class is associated for the key: {}, skipping.", key);
             return;
         }
 
         JsonRpcResult result = response.getResult();
 
         Class<?> rClass = rClasses.remove(key);
-        LOGGER.debug("Fetching result class:" + rClass);
+        LOGGER.debug("Fetching result class: {}",rClass);
 
         JsonRpcPromise promise = promises.remove(key);
-        LOGGER.debug("Fetching promise:" + promise);
+        LOGGER.debug("Fetching promise: {}", promise);
 
         if (result.isSingle()) {
             processOne(endpointId, result, rClass, cast(promise.getSuccessConsumer()));

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ResponseDispatcher.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -111,18 +110,15 @@ public class ResponseDispatcher {
     }
 
     private void dispatchResult(String endpointId, JsonRpcResponse response, String key) {
-        JsonRpcResult result = response.getResult();
-        if (result.isSingle()) {
-            Optional.ofNullable(singleTypedPromises.remove(key)).ifPresent(
-                    promise -> promise.getSuccessConsumer().ifPresent(
-                            consumer -> promise.getType().ifPresent(
-                                    type -> consumer.accept(endpointId, composer.composeOne(result, type)))));
-        } else {
-            Optional.ofNullable(listTypedPromises.remove(key)).ifPresent(
-                    promise -> promise.getSuccessConsumer().ifPresent(
-                            consumer -> promise.getType().ifPresent(
-                                    type -> consumer.accept(endpointId, composer.composeMany(result, type)))));
-        }
+        Optional.ofNullable(listTypedPromises.remove(key)).ifPresent(
+                promise -> promise.getSuccessConsumer().ifPresent(
+                        consumer -> promise.getType().ifPresent(
+                                type -> consumer.accept(endpointId, composer.composeMany(response.getResult(), type)))));
+
+        Optional.ofNullable(singleTypedPromises.remove(key)).ifPresent(
+                promise -> promise.getSuccessConsumer().ifPresent(
+                        consumer -> promise.getType().ifPresent(
+                                type -> consumer.accept(endpointId, composer.composeOne(response.getResult(), type)))));
     }
 
     private void dispatchError(String endpointId, JsonRpcResponse response, String key) {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/TimeoutActionRunner.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/TimeoutActionRunner.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.commons;
+
+/**
+ * Executes operation on timeout
+ */
+public interface TimeoutActionRunner {
+    void schedule(int timeoutInMillis, Runnable runnable);
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/transmission/SendConfiguratorFromMany.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/transmission/SendConfiguratorFromMany.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.jsonrpc.commons.transmission;
 
-import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcErrorTransmitter;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcMarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcParams;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
@@ -65,7 +64,11 @@ public class SendConfiguratorFromMany<P> {
         transmitNotification();
     }
 
-    public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(final Class<R> rClass) {
+    public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(Class<R> rClass) {
+        return sendAndReceiveResultAsDto(rClass, 0);
+    }
+
+    public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(Class<R> rClass, int timeoutInMillis) {
         checkNotNull(rClass, "Result class value must not be null");
 
         final String requestId = transmitRequest();
@@ -78,10 +81,14 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result object class: " + rClass);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, rClass);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, rClass, timeoutInMillis);
     }
 
     public JsonRpcPromise<String> sendAndReceiveResultAsString() {
+        return sendAndReceiveResultAsString(0);
+    }
+
+    public JsonRpcPromise<String> sendAndReceiveResultAsString(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -92,10 +99,14 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result object class: " + String.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, String.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, String.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<Boolean> sendAndReceiveResultAsBoolean() {
+        return sendAndReceiveResultAsBoolean(0);
+    }
+
+    public JsonRpcPromise<Boolean> sendAndReceiveResultAsBoolean(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -106,10 +117,14 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result object class: " + Boolean.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Boolean.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Boolean.class, timeoutInMillis);
     }
 
     public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(Class<R> rClass) {
+        return sendAndReceiveResultAsListOfDto(rClass, 0);
+    }
+
+    public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(Class<R> rClass, int timeoutInMillis) {
         checkNotNull(rClass, "Result class value must not be null");
 
         final String requestId = transmitRequest();
@@ -122,11 +137,14 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result list items class: " + rClass);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, rClass);
-
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, rClass, timeoutInMillis);
     }
 
     public JsonRpcPromise<List<String>> sendAndReceiveResultAsListOfString() {
+        return sendAndReceiveResultAsListOfString(0);
+    }
+
+    public JsonRpcPromise<List<String>> sendAndReceiveResultAsListOfString(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -137,10 +155,14 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result list items class: " + String.class);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, String.class);
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, String.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<List<Boolean>> sendAndReceiveResultAsListOfBoolean() {
+        return sendAndReceiveResultAsListOfBoolean(0);
+    }
+
+    public JsonRpcPromise<List<Boolean>> sendAndReceiveResultAsListOfBoolean(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -151,10 +173,14 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result list items class: " + Boolean.class);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, Boolean.class);
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, Boolean.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<Void> sendAndReceiveResultAsEmpty() {
+        return sendAndReceiveResultAsEmpty(0);
+    }
+
+    public JsonRpcPromise<Void> sendAndReceiveResultAsEmpty(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -165,7 +191,7 @@ public class SendConfiguratorFromMany<P> {
                      "params list value" + pListValue + ", " +
                      "result object class: " + Void.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Void.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Void.class, timeoutInMillis);
     }
 
     private void transmitNotification() {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/transmission/SendConfiguratorFromNone.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/transmission/SendConfiguratorFromNone.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.jsonrpc.commons.transmission;
 
-import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcErrorTransmitter;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcMarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcRequest;
@@ -58,6 +57,10 @@ public class SendConfiguratorFromNone {
     }
 
     public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(final Class<R> rClass) {
+        return sendAndReceiveResultAsDto(rClass, 0);
+    }
+
+    public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(final Class<R> rClass, int timeInMillis) {
         checkNotNull(rClass, "Result class value must not be null");
 
         final String requestId = transmitRequest();
@@ -68,11 +71,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result object class: " + rClass);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, rClass);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, rClass, timeInMillis);
     }
 
-
     public JsonRpcPromise<String> sendAndReceiveResultAsString() {
+        return sendAndReceiveResultAsString(0);
+    }
+
+    public JsonRpcPromise<String> sendAndReceiveResultAsString(int timeInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -81,11 +87,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result object class: " + String.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, String.class);
-
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, String.class, timeInMillis);
     }
 
     public JsonRpcPromise<Double> sendAndReceiveResultAsDouble() {
+        return sendAndReceiveResultAsDouble(0);
+    }
+
+    public JsonRpcPromise<Double> sendAndReceiveResultAsDouble(int timeInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -94,11 +103,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result object class: " + Double.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Double.class);
-
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Double.class, timeInMillis);
     }
 
     public JsonRpcPromise<Boolean> sendAndReceiveResultAsBoolean() {
+        return sendAndReceiveResultAsBoolean(0);
+    }
+
+    public JsonRpcPromise<Boolean> sendAndReceiveResultAsBoolean(int timeInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -107,10 +119,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result object class: " + Boolean.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Boolean.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Boolean.class, timeInMillis);
     }
 
     public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(final Class<R> rClass) {
+        return sendAndReceiveResultAsListOfDto(rClass, 0);
+    }
+
+    public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(final Class<R> rClass, int timeInMillis) {
         checkNotNull(rClass, "Result class value must not be null");
 
         final String requestId = transmitRequest();
@@ -121,11 +137,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result list items class: " + rClass);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, rClass);
-
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, rClass, timeInMillis);
     }
 
     public JsonRpcPromise<List<String>> sendAndReceiveResultAsListOfString() {
+        return sendAndReceiveResultAsListOfString(0);
+    }
+
+    public JsonRpcPromise<List<String>> sendAndReceiveResultAsListOfString(int timeInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -134,10 +153,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result list items class: " + String.class);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, String.class);
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, String.class, timeInMillis);
     }
 
     public JsonRpcPromise<List<Boolean>> sendAndReceiveResultAsListOfBoolean() {
+        return sendAndReceiveResultAsListOfBoolean(0);
+    }
+
+    public JsonRpcPromise<List<Boolean>> sendAndReceiveResultAsListOfBoolean(int timeInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -146,10 +169,14 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result list items class: " + Boolean.class);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, Boolean.class);
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, Boolean.class, timeInMillis);
     }
 
     public JsonRpcPromise<Void> sendAndReceiveResultAsEmpty() {
+        return sendAndReceiveResultAsEmpty(0);
+    }
+
+    public JsonRpcPromise<Void> sendAndReceiveResultAsEmpty(int timeInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -158,7 +185,7 @@ public class SendConfiguratorFromNone {
                      "method: " + method + ", " +
                      "result list items class: " + Void.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Void.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Void.class, timeInMillis);
     }
 
     private void transmitNotification() {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/transmission/SendConfiguratorFromOne.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/transmission/SendConfiguratorFromOne.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.jsonrpc.commons.transmission;
 
-import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcErrorTransmitter;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcMarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcParams;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
@@ -66,6 +65,10 @@ public class SendConfiguratorFromOne<P> {
     }
 
     public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(final Class<R> rClass) {
+        return sendAndReceiveResultAsDto(rClass, 0);
+    }
+
+    public <R> JsonRpcPromise<R> sendAndReceiveResultAsDto(final Class<R> rClass, int timeoutInMillis) {
         checkNotNull(rClass, "Result class value must not be null");
 
         final String requestId = transmitRequest();
@@ -78,11 +81,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result object class: " + rClass);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, rClass);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, rClass, timeoutInMillis);
     }
 
-
     public JsonRpcPromise<String> sendAndReceiveResultAsString() {
+        return sendAndReceiveResultAsString(0);
+    }
+
+    public JsonRpcPromise<String> sendAndReceiveResultAsString(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -93,11 +99,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result object class: " + String.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, String.class);
-
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, String.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<Double> sendAndReceiveResultAsDouble() {
+        return sendAndReceiveResultAsDouble(0);
+    }
+
+    public JsonRpcPromise<Double> sendAndReceiveResultAsDouble(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -108,11 +117,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result object class: " + Double.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Double.class);
-
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Double.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<Boolean> sendAndReceiveResultAsBoolean() {
+        return sendAndReceiveResultAsBoolean(0);
+    }
+
+    public JsonRpcPromise<Boolean> sendAndReceiveResultAsBoolean(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -123,10 +135,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result object class: " + Boolean.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Boolean.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Boolean.class, timeoutInMillis);
     }
 
-    public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(final Class<R> rClass) {
+    public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(Class<R> rClass) {
+        return sendAndReceiveResultAsListOfDto(rClass, 0);
+    }
+
+    public <R> JsonRpcPromise<List<R>> sendAndReceiveResultAsListOfDto(Class<R> rClass, int timeoutInMillis) {
         checkNotNull(rClass, "Result class value must not be null");
 
         final String requestId = transmitRequest();
@@ -139,11 +155,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result list items class: " + rClass);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, rClass);
-
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, rClass, timeoutInMillis);
     }
 
     public JsonRpcPromise<List<String>> sendAndReceiveResultAsListOfString() {
+        return sendAndReceiveResultAsListOfString(0);
+    }
+
+    public JsonRpcPromise<List<String>> sendAndReceiveResultAsListOfString(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -154,10 +173,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result list items class: " + String.class);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, String.class);
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, String.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<List<Boolean>> sendAndReceiveResultAsListOfBoolean() {
+        return sendAndReceiveResultAsListOfBoolean(0);
+    }
+
+    public JsonRpcPromise<List<Boolean>> sendAndReceiveResultAsListOfBoolean(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -168,10 +191,14 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result list items class: " + Boolean.class);
 
-        return dispatcher.registerPromiseOfMany(endpointId, requestId, Boolean.class);
+        return dispatcher.registerPromiseForListOfObjects(endpointId, requestId, Boolean.class, timeoutInMillis);
     }
 
     public JsonRpcPromise<Void> sendAndReceiveResultAsEmpty() {
+        return sendAndReceiveResultAsEmpty(0);
+    }
+
+    public JsonRpcPromise<Void> sendAndReceiveResultAsEmpty(int timeoutInMillis) {
         final String requestId = transmitRequest();
 
         LOGGER.debug("Transmitting request: " +
@@ -182,7 +209,7 @@ public class SendConfiguratorFromOne<P> {
                      "params list value" + pValue + ", " +
                      "result list items class: " + Void.class);
 
-        return dispatcher.registerPromiseOfOne(endpointId, requestId, Void.class);
+        return dispatcher.registerPromiseForSingleObject(endpointId, requestId, Void.class, timeoutInMillis);
     }
 
     private void transmitNotification() {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcModule.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcModule.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcMarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcQualifier;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcUnmarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.TimeoutActionRunner;
 
 import javax.inject.Singleton;
 
@@ -37,6 +38,7 @@ public class JsonRpcModule extends AbstractModule {
         bind(JsonRpcComposer.class).to(GsonJsonRpcComposer.class);
 
         bind(RequestProcessor.class).to(ServerSideRequestProcessor.class);
+        bind(TimeoutActionRunner.class).to(ServerSideTimeoutActionRunner.class);
     }
 
     @Provides

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideTimeoutActionRunner.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideTimeoutActionRunner.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.core.jsonrpc.commons.TimeoutActionRunner;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+@Singleton
+public class ServerSideTimeoutActionRunner implements TimeoutActionRunner {
+
+    @Override
+    public void schedule(int timeoutInMillis, Runnable runnable) {
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                runnable.run();
+            }
+        }, timeoutInMillis);
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/JsonRpcModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/JsonRpcModule.java
@@ -20,9 +20,11 @@ import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcMarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcQualifier;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcUnmarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.TimeoutActionRunner;
 import org.eclipse.che.ide.api.event.ng.JsonRpcWebSocketAgentEventListener;
 import org.eclipse.che.ide.api.jsonrpc.WorkspaceMasterJsonRpcInitializer;
 import org.eclipse.che.ide.jsonrpc.ClientSideRequestProcessor;
+import org.eclipse.che.ide.jsonrpc.ClientSideTimeoutActionRunner;
 import org.eclipse.che.ide.jsonrpc.ElementalJsonRpcComposer;
 import org.eclipse.che.ide.jsonrpc.ElementalJsonRpcMarshaller;
 import org.eclipse.che.ide.jsonrpc.ElementalJsonRpcQualifier;
@@ -53,5 +55,6 @@ public class JsonRpcModule extends AbstractGinModule {
         bind(JsonRpcQualifier.class).to(ElementalJsonRpcQualifier.class);
 
         bind(RequestProcessor.class).to(ClientSideRequestProcessor.class);
+        bind(TimeoutActionRunner.class).to(ClientSideTimeoutActionRunner.class);
     }
 }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/ClientSideTimeoutActionRunner.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/ClientSideTimeoutActionRunner.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.jsonrpc;
+
+import com.google.gwt.user.client.Timer;
+
+import org.eclipse.che.api.core.jsonrpc.commons.TimeoutActionRunner;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class ClientSideTimeoutActionRunner implements TimeoutActionRunner {
+
+    @Override
+    public void schedule(int timeoutInMillis, Runnable runnable) {
+        new Timer() {
+            @Override
+            public void run() {
+                runnable.run();
+            }
+        }.schedule(timeoutInMillis);
+    }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import static org.eclipse.che.api.languageserver.shared.ProjectExtensionKey.createProjectKey;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 
 
 /**
@@ -107,12 +108,14 @@ public class LanguageServerRegistry {
                          .onSuccess(loader::hide)
                          .onFailure((error) -> {
                              notificationManager
-                                     .notify("Initializing Language Server for " + ext, error.getMessage(), FAIL, EMERGE_MODE);
+                                     .notify("Failed to initialize language server for " + ext + " : ", error.getMessage(), FAIL,
+                                             EMERGE_MODE);
                              loader.hide();
                          })
                          .onTimeout(() -> {
                              notificationManager
-                                     .notify("Initializing Language Server for " + ext + " failed due timeout", FAIL, EMERGE_MODE);
+                                     .notify("Failed to initialize language server for " + ext + " : " + "due to timeout", FAIL,
+                                             EMERGE_MODE);
                              loader.hide();
                          });
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import static org.eclipse.che.api.languageserver.shared.ProjectExtensionKey.createProjectKey;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
-import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.WARNING;
 
 
 /**
@@ -114,7 +114,8 @@ public class LanguageServerRegistry {
                          })
                          .onTimeout(() -> {
                              notificationManager
-                                     .notify("Failed to initialize language server for " + ext + " : " + "due to timeout", FAIL,
+                                     .notify("Possible problem starting a language server", "The server either hangs or starts long",
+                                             WARNING,
                                              EMERGE_MODE);
                              loader.hide();
                          });

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryJsonRpcClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryJsonRpcClient.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.languageserver.ide.service;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
+
+@Singleton
+public class LanguageServerRegistryJsonRpcClient {
+
+    private final RequestTransmitter requestTransmitter;
+
+    @Inject
+    public LanguageServerRegistryJsonRpcClient(RequestTransmitter requestTransmitter) {
+        this.requestTransmitter = requestTransmitter;
+    }
+
+    public JsonRpcPromise<Boolean> initializeServer(String path) {
+        return requestTransmitter.newRequest()
+                                 .endpointId("ws-agent")
+                                 .methodName("languageServer/initialize")
+                                 .paramsAsString(path)
+                                 .sendAndReceiveResultAsBoolean(5_000);
+    }
+
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryJsonRpcClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryJsonRpcClient.java
@@ -34,7 +34,7 @@ public class LanguageServerRegistryJsonRpcClient {
                                  .endpointId("ws-agent")
                                  .methodName("languageServer/initialize")
                                  .paramsAsString(path)
-                                 .sendAndReceiveResultAsBoolean(5_000);
+                                 .sendAndReceiveResultAsBoolean(30_000);
     }
 
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.languageserver.registry.LanguageServerRegistryImpl;
 import org.eclipse.che.api.languageserver.registry.ServerInitializer;
 import org.eclipse.che.api.languageserver.registry.ServerInitializerImpl;
 import org.eclipse.che.api.languageserver.service.LanguageRegistryService;
+import org.eclipse.che.api.languageserver.service.LanguageServerInitializationHandler;
 import org.eclipse.che.api.languageserver.service.TextDocumentService;
 import org.eclipse.che.api.languageserver.service.WorkspaceService;
 
@@ -39,5 +40,7 @@ public class LanguageServerModule extends AbstractModule {
         bind(TextDocumentService.class).asEagerSingleton();
         bind(PublishDiagnosticsParamsJsonRpcTransmitter.class).asEagerSingleton();
         bind(ShowMessageJsonRpcTransmitter.class).asEagerSingleton();
+
+        bind(LanguageServerInitializationHandler.class).asEagerSingleton();
     }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.languageserver.service;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.languageserver.exception.LanguageServerException;
+import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
+
+import static java.lang.Thread.sleep;
+
+@Singleton
+public class LanguageServerInitializationHandler {
+
+    @Inject
+    public LanguageServerInitializationHandler(RequestHandlerConfigurator requestHandlerConfigurator, LanguageServerRegistry registry) {
+        requestHandlerConfigurator.newConfiguration()
+                                  .methodName("languageServer/initialize")
+                                  .paramsAsString()
+                                  .resultAsBoolean()
+                                  .withFunction(path -> {
+                                      try {
+                                          return registry.findServer(TextDocumentServiceUtils.prefixURI(path)) != null;
+                                      } catch (LanguageServerException | InterruptedException e) {
+                                          throw new JsonRpcException(-27000, e.getMessage());
+                                      }
+                                  });
+    }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
@@ -32,7 +32,7 @@ public class LanguageServerInitializationHandler {
                                   .withFunction(path -> {
                                       try {
                                           return registry.findServer(TextDocumentServiceUtils.prefixURI(path)) != null;
-                                      } catch (LanguageServerException | InterruptedException e) {
+                                      } catch (LanguageServerException e) {
                                           throw new JsonRpcException(-27000, e.getMessage());
                                       }
                                   });

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
@@ -18,8 +18,6 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 
-import static java.lang.Thread.sleep;
-
 @Singleton
 public class LanguageServerInitializationHandler {
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes language server initialization loader that freezes IDE. This is a temporary workaround, to properly fix this issue we need to totally redesign language server initialization process taking into account health checking and using asynchronous transport (like JSON-RPC) 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5361

#### Changelog
Fixed freezing of IDE in case of LS initialization timeout or failure

#### Release Notes
Fixed freezing of IDE in case of LS initialization timeout or failure


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
