### PR TITLE
CODENVY-2285: Add repository and registry host in log on snapshot deletion failure

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -200,7 +200,11 @@ public class DockerInstanceProvider implements InstanceProvider {
                 conn.disconnect();
             }
         } catch (IOException e) {
-            LOG.error(e.getLocalizedMessage(), e);
+            LOG.error("Failed to remove {} snapshot from {}. Cause: {}",
+                      dockerMachineSource.getRepository(),
+                      dockerMachineSource.getRegistry(),
+                      e.getLocalizedMessage(),
+                      e);
         }
     }
 
@@ -239,7 +243,11 @@ public class DockerInstanceProvider implements InstanceProvider {
                 conn.disconnect();
             }
         } catch (IOException e) {
-            LOG.error(e.getLocalizedMessage(), e);
+            LOG.error("Failed to remove {} snapshot from {}. Cause: {}",
+                    repository,
+                    DOCKER_HUB_BASE_URI,
+                    e.getLocalizedMessage(),
+                    e);
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
Adds snapshot repository and its docker registry hostname in log on snapshot deletion failure.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2285

#### Changelog
Added logging of image name and registry hostname on snapshot deletion failure.

#### Release Notes
N/A

#### Docs PR
N/A