### PR TITLE
Move JSON-RPC endpoints ids to constants

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventServiceImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/ClientServerEventServiceImpl.java
@@ -27,13 +27,13 @@ import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperation
 import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.START;
 import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.STOP;
 import static org.eclipse.che.api.project.shared.dto.event.FileTrackingOperationDto.Type.SUSPEND;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 /**
  * @author Roman Nikitenko
  */
 @Singleton
 public class ClientServerEventServiceImpl implements ClientServerEventService {
-    private static final String ENDPOINT_ID      = "ws-agent";
     private static final String OUTCOMING_METHOD = "track:editor-file";
 
     private final DtoFactory         dtoFactory;
@@ -81,7 +81,7 @@ public class ClientServerEventServiceImpl implements ClientServerEventService {
                                                        .withOldPath(oldPath);
         return promises.create((AsyncCallback<Void> callback) -> {
             JsonRpcPromise<Void> jsonRpcPromise = requestTransmitter.newRequest()
-                                                                    .endpointId(ENDPOINT_ID)
+                                                                    .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                                                     .methodName(OUTCOMING_METHOD)
                                                                     .paramsAsDto(dto)
                                                                     .sendAndReceiveResultAsEmpty();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/Constants.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/Constants.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.workspace;
+
+public final class Constants {
+
+    public static final String WORKSAPCE_STATUSES_ENDPOINT_ID = "workspace/statuses";
+    public static final String WORKSAPCE_OUTPUT_ENDPOINT_ID   = "workspace/output";
+    public static final String WORKSAPCE_AGENT_ENDPOINT_ID    = "workspace/agent";
+
+    private Constants() {
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/workingCopy/EditorWorkingCopySynchronizerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/workingCopy/EditorWorkingCopySynchronizerImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.che.ide.util.loging.Log;
 
 import static org.eclipse.che.api.project.shared.dto.EditorChangesDto.Type.INSERT;
 import static org.eclipse.che.api.project.shared.dto.EditorChangesDto.Type.REMOVE;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 /**
  * Default implementation of {@link EditorWorkingCopySynchronizer} which provides synchronization working copy on server side.
@@ -33,7 +34,6 @@ import static org.eclipse.che.api.project.shared.dto.EditorChangesDto.Type.REMOV
  */
 @Singleton
 public class EditorWorkingCopySynchronizerImpl implements EditorWorkingCopySynchronizer {
-    private static final String ENDPOINT_ID                   = "ws-agent";
     private static final String WORKING_COPY_ERROR_METHOD     = "track:editor-working-copy-error";
     private static final String EDITOR_CONTENT_CHANGES_METHOD = "track:editor-content-changes";
 
@@ -73,7 +73,7 @@ public class EditorWorkingCopySynchronizerImpl implements EditorWorkingCopySynch
         }
 
         return requestTransmitter.newRequest()
-                          .endpointId(ENDPOINT_ID)
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName(EDITOR_CONTENT_CHANGES_METHOD)
                           .paramsAsDto(changes)
                           .sendAndReceiveResultAsEmpty();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
@@ -63,6 +63,7 @@ import static org.eclipse.che.api.core.ErrorCodes.UNAUTHORIZED_GIT_OPERATION;
 import static org.eclipse.che.api.core.ErrorCodes.UNAUTHORIZED_SVN_OPERATION;
 import static org.eclipse.che.api.git.shared.ProviderInfo.AUTHENTICATE_URL;
 import static org.eclipse.che.api.git.shared.ProviderInfo.PROVIDER_NAME;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.PROGRESS;
@@ -302,7 +303,7 @@ public class FactoryProjectImporter extends AbstractImporter {
 
         checkoutContextRegistry.put(key, new CheckoutContext(projectName, repository, branch, startPoint));
         requestTransmitter.newRequest()
-                          .endpointId("ws-agent")
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName("git/checkoutOutput/subscribe")
                           .paramsAsString(key)
                           .sendAndSkipResult();
@@ -313,7 +314,7 @@ public class FactoryProjectImporter extends AbstractImporter {
 
         checkoutContextRegistry.remove(key);
         requestTransmitter.newRequest()
-                          .endpointId("ws-agent")
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName("git/checkoutOutput/unsubscribe")
                           .paramsAsString(key)
                           .sendAndSkipResult();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsAgentJsonRpcInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsAgentJsonRpcInitializer.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.machine.shared.Constants.WSAGENT_REFERENCE;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 /** Initializes JSON-RPC connection to the ws-agent server. */
 @Singleton
@@ -43,7 +44,7 @@ public class WsAgentJsonRpcInitializer {
         this.initializer = initializer;
 
         eventBus.addHandler(WsAgentServerRunningEvent.TYPE, event -> initializeJsonRpcService());
-        eventBus.addHandler(WsAgentServerStoppedEvent.TYPE, event -> initializer.terminate("ws-agent"));
+        eventBus.addHandler(WsAgentServerStoppedEvent.TYPE, event -> initializer.terminate(WORKSAPCE_AGENT_ENDPOINT_ID));
 
         // in case ws-agent is already running
         eventBus.addHandler(BasicIDEInitializedEvent.TYPE, event -> {
@@ -86,7 +87,7 @@ public class WsAgentJsonRpcInitializer {
                 final String wsAgentWebSocketUrl = wsAgentBaseUrl.replaceFirst("http", "ws") + "/ws"; // TODO (spi ide): remove path when it comes with URL
                 final String wsAgentUrl = wsAgentWebSocketUrl.replaceFirst("(api)(/)(ws)", "websocket" + "$2" + appContext.getAppId());
 
-                initializer.initialize("ws-agent", singletonMap("url", wsAgentUrl));
+                initializer.initialize(WORKSAPCE_AGENT_ENDPOINT_ID, singletonMap("url", wsAgentUrl));
             });
         });
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterOutputJsonRpcInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterOutputJsonRpcInitializer.java
@@ -19,6 +19,7 @@ import javax.inject.Singleton;
 import static com.google.gwt.user.client.Window.Location.getHost;
 import static com.google.gwt.user.client.Window.Location.getProtocol;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_OUTPUT_ENDPOINT_ID;
 
 /** Initializes JSON-RPC connection to the workspace master for listening to the output of intallers, machines. */
 @Singleton
@@ -38,7 +39,7 @@ public class WsMasterOutputJsonRpcInitializer {
     private void initialize() {
         String workspaceMasterUrl = getWsMasterURL();
 
-        initializer.initialize("workspace/output", singletonMap("url", workspaceMasterUrl));
+        initializer.initialize(WORKSAPCE_OUTPUT_ENDPOINT_ID, singletonMap("url", workspaceMasterUrl));
     }
 
     private String getWsMasterURL() {
@@ -50,6 +51,6 @@ public class WsMasterOutputJsonRpcInitializer {
     }
 
     public void terminate() {
-        initializer.terminate("workspace/output");
+        initializer.terminate(WORKSAPCE_OUTPUT_ENDPOINT_ID);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterStatusesJsonRpcInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterStatusesJsonRpcInitializer.java
@@ -22,6 +22,7 @@ import javax.inject.Singleton;
 import static com.google.gwt.user.client.Window.Location.getHost;
 import static com.google.gwt.user.client.Window.Location.getProtocol;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_STATUSES_ENDPOINT_ID;
 
 /** Initializes JSON-RPC connection to the workspace master for listening to the statuses of workspaces, machines, servers. */
 @Singleton
@@ -76,7 +77,7 @@ public class WsMasterStatusesJsonRpcInitializer {
             workspaceMasterUrl = getWsMasterURL();
         }
 
-        initializer.initialize("workspace/statuses", singletonMap("url", workspaceMasterUrl));
+        initializer.initialize(WORKSAPCE_STATUSES_ENDPOINT_ID, singletonMap("url", workspaceMasterUrl));
     }
 
     private String getWsMasterURL() {
@@ -88,6 +89,6 @@ public class WsMasterStatusesJsonRpcInitializer {
     }
 
     public void terminate() {
-        initializer.terminate("workspace/statuses");
+        initializer.terminate(WORKSAPCE_STATUSES_ENDPOINT_ID);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -57,6 +57,7 @@ import java.util.Set;
 
 import static org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto.Type.START;
 import static org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto.Type.STOP;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.ADDED;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.MOVED_FROM;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.MOVED_TO;
@@ -148,7 +149,6 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
 
     @Inject
     public void initFileWatchers() {
-        final String endpointId = "ws-agent";
         final String method = "track:project-tree";
 
         getTree().addExpandHandler(event -> {
@@ -157,7 +157,7 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
             if (node instanceof ResourceNode) {
                 Resource data = ((ResourceNode)node).getData();
                 requestTransmitter.newRequest()
-                                  .endpointId(endpointId)
+                                  .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                   .methodName(method)
                                   .paramsAsDto(dtoFactory.createDto(ProjectTreeTrackingOperationDto.class)
                                                          .withPath(data.getLocation().toString())
@@ -173,7 +173,7 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
             if (node instanceof ResourceNode) {
                 Resource data = ((ResourceNode)node).getData();
                 requestTransmitter.newRequest()
-                                  .endpointId(endpointId)
+                                  .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                   .methodName(method)
                                   .paramsAsDto(dtoFactory.createDto(ProjectTreeTrackingOperationDto.class)
                                                          .withPath(data.getLocation().toString())

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectTreeNotificationsSubscriber.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectTreeNotificationsSubscriber.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.dto.DtoFactory;
 
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto.Type.START;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 /** Subscribes on receiving notifications about any changes in the project tree. */
 @Singleton
@@ -55,7 +56,7 @@ public class ProjectTreeNotificationsSubscriber {
                                                            .withType(START);
 
         requestTransmitter.newRequest()
-                          .endpointId("ws-agent")
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName("track:project-tree")
                           .paramsAsDto(params)
                           .sendAndSkipResult();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/ProjectImportNotificationSubscriber.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/ProjectImportNotificationSubscriber.java
@@ -20,6 +20,7 @@ import org.eclipse.che.ide.api.machine.events.WsAgentStateHandler;
 
 import static org.eclipse.che.api.project.shared.Constants.EVENT_IMPORT_OUTPUT_SUBSCRIBE;
 import static org.eclipse.che.api.project.shared.Constants.EVENT_IMPORT_OUTPUT_UN_SUBSCRIBE;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 /**
  * Subscriber that register and deregister a listener for import project progress.
@@ -29,20 +30,18 @@ import static org.eclipse.che.api.project.shared.Constants.EVENT_IMPORT_OUTPUT_U
 @Singleton
 public class ProjectImportNotificationSubscriber {
 
-    public static final String WS_AGENT_ENDPOINT = "ws-agent";
-
     @Inject
     public ProjectImportNotificationSubscriber(EventBus eventBus, RequestTransmitter transmitter) {
         eventBus.addHandler(WsAgentStateEvent.TYPE, new WsAgentStateHandler() {
             @Override
             public void onWsAgentStarted(WsAgentStateEvent event) {
-                transmitter.newRequest().endpointId(WS_AGENT_ENDPOINT).methodName(EVENT_IMPORT_OUTPUT_SUBSCRIBE).noParams()
+                transmitter.newRequest().endpointId(WORKSAPCE_AGENT_ENDPOINT_ID).methodName(EVENT_IMPORT_OUTPUT_SUBSCRIBE).noParams()
                            .sendAndSkipResult();
             }
 
             @Override
             public void onWsAgentStopped(WsAgentStateEvent event) {
-                transmitter.newRequest().endpointId(WS_AGENT_ENDPOINT).methodName(EVENT_IMPORT_OUTPUT_UN_SUBSCRIBE).noParams()
+                transmitter.newRequest().endpointId(WORKSAPCE_AGENT_ENDPOINT_ID).methodName(EVENT_IMPORT_OUTPUT_UN_SUBSCRIBE).noParams()
                            .sendAndSkipResult();
             }
         });

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/CurrentWorkspaceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/CurrentWorkspaceManager.java
@@ -38,6 +38,8 @@ import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_OUTPUT_ENDPOINT_ID;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_STATUSES_ENDPOINT_ID;
 
 /** Performs the routines required to start/stop the current workspace. */
 @Singleton
@@ -99,11 +101,10 @@ public class CurrentWorkspaceManager {
     private void subscribeToEvents() {
         Map<String, String> scope = singletonMap("workspaceId", appContext.getWorkspaceId());
 
-        // TODO (spi ide): consider shared constants for the endpoints
-        subscriptionManagerClient.subscribe("workspace/statuses", WORKSPACE_STATUS_CHANGED_METHOD, scope);
-        subscriptionManagerClient.subscribe("workspace/statuses", MACHINE_STATUS_CHANGED_METHOD, scope);
-        subscriptionManagerClient.subscribe("workspace/statuses", SERVER_STATUS_CHANGED_METHOD, scope);
-        subscriptionManagerClient.subscribe("workspace/output", MACHINE_LOG_METHOD, scope);
-        subscriptionManagerClient.subscribe("workspace/output", INSTALLER_LOG_METHOD, scope);
+        subscriptionManagerClient.subscribe(WORKSAPCE_STATUSES_ENDPOINT_ID, WORKSPACE_STATUS_CHANGED_METHOD, scope);
+        subscriptionManagerClient.subscribe(WORKSAPCE_STATUSES_ENDPOINT_ID, MACHINE_STATUS_CHANGED_METHOD, scope);
+        subscriptionManagerClient.subscribe(WORKSAPCE_STATUSES_ENDPOINT_ID, SERVER_STATUS_CHANGED_METHOD, scope);
+        subscriptionManagerClient.subscribe(WORKSAPCE_OUTPUT_ENDPOINT_ID, MACHINE_LOG_METHOD, scope);
+        subscriptionManagerClient.subscribe(WORKSAPCE_OUTPUT_ENDPOINT_ID, INSTALLER_LOG_METHOD, scope);
     }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/WorkspaceEventsUnsubscriber.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/WorkspaceEventsUnsubscriber.java
@@ -26,6 +26,8 @@ import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_OUTPUT_ENDPOINT_ID;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_STATUSES_ENDPOINT_ID;
 
 /** Unsubscribes from receiving JSON-RPC notifications from WS-master when workspace is stopped. */
 @Singleton
@@ -36,12 +38,11 @@ class WorkspaceEventsUnsubscriber {
         eventBus.addHandler(WorkspaceStoppedEvent.TYPE, e -> {
             Map<String, String> scope = singletonMap("workspaceId", appContext.getWorkspaceId());
 
-            // TODO (spi ide): consider shared constants for the endpoints
-            subscriptionManagerClient.unSubscribe("workspace/statuses", WORKSPACE_STATUS_CHANGED_METHOD, scope);
-            subscriptionManagerClient.unSubscribe("workspace/statuses", MACHINE_STATUS_CHANGED_METHOD, scope);
-            subscriptionManagerClient.unSubscribe("workspace/statuses", SERVER_STATUS_CHANGED_METHOD, scope);
-            subscriptionManagerClient.unSubscribe("workspace/output", MACHINE_LOG_METHOD, scope);
-            subscriptionManagerClient.unSubscribe("workspace/output", INSTALLER_LOG_METHOD, scope);
+            subscriptionManagerClient.unSubscribe(WORKSAPCE_STATUSES_ENDPOINT_ID, WORKSPACE_STATUS_CHANGED_METHOD, scope);
+            subscriptionManagerClient.unSubscribe(WORKSAPCE_STATUSES_ENDPOINT_ID, MACHINE_STATUS_CHANGED_METHOD, scope);
+            subscriptionManagerClient.unSubscribe(WORKSAPCE_STATUSES_ENDPOINT_ID, SERVER_STATUS_CHANGED_METHOD, scope);
+            subscriptionManagerClient.unSubscribe(WORKSAPCE_OUTPUT_ENDPOINT_ID, MACHINE_LOG_METHOD, scope);
+            subscriptionManagerClient.unSubscribe(WORKSAPCE_OUTPUT_ENDPOINT_ID, INSTALLER_LOG_METHOD, scope);
         });
     }
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 
@@ -86,7 +87,6 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAI
 public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
     public static final String LOCAL_STORAGE_DEBUGGER_SESSION_KEY = "che-debugger-session";
     public static final String LOCAL_STORAGE_DEBUGGER_STATE_KEY   = "che-debugger-state";
-    public static final String WS_AGENT_ENDPOINT                  = "ws-agent";
 
     public static final String EVENT_DEBUGGER_MESSAGE_BREAKPOINT = "event:debugger:breakpoint";
     public static final String EVENT_DEBUGGER_MESSAGE_DISCONNECT = "event:debugger:disconnect";
@@ -288,7 +288,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
 
     private void subscribeToDebuggerEvents() {
         transmitter.newRequest()
-                   .endpointId(WS_AGENT_ENDPOINT)
+                   .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                    .methodName(EVENT_DEBUGGER_SUBSCRIBE)
                    .noParams()
                    .sendAndSkipResult();
@@ -296,7 +296,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
 
     private void unsubscribeFromDebuggerEvents() {
         transmitter.newRequest()
-                   .endpointId(WS_AGENT_ENDPOINT)
+                   .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                    .methodName(EVENT_DEBUGGER_UN_SUBSCRIBE)
                    .noParams()
                    .sendAndSkipResult();

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitCheckoutNotificationsSubscriber.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitCheckoutNotificationsSubscriber.java
@@ -20,6 +20,7 @@ import org.eclipse.che.ide.api.machine.events.WsAgentServerRunningEvent;
 import org.eclipse.che.ide.bootstrap.BasicIDEInitializedEvent;
 
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 /** Subscribes on receiving notifications about changing the current git branch. */
 @Singleton
@@ -49,7 +50,7 @@ public class GitCheckoutNotificationsSubscriber {
 
     private void subscribe() {
         requestTransmitter.newRequest()
-                          .endpointId("ws-agent")
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName("track:git-checkout")
                           .noParams()
                           .sendAndSkipResult();

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcileClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcileClient.java
@@ -24,12 +24,13 @@ import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.util.loging.Log;
 
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
+
 /**
  * @author Evgen Vidolob
  */
 @Singleton
 public class JavaReconcileClient {
-    private static final String ENDPOINT_ID      = "ws-agent";
     private static final String OUTCOMING_METHOD = "request:java-reconcile";
 
     private final RequestTransmitter     requestTransmitter;
@@ -65,7 +66,7 @@ public class JavaReconcileClient {
                                                 .withFQN(fqn)
                                                 .withProjectPath(projectPath);
         return requestTransmitter.newRequest()
-                                 .endpointId(ENDPOINT_ID)
+                                 .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                  .methodName(OUTCOMING_METHOD)
                                  .paramsAsDto(javaClassInfo)
                                  .sendAndReceiveResultAsDto(ReconcileResult.class);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryJsonRpcClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryJsonRpcClient.java
@@ -15,9 +15,8 @@ import com.google.inject.Singleton;
 
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcPromise;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
-import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.rest.AsyncRequestFactory;
-import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
+
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 
 @Singleton
 public class LanguageServerRegistryJsonRpcClient {
@@ -31,7 +30,7 @@ public class LanguageServerRegistryJsonRpcClient {
 
     public JsonRpcPromise<Boolean> initializeServer(String path) {
         return requestTransmitter.newRequest()
-                                 .endpointId("ws-agent")
+                                 .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                  .methodName("languageServer/initialize")
                                  .paramsAsString(path)
                                  .sendAndReceiveResultAsBoolean(30_000);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/PublishDiagnosticsReceiver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/PublishDiagnosticsReceiver.java
@@ -19,6 +19,8 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.plugin.languageserver.ide.editor.PublishDiagnosticsProcessor;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
+
 /**
  * Subscribes and receives JSON-RPC messages related to 'textDocument/publishDiagnostics' events
  */
@@ -36,7 +38,7 @@ public class PublishDiagnosticsReceiver {
     @Inject
     private void subscribe(RequestTransmitter transmitter) {
         transmitter.newRequest()
-                   .endpointId("ws-agent")
+                   .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                    .methodName("textDocument/publishDiagnostics/subscribe")
                    .noParams()
                    .sendAndSkipResult();

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ShowMessageJsonRpcReceiver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ShowMessageJsonRpcReceiver.java
@@ -19,6 +19,8 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.plugin.languageserver.ide.editor.ShowMessageProcessor;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
+
 /**
  * Subscribes and receives JSON-RPC messages related to 'window/showMessage' events
  */
@@ -36,7 +38,7 @@ public class ShowMessageJsonRpcReceiver {
     @Inject
     private void subscribe(RequestTransmitter transmitter) {
         transmitter.newRequest()
-                   .endpointId("ws-agent")
+                   .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                    .methodName("window/showMessage/subscribe")
                    .noParams()
                    .sendAndSkipResult();

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
@@ -44,6 +44,8 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 
 import java.util.List;
 
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
+
 
 @Singleton
 public class TextDocumentServiceClient {
@@ -215,7 +217,7 @@ public class TextDocumentServiceClient {
 
     private <T> Promise<T> transmitDtoAndReceiveDto(Object jsonSerializable, String name, Class<T> resultDtoClass) {
         return Promises.create((resolve, reject) -> requestTransmitter.newRequest()
-                                                                      .endpointId("ws-agent")
+                                                                      .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                                                       .methodName(name)
                                                                       .paramsAsDto(jsonSerializable)
                                                                       .sendAndReceiveResultAsDto(resultDtoClass)
@@ -225,7 +227,7 @@ public class TextDocumentServiceClient {
 
     private <T> Promise<List<T>> transmitDtoAndReceiveDtoList(Object jsonSerializable, String name, Class<T> resultDtoClass) {
         return Promises.create((resolve, reject) -> requestTransmitter.newRequest()
-                                                                      .endpointId("ws-agent")
+                                                                      .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                                                                       .methodName(name)
                                                                       .paramsAsDto(jsonSerializable)
                                                                       .sendAndReceiveResultAsListOfDto(resultDtoClass)
@@ -235,7 +237,7 @@ public class TextDocumentServiceClient {
 
     private void transmitDtoAndReceiveNothing(Object jsonSerializable, String name) {
         requestTransmitter.newRequest()
-                          .endpointId("ws-agent")
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName(name)
                           .paramsAsDto(jsonSerializable)
                           .sendAndSkipResult();

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenJsonRpcHandler.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenJsonRpcHandler.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static org.eclipse.che.ide.api.workspace.Constants.WORKSAPCE_AGENT_ENDPOINT_ID;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_ARCHETYPE_CHANEL_OUTPUT;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_ARCHETYPE_CHANEL_SUBSCRIBE;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_CHANEL_SUBSCRIBE;
@@ -40,8 +41,6 @@ import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_OUTPUT_U
  */
 @Singleton
 public class MavenJsonRpcHandler {
-    private static final String WS_AGENT_ENDPOINT = "ws-agent";
-
     private RequestHandlerConfigurator configurator;
 
     private Set<Consumer<TextMessageDto>>             textConsumers             = new HashSet<>();
@@ -67,13 +66,13 @@ public class MavenJsonRpcHandler {
         }
 
         requestTransmitter.newRequest()
-                          .endpointId(WS_AGENT_ENDPOINT)
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName(MAVEN_CHANEL_SUBSCRIBE)
                           .noParams()
                           .sendAndSkipResult();
 
         requestTransmitter.newRequest()
-                          .endpointId(WS_AGENT_ENDPOINT)
+                          .endpointId(WORKSAPCE_AGENT_ENDPOINT_ID)
                           .methodName(MAVEN_ARCHETYPE_CHANEL_SUBSCRIBE)
                           .noParams()
                           .sendAndSkipResult();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Moves identifiers of JSON-RPC endpoints to org.eclipse.che.ide.api.workspace.Constants.

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->
Added org.eclipse.che.ide.api.workspace.Constants with JSON-RPC endpoints ids.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A