### PR TITLE
CHE-5206. Fix focus position at editor state restoring

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -17,7 +17,6 @@ import elemental.util.ArrayOf;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 
@@ -58,7 +57,6 @@ import org.eclipse.che.ide.api.parts.EditorMultiPartStackState;
 import org.eclipse.che.ide.api.parts.EditorPartStack;
 import org.eclipse.che.ide.api.parts.EditorTab;
 import org.eclipse.che.ide.api.parts.PartPresenter;
-import org.eclipse.che.ide.api.parts.PropertyListener;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
 import org.eclipse.che.ide.api.resources.Resource;
@@ -106,7 +104,7 @@ public class EditorAgentImpl implements EditorAgent,
 
     private final List<EditorPartPresenter>           openedEditors;
     private final Map<EditorPartPresenter, String>    openedEditorsToProviders;
-    private final Provider<EditorContentSynchronizer> editorContentSynchronizerProvider;
+    private final EditorContentSynchronizer           editorContentSynchronizer;
     private final PromiseProvider                     promiseProvider;
     private final ResourceProvider                    resourceProvider;
     private       List<EditorPartPresenter>           dirtyEditors;
@@ -121,7 +119,7 @@ public class EditorAgentImpl implements EditorAgent,
                            WorkspaceAgent workspaceAgent,
                            CoreLocalizationConstant coreLocalizationConstant,
                            EditorMultiPartStackPresenter editorMultiPartStack,
-                           Provider<EditorContentSynchronizer> editorContentSynchronizerProvider,
+                           EditorContentSynchronizer editorContentSynchronizer,
                            PromiseProvider promiseProvider,
                            ResourceProvider resourceProvider) {
         this.eventBus = eventBus;
@@ -131,7 +129,7 @@ public class EditorAgentImpl implements EditorAgent,
         this.workspaceAgent = workspaceAgent;
         this.coreLocalizationConstant = coreLocalizationConstant;
         this.editorMultiPartStack = editorMultiPartStack;
-        this.editorContentSynchronizerProvider = editorContentSynchronizerProvider;
+        this.editorContentSynchronizer = editorContentSynchronizer;
         this.promiseProvider = promiseProvider;
         this.resourceProvider = resourceProvider;
         this.openedEditors = newArrayList();
@@ -236,7 +234,7 @@ public class EditorAgentImpl implements EditorAgent,
         editor.close(false);
 
         if (editor instanceof TextEditor) {
-            editorContentSynchronizerProvider.get().unTrackEditor(editor);
+            editorContentSynchronizer.unTrackEditor(editor);
         }
 
         if (activeEditor != null && activeEditor == editor) {
@@ -291,28 +289,31 @@ public class EditorAgentImpl implements EditorAgent,
         finalizeInit(file, callback, editor, editorProvider);
     }
 
-    private void finalizeInit(final VirtualFile file, final OpenEditorCallback callback, final EditorPartPresenter editor,
-                              EditorProvider editorProvider) {
-        openedEditors.add(editor);
-        openedEditorsToProviders.put(editor, editorProvider.getId());
+    private Promise<Void> finalizeInit(final VirtualFile file,
+                                       final OpenEditorCallback openEditorCallback,
+                                       final EditorPartPresenter editor,
+                                       EditorProvider editorProvider) {
+        return AsyncPromiseHelper.createFromAsyncRequest(promiseCallback -> {
+            openedEditors.add(editor);
+            openedEditorsToProviders.put(editor, editorProvider.getId());
 
-        workspaceAgent.setActivePart(editor);
-        editor.addPropertyListener(new PropertyListener() {
-            @Override
-            public void propertyChanged(PartPresenter source, int propId) {
+            workspaceAgent.setActivePart(editor);
+            editor.addPropertyListener((source, propId) -> {
                 if (propId == EditorPartPresenter.PROP_INPUT) {
+                    promiseCallback.onSuccess(null);
+
                     if (editor instanceof HasReadOnlyProperty) {
                         ((HasReadOnlyProperty)editor).setReadOnly(file.isReadOnly());
                     }
 
                     if (editor instanceof TextEditor) {
-                        editorContentSynchronizerProvider.get().trackEditor(editor);
+                        editorContentSynchronizer.trackEditor(editor);
                     }
-                    callback.onEditorOpened(editor);
+                    openEditorCallback.onEditorOpened(editor);
                     eventBus.fireEvent(FileEvent.createFileOpenedEvent(file));
                     eventBus.fireEvent(new EditorOpenedEvent(file, editor));
                 }
-            }
+            });
         });
     }
 
@@ -557,34 +558,35 @@ public class EditorAgentImpl implements EditorAgent,
 
         final EditorProvider provider = editorRegistry.findEditorProviderById(providerId);
         if (provider instanceof AsyncEditorProvider) {
-            ((AsyncEditorProvider)provider).createEditor(resourceFile).then(new Operation<EditorPartPresenter>() {
-                @Override
-                public void apply(EditorPartPresenter arg) throws OperationException {
-                    restoreInitEditor(resourceFile, callback, fileTypeRegistry.getFileTypeByFile(resourceFile), arg, provider,
-                                      editorPartStack);
+            ((AsyncEditorProvider)provider).createEditor(resourceFile).then(editor -> {
+                restoreInitEditor(resourceFile, callback, fileTypeRegistry.getFileTypeByFile(resourceFile), editor, provider,
+                                  editorPartStack).then(arg -> {
                     if (active) {
-                        activeEditors.put(arg, editorPartStack);
+                        activeEditors.put(editor, editorPartStack);
                     }
-
-                }
+                    openCallback.onSuccess(null);
+                });
             });
         } else {
             EditorPartPresenter editor = provider.getEditor();
-            restoreInitEditor(resourceFile, callback, fileTypeRegistry.getFileTypeByFile(resourceFile), editor, provider, editorPartStack);
-            if (active) {
-                activeEditors.put(editor, editorPartStack);
-            }
+            restoreInitEditor(resourceFile, callback, fileTypeRegistry.getFileTypeByFile(resourceFile), editor, provider, editorPartStack)
+                    .then(arg -> {
+                        if (active) {
+                            activeEditors.put(editor, editorPartStack);
+                        }
+                        openCallback.onSuccess(null);
+                    });
         }
-        openCallback.onSuccess(null);
     }
 
-    private void restoreInitEditor(final VirtualFile file, final OpenEditorCallback callback, FileType fileType,
-                                   final EditorPartPresenter editor, EditorProvider editorProvider, EditorPartStack editorPartStack) {
+    private Promise<Void> restoreInitEditor(final VirtualFile file, final OpenEditorCallback callback, FileType fileType,
+                                            final EditorPartPresenter editor, EditorProvider editorProvider,
+                                            EditorPartStack editorPartStack) {
         editor.init(new EditorInputImpl(fileType, file), callback);
         editor.addCloseHandler(this);
 
         editorPartStack.addPart(editor);
-        finalizeInit(file, callback, editor, editorProvider);
+        return finalizeInit(file, callback, editor, editorProvider);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
We need set focus in corresponding editor when editor has initialized. Otherwise we have case when active tab does not match editor which has actual focus. It leads to different issues related with editor content sync.
![editor_focus](https://user-images.githubusercontent.com/5676062/28257617-dd512b50-6ad4-11e7-9ee5-6b84b99fb39b.png)

### What issues does this PR fix or reference?
#5206 #5190

#### Changelog
Fix focus position at editor state restoring

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
