### PR TITLE
CHE-5503: Remove unnecessary stack trace

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/MachineProviderImpl.java
@@ -554,7 +554,7 @@ public class MachineProviderImpl implements MachineInstanceProvider {
                                                       .withFilters(new Filters().withFilter("reference", imageName)))
                           .isEmpty();
         } catch (IOException e) {
-            LOG.warn("Failed to check image {} availability. Cause: {}", imageName, e.getMessage(), e);
+            LOG.warn("Failed to check image {} availability. Cause: {}", imageName, e.getMessage());
             return false; // consider that image doesn't exist locally
         }
     }


### PR DESCRIPTION
### What does this PR do?
Removes unnecessary stack trace on log warning when check for local docker image availability failed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5503

#### Changelog
Removed unnecessary stack trace logging when check for a local docker image availability failed.

#### Release Notes
N/A

#### Docs PR
N/A
