### PR TITLE
CHE-5350: change names of methods for WebSocket communication

### DIFF
--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenJsonRpcHandler.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenJsonRpcHandler.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_ARCHETYPE_CHANEL_OUTPUT;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_ARCHETYPE_CHANEL_SUBSCRIBE;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_CHANEL_SUBSCRIBE;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_SUBSCRIBE;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_PERCENT_METHOD;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_PERCENT_UNDEFINED_METHOD;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_START_STOP_METHOD;
@@ -68,7 +68,7 @@ public class MavenJsonRpcHandler {
 
         requestTransmitter.newRequest()
                           .endpointId(WS_AGENT_ENDPOINT)
-                          .methodName(MAVEN_CHANEL_SUBSCRIBE)
+                          .methodName(MAVEN_OUTPUT_SUBSCRIBE)
                           .noParams()
                           .sendAndSkipResult();
 

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenJsonRpcCommunication.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/MavenJsonRpcCommunication.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.newConcurrentHashSet;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_CHANEL_SUBSCRIBE;
-import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_CHANEL_UNSUBSCRIBE;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_SUBSCRIBE;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_UNSUBSCRIBE;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_PERCENT_METHOD;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_PERCENT_UNDEFINED_METHOD;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_START_STOP_METHOD;
@@ -75,13 +75,13 @@ public class MavenJsonRpcCommunication implements EventSubscriber<MavenOutputEve
     @Inject
     private void configureHandlers(RequestHandlerConfigurator configurator) {
         configurator.newConfiguration()
-                    .methodName(MAVEN_CHANEL_SUBSCRIBE)
+                    .methodName(MAVEN_OUTPUT_SUBSCRIBE)
                     .noParams()
                     .noResult()
                     .withConsumer(endpointIds::add);
 
         configurator.newConfiguration()
-                    .methodName(MAVEN_CHANEL_UNSUBSCRIBE)
+                    .methodName(MAVEN_OUTPUT_UNSUBSCRIBE)
                     .noParams()
                     .noResult()
                     .withConsumer(endpointIds::remove);

--- a/plugins/plugin-maven/che-plugin-maven-shared/src/main/java/org/eclipse/che/plugin/maven/shared/MavenAttributes.java
+++ b/plugins/plugin-maven/che-plugin-maven-shared/src/main/java/org/eclipse/che/plugin/maven/shared/MavenAttributes.java
@@ -52,8 +52,8 @@ public interface MavenAttributes {
     String MAVEN_CHANEL_NAME = "maven:workspace";
 
 
-    String MAVEN_CHANEL_UNSUBSCRIBE              = "mavenOutput/unsubscribe";
-    String MAVEN_CHANEL_SUBSCRIBE                = "mavenOutput/subscribe";
+    String MAVEN_OUTPUT_UNSUBSCRIBE              = "mavenOutput/unsubscribe";
+    String MAVEN_OUTPUT_SUBSCRIBE                = "mavenOutput/subscribe";
     String MAVEN_OUTPUT_TEXT_METHOD              = "mavenOutput/text";
     String MAVEN_OUTPUT_UPDATE_METHOD            = "mavenOutput/update";
     String MAVEN_OUTPUT_START_STOP_METHOD        = "mavenOutput/start_stop";

--- a/plugins/plugin-maven/che-plugin-maven-shared/src/main/java/org/eclipse/che/plugin/maven/shared/MavenAttributes.java
+++ b/plugins/plugin-maven/che-plugin-maven-shared/src/main/java/org/eclipse/che/plugin/maven/shared/MavenAttributes.java
@@ -52,8 +52,8 @@ public interface MavenAttributes {
     String MAVEN_CHANEL_NAME = "maven:workspace";
 
 
-    String MAVEN_CHANEL_UNSUBSCRIBE              = "mavenOutput/subscribe";
-    String MAVEN_CHANEL_SUBSCRIBE                = "mavenOutput/unsubscribe";
+    String MAVEN_CHANEL_UNSUBSCRIBE              = "mavenOutput/unsubscribe";
+    String MAVEN_CHANEL_SUBSCRIBE                = "mavenOutput/subscribe";
     String MAVEN_OUTPUT_TEXT_METHOD              = "mavenOutput/text";
     String MAVEN_OUTPUT_UPDATE_METHOD            = "mavenOutput/update";
     String MAVEN_OUTPUT_START_STOP_METHOD        = "mavenOutput/start_stop";


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes typo mistake related to names of methods for JSON-RPC communication

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5350

