### PR TITLE
Fix for DefaultOutputCustomizerTest.java - wrong API is used in place…

### DIFF
--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/DefaultOutputCustomizerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/DefaultOutputCustomizerTest.java
@@ -12,11 +12,11 @@ package org.eclipse.che.ide.console;
 
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.testng.Assert;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
@@ -40,13 +40,15 @@ public class DefaultOutputCustomizerTest {
     }
 
     private void testStackTraceLine(boolean shouldBeCustomizable, String line, String expectedCustomization) throws Exception {
-        Assert.assertEquals(outputCustomizer.canCustomize(line), shouldBeCustomizable, 
+        Assert.assertEquals( 
                 "Line [" + line + "] is " + (shouldBeCustomizable ? "" : "not ") +
                 "customizable while it should" +
-                (shouldBeCustomizable ? "n\'t " : " ") + "be: ");
+                (shouldBeCustomizable ? "n\'t " : " ") + "be: ",
+                Boolean.valueOf(outputCustomizer.canCustomize(line)), 
+                Boolean.valueOf(shouldBeCustomizable));
         if (shouldBeCustomizable) {
-            Assert.assertEquals(outputCustomizer.customize(line), expectedCustomization, 
-                    "Wrong customization result:");
+            Assert.assertEquals("Wrong customization result:",
+                    outputCustomizer.customize(line), expectedCustomization);
         }       
     }
 


### PR DESCRIPTION
… of org.junit.Assert

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?


### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
