### PR TITLE
CHE-4998: Update modification stamp on open and on update document.

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/ModificationTracker.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/ModificationTracker.java
@@ -30,4 +30,12 @@ public interface ModificationTracker {
      * @return modification tracker value
      */
     String getModificationStamp();
+
+    /**
+     * Update modification tracker value by content. Modification tracker is a value is changed by any modification of the content
+     * of the file.
+     *
+     * @param content actual file content
+     */
+    void updateModificationStamp(String content);
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
@@ -168,7 +168,7 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
         });
     }
 
-    private void updateContent(String newContent, String oldStamp, VirtualFile virtualFile) {
+    private void updateContent(String newContent, String eventModificationStamp, VirtualFile virtualFile) {
         final DocumentHandle documentHandle = getDocumentHandleFor(groupLeaderEditor);
         if (documentHandle == null) {
             return;
@@ -184,14 +184,14 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
         }
 
         final File file = (File)virtualFile;
-        final String newStamp = file.getModificationStamp();
+        final String currentStamp = file.getModificationStamp();
 
-        if (oldStamp == null && !Objects.equals(newContent, oldContent)) {
+        if (eventModificationStamp == null && !Objects.equals(newContent, oldContent)) {
             replaceContent(document, newContent, oldContent, cursorPosition);
             return;
         }
 
-        if (!Objects.equals(oldStamp, newStamp)) {
+        if (!Objects.equals(eventModificationStamp, currentStamp)) {
             replaceContent(document, newContent, oldContent, cursorPosition);
 
             notificationManager.notify("External operation", "File '" + file.getName() + "' is updated", SUCCESS, EMERGE_MODE);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/FileImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/FileImpl.java
@@ -110,7 +110,7 @@ class FileImpl extends ResourceImpl implements File {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> updateContent(String content) {
-        setModificationStamp(TextUtils.md5(content));
+        updateModificationStamp(content);
 
         return resourceManager.write(this, content);
     }
@@ -139,5 +139,10 @@ class FileImpl extends ResourceImpl implements File {
     @Override
     public String getModificationStamp() {
         return modificationStamp;
+    }
+
+    @Override
+    public void updateModificationStamp(String content) {
+        this.modificationStamp = TextUtils.md5(content);
     }
 }

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -12,6 +12,8 @@ package org.eclipse.che.ide.editor.orion.client;
 
 import com.google.web.bindery.event.shared.HandlerRegistration;
 
+import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.editor.orion.client.jso.ModelChangedEventOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionEditorOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionPixelPositionOverlay;
@@ -197,6 +199,7 @@ public class OrionDocument extends AbstractDocument {
 
     public void replace(int offset, int length, String text) {
         this.editorOverlay.getModel().setText(text, offset, offset + length);
+        updateModificationTimeStamp();
     }
 
     @Override
@@ -205,6 +208,14 @@ public class OrionDocument extends AbstractDocument {
         int lineStart = model.getLineStart(startLine);
         int lineEnd = model.getLineStart(endLine);
         editorOverlay.setText(text, lineStart + startChar, lineEnd + endChar);
+        updateModificationTimeStamp();
+    }
+
+    private void updateModificationTimeStamp() {
+        VirtualFile file = this.getFile();
+        if (file  instanceof File) {
+            ((File)file).updateModificationStamp(editorOverlay.getText());
+        }
     }
 
     public int getContentsCharCount() {

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -1014,7 +1014,13 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
             editorView.setEditorWidget(editorWidget);
 
             document = editorWidget.getDocument();
-            document.setFile(input.getFile());
+            final VirtualFile file = input.getFile();
+            document.setFile(file);
+
+            if (file instanceof File) {
+                ((File)file).updateModificationStamp(content);
+            }
+
             cursorModel = new OrionCursorModel(document);
 
             editorWidget.setTabSize(configuration.getTabWidth());
@@ -1031,7 +1037,7 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
             if (delayedFocus) {
                 editorWidget.refresh();
                 editorWidget.setFocus();
-                setSelection(new Selection<>(input.getFile()));
+                setSelection(new Selection<>(file));
                 delayedFocus = false;
             }
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
@@ -26,7 +26,6 @@ import org.eclipse.che.ide.api.event.ng.DeletedFilesController;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.resources.ExternalResourceDelta;
-import org.eclipse.che.ide.api.resources.ModificationTracker;
 import org.eclipse.che.ide.api.resources.ResourceDelta;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.ext.java.shared.dto.refactoring.ChangeInfo;
@@ -166,12 +165,6 @@ public class RefactoringUpdater {
 
     private void updateFileContent(VirtualFile virtualFile) {
         String path = virtualFile.getLocation().toString();
-
-        if (virtualFile instanceof ModificationTracker) {
-            String modificationStamp = ((ModificationTracker)virtualFile).getModificationStamp();
-            eventBus.fireEvent(new FileContentUpdateEvent(path, modificationStamp));
-            return;
-        }
 
         eventBus.fireEvent(new FileContentUpdateEvent(path));
     }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/event/detectors/EditorFileTracker.java
@@ -202,6 +202,7 @@ public class EditorFileTracker {
             @Override
             public void run() {
                 if (!Files.exists(FileWatcherUtils.toNormalPath(root.toPath(), it))) {
+                    hashRegistry.remove(path + endpointId);
                     FileStateUpdateDto params = newDto(FileStateUpdateDto.class).withPath(path).withType(DELETED);
                     transmitter.newRequest()
                                .endpointId(endpointId)


### PR DESCRIPTION
### What does this PR do?
Update modification stamp on open and on update document. When we get "FileContentUpdateEvent" before update file we check modification stamp, but this modification stamp is updating only after save file. When we get few FileContentUpdateEvent events in very short time (less than autosave 1 sec  timeout),  file modification stamp contains not updated modification stamp and we can get situation when we skip file changes, because modification stamp is not actual. So this pull request force update modification stamp in case update content of the editor and on open editor.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4998

#### Changelog
Update modification stamp on open and on update document. 
Fix refactor rename from 'Rename' window.

#### Release Notes
Update modification stamp on open and on update document. 
Fix refactor rename from 'Rename' window.

#### Docs PR
Don't need. It's a bug fix.
