### PR TITLE
C/CPP compilation error/warning messages support #5565

### DIFF
--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -345,6 +345,8 @@
                         <exclude>**/CompoundOutputCustomizerTest.java</exclude>
                         <exclude>**/CSharpOutputCustomizer.java</exclude>
                         <exclude>**/CSharpOutputCustomizerTest.java</exclude>
+                        <exclude>**/CPPOutputCustomizer.java</exclude>
+                        <exclude>**/CPPOutputCustomizerTest.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CPPOutputCustomizer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CPPOutputCustomizer.java
@@ -55,8 +55,8 @@ public class CPPOutputCustomizer extends AbstractOutputCustomizer {
      */
     @Override
     public boolean canCustomize(String text) {
-        return (COMPILATION_MESSAGE.exec(text) != null || 
-                LINKER_MESSAGE.exec(text) != null);
+        return (COMPILATION_MESSAGE.test(text) || 
+                LINKER_MESSAGE.test(text));
     }
 
     /*
@@ -67,10 +67,10 @@ public class CPPOutputCustomizer extends AbstractOutputCustomizer {
      */
     @Override
     public String customize(String text) {
-        if (COMPILATION_MESSAGE.exec(text) != null)
+        if (COMPILATION_MESSAGE.test(text))
             return customizeCompilationMessage(text);
 
-        if (LINKER_MESSAGE.exec(text) != null)
+        if (LINKER_MESSAGE.test(text))
             return customizeLinkerMessage(text);
 
         return text;
@@ -81,11 +81,13 @@ public class CPPOutputCustomizer extends AbstractOutputCustomizer {
      */
     private String customizeCompilationMessage(String text) {
         try {
-            int lineStart = text.indexOf(":") + ":".length(), lineEnd = text.indexOf(":", lineStart),
-                    columnStart = lineEnd + ":".length(), columnEnd = text.indexOf(":", columnStart);
+            int lineStart = text.indexOf(":") + ":".length();
+            int lineEnd = text.indexOf(":", lineStart);
+            int columnStart = lineEnd + ":".length();
+            int columnEnd = text.indexOf(":", columnStart);
             String fileName = text.substring(0, text.indexOf(":")).trim();
-            int lineNumber = Integer.valueOf(text.substring(lineStart, lineEnd).trim()),
-                    columnNumber = Integer.valueOf(text.substring(columnStart, columnEnd).trim());
+            int lineNumber = Integer.valueOf(text.substring(lineStart, lineEnd).trim());
+            int columnNumber = Integer.valueOf(text.substring(columnStart, columnEnd).trim());
 
             String customText = "<a href='javascript:openCM(\"" + fileName + "\"," + lineNumber + "," + columnNumber
                     + ");'>";

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CPPOutputCustomizer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CPPOutputCustomizer.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.console;
+
+import static com.google.gwt.regexp.shared.RegExp.compile;
+
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.resource.Path;
+
+import com.google.gwt.regexp.shared.RegExp;
+
+/**
+ * Output customizer adds an anchor link to the lines that match C/CPP
+ * compilation error or warning message and installs the handler functions for
+ * the links. The handler parses the C/CPP compilation error or warning message
+ * line, searches for a candidate C/CPP file to navigate to, opens the found
+ * file in editor and reveals it to the required line and column (if available)
+ * according to the line information
+ * 
+ * @author Victor Rubezhny
+ */
+public class CPPOutputCustomizer extends AbstractOutputCustomizer {
+
+    private static final RegExp COMPILATION_MESSAGE = 
+            compile("(.+\\.(c|C|cc|CC|cpp|CPP|h|H|hpp|HPP):\\d+:\\d+: (error|fatal error|note|warning): .+)");
+    private static final RegExp LINKER_MESSAGE = compile("(.+\\.(c|C|cc|CC|cpp|CPP|h|H|hpp|HPP):\\d+: .+)");
+
+    /**
+     * Constructs C/CPP Output Customizer Object
+     * 
+     * @param appContext
+     * @param editorAgent
+     */
+    public CPPOutputCustomizer(AppContext appContext, EditorAgent editorAgent) {
+        super(appContext, editorAgent);
+
+        exportCompilationMessageAnchorClickHandlerFunction();
+        exportLinkerMessageAnchorClickHandlerFunction();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.che.ide.extension.machine.client.outputspanel.console.
+     * OutputCustomizer#canCustomize(java.lang.String)
+     */
+    @Override
+    public boolean canCustomize(String text) {
+        return (COMPILATION_MESSAGE.exec(text) != null || 
+                LINKER_MESSAGE.exec(text) != null);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.che.ide.extension.machine.client.outputspanel.console.
+     * OutputCustomizer#customize(java.lang.String)
+     */
+    @Override
+    public String customize(String text) {
+        if (COMPILATION_MESSAGE.exec(text) != null)
+            return customizeCompilationMessage(text);
+
+        if (LINKER_MESSAGE.exec(text) != null)
+            return customizeLinkerMessage(text);
+
+        return text;
+    }
+
+    /*
+     * Customizes a compilation message line
+     */
+    private String customizeCompilationMessage(String text) {
+        try {
+            int lineStart = text.indexOf(":") + ":".length(), lineEnd = text.indexOf(":", lineStart),
+                    columnStart = lineEnd + ":".length(), columnEnd = text.indexOf(":", columnStart);
+            String fileName = text.substring(0, text.indexOf(":")).trim();
+            int lineNumber = Integer.valueOf(text.substring(lineStart, lineEnd).trim()),
+                    columnNumber = Integer.valueOf(text.substring(columnStart, columnEnd).trim());
+
+            String customText = "<a href='javascript:openCM(\"" + fileName + "\"," + lineNumber + "," + columnNumber
+                    + ");'>";
+            customText += text.substring(0, columnEnd);
+            customText += "</a>";
+            customText += text.substring(columnEnd);
+            text = customText;
+        } catch (IndexOutOfBoundsException ex) {
+            // ignore
+        } catch (NumberFormatException ex) {
+            // ignore
+        }
+
+        return text;
+    }
+
+    /*
+     * Customizes a linker message line
+     */
+    private String customizeLinkerMessage(String text) {
+        try {
+            int lineStart = text.indexOf(":") + ":".length(), lineEnd = text.indexOf(":", lineStart);
+            String fileName = text.substring(0, text.indexOf(":")).trim();
+            int lineNumber = Integer.valueOf(text.substring(lineStart, lineEnd).trim());
+
+            String customText = "<a href='javascript:openLM(\"" + fileName + "\"," + lineNumber + ");'>";
+            customText += text.substring(0, lineEnd);
+            customText += "</a>";
+            customText += text.substring(lineEnd);
+            text = customText;
+        } catch (IndexOutOfBoundsException ex) {
+            // ignore
+        } catch (NumberFormatException ex) {
+            // ignore
+        }
+
+        return text;
+    }
+
+    /**
+     * A callback that is to be called for a compilation message anchor
+     * 
+     * @param fileName
+     * @param lineNumber
+     * @param columnNumber
+     */
+    public void handleCompilationMessageAnchorClick(String fileName, final int lineNumber, int columnNumber) {
+        if (fileName == null) {
+            return;
+        }
+
+        collectChildren(appContext.getWorkspaceRoot(), Path.valueOf(fileName))
+        .then(files -> {
+            if (!files.isEmpty()) {
+                openFileInEditorAndReveal(appContext, editorAgent, files.get(0).getLocation(), lineNumber, columnNumber);
+            }
+        });
+    }
+
+    /**
+     * A callback that is to be called for a linker message anchor
+     * 
+     * @param fileName
+     * @param lineNumber
+     */
+    public void handleLinkerMessageAnchorClick(String fileName, final int lineNumber) {
+        if (fileName == null) {
+            return;
+        }
+
+        openFileInEditorAndReveal(appContext, editorAgent,
+                Path.valueOf(fileName).removeFirstSegments(1), lineNumber, 0);
+    }
+
+    /**
+     * Sets up a C/CPP callback to be called for a compilation message anchor
+     */
+    public native void exportCompilationMessageAnchorClickHandlerFunction() /*-{
+        var that = this;
+        $wnd.openCM = $entry(function(fileName,lineNumber,columnNumber) {
+            that.@org.eclipse.che.ide.console.CPPOutputCustomizer::handleCompilationMessageAnchorClick(*)(fileName,lineNumber,columnNumber);
+        });
+    }-*/;
+
+    /**
+     * Sets up a C/CPP callback to be called for a compilation message anchor
+     */
+    public native void exportLinkerMessageAnchorClickHandlerFunction() /*-{
+        var that = this;
+        $wnd.openLM = $entry(function(fileName,lineNumber) {
+            that.@org.eclipse.che.ide.console.CPPOutputCustomizer::handleLinkerMessageAnchorClick(*)(fileName,lineNumber);
+        });
+    }-*/;
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CommandOutputConsolePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/CommandOutputConsolePresenter.java
@@ -92,7 +92,8 @@ public class CommandOutputConsolePresenter implements CommandOutputConsole, Outp
 
         setCustomizer(new CompoundOutputCustomizer(
                 new JavaOutputCustomizer(appContext, editorAgent),
-                new CSharpOutputCustomizer(appContext, editorAgent)));
+                new CSharpOutputCustomizer(appContext, editorAgent),
+                new CPPOutputCustomizer(appContext, editorAgent)));
         
         view.setDelegate(this);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/DefaultOutputConsole.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/DefaultOutputConsole.java
@@ -56,7 +56,8 @@ public class DefaultOutputConsole implements OutputConsole, OutputConsoleView.Ac
 
         setCustomizer(new CompoundOutputCustomizer(
                 new JavaOutputCustomizer(appContext, editorAgent),
-                new CSharpOutputCustomizer(appContext, editorAgent)));
+                new CSharpOutputCustomizer(appContext, editorAgent),
+                new CPPOutputCustomizer(appContext, editorAgent)));
 
         view.setDelegate(this);
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/CPPOutputCustomizerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/CPPOutputCustomizerTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.console;
+
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+/**
+ * JUnit test for C/CPP Compilation Error/Warning line detection in
+ * CPPOutputCustomizer.
+ * 
+ * See: Issue #5565 - C/CPP compilation error/warning messages support #5565
+ * 
+ * @author Victor Rubezhny
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class CPPOutputCustomizerTest extends BaseOutputCustomizerTest {
+    @Mock
+    AppContext appContext;
+    @Mock
+    EditorAgent editorAgent;
+
+    @Before
+    public void setUp() throws Exception {
+        OutputCustomizer outputCustomizer = new CPPOutputCustomizer(appContext, editorAgent);
+        setupTestCustomizers(outputCustomizer, new OutputCustomizer[] { outputCustomizer });
+    }
+
+    /**
+     * Test for the detection of initial Compilation Message lines in CPPOutputCustomizer.
+     * These lines are not to be customized, however these lines show an examples of
+     * beginning of a compilation message and might be used in future to set up the customizer
+     * properly.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testInitialCompilationMessageLines() throws Exception {
+        testStackTraceLine("hello.cc: In function ‘int main()’:");
+        testStackTraceLine("hello.o: In function `main':");
+    }
+
+    /**
+     * Test for the detection of Compilation Message lines in
+     * CPPOutputCustomizer. These lines have an information on file relative
+     * path, project file path and line and column numbers for a Compilation
+     * Error/Warning Message
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testValuableCompilationMessagesLines() throws Exception {
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "hello.cc:8:13: warning: division by zero [-Wdiv-by-zero]",
+                "<a href='javascript:openCM(\"hello.cc\",8,13);'>hello.cc:8:13</a>: warning: division by zero [-Wdiv-by-zero]");
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "hello.cc:8:2: error: ‘Module’ was not declared in this scope",
+                "<a href='javascript:openCM(\"hello.cc\",8,2);'>hello.cc:8:2</a>: error: ‘Module’ was not declared in this scope");
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "hello.cc:4:25: fatal error: module/Module: No such file or directory",
+                "<a href='javascript:openCM(\"hello.cc\",4,25);'>hello.cc:4:25</a>: fatal error: module/Module: No such file or directory");
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "/projects/console-cc-simple/hello.cc:23: undefined reference to `Module::sayHello[abi:cxx11]()'",
+                "<a href='javascript:openLM(\"/projects/console-cc-simple/hello.cc\",23);'>/projects/console-cc-simple/hello.cc:23</a>: undefined reference to `Module::sayHello[abi:cxx11]()'");
+    }
+
+    /**
+     * Test for the detection of other Compilation Message lines in CPPOutputCustomizer.
+     * Other lines that can be a part of Compilation Message, however do not contain any
+     * useful information
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testOtherCompilationMessageLines() throws Exception {
+        testStackTraceLine("     return 0/0;");
+        testStackTraceLine("             ^");
+        testStackTraceLine("compilation terminated.");
+        testStackTraceLine("collect2: error: ld returned 1 exit status");
+    }
+
+    /**
+     * Test for the detection of non-Compilation Message lines and parts of other
+     * kinds of stacktraces that must not be customized in CPPOutputCustomizer.
+     * Other lines that might occur in output console
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testNonCPPCompilationMessageLines() throws Exception {
+        // Terminal Console
+        testStackTraceLine("[STDOUT] Listening for transport dt_socket at address: 4403");
+        testStackTraceLine(
+                "[STDOUT] 2017-07-06 08:58:34,647 [ForkJoinPool.commonPool-worker-3] DEBUG o.j.t.l.t.DocumentManager.findSelectedWord - Looking for word at Position 2 in 'textDocument/badWord:Warning:name:So bad! '");
+
+        // C#
+        testStackTraceLine(
+                "Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.");
+        testStackTraceLine(
+                "   at hwapp.ppp.PPPProgram.Main1(String[] args) in /home/jeremy/projects/csharp/hwapp/ppp/PPPProgram.cs:line 18");
+        testStackTraceLine(
+                "   at hwapp.Program.Main(String[] args) in /home/jeremy/projects/csharp/hwapp/Program.cs:line 10");
+        testStackTraceLine(
+                "Program.cs(2,13): error CS0234: The type or namespace name 'ppp' does not exist in the namespace 'hwapp' (are you missing an assembly reference?) [/home/jeremy/projects/csharp/hwapp/hwapp.csproj]");
+        testStackTraceLine(
+                "ppp/PPPProgram.cs(9,17): warning CS0219: The variable 'testIntValue' is assigned but its value is never used [/home/jeremy/projects/csharp/hwapp/hwapp.csproj]");
+        testStackTraceLine(
+                "[STDOUT] 2017-07-06 08:58:34,647 [ForkJoinPool.commonPool-worker-3] DEBUG o.j.t.l.t.DocumentManager.findSelectedWord - Looking for word at Position 2 in 'textDocument/badWord:Warning:name:So bad! '");
+
+        // Java Stacktrace
+        testStackTraceLine(
+                "org.test.HighLevelException: org.test.MidLevelException: org.test.LowLevelException");
+        testStackTraceLine(
+                "Caused by: org.test.MidLevelException: org.test.LowLevelException");
+        testStackTraceLine( 
+                "Caused by: org.test.LowLevelException");
+        testStackTraceLine(
+                "Exception in thread \"main\" java.lang.ArithmeticException: / by zero");
+        testStackTraceLine( 
+                "   at org.test.Junk.main(Junk.java:6)");
+        testStackTraceLine(
+                "   at org.test.TrashClass.throwItThere(Junk.java:51)");
+        testStackTraceLine(
+                "   at MyClass$ThrowInConstructor.<init>(MyClass.java:16)");
+        testStackTraceLine("   ... 1 more");
+    }
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/CSharpOutputCustomizerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/CSharpOutputCustomizerTest.java
@@ -98,8 +98,12 @@ public class CSharpOutputCustomizerTest extends BaseOutputCustomizerTest {
      */
     @Test
     public void testNonCSharpStackTraceLines() throws Exception {
+        // Terminal Console
+        testStackTraceLine("[STDOUT] Listening for transport dt_socket at address: 4403");
         testStackTraceLine(
-                "[STDOUT] Listening for transport dt_socket at address: 4403");
+                "[STDOUT] 2017-07-06 08:58:34,647 [ForkJoinPool.commonPool-worker-3] DEBUG o.j.t.l.t.DocumentManager.findSelectedWord - Looking for word at Position 2 in 'textDocument/badWord:Warning:name:So bad! '");
+
+        // Java Stacktrace
         testStackTraceLine(
                 "org.test.HighLevelException: org.test.MidLevelException: org.test.LowLevelException");
         testStackTraceLine(
@@ -115,5 +119,16 @@ public class CSharpOutputCustomizerTest extends BaseOutputCustomizerTest {
         testStackTraceLine(
                 "   at MyClass$ThrowInConstructor.<init>(MyClass.java:16)");
         testStackTraceLine("   ... 1 more");
+        
+        // C/CPP 
+        testStackTraceLine(
+                "hello.cc: In function ‘int main()’:");
+        testStackTraceLine(
+                "hello.cc:8:13: warning: division by zero [-Wdiv-by-zero]");
+        testStackTraceLine("hello.cc:8:2: error: ‘Module’ was not declared in this scope");
+        testStackTraceLine("hello.cc:4:25: fatal error: module/Module: No such file or directory");
+        testStackTraceLine("/projects/console-cc-simple/hello.cc:23: undefined reference to `Module::sayHello[abi:cxx11]()'");
+        testStackTraceLine("     return 0/0;");
+        testStackTraceLine("             ^");
     }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/CompoundOutputCustomizerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/CompoundOutputCustomizerTest.java
@@ -26,8 +26,9 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
  * - CSharpOutputCustomizer - that is expected to process C# Compilation 
  *   Error/Warning and Stacktrace lines
  * 
- * See: CHE-15 - Java stacktrace support (From Platform to Che Workspace) See:
- * Issue #5489 - .NET C# stacktrace support #5489
+ * See: CHE-15 - Java stacktrace support (From Platform to Che Workspace) 
+ * See: Issue #5489 - .NET C# stacktrace support #5489
+ * See: Issue #5565 - C/CPP compilation error/warning messages support #5565
  * 
  * @author Victor Rubezhny
  */
@@ -42,7 +43,8 @@ public class CompoundOutputCustomizerTest extends BaseOutputCustomizerTest {
     public void setUp() throws Exception {
         OutputCustomizer[] customizers = new OutputCustomizer[] { 
                 new JavaOutputCustomizer(appContext, editorAgent),
-                new CSharpOutputCustomizer(appContext, editorAgent)
+                new CSharpOutputCustomizer(appContext, editorAgent),
+                new CPPOutputCustomizer(appContext, editorAgent)
             };
 
         setupTestCustomizers(new CompoundOutputCustomizer(customizers), customizers);
@@ -67,6 +69,9 @@ public class CompoundOutputCustomizerTest extends BaseOutputCustomizerTest {
         // .NET C# Stacktrace lines
         testStackTraceLine(
                 "Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.");
+
+        // CPP Compilation Messages
+        testStackTraceLine("hello.cc: In function ‘int main()’:");
     }
 
     /**
@@ -104,6 +109,20 @@ public class CompoundOutputCustomizerTest extends BaseOutputCustomizerTest {
         testStackTraceLine(CSharpOutputCustomizer.class,
                 "ppp/PPPProgram.cs(9,17): warning CS0219: The variable 'testIntValue' is assigned but its value is never used [/home/jeremy/projects/csharp/hwapp/hwapp.csproj]",
                 "<a href='javascript:openCSCM(\"ppp/PPPProgram.cs\",\"/home/jeremy/projects/csharp/hwapp/hwapp.csproj\",9,17);'>ppp/PPPProgram.cs(9,17)</a>: warning CS0219: The variable 'testIntValue' is assigned but its value is never used [/home/jeremy/projects/csharp/hwapp/hwapp.csproj]");
+
+        // CPP Compilation Messages
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "hello.cc:8:13: warning: division by zero [-Wdiv-by-zero]",
+                "<a href='javascript:openCM(\"hello.cc\",8,13);'>hello.cc:8:13</a>: warning: division by zero [-Wdiv-by-zero]");
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "hello.cc:8:2: error: ‘Module’ was not declared in this scope",
+                "<a href='javascript:openCM(\"hello.cc\",8,2);'>hello.cc:8:2</a>: error: ‘Module’ was not declared in this scope");
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "hello.cc:4:25: fatal error: module/Module: No such file or directory",
+                "<a href='javascript:openCM(\"hello.cc\",4,25);'>hello.cc:4:25</a>: fatal error: module/Module: No such file or directory");
+        testStackTraceLine(CPPOutputCustomizer.class,
+                "/projects/console-cc-simple/hello.cc:23: undefined reference to `Module::sayHello[abi:cxx11]()'",
+                "<a href='javascript:openLM(\"/projects/console-cc-simple/hello.cc\",23);'>/projects/console-cc-simple/hello.cc:23</a>: undefined reference to `Module::sayHello[abi:cxx11]()'");
     }
 
     /**
@@ -117,6 +136,10 @@ public class CompoundOutputCustomizerTest extends BaseOutputCustomizerTest {
     public void testOtherStackTraceLines() throws Exception {
         // Java Stacktrace lines
         testStackTraceLine("   ... 1 more");
+
+        // CPP Compilation Messages
+        testStackTraceLine("     return 0/0;");
+        testStackTraceLine("             ^");
     }
 
     /**
@@ -128,5 +151,7 @@ public class CompoundOutputCustomizerTest extends BaseOutputCustomizerTest {
     @Test
     public void testNonStackTraceLines() throws Exception {
         testStackTraceLine("[STDOUT] Listening for transport dt_socket at address: 4403");
+        testStackTraceLine(
+                "[STDOUT] 2017-07-06 08:58:34,647 [ForkJoinPool.commonPool-worker-3] DEBUG o.j.t.l.t.DocumentManager.findSelectedWord - Looking for word at Position 2 in 'textDocument/badWord:Warning:name:So bad! '");
     }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/JavaOutputCustomizerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/console/JavaOutputCustomizerTest.java
@@ -100,7 +100,12 @@ public class JavaOutputCustomizerTest extends BaseOutputCustomizerTest {
      */
     @Test
     public void testNonStackTraceLines() throws Exception {
+        // Terminal Console
         testStackTraceLine("[STDOUT] Listening for transport dt_socket at address: 4403");
+        testStackTraceLine(
+                "[STDOUT] 2017-07-06 08:58:34,647 [ForkJoinPool.commonPool-worker-3] DEBUG o.j.t.l.t.DocumentManager.findSelectedWord - Looking for word at Position 2 in 'textDocument/badWord:Warning:name:So bad! '");
+
+        // C#
         testStackTraceLine(
                 "Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.");
         testStackTraceLine(
@@ -111,5 +116,17 @@ public class JavaOutputCustomizerTest extends BaseOutputCustomizerTest {
                 "Program.cs(2,13): error CS0234: The type or namespace name 'ppp' does not exist in the namespace 'hwapp' (are you missing an assembly reference?) [/home/jeremy/projects/csharp/hwapp/hwapp.csproj]");
         testStackTraceLine(
                 "ppp/PPPProgram.cs(9,17): warning CS0219: The variable 'testIntValue' is assigned but its value is never used [/home/jeremy/projects/csharp/hwapp/hwapp.csproj]");
+        testStackTraceLine(
+                "[STDOUT] 2017-07-06 08:58:34,647 [ForkJoinPool.commonPool-worker-3] DEBUG o.j.t.l.t.DocumentManager.findSelectedWord - Looking for word at Position 2 in 'textDocument/badWord:Warning:name:So bad! '");
+
+        // C/CPP 
+        testStackTraceLine(
+                "hello.cc: In function ‘int main()’:");
+        testStackTraceLine("hello.cc:8:13: warning: division by zero [-Wdiv-by-zero]");
+        testStackTraceLine("hello.cc:8:2: error: ‘Module’ was not declared in this scope");
+        testStackTraceLine("hello.cc:4:25: fatal error: module/Module: No such file or directory");
+        testStackTraceLine("/projects/console-cc-simple/hello.cc:23: undefined reference to `Module::sayHello[abi:cxx11]()'");
+        testStackTraceLine("     return 0/0;");
+        testStackTraceLine("             ^");
     }
 }


### PR DESCRIPTION
Adds the possibility to click on a compilation error/warning message lines in order to open a specified C/CPP file in editor.

Example:
![Example](https://user-images.githubusercontent.com/620781/28073125-25a8beba-6655-11e7-8739-8669fe85160c.gif)

Fixes #5565

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds the possibility to click on a stacktrace and compilation error/warning message lines in order to open a specified C/CPP file in editor.

### What issues does this PR fix or reference?
Issue #5565

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
This version introduces new capabilities to the C/CPP developers. Eclipse Che, now analyzes compilation error/warning messages from the console to intercept files and lines references. Those references are highlighted as links, when clicked, it opens C/CPP file in editor and reveal it to the line according to the info provided in the console output line.

[Animated Gif]

The smart selection capability is available for C/CPP compilation error/warning messages as well as for .NET C#, Java and NodeJS stacktraces and/or compilation messages at this moment. 

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
