### PR TITLE
Handle no-content response in DefaultHttpJsonRequest

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
@@ -22,7 +22,6 @@ import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.Pair;
-import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.dto.server.JsonArrayImpl;
 import org.eclipse.che.dto.server.JsonSerializable;
@@ -281,7 +280,9 @@ public class DefaultHttpJsonRequest implements HttpJsonRequest {
                                                     UriBuilder.fromUri(url).replaceQuery("token").build(), method, responseCode, str));
             }
             final String contentType = conn.getContentType();
-            if (contentType != null && !contentType.startsWith(MediaType.APPLICATION_JSON)) {
+            if (responseCode != HttpURLConnection.HTTP_NO_CONTENT
+                && contentType != null
+                && !contentType.startsWith(MediaType.APPLICATION_JSON)) {
                 throw new IOException(conn.getResponseMessage());
             }
 

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
@@ -256,6 +256,11 @@ public class DefaultHttpJsonRequestTest {
     }
 
     @Test
+    public void shouldThrowIOExceptionIfServerDoesNotReturnContentTypeOnNoContentResponse(ITestContext ctx) throws Exception {
+        new DefaultHttpJsonRequest(getUrl(ctx) + "/no-content").useDeleteMethod().request();
+    }
+
+    @Test
     public void shouldReadJsonObjectBodyAsString(ITestContext ctx) throws Exception {
         final DefaultHttpJsonRequest request = new DefaultHttpJsonRequest(getUrl(ctx) + "/application-json");
         request.useGetMethod();

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/TestService.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/TestService.java
@@ -18,6 +18,7 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.dto.server.JsonArrayImpl;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -124,6 +125,13 @@ public class TestService extends Service {
         return Response.ok()
                        .entity(page.getItems())
                        .header("Link", createLinkHeader(page, "getStringList", singletonMap("query-param", param), value))
+                       .build();
+    }
+
+    @DELETE
+    @Path("no-content")
+    public Response noContent() {
+        return Response.noContent()
                        .build();
     }
 }


### PR DESCRIPTION
### What does this PR do?
This request fixes **DefaultHttpJsonRequest** class not to check _Content Type_ of response if it has status code **204 "No Content"**. 
It allows, for example, to avoid unexpected _IOException "No content"_ in case of successful **DELETE** request with empty response.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>

@evoevodin, @tolusha: please, review this request.