### PR TITLE
CHE-5092 Fix returning of runtime while it is starting

### DIFF
--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContext.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContext.java
@@ -20,7 +20,6 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.URLRewriter;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.eclipse.che.api.workspace.shared.Utils;
@@ -30,10 +29,7 @@ import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -59,7 +55,6 @@ public class DockerRuntimeContext extends RuntimeContext {
     private final DockerEnvironment    dockerEnvironment;
     private final URLRewriter          urlRewriter;
     private final List<String>         orderedServices;
-    private final StartSynchronizer    startSynchronizer;
     private final String               devMachineName;
     private final ContextsStorage      contextsStorage;
     private final SnapshotDao          snapshotDao;
@@ -93,7 +88,6 @@ public class DockerRuntimeContext extends RuntimeContext {
         this.snapshotDao = snapshotDao;
         this.dockerRegistryClient = dockerRegistryClient;
         this.eventService = eventService;
-        this.startSynchronizer = new StartSynchronizer();
     }
 
     @Override
@@ -118,64 +112,7 @@ public class DockerRuntimeContext extends RuntimeContext {
                                          serviceStarter,
                                          snapshotDao,
                                          dockerRegistryClient,
-                                         startSynchronizer,
                                          identity,
                                          eventService);
-    }
-
-
-    static class StartSynchronizer {
-        private Thread                     startThread;
-        private boolean                    stopCalled;
-        private Map<String, DockerMachine> machines;
-
-        public StartSynchronizer() {
-            this.stopCalled = false;
-            this.machines = new HashMap<>();
-        }
-
-        public synchronized Map<String, DockerMachine> getMachines() {
-            return Collections.unmodifiableMap(machines);
-        }
-
-        public synchronized void addMachine(String name, DockerMachine machine) throws InternalInfrastructureException {
-            if (machines != null) {
-                machines.put(name, machine);
-            } else {
-                throw new InternalInfrastructureException("Machines entities are missing");
-            }
-        }
-
-        public synchronized Map<String, DockerMachine> removeMachines() throws InfrastructureException {
-            if (machines != null) {
-                Map<String, DockerMachine> machines = this.machines;
-                // unset to identify error if method called second time
-                this.machines = null;
-                return machines;
-            }
-            throw new InfrastructureException("");
-        }
-
-        public synchronized void setStartThread() throws InternalInfrastructureException {
-            if (startThread != null) {
-                throw new InternalInfrastructureException("Docker infrastructure context of workspace already started");
-            }
-            startThread = Thread.currentThread();
-        }
-
-        public synchronized void interruptStartThread() throws InfrastructureException {
-            if (startThread == null) {
-                throw new InternalInfrastructureException("Stop of non started context not allowed");
-            }
-            if (stopCalled) {
-                throw new InternalInfrastructureException("Stop is called twice");
-            }
-            stopCalled = true;
-            startThread.interrupt();
-        }
-
-        public synchronized boolean isStopCalled() {
-            return stopCalled;
-        }
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -205,12 +205,6 @@ public class WorkspaceRuntimes {
                                         "' because its status is 'RUNNING'");
         }
 
-        eventService.publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
-                                       .withWorkspaceId(workspaceId)
-                                       .withStatus(WorkspaceStatus.STARTING)
-                                       .withEventType(EventType.STARTING)
-                                       .withPrevStatus(WorkspaceStatus.STOPPED));
-
         Subject subject = EnvironmentContext.getCurrent().getSubject();
         RuntimeIdentity runtimeId = new RuntimeIdentityImpl(workspaceId, envName, subject.getUserName());
         try {
@@ -223,6 +217,11 @@ public class WorkspaceRuntimes {
                         + RuntimeInfrastructure.class);
             }
             runtimes.put(workspaceId, runtime);
+            eventService.publish(DtoFactory.newDto(WorkspaceStatusEvent.class)
+                                           .withWorkspaceId(workspaceId)
+                                           .withStatus(WorkspaceStatus.STARTING)
+                                           .withEventType(EventType.STARTING)
+                                           .withPrevStatus(WorkspaceStatus.STOPPED));
             return CompletableFuture.runAsync(ThreadLocalPropagateContext.wrap(() -> {
                 try {
                     runtime.start(options);


### PR DESCRIPTION
### What does this PR do?
Moves StartSynchronizer to DockerInternalRuntimes because it is unused in DockerRuntimeContext.
Fixes destroying of a newly created machine when start is canceled.
Moves publishing of STARTING workspace event to a place where runtime is already ready.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5092