### PR TITLE
CHE-5469: Fix group by folders view in commit dialog

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelViewImpl.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Comparator.naturalOrder;
 import static org.eclipse.che.ide.ext.git.client.compare.changespanel.ViewMode.TREE;
 
 /**
@@ -281,6 +282,7 @@ public class ChangesPanelViewImpl extends Composite implements ChangesPanelView 
 
     private List<String> getCommonPaths(List<String> allPaths) {
         List<String> commonPaths = new ArrayList<>();
+        allPaths.sort(naturalOrder());
         for (String path : allPaths) {
             int pathIndex = allPaths.indexOf(path);
             if (pathIndex + 1 == allPaths.size()) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add files name sorting when viewing changed files in 'groupe by folders view' in Git commit dialog.

### What issues does this PR fix or reference?
#5469 

#### Changelog
Fix 'group by folders' view in commit dialog.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
