### PR TITLE
CHE-5477: Save button in Workspace config tab appears only after adding second symbol to config

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -486,11 +486,10 @@ export class WorkspaceDetailsController {
    * @param config {che.IWorkspaceConfig} workspace config
    */
   updateWorkspaceConfigImport(config: che.IWorkspaceConfig): void {
-    this.switchEditMode(config);
-
     if (!config) {
       return;
     }
+    this.switchEditMode(config);
 
     if (this.newName !== config.name) {
       this.newName = config.name;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -386,7 +386,7 @@ export class WorkspaceDetailsController {
       this.copyWorkspaceDetails.config.name = this.newName;
     }
 
-    this.switchEditMode();
+    this.switchEditMode(this.workspaceDetails.config);
   }
 
   /**
@@ -486,7 +486,7 @@ export class WorkspaceDetailsController {
    * @param config {che.IWorkspaceConfig} workspace config
    */
   updateWorkspaceConfigImport(config: che.IWorkspaceConfig): void {
-    this.switchEditMode();
+    this.switchEditMode(config);
 
     if (!config) {
       return;
@@ -509,12 +509,12 @@ export class WorkspaceDetailsController {
    */
   updateWorkspaceConfigEnvironment(): void {
     this.workspaceImportedRecipe = null;
-    this.switchEditMode();
+    this.switchEditMode(this.workspaceDetails.config);
   }
 
-  switchEditMode(): void {
+  switchEditMode(changedConfig: che.IWorkspaceConfig): void {
     if (!this.isCreationFlow) {
-      this.editMode = !angular.equals(this.copyWorkspaceDetails.config, this.workspaceDetails.config);
+      this.editMode = !angular.equals(this.copyWorkspaceDetails.config, changedConfig);
 
       let status = this.getWorkspaceStatus();
       if (status === 'STOPPED' || status === 'STOPPING') {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It fixes the corresponding issue - the save button in the workspace config tab appears only after adding second symbol to config

### What issues does this PR fix or reference?
#5477 

#### Changelog
Changed workspace is passed into the `updateWorkspaceConfigImport` method and must be used further in `switchEditMode` to detect the presence of changes instead of `this.workspaceDetails.config`.
