### PR TITLE
CHE-274 - Improve idling implementation

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -171,7 +171,8 @@ public class WsMasterModule extends AbstractModule {
         bindConstant().annotatedWith(Names.named("machine.terminal_agent.run_command"))
                       .to("$HOME/che/terminal/che-websocket-terminal " +
                           "-addr :4411 " +
-                          "-cmd ${SHELL_INTERPRETER}");
+                          "-cmd ${SHELL_INTERPRETER} " +
+                          "-enable-activity-tracking");
         bindConstant().annotatedWith(Names.named("machine.exec_agent.run_command"))
                       .to("$HOME/che/exec-agent/che-exec-agent " +
                           "-addr :4412 " +
@@ -184,6 +185,7 @@ public class WsMasterModule extends AbstractModule {
                 Multibinder.newSetBinder(binder(), org.eclipse.che.api.machine.server.spi.InstanceProvider.class);
         machineImageProviderMultibinder.addBinding().to(org.eclipse.che.plugin.docker.machine.DockerInstanceProvider.class);
 
+        install(new org.eclipse.che.api.workspace.server.activity.inject.WorkspaceActivityModule());
         bind(org.eclipse.che.api.environment.server.MachineInstanceProvider.class)
                 .to(org.eclipse.che.plugin.docker.machine.MachineProviderImpl.class);
 

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -115,6 +115,14 @@ che.workspace.agent.dev.ping_timeout_error_msg=Timeout. The Che server is unable
 che.agent.dev.max_start_time_ms=120000
 che.agent.dev.ping_delay_ms=2000
 
+# Idle Timeout
+#     The system will suspend the workspace and snapshot it if the end user is idle for
+#     this length of time. Idleness is determined by the length of time that a user has
+#     not interacted with the workspace, meaning that one of our agents has not received
+#     instructions. Leaving a browser window open counts as idleness time.
+che.machine.ws.agent.inactive.stop.timeout.ms=3600000
+stop.workspace.scheduler.period=60
+
 ### TEMPLATES
 # Folder that contains JSON files with code templates and samples
 che.template.storage=${che.home}/templates

--- a/wsagent/che-wsagent-core/pom.xml
+++ b/wsagent/che-wsagent-core/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace-shared</artifactId>
         </dependency>
         <dependency>

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentServletModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentServletModule.java
@@ -25,5 +25,6 @@ public class WsAgentServletModule extends ServletModule {
     @Override
     protected void configureServlets() {
         getServletContext().addListener(new WSConnectionTracker());
+        filter("/*").through(org.eclipse.che.api.agent.server.activity.LastAccessTimeFilter.class);
     }
 }

--- a/wsagent/che-wsagent-core/src/main/webapp/WEB-INF/classes/codenvy/che-machine-configuration.properties
+++ b/wsagent/che-wsagent-core/src/main/webapp/WEB-INF/classes/codenvy/che-machine-configuration.properties
@@ -54,3 +54,6 @@ oauth.github.redirecturis= http://localhost:${SERVER_PORT}/che/api/oauth/callbac
 git.server.uri.prefix=git
 
 project.importer.default_importer_id=git
+
+workspace.activity.notify_time_threshold_ms=60000
+workspace.activity.schedule_period_s=60

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -55,5 +55,7 @@ public final class Constants {
     public static final String COMMAND_PREVIEW_URL_ATTRIBUTE_NAME = "previewUrl";
     public static final String COMMAND_GOAL_ATTRIBUTE_NAME        = "goal";
 
+    public static final String ACTIVITY_CHECKER     = "activity-checker";
+
     private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace/pom.xml
+++ b/wsmaster/che-core-api-workspace/pom.xml
@@ -106,6 +106,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-schedule</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-core</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/LastAccessTimeFilter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/LastAccessTimeFilter.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.activity;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+/**
+ * Counts every request to the agent as a workspace activity
+ *
+ * @author Mihail Kuznyetsov
+ */
+@Singleton
+public class LastAccessTimeFilter implements Filter {
+    private static final Logger LOG = LoggerFactory.getLogger(LastAccessTimeFilter.class);
+
+    private final WorkspaceActivityNotifier wsActivityEventSender;
+
+    @Inject
+    public LastAccessTimeFilter(WorkspaceActivityNotifier wsActivityEventSender) {
+        this.wsActivityEventSender = wsActivityEventSender;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        try {
+            wsActivityEventSender.onActivity();
+        } catch (Exception e) {
+            LOG.error("Failed to notify about the workspace activity", e);
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/WorkspaceActivityNotifier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/WorkspaceActivityNotifier.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.activity;
+
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.commons.schedule.ScheduleRate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Notifies master about activity in workspace, but not more often than once per minute.
+ *
+ * @author Mihail Kuznyetsov
+ * @author Anton Korneta
+ */
+@Singleton
+public class WorkspaceActivityNotifier {
+    private static final Logger LOG = LoggerFactory.getLogger(WorkspaceActivityNotifier.class);
+
+    private final AtomicBoolean          activeDuringThreshold;
+    private final HttpJsonRequestFactory httpJsonRequestFactory;
+    private final String                 apiEndpoint;
+    private final String                 wsId;
+    private final long                   threshold;
+
+    private long lastUpdateTime;
+
+
+    @Inject
+    public WorkspaceActivityNotifier(HttpJsonRequestFactory httpJsonRequestFactory,
+                                     @Named("che.api") String apiEndpoint,
+                                     @Named("env.CHE_WORKSPACE_ID") String wsId,
+                                     @Named("workspace.activity.notify_time_threshold_ms") long threshold) {
+        this.httpJsonRequestFactory = httpJsonRequestFactory;
+        this.apiEndpoint = apiEndpoint;
+        this.wsId = wsId;
+        this.activeDuringThreshold = new AtomicBoolean(false);
+        this.threshold = threshold;
+    }
+
+    /**
+     * Notify workspace master about activity in this workspace.
+     * <p/>
+     * After last notification, any consecutive activities that come within specific amount of time
+     * - {@code threshold}, will not notify immediately, but trigger notification in scheduler method
+     * {@link WorkspaceActivityNotifier#scheduleActivityNotification}
+     */
+    public void onActivity() {
+        long currentTime = System.currentTimeMillis();
+        if (currentTime < (lastUpdateTime + threshold)) {
+            activeDuringThreshold.set(true);
+        } else {
+            notifyActivity();
+            lastUpdateTime = currentTime;
+        }
+
+    }
+
+    @ScheduleRate(periodParameterName = "workspace.activity.schedule_period_s")
+    private void scheduleActivityNotification() {
+        if (activeDuringThreshold.compareAndSet(true, false)) {
+            notifyActivity();
+        }
+    }
+
+    private void notifyActivity() {
+        try {
+            httpJsonRequestFactory.fromUrl(apiEndpoint + "/activity/" + wsId)
+                                  .usePutMethod()
+                                  .request();
+        } catch (Exception e) {
+            LOG.error("Cannot notify master about workspace " + wsId + " activity", e);
+        }
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/websocket/WorkspaceWebsocketConnectionListener.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/websocket/WorkspaceWebsocketConnectionListener.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.activity.websocket;
+
+import org.eclipse.che.api.agent.server.activity.WorkspaceActivityNotifier;
+import org.everrest.websockets.WSConnection;
+import org.everrest.websockets.WSConnectionContext;
+import org.everrest.websockets.WSConnectionListener;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Registers {@link WorkspaceWebsocketMessageReceiver} on opened connection
+ *
+ * @author Mihail Kuznyetsov
+ */
+@Singleton
+public class WorkspaceWebsocketConnectionListener implements WSConnectionListener {
+
+    private final WorkspaceActivityNotifier workspaceActivityNotifier;
+
+    @Inject
+    public WorkspaceWebsocketConnectionListener(WorkspaceActivityNotifier workspaceActivityNotifier) {
+        this.workspaceActivityNotifier = workspaceActivityNotifier;
+    }
+
+    @Override
+    public void onOpen(WSConnection connection) {
+        connection.registerMessageReceiver(new WorkspaceWebsocketMessageReceiver(workspaceActivityNotifier));
+    }
+
+    @Override
+    public void onClose(WSConnection connection) {
+    }
+
+    @PostConstruct
+    public void start() {
+        WSConnectionContext.registerConnectionListener(this);
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/websocket/WorkspaceWebsocketMessageReceiver.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/activity/websocket/WorkspaceWebsocketMessageReceiver.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.agent.server.activity.websocket;
+
+import org.eclipse.che.api.agent.server.activity.WorkspaceActivityNotifier;
+import org.everrest.websockets.WSMessageReceiver;
+import org.everrest.websockets.message.InputMessage;
+import org.everrest.websockets.message.Pair;
+import org.everrest.websockets.message.RestInputMessage;
+
+import java.util.Arrays;
+
+/**
+ * Updates workspace activity on message receival by websocket.
+ *
+ * @author Mihail Kuznyetsov
+ * @author Anton Korneta
+ */
+public class WorkspaceWebsocketMessageReceiver implements WSMessageReceiver {
+
+    private final WorkspaceActivityNotifier workspaceActivityNotifier;
+
+    public WorkspaceWebsocketMessageReceiver(WorkspaceActivityNotifier workspaceActivityNotifier) {
+        this.workspaceActivityNotifier = workspaceActivityNotifier;
+    }
+
+    @Override
+    public void onMessage(InputMessage input) {
+        // only user activity matters
+        if (input instanceof RestInputMessage) {
+            final Pair[] headers = ((RestInputMessage)input).getHeaders();
+            final boolean containsPingHeader = Arrays.stream(headers)
+                                                     .anyMatch(pair -> "x-everrest-websocket-message-type".equals(pair.getName())
+                                                                       && "ping".equals(pair.getValue()));
+
+            if (!containsPingHeader) {
+                workspaceActivityNotifier.onActivity();
+            }
+        } else {
+            workspaceActivityNotifier.onActivity();
+        }
+    }
+
+    @Override
+    public void onError(Exception error) {
+        workspaceActivityNotifier.onActivity();
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/activity/WorkspaceActivityManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/activity/WorkspaceActivityManager.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.activity;
+
+import static org.eclipse.che.api.workspace.shared.Constants.ACTIVITY_CHECKER;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STOPPED_BY;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+import org.eclipse.che.commons.schedule.ScheduleRate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+
+/**
+ * Stops the inactive workspaces by given expiration time.
+ *
+ * <p>Note that the workspace is not stopped immediately, scheduler will stop the workspaces with one minute rate.
+ * If workspace idle timeout is negative, then workspace would not be stopped automatically.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class WorkspaceActivityManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WorkspaceActivityManager.class);
+
+    private final long                 timeout;
+    private final Map<String, Long>    activeWorkspaces;
+    private final WorkspaceManager     workspaceManager;
+    private final EventService         eventService;
+    private final EventSubscriber<?>   workspaceEventsSubscriber;
+
+    @Inject
+    public WorkspaceActivityManager(WorkspaceManager workspaceManager,
+                                    EventService eventService,
+                                    @Named("che.machine.ws.agent.inactive.stop.timeout.ms") long timeout) {
+        this.timeout = timeout;
+        this.workspaceManager = workspaceManager;
+        this.eventService = eventService;
+        this.activeWorkspaces = new ConcurrentHashMap<>();
+        this.workspaceEventsSubscriber = new EventSubscriber<WorkspaceStatusEvent>() {
+            @Override
+            public void onEvent(WorkspaceStatusEvent event) {
+                switch (event.getEventType()) {
+                    case RUNNING:
+                        try {
+                            Workspace workspace = workspaceManager.getWorkspace(event.getWorkspaceId());
+                            if (workspace.getAttributes().remove(WORKSPACE_STOPPED_BY) != null) {
+                                workspaceManager.updateWorkspace(event.getWorkspaceId(), workspace);
+                            }
+                        } catch (Exception ex) {
+                            LOG.warn("Failed to remove stopped information attribute for workspace " + event.getWorkspaceId());
+                        }
+                        update(event.getWorkspaceId(), System.currentTimeMillis());
+                        break;
+                    case STOPPED:
+                        activeWorkspaces.remove(event.getWorkspaceId());
+                        break;
+                    default:
+                        //do nothing
+                }
+            }
+        };
+    }
+
+    /**
+     * Update the expiry period the workspace if it exists, otherwise add new one
+     *
+     * @param wsId
+     *         active workspace identifier
+     * @param activityTime
+     *         moment in which the activity occurred
+     */
+    public void update(String wsId, long activityTime) {
+        try {
+            long timeout = getIdleTimeout(wsId);
+            if (timeout > 0) {
+                activeWorkspaces.put(wsId, activityTime + timeout);
+            }
+        } catch (NotFoundException | ServerException e) {
+            LOG.error(e.getLocalizedMessage(), e);
+        }
+    }
+
+    private long getIdleTimeout(String workspaceId) throws NotFoundException, ServerException {
+        if (timeout > 0) {
+            return timeout;
+        } else {
+            return -1;
+        }
+    }
+
+    @ScheduleRate(periodParameterName = "stop.workspace.scheduler.period")
+    private void invalidate() {
+        final long currentTime = System.currentTimeMillis();
+        for (Map.Entry<String, Long> workspaceExpireEntry : activeWorkspaces.entrySet()) {
+            if (workspaceExpireEntry.getValue() <= currentTime) {
+                try {
+                    String workspaceId = workspaceExpireEntry.getKey();
+                    Workspace workspace = workspaceManager.getWorkspace(workspaceId);
+                    workspace.getAttributes().put(WORKSPACE_STOPPED_BY, ACTIVITY_CHECKER);
+                    workspaceManager.updateWorkspace(workspaceId, workspace);
+                    workspaceManager.stopWorkspace(workspaceId);
+                } catch (NotFoundException e) {
+                    LOG.info("Workspace already stopped");
+                } catch (ConflictException e) {
+                    LOG.warn(e.getLocalizedMessage());
+                } catch (Exception ex) {
+                    LOG.error(ex.getLocalizedMessage());
+                    LOG.debug(ex.getLocalizedMessage(), ex);
+                } finally {
+                    activeWorkspaces.remove(workspaceExpireEntry.getKey());
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @PostConstruct
+    void subscribe() {
+        eventService.subscribe(workspaceEventsSubscriber);
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/activity/WorkspaceActivityService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/activity/WorkspaceActivityService.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.activity;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.rest.Service;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+
+/**
+ * Monitors the activity of the runtime workspace.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+@Path("/activity")
+public class WorkspaceActivityService extends Service {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WorkspaceActivityService.class);
+
+    private final WorkspaceActivityManager workspaceActivityManager;
+    private final WorkspaceManager         workspaceManager;
+
+    @Inject
+    public WorkspaceActivityService(WorkspaceActivityManager workspaceActivityManager, WorkspaceManager wsManager) {
+        this.workspaceActivityManager = workspaceActivityManager;
+        this.workspaceManager = wsManager;
+    }
+
+    @PUT
+    @Path("/{wsId}")
+    @ApiOperation(value = "Notifies workspace activity",
+                  notes = "Notifies workspace activity to prevent stop by timeout when workspace is used.")
+    @ApiResponses(@ApiResponse(code = 204, message = "Activity counted"))
+    public void active(@ApiParam(value = "Workspace id")
+                       @PathParam("wsId") String wsId) throws ForbiddenException, NotFoundException, ServerException {
+        final WorkspaceImpl workspace = workspaceManager.getWorkspace(wsId);
+        if (workspace.getStatus() == RUNNING) {
+            workspaceActivityManager.update(wsId, System.currentTimeMillis());
+            LOG.debug("Updated activity on workspace {}", wsId);
+        }
+    }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/activity/inject/WorkspaceActivityModule.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/activity/inject/WorkspaceActivityModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.activity.inject;
+
+import org.eclipse.che.api.workspace.server.activity.WorkspaceActivityManager;
+import org.eclipse.che.api.workspace.server.activity.WorkspaceActivityService;
+
+import com.google.inject.AbstractModule;
+
+public class WorkspaceActivityModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(WorkspaceActivityService.class);
+        bind(WorkspaceActivityManager.class);
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Enable workspace shutdown after a specified inactivity period.

### What issues does this PR fix or reference?

https://issues.jboss.org/browse/CHE-274

### Changelog

Added the che.machine.ws.agent.inactive.stop.timeout.ms=3600000 and stop.workspace.scheduler.period property

### Release Notes

Per default, a workspace will be stopped after one hour of inactivity.

### Docs PR

N/A

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>

See https://github.com/eclipse/che/pull/5386