### PR TITLE
Fix using project path and fileUri

### DIFF
--- a/plugins/plugin-csharp/che-plugin-csharp-lang-server/src/main/java/org/eclipse/che/plugin/csharp/languageserver/CSharpLanguageServerLauncher.java
+++ b/plugins/plugin-csharp/che-plugin-csharp-lang-server/src/main/java/org/eclipse/che/plugin/csharp/languageserver/CSharpLanguageServerLauncher.java
@@ -12,10 +12,12 @@ package org.eclipse.che.plugin.csharp.languageserver;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
 import org.eclipse.che.api.languageserver.registry.DocumentFilter;
 import org.eclipse.che.api.languageserver.registry.LanguageServerDescription;
+import org.eclipse.che.api.languageserver.service.LanguageServiceUtils;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.plugin.csharp.inject.CSharpModule;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -64,7 +66,7 @@ public class CSharpLanguageServerLauncher extends LanguageServerLauncherTemplate
 
     private void restoreDependencies(String projectPath) throws LanguageServerException {
         ProcessBuilder processBuilder = new ProcessBuilder("dotnet", "restore");
-        processBuilder.directory(new File(projectPath));
+        processBuilder.directory(new File(LanguageServiceUtils.removeUriScheme(projectPath)));
         try {
             Process process = processBuilder.start();
             int resultCode = process.waitFor();

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImpl.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/ServerInitializerImpl.java
@@ -10,19 +10,16 @@
  *******************************************************************************/
 package org.eclipse.che.api.languageserver.registry;
 
-import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.api.core.notification.EventService;
+
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
+import org.eclipse.che.api.languageserver.service.LanguageServiceUtils;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
-import org.eclipse.lsp4j.MessageParams;
-import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.slf4j.Logger;
@@ -114,7 +111,7 @@ public class ServerInitializerImpl implements ServerInitializer {
     private InitializeParams prepareInitializeParams(String projectPath) {
         InitializeParams initializeParams = new InitializeParams();
         initializeParams.setProcessId(PROCESS_ID);
-        initializeParams.setRootPath(projectPath);
+        initializeParams.setRootPath(LanguageServiceUtils.removeUriScheme(projectPath));
         initializeParams.setCapabilities(new ClientCapabilities());
         initializeParams.setClientName(CLIENT_NAME);
         return initializeParams;

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageRegistryService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageRegistryService.java
@@ -50,7 +50,7 @@ public class LanguageRegistryService {
     @Path("initialize")
     public ServerCapabilitiesDto initialize(@QueryParam("path") String path) throws LanguageServerException {
         //in most cases starts new LS if not already started
-        ServerCapabilities capabilities = registry.initialize(TextDocumentServiceUtils.prefixURI(path));
+        ServerCapabilities capabilities = registry.initialize(LanguageServiceUtils.prefixURI(path));
         return capabilities == null ? null : new ServerCapabilitiesDto(capabilities);
     }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServerInitializationHandler.java
@@ -30,7 +30,7 @@ public class LanguageServerInitializationHandler {
                                   .resultAsDto(ServerCapabilitiesDto.class)
                                   .withFunction(path -> {
                                       try {
-                                          ServerCapabilities capabilities = registry.initialize(TextDocumentServiceUtils.prefixURI(path));
+                                          ServerCapabilities capabilities = registry.initialize(LanguageServiceUtils.prefixURI(path));
                                           return capabilities == null ? null : new ServerCapabilitiesDto(capabilities);
                                       } catch (LanguageServerException e) {
                                           throw new JsonRpcException(-27000, e.getMessage());

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServiceUtils.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServiceUtils.java
@@ -11,21 +11,29 @@
 package org.eclipse.che.api.languageserver.service;
 
 /**
- * Text document service utilities
+ * Language service service utilities
  */
-class TextDocumentServiceUtils {
+public class LanguageServiceUtils {
     private static final String FILE_PROJECTS = "file:///projects";
 
-    static String prefixURI(String relativePath) {
+    public static String prefixURI(String relativePath) {
         return FILE_PROJECTS + relativePath;
     }
 
-    static String removePrefixUri(String uri) {
+    public static String removePrefixUri(String uri) {
         return uri.startsWith(FILE_PROJECTS) ? uri.substring(FILE_PROJECTS.length()) : uri;
     }
+
+    public static String removeUriScheme(String uri) {
+        return uri.startsWith(FILE_PROJECTS) ? uri.substring("file://".length()) : uri;
+    }
     
-    static boolean truish(Boolean b) {
+    public static boolean truish(Boolean b) {
         return b != null && b;
+    }
+
+    public static  boolean isProjectUri(String path) {
+        return path.startsWith(FILE_PROJECTS);
     }
 
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/TextDocumentService.java
@@ -68,8 +68,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.eclipse.che.api.languageserver.service.TextDocumentServiceUtils.prefixURI;
-import static org.eclipse.che.api.languageserver.service.TextDocumentServiceUtils.removePrefixUri;
+import static org.eclipse.che.api.languageserver.service.LanguageServiceUtils.prefixURI;
+import static org.eclipse.che.api.languageserver.service.LanguageServiceUtils.removePrefixUri;
 
 /**
  * Json RPC API for the textDoc

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/WorkspaceService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/WorkspaceService.java
@@ -35,8 +35,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-import static org.eclipse.che.api.languageserver.service.TextDocumentServiceUtils.removePrefixUri;
-import static org.eclipse.che.api.languageserver.service.TextDocumentServiceUtils.truish;
+import static org.eclipse.che.api.languageserver.service.LanguageServiceUtils.removePrefixUri;
+import static org.eclipse.che.api.languageserver.service.LanguageServiceUtils.truish;
 
 /**
  * REST API for the workspace/* services defined in


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
In some place where we communicate with language server we should use file path in URI format like (file://projects/someproject/file), but for starting language server process regular file path (/projects/someproject)



### What issues does this PR fix or reference?
#5547 

