### PR TITLE
Remove deprecated single descriptor and move to multi descriptors which is the replacement

### DIFF
--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -103,7 +103,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                      <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -75,7 +75,9 @@
                     <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>ext-server-${project.version}</finalName>
                 </configuration>
             </plugin>


### PR DESCRIPTION
It will allow to upgrade maven assembly descriptor

### What does this PR do?
Replace deprecated pom.xml entry and use the newer way
Linked to https://github.com/eclipse/che/issues/5326 (update plugin)

#### Changelog
Replace deprecated pom.xml entry and use the newer way

#### Release Notes
N/A


#### Docs PR
N/A

Change-Id: I11fb19428ce484457074fa7c8a7b4ad7a5c5653f
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

