### PR TITLE
CHE-2242: Limit username length to 39 chars

### DIFF
--- a/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/spi/AccountValidator.java
+++ b/wsmaster/che-core-api-account/src/main/java/org/eclipse/che/account/spi/AccountValidator.java
@@ -69,11 +69,13 @@ public class AccountValidator {
     public String normalizeAccountName(String name, String prefix) throws ServerException {
         String normalized = ILLEGAL_ACCOUNT_NAME_CHARACTERS.matcher(name).replaceAll("");
         String candidate = normalized.isEmpty() ? NameGenerator.generate(prefix, 4) : normalized;
+        candidate = candidate.length() > 39 ? candidate.substring(0, 39) : candidate;
 
         int i = 1;
         try {
             while (accountExists(candidate)) {
-                candidate = normalized.isEmpty() ? NameGenerator.generate(prefix, 4) : normalized + String.valueOf(i++);
+                candidate = candidate.length() == 39 ? NameGenerator.generate(candidate.substring(0, 35), 4)
+                                                     : normalized + String.valueOf(i++);
             }
         } catch (ServerException e) {
             LOG.warn("Error occurred during account name normalization", e);

--- a/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/AccountValidatorTest.java
+++ b/wsmaster/che-core-api-account/src/test/java/org/eclipse/che/account/spi/AccountValidatorTest.java
@@ -20,8 +20,13 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests of {@link AccountValidator}.
@@ -32,6 +37,8 @@ import static org.mockito.Mockito.doThrow;
  */
 @Listeners(MockitoTestNGListener.class)
 public class AccountValidatorTest {
+
+    private final static String LONG_ACCOUNT_NAME = "accountNameThatContainsMoreThan39Characters";
 
     @Mock
     private AccountManager accountManager;
@@ -50,7 +57,22 @@ public class AccountValidatorTest {
     public void testNormalizeAccountNameWhenInputDoesNotContainAnyValidCharacter() throws Exception {
         doThrow(NotFoundException.class).when(accountManager).getByName(anyString());
 
-        Assert.assertTrue(accountValidator.normalizeAccountName("#", "name").startsWith("name"));
+        assertTrue(accountValidator.normalizeAccountName("#", "name").startsWith("name"));
+    }
+
+    @Test
+    public void shouldChangeLast4CharactersInAccountNameIfAccountNameContains39CharactersAndAccountAlreadyExists() throws Exception {
+        //given
+        String accountName = LONG_ACCOUNT_NAME.substring(0, 39);
+        doThrow(NotFoundException.class).when(accountManager).getByName(not(eq(accountName)));
+
+        //when
+        String normalizedAccountName = accountValidator.normalizeAccountName(accountName, "name");
+
+        //then
+        assertTrue(normalizedAccountName.length() == 39);
+        assertNotEquals(normalizedAccountName, accountName);
+        assertEquals(normalizedAccountName.substring(0, 35), accountName.substring(0, 35));
     }
 
     @Test(dataProvider = "namesToValidate")
@@ -62,39 +84,40 @@ public class AccountValidatorTest {
 
     @DataProvider
     public Object[][] namesToNormalize() {
-        return new Object[][] {{"test", "test"},
-                               {"test123", "test123"},
-                               {"test 123", "test123"},
-                               {"test@gmail.com", "testgmailcom"},
-                               {"TEST", "TEST"},
-                               {"test-", "test"},
-                               {"-test", "test"},
-                               {"te_st", "test"},
-                               {"te#st", "test"},
-                               {"-test", "test"},
-                               {"test-", "test"},
-                               {"--test--", "test"},
-                               {"t-----e--s-t", "t-e-s-t"}
+        return new Object[][]{{"test", "test"},
+                              {"test123", "test123"},
+                              {"test 123", "test123"},
+                              {"test@gmail.com", "testgmailcom"},
+                              {"TEST", "TEST"},
+                              {"test-", "test"},
+                              {"-test", "test"},
+                              {"te_st", "test"},
+                              {"te#st", "test"},
+                              {"-test", "test"},
+                              {"test-", "test"},
+                              {"--test--", "test"},
+                              {"t-----e--s-t", "t-e-s-t"},
+                              {"testTestTestTestTestTestTestTestTestTestTest", "testTestTestTestTestTestTestTestTestTes"}
         };
     }
 
     @DataProvider
     public Object[][] namesToValidate() {
-        return new Object[][] {{"test", true},
-                               {"t-e-s-t", true},
-                               {"test123", true},
-                               {"TEST", true},
-                               {"te-st", true},
-                               {"test 123", false},
-                               {"test@gmail.com", false},
-                               {"test-", false},
-                               {"-test", false},
-                               {"te_st", false},
-                               {"te#st", false},
-                               {"-test", false},
-                               {"test-", false},
-                               {"--test--", false},
-                               {"te--st", false}
+        return new Object[][]{{"test", true},
+                              {"t-e-s-t", true},
+                              {"test123", true},
+                              {"TEST", true},
+                              {"te-st", true},
+                              {"test 123", false},
+                              {"test@gmail.com", false},
+                              {"test-", false},
+                              {"-test", false},
+                              {"te_st", false},
+                              {"te#st", false},
+                              {"-test", false},
+                              {"test-", false},
+                              {"--test--", false},
+                              {"te--st", false}
         };
     }
 }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserValidator.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserValidator.java
@@ -54,6 +54,9 @@ public class UserValidator {
         if (isNullOrEmpty(user.getName())) {
             throw new BadRequestException("User name required");
         }
+        if (user.getName().length() > 39) {
+            throw new BadRequestException("Username should contain less then 39 characters");
+        }
         if (!isValidName(user.getName())) {
             throw new BadRequestException("Username may only contain alphanumeric characters or single hyphens inside");
         }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserValidator.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserValidator.java
@@ -55,7 +55,7 @@ public class UserValidator {
             throw new BadRequestException("User name required");
         }
         if (user.getName().length() > 39) {
-            throw new BadRequestException("Username should contain less then 39 characters");
+            throw new BadRequestException("Username should contain less than 39 characters");
         }
         if (!isValidName(user.getName())) {
             throw new BadRequestException("Username may only contain alphanumeric characters or single hyphens inside");

--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserValidatorTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserValidatorTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.api.user.server;
 
 import org.eclipse.che.account.spi.AccountValidator;
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.model.user.User;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -19,6 +21,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -30,6 +33,8 @@ import static org.testng.Assert.assertEquals;
  */
 @Listeners(MockitoTestNGListener.class)
 public class UserValidatorTest {
+
+    private final static String LONG_USERNAME = "usernameThatContainsMoreThan39Characters";
 
     @Mock
     private AccountValidator accountValidator;
@@ -59,5 +64,16 @@ public class UserValidatorTest {
 
         assertEquals(userNameValidator.isValidName("toTest"), false);
         verify(accountValidator).isValidName("toTest");
+    }
+
+    @Test(expectedExceptions = BadRequestException.class,
+          expectedExceptionsMessageRegExp = "Username should contain less then 39 characters")
+    public void shouldThrowExceptionIfUsernameIsLongerThan39Characters() throws Exception {
+        //given
+        User user = mock(User.class);
+        when(user.getName()).thenReturn(LONG_USERNAME);
+
+        //when
+        userNameValidator.checkUser(user);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Limit username length to 39 chars.
1. User is created with oauth:
-- automatically cut username to 39 chars 
-- if username wich consist of 39 charackters already exists, replace the last 4 chars with a random ones.

2. User is created by API
-- If username contains more than 39 chars return the error message: "Username should contain less then 39 chars.".

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2242

#### Changelog
Limit username length to 39 chars

#### Release Notes
N/A

#### Docs PR
N/A