### PR TITLE
Fix broken links to che-docs

### DIFF
--- a/samples/sample-plugin-json/README.md
+++ b/samples/sample-plugin-json/README.md
@@ -1,11 +1,11 @@
 ## Description
 
-The **JSON Example** is a providing a plugin sample which is use as a continuous example in the plugin documentation. You can learn more about it at: https://www.eclipse.org/che/docs/plugins/introduction/index.html#the-json-example
+The **JSON Example** is a providing a plugin sample which is use as a continuous example in the plugin documentation. You can learn more about it at: https://www.eclipse.org/che/docs/assemblies/intro/index.html
 
 This sample demonstrate how to extend the Eclipse Che in various ways:
-- How to register a new file type and add code completion (Read the tutorial at:https://www.eclipse.org/che/docs/plugins/code-editors/index.html#code-completion)  
+- How to register a new file type and add code completion (Read the tutorial at:https://www.eclipse.org/che/docs/assemblies/sdk-code-editors/index.html#code-completion)
 
-- How to define a custom project type with project creation wizard and register project-specific actions (Read the tutorial at: https://www.eclipse.org/che/docs/plugins/project-types/index.html)
+- How to define a custom project type with project creation wizard and register project-specific actions (Read the tutorial at: https://www.eclipse.org/che/docs/assemblies/sdk-project-types/index.html)
 
 
 ## How to build sample-plugin-json plugin


### PR DESCRIPTION
See che-docs#149

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

Fixes links in json sample since che-docs#149 refactored che-docs for assemblies.

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->
Fix links to documentation in JSON sample

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
