### PR TITLE
Move binding ServerIdleDetctor to the assembly module

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -219,5 +219,7 @@ public class WsMasterModule extends AbstractModule {
 
         bind(org.eclipse.che.api.agent.server.filters.AddExecAgentInWorkspaceFilter.class);
         bind(org.eclipse.che.api.agent.server.filters.AddExecAgentInStackFilter.class);
+
+        bind(org.eclipse.che.api.workspace.server.idle.ServerIdleDetector.class);
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -169,7 +169,6 @@
                         <exclude>**/LocalDockerCustomServerEvaluationStrategyTest.java</exclude>
                         <exclude>**/DockerInstanceRuntimeInfo.java</exclude>
                         <exclude>**/DockerInstanceRuntimeInfoTest.java</exclude>
-                        <exclude>**/ServerIdleDetector.java</exclude>
                         <!-- End excluded files -->
                     </excludes>
                 </configuration>

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerMachineModule.java
@@ -33,7 +33,6 @@ public class DockerMachineModule extends AbstractModule {
     protected void configure() {
         bind(org.eclipse.che.plugin.docker.machine.cleaner.DockerAbandonedResourcesCleaner.class);
         bind(org.eclipse.che.plugin.docker.machine.cleaner.RemoveWorkspaceFilesAfterRemoveWorkspaceEventSubscriber.class);
-        bind(org.eclipse.che.plugin.docker.machine.idle.ServerIdleDetector.class);
 
         @SuppressWarnings("unused") Multibinder<String> devMachineEnvVars =
                 Multibinder.newSetBinder(binder(),

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -41,9 +41,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.eclipse.che.api.core.event.ServerIdleEvent;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.event.ServerIdleEvent;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnector;

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleaner.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleaner.java
@@ -24,11 +24,11 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.event.ServerIdleEvent;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner;
+import org.eclipse.che.api.workspace.server.event.ServerIdleEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleanerTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleanerTest.java
@@ -25,9 +25,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.event.ServerIdleEvent;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.event.ServerIdleEvent;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.mockito.ArgumentCaptor;

--- a/wsmaster/che-core-api-workspace/pom.xml
+++ b/wsmaster/che-core-api-workspace/pom.xml
@@ -218,6 +218,18 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- Exclude files until #3281 is resolved -->
+                        <exclude>**/ServerIdleDetector.java</exclude>
+                        <exclude>**/ServerIdleEvent.java</exclude>
+                        <!-- End excluded files -->
+                    </excludes>
+                </configuration>
+            </plugin>
             <!-- Create the test jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/ServerIdleEvent.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/ServerIdleEvent.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.core.event;
+package org.eclipse.che.api.workspace.server.event;
 /**
  * Event informing about idling the che server.
  */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/idle/ServerIdleDetector.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/idle/ServerIdleDetector.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.plugin.docker.machine.idle;
+package org.eclipse.che.api.workspace.server.idle;
 
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -21,9 +21,10 @@ import javax.annotation.PreDestroy;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.eclipse.che.api.core.event.ServerIdleEvent;
+
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.event.ServerIdleEvent;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.slf4j.Logger;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 /**
  * Notifies about idling the che server
- * Fires {@link org.eclipse.che.api.core.event.ServerIdleEvent} if no workspace
+ * Fires {@link ServerIdleEvent} if no workspace
  * is run for <b>che.openshift.server.inactive.stop.timeout.ms</b> milliseconds
  */
 @Singleton


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?

1. Move binding ServerIdleDetctor to the assembly module
2. Move Move ServerIdleDetctor and ServerIdleEvent to the Workspace API module


