### PR TITLE
Factorize code of `ServerEvaluationStrategy` classes, to use the Custom strategy as the basis of other strategies

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -67,6 +67,12 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
      */
     public static final String CHE_WORKSPACE_ID_PREFIX = "workspace";
 
+
+    /**
+     * name of the macro that indicates if the machine is the dev machine
+     */
+    public static final String IS_DEV_MACHINE_MACRO = "isDevMachine";
+
     /**
      * Used to store the address set by property {@code che.docker.ip}, if applicable.
      */
@@ -407,7 +413,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
             globalPropertiesMap.put("wildcardNipDomain", getWildcardNipDomain(externalAddress));
             globalPropertiesMap.put("wildcardXipDomain", getWildcardXipDomain(externalAddress));
             globalPropertiesMap.put("chePort", chePort);
-            globalPropertiesMap.put("isDevMachine", getIsDevMachine());
+            globalPropertiesMap.put(IS_DEV_MACHINE_MACRO, getIsDevMachine());
         }
 
         /**
@@ -421,7 +427,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
             }
             ST stringTemplate = new ST(template);
             globalPropertiesMap.forEach((key, value) -> stringTemplate.add(key, 
-                                                                           "isDevMachine".equals(key) ? 
+                                                                           IS_DEV_MACHINE_MACRO.equals(key) ? 
                                                                                Boolean.parseBoolean(value)
                                                                                : value));
             stringTemplate.add("serverName", portsToRefName.get(port));

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -165,11 +165,11 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
         
         if (isNullOrEmpty(cheDockerCustomExternalTemplate)) {
             return getExposedPortsToAddressPorts(renderingEvaluation.getExternalAddress(), ports, false);
-        } else {
-            return ports.keySet().stream()
+        }
+        
+        return ports.keySet().stream()
                 .collect(Collectors.toMap(portKey -> portKey,
                                           portKey -> renderingEvaluation.render(cheDockerCustomExternalTemplate, portKey)));
-        }
     }
 
 
@@ -281,13 +281,13 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
                     !isNullOrEmpty(gatewayAddressContainer) ?
                     gatewayAddressContainer :
                     this.internalHost;
-            } else {
-                return externalAddressProperty != null ?
+            }
+            
+            return externalAddressProperty != null ?
                     externalAddressProperty :
                     internalAddressProperty != null ?
                     internalAddressProperty :
                     this.internalHost;
-            }
         }
     }
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -171,10 +171,10 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
         if (isNullOrEmpty(cheDockerCustomExternalTemplate)) {
             return getExposedPortsToAddressPorts(renderingEvaluation.getExternalAddress(), ports, false);
         }
-        
+
         return ports.keySet().stream()
-                .collect(Collectors.toMap(portKey -> portKey,
-                                          portKey -> renderingEvaluation.render(cheDockerCustomExternalTemplate, portKey)));
+                  .collect(Collectors.toMap(portKey -> portKey,
+                                            portKey -> renderingEvaluation.render(cheDockerCustomExternalTemplate, portKey)));
     }
 
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -179,8 +179,8 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
         }
 
         return ports.keySet().stream()
-                  .collect(Collectors.toMap(portKey -> portKey,
-                                            portKey -> renderingEvaluation.render(cheDockerCustomExternalTemplate, portKey)));
+                    .collect(Collectors.toMap(portKey -> portKey,
+                                              portKey -> renderingEvaluation.render(cheDockerCustomExternalTemplate, portKey)));
     }
 
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -392,6 +392,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
             globalPropertiesMap.put("externalAddress", externalAddress);
             globalPropertiesMap.put("externalIP", externalIP);
             globalPropertiesMap.put("workspaceId", getWorkspaceId());
+            globalPropertiesMap.put("workspaceIdWithoutPrefix", getWorkspaceId().replaceFirst("workspace",""));
             globalPropertiesMap.put("machineName", getMachineName());
             globalPropertiesMap.put("wildcardNipDomain", getWildcardNipDomain(externalAddress));
             globalPropertiesMap.put("wildcardXipDomain", getWildcardXipDomain(externalAddress));

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -58,6 +58,11 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
     public static final String CHE_MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=";
 
     /**
+     * Name of the property to get the property that indicates if the machine is the dev machine
+     */
+    public static final String CHE_IS_DEV_MACHINE_PROPERTY = "CHE_IS_DEV_MACHINE=";
+
+    /**
      * Used to store the address set by property {@code che.docker.ip}, if applicable.
      */
     protected String internalAddressProperty;
@@ -397,6 +402,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
             globalPropertiesMap.put("wildcardNipDomain", getWildcardNipDomain(externalAddress));
             globalPropertiesMap.put("wildcardXipDomain", getWildcardXipDomain(externalAddress));
             globalPropertiesMap.put("chePort", chePort);
