### PR TITLE
Improve Processes panel loading sequence: enable Terminal as soon as terminal server starts.

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandExecutor.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/command/CommandExecutor.java
@@ -12,7 +12,6 @@ package org.eclipse.che.ide.api.command;
 
 import org.eclipse.che.api.core.model.workspace.config.Command;
 import org.eclipse.che.ide.api.macro.Macro;
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 
 /** Allows to execute a command. */
 public interface CommandExecutor {
@@ -24,11 +23,11 @@ public interface CommandExecutor {
      *
      * @param command
      *         command to execute
-     * @param machine
-     *         machine to execute the command
+     * @param machineName
+     *         name of the machine where execute the command
      * @see Macro
      */
-    void executeCommand(Command command, MachineImpl machine);
+    void executeCommand(Command command, String machineName);
 
     /**
      * Sends the the given {@code command} for execution.

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/events/ProcessFinishedEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/events/ProcessFinishedEvent.java
@@ -13,8 +13,6 @@ package org.eclipse.che.ide.api.machine.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
-import org.eclipse.che.api.core.model.workspace.runtime.Machine;
-
 
 /**
  * @author Dmitry Shnurenko
@@ -30,20 +28,20 @@ public class ProcessFinishedEvent extends GwtEvent<ProcessFinishedEvent.Handler>
 
     public static final Type<ProcessFinishedEvent.Handler> TYPE = new Type<>();
 
-    private final int     processID;
-    private final Machine machine;
+    private final int    processID;
+    private final String machineName;
 
-    public ProcessFinishedEvent(int processID, Machine machine) {
+    public ProcessFinishedEvent(int processID, String machineName) {
         this.processID = processID;
-        this.machine = machine;
+        this.machineName = machineName;
     }
 
     public int getProcessID() {
         return processID;
     }
 
-    public Machine getMachine() {
-        return machine;
+    public String getMachineName() {
+        return machineName;
     }
 
     @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/events/ProcessStartedEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/machine/events/ProcessStartedEvent.java
@@ -13,26 +13,24 @@ package org.eclipse.che.ide.api.machine.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-
 public class ProcessStartedEvent extends GwtEvent<ProcessStartedEvent.Handler> {
 
     public static final Type<ProcessStartedEvent.Handler> TYPE = new Type<>();
 
-    private final int         processID;
-    private final MachineImpl machine;
+    private final int    processID;
+    private final String machineName;
 
-    public ProcessStartedEvent(int processID, MachineImpl machine) {
+    public ProcessStartedEvent(int processID, String machineName) {
         this.processID = processID;
-        this.machine = machine;
+        this.machineName = machineName;
     }
 
     public int getProcessID() {
         return processID;
     }
 
-    public MachineImpl getMachine() {
-        return machine;
+    public String getMachineName() {
+        return machineName;
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
@@ -61,6 +61,6 @@ public class RunCommandAction extends Action {
 
         final WorkspaceImpl workspace = appContext.getWorkspace();
         workspace.getDevMachine().ifPresent(m -> commandManager.getCommand(name)
-                                                               .ifPresent(command -> commandExecutor.executeCommand(command, m)));
+                                                               .ifPresent(command -> commandExecutor.executeCommand(command, m.getName())));
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/CommandExecutorImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/CommandExecutorImpl.java
@@ -54,7 +54,7 @@ public class CommandExecutorImpl implements CommandExecutor {
     }
 
     @Override
-    public void executeCommand(Command command, MachineImpl machine) {
+    public void executeCommand(Command command, String machineName) {
         final String name = command.getName();
         final String type = command.getType();
         final String commandLine = command.getCommandLine();
@@ -62,12 +62,11 @@ public class CommandExecutorImpl implements CommandExecutor {
 
         macroProcessor.expandMacros(commandLine).then(expandedCommandLine -> {
             final CommandImpl expandedCommand = new CommandImpl(name, expandedCommandLine, type, attributes);
-            final CommandOutputConsole console = commandConsoleFactory.create(expandedCommand, machine);
-            final String machineId = machine.getName();
+            final CommandOutputConsole console = commandConsoleFactory.create(expandedCommand, machineName);
 
-            processesPanelPresenter.addCommandOutput(machineId, console);
+            processesPanelPresenter.addCommandOutput(machineName, console);
 
-            execAgentClient.startProcess(machineId, expandedCommand)
+            execAgentClient.startProcess(machineName, expandedCommand)
                            .thenIfProcessStartedEvent(console.getProcessStartedConsumer())
                            .thenIfProcessDiedEvent(console.getProcessDiedConsumer())
                            .thenIfProcessStdOutEvent(console.getStdOutConsumer())
@@ -80,10 +79,10 @@ public class CommandExecutorImpl implements CommandExecutor {
         final MachineImpl selectedMachine = getSelectedMachine();
 
         if (selectedMachine != null) {
-            executeCommand(command, selectedMachine);
+            executeCommand(command, selectedMachine.getName());
         } else {
             machineChooser.show().then(machine -> {
-                executeCommand(command, machine);
+                executeCommand(command, machine.getName());
             });
         }
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/palette/CommandsPalettePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/palette/CommandsPalettePresenter.java
@@ -92,7 +92,7 @@ public class CommandsPalettePresenter implements CommandsPaletteView.ActionDeleg
             dialogFactory.createMessageDialog("", messages.messageNoMachine(), null).show();
         } else {
             machineChooser.show().then(machine -> {
-                commandExecutor.executeCommand(command, machine);
+                commandExecutor.executeCommand(command, machine.getName());
             });
         }
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/commands/ExecuteCommandPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/commands/ExecuteCommandPresenter.java
@@ -85,7 +85,7 @@ public class ExecuteCommandPresenter implements Presenter, ExecuteCommandView.Ac
 
     @Override
     public void onCommandExecute(CommandImpl command, MachineImpl machine) {
-        commandExecutorProvider.get().executeCommand(command, machine);
+        commandExecutorProvider.get().executeCommand(command, machine.getName());
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/Process.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/Process.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.ide.command.toolbar.processes;
 
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-
 /** Model of the process. */
 public interface Process {
 
@@ -23,5 +21,5 @@ public interface Process {
 
     boolean isAlive();
 
-    MachineImpl getMachine();
+    String getMachineName();
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessImpl.java
@@ -10,25 +10,23 @@
  *******************************************************************************/
 package org.eclipse.che.ide.command.toolbar.processes;
 
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
-
 import java.util.Objects;
 
 /** Data object for {@link Process}. */
 public class ProcessImpl implements Process {
 
-    private final String      commandName;
-    private final String      commandLine;
-    private final int         pid;
-    private final boolean     alive;
-    private final MachineImpl machine;
+    private final String  commandName;
+    private final String  commandLine;
+    private final int     pid;
+    private final boolean alive;
+    private final String  machineName;
 
-    public ProcessImpl(String commandName, String commandLine, int pid, boolean alive, MachineImpl machine) {
+    public ProcessImpl(String commandName, String commandLine, int pid, boolean alive, String machineName) {
         this.commandName = commandName;
         this.commandLine = commandLine;
         this.pid = pid;
         this.alive = alive;
-        this.machine = machine;
+        this.machineName = machineName;
     }
 
     @Override
@@ -52,8 +50,8 @@ public class ProcessImpl implements Process {
     }
 
     @Override
-    public MachineImpl getMachine() {
-        return machine;
+    public String getMachineName() {
+        return machineName;
     }
 
     @Override
@@ -67,11 +65,11 @@ public class ProcessImpl implements Process {
                alive == process.alive &&
                Objects.equals(commandName, process.commandName) &&
                Objects.equals(commandLine, process.commandLine) &&
-               Objects.equals(machine, process.machine);
+               Objects.equals(machineName, process.machineName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(commandName, commandLine, pid, alive, machine);
+        return Objects.hash(commandName, commandLine, pid, alive, machineName);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessWidget.java
@@ -85,7 +85,7 @@ class ProcessWidget extends FlowPanel {
     }
 
     private Label createMachineNameLabel(Process process) {
-        final Label label = new InlineHTML(process.getMachine().getName() + ":&nbsp;");
+        final Label label = new InlineHTML(process.getMachineName() + ":&nbsp;");
 
         label.addStyleName(RESOURCES.commandToolbarCss().processWidgetText());
         label.addStyleName(RESOURCES.commandToolbarCss().processWidgetMachineNameLabel());

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessesListPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/processes/ProcessesListPresenter.java
@@ -83,7 +83,7 @@ public class ProcessesListPresenter implements Presenter, ProcessesListView.Acti
         });
 
         eventBus.addHandler(ProcessStartedEvent.TYPE, event -> addProcessToList(event.getProcessID(),
-                                                                                event.getMachine()));
+                                                                                event.getMachineName()));
 
         eventBus.addHandler(ProcessFinishedEvent.TYPE, event -> {
             final Process process = runningProcesses.get(event.getProcessID());
@@ -121,7 +121,7 @@ public class ProcessesListPresenter implements Presenter, ProcessesListView.Acti
                                                             p.getCommandLine(),
                                                             p.getPid(),
                                                             p.isAlive(),
-                                                            machine);
+                                                            machine.getName());
                     runningProcesses.put(process.getPid(), process);
 
                     view.addProcess(process);
@@ -138,13 +138,13 @@ public class ProcessesListPresenter implements Presenter, ProcessesListView.Acti
      * @param machine
      *         machine where process were run or currently running
      */
-    private void addProcessToList(int pid, MachineImpl machine) {
-        execAgentClient.getProcess(machine.getName(), pid).onSuccess(processDto -> {
+    private void addProcessToList(int pid, String machineName) {
+        execAgentClient.getProcess(machineName, pid).onSuccess(processDto -> {
             final Process process = new ProcessImpl(processDto.getName(),
                                                     processDto.getCommandLine(),
                                                     processDto.getPid(),
                                                     processDto.isAlive(),
-                                                    machine);
+                                                    machineName);
             runningProcesses.put(process.getPid(), process);
 
             view.addProcess(process);
@@ -164,12 +164,12 @@ public class ProcessesListPresenter implements Presenter, ProcessesListView.Acti
     @Override
     public void onReRunProcess(Process process) {
         commandManager.getCommand(process.getName())
-                      .ifPresent(command -> commandExecutorProvider.get().executeCommand(command, process.getMachine()));
+                      .ifPresent(command -> commandExecutorProvider.get().executeCommand(command, process.getMachineName()));
     }
 
     @Override
     public void onStopProcess(Process process) {
-        execAgentClient.killProcess(process.getMachine().getName(), process.getPid());
+        execAgentClient.killProcess(process.getMachineName(), process.getPid());
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CommandConsoleFactory.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CommandConsoleFactory.java
@@ -14,14 +14,13 @@ import com.google.inject.name.Named;
 
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.outputconsole.OutputConsole;
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 
 /** @author Artem Zatsarynnyi */
 public interface CommandConsoleFactory {
 
     /** Create the instance of {@link CommandOutputConsole} for the given {@code command}. */
     @Named("command")
-    CommandOutputConsole create(CommandImpl command, MachineImpl machine);
+    CommandOutputConsole create(CommandImpl command, String machineName);
 
     /** Create the instance of {@link DefaultOutputConsole} for the given title. */
     @Named("default")

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CommandOutputConsolePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CommandOutputConsolePresenter.java
@@ -32,7 +32,6 @@ import org.eclipse.che.ide.api.machine.ExecAgentCommandManager;
 import org.eclipse.che.ide.api.machine.events.ProcessFinishedEvent;
 import org.eclipse.che.ide.api.machine.events.ProcessStartedEvent;
 import org.eclipse.che.ide.api.macro.MacroProcessor;
-import org.eclipse.che.ide.api.workspace.model.MachineImpl;
 import org.eclipse.che.ide.machine.MachineResources;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
@@ -54,7 +53,7 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
     private final MachineResources        resources;
     private final CommandImpl             command;
     private final EventBus                eventBus;
-    private final MachineImpl             machine;
+    private final String                  machineName;
     private final CommandExecutor         commandExecutor;
     private final ExecAgentCommandManager execAgentCommandManager;
 
@@ -79,14 +78,14 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
                                          EventBus eventBus,
                                          ExecAgentCommandManager execAgentCommandManager,
                                          @Assisted CommandImpl command,
-                                         @Assisted MachineImpl machine,
+                                         @Assisted String machineName,
                                          AppContext appContext,
                                          EditorAgent editorAgent) {
         this.view = view;
         this.resources = resources;
         this.execAgentCommandManager = execAgentCommandManager;
         this.command = command;
-        this.machine = machine;
+        this.machineName = machineName;
         this.eventBus = eventBus;
         this.commandExecutor = commandExecutor;
 
@@ -179,7 +178,7 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
 
             pid = event.getPid();
 
-            eventBus.fireEvent(new ProcessStartedEvent(pid, machine));
+            eventBus.fireEvent(new ProcessStartedEvent(pid, machineName));
         };
     }
 
@@ -190,7 +189,7 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
             view.enableStopButton(false);
             view.toggleScrollToEndButton(false);
 
-            eventBus.fireEvent(new ProcessFinishedEvent(pid, machine));
+            eventBus.fireEvent(new ProcessFinishedEvent(pid, machineName));
         };
     }
 
@@ -211,7 +210,7 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
 
     @Override
     public void stop() {
-        execAgentCommandManager.killProcess(machine.getName(), pid);
+        execAgentCommandManager.killProcess(machineName, pid);
     }
 
     @Override
@@ -227,10 +226,10 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
     @Override
     public void reRunProcessButtonClicked() {
         if (isFinished()) {
-            commandExecutor.executeCommand(command, machine);
+            commandExecutor.executeCommand(command, machineName);
         } else {
-            execAgentCommandManager.killProcess(machine.getName(), pid)
-                                   .onSuccess(() -> commandExecutor.executeCommand(command, machine));
+            execAgentCommandManager.killProcess(machineName, pid)
+                                   .onSuccess(() -> commandExecutor.executeCommand(command, machineName));
         }
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalInitializer.java
@@ -19,7 +19,6 @@ import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 
-import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper;
 import org.eclipse.che.ide.api.app.AppContext;
@@ -29,9 +28,12 @@ import org.eclipse.che.ide.api.parts.Perspective;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStartingEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.bootstrap.BasicIDEInitializedEvent;
 import org.eclipse.che.ide.macro.ServerAddressMacroRegistrar;
 import org.eclipse.che.lib.terminal.client.TerminalResources;
 import org.eclipse.che.requirejs.RequireJsLoader;
+
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 
 /**
  * Terminal entry point.
@@ -68,9 +70,11 @@ public class TerminalInitializer {
 
         eventBus.addHandler(WorkspaceStoppedEvent.TYPE, event -> maximizeTerminal());
 
-        if (appContext.getWorkspace() == null || WorkspaceStatus.RUNNING != appContext.getWorkspace().getStatus()) {
-            maximizeTerminal();
-        }
+        eventBus.addHandler(BasicIDEInitializedEvent.TYPE, event -> {
+            if (RUNNING != appContext.getWorkspace().getStatus()) {
+                maximizeTerminal();
+            }
+        });
 
         Promise<Void> termInitPromise = AsyncPromiseHelper.createFromAsyncRequest(callback -> injectTerminal(requireJsLoader, callback));
         terminalModule.setInitializerPromise(termInitPromise);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/RunCommandActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/RunCommandActionTest.java
@@ -71,7 +71,7 @@ public class RunCommandActionTest {
         when(event.getParameters()).thenReturn(Collections.singletonMap("otherParam", "MCI"));
         action.actionPerformed(event);
 
-        verify(commandExecutor, never()).executeCommand(any(CommandImpl.class), any(MachineImpl.class));
+        verify(commandExecutor, never()).executeCommand(any(CommandImpl.class), anyString());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class RunCommandActionTest {
 
         action.actionPerformed(event);
 
-        verify(commandExecutor).executeCommand(eq(command), any(MachineImpl.class));
+        verify(commandExecutor).executeCommand(eq(command), anyString());
     }
 
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/palette/CommandsPalettePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/palette/CommandsPalettePresenterTest.java
@@ -137,6 +137,7 @@ public class CommandsPalettePresenterTest {
 
         Map<String, MachineImpl> machines = new HashMap<>();
         MachineImpl chosenMachine = mock(MachineImpl.class);
+        when(chosenMachine.getName()).thenReturn("machine_id");
         machines.put("machine_id", chosenMachine);
         when(workspaceRuntime.getMachines()).thenReturn(machines);
 
@@ -154,6 +155,6 @@ public class CommandsPalettePresenterTest {
         verify(machinePromise).then(selectedMachineCaptor.capture());
         selectedMachineCaptor.getValue().apply(chosenMachine);
 
-        verify(commandExecutor).executeCommand(eq(commandToExecute), eq(chosenMachine));
+        verify(commandExecutor).executeCommand(eq(commandToExecute), eq("machine_id"));
     }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/toolbar/commands/ExecuteCommandPresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/toolbar/commands/ExecuteCommandPresenterTest.java
@@ -93,10 +93,11 @@ public class ExecuteCommandPresenterTest {
     public void shouldExecuteCommandOnMachine() throws Exception {
         CommandImpl command = mock(CommandImpl.class);
         MachineImpl machine = mock(MachineImpl.class);
+        when(machine.getName()).thenReturn("machine_name");
 
         presenter.onCommandExecute(command, machine);
 
-        verify(commandExecutor).executeCommand(eq(command), eq(machine));
+        verify(commandExecutor).executeCommand(eq(command), eq("machine_name"));
     }
 
     @Test

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -186,11 +186,10 @@ public class TestServiceClient {
                             CommandImpl expandedCommand = new CommandImpl(command.getName(), expandedCommandLine,
                                                                           command.getType(), attributes);
 
-                            final CommandOutputConsole console = commandConsoleFactory.create(expandedCommand, machine);
-                            final String machineId = machine.getName();
+                            final CommandOutputConsole console = commandConsoleFactory.create(expandedCommand, machine.getName());
 
                             processesPanelPresenter.addCommandOutput(console);
-                            ExecAgentConsumer<ProcessStartResponseDto> processPromise = execAgentCommandManager.startProcess(machineId,
+                            ExecAgentConsumer<ProcessStartResponseDto> processPromise = execAgentCommandManager.startProcess(machine.getName(),
                                                                                                                              expandedCommand);
                             processPromise.then(startResonse -> {
                                 if (!startResonse.getAlive()) {

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/test/java/org/eclipse/che/plugin/testing/ide/TestServiceClientTest.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/test/java/org/eclipse/che/plugin/testing/ide/TestServiceClientTest.java
@@ -170,7 +170,7 @@ public class TestServiceClientTest implements MockitoPrinter {
             return new PromiseMocker<String>().applyOnThenOperation(processedCommandLine).getPromise();
         })).when(macroProcessor).expandMacros(anyString());
 
-        when(commandConsoleFactory.create(any(CommandImpl.class), any(MachineImpl.class))).then(createCall -> {
+        when(commandConsoleFactory.create(any(CommandImpl.class), anyString())).then(createCall -> {
             CommandOutputConsole commandOutputConsole = mock(CommandOutputConsole.class);
             when(commandOutputConsole.getProcessStartedConsumer()).thenReturn(processStartedEvent -> {
                 consoleEvents.add(processStartedEvent);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Improves Processes panel loading sequence: enables Terminal in IDE as soon as terminal server starts.

### What issues does this PR fix or reference?
#5175 

#### Changelog
<!-- one line entry to be added to changelog -->
Terminal in IDE becomes available as soon as the terminal server starts.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Terminal in IDE becomes available as soon as the terminal server starts.

#### Docs PR
N/A
