### PR TITLE
CHE-5215. Display notifications about external delete operation in Events panel

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/EditorFileStatusNotificationOperation.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/EditorFileStatusNotificationOperation.java
@@ -29,10 +29,9 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.List;
-
 import java.util.function.BiConsumer;
 
-import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 import static org.eclipse.che.ide.api.resources.ResourceDelta.REMOVED;
 
@@ -97,7 +96,7 @@ public class EditorFileStatusNotificationOperation implements BiConsumer<String,
                 final Path path = Path.valueOf(stringPath);
                 appContext.getWorkspaceRoot().synchronize(new ExternalResourceDelta(path, path, REMOVED));
                 if (notificationManager != null && !deletedFilesController.remove(stringPath)) {
-                    notificationManager.notify("External operation", "File '" + name + "' is removed", SUCCESS, EMERGE_MODE);
+                    notificationManager.notify("External operation", "File '" + name + "' is removed", SUCCESS, NOT_EMERGE_MODE);
                     closeOpenedEditor(path);
                 }
 


### PR DESCRIPTION
### What does this PR do?
Change the way of notification about external delete operation - current behavior: we display popup, new behavior: we display this kind of notifications ONLY in Events panel.
We did the same for external modify operations here https://github.com/eclipse/che/pull/5495

### What issues does this PR fix or reference?
#5215

#### Changelog
Display notifications about external delete operation in Events panel

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
