### PR TITLE
Add machine + runtime identity to docker labels serialization

### DIFF
--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -15,6 +15,7 @@ import com.google.inject.assistedinject.Assisted;
 
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.model.machine.MachineSource;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -120,19 +121,23 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         startSynchronizer.setStartThread();
         try {
             contextsStorage.add((DockerRuntimeContext)getContext());
-            checkStartInterruption();
             dockerNetworkLifecycle.createNetwork(dockerEnvironment.getNetwork());
+
+            boolean restore = isRestoreEnabled(startOptions);
 
             String machineName = startQueue.peek();
             while (machineName != null) {
                 DockerContainerConfig service = dockerEnvironment.getServices().get(machineName);
-                checkStartInterruption();
                 eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
                                                .withIdentity(DtoConverter.asDto(identity))
                                                .withEventType(MachineStatus.STARTING)
                                                .withMachineName(machineName));
                 try {
-                    startMachine(machineName, service, startOptions, machineName.equals(devMachineName));
+                    if (restore) {
+                        restoreMachine(machineName, service);
+                    } else {
+                        startMachine(machineName, service);
+                    }
                     eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
                                                    .withIdentity(DtoConverter.asDto(identity))
                                                    .withEventType(MachineStatus.RUNNING)
@@ -194,66 +199,57 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         return Collections.unmodifiableMap(properties);
     }
 
-    private void startMachine(String name,
-                              DockerContainerConfig containerConfig,
-                              Map<String, String> startOptions,
-                              boolean isDev) throws InfrastructureException {
-        DockerMachine dockerMachine;
-        // TODO property name
-        final RuntimeIdentity identity = getContext().getIdentity();
-        if ("true".equals(startOptions.get("restore"))) {
-            MachineSourceImpl machineSource;
-            try {
-                SnapshotImpl snapshot = snapshotDao.getSnapshot(identity.getWorkspaceId(),
-                                                                identity.getEnvName(),
-                                                                name);
-                machineSource = snapshot.getMachineSource();
-                // Snapshot image location has SHA-256 digest which needs to be removed,
-                // otherwise it will be pulled without tag and cause problems
-                String imageName = machineSource.getLocation();
-                if (imageName.contains("@sha256:")) {
-                    machineSource.setLocation(imageName.substring(0, imageName.indexOf('@')));
-                }
+    private void restoreMachine(String name, DockerContainerConfig originalConfig) throws InfrastructureException {
+        try {
+            SnapshotImpl snapshot = snapshotDao.getSnapshot(identity.getWorkspaceId(), identity.getEnvName(), name);
+            startMachine(name, configForSnapshot(snapshot, originalConfig));
+        } catch (NotFoundException | SourceNotFoundException x) {
+            LOG.warn("Snapshot for machine '{}:{}:{}' is missing, machine will be started from source",
+                     identity.getWorkspaceId(),
+                     identity.getEnvName(),
+                     name);
+            startMachine(name, originalConfig);
+        } catch (SnapshotException x) {
+            throw new InternalInfrastructureException(x);
+        }
+    }
 
-                DockerContainerConfig imageContainerConfig = normalizeSource(containerConfig, machineSource);
-                dockerMachine = serviceStarter.startService(dockerEnvironment.getNetwork(),
-                                                            name,
-                                                            imageContainerConfig,
-                                                            identity,
-                                                            isDev);
-            } catch (NotFoundException | SnapshotException | SourceNotFoundException e) {
-                // slip to start without recovering
-                dockerMachine = serviceStarter.startService(dockerEnvironment.getNetwork(),
+    private void startMachine(String name, DockerContainerConfig containerConfig) throws InfrastructureException {
+        InternalMachineConfig machineCfg = getContext().getMachineConfigs().get(name);
+
+        Map<String, String> labels = new HashMap<>(containerConfig.getLabels());
+        labels.putAll(Labels.newSerializer()
+                            .machineName(name)
+                            .runtimeId(identity)
+                            .servers(machineCfg.getServers())
+                            .labels());
+        containerConfig.setLabels(labels);
+
+        DockerMachine machine = serviceStarter.startService(dockerEnvironment.getNetwork(),
                                                             name,
                                                             containerConfig,
                                                             identity,
-                                                            isDev);
-            }
-        } else {
-            dockerMachine = serviceStarter.startService(dockerEnvironment.getNetwork(),
-                                                        name,
-                                                        containerConfig,
-                                                        identity,
-                                                        isDev);
-        }
-
+                                                            devMachineName.equals(name));
         try {
-            checkStartInterruption();
-            startSynchronizer.addMachine(name, dockerMachine);
+            startSynchronizer.addMachine(name, machine);
 
-            InternalMachineConfig machineConfig = getContext().getMachineConfigs().get(name);
-            if (machineConfig == null) {
-                throw new InfrastructureException("Machine %s is not found in internal machines config of RuntimeContext");
-            }
+            bootstrapperFactory.create(name, identity, machine, machineCfg.getInstallers()).bootstrap();
 
-            bootstrapperFactory.create(name, identity, dockerMachine, machineConfig.getInstallers())
-                               .bootstrap();
-
-            checkServersReadiness(name, dockerMachine);
+            checkServersReadiness(name, machine);
         } catch (InfrastructureException e) {
-            destroyMachineQuietly(name, dockerMachine);
+            destroyMachineQuietly(name, machine);
             throw e;
         }
+    }
+
+    // TODO support configuration properties as well
+    private boolean isRestoreEnabled(Map<String, String> startOpts) {
+        return Boolean.parseBoolean(startOpts.get("restore"));
+    }
+
+    // TODO support configuration properties as well
+    private boolean isSnapshotEnabled(Map<String, String> stopOpts) {
+        return stopOpts != null && Boolean.parseBoolean(stopOpts.get("create-snapshot"));
     }
 
     private void checkServersReadiness(String machineName, DockerMachine dockerMachine)
@@ -294,7 +290,6 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         while (System.currentTimeMillis() < readinessDeadLine) {
             LOG.info("Checking server {} of machine {} at {}", serverRef, machineName,
                      System.currentTimeMillis());
-            checkStartInterruption();
             if (isHttpConnectionSucceed(url, checker)) {
                 // TODO protect with lock, from null, from exceptions
                 DockerMachine machine = startSynchronizer.getMachines().get(machineName);
@@ -357,6 +352,18 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         }
     }
 
+    private DockerContainerConfig configForSnapshot(SnapshotImpl snapshot, DockerContainerConfig originCfg)
+            throws NotFoundException, SnapshotException {
+        MachineSourceImpl machineSource = snapshot.getMachineSource();
+        // Snapshot image location has SHA-256 digest which needs to be removed,
+        // otherwise it will be pulled without tag and cause problems
+        String imageName = machineSource.getLocation();
+        if (imageName.contains("@sha256:")) {
+            machineSource.setLocation(imageName.substring(0, imageName.indexOf('@')));
+        }
+        return normalizeSource(originCfg, machineSource);
+    }
+
     private DockerContainerConfig normalizeSource(DockerContainerConfig containerConfig,
                                                   MachineSource machineSource) {
         DockerContainerConfig serviceWithNormalizedSource = new DockerContainerConfig(containerConfig);
@@ -381,18 +388,17 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         return serviceWithNormalizedSource;
     }
 
-    private void checkStartInterruption() throws InfrastructureException {
-        if (Thread.currentThread().isInterrupted()) {
-            throw new InfrastructureException("Docker infrastructure runtime start was interrupted");
-        }
-    }
-
     private void destroyRuntime(Map<String, String> stopOptions) throws InfrastructureException {
-        if (stopOptions != null && "true".equals(stopOptions.get("create-snapshot"))) {
-            snapshotMachines(startSynchronizer.removeMachines());
-        } else {
-            startSynchronizer.removeMachines()
-                             .forEach(this::destroyMachineQuietly);
+        Map<String, DockerMachine> machines = startSynchronizer.removeMachines();
+        if (isSnapshotEnabled(stopOptions)) {
+            snapshotMachines(machines);
+        }
+        for (Map.Entry<String, DockerMachine> entry : machines.entrySet()) {
+            destroyMachineQuietly(entry.getKey(), entry.getValue());
+            eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
+                                           .withEventType(MachineStatus.STOPPED)
+                                           .withIdentity(DtoConverter.asDto(identity))
+                                           .withMachineName(entry.getKey()));
         }
         // TODO what happens when context throws exception here
         dockerNetworkLifecycle.destroyNetwork(dockerEnvironment.getNetwork());
@@ -404,10 +410,6 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     private void destroyMachineQuietly(String machineName, DockerMachine machine) {
         try {
             machine.destroy();
-            eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
-                                           .withIdentity(DtoConverter.asDto(identity))
-                                           .withEventType(MachineStatus.STOPPED)
-                                           .withMachineName(machineName));
         } catch (InfrastructureException e) {
             LOG.error(format("Error occurs on destroying of docker machine '%s' in workspace '%s'. Container '%s'",
                              machineName,

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.spi.RuntimeIdentityImpl;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helps to convert docker infrastructure entities
+ * to docker labels and vise-versa.
+ *
+ * @author Yevhenii Voevodin
+ */
+public final class Labels {
+
+    private static final String LABEL_PREFIX              = "org.eclipse.che.";
+    private static final String LABEL_MACHINE_NAME        = LABEL_PREFIX + "machine.name";
+    private static final String LABEL_WORKSPACE_ID        = LABEL_PREFIX + "workspace.id";
+    private static final String LABEL_WORKSPACE_ENV       = LABEL_PREFIX + "workspace.env";
+    private static final String LABEL_WORKSPACE_OWNER     = LABEL_PREFIX + "workspace.owner";
+    private static final String SERVER_PORT_LABEL_FMT     = LABEL_PREFIX + "server.%s.port";
+    private static final String SERVER_PROTOCOL_LABEL_FMT = LABEL_PREFIX + "server.%s.protocol";
+    private static final String SERVER_PATH_LABEL_FMT     = LABEL_PREFIX + "server.%s.path";
+
+    /** Pattern that matches server labels e.g. "org.eclipse.che.server.exec-agent.port". */
+    private static final Pattern SERVER_LABEL_PATTERN = Pattern.compile("org\\.eclipse\\.che\\.server\\.(?<ref>[\\w-]+)\\..+");
+
+    /** Creates new label serializer. */
+    public static Serializer newSerializer() { return new Serializer(); }
+
+    /** Creates new label deserializer from given labels. */
+    public static Deserializer newDeserializer(Map<String, String> labels) { return new Deserializer(labels); }
+
+    /** Helps to serialize known entities to docker labels. */
+    public static class Serializer {
+
+        private final Map<String, String> labels = new LinkedHashMap<>();
+
+        /**
+         * Serializes machine name as docker container label.
+         * Appends serialization result to this aggregate.
+         *
+         * @param name
+         *         machine name
+         * @return this serializer
+         */
+        public Serializer machineName(String name) {
+            labels.put(LABEL_MACHINE_NAME, name);
+            return this;
+        }
+
+        /**
+         * Serializes runtime identity as docker container labels.
+         * Appends serialization result to this aggregate.
+         *
+         * @param runtimeId
+         *         the id of runtime
+         * @return this serializer
+         */
+        public Serializer runtimeId(RuntimeIdentity runtimeId) {
+            labels.put(LABEL_WORKSPACE_ID, runtimeId.getWorkspaceId());
+            labels.put(LABEL_WORKSPACE_ENV, runtimeId.getEnvName());
+            labels.put(LABEL_WORKSPACE_OWNER, runtimeId.getOwner());
+            return this;
+        }
+
+        /**
+         * Serializes server configuration as docker container labels.
+         * Appends serialization result to this aggregate.
+         *
+         * @param ref
+         *         server reference e.g. "exec-agent"
+         * @param server
+         *         server configuration
+         * @return this serializer
+         */
+        public Serializer server(String ref, ServerConfig server) {
+            labels.put(String.format(SERVER_PORT_LABEL_FMT, ref), server.getPort());
+            labels.put(String.format(SERVER_PROTOCOL_LABEL_FMT, ref), server.getProtocol());
+            labels.put(String.format(SERVER_PATH_LABEL_FMT, ref), server.getPath());
+            return this;
+        }
+
+        /**
+         * Serializer many servers as docker container labels.
+         * Appends serialization result to this aggregate.
+         *
+         * @param servers
+         *         ref -> server map
+         * @return this serializer
+         */
+        public Serializer servers(Map<String, ? extends ServerConfig> servers) {
+            servers.forEach(this::server);
+            return this;
+        }
+
+        /** Returns docker container labels aggregated during serialization. */
+        public Map<String, String> labels() { return labels; }
+    }
+
+    /** Helps to deserializer docker labels to known entities. */
+    public static class Deserializer {
+
+        private final Map<String, String> labels;
+
+        public Deserializer(Map<String, String> labels) { this.labels = Objects.requireNonNull(labels); }
+
+        /** Retrieves machine name from docker container labels and returns it. */
+        public String machineName() {
+            return labels.get(LABEL_MACHINE_NAME);
+        }
+
+        /** Retrieves runtime identity from docker labels and returns it. */
+        public RuntimeIdentity runtimeId() {
+            return new RuntimeIdentityImpl(labels.get(LABEL_WORKSPACE_ID),
+                                           labels.get(LABEL_WORKSPACE_ENV),
+                                           labels.get(LABEL_WORKSPACE_OWNER));
+        }
+
+        /** Retrieves server configuration from docker labels and returns (ref -> server config) map. */
+        public Map<String, ServerConfig> servers() {
+            Map<String, ServerConfig> servers = new HashMap<>();
+            for (Map.Entry<String, String> entry : labels.entrySet()) {
+                Matcher refMatcher = SERVER_LABEL_PATTERN.matcher(entry.getKey());
+                if (refMatcher.matches()) {
+                    String ref = refMatcher.group("ref");
+                    if (!servers.containsKey(ref)) {
+                        servers.put(ref, new ServerConfigImpl(labels.get(String.format(SERVER_PORT_LABEL_FMT, ref)),
+                                                              labels.get(String.format(SERVER_PROTOCOL_LABEL_FMT, ref)),
+                                                              labels.get(String.format(SERVER_PATH_LABEL_FMT, ref))));
+                    }
+                }
+            }
+            return servers;
+        }
+    }
+
+    private Labels() {}
+}

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/snapshot/SnapshotDao.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/snapshot/SnapshotDao.java
@@ -21,8 +21,6 @@ import java.util.List;
  * @author andrew00x
  * @author Yevhenii Voevodin
  *
- * @deprecated  to remove to Docker specific
- *
  */
 public interface SnapshotDao {
 

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.spi.RuntimeIdentityImpl;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Tests {@link Labels}.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class LabelsTest {
+
+    @Test
+    public void serialization() {
+        Map<String, String> serialized = Labels.newSerializer()
+                                               .machineName("dev-machine")
+                                               .runtimeId(new RuntimeIdentityImpl("workspace123", "my-env", "owner"))
+                                               .server("my-server1", new ServerConfigImpl("8000/tcp", "http", "/api/info"))
+                                               .server("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect"))
+                                               .labels();
+        Map<String, String> expected =
+                ImmutableMap.<String, String>builder()
+                        .put("org.eclipse.che.machine.name", "dev-machine")
+                        .put("org.eclipse.che.workspace.id", "workspace123")
+                        .put("org.eclipse.che.workspace.env", "my-env")
+                        .put("org.eclipse.che.workspace.owner", "owner")
+                        .put("org.eclipse.che.server.my-server1.port", "8000/tcp")
+                        .put("org.eclipse.che.server.my-server1.protocol", "http")
+                        .put("org.eclipse.che.server.my-server1.path", "/api/info")
+                        .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
+                        .put("org.eclipse.che.server.my-server2.protocol", "ws")
+                        .put("org.eclipse.che.server.my-server2.path", "/connect")
+                        .build();
+
+        assertEquals(serialized, expected);
+    }
+
+    @Test
+    public void deserialization() {
+        ImmutableMap<String, String> labels =
+                ImmutableMap.<String, String>builder()
+                        .put("custom-label", "value")
+                        .put("org.eclipse.che.machine.unknown-label", "value")
+                        .put("org.eclipse.che.machine.name", "dev-machine")
+                        .put("org.eclipse.che.workspace.id", "workspace123")
+                        .put("org.eclipse.che.workspace.env", "my-env")
+                        .put("org.eclipse.che.workspace.owner", "owner")
+                        .put("org.eclipse.che.server.my-server1.port", "8000/tcp")
+                        .put("org.eclipse.che.server.my-server1.protocol", "http")
+                        .put("org.eclipse.che.server.my-server1.path", "/api/info")
+                        .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
+                        .put("org.eclipse.che.server.my-server2.protocol", "ws")
+                        .put("org.eclipse.che.server.my-server2.path", "/connect")
+                        .build();
+
+        Labels.Deserializer deserializer = Labels.newDeserializer(labels);
+
+        assertEquals(deserializer.machineName(), "dev-machine");
+
+        RuntimeIdentity runtimeId = deserializer.runtimeId();
+        assertEquals(runtimeId.getWorkspaceId(), "workspace123", "workspace id");
+        assertEquals(runtimeId.getEnvName(), "my-env", "workspace environment name");
+        assertEquals(runtimeId.getOwner(), "owner", "workspace owner");
+
+        Map<String, ServerConfig> servers = deserializer.servers();
+        ServerConfig server1 = servers.get("my-server1");
+        assertNotNull(server1, "first server");
+        assertEquals(server1.getPort(), "8000/tcp");
+        assertEquals(server1.getProtocol(), "http");
+        assertEquals(server1.getPath(), "/api/info");
+
+        ServerConfig server2 = servers.get("my-server2");
+        assertNotNull(server2, "second server");
+        assertEquals(server2.getPort(), "8080/tcp");
+        assertEquals(server2.getProtocol(), "ws");
+        assertEquals(server2.getPath(), "/connect");
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds machine name + runtime identity + server configurations to docker labels serialization.

I tried to follow [key format recommendations](https://docs.docker.com/engine/userguide/labels-custom-metadata/), so the proposed format was a bit changed. 
Serialized labels
```
"org.eclipse.che.machine.name": "default",
"org.eclipse.che.workspace.env": "test",
"org.eclipse.che.workspace.id": "workspace28t00rschopreajr",
"org.eclipse.che.workspace.owner": "che"
"org.eclipse.che.server.exec-agent.port": "4412/tcp",
"org.eclipse.che.server.exec-agent.protocol": "http",
"org.eclipse.che.server.ssh.port": "22/tcp",
"org.eclipse.che.server.ssh.protocol": "ssh",
"org.eclipse.che.server.terminal.port": "4411/tcp",
"org.eclipse.che.server.terminal.protocol": "http",
"org.eclipse.che.server.wsagent.port": "4401/tcp",
"org.eclipse.che.server.wsagent.protocol": "http",
```

### What issues does this PR fix or reference?
Resolves #4104