+            globalPropertiesMap.put("isDevMachine", getIsDevMachine());
         }
 
         /**
@@ -409,9 +415,23 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
                 this.initialized = true;
             }
             ST stringTemplate = new ST(template);
-            globalPropertiesMap.forEach((key, value) -> stringTemplate.add(key, value));
+            globalPropertiesMap.forEach((key, value) -> stringTemplate.add(key, 
+                                                                           "isDevMachine".equals(key) ? 
+                                                                               Boolean.parseBoolean(value)
+                                                                               : value));
             stringTemplate.add("serverName", portsToRefName.get(port));
             return stringTemplate.render();
+        }
+
+        /**
+         * returns if the current machine is the dev machine
+         *
+         * @return true if the curent machine is the dev machine
+         */
+        protected String getIsDevMachine() {
+            return Arrays.stream(env).filter(env -> env.startsWith(CHE_IS_DEV_MACHINE_PROPERTY))
+                         .map(s -> s.substring(CHE_IS_DEV_MACHINE_PROPERTY.length()))
+                         .findFirst().get();
         }
 
         /**

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -173,7 +173,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
 
         // get current ports
         Map<String, List<PortBinding>> ports = containerInfo.getNetworkSettings().getPorts();
-        
+
         if (isNullOrEmpty(cheDockerCustomExternalTemplate)) {
             return getExposedPortsToAddressPorts(renderingEvaluation.getExternalAddress(), ports, false);
         }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -114,14 +114,14 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
     /**
      * Constructor to be called by derived strategies
      */
-    public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
-                                          @Nullable @Named("che.docker.ip.external") String externalAddress,
+    public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String cheDockerIp,
+                                          @Nullable @Named("che.docker.ip.external") String cheDockerIpExternal,
                                           @Nullable @Named("che.docker.server_evaluation_strategy.custom.template") String cheDockerCustomExternalTemplate,
                                           @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.protocol") String cheDockerCustomExternalProtocol,
                                           @Named("che.port") String chePort,
                                           boolean useContainerAddress) {
-        this.internalAddressProperty = internalAddress;
-        this.externalAddressProperty = externalAddress;
+        this.internalAddressProperty = cheDockerIp;
+        this.externalAddressProperty = cheDockerIpExternal;
         this.chePort = chePort;
         this.cheDockerCustomExternalTemplate = cheDockerCustomExternalTemplate;
         this.cheDockerCustomExternalProtocol = cheDockerCustomExternalProtocol;

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -383,7 +383,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
             // add to this map only port without a known ref name
             Map<String, String> portsToUnkownRefName =
                     exposedPorts.stream().filter((port) -> !portsToKnownRefName.containsKey(port))
-                                .collect(Collectors.toMap(p -> p, p -> "Server-" + p.replace('/', '-')));
+                                .collect(Collectors.toMap(p -> p, p -> "server-" + p.replace('/', '-')));
 
             // list of all ports with refName (known/unknown)
             this.portsToRefName = new HashMap(portsToKnownRefName);

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -159,7 +159,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
 
         // create Rendering evaluation
         RenderingEvaluation renderingEvaluation = getOnlineRenderingEvaluation(containerInfo, internalHost);
-        
+
         // get current ports
         Map<String, List<PortBinding>> ports = containerInfo.getNetworkSettings().getPorts();
         

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -65,12 +65,12 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
     /**
      * Used to store the address set by property {@code che.docker.ip}, if applicable.
      */
-    protected String internalAddressProperty;
+    protected String cheDockerIp;
 
     /**
      * Used to store the address set by property {@code che.docker.ip.external}. if applicable.
      */
-    protected String externalAddressProperty;
+    protected String cheDockerIpExternal;
 
     /**
      * The current port of che.
@@ -120,8 +120,8 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
                                           @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.protocol") String cheDockerCustomExternalProtocol,
                                           @Named("che.port") String chePort,
                                           boolean useContainerAddress) {
-        this.internalAddressProperty = cheDockerIp;
-        this.externalAddressProperty = cheDockerIpExternal;
+        this.cheDockerIp = cheDockerIp;
+        this.cheDockerIpExternal = cheDockerIpExternal;
         this.chePort = chePort;
         this.cheDockerCustomExternalTemplate = cheDockerCustomExternalTemplate;
         this.cheDockerCustomExternalProtocol = cheDockerCustomExternalProtocol;
@@ -140,8 +140,8 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
                 internalHost;
         } else {
             internalAddress =
-                internalAddressProperty != null ?
-                internalAddressProperty :
+                cheDockerIp != null ?
+                cheDockerIp :
                 internalHost;
         }
         
@@ -276,17 +276,17 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
         @Override
         public String getExternalAddress() {
             if (useContainerAddress) {
-                return externalAddressProperty != null ?
-                    externalAddressProperty :
+                return cheDockerIpExternal != null ?
+                    cheDockerIpExternal :
                     !isNullOrEmpty(gatewayAddressContainer) ?
                     gatewayAddressContainer :
                     this.internalHost;
             }
             
-            return externalAddressProperty != null ?
-                    externalAddressProperty :
-                    internalAddressProperty != null ?
-                    internalAddressProperty :
+            return cheDockerIpExternal != null ?
+                    cheDockerIpExternal :
+                    cheDockerIp != null ?
+                    cheDockerIp :
                     this.internalHost;
         }
     }
@@ -383,8 +383,8 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
          * Gets default external address.
          */
         public String getExternalAddress() {
-            return externalAddressProperty != null ?
-                   externalAddressProperty : internalAddressProperty;
+            return cheDockerIpExternal != null ?
+                   cheDockerIpExternal : cheDockerIp;
         }
 
         /**
@@ -393,7 +393,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
         protected void populateGlobalProperties() {
             String externalAddress = getExternalAddress();
             String externalIP = getExternalIp(externalAddress);
-            globalPropertiesMap.put("internalIp", internalAddressProperty);
+            globalPropertiesMap.put("internalIp", cheDockerIp);
             globalPropertiesMap.put("externalAddress", externalAddress);
             globalPropertiesMap.put("externalIP", externalIP);
             globalPropertiesMap.put("workspaceId", getWorkspaceId());

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -103,12 +103,12 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
      * Default constructor
      */
     @Inject
-    public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
-                                          @Nullable @Named("che.docker.ip.external") String externalAddress,
+    public CustomServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String cheDockerIp,
+                                          @Nullable @Named("che.docker.ip.external") String cheDockerIpExternal,
                                           @Nullable @Named("che.docker.server_evaluation_strategy.custom.template") String cheDockerCustomExternalTemplate,
                                           @Nullable @Named("che.docker.server_evaluation_strategy.custom.external.protocol") String cheDockerCustomExternalProtocol,
                                           @Named("che.port") String chePort) {
-        this(internalAddress, externalAddress, cheDockerCustomExternalTemplate, cheDockerCustomExternalProtocol, chePort, false);
+        this(cheDockerIp, cheDockerIpExternal, cheDockerCustomExternalTemplate, cheDockerCustomExternalProtocol, chePort, false);
     }
 
     /**
@@ -130,9 +130,9 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
 
     @Override
     protected Map<String, String> getInternalAddressesAndPorts(ContainerInfo containerInfo, String internalHost) {
-        String internalAddressContainer = containerInfo.getNetworkSettings().getIpAddress();
+        final String internalAddressContainer = containerInfo.getNetworkSettings().getIpAddress();
         
-        String internalAddress;
+        final String internalAddress;
         
         if (useContainerAddress) {
             internalAddress = !isNullOrEmpty(internalAddressContainer) ?

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategy.java
@@ -63,6 +63,11 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
     public static final String CHE_IS_DEV_MACHINE_PROPERTY = "CHE_IS_DEV_MACHINE=";
 
     /**
+     * Prefix added in front of the generated name to build the workspaceId
+     */
+    public static final String CHE_WORKSPACE_ID_PREFIX = "workspace";
+
+    /**
      * Used to store the address set by property {@code che.docker.ip}, if applicable.
      */
     protected String cheDockerIp;
