### PR TITLE
CHE-5215. Add ability to exclude tracking files by file watcher

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileWatcherExcludesOperation.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/FileWatcherExcludesOperation.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.event.ng;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.event.WindowActionEvent;
+import org.eclipse.che.ide.api.event.WindowActionHandler;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tracks and allows to manage the file watcher exclude patterns for tracking creation,
+ * modification and deletion events for corresponding entries.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class FileWatcherExcludesOperation implements WindowActionHandler {
+    private static final String ENDPOINT_ID          = "ws-agent";
+    private static final String EXCLUDES_SUBSCRIBE   = "fileWatcher/excludes/subscribe";
+    private static final String EXCLUDES_UNSUBSCRIBE = "fileWatcher/excludes/unsubscribe";
+    private static final String EXCLUDES_CHANGED     = "fileWatcher/excludes/changed";
+    private static final String ADD_TO_EXCLUDES      = "fileWatcher/excludes/addToExcludes";
+    private static final String REMOVE_FROM_EXCLUDES = "fileWatcher/excludes/removeFromExcludes";
+    private static final String EXCLUDES_CLEAN_UP    = "fileWatcher/excludes/cleanup";
+
+    private PromiseProvider    promises;
+    private RequestTransmitter requestTransmitter;
+    private Set<String> excludes = new HashSet<>();
+
+    @Inject
+    public FileWatcherExcludesOperation(EventBus eventBus,
+                                        PromiseProvider promises,
+                                        RequestTransmitter requestTransmitter) {
+        this.promises = promises;
+        this.requestTransmitter = requestTransmitter;
+        eventBus.addHandler(WindowActionEvent.TYPE, this);
+        subscribe();
+    }
+
+    @Inject
+    private void configureHandlers(RequestHandlerConfigurator configurator) {
+        configurator.newConfiguration()
+                    .methodName(EXCLUDES_CHANGED)
+                    .paramsAsListOfString()
+                    .noResult()
+                    .withConsumer(newExcludes -> {
+                        excludes.clear();
+                        excludes.addAll(newExcludes);
+                    });
+
+        configurator.newConfiguration()
+                    .methodName(EXCLUDES_CLEAN_UP)
+                    .noParams()
+                    .noResult()
+                    .withConsumer(s -> excludes.clear());
+    }
+
+    /**
+     * Checks if specified path is within excludes
+     *
+     * @param pathToTest
+     *         path being examined
+     * @return true if path is within excludes, false otherwise
+     */
+    public boolean isExcluded(String pathToTest) {
+        return excludes.contains(pathToTest);
+    }
+
+    /**
+     * Registers a set of paths to skip tracking of creation,
+     * modification and deletion events for corresponding entries.
+     *
+     * @param pathsToExclude
+     *         entries' paths to adding to excludes
+     */
+    public Promise<Boolean> addToFileWatcherExcludes(Set<String> pathsToExclude) {
+        JsonRpcPromise<Boolean> jsonRpcPromise = requestTransmitter.newRequest()
+                                                                   .endpointId(ENDPOINT_ID)
+                                                                   .methodName(ADD_TO_EXCLUDES)
+                                                                   .paramsAsListOfString(new ArrayList<>(pathsToExclude))
+                                                                   .sendAndReceiveResultAsBoolean();
+        return toPromise(jsonRpcPromise);
+    }
+
+    /**
+     * Removes a set of paths from excludes to resume tracking of corresponding entries creation,
+     * modification and deletion events.
+     *
+     * @param paths
+     *         entries' paths to remove from excludes
+     */
+    public Promise<Boolean> removeFromFileWatcherExcludes(Set<String> paths) {
+        JsonRpcPromise<Boolean> jsonRpcPromise = requestTransmitter.newRequest()
+                                                                   .endpointId(ENDPOINT_ID)
+                                                                   .methodName(REMOVE_FROM_EXCLUDES)
+                                                                   .paramsAsListOfString(new ArrayList<>(paths))
+                                                                   .sendAndReceiveResultAsBoolean();
+        return toPromise(jsonRpcPromise);
+    }
+
+    private Promise<Boolean> toPromise(JsonRpcPromise<Boolean> jsonRpcPromise) {
+        return promises.create((AsyncCallback<Boolean> callback) -> {
+
+            jsonRpcPromise.onSuccess(callback::onSuccess);
+
+            jsonRpcPromise.onFailure(jsonRpcError -> callback.onFailure(new Throwable(jsonRpcError.getMessage())));
+        });
+    }
+
+    @Override
+    public void onWindowClosing(WindowActionEvent event) {
+    }
+
+    @Override
+    public void onWindowClosed(WindowActionEvent event) {
+        unSubscribe();
+    }
+
+    private void subscribe() {
+        requestTransmitter.newRequest()
+                          .endpointId(ENDPOINT_ID)
+                          .methodName(EXCLUDES_SUBSCRIBE)
+                          .noParams()
+                          .sendAndSkipResult();
+    }
+
+    private void unSubscribe() {
+        requestTransmitter.newRequest()
+                          .endpointId(ENDPOINT_ID)
+                          .methodName(EXCLUDES_UNSUBSCRIBE)
+                          .noParams()
+                          .sendAndSkipResult();
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -50,6 +50,20 @@ public interface CoreLocalizationConstant extends Messages {
     @Key("appearance.category")
     String appearanceCategory();
 
+    /* Add resources to File Watcher excludes */
+    @Key("action.fileWatcher.add.excludes.text")
+    String addToFileWatcherExludesName();
+
+    @Key("action.fileWatcher.add.excludes.description")
+    String addToFileWatcherExludesDescription();
+
+    /* Remove resources from File Watcher excludes */
+    @Key("action.fileWatcher.remove.excludes.text")
+    String removeFromFileWatcherExludesName();
+
+    @Key("action.fileWatcher.remove.excludes.description")
+    String removeFromFileWatcherExludesDescription();
+
     /* DeleteItem */
     @Key("action.delete.text")
     String deleteItemActionText();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/AddToFileWatcherExcludesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/AddToFileWatcherExcludesAction.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.event.ng.FileWatcherExcludesOperation;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.resources.Resource;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Adds resources which are in application context to File Watcher excludes.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class AddToFileWatcherExcludesAction extends AbstractPerspectiveAction {
+
+    private AppContext                   appContext;
+    private NotificationManager          notificationManager;
+    private FileWatcherExcludesOperation fileWatcherExcludesOperation;
+
+    @Inject
+    public AddToFileWatcherExcludesAction(AppContext appContext,
+                                          CoreLocalizationConstant locale,
+                                          NotificationManager notificationManager,
+                                          FileWatcherExcludesOperation fileWatcherExcludesOperation) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID),
+              locale.addToFileWatcherExludesName(),
+              locale.addToFileWatcherExludesDescription(),
+              null,
+              null);
+        this.appContext = appContext;
+        this.notificationManager = notificationManager;
+        this.fileWatcherExcludesOperation = fileWatcherExcludesOperation;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        final Resource[] resources = appContext.getResources();
+        Set<String> pathsToExclude = stream(resources).map(resource -> resource.getLocation().toString())
+                                                      .collect(toSet());
+
+        fileWatcherExcludesOperation.addToFileWatcherExcludes(pathsToExclude)
+                                    .catchError(error -> {
+                                        notificationManager.notify(error.getMessage(), FAIL, EMERGE_MODE);
+                                    });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent e) {
+        Resource[] resources = appContext.getResources();
+
+        e.getPresentation().setVisible(true);
+        e.getPresentation().setEnabled(containsResourcesToExcludes(resources));
+    }
+
+    private boolean containsResourcesToExcludes(Resource[] resources) {
+        if (resources == null || resources.length <= 0) {
+            return false;
+        }
+
+        List<Resource> resourcesToExclude = asList(resources);
+        return resourcesToExclude.stream()
+                                 .map(resource -> resource.getLocation().toString())
+                                 .anyMatch(pathToExclude -> !fileWatcherExcludesOperation.isExcluded(pathToExclude));
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/AddToFileWatcherExcludesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/AddToFileWatcherExcludesAction.java
@@ -60,7 +60,6 @@ public class AddToFileWatcherExcludesAction extends AbstractPerspectiveAction {
         this.fileWatcherExcludesOperation = fileWatcherExcludesOperation;
     }
 
-    /** {@inheritDoc} */
     @Override
     public void actionPerformed(ActionEvent e) {
         final Resource[] resources = appContext.getResources();
@@ -73,7 +72,6 @@ public class AddToFileWatcherExcludesAction extends AbstractPerspectiveAction {
                                     });
     }
 
-    /** {@inheritDoc} */
     @Override
     public void updateInPerspective(@NotNull ActionEvent e) {
         Resource[] resources = appContext.getResources();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RemoveFromFileWatcherExcludesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RemoveFromFileWatcherExcludesAction.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.event.ng.FileWatcherExcludesOperation;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.resources.Resource;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Removes resources which are in application context from File Watcher excludes.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class RemoveFromFileWatcherExcludesAction extends AbstractPerspectiveAction {
+
+    private AppContext                   appContext;
+    private NotificationManager          notificationManager;
+    private FileWatcherExcludesOperation fileWatcherExcludesOperation;
+
+    @Inject
+    public RemoveFromFileWatcherExcludesAction(AppContext appContext,
+                                               CoreLocalizationConstant locale,
+                                               NotificationManager notificationManager,
+                                               FileWatcherExcludesOperation fileWatcherExcludesOperation) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID),
+              locale.removeFromFileWatcherExludesName(),
+              locale.removeFromFileWatcherExludesDescription(),
+              null,
+              null);
+        this.appContext = appContext;
+        this.notificationManager = notificationManager;
+        this.fileWatcherExcludesOperation = fileWatcherExcludesOperation;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        final Resource[] resources = appContext.getResources();
+        Set<String> pathsToRemove = stream(resources).map(resource -> resource.getLocation().toString())
+                                                     .collect(toSet());
+
+        fileWatcherExcludesOperation.removeFromFileWatcherExcludes(pathsToRemove)
+                                    .catchError(error -> {
+                                        notificationManager.notify(error.getMessage(), FAIL, EMERGE_MODE);
+                                    });
+    }
+
+
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent e) {
+        Resource[] resources = appContext.getResources();
+
+        e.getPresentation().setVisible(true);
+        e.getPresentation().setEnabled(containsResourcesToRemoveFromExcludes(resources));
+    }
+
+    private boolean containsResourcesToRemoveFromExcludes(Resource[] resources) {
+        if (resources == null || resources.length <= 0) {
+            return false;
+        }
+
+        List<Resource> resourcesToExclude = asList(resources);
+        return resourcesToExclude.stream()
+                                 .map(resource -> resource.getLocation().toString())
+                                 .anyMatch(pathToExclude -> fileWatcherExcludesOperation.isExcluded(pathToExclude));
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ClientServerEventModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ClientServerEventModule.java
@@ -17,6 +17,7 @@ import org.eclipse.che.ide.api.event.ng.ClientServerEventService;
 import org.eclipse.che.ide.api.event.ng.ClientServerEventServiceImpl;
 import org.eclipse.che.ide.api.event.ng.EditorFileStatusNotificationOperation;
 import org.eclipse.che.ide.api.event.ng.FileOpenCloseEventListener;
+import org.eclipse.che.ide.api.event.ng.FileWatcherExcludesOperation;
 import org.eclipse.che.ide.api.event.ng.ProjectTreeStateNotificationOperation;
 
 /**
@@ -41,5 +42,6 @@ public class ClientServerEventModule extends AbstractGinModule {
     private void notificationOperations() {
         bind(EditorFileStatusNotificationOperation.class).asEagerSingleton();
         bind(ProjectTreeStateNotificationOperation.class).asEagerSingleton();
+        bind(FileWatcherExcludesOperation.class).asEagerSingleton();
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -16,6 +16,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 
 import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.actions.AddToFileWatcherExcludesAction;
 import org.eclipse.che.ide.actions.CloseActiveEditorAction;
 import org.eclipse.che.ide.actions.CollapseAllAction;
 import org.eclipse.che.ide.actions.CompleteAction;
@@ -38,6 +39,7 @@ import org.eclipse.che.ide.actions.OpenFileAction;
 import org.eclipse.che.ide.actions.ProjectConfigurationAction;
 import org.eclipse.che.ide.actions.RedoAction;
 import org.eclipse.che.ide.actions.RefreshPathAction;
+import org.eclipse.che.ide.actions.RemoveFromFileWatcherExcludesAction;
 import org.eclipse.che.ide.actions.RenameItemAction;
 import org.eclipse.che.ide.actions.RunCommandAction;
 import org.eclipse.che.ide.actions.SaveAction;
@@ -416,6 +418,12 @@ public class StandardComponentInitializer {
     private ShowConsoleTreeAction showConsoleTreeAction;
 
     @Inject
+    private AddToFileWatcherExcludesAction addToFileWatcherExcludesAction;
+
+    @Inject
+    private RemoveFromFileWatcherExcludesAction removeFromFileWatcherExcludesAction;
+
+    @Inject
     private PerspectiveManager perspectiveManager;
 
     @Inject
@@ -723,6 +731,10 @@ public class StandardComponentInitializer {
         resourceOperation.add(linkWithEditorAction);
         resourceOperation.addSeparator();
         resourceOperation.add(convertFolderToProjectAction);
+        resourceOperation.addSeparator();
+        resourceOperation.addSeparator();
+        resourceOperation.add(addToFileWatcherExcludesAction);
+        resourceOperation.add(removeFromFileWatcherExcludesAction);
         resourceOperation.addSeparator();
 
         DefaultActionGroup mainContextMenuGroup = (DefaultActionGroup)actionManager.getAction(GROUP_MAIN_CONTEXT_MENU);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 
@@ -194,7 +195,7 @@ public class EditorGroupSynchronizationImpl implements EditorGroupSynchronizatio
         if (!Objects.equals(eventModificationStamp, currentStamp)) {
             replaceContent(document, newContent, oldContent, cursorPosition);
 
-            notificationManager.notify("External operation", "File '" + file.getName() + "' is updated", SUCCESS, EMERGE_MODE);
+            notificationManager.notify("External operation", "File '" + file.getName() + "' is updated", SUCCESS, NOT_EMERGE_MODE);
         }
     }
 

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -50,6 +50,14 @@ navigateToFile.searchIsCaseSensitive = Search is case sensitive
 action.delete.text = Delete...
 action.delete.description = Delete selected item
 
+############### Add resources to File Watcher excludes ###############
+action.fileWatcher.add.excludes.text = Add to File Watcher excludes
+action.fileWatcher.add.excludes.description = Adds resources to File Watcher excludes 
+
+############### Remove resources from File Watcher excludes ###############
+action.fileWatcher.remove.excludes.text = Remove from File Watcher excludes
+action.fileWatcher.remove.excludes.description = Removes resources from File Watcher excludes
+
 ############### Cut ###################
 action.cut.text=Cut
 action.cut.description=Cut to clipboard

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectApiModule.java
@@ -38,6 +38,7 @@ import org.eclipse.che.api.vfs.search.SearcherProvider;
 import org.eclipse.che.api.vfs.search.impl.FSLuceneSearcherProvider;
 import org.eclipse.che.api.vfs.watcher.FileTreeWalker;
 import org.eclipse.che.api.vfs.watcher.FileWatcherByPathMatcher;
+import org.eclipse.che.api.vfs.watcher.FileWatcherIgnoreFileTracker;
 import org.eclipse.che.api.vfs.watcher.IndexedFileCreateConsumer;
 import org.eclipse.che.api.vfs.watcher.IndexedFileDeleteConsumer;
 import org.eclipse.che.api.vfs.watcher.IndexedFileUpdateConsumer;
@@ -97,6 +98,7 @@ public class ProjectApiModule extends AbstractModule {
 
         bind(EditorChangesTracker.class).asEagerSingleton();
         bind(EditorWorkingCopyManager.class).asEagerSingleton();
+        bind(FileWatcherIgnoreFileTracker.class).asEagerSingleton();
 
         configureVfsFilters(excludeMatcher);
         configureVfsFilters(fileWatcherExcludes);

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherExcludePatternsRegistry.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherExcludePatternsRegistry.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+
+/**
+ * Registry for managing of tracking creation,
+ * modification and deletion events for corresponding entries.
+ * Allows to add entries to excludes or includes by {@link PathMatcher}.
+ */
+@Singleton
+public class FileWatcherExcludePatternsRegistry {
+    private Set<PathMatcher> excludes;
+    private Set<PathMatcher> includes = newConcurrentHashSet();
+
+    @Inject
+    public FileWatcherExcludePatternsRegistry(@Named("che.user.workspaces.storage.excludes") Set<PathMatcher> excludes) {
+        this.excludes = newConcurrentHashSet(excludes);
+    }
+
+    /**
+     * Registers a matcher to skip tracking of creation,
+     * modification and deletion events for corresponding entries.
+     *
+     * @param matcher
+     *         matcher's pattern
+     */
+    public void addExcludeMatcher(PathMatcher matcher) {
+        excludes.add(matcher);
+    }
+
+    /**
+     * Removes a matcher from excludes to resume tracking of corresponding entries creation,
+     * modification and deletion events.
+     *
+     * @param matcher
+     *         matcher's pattern
+     */
+    public void removeExcludeMatcher(PathMatcher matcher) {
+        excludes.remove(matcher);
+    }
+
+    /**
+     * Adds entries to includes by path matcher for tracking creation,
+     * modification and deletion events for corresponding entries.
+     * Note: the goal of this method is to add some entries to includes in case when parent directory is added to excludes.
+     *
+     * @param matcher
+     *         matcher's pattern
+     */
+    public void addIncludeMatcher(PathMatcher matcher) {
+        includes.add(matcher);
+    }
+
+    /**
+     * Removes entries from includes by path matcher.
+     * Note: use this method to remove some entries from includes
+     * in case when these one are added to includes by {@link #addIncludeMatcher}.
+     *
+     * @param matcher
+     *         matcher's pattern
+     */
+    public void removeIncludeMatcher(PathMatcher matcher) {
+        includes.remove(matcher);
+    }
+
+    /**
+     * Checks if specified path is within excludes
+     *
+     * @param path
+     *         path being examined
+     * @return true if path is within excludes, false otherwise
+     */
+    public boolean isExcluded(Path path) {
+        return !isIncluded(path) && excludes.stream().anyMatch(pathMatcher -> pathMatcher.matches(path));
+    }
+
+    /**
+     * Checks if specified path is within includes
+     *
+     * @param path
+     *         path being examined
+     * @return true if path is within includes, false otherwise
+     */
+    public boolean isIncluded(Path path) {
+        return includes.stream().anyMatch(pathMatcher -> pathMatcher.matches(path));
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
@@ -1,0 +1,367 @@
+
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.watcher;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.project.server.FolderEntry;
+import org.eclipse.che.api.project.server.ProjectManager;
+import org.eclipse.che.api.project.server.RegisteredProject;
+import org.eclipse.che.api.project.server.VirtualFileEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isDirectory;
+import static java.nio.file.Files.lines;
+import static java.nio.file.Files.write;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.che.api.project.shared.Constants.CHE_DIR;
+import static org.eclipse.che.api.vfs.watcher.FileWatcherUtils.toInternalPath;
+import static org.eclipse.che.api.vfs.watcher.FileWatcherUtils.toNormalPath;
+
+/**
+ * Watches the file which contains exclude patterns for managing of tracking creation,
+ * modification and deletion events for corresponding entries.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class FileWatcherIgnoreFileTracker {
+    private static final Logger LOG                           = LoggerFactory.getLogger(FileWatcherIgnoreFileTracker.class);
+    private static final String FILE_WATCHER_IGNORE_FILE_NAME = "fileWatcherIgnore";
+    private static final String FILE_WATCHER_IGNORE_FILE_PATH = "/" + CHE_DIR + "/" + FILE_WATCHER_IGNORE_FILE_NAME;
+    private static final String EXCLUDES_SUBSCRIBE            = "fileWatcher/excludes/subscribe";
+    private static final String EXCLUDES_UNSUBSCRIBE          = "fileWatcher/excludes/unsubscribe";
+    private static final String EXCLUDES_CHANGED              = "fileWatcher/excludes/changed";
+    private static final String EXCLUDES_CLEAN_UP             = "fileWatcher/excludes/cleanup";
+    private static final String ADD_TO_EXCLUDES               = "fileWatcher/excludes/addToExcludes";
+    private static final String REMOVE_FROM_EXCLUDES          = "fileWatcher/excludes/removeFromExcludes";
+
+    private final Set<String>          endpointIds = newConcurrentHashSet();
+    private final Map<Path, Set<Path>> excludes    = new ConcurrentHashMap<>();
+    private final RequestTransmitter         transmitter;
+    private final FileWatcherManager         fileWatcherManager;
+    private final Provider<ProjectManager>   projectManagerProvider;
+    private final RequestHandlerConfigurator configurator;
+    private final Path                       root;
+    private       int                        fileWatchingOperationID;
+
+    @Inject
+    public FileWatcherIgnoreFileTracker(FileWatcherManager fileWatcherManager,
+                                        RequestTransmitter transmitter,
+                                        RequestHandlerConfigurator configurator,
+                                        Provider<ProjectManager> projectManagerProvider,
+                                        @Named("che.user.workspaces.storage") File root) {
+        this.projectManagerProvider = projectManagerProvider;
+        this.transmitter = transmitter;
+        this.fileWatcherManager = fileWatcherManager;
+        this.configurator = configurator;
+        this.root = root.toPath().normalize().toAbsolutePath();
+    }
+
+    @PostConstruct
+    public void initialize() {
+        configureHandlers();
+        startTrackingIgnoreFile();
+        readExcludesFromIgnoreFiles();
+        addFileWatcherExcludesMatcher();
+    }
+
+    @PreDestroy
+    public void stopWatching() {
+        fileWatcherManager.unRegisterByMatcher(fileWatchingOperationID);
+    }
+
+    private void configureHandlers() {
+        configurator.newConfiguration()
+                    .methodName(EXCLUDES_SUBSCRIBE)
+                    .noParams()
+                    .noResult()
+                    .withConsumer(endpointId -> {
+                        endpointIds.add(endpointId);
+                        notifyAboutIgnoreFileChanges();
+                    });
+
+        configurator.newConfiguration()
+                    .methodName(EXCLUDES_UNSUBSCRIBE)
+                    .noParams()
+                    .noResult()
+                    .withConsumer(endpointIds::remove);
+
+        configurator.newConfiguration()
+                    .methodName(ADD_TO_EXCLUDES)
+                    .paramsAsListOfString()
+                    .resultAsBoolean()
+                    .withFunction((endpointId, pathsToExclude) -> addExcludesToIgnoreFile(pathsToExclude));
+
+
+        configurator.newConfiguration()
+                    .methodName(REMOVE_FROM_EXCLUDES)
+                    .paramsAsListOfString().resultAsBoolean()
+                    .withFunction((endpointId, excludesToRemove) -> removeExcludesFromIgnoreFile(excludesToRemove));
+    }
+
+    private void readExcludesFromIgnoreFiles() {
+        try {
+            projectManagerProvider.get().getProjects().stream()
+                                  .map(this::getFileWatcherIgnoreFileLocation)
+                                  .forEach(this::fillUpExcludesFromIgnoreFile);
+        } catch (ServerException e) {
+            LOG.debug("Can not fill up file watcher excludes: " + e.getLocalizedMessage());
+        }
+    }
+
+    private String getFileWatcherIgnoreFileLocation(RegisteredProject project) {
+        FolderEntry baseFolder = project.getBaseFolder();
+        return baseFolder == null ? "" : baseFolder.getPath().toString() + FILE_WATCHER_IGNORE_FILE_PATH;
+    }
+
+    private void startTrackingIgnoreFile() {
+        fileWatcherManager.addIncludeMatcher(getIgnoreFileMatcher());
+        fileWatchingOperationID = fileWatcherManager.registerByMatcher(getCheDirectoryMatcher(),
+                                                                       getCreateConsumer(),
+                                                                       getModifyConsumer(),
+                                                                       getDeleteConsumer());
+    }
+
+    private PathMatcher getCheDirectoryMatcher() {
+        return path -> isDirectory(path) &&
+                       CHE_DIR.equals(path.getFileName().toString());
+    }
+
+    private PathMatcher getIgnoreFileMatcher() {
+        return path -> !isDirectory(path) &&
+                       FILE_WATCHER_IGNORE_FILE_NAME.equals(path.getFileName().toString()) &&
+                       CHE_DIR.equals(path.getParent().getFileName().toString());
+    }
+
+    private Consumer<String> getCreateConsumer() {
+        return getModifyConsumer();
+    }
+
+    private Consumer<String> getModifyConsumer() {
+        return location -> {
+            Path path = toNormalPath(root, location);
+            if (getIgnoreFileMatcher().matches(path)) {
+                fillUpExcludesFromIgnoreFile(location);
+                notifyAboutIgnoreFileChanges();
+            }
+        };
+    }
+
+    private Consumer<String> getDeleteConsumer() {
+        return location -> {
+            Path path = toNormalPath(root, location);
+            if (getIgnoreFileMatcher().matches(path)) {
+                Path projectPath = path.getParent().getParent();
+                excludes.remove(projectPath);
+                notifyAboutIgnoreFileChanges();
+            }
+        };
+    }
+
+    private void addFileWatcherExcludesMatcher() {
+        fileWatcherManager.addExcludeMatcher(path -> excludes.values().stream()
+                                                             .flatMap(Collection::stream)
+                                                             .anyMatch(path::startsWith));
+    }
+
+    private void fillUpExcludesFromIgnoreFile(String ignoreFileLocation) {
+        try {
+            if (isNullOrEmpty(ignoreFileLocation)) {
+                return;
+            }
+
+            Path ignoreFilePath = toNormalPath(root, ignoreFileLocation);
+            if (!exists(ignoreFilePath)) {
+                return;
+            }
+
+            Path projectPath = ignoreFilePath.getParent().getParent();
+            excludes.remove(projectPath);
+
+            List<String> lines = lines(ignoreFilePath).collect(toList());
+            Set<Path> projectExcludes = lines.stream()
+                                             .filter(line -> !isNullOrEmpty(line.trim()))
+                                             .map(line -> projectPath.resolve(line.trim()))
+                                             .filter(excludePath -> exists(excludePath))
+                                             .collect(toSet());
+
+            if (!projectExcludes.isEmpty()) {
+                excludes.put(projectPath, projectExcludes);
+            }
+        } catch (IOException e) {
+            LOG.error(format("Can not fill up file watcher excludes from file %s, the reason is: %s",
+                             ignoreFileLocation,
+                             e.getLocalizedMessage()));
+        }
+    }
+
+    private boolean addExcludesToIgnoreFile(List<String> pathsToExclude) {
+        boolean isRemoved = pathsToExclude.removeIf(location -> {
+            Path pathToExclude = toNormalPath(root, location);
+            return excludes.values().stream()
+                           .flatMap(Collection::stream)
+                           .anyMatch(path -> path.equals(pathToExclude));
+        });
+
+        if (pathsToExclude.isEmpty()) {
+            return false;
+        }
+
+        Map<Path, Set<String>> excludesToWrite = groupExcludes(pathsToExclude);
+        excludesToWrite.keySet()
+                       .forEach(ignoreFilePath -> writeExcludesToIgnoreFile(ignoreFilePath, excludesToWrite.get(ignoreFilePath)));
+        return !isRemoved;
+    }
+
+    private void writeExcludesToIgnoreFile(Path ignoreFilePath, Set<String> locationsToExclude) {
+        try {
+            write(ignoreFilePath, locationsToExclude, UTF_8, CREATE, APPEND);
+        } catch (IOException e) {
+            String errorMessage = "Can not add paths to File Watcher excludes ";
+
+            LOG.error(errorMessage + e.getLocalizedMessage());
+
+            throw new JsonRpcException(500, errorMessage);
+        }
+    }
+
+    private boolean removeExcludesFromIgnoreFile(List<String> pathsToRemove) {
+        Map<Path, Set<String>> excludesToRemove = groupExcludes(pathsToRemove);
+        if (excludesToRemove.isEmpty()) {
+            return false;
+        }
+
+        excludesToRemove.keySet()
+                        .forEach(ignoreFilePath -> removeExcludesFromIgnoreFile(ignoreFilePath, excludesToRemove.get(ignoreFilePath)));
+        return true;
+    }
+
+    private void removeExcludesFromIgnoreFile(Path ignoreFilePath, Set<String> pathsToExclude) {
+        try {
+            if (!exists(ignoreFilePath)) {
+                throw new JsonRpcException(400,
+                                           "Can not remove paths from File Watcher excludes: ignore file is not found by path " +
+                                           ignoreFilePath);
+            }
+
+            Set<String> projectExcludes = lines(ignoreFilePath)
+                    .filter(line -> {
+                        String location = line.trim();
+                        return !location.isEmpty() && !pathsToExclude.contains(location);
+                    })
+                    .collect(toSet());
+
+            write(ignoreFilePath, projectExcludes, UTF_8);
+        } catch (IOException e) {
+            String errorMessage = "Can not remove paths from File Watcher excludes ";
+
+            LOG.error(errorMessage + e.getLocalizedMessage());
+
+            throw new JsonRpcException(500, errorMessage);
+        }
+    }
+
+    private Map<Path, Set<String>> groupExcludes(List<String> locationsToExclude) {
+        Map<Path, Set<String>> groupedExcludes = new HashMap<>();
+        try {
+            for (String location : locationsToExclude) {
+                if (isNullOrEmpty(location)) {
+                    throw new NotFoundException("The path to exclude should not be empty");
+                }
+
+                VirtualFileEntry itemToExclude = projectManagerProvider.get().getProjectsRoot().getChild(location);
+                if (itemToExclude == null) {
+                    throw new NotFoundException("The file is not found by path " + location);
+                }
+
+                String projectLocation = itemToExclude.getProject();
+                if (isNullOrEmpty(projectLocation)) {
+                    throw new ServerException("The project is not recognized for " + location);
+                }
+
+                Path pathToExclude = toNormalPath(root, location);
+                Path projectPath = toNormalPath(root, projectLocation);
+                Path ignoreFilePath = toNormalPath(root, projectLocation + FILE_WATCHER_IGNORE_FILE_PATH);
+
+                Set<String> excludesToWrite = groupedExcludes.computeIfAbsent(ignoreFilePath, k -> new HashSet<>());
+                excludesToWrite.add(projectPath.relativize(pathToExclude).toString());
+            }
+        } catch (NotFoundException e) {
+            String errorMessage = "Can not add path to File Watcher excludes: " + e.getLocalizedMessage();
+
+            LOG.error(errorMessage);
+
+            throw new JsonRpcException(400, errorMessage);
+
+        } catch (ServerException e) {
+            String errorMessage = "Can not add path to File Watcher excludes ";
+
+            LOG.error(errorMessage + e.getLocalizedMessage());
+
+            throw new JsonRpcException(500, errorMessage);
+        }
+        return groupedExcludes;
+    }
+
+    private void notifyAboutIgnoreFileChanges() {
+        List<String> ignoreFileExcludes = excludes.keySet().stream()
+                                                  .flatMap(projectPath -> excludes.get(projectPath).stream()
+                                                                                  .map(path -> toInternalPath(root, path)))
+                                                  .collect(toList());
+        if (ignoreFileExcludes.isEmpty()) {
+            endpointIds.forEach(it -> transmitter.newRequest()
+                                                 .endpointId(it)
+                                                 .methodName(EXCLUDES_CLEAN_UP)
+                                                 .noParams()
+                                                 .sendAndSkipResult());
+            return;
+        }
+
+        endpointIds.forEach(it -> transmitter.newRequest()
+                                             .endpointId(it)
+                                             .methodName(EXCLUDES_CHANGED)
+                                             .paramsAsListOfString(ignoreFileExcludes)
+                                             .sendAndSkipResult());
+    }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
@@ -133,7 +133,6 @@ public class FileWatcherIgnoreFileTracker {
                     .resultAsBoolean()
                     .withFunction((endpointId, pathsToExclude) -> addExcludesToIgnoreFile(pathsToExclude));
 
-
         configurator.newConfiguration()
                     .methodName(REMOVE_FROM_EXCLUDES)
                     .paramsAsListOfString().resultAsBoolean()

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileWatcherManagerTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileWatcherManagerTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.vfs.watcher;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,11 +37,13 @@ public class FileWatcherManagerTest {
     public TemporaryFolder rootFolder = new TemporaryFolder();
 
     @Mock
-    FileWatcherByPathValue   fileWatcherByPathValue;
+    FileWatcherByPathValue             fileWatcherByPathValue;
     @Mock
-    FileWatcherByPathMatcher fileWatcherByPathMatcher;
+    FileWatcherByPathMatcher           fileWatcherByPathMatcher;
     @Mock
-    FileWatcherService       service;
+    FileWatcherExcludePatternsRegistry fileWatcherExcludePatternsRegistry;
+    @Mock
+    FileWatcherService                 service;
 
     FileWatcherManager manager;
 
@@ -57,7 +58,8 @@ public class FileWatcherManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        manager = new FileWatcherManager(rootFolder.getRoot(), fileWatcherByPathValue, fileWatcherByPathMatcher, service);
+        manager = new FileWatcherManager(rootFolder.getRoot(), fileWatcherByPathValue, fileWatcherByPathMatcher, service,
+                                         fileWatcherExcludePatternsRegistry);
     }
 
     @Test

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileWatcherServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileWatcherServiceTest.java
@@ -23,15 +23,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.nio.file.WatchService;
-import java.util.Set;
 
 import static java.nio.file.Files.createDirectory;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
-import static java.util.Collections.emptySet;
 import static org.apache.commons.io.FileUtils.write;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -52,8 +49,9 @@ public class FileWatcherServiceTest {
     public TemporaryFolder rootFolder = new TemporaryFolder();
 
     @Mock
-    FileWatcherEventHandler handler;
-    Set<PathMatcher> excludes     = emptySet();
+    FileWatcherEventHandler            handler;
+    @Mock
+    FileWatcherExcludePatternsRegistry fileWatcherExcludePatternsRegistry;
     WatchService     watchService = FileSystems.getDefault().newWatchService();
 
     FileWatcherService service;
@@ -63,7 +61,7 @@ public class FileWatcherServiceTest {
 
     @BeforeClass
     public void setUp() throws Exception {
-        service = new FileWatcherService(excludes, handler, watchService);
+        service = new FileWatcherService(fileWatcherExcludePatternsRegistry, handler, watchService);
 
         service.start();
     }


### PR DESCRIPTION
### What does this PR do?
- Add ability to manage file watcher tracking creation, modification and deletion events.
- Allows to add and remove entries to excludes by 'Add to File Watcher excludes' and 'Remove from File Watcher excludes' actions or by editing projectPath/.che/fileWatcherIgnore file manually
- Change the way of notification about external changes - current behavior: we display popup, new behavior: we display this kind of notifications ONLY in Events panel. We are going to improve this behavior by #5514

### What issues does this PR fix or reference?
#5215 

#### Changelog
Add ability to manage file watcher tracking creation, modification and deletion events.

#### Release Notes
File watchers allow to keep notified about changes on files when they are done from multiple clients. For example, you might be editing files of projects from Che's editor, Che's terminal or any other clients if you are using ssh. The file watcher provide the ability track any creation, modification and deletion on your projects' files. 
In this version, we added the ability to manage the file watcher behaviours. In certain cases, you might not want to keep track of certain files/folders of your projects. We added a `fileWatcherIgnore`which behave similarly to a `.gitignore`. You manage the file yourself by editing the `projectPath/.che/fileWatcherIgnore` or you can do a right click on a file/folder to get the actions 'Add to File Watcher excludes' or 'Remove from File Watcher excludes'.

![filewatcherignore](https://user-images.githubusercontent.com/5676062/28076832-8ea3f020-6668-11e7-9414-330a30e49c81.gif)


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

