### PR TITLE
Rework Navigate to File feature to avoid using Everrest based Websocket calls

### DIFF
--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/navigation/NavigateToFilePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/navigation/NavigateToFilePresenterTest.java
@@ -13,13 +13,15 @@ package org.eclipse.che.ide.navigation;
 import com.google.common.base.Optional;
 import com.google.web.bindery.event.shared.EventBus;
 
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.machine.events.WsAgentStateEvent;
-import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.resources.Container;
 import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.websocket.MessageBus;
@@ -66,6 +68,10 @@ public class NavigateToFilePresenterTest {
     private AppContext              appContext;
     @Mock
     private EditorAgent             editorAgent;
+    @Mock
+    private DtoFactory              dtoFactory;
+    @Mock
+    private RequestTransmitter      requestTransmitter;
 
     private NavigateToFilePresenter presenter;
 
@@ -79,13 +85,10 @@ public class NavigateToFilePresenterTest {
         when(messageBusProvider.getMachineMessageBus()).thenReturn(messageBus);
 
         presenter = new NavigateToFilePresenter(view,
-                                                eventBus,
-                                                dtoUnmarshallerFactory,
-                                                messageBusProvider,
                                                 appContext,
-                                                editorAgent);
-
-        presenter.onWsAgentStarted(wsAgentStateEvent);
+                                                editorAgent,
+                                                requestTransmitter,
+                                                dtoFactory);
     }
 
     @Test

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/ProjectSearchRequestDto.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/ProjectSearchRequestDto.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface ProjectSearchRequestDto {
+    String getPath();
+
+    ProjectSearchRequestDto withPath(String path);
+
+    String getName();
+
+    ProjectSearchRequestDto withName(String name);
+
+    String getText();
+
+    ProjectSearchRequestDto withText(String text);
+
+    int getMaxItems();
+
+    ProjectSearchRequestDto withMaxItems(int maxItems);
+
+    int getSkipCount();
+
+    ProjectSearchRequestDto withSkipCount(int skipCount);
+}

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/ProjectSearchResponseDto.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/ProjectSearchResponseDto.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+import java.util.List;
+
+@DTO
+public interface ProjectSearchResponseDto {
+    List<ItemReference> getItemReferences();
+
+    ProjectSearchResponseDto withItemReferences(List<ItemReference> itemReferences);
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -949,10 +949,6 @@ public class ProjectService extends Service {
         }
     }
 
-    /* --------------------------------------------------------------------------- */
-    /* TODO check "upload" methods below, they were copied from old VFS as is      */
-    /* --------------------------------------------------------------------------- */
-
     private void logProjectCreatedEvent(@NotNull String projectName, @NotNull String projectType) {
         LOG.info("EVENT#project-created# PROJECT#{}# TYPE#{}# WS#{}# USER#{}# PAAS#default#",
                  projectName,

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -25,6 +25,8 @@ import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.UnauthorizedException;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.api.core.model.project.type.Value;
 import org.eclipse.che.api.core.notification.EventService;
@@ -40,6 +42,8 @@ import org.eclipse.che.api.project.server.type.ProjectTypeResolution;
 import org.eclipse.che.api.project.shared.dto.CopyOptions;
 import org.eclipse.che.api.project.shared.dto.ItemReference;
 import org.eclipse.che.api.project.shared.dto.MoveOptions;
+import org.eclipse.che.api.project.shared.dto.ProjectSearchRequestDto;
+import org.eclipse.che.api.project.shared.dto.ProjectSearchResponseDto;
 import org.eclipse.che.api.project.shared.dto.SourceEstimation;
 import org.eclipse.che.api.project.shared.dto.TreeElement;
 import org.eclipse.che.api.vfs.VirtualFile;
@@ -921,6 +925,33 @@ public class ProjectService extends Service {
 
         return items;
     }
+
+    @Inject
+    private void configureProjectSearchRequestHandler(RequestHandlerConfigurator requestHandlerConfigurator){
+        requestHandlerConfigurator.newConfiguration()
+                                  .methodName("project/search")
+                                  .paramsAsDto(ProjectSearchRequestDto.class)
+                                  .resultAsDto(ProjectSearchResponseDto.class)
+                                  .withFunction(this::search);
+    }
+
+    public ProjectSearchResponseDto search(ProjectSearchRequestDto request) {
+        String path = request.getPath();
+        String name = request.getName();
+        String text = request.getText();
+        int maxItems = request.getMaxItems();
+        int skipCount = request.getSkipCount();
+
+        try {
+            return newDto(ProjectSearchResponseDto.class).withItemReferences(search(path, name, text, maxItems, skipCount));
+        } catch (ServerException | ConflictException | NotFoundException | ForbiddenException e) {
+            throw new JsonRpcException(-27000, e.getMessage());
+        }
+    }
+
+    /* --------------------------------------------------------------------------- */
+    /* TODO check "upload" methods below, they were copied from old VFS as is      */
+    /* --------------------------------------------------------------------------- */
 
     private void logProjectCreatedEvent(@NotNull String projectName, @NotNull String projectType) {
         LOG.info("EVENT#project-created# PROJECT#{}# TYPE#{}# WS#{}# USER#{}# PAAS#default#",


### PR DESCRIPTION
### What does this PR do?
Replaces REST calls with JSON-RPC calls  for Navigate to File operations

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5522

#### Changelog
Replaced REST calls with JSON-RPC calls  for Navigate to File operations

#### Release Notes
Replaced REST calls with JSON-RPC calls  for Navigate to File operations