### PR TITLE
Fix build module 'agents/go-agents' for maven 3.3.3

### DIFF
--- a/agents/go-agents/pom.xml
+++ b/agents/go-agents/pom.xml
@@ -26,7 +26,9 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <includes>**/**</includes>
+                    <includes>
+                        <include>**/**</include>
+                    </includes>
                     <excludes>
                         <exclude>docs/**</exclude>
                         <exclude>terminal-agent/term/server.go</exclude>


### PR DESCRIPTION
### What does this PR do?
Fix build module 'agents/go-agents' for maven 3.3.3

#### Docs PR
Don't need.

Signed-off-by: Aleksandr Andriienko <oandriie@redhat.com>