@@ -397,7 +402,7 @@ public class CustomServerEvaluationStrategy extends ServerEvaluationStrategy {
             globalPropertiesMap.put("externalAddress", externalAddress);
             globalPropertiesMap.put("externalIP", externalIP);
             globalPropertiesMap.put("workspaceId", getWorkspaceId());
-            globalPropertiesMap.put("workspaceIdWithoutPrefix", getWorkspaceId().replaceFirst("workspace",""));
+            globalPropertiesMap.put("workspaceIdWithoutPrefix", getWorkspaceId().replaceFirst(CHE_WORKSPACE_ID_PREFIX,""));
             globalPropertiesMap.put("machineName", getMachineName());
             globalPropertiesMap.put("wildcardNipDomain", getWildcardNipDomain(externalAddress));
             globalPropertiesMap.put("wildcardXipDomain", getWildcardXipDomain(externalAddress));

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategy.java
@@ -56,7 +56,7 @@ public class DefaultServerEvaluationStrategy extends ServerEvaluationStrategy {
                                  internalAddressProperty :
                                  internalHost;
 
-        return getExposedPortsToAddressPorts(internalAddress, containerInfo.getNetworkSettings().getPorts());
+        return getExposedPortsToAddressPorts(internalAddress, containerInfo.getNetworkSettings().getPorts(), false);
     }
 
     @Override
@@ -68,7 +68,7 @@ public class DefaultServerEvaluationStrategy extends ServerEvaluationStrategy {
                                  internalAddressProperty :
                                  internalHost;
 
-        return super.getExposedPortsToAddressPorts(externalAddress, containerInfo.getNetworkSettings().getPorts());
+        return super.getExposedPortsToAddressPorts(externalAddress, containerInfo.getNetworkSettings().getPorts(), false);
     }
 
     @Override

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DefaultServerEvaluationStrategy.java
@@ -31,48 +31,11 @@ import java.util.Map;
  * @author Alexander Garagatyi
  * @see ServerEvaluationStrategy
  */
-public class DefaultServerEvaluationStrategy extends ServerEvaluationStrategy {
-
-    /**
-     * Used to store the address set by property {@code che.docker.ip}, if applicable.
-     */
-    protected String internalAddressProperty;
-
-    /**
-     * Used to store the address set by property {@code che.docker.ip.external}. if applicable.
-     */
-    protected String externalAddressProperty;
+public class DefaultServerEvaluationStrategy extends CustomServerEvaluationStrategy {
 
     @Inject
     public DefaultServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
                                            @Nullable @Named("che.docker.ip.external") String externalAddress) {
-        this.internalAddressProperty = internalAddress;
-        this.externalAddressProperty = externalAddress;
-    }
-
-    @Override
-    protected Map<String, String> getInternalAddressesAndPorts(ContainerInfo containerInfo, String internalHost) {
-        String internalAddress = internalAddressProperty != null ?
-                                 internalAddressProperty :
-                                 internalHost;
-
-        return getExposedPortsToAddressPorts(internalAddress, containerInfo.getNetworkSettings().getPorts(), false);
-    }
-
-    @Override
-    protected Map<String, String> getExternalAddressesAndPorts(ContainerInfo containerInfo,
-                                                               String internalHost) {
-        String externalAddress = externalAddressProperty != null ?
-                                 externalAddressProperty :
-                                 internalAddressProperty != null ?
-                                 internalAddressProperty :
-                                 internalHost;
-
-        return super.getExposedPortsToAddressPorts(externalAddress, containerInfo.getNetworkSettings().getPorts(), false);
-    }
-
-    @Override
-    protected boolean useHttpsForExternalUrls() {
-        return false;
+        super(internalAddress, externalAddress, null, null, null, false);
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceRuntimeInfo.java
@@ -69,6 +69,11 @@ public class DockerInstanceRuntimeInfo implements MachineRuntimeInfo {
     public static final String CHE_MACHINE_NAME = "CHE_MACHINE_NAME";
 
     /**
+     * Environment variable that will contain Name of the machine
+     */
+    public static final String CHE_IS_DEV_MACHINE = "CHE_IS_DEV_MACHINE";
+    
+    /**
      * Default HOSTNAME that will be added in all docker containers that are started. This host will container the Docker host's ip
      * reachable inside the container.
      */

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
@@ -36,60 +36,11 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  * @author Angel Misevski <amisevsk@redhat.com>
  * @see ServerEvaluationStrategy
  */
-public class LocalDockerServerEvaluationStrategy extends ServerEvaluationStrategy {
-
-    /**
-     * Used to store the address set by property {@code che.docker.ip}, if applicable.
-     */
-    protected String internalAddressProperty;
-
-    /**
-     * Used to store the address set by property {@code che.docker.ip.external}. if applicable.
-     */
-    protected String externalAddressProperty;
+public class LocalDockerServerEvaluationStrategy extends CustomServerEvaluationStrategy {
 
     @Inject
     public LocalDockerServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
                                                @Nullable @Named("che.docker.ip.external") String externalAddress) {
-        this.internalAddressProperty = internalAddress;
-        this.externalAddressProperty = externalAddress;
+        super(internalAddress, externalAddress, null, null, null, true);
     }
-
-    @Override
-    protected Map<String, String> getInternalAddressesAndPorts(ContainerInfo containerInfo, String internalHost) {
-        String internalAddressContainer = containerInfo.getNetworkSettings().getIpAddress();
-
-        String internalAddress;
-        boolean useExposedPorts = true;
-        if (!isNullOrEmpty(internalAddressContainer)) {
-            internalAddress = internalAddressContainer;
-        } else {
-            internalAddress = internalHost;
-            useExposedPorts = false;
-        }
-
-        return getExposedPortsToAddressPorts(internalAddress, containerInfo.getNetworkSettings().getPorts(), useExposedPorts);
-    }
-
-    @Override
-    protected Map<String, String> getExternalAddressesAndPorts(ContainerInfo containerInfo,
-                                                               String internalHost) {
-        String cheExternalAddress = getCheExternalAddress(containerInfo, internalHost);
-        return getExposedPortsToAddressPorts(cheExternalAddress, containerInfo.getNetworkSettings().getPorts(), false);
-    }
-
-    protected String getCheExternalAddress(ContainerInfo containerInfo, String internalHost) {
-        String externalAddressContainer = containerInfo.getNetworkSettings().getGateway();
-        return externalAddressProperty != null ?
-                externalAddressProperty :
-                !isNullOrEmpty(externalAddressContainer) ?
-                        externalAddressContainer :
-                        internalHost;
-    }
-
-    @Override
-    protected boolean useHttpsForExternalUrls() {
-        return false;
-    }
-
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
@@ -68,26 +68,14 @@ public class LocalDockerServerEvaluationStrategy extends ServerEvaluationStrateg
             useExposedPorts = false;
         }
 
-        Map<String, List<PortBinding>> portBindings = containerInfo.getNetworkSettings().getPorts();
-
-        Map<String, String> addressesAndPorts = new HashMap<>();
-        for (Map.Entry<String, List<PortBinding>> portEntry : portBindings.entrySet()) {
-            String exposedPort = portEntry.getKey().split("/")[0];
-            String ephemeralPort = portEntry.getValue().get(0).getHostPort();
-            if (useExposedPorts) {
-                addressesAndPorts.put(portEntry.getKey(), internalAddress + ":" + exposedPort);
-            } else {
-                addressesAndPorts.put(portEntry.getKey(), internalAddress + ":" + ephemeralPort);
-            }
-        }
-        return addressesAndPorts;
+        return getExposedPortsToAddressPorts(internalAddress, containerInfo.getNetworkSettings().getPorts(), useExposedPorts);
     }
 
     @Override
     protected Map<String, String> getExternalAddressesAndPorts(ContainerInfo containerInfo,
                                                                String internalHost) {
         String cheExternalAddress = getCheExternalAddress(containerInfo, internalHost);
-        return getExposedPortsToAddressPorts(cheExternalAddress, containerInfo.getNetworkSettings().getPorts());
+        return getExposedPortsToAddressPorts(cheExternalAddress, containerInfo.getNetworkSettings().getPorts(), false);
     }
 
     protected String getCheExternalAddress(ContainerInfo containerInfo, String internalHost) {

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
@@ -10,19 +10,14 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.machine;
 
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
+import java.util.Map;
 
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
-import org.eclipse.che.plugin.docker.client.json.PortBinding;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 /**
  * Represents a server evaluation strategy for the configuration where the workspace server and

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategy.java
@@ -10,14 +10,14 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.docker.machine;
 
-import java.util.Map;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
 
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
+import java.util.Map;
 
 /**
  * Represents a server evaluation strategy for the configuration where the workspace server and

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
@@ -11,19 +11,11 @@
 
 package org.eclipse.che.plugin.docker.machine;
 
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
-import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
-import org.eclipse.che.plugin.docker.client.json.PortBinding;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 
 /**
@@ -48,6 +40,6 @@ public class LocalDockerSinglePortServerEvaluationStrategy extends CustomServerE
                                                          @Nullable @Named("che.docker.ip.external") String externalAddress,
                                                          @Named("che.docker.server_evaluation_strategy.secure.external.urls") boolean secureExternalUrls
                                                          ) {
-        super(internalAddress, externalAddress, "<serverName>-<workspaceIdWithoutPrefix>-<externalAddress>", secureExternalUrls ? "https" : "http", null, true);
+        super(internalAddress, externalAddress, "<serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<externalAddress>", secureExternalUrls ? "https" : "http", null, true);
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
@@ -41,57 +41,13 @@ import java.util.stream.Stream;
  * @author Mario Loriedo <mloriedo@redhat.com>
  * @see ServerEvaluationStrategy
  */
-public class LocalDockerSinglePortServerEvaluationStrategy extends LocalDockerServerEvaluationStrategy {
-
-    private static final String CHE_WORKSPACE_ID_ENV_VAR = "CHE_WORKSPACE_ID";
-
-    private boolean secureExternalUrls;
+public class LocalDockerSinglePortServerEvaluationStrategy extends CustomServerEvaluationStrategy {
 
     @Inject
     public LocalDockerSinglePortServerEvaluationStrategy(@Nullable @Named("che.docker.ip") String internalAddress,
                                                          @Nullable @Named("che.docker.ip.external") String externalAddress,
-                                                         @Named("che.docker.server_evaluation_strategy.secure.external.urls") boolean secureExternalUrls) {
-        super(internalAddress, externalAddress);
-        this.secureExternalUrls = secureExternalUrls;
-    }
-
-    @Override
-    protected boolean useHttpsForExternalUrls() {
-        return this.secureExternalUrls;
-    }
-
-    @Override
-    protected Map<String, String> getExternalAddressesAndPorts(ContainerInfo containerInfo,
-                                                               String internalHost) {
-        String cheExternalAddress = getCheExternalAddress(containerInfo, internalHost);
-        String workspaceID        = getWorkspaceID(containerInfo.getConfig().getEnv());
-        Map<String, String> labels= containerInfo.getConfig().getLabels();
-
-        Map<String, List<PortBinding>> portBindings = containerInfo.getNetworkSettings().getPorts();
-        Map<String, String> addressesAndPorts = new HashMap<>();
-        for (String serverKey : portBindings.keySet()) {
-            String serverName = getWorkspaceServerName(labels, serverKey);
-            String serverURL = serverName + "-" + workspaceID + "-" + cheExternalAddress;
-            addressesAndPorts.put(serverKey, serverURL);
-        }
-
-        return addressesAndPorts;
-    }
-
-    private String getWorkspaceServerName(Map<String, String> labels, String portKey) {
-        ServerConfImpl serverConf = getServerConfImpl(portKey, labels, new HashMap<>());
-        if (serverConf == null) {
-            return "server-" + portKey.split("/",2)[0];
-        }
-        return serverConf.getRef();
-    }
-
-    private String getWorkspaceID(String[] env) {
-        Stream<String> envStream = Arrays.stream(env);
-        return envStream.filter(v -> v.startsWith(CHE_WORKSPACE_ID_ENV_VAR) && v.contains("=")).
-                                         map(v -> v.split("=",2)[1]).
-                                         findFirst().
-                                         orElse("unknown-ws").
-                                         replaceFirst("workspace","");
+                                                         @Named("che.docker.server_evaluation_strategy.secure.external.urls") boolean secureExternalUrls
+                                                         ) {
+        super(internalAddress, externalAddress, "<serverName>-<workspaceId>-<externalAddress>", secureExternalUrls ? "https" : "http", null, true);
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
@@ -48,6 +48,6 @@ public class LocalDockerSinglePortServerEvaluationStrategy extends CustomServerE
                                                          @Nullable @Named("che.docker.ip.external") String externalAddress,
                                                          @Named("che.docker.server_evaluation_strategy.secure.external.urls") boolean secureExternalUrls
                                                          ) {
-        super(internalAddress, externalAddress, "<serverName>-<workspaceId>-<externalAddress>", secureExternalUrls ? "https" : "http", null, true);
+        super(internalAddress, externalAddress, "<serverName>-<workspaceIdWithoutPrefix>-<externalAddress>", secureExternalUrls ? "https" : "http", null, true);
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategy.java
@@ -11,11 +11,11 @@
 
 package org.eclipse.che.plugin.docker.machine;
 
-import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
-import org.eclipse.che.commons.annotation.Nullable;
-
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+
+import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.commons.annotation.Nullable;
 
 
 /**

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -666,6 +666,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
         // register workspace ID and Machine Name
         env.put(DockerInstanceRuntimeInfo.CHE_WORKSPACE_ID, workspaceId);
         env.put(DockerInstanceRuntimeInfo.CHE_MACHINE_NAME, machineName);
+        env.put(DockerInstanceRuntimeInfo.CHE_IS_DEV_MACHINE, Boolean.toString(isDev));
 
         composeService.getExpose().addAll(portsToExpose);
         composeService.getEnvironment().putAll(env);

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
@@ -240,17 +240,24 @@ public abstract class ServerEvaluationStrategy {
      *     "9090/udp" : "my-host.com:32722"
      * }
      * }</pre>
+     * 
      */
-    protected Map<String, String> getExposedPortsToAddressPorts(String address, Map<String, List<PortBinding>> ports) {
+    protected Map<String, String> getExposedPortsToAddressPorts(String address, Map<String, List<PortBinding>> ports, boolean useExposedPorts) {
         Map<String, String> addressesAndPorts = new HashMap<>();
         for (Map.Entry<String, List<PortBinding>> portEntry : ports.entrySet()) {
+            String exposedPort = portEntry.getKey().split("/")[0];
             // there is one value always
-            String port = portEntry.getValue().get(0).getHostPort();
-            addressesAndPorts.put(portEntry.getKey(), address + ":" + port);
+            String ephemeralPort = portEntry.getValue().get(0).getHostPort();
+            if (useExposedPorts) {
+                addressesAndPorts.put(portEntry.getKey(), address + ":" + exposedPort);
+            } else {
+                addressesAndPorts.put(portEntry.getKey(), address + ":" + ephemeralPort);
+            }
         }
         return addressesAndPorts;
     }
 
+    
     /**
      * @param protocolForInternalUrl
      * @return https, if {@link #useHttpsForExternalUrls()} method in sub-class returns true and protocol for internal Url is http

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
@@ -257,6 +257,10 @@ public abstract class ServerEvaluationStrategy {
         return addressesAndPorts;
     }
 
+    protected Map<String, String> getExposedPortsToAddressPorts(String address, Map<String, List<PortBinding>> ports) {
+        return getExposedPortsToAddressPorts(address, ports, false);
+    }
+
     
     /**
      * @param protocolForInternalUrl

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategy.java
@@ -45,7 +45,10 @@ public abstract class ServerEvaluationStrategy {
     /**
      * @return true if <strong>external</strong> addresses need to be exposed against https, false otherwise
      */
-    protected abstract boolean useHttpsForExternalUrls();
+    protected boolean useHttpsForExternalUrls() {
+        return false;
+    }
+    
 
     /**
      * Gets a map of all <strong>internal</strong> addresses exposed by the container in the form of

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.che.plugin.docker.machine.CustomServerEvaluationStrategy.CHE_WORKSPACE_ID_PREFIX;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,7 +44,7 @@ public class CustomServerEvaluationStrategyTest {
 
     private static final String ALL_IP_ADDRESS = "0.0.0.0";
 
-    private static final String WORKSPACE_ID_VALUE    = "work123";
+    private static final String WORKSPACE_ID_VALUE    = "workspaceABCDEFG";
     private static final String WORKSPACE_ID_PROPERTY = "CHE_WORKSPACE_ID=" + WORKSPACE_ID_VALUE;
 
     private static final String MACHINE_NAME_VALUE    = "myMachine";
@@ -129,6 +130,34 @@ public class CustomServerEvaluationStrategyTest {
         Assert.assertEquals(portMapping.get("4401/tcp"), WORKSPACE_ID_VALUE);
     }
 
+    /**
+     * Check workspace Id without prefix template
+     */
+    @Test
+    public void testWorkspaceIdWithoutPrefixRule() throws Throwable {
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1", "<workspaceIdWithoutPrefix>", "http", "8080");
+
+        Map<String, String> portMapping = this.customServerEvaluationStrategy.getExternalAddressesAndPorts(containerInfo, "localhost");
+
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        Assert.assertEquals(portMapping.get("4401/tcp"), WORKSPACE_ID_VALUE.replaceFirst(CHE_WORKSPACE_ID_PREFIX, ""));
+    }
+
+    /**
+     * Check the isDevMachine macro in template
+     */
+    @Test
+    public void testIsDevMachine() throws Throwable {
+        this.customServerEvaluationStrategy =
+                new CustomServerEvaluationStrategy("10.0.0.1", "192.168.1.1",
+                                                   "<if(isDevMachine)><workspaceId><else><machineName><endif>", "http", "8080");
+
+        Map<String, String> portMapping = this.customServerEvaluationStrategy.getExternalAddressesAndPorts(containerInfo, "localhost");
+
+        Assert.assertTrue(portMapping.containsKey("4401/tcp"));
+        Assert.assertEquals(portMapping.get("4401/tcp"), WORKSPACE_ID_VALUE);
+    }
 
     /**
      * Check workspace Id template

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/CustomServerEvaluationStrategyTest.java
@@ -49,6 +49,9 @@ public class CustomServerEvaluationStrategyTest {
     private static final String MACHINE_NAME_VALUE    = "myMachine";
     private static final String MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=" + MACHINE_NAME_VALUE;
 
+    private static final String IS_DEV_MACHINE_VALUE    = "true";
+    private static final String IS_DEV_MACHINE_PROPERTY = "CHE_IS_DEV_MACHINE=" + IS_DEV_MACHINE_VALUE;
+
     @Mock
     private ContainerConfig containerConfig;
 
@@ -76,7 +79,7 @@ public class CustomServerEvaluationStrategyTest {
         when(containerConfig.getLabels()).thenReturn(containerLabels);
         when(containerConfig.getExposedPorts()).thenReturn(containerExposedPorts);
 
-        envContainerConfig = new String[]{WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY};
+        envContainerConfig = new String[]{WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY, IS_DEV_MACHINE_PROPERTY};
         when(containerConfig.getEnv()).thenReturn(envContainerConfig);
 
         when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
@@ -213,7 +216,7 @@ public class CustomServerEvaluationStrategyTest {
         exposedPorts.add("4401/tcp");
         exposedPorts.add("4411/tcp");
         exposedPorts.add("8080/tcp");
-        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY);
+        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY, IS_DEV_MACHINE_PROPERTY);
         this.customServerEvaluationStrategy =
                 new CustomServerEvaluationStrategy("127.0.0.1", null, "<externalAddress>-<workspaceId>", "https", "8080");
         CustomServerEvaluationStrategy.RenderingEvaluation renderingEvaluation = this.customServerEvaluationStrategy
@@ -233,7 +236,7 @@ public class CustomServerEvaluationStrategyTest {
         exposedPorts.add("4401/tcp");
         exposedPorts.add("4411/tcp");
         exposedPorts.add("8080/tcp");
-        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY);
+        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY, IS_DEV_MACHINE_PROPERTY);
         this.customServerEvaluationStrategy =
                 new CustomServerEvaluationStrategy("127.0.0.1", "127.0.0.1", "<externalAddress>-<workspaceId>", "https", "8080");
         CustomServerEvaluationStrategy.RenderingEvaluation renderingEvaluation = this.customServerEvaluationStrategy
@@ -253,7 +256,7 @@ public class CustomServerEvaluationStrategyTest {
         exposedPorts.add("4401/tcp");
         exposedPorts.add("4411/tcp");
         exposedPorts.add("8080/tcp");
-        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY);
+        List<String> env = Arrays.asList(WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY, IS_DEV_MACHINE_PROPERTY);
         this.customServerEvaluationStrategy =
                 new CustomServerEvaluationStrategy("127.0.0.1", "300.300.300.300", "<externalAddress>-<workspaceId>", "https", "8080");
         CustomServerEvaluationStrategy.RenderingEvaluation renderingEvaluation = this.customServerEvaluationStrategy

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategyTest.java
@@ -210,7 +210,7 @@ public class LocalDockerServerEvaluationStrategyTest {
                                                                     serverConfs);
 
         // then
-        assertEquals(servers, expectedServers);
+        assertEquals(servers.toString(), expectedServers.toString());
     }
 
     private Map<String, ServerImpl> getExpectedServers(String externalAddress,

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerServerEvaluationStrategyTest.java
@@ -210,7 +210,7 @@ public class LocalDockerServerEvaluationStrategyTest {
                                                                     serverConfs);
 
         // then
-        assertEquals(servers.toString(), expectedServers.toString());
+        assertEquals(servers, expectedServers);
     }
 
     private Map<String, ServerImpl> getExpectedServers(String externalAddress,

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategyTest.java
@@ -40,6 +40,13 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
     private static final String CONTAINERCONFIG_HOSTNAME = "che-ws-y6jwknht0efzczit-4086112300-fm0aj";
     private static final String WORKSPACE_ID             = "79rfwhqaztq2ru2k";
 
+    private static final String WORKSPACE_ID_VALUE    = WORKSPACE_ID;
+    private static final String WORKSPACE_ID_PROPERTY = "CHE_WORKSPACE_ID=" + WORKSPACE_ID_VALUE;
+
+    private static final String MACHINE_NAME_VALUE    = "myMachine";
+    private static final String MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=" + MACHINE_NAME_VALUE;
+
+    
     @Mock
     private ContainerInfo   containerInfo;
     @Mock
@@ -56,6 +63,9 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
     private Map<String, String> labels;
 
     private String[] env;
+    
+    private String[] envContainerConfig;
+    
 
     @BeforeMethod
     public void setUp() {
@@ -83,6 +93,10 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
         when(containerConfig.getHostname()).thenReturn(CONTAINERCONFIG_HOSTNAME);
         when(containerConfig.getEnv()).thenReturn(env);
         when(containerConfig.getLabels()).thenReturn(labels);
+        
+        envContainerConfig = new String[]{WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY};
+        when(containerConfig.getEnv()).thenReturn(envContainerConfig);
+
     }
 
     /**
@@ -92,7 +106,7 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
     @Test
     public void shouldUseServerRefToBuildAddressWhenAvailable() throws Exception {
         // given
-        strategy = new LocalDockerSinglePortServerEvaluationStrategy(null, null, false);
+        strategy = new LocalDockerSinglePortServerEvaluationStrategy(null, null, false).withThrowOnUnknownHost(false);
 
         final Map<String, ServerImpl> expectedServers = getExpectedServers(CHE_DOCKER_IP_EXTERNAL,
                                                                            CONTAINERCONFIG_HOSTNAME,

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/LocalDockerSinglePortServerEvaluationStrategyTest.java
@@ -46,6 +46,8 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
     private static final String MACHINE_NAME_VALUE    = "myMachine";
     private static final String MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=" + MACHINE_NAME_VALUE;
 
+    private static final String IS_DEV_MACHINE_VALUE    = "true";
+    private static final String IS_DEV_MACHINE_PROPERTY = "CHE_IS_DEV_MACHINE=" + IS_DEV_MACHINE_VALUE;
     
     @Mock
     private ContainerInfo   containerInfo;
@@ -94,7 +96,7 @@ public class LocalDockerSinglePortServerEvaluationStrategyTest {
         when(containerConfig.getEnv()).thenReturn(env);
         when(containerConfig.getLabels()).thenReturn(labels);
         
-        envContainerConfig = new String[]{WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY};
+        envContainerConfig = new String[]{WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY, IS_DEV_MACHINE_PROPERTY};
         when(containerConfig.getEnv()).thenReturn(envContainerConfig);
 
     }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/ServerEvaluationStrategyTest.java
@@ -83,7 +83,7 @@ public class ServerEvaluationStrategyTest {
         expected.put("9090/udp", DEFAULT_HOSTNAME + ":" + "32101");
 
         // when
-        Map<String, String> actual = strategy.getExposedPortsToAddressPorts(DEFAULT_HOSTNAME, ports);
+        Map<String, String> actual = strategy.getExposedPortsToAddressPorts(DEFAULT_HOSTNAME, ports, false);
 
         // then
         assertEquals(actual, expected);
@@ -108,7 +108,7 @@ public class ServerEvaluationStrategyTest {
         expected.put("9090/udp", DEFAULT_HOSTNAME + ":" + "32101");
 
         // when
-        Map<String, String> actual = strategy.getExposedPortsToAddressPorts(DEFAULT_HOSTNAME, ports);
+        Map<String, String> actual = strategy.getExposedPortsToAddressPorts(DEFAULT_HOSTNAME, ports, false);
 
         // then
         assertEquals(actual, expected);
@@ -375,7 +375,7 @@ public class ServerEvaluationStrategyTest {
                                                                          .withHostPort("32101")));
         when(networkSettings.getPorts()).thenReturn(ports);
         Map<String, String> exposedPortsToAddressPorts =
-                strategy.getExposedPortsToAddressPorts(DEFAULT_HOSTNAME, ports);
+                strategy.getExposedPortsToAddressPorts(DEFAULT_HOSTNAME, ports, false);
         when(strategy.getExternalAddressesAndPorts(containerInfo, DEFAULT_HOSTNAME))
                 .thenReturn(exposedPortsToAddressPorts);
         when(strategy.getInternalAddressesAndPorts(containerInfo, DEFAULT_HOSTNAME))


### PR DESCRIPTION
### What does this PR do?

This PR makes the `CustomServerEvaluationStrategy` the basis of all other strategies. This allows having the `LocalDockerSinglePortStrategy` simply use a custom template. 

For the moment the properties in `che.properties` are not changed, and other strategies extend the `custom` strategy with specific settings. So this change should have *no impact* on existing configurations / installations.

### What issues does this PR fix or reference?

https://issues.jboss.org/browse/CHE-277
