### PR TITLE
Openshift : add mounted volume for logs

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -163,6 +163,8 @@ public class OpenShiftConnector extends DockerConnector {
     private static final Logger LOG                                      = LoggerFactory.getLogger(OpenShiftConnector.class);
     public static final String CHE_OPENSHIFT_RESOURCES_PREFIX           = "che-ws-";
     public static final String OPENSHIFT_DEPLOYMENT_LABEL               = "deployment";
+    public static final String CHE_MOUNTED_WORKSPACE_FOLDER             = "/workspace-logs";
+    public static final String WORKSPACE_LOGS_FOLDER_SUFFIX             = "-logs";
 
     private static final String CHE_CONTAINER_IDENTIFIER_LABEL_KEY       = "cheContainerIdentifier";
     private static final String CHE_DEFAULT_EXTERNAL_ADDRESS             = "172.17.0.1";
@@ -1489,7 +1491,16 @@ public class OpenShiftConnector extends DockerConnector {
                     .withName(workspacesPersistentVolumeClaim)
                     .withSubPath(subPath)
                     .build();
+
+                // add a mount from PVC for the logs
+                VolumeMount logsVm = new VolumeMountBuilder()
+                        .withMountPath(CHE_MOUNTED_WORKSPACE_FOLDER)
+                        .withName(workspacesPersistentVolumeClaim)
+                        .withSubPath(subPath + WORKSPACE_LOGS_FOLDER_SUFFIX)
+                        .build();
+
                 vms.add(vm);
+                vms.add(logsVm);
             }
         }
         return vms;


### PR DESCRIPTION
### What does this PR do?

Adds a `/workspace-logs` folder linked to the persistent volume
Each pod has a dedicated folder matching the workspace id  for the project's source, it is currently using :  `/projects ---> <PV>/<workspace-name>`  and for the logs it's now using as well `/workspace-logs ---> <PV>/<workspace-name>-logs/`

example : `/workspace-logs/dev-machine-ws-agent/logs/catalina.log`  for the log of the dev-machine workspace agent.


### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/145

#### Changelog
Add folder (/workspace-logs) on OpenShift linked to persistent volume

#### Release Notes
N/A

#### Docs PR
N/A