### PR TITLE
Rework importing a project while consuming Factory to avoid using Everrest based Websocket calls

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
@@ -47,14 +47,15 @@ import org.eclipse.che.ide.util.ExceptionUtils;
 import org.eclipse.che.ide.util.StringUtils;
 import org.eclipse.che.security.oauth.OAuthStatus;
 
+import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.eclipse.che.api.core.ErrorCodes.FAILED_CHECKOUT;
@@ -74,6 +75,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUC
  * @author Valeriy Svydenko
  * @author Anton Korneta
  */
+@Singleton
 public class FactoryProjectImporter extends AbstractImporter {
     private final AskCredentialsDialog               askCredentialsDialog;
     private final CoreLocalizationConstant           locale;
@@ -84,7 +86,7 @@ public class FactoryProjectImporter extends AbstractImporter {
     private final RequestTransmitter                 requestTransmitter;
     private final ProjectImportOutputJsonRpcNotifier subscriber;
 
-    private final Map<String, CheckoutContext> checkoutContextRegistry = new ConcurrentHashMap<>();
+    private final Map<String, CheckoutContext> checkoutContextRegistry = new HashMap<>();
 
     private FactoryDto          factory;
     private AsyncCallback<Void> callback;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
@@ -14,6 +14,8 @@ package org.eclipse.che.ide.factory.utils;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.api.core.model.project.SourceStorage;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
 import org.eclipse.che.api.git.shared.GitCheckoutEvent;
@@ -38,15 +40,11 @@ import org.eclipse.che.ide.api.project.wizard.ProjectNotificationSubscriber;
 import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.user.AskCredentialsDialog;
 import org.eclipse.che.ide.api.user.Credentials;
+import org.eclipse.che.ide.projectimport.wizard.ProjectImportOutputJsonRpcNotifier;
 import org.eclipse.che.ide.resource.Path;
-import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.rest.RestContext;
 import org.eclipse.che.ide.util.ExceptionUtils;
 import org.eclipse.che.ide.util.StringUtils;
-import org.eclipse.che.ide.websocket.MessageBus;
-import org.eclipse.che.ide.websocket.MessageBusProvider;
-import org.eclipse.che.ide.websocket.WebSocketException;
-import org.eclipse.che.ide.websocket.rest.SubscriptionHandler;
 import org.eclipse.che.security.oauth.OAuthStatus;
 
 import javax.validation.constraints.NotNull;
@@ -56,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.eclipse.che.api.core.ErrorCodes.FAILED_CHECKOUT;
@@ -76,16 +75,16 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUC
  * @author Anton Korneta
  */
 public class FactoryProjectImporter extends AbstractImporter {
-    private static final String CHANNEL = "git:checkout:";
+    private final AskCredentialsDialog               askCredentialsDialog;
+    private final CoreLocalizationConstant           locale;
+    private final NotificationManager                notificationManager;
+    private final String                             restContext;
+    private final DialogFactory                      dialogFactory;
+    private final OAuth2AuthenticatorRegistry        oAuth2AuthenticatorRegistry;
+    private final RequestTransmitter                 requestTransmitter;
+    private final ProjectImportOutputJsonRpcNotifier subscriber;
 
-    private final MessageBusProvider          messageBusProvider;
-    private final AskCredentialsDialog        askCredentialsDialog;
-    private final CoreLocalizationConstant    locale;
-    private final NotificationManager         notificationManager;
-    private final String                      restContext;
-    private final DialogFactory               dialogFactory;
-    private final OAuth2AuthenticatorRegistry oAuth2AuthenticatorRegistry;
-    private final DtoUnmarshallerFactory      dtoUnmarshallerFactory;
+    private final Map<String, CheckoutContext> checkoutContextRegistry = new ConcurrentHashMap<>();
 
     private FactoryDto          factory;
     private AsyncCallback<Void> callback;
@@ -99,8 +98,8 @@ public class FactoryProjectImporter extends AbstractImporter {
                                   @RestContext String restContext,
                                   DialogFactory dialogFactory,
                                   OAuth2AuthenticatorRegistry oAuth2AuthenticatorRegistry,
-                                  MessageBusProvider messageBusProvider,
-                                  DtoUnmarshallerFactory dtoUnmarshallerFactory) {
+                                  RequestTransmitter requestTransmitter,
+                                  ProjectImportOutputJsonRpcNotifier subscriber) {
         super(appContext, subscriberFactory);
         this.notificationManager = notificationManager;
         this.askCredentialsDialog = askCredentialsDialog;
@@ -108,8 +107,34 @@ public class FactoryProjectImporter extends AbstractImporter {
         this.restContext = restContext;
         this.dialogFactory = dialogFactory;
         this.oAuth2AuthenticatorRegistry = oAuth2AuthenticatorRegistry;
-        this.messageBusProvider = messageBusProvider;
-        this.dtoUnmarshallerFactory = dtoUnmarshallerFactory;
+        this.requestTransmitter = requestTransmitter;
+        this.subscriber = subscriber;
+    }
+
+    @Inject
+    private void configure(RequestHandlerConfigurator requestHandlerConfigurator) {
+        requestHandlerConfigurator.newConfiguration()
+                                  .methodName("git/checkoutOutput")
+                                  .paramsAsDto(GitCheckoutEvent.class)
+                                  .noResult()
+                                  .withConsumer(this::consumeGitCheckoutEvent);
+    }
+
+    private void consumeGitCheckoutEvent(GitCheckoutEvent event) {
+        CheckoutContext context = checkoutContextRegistry.get(event.getWorkspaceId() + event.getProjectName());
+        if (context == null) {
+            return;
+        }
+
+        String projectName = context.projectName;
+        String reference = event.isCheckoutOnly() ? event.getBranchRef() : context.startPoint;
+        String repository = context.repository;
+        String branch = context.branch;
+
+        String title = locale.clonedSource(projectName);
+        String content = locale.clonedSourceWithCheckout(projectName, repository, reference, branch);
+
+        notificationManager.notify(title, content, SUCCESS, FLOAT_MODE);
     }
 
     public void startImporting(FactoryDto factory, AsyncCallback<Void> callback) {
@@ -186,7 +211,6 @@ public class FactoryProjectImporter extends AbstractImporter {
                                       @NotNull final SourceStorage sourceStorage) {
         final String projectName = pathToProject.lastSegment();
         final StatusNotification notification = notificationManager.notify(locale.cloningSource(projectName), null, PROGRESS, FLOAT_MODE);
-        final ProjectNotificationSubscriber subscriber = subscriberFactory.createSubscriber();
         subscriber.subscribe(projectName, notification);
         String location = sourceStorage.getLocation();
         // it's needed for extract repository name from repository url e.g https://github.com/codenvy/che-core.git
@@ -195,37 +219,8 @@ public class FactoryProjectImporter extends AbstractImporter {
         final Map<String, String> parameters = firstNonNull(sourceStorage.getParameters(), Collections.<String, String>emptyMap());
         final String branch = parameters.get("branch");
         final String startPoint = parameters.get("startPoint");
-        final MessageBus messageBus = messageBusProvider.getMachineMessageBus();
-        final String channel = CHANNEL + appContext.getWorkspaceId() + ':' + projectName;
-        final SubscriptionHandler<GitCheckoutEvent> successImportHandler = new SubscriptionHandler<GitCheckoutEvent>(
-                dtoUnmarshallerFactory.newWSUnmarshaller(GitCheckoutEvent.class)) {
-            @Override
-            protected void onMessageReceived(GitCheckoutEvent result) {
-                if (result.isCheckoutOnly()) {
-                    notificationManager.notify(locale.clonedSource(projectName),
-                                               locale.clonedSourceWithCheckout(projectName, repository, result.getBranchRef(), branch),
-                                               SUCCESS,
-                                               FLOAT_MODE);
-                } else {
-                    notificationManager.notify(locale.clonedSource(projectName),
-                                               locale.clonedWithCheckoutOnStartPoint(projectName, repository, startPoint, branch),
-                                               SUCCESS,
-                                               FLOAT_MODE);
-                }
-            }
 
-            @Override
-            protected void onErrorReceived(Throwable e) {
-                try {
-                    messageBus.unsubscribe(channel, this);
-                } catch (WebSocketException ignore) {
-                }
-            }
-        };
-        try {
-            messageBus.subscribe(channel, successImportHandler);
-        } catch (WebSocketException ignore) {
-        }
+        subscribe(projectName, repository, branch, startPoint);
 
         MutableProjectConfig importConfig = new MutableProjectConfig();
         importConfig.setPath(pathToProject.toString());
@@ -239,6 +234,8 @@ public class FactoryProjectImporter extends AbstractImporter {
                              @Override
                              public Project apply(Project project) throws FunctionException {
                                  subscriber.onSuccess();
+                                 unsubscribe(projectName);
+
                                  notification.setContent(locale.clonedSource(projectName));
                                  notification.setStatus(SUCCESS);
 
@@ -249,9 +246,11 @@ public class FactoryProjectImporter extends AbstractImporter {
                              @Override
                              public Promise<Project> apply(PromiseError err) throws FunctionException {
                                  final int errorCode = ExceptionUtils.getErrorCode(err.getCause());
+                                 unsubscribe(projectName);
                                  switch (errorCode) {
                                      case UNAUTHORIZED_GIT_OPERATION:
                                          subscriber.onFailure(err.getMessage());
+
                                          final Map<String, String> attributes = ExceptionUtils.getAttributes(err.getCause());
                                          final String providerName = attributes.get(PROVIDER_NAME);
                                          final String authenticateUrl = attributes.get(AUTHENTICATE_URL);
@@ -299,6 +298,28 @@ public class FactoryProjectImporter extends AbstractImporter {
                          });
     }
 
+    private void subscribe(String projectName, String repository, String branch, String startPoint) {
+        String key = appContext.getWorkspaceId() + projectName;
+
+        checkoutContextRegistry.put(key, new CheckoutContext(projectName, repository, branch, startPoint));
+        requestTransmitter.newRequest()
+                          .endpointId("ws-agent")
+                          .methodName("git/checkoutOutput/subscribe")
+                          .paramsAsString(key)
+                          .sendAndSkipResult();
+    }
+
+    private void unsubscribe(String projectName) {
+        String key = appContext.getWorkspaceId() + projectName;
+
+        checkoutContextRegistry.remove(key);
+        requestTransmitter.newRequest()
+                          .endpointId("ws-agent")
+                          .methodName("git/checkoutOutput/unsubscribe")
+                          .paramsAsString(key)
+                          .sendAndSkipResult();
+    }
+
     private Promise<Project> tryAuthenticateAndRepeatImport(@NotNull final String providerName,
                                                             @NotNull final String authenticateUrl,
                                                             @NotNull final Path pathToProject,
@@ -339,5 +360,19 @@ public class FactoryProjectImporter extends AbstractImporter {
                                    .catchError(error -> {
                                               callback.onFailure(error.getCause());
                                           });
+    }
+
+    private class CheckoutContext {
+        private final String projectName;
+        private final String repository;
+        private final String branch;
+        private final String startPoint;
+
+        private CheckoutContext(String projectName, String repository, String branch, String startPoint) {
+            this.projectName = projectName;
+            this.repository = repository;
+            this.branch = branch;
+            this.startPoint = startPoint;
+        }
     }
 }

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitJsonRpcMessenger.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitJsonRpcMessenger.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.git;
+
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.git.shared.GitCheckoutEvent;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+
+@Singleton
+public class GitJsonRpcMessenger implements EventSubscriber<GitCheckoutEvent> {
+    private final Map<String, Set<String>> endpointIds = new ConcurrentHashMap<>();
+
+    private final EventService       eventService;
+    private final RequestTransmitter transmitter;
+
+    @Inject
+    public GitJsonRpcMessenger(EventService eventService, RequestTransmitter transmitter) {
+        this.eventService = eventService;
+        this.transmitter = transmitter;
+    }
+
+    @PostConstruct
+    private void subscribe() {
+        eventService.subscribe(this);
+    }
+
+    @PreDestroy
+    private void unsubscribe() {
+        eventService.unsubscribe(this);
+    }
+
+    @Override
+    public void onEvent(GitCheckoutEvent event) {
+        String workspaceIdAndProjectName = event.getWorkspaceId() + event.getProjectName();
+        endpointIds.entrySet()
+                   .stream()
+                   .filter(it -> it.getValue().contains(workspaceIdAndProjectName))
+                   .map(Entry::getKey)
+                   .forEach(it -> transmitter.newRequest()
+                                             .endpointId(it)
+                                             .methodName("git/checkoutOutput")
+                                             .paramsAsDto(event)
+                                             .sendAndSkipResult());
+    }
+
+    @Inject
+    private void configureSubscribeHandler(RequestHandlerConfigurator configurator) {
+        configurator.newConfiguration()
+                    .methodName("git/checkoutOutput/subscribe")
+                    .paramsAsString()
+                    .noResult()
+                    .withBiConsumer((endpointId, workspaceIdAndProjectName) -> {
+                        endpointIds.putIfAbsent(endpointId, newConcurrentHashSet());
+                        endpointIds.get(endpointId).add(workspaceIdAndProjectName);
+                    });
+    }
+
+    @Inject
+    private void configureUnSubscribeHandler(RequestHandlerConfigurator configurator) {
+        configurator.newConfiguration()
+                    .methodName("git/checkoutOutput/unsubscribe")
+                    .paramsAsString()
+                    .noResult()
+                    .withBiConsumer((endpointId, workspaceIdAndProjectName) -> {
+                        endpointIds.getOrDefault(endpointId, newConcurrentHashSet()).remove(workspaceIdAndProjectName);
+                        endpointIds.computeIfPresent(endpointId, (key, value) -> value.isEmpty() ? null : value);
+                    });
+    }
+}

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitModule.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitModule.java
@@ -48,6 +48,7 @@ public class GitModule extends AbstractModule {
         bind(StatusPageWriter.class);
         bind(TagListWriter.class);
         bind(GitWebSocketMessenger.class);
+        bind(GitJsonRpcMessenger.class);
 
         Multibinder.newSetBinder(binder(), CredentialsProvider.class).addBinding().to(GitBasicAuthenticationCredentialsProvider.class);
 


### PR DESCRIPTION
Signed-off-by: Dmitry Kuleshov <dkuleshov@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Replacing old websocket mechanism to a new one for Factory importer

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5352

#### Changelog
Replaced old websocket mechanism to a new one for Factory importer

#### Release Notes
Replaced old websocket mechanism to a new one for Factory importer


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
