### PR TITLE
CHE-5505: Fix NPE in DockerConnector

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -1348,7 +1348,8 @@ public class DockerConnector {
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             T objectFromJson = GSON.fromJson(reader, clazz);
             if (objectFromJson == null) {
-                throw new IOException("Docker responded with an empty stream.");
+                LOG.error("Docker response doesn't contain any data, though it was expected to contain some.");
+                throw new IOException("Internal server error. Unexpected response body received from Docker.");
             }
             return objectFromJson;
         } catch (JsonParseException e) {
@@ -1360,7 +1361,8 @@ public class DockerConnector {
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             T objectFromJson = GSON.fromJson(reader, tt.getType());
             if (objectFromJson == null) {
-                throw new IOException("Docker responded with an empty stream.");
+                LOG.error("Docker response doesn't contain any data, though it was expected to contain some.");
+                throw new IOException("Internal server error. Unexpected response body received from Docker.");
             }
             return objectFromJson;
         } catch (JsonParseException e) {

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -1346,7 +1346,11 @@ public class DockerConnector {
 
     protected <T> T parseResponseStreamAndClose(InputStream inputStream, Class<T> clazz) throws IOException {
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
-            return GSON.fromJson(reader, clazz);
+            T objectFromJson = GSON.fromJson(reader, clazz);
+            if (objectFromJson == null) {
+                throw new IOException("Docker responded with an empty stream.");
+            }
+            return objectFromJson;
         } catch (JsonParseException e) {
             throw new IOException(e.getLocalizedMessage(), e);
         }
@@ -1354,7 +1358,11 @@ public class DockerConnector {
 
     protected <T> T parseResponseStreamAndClose(InputStream inputStream, TypeToken<T> tt) throws IOException {
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
-            return GSON.fromJson(reader, tt.getType());
+            T objectFromJson = GSON.fromJson(reader, tt.getType());
+            if (objectFromJson == null) {
+                throw new IOException("Docker responded with an empty stream.");
+            }
+            return objectFromJson;
         } catch (JsonParseException e) {
             throw new IOException(e.getLocalizedMessage(), e);
         }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -1617,6 +1617,17 @@ public class DockerConnectorTest {
         assertEquals(containers.size(), 0);
     }
 
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Docker responded with an empty stream.")
+    public void shouldThrowIOExceptionWhenParseEmptyResponseStringByClass() throws IOException {
+        dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream("".getBytes()), Version.class);
+    }
+
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Docker responded with an empty stream.")
+    public void shouldThrowIOExceptionWhenParseEmptyResponseStringByTypeToken() throws IOException {
+        dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream("".getBytes()),
+                                                    new TypeToken<List<ContainerListEntry>>() {});
+    }
+
     @Test
     public void shouldBeAbleToGetNetworks() throws Exception {
         // given

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -1617,12 +1617,14 @@ public class DockerConnectorTest {
         assertEquals(containers.size(), 0);
     }
 
-    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Docker responded with an empty stream.")
+    @Test(expectedExceptions = IOException.class,
+          expectedExceptionsMessageRegExp = "Internal server error. Unexpected response body received from Docker.")
     public void shouldThrowIOExceptionWhenParseEmptyResponseStringByClass() throws IOException {
         dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream("".getBytes()), Version.class);
     }
 
-    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Docker responded with an empty stream.")
+    @Test(expectedExceptions = IOException.class,
+          expectedExceptionsMessageRegExp = "Internal server error. Unexpected response body received from Docker.")
     public void shouldThrowIOExceptionWhenParseEmptyResponseStringByTypeToken() throws IOException {
         dockerConnector.parseResponseStreamAndClose(new ByteArrayInputStream("".getBytes()),
                                                     new TypeToken<List<ContainerListEntry>>() {});


### PR DESCRIPTION
### What does this PR do?
Fixes NPE in `DockerConnector` when Docker respond with 200 response code and empty stream.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5505

#### Changelog
Fixed NPE when docker responds with 200 response code and empty stream.

#### Release Notes
N/A

#### Docs PR
N/A