### PR TITLE
CHE-5390: Fix bug when failed to commit renamed files

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/commit/CommitPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/commit/CommitPresenter.java
@@ -115,7 +115,7 @@ public class CommitPresenter implements CommitView.ActionDelegate {
         view.setEnableAmendCheckBox(true);
         view.setEnablePushAfterCommitCheckBox(true);
         view.setEnableRemoteBranchesDropDownLis(false);
-        service.diff(appContext.getDevMachine(), project.getLocation(), null, NAME_STATUS, false, 0, "HEAD", false)
+        service.diff(appContext.getDevMachine(), project.getLocation(), null, NAME_STATUS, true, 0, "HEAD", false)
                .then(diff -> {
                    service.log(appContext.getDevMachine(), project.getLocation(), null, -1, 1, false)
                           .then(arg -> {


### PR DESCRIPTION
### What does this PR do?
Change diff request paarmeter in Git commit presenter to recieve Git diff without renames.
This fixes bug when commiting renamed files.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/5390

#### Changelog
Fix bug when failed to commit renamed files

#### Release Notes
N/A

#### Docs PR
N/A