### PR TITLE
[OpenShift] Allow to run some extra commands when running the container command.

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/local/LocalDockerModule.java
@@ -26,7 +26,9 @@ import org.eclipse.che.plugin.docker.machine.DockerProcess;
 import org.eclipse.che.plugin.docker.machine.LocalDockerCustomServerEvaluationStrategy;
 import org.eclipse.che.plugin.docker.machine.ServerEvaluationStrategy;
 import org.eclipse.che.plugin.docker.machine.node.DockerNode;
+import org.eclipse.che.plugin.openshift.client.OpenShiftCommandAppender;
 import org.eclipse.che.plugin.openshift.client.OpenShiftConnector;
+import org.eclipse.che.plugin.openshift.client.OpenShiftWorkspaceLogCommandAppender;
 
 import java.util.Set;
 
@@ -68,6 +70,9 @@ public class LocalDockerModule extends AbstractModule {
         bind(org.eclipse.che.plugin.docker.client.DockerRegistryDynamicAuthResolver.class)
                 .to(org.eclipse.che.plugin.docker.client.NoOpDockerRegistryDynamicAuthResolverImpl.class);
         bind(org.eclipse.che.plugin.docker.client.DockerRegistryChecker.class).asEagerSingleton();
+
+        Multibinder<OpenShiftCommandAppender> goalBinder = Multibinder.newSetBinder(binder(), OpenShiftCommandAppender.class);
+        goalBinder.addBinding().to(OpenShiftWorkspaceLogCommandAppender.class);
 
         MapBinder<String, DockerConnector> dockerConnectors = MapBinder.newMapBinder(binder(), String.class, DockerConnector.class);
         dockerConnectors.addBinding("default").to(DockerConnector.class);

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftCommandAppender.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftCommandAppender.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client;
+
+/**
+ * Defines an interface allowing to execute commands when the workspace containers are started.
+ * Note: it requires to be command that finished (to background/waiting commands)
+ * @author Florent Benoit
+ */
+public interface OpenShiftCommandAppender {
+
+    /**
+     * Provides the command that will be executed on the container in addition to other commands.
+     * @return the command to execute
+     */
+    String getCommand();
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceLogCommandAppender.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceLogCommandAppender.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.plugin.openshift.client;
+
+/**
+ * Display the path to workspace log.
+ * @author Florent Benoit
+ */
+public class OpenShiftWorkspaceLogCommandAppender implements OpenShiftCommandAppender {
+
+    /**
+     * Provides the command that will be executed on the container in addition to other commands.
+     *
+     * @return the command to execute
+     */
+    @Override
+    public String getCommand() {
+        return "echo \'\nWorkspaces does not log to stdout. Agents log files can be found inside the container:\n   - ws-agent logs are in folder /home/user/che/ws-agent/logs\'";
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Allow to run some extra commands when running the container command.

So we can for example add location of the log file
https://github.com/redhat-developer/rh-che/issues/145

### What issues does this PR fix or reference?


#### Changelog
OpenShift connector : allow to start extra commands

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I75862d07759fc9c163ff579ae3b4e10d74dd1c93
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

