### PR TITLE
CHE-5621: Avoid using ProjectManager just for taking project root dir

### DIFF
--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenModelReader.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenModelReader.java
@@ -155,6 +155,8 @@ public class MavenModelReader {
             problems.add(MavenProjectProblem.newProblem(pom.getPath(), e.getMessage(), MavenProblemType.SYNTAX));
         } catch (XMLTreeException xmlExc) {
             problems.add(MavenProjectProblem.newProblem(pom.getPath(), xmlExc.getMessage(), MavenProblemType.STRUCTURE));
+        } catch (Exception exc) {
+            problems.add(MavenProjectProblem.newProblem(pom.getPath(), exc.getMessage(), MavenProblemType.STRUCTURE));
         }
 
         if (model == null) {

--- a/plugins/plugin-testing-php/plugin-testing-phpunit/che-plugin-testing-phpunit-server/src/main/java/org/eclipse/che/plugin/testing/phpunit/server/PHPUnitTestRunner.java
+++ b/plugins/plugin-testing-php/plugin-testing-phpunit/che-plugin-testing-phpunit-server/src/main/java/org/eclipse/che/plugin/testing/phpunit/server/PHPUnitTestRunner.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.testing.phpunit.server;
 
-import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.testing.server.framework.TestRunner;
 import org.eclipse.che.api.testing.shared.TestDetectionContext;
 import org.eclipse.che.api.testing.shared.TestExecutionContext;
@@ -23,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -49,8 +50,8 @@ public class PHPUnitTestRunner implements TestRunner {
     private final PHPUnitTestEngine testEngine;
 
     @Inject
-    public PHPUnitTestRunner(ProjectManager projectManager) {
-        testEngine = new PHPUnitTestEngine(projectManager);
+    public PHPUnitTestRunner(@Named("che.user.workspaces.storage") File projectsRoot) {
+        testEngine = new PHPUnitTestEngine(projectsRoot);
     }
 
     /**


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Avoid using ProjectManager only for taking project root dir instead of we will use special properties 

### What issues does this PR fix or reference?
#5621 

