### PR TITLE
CHE-5592: refresh commands list in project's context menu in IDE

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.service.ts
@@ -109,6 +109,8 @@ export class ProjectSourceSelectorService extends ProjectSourceSelectorServiceOb
       case ProjectSource.GIT: {
         const projectProps = this.importGitProjectService.getProjectProps();
         const projectTemplate = this.buildProjectTemplate(projectProps);
+        delete projectTemplate.type;
+        delete projectTemplate.projectType;
         this.addProjectTemplate(source, projectTemplate);
       }
         break;
@@ -116,6 +118,8 @@ export class ProjectSourceSelectorService extends ProjectSourceSelectorServiceOb
         const repositoriesProps = this.importGithubProjectService.getRepositoriesProps();
         repositoriesProps.forEach((repositoryProps: che.IProjectTemplate) => {
           const projectTemplate = this.buildProjectTemplate(repositoryProps);
+          delete projectTemplate.type;
+          delete projectTemplate.projectType;
           this.addProjectTemplate(source, projectTemplate);
         });
       }
@@ -123,6 +127,8 @@ export class ProjectSourceSelectorService extends ProjectSourceSelectorServiceOb
       case ProjectSource.ZIP: {
         const projectProps = this.importZipProjectService.getProjectProps();
         const projectTemplate = this.buildProjectTemplate(projectProps);
+        delete projectTemplate.type;
+        delete projectTemplate.projectType;
         this.addProjectTemplate(source, projectTemplate);
       }
         break;
@@ -146,6 +152,10 @@ export class ProjectSourceSelectorService extends ProjectSourceSelectorServiceOb
       projectTemplate.name = newName;
       projectTemplate.displayName = newName;
       projectTemplate.path = '/' +  newName.replace(/[^\w-_]/g, '_');
+    }
+
+    if (!projectTemplate.type && projectTemplate.projectType) {
+      projectTemplate.type = projectTemplate.projectType;
     }
 
     this.projectTemplates.push(projectTemplate);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
@@ -22,6 +22,7 @@ import org.eclipse.che.ide.api.command.CommandAddedEvent;
 import org.eclipse.che.ide.api.command.CommandGoalRegistry;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandManager;
+import org.eclipse.che.ide.api.command.CommandsLoadedEvent;
 import org.eclipse.che.ide.api.command.CommandRemovedEvent;
 import org.eclipse.che.ide.api.command.CommandUpdatedEvent;
 import org.eclipse.che.ide.api.component.WsAgentComponent;
@@ -84,6 +85,10 @@ public class ExecuteCommandActionManager implements WsAgentComponent {
 
         eventBus.addHandler(CommandAddedEvent.getType(), e -> addAction(e.getCommand()));
         eventBus.addHandler(CommandRemovedEvent.getType(), e -> removeAction(e.getCommand()));
+        eventBus.addHandler(CommandsLoadedEvent.getType(), e -> {
+            commandManager.getCommands().forEach(this::removeAction);
+            commandManager.getCommands().forEach(this::addAction);
+        });
         eventBus.addHandler(CommandUpdatedEvent.getType(), e -> {
             removeAction(e.getInitialCommand());
             addAction(e.getUpdatedCommand());


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR fixes bug when project's context menu doesn't contain imported project's commands. 

### What issues does this PR fix or reference?
fixes #5592 

#### Changelog
<!-- one line entry to be added to changelog -->
Fixed bug when project's context menu doesn't contain imported project's commands.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix
