### PR TITLE
CHE-5333. Mark editor state as dirty after undo/redo operations

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/EditorWidget.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/EditorWidget.java
@@ -108,6 +108,9 @@ public interface EditorWidget extends IsWidget,
     /** Marks the editor as clean i.e change the dirty state to false. */
     void markClean();
 
+    /** Marks the editor as dirty i.e change the dirty state to true. */
+    void markDirty();
+
     /**
      * Returns the tab size (equivalent number of spaces).
      *

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/HandlesUndoRedo.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/HandlesUndoRedo.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.editor.texteditor;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Interface for an editor that allow undo/redo operations.
  */
@@ -48,4 +50,16 @@ public interface HandlesUndoRedo {
      * are considered to be individually undo-able.
      */
     void endCompoundChange();
+
+    /**
+     * Adds a listener for undo/redo operations. Has no effect if an identical listener is already registered.
+     *
+     * @param listener
+     *         undo/redo operations listener
+     */
+    void addUndoRedoOperationsListener(@NotNull UndoRedoOperationsListener listener);
+
+    interface UndoRedoOperationsListener {
+        void onOperationExecuted();
+    }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -167,6 +167,8 @@ public class StandardComponentInitializer {
     public static final String COPY                  = "copy";
     public static final String CUT                   = "cut";
     public static final String PASTE                 = "paste";
+    public static final String UNDO                  = "undo";
+    public static final String REDO                  = "redo";
     public static final String SWITCH_LEFT_TAB       = "switchLeftTab";
     public static final String SWITCH_RIGHT_TAB      = "switchRightTab";
     public static final String OPEN_RECENT_FILES     = "openRecentFiles";
@@ -628,10 +630,10 @@ public class StandardComponentInitializer {
 
         editGroup.add(saveAction);
 
-        actionManager.registerAction("undo", undoAction);
+        actionManager.registerAction(UNDO, undoAction);
         editGroup.add(undoAction);
 
-        actionManager.registerAction("redo", redoAction);
+        actionManager.registerAction(REDO, redoAction);
         editGroup.add(redoAction);
 
         actionManager.registerAction(SOFT_WRAP, softWrapAction);
@@ -842,6 +844,9 @@ public class StandardComponentInitializer {
         keyBinding.getGlobal().addKey(new KeyBuilder().shift().charCode(KeyCodeMap.F10).build(), SHOW_COMMANDS_PALETTE);
 
         keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('s').build(), SAVE);
+
+        keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('z').build(), UNDO);
+        keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('y').build(), REDO);
 
         if (UserAgent.isMac()) {
             keyBinding.getGlobal().addKey(new KeyBuilder().control().charCode('w').build(), CLOSE_ACTIVE_EDITOR);

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -1060,6 +1060,11 @@ public class OrionEditorPresenter extends AbstractEditorPresenter implements Tex
                     contextMenu.show(event.getNativeEvent().getClientX(), event.getNativeEvent().getClientY());
                 }
             }, ContextMenuEvent.getType());
+
+            getUndoRedo().addUndoRedoOperationsListener(() -> Scheduler.get().scheduleDeferred(() -> {
+                editorWidget.markDirty();
+                updateDirtyState(true);
+            }));
         }
     }
 

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorWidget.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorWidget.java
@@ -302,6 +302,11 @@ public class OrionEditorWidget extends Composite implements EditorWidget,
         this.editorOverlay.setDirty(false);
     }
 
+    @Override
+    public void markDirty() {
+        this.editorOverlay.setDirty(true);
+    }
+
     private void selectKeyMode(Keymap keymap) {
         resetKeyModes();
         Keymap usedKeymap = keymap;

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionUndoRedo.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionUndoRedo.java
@@ -23,6 +23,8 @@ class OrionUndoRedo implements HandlesUndoRedo {
     /** The document. */
     private final OrionUndoStackOverlay undoStack;
 
+    private UndoRedoOperationsListener undoRedoOperationsListener;
+
     public OrionUndoRedo(final OrionUndoStackOverlay undoStack) {
         this.undoStack = undoStack;
     }
@@ -40,11 +42,19 @@ class OrionUndoRedo implements HandlesUndoRedo {
     @Override
     public void redo() {
         this.undoStack.redo();
+
+        if (undoRedoOperationsListener != null) {
+            undoRedoOperationsListener.onOperationExecuted();
+        }
     }
 
     @Override
     public void undo() {
         this.undoStack.undo();
+
+        if (undoRedoOperationsListener != null) {
+            undoRedoOperationsListener.onOperationExecuted();
+        }
     }
 
     @Override
@@ -55,5 +65,10 @@ class OrionUndoRedo implements HandlesUndoRedo {
     @Override
     public void endCompoundChange() {
         this.undoStack.endCompoundChange();
+    }
+
+    @Override
+    public void addUndoRedoOperationsListener(UndoRedoOperationsListener listener) {
+        undoRedoOperationsListener = listener;
     }
 }


### PR DESCRIPTION
### What does this PR do?
We have incorrect dirty state for editor at undo/redo operations and it leads to some bugs related to unsaved data.
So we need to track these operations and set a corresponding dirty state for editor.

### What issues does this PR fix or reference?
#5333 

#### Changelog
Mark editor state as dirty after undo/redo operations

#### Release Notes
Mark editor state as dirty after undo/redo operations

#### Docs PR
Don't need. It's a bug fix.

Signed-off-by: Roman Nikitenko <rnikitenko@redhat.com>