### PR TITLE
Recover runtimes on master startup

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/ValidationException.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/ValidationException.java
@@ -26,4 +26,12 @@ public class ValidationException extends Exception {
     public ValidationException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Creates an exception with a formatted message.
+     * Please follow {@link String#format(String, Object...)} formatting patterns.
+     */
+    public ValidationException(String fmt, Object... args) {
+        this(String.format(fmt, args));
+    }
 }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DefaultInfrastructureProvisioner.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DefaultInfrastructureProvisioner.java
@@ -10,13 +10,16 @@
  *******************************************************************************/
 package org.eclipse.che.workspace.infrastructure.docker;
 
-import org.eclipse.che.api.installer.server.exception.InstallerException;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.installer.server.exception.InstallerException;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
 import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
 
 import javax.inject.Inject;
+import java.util.Map;
 
 /**
  * Implementation of CHE infrastructure provisioner that adds agent-specific infrastructure to internal environment representation.
@@ -40,6 +43,16 @@ public class DefaultInfrastructureProvisioner implements InfrastructureProvision
             installerConfigApplier.apply(envConfig, dockerEnvironment);
         } catch (InstallerException e) {
             throw new InfrastructureException(e.getLocalizedMessage(), e);
+        }
+
+        for (Map.Entry<String, ? extends MachineConfig> entry : envConfig.getMachines().entrySet()) {
+            String name = entry.getKey();
+            DockerContainerConfig container = dockerEnvironment.getContainers().get(name);
+            container.getLabels().putAll(Labels.newSerializer()
+                                               .machineName(name)
+                                               .runtimeId(runtimeIdentity)
+                                               .servers(entry.getValue().getServers())
+                                               .labels());
         }
     }
 }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerContainers.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerContainers.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.plugin.docker.client.DockerConnector;
+import org.eclipse.che.plugin.docker.client.json.ContainerListEntry;
+import org.eclipse.che.plugin.docker.client.json.Filters;
+import org.eclipse.che.plugin.docker.client.params.ListContainersParams;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Facade for operations with docker containers in infrastructure domain context. */
+@Singleton
+public class DockerContainers {
+
+    private final DockerConnector docker;
+
+    @Inject
+    public DockerContainers(DockerConnector docker) {
+        this.docker = docker;
+    }
+
+    /**
+     * Lookups all containers owned by runtime with given identity.
+     *
+     * @param id
+     *         identity of runtime which owns containers
+     * @return list of running containers owned by runtime with given id
+     * @throws InternalInfrastructureException
+     *         when any error occurs during lookup
+     */
+    public List<ContainerListEntry> find(RuntimeIdentity id) throws InternalInfrastructureException {
+        return listNonStoppedContainers(Labels.newSerializer()
+                                              .runtimeId(id)
+                                              .labels()
+                                              .entrySet()
+                                              .stream()
+                                              .map(entry -> entry.getKey() + '=' + entry.getValue())
+                                              .toArray(String[]::new));
+    }
+
+    /**
+     * Lookups all runtime identifiers provided by running containers labels.
+     *
+     * @return unique runtime identifiers of running containers
+     * @throws InternalInfrastructureException
+     *         when any error occurs during lookup
+     */
+    public Set<RuntimeIdentity> findIdentities() throws InternalInfrastructureException {
+        return listNonStoppedContainers(Labels.LABEL_WORKSPACE_ID, Labels.LABEL_WORKSPACE_ID, Labels.LABEL_WORKSPACE_OWNER)
+                .stream()
+                .map(e -> Labels.newDeserializer(e.getLabels()).runtimeId())
+                .collect(Collectors.toSet());
+    }
+
+    private List<ContainerListEntry> listNonStoppedContainers(String... labelFilterValues) throws InternalInfrastructureException {
+        try {
+            return docker.listContainers(ListContainersParams.create()
+                                                             .withAll(false)
+                                                             .withFilters(Filters.label(labelFilterValues)));
+        } catch (IOException x) {
+            throw new InternalInfrastructureException(x.getMessage(), x);
+        }
+    }
+}

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
@@ -21,6 +21,8 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.plugin.docker.client.DockerRegistryDynamicAuthResolver;
 import org.eclipse.che.plugin.docker.client.NoOpDockerRegistryDynamicAuthResolverImpl;
 import org.eclipse.che.workspace.infrastructure.docker.bootstrap.DockerBootstrapperFactory;
+import org.eclipse.che.workspace.infrastructure.docker.bootstrap.DockerBootstrapper;
+import org.eclipse.che.workspace.infrastructure.docker.bootstrap.DockerBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.docker.config.DockerExtraHostsFromPropertyProvider;
 import org.eclipse.che.workspace.infrastructure.docker.config.dns.DnsResolversModule;
 import org.eclipse.che.workspace.infrastructure.docker.config.env.ApiEndpointEnvVariableProvider;
@@ -106,8 +108,8 @@ public class DockerInfraModule extends AbstractModule {
         bind(DockerRegistryDynamicAuthResolver.class).to(NoOpDockerRegistryDynamicAuthResolverImpl.class);
 
         install(new FactoryModuleBuilder().build(DockerRuntimeFactory.class));
-
         install(new FactoryModuleBuilder().build(DockerBootstrapperFactory.class));
+        install(new FactoryModuleBuilder().build(DockerRuntimeContextFactory.class));
 
         bind(ServerCheckerFactory.class).to(ServerCheckerFactoryImpl.class);
     }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.workspace.infrastructure.docker;
 
 import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
 
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
@@ -29,12 +30,15 @@ import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.ServerStatusEvent;
 import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.plugin.docker.client.ProgressMonitor;
+import org.eclipse.che.plugin.docker.client.json.ContainerListEntry;
 import org.eclipse.che.workspace.infrastructure.docker.bootstrap.DockerBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.docker.exception.SourceNotFoundException;
 import org.eclipse.che.workspace.infrastructure.docker.model.DockerBuildContext;
 import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
 import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.monit.AbnormalMachineStopHandler;
+import org.eclipse.che.workspace.infrastructure.docker.monit.DockerMachineStopDetector;
 import org.eclipse.che.workspace.infrastructure.docker.server.ServerCheckerFactory;
 import org.eclipse.che.workspace.infrastructure.docker.server.ServersReadinessChecker;
 import org.eclipse.che.workspace.infrastructure.docker.snapshot.MachineSource;
@@ -44,7 +48,6 @@ import org.eclipse.che.workspace.infrastructure.docker.snapshot.SnapshotExceptio
 import org.eclipse.che.workspace.infrastructure.docker.snapshot.SnapshotImpl;
 import org.slf4j.Logger;
 
-import javax.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,53 +71,115 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
     private final StartSynchronizer         startSynchronizer;
     private final Map<String, String>       properties;
-    private final Queue<String>             startQueue;
-    private final NetworkLifecycle          dockerNetworkLifecycle;
-    private final String                    devMachineName;
-    private final DockerEnvironment         dockerEnvironment;
+    private final NetworkLifecycle          networks;
     private final DockerMachineStarter      containerStarter;
     private final SnapshotDao               snapshotDao;
     private final DockerRegistryClient      dockerRegistryClient;
-    private final RuntimeIdentity           identity;
     private final EventService              eventService;
     private final DockerBootstrapperFactory bootstrapperFactory;
     private final ServerCheckerFactory      serverCheckerFactory;
+    private final MachineLoggersFactory     loggers;
 
-    @Inject
+    /**
+     * Creates non running runtime.
+     * Normally created by {@link DockerRuntimeFactory#create(DockerRuntimeContext)}.
+     */
+    @AssistedInject
     public DockerInternalRuntime(@Assisted DockerRuntimeContext context,
-                                 @Assisted String devMachineName,
-                                 @Assisted List<String> orderedContainers,
-                                 @Assisted DockerEnvironment dockerEnvironment,
-                                 @Assisted RuntimeIdentity identity,
                                  URLRewriter urlRewriter,
-                                 NetworkLifecycle dockerNetworkLifecycle,
-                                 DockerMachineStarter containerStarter,
+                                 NetworkLifecycle networks,
+                                 DockerMachineStarter machineStarter,
                                  SnapshotDao snapshotDao,
                                  DockerRegistryClient dockerRegistryClient,
                                  EventService eventService,
                                  DockerBootstrapperFactory bootstrapperFactory,
-                                 ServerCheckerFactory serverCheckerFactory) {
-        super(context, urlRewriter);
-        this.devMachineName = devMachineName;
-        this.dockerEnvironment = dockerEnvironment;
-        this.identity = identity;
+                                 ServerCheckerFactory serverCheckerFactory,
+                                 MachineLoggersFactory loggers) {
+        this(context,
+             urlRewriter,
+             false, // <- non running
+             networks,
+             machineStarter,
+             snapshotDao,
+             dockerRegistryClient,
+             eventService,
+             bootstrapperFactory,
+             serverCheckerFactory,
+             loggers);
+    }
+
+    /**
+     * Creates a running runtime from the list of given containers.
+     * Normally created by {@link DockerRuntimeFactory#create(DockerRuntimeContext, List)}.
+     */
+    @AssistedInject
+    public DockerInternalRuntime(@Assisted DockerRuntimeContext context,
+                                 @Assisted List<ContainerListEntry> containers,
+                                 URLRewriter urlRewriter,
+                                 NetworkLifecycle networks,
+                                 DockerMachineStarter machineStarter,
+                                 SnapshotDao snapshotDao,
+                                 DockerRegistryClient dockerRegistryClient,
+                                 EventService eventService,
+                                 DockerBootstrapperFactory bootstrapperFactory,
+                                 ServerCheckerFactory serverCheckerFactory,
+                                 MachineLoggersFactory loggers,
+                                 DockerMachineCreator machineCreator,
+                                 DockerMachineStopDetector stopDetector) throws InfrastructureException {
+        this(context,
+             urlRewriter,
+             true, // <- running
+             networks,
+             machineStarter,
+             snapshotDao,
+             dockerRegistryClient,
+             eventService,
+             bootstrapperFactory,
+             serverCheckerFactory,
+             loggers);
+
+        for (ContainerListEntry container : containers) {
+            DockerMachine machine = machineCreator.create(container);
+            String name = Labels.newDeserializer(container.getLabels()).machineName();
+
+            startSynchronizer.addMachine(name, machine);
+            stopDetector.startDetection(container.getId(), name, new AbnormalMachineStopHandlerImpl());
+            streamLogsAsync(name, container.getId());
+        }
+    }
+
+    private DockerInternalRuntime(DockerRuntimeContext context,
+                                  URLRewriter urlRewriter,
+                                  boolean running,
+                                  NetworkLifecycle networks,
+                                  DockerMachineStarter machineStarter,
+                                  SnapshotDao snapshotDao,
+                                  DockerRegistryClient dockerRegistryClient,
+                                  EventService eventService,
+                                  DockerBootstrapperFactory bootstrapperFactory,
+                                  ServerCheckerFactory serverCheckerFactory,
+                                  MachineLoggersFactory loggers) {
+        super(context, urlRewriter, running);
+        this.networks = networks;
+        this.containerStarter = machineStarter;
+        this.snapshotDao = snapshotDao;
+        this.dockerRegistryClient = dockerRegistryClient;
         this.eventService = eventService;
         this.bootstrapperFactory = bootstrapperFactory;
         this.serverCheckerFactory = serverCheckerFactory;
         this.properties = new HashMap<>();
         this.startSynchronizer = new StartSynchronizer();
-        this.dockerNetworkLifecycle = dockerNetworkLifecycle;
-        this.containerStarter = containerStarter;
-        this.snapshotDao = snapshotDao;
-        this.dockerRegistryClient = dockerRegistryClient;
-        this.startQueue = new ArrayDeque<>(orderedContainers);
+        this.loggers = loggers;
     }
 
     @Override
     protected void internalStart(Map<String, String> startOptions) throws InfrastructureException {
         startSynchronizer.setStartThread();
+
+        DockerEnvironment dockerEnvironment = getContext().getDockerEnvironment();
+        Queue<String> startQueue = new ArrayDeque<>(getContext().getOrderedContainers());
         try {
-            dockerNetworkLifecycle.createNetwork(dockerEnvironment.getNetwork());
+            networks.createNetwork(getContext().getDockerEnvironment().getNetwork());
 
             boolean restore = isRestoreEnabled(startOptions);
 
@@ -178,6 +243,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
     private void restoreMachine(String name, DockerContainerConfig originalConfig)
             throws InfrastructureException, InterruptedException {
+        RuntimeIdentity identity = getContext().getIdentity();
         try {
             SnapshotImpl snapshot = snapshotDao.getSnapshot(identity.getWorkspaceId(), identity.getEnvName(), name);
             startMachine(name, configForSnapshot(snapshot, originalConfig));
@@ -192,23 +258,22 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         }
     }
 
+    /** Checks servers availability on all the machines. */
+    void checkServers() throws InfrastructureException {
+        for (Map.Entry<String, ? extends DockerMachine> entry : startSynchronizer.getMachines().entrySet()) {
+            new ServersReadinessChecker(entry.getKey(), entry.getValue().getServers(), serverCheckerFactory).checkOnce();
+        }
+    }
+
     private void startMachine(String name, DockerContainerConfig containerConfig)
             throws InfrastructureException, InterruptedException {
         InternalMachineConfig machineCfg = getContext().getMachineConfigs().get(name);
 
-        Map<String, String> labels = new HashMap<>(containerConfig.getLabels());
-        labels.putAll(Labels.newSerializer()
-                            .machineName(name)
-                            .runtimeId(identity)
-                            .servers(machineCfg.getServers())
-                            .labels());
-        containerConfig.setLabels(labels);
-
-        DockerMachine machine = containerStarter.startContainer(dockerEnvironment.getNetwork(),
+        DockerMachine machine = containerStarter.startContainer(getContext().getDockerEnvironment().getNetwork(),
                                                                 name,
                                                                 containerConfig,
-                                                                identity,
-                                                                devMachineName.equals(name),
+                                                                getContext().getIdentity(),
+                                                                getContext().getDevMachineName().equals(name),
                                                                 new AbnormalMachineStopHandlerImpl());
         try {
             startSynchronizer.addMachine(name, machine);
@@ -218,13 +283,12 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
             destroyMachineQuietly(name, machine);
             throw e;
         }
-        bootstrapperFactory.create(name, identity, machineCfg.getInstallers(), machine).bootstrap();
+        bootstrapperFactory.create(name, getContext().getIdentity(), machineCfg.getInstallers(), machine).bootstrap();
 
         ServersReadinessChecker readinessChecker = new ServersReadinessChecker(name,
                                                                                machine.getServers(),
-                                                                               new ServerReadinessHandler(name),
                                                                                serverCheckerFactory);
-        readinessChecker.startAsync();
+        readinessChecker.startAsync(new ServerReadinessHandler(name));
         readinessChecker.await();
     }
 
@@ -236,6 +300,14 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     // TODO support configuration properties as well
     private boolean isSnapshotEnabled(Map<String, String> stopOpts) {
         return stopOpts != null && Boolean.parseBoolean(stopOpts.get("create-snapshot"));
+    }
+
+    // TODO stream bootstrapper logs as well
+    private void streamLogsAsync(String name, String containerId) {
+        containerStarter.readContainerLogsInSeparateThread(containerId,
+                                                           getContext().getIdentity().getWorkspaceId(),
+                                                           name,
+                                                           loggers.newLogsProcessor(name, getContext().getIdentity()));
     }
 
     private class ServerReadinessHandler implements Consumer<String> {
@@ -255,7 +327,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
             machine.setServerStatus(serverRef, ServerStatus.RUNNING);
 
             eventService.publish(DtoFactory.newDto(ServerStatusEvent.class)
-                                           .withIdentity(DtoConverter.asDto(identity))
+                                           .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
                                            .withMachineName(machineName)
                                            .withServerName(serverRef)
                                            .withStatus(ServerStatus.RUNNING)
@@ -307,10 +379,14 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         }
         for (Map.Entry<String, DockerMachine> entry : machines.entrySet()) {
             destroyMachineQuietly(entry.getKey(), entry.getValue());
+            eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
+                                           .withEventType(MachineStatus.STOPPED)
+                                           .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
+                                           .withMachineName(entry.getKey()));
             sendStoppedEvent(entry.getKey());
         }
         // TODO what happens when context throws exception here
-        dockerNetworkLifecycle.destroyNetwork(dockerEnvironment.getNetwork());
+        networks.destroyNetwork(getContext().getDockerEnvironment().getNetwork());
     }
 
     /**
@@ -337,6 +413,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     private void snapshotMachines(Map<String, DockerMachine> machines) {
         List<SnapshotImpl> newSnapshots = new ArrayList<>();
         final RuntimeIdentity identity = getContext().getIdentity();
+        String devMachineName = getContext().getDevMachineName();
         for (Map.Entry<String, DockerMachine> dockerMachineEntry : machines.entrySet()) {
             SnapshotImpl snapshot = SnapshotImpl.builder()
                                                 .generateId()
@@ -349,7 +426,8 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
                                                 .useCurrentCreationDate()
                                                 .build();
             try {
-                DockerMachineSource machineSource = dockerMachineEntry.getValue().saveToSnapshot();
+                ProgressMonitor monitor = loggers.newProgressMonitor(dockerMachineEntry.getKey(), identity);
+                DockerMachineSource machineSource = dockerMachineEntry.getValue().saveToSnapshot(monitor);
                 snapshot.setMachineSource(new MachineSourceImpl(machineSource));
                 newSnapshots.add(snapshot);
             } catch (SnapshotException e) {
@@ -401,7 +479,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
                 LOG.error(e.getLocalizedMessage(), e);
             } finally {
                 eventService.publish(DtoFactory.newDto(RuntimeStatusEvent.class)
-                                               .withIdentity(DtoConverter.asDto(identity))
+                                               .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
                                                .withStatus("STOPPED")
                                                .withPrevStatus("RUNNING")
                                                .withFailed(true)
@@ -412,21 +490,21 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
     private void sendStartingEvent(String machineName) {
         eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
-                                       .withIdentity(DtoConverter.asDto(identity))
+                                       .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
                                        .withEventType(MachineStatus.STARTING)
                                        .withMachineName(machineName));
     }
 
     private void sendRunningEvent(String machineName) {
         eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
-                                       .withIdentity(DtoConverter.asDto(identity))
+                                       .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
                                        .withEventType(MachineStatus.RUNNING)
                                        .withMachineName(machineName));
     }
 
     private void sendFailedEvent(String machineName, String message) {
         eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
-                                       .withIdentity(DtoConverter.asDto(identity))
+                                       .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
                                        .withEventType(MachineStatus.FAILED)
                                        .withMachineName(machineName)
                                        .withError(message));
@@ -435,7 +513,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     private void sendStoppedEvent(String machineName) {
         eventService.publish(DtoFactory.newDto(MachineStatusEvent.class)
                                        .withEventType(MachineStatus.STOPPED)
-                                       .withIdentity(DtoConverter.asDto(identity))
+                                       .withIdentity(DtoConverter.asDto(getContext().getIdentity()))
                                        .withMachineName(machineName));
     }
 

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.plugin.docker.client.DockerConnector;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
+import org.eclipse.che.plugin.docker.client.json.ContainerListEntry;
+import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
+import org.eclipse.che.workspace.infrastructure.docker.monit.DockerMachineStopDetector;
+import org.eclipse.che.workspace.infrastructure.docker.strategy.ServersMapper;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Map;
+
+/** Helps to create {@link DockerMachine} instances. */
+@Singleton
+public class DockerMachineCreator {
+
+    private final DockerConnector           docker;
+    private final String                    registry;
+    private final boolean                   snapshotUseRegistry;
+    private final String                    registryNamespace;
+    private final DockerMachineStopDetector dockerMachineStopDetector;
+
+    @Inject
+    public DockerMachineCreator(DockerConnector docker,
+                                @Named("che.docker.registry") String registry,
+                                @Named("che.docker.registry_for_snapshots") boolean snapshotUseRegistry,
+                                @Named("che.docker.namespace") @Nullable String registryNamespace,
+                                DockerMachineStopDetector dockerMachineStopDetector) {
+        this.docker = docker;
+        this.registry = registry;
+        this.snapshotUseRegistry = snapshotUseRegistry;
+        this.registryNamespace = registryNamespace;
+        this.dockerMachineStopDetector = dockerMachineStopDetector;
+    }
+
+    /** Creates new docker machine instance from the short container description. */
+    public DockerMachine create(ContainerListEntry container) throws InfrastructureException {
+        try {
+            return create(docker.inspectContainer(container.getId()));
+        } catch (IOException x) {
+            throw new InfrastructureException(x.getMessage(), x);
+        }
+    }
+
+    /** Creates new docker machine instance from the full container description. */
+    public DockerMachine create(ContainerInfo container) {
+        NetworkSettings networkSettings = container.getNetworkSettings();
+        String hostname = networkSettings.getGateway();
+        Map<String, ServerConfig> configs = Labels.newDeserializer(container.getConfig().getLabels()).servers();
+
+        return new DockerMachine(container.getId(),
+                                 container.getImage(),
+                                 docker,
+                                 new ServersMapper(hostname).map(networkSettings.getPorts(), configs),
+                                 registry,
+                                 snapshotUseRegistry,
+                                 registryNamespace,
+                                 dockerMachineStopDetector);
+    }
+}

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContext.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContext.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.workspace.infrastructure.docker;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
 
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
@@ -18,14 +20,19 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.installer.server.InstallerRegistry;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.eclipse.che.api.workspace.shared.Utils;
+import org.eclipse.che.plugin.docker.client.json.ContainerListEntry;
+import org.eclipse.che.workspace.infrastructure.docker.environment.ContainersStartStrategy;
 import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.inject.Named;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriBuilderException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 
 import static org.eclipse.che.api.workspace.server.OutputEndpoint.OUTPUT_WEBSOCKET_ENDPOINT_BASE;
@@ -34,30 +41,52 @@ import static org.eclipse.che.api.workspace.server.OutputEndpoint.OUTPUT_WEBSOCK
  * Docker specific implementation of {@link RuntimeContext}.
  *
  * @author Alexander Garagatyi
+ * @author Yevhenii Voievodin
  */
 public class DockerRuntimeContext extends RuntimeContext {
-    private final DockerEnvironment    dockerEnvironment;
-    private final DockerRuntimeFactory dockerRuntimeFactory;
-    private final List<String>         orderedContainers;
-    private final String               devMachineName;
-    private final String               websocketEndpointBase;
 
+    private static final Logger LOG = LoggerFactory.getLogger(DockerRuntimeContext.class);
+
+    private final DockerEnvironment         dockerEnvironment;
+    private final List<String>              orderedContainers;
+    private final String                    devMachineName;
+    private final String                    websocketEndpointBase;
+    private final DockerRuntimeFactory      runtimeFactory;
+    private final DockerContainers          containers;
+    private final RuntimeConsistencyChecker consistencyChecker;
+    private final DockerSharedPool          sharedPool;
+
+    @AssistedInject
     public DockerRuntimeContext(@Assisted DockerRuntimeInfrastructure infrastructure,
                                 @Assisted RuntimeIdentity identity,
                                 @Assisted Environment environment,
-                                @Assisted DockerEnvironment dockerEnvironment,
-                                @Assisted List<String> orderedContainers,
+                                @Assisted DockerEnvironment dockerEnv,
                                 InstallerRegistry installerRegistry,
-                                DockerRuntimeFactory dockerRuntimeFactory,
-                                String websocketEndpointBase)
-            throws ValidationException, InfrastructureException {
+                                ContainersStartStrategy startStrategy,
+                                DockerRuntimeFactory runtimeFactory,
+                                DockerContainers containers,
+                                DockerSharedPool sharedPool,
+                                RuntimeConsistencyChecker consistencyChecker,
+                                @Named("che.websocket.endpoint.base") String websocketEndpointBase) throws InfrastructureException, ValidationException {
         super(environment, identity, infrastructure, installerRegistry);
         this.devMachineName = Utils.getDevMachineName(environment);
-        this.orderedContainers = orderedContainers;
-        this.dockerEnvironment = dockerEnvironment;
-        this.dockerRuntimeFactory = dockerRuntimeFactory;
+        this.dockerEnvironment = dockerEnv;
+        this.orderedContainers = ImmutableList.copyOf(startStrategy.order(dockerEnvironment));
         this.websocketEndpointBase = websocketEndpointBase;
+        this.runtimeFactory = runtimeFactory;
+        this.containers = containers;
+        this.sharedPool = sharedPool;
+        this.consistencyChecker = consistencyChecker;
     }
+
+    /** Returns docker environment which based on normalized context environment configuration. */
+    public DockerEnvironment getDockerEnvironment() { return dockerEnvironment;}
+
+    /** Returns the name of the dev machine. */
+    public String getDevMachineName() { return devMachineName; }
+
+    /** Returns the list of the ordered containers, machines must be started in the same order. */
+    public List<String> getOrderedContainers() { return orderedContainers; }
 
     @Override
     public URI getOutputChannel() throws InfrastructureException {
@@ -72,11 +101,35 @@ public class DockerRuntimeContext extends RuntimeContext {
     }
 
     @Override
-    public InternalRuntime getRuntime() {
-        return dockerRuntimeFactory.createRuntime(this,
-                                                  devMachineName,
-                                                  orderedContainers,
-                                                  dockerEnvironment,
-                                                  identity);
+    public DockerInternalRuntime getRuntime() throws InfrastructureException {
+        List<ContainerListEntry> runningContainers = containers.find(identity);
+        if (runningContainers.isEmpty()) {
+            return runtimeFactory.create(this);
+        }
+
+        DockerInternalRuntime runtime = runtimeFactory.create(this, runningContainers);
+        try {
+            consistencyChecker.check(environment, runtime);
+            runtime.checkServers();
+        } catch (InfrastructureException | ValidationException x) {
+            LOG.warn("Runtime '{}:{}' will be stopped as it is not consistent with its configuration. " +
+                     "The problem: {}",
+                     identity.getWorkspaceId(),
+                     identity.getEnvName(),
+                     x.getMessage());
+            stopAsync(runtime);
+            throw new InfrastructureException(x.getMessage(), x);
+        }
+        return runtime;
+    }
+
+    private void stopAsync(DockerInternalRuntime runtime) {
+        sharedPool.execute(() -> {
+            try {
+                runtime.stop(Collections.emptyMap());
+            } catch (Exception x) {
+                LOG.error("Couldn't stop workspace runtime due to error: {}", x.getMessage());
+            }
+        });
     }
 }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContextFactory.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContextFactory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+
+/** Helps to create {@link DockerRuntimeContext} instances. */
+public interface DockerRuntimeContextFactory {
+    DockerRuntimeContext create(DockerRuntimeInfrastructure infra,
+                                RuntimeIdentity identity,
+                                Environment environment,
+                                DockerEnvironment dockerEnv) throws InfrastructureException, ValidationException;
+}

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeFactory.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeFactory.java
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.workspace.infrastructure.docker;
 
-import com.google.inject.assistedinject.Assisted;
-
-import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+import org.eclipse.che.plugin.docker.client.json.ContainerListEntry;
 
 import java.util.List;
 
@@ -21,9 +18,6 @@ import java.util.List;
  * @author Alexander Garagatyi
  */
 public interface DockerRuntimeFactory {
-    DockerInternalRuntime createRuntime(@Assisted DockerRuntimeContext context,
-                                        @Assisted String devMachineName,
-                                        @Assisted List<String> orderedContainers,
-                                        @Assisted DockerEnvironment dockerEnvironment,
-                                        @Assisted RuntimeIdentity identity);
+    DockerInternalRuntime create(DockerRuntimeContext context);
+    DockerInternalRuntime create(DockerRuntimeContext context, List<ContainerListEntry> containers);
 }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerSharedPool.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerSharedPool.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides a single non-daemon {@link ExecutorService}
+ * instance for docker infrastructure components.
+ */
+@Singleton
+public class DockerSharedPool {
+
+    private final ExecutorService executor =
+            Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(), // <- experimental value
+                                         new ThreadFactoryBuilder().setNameFormat("DockerSharedPool-%d")
+                                                                   .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+                                                                   .setDaemon(false)
+                                                                   .build());
+
+    /**
+     * Delegates call to {@link ExecutorService#execute(Runnable)}
+     * and propagates thread locals to it like defined by {@link ThreadLocalPropagateContext}.
+     */
+    public void execute(Runnable runnable) {
+        executor.execute(ThreadLocalPropagateContext.wrap(runnable));
+    }
+
+    @PreDestroy
+    private void terminate() throws InterruptedException {
+        if (!executor.isShutdown()) {
+            executor.shutdown();
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                    LoggerFactory.getLogger(DockerSharedPool.class).error("Couldn't terminate docker infrastructure thread pool");
+                }
+            }
+        }
+    }
+}

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/InstallerConfigApplier.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/InstallerConfigApplier.java
@@ -105,18 +105,9 @@ public class InstallerConfigApplier {
     }
 
     private void addLabels(DockerContainerConfig container, Map<String, ? extends ServerConfig> servers) {
-        for (Map.Entry<String, ? extends ServerConfig> entry : servers.entrySet()) {
-            String ref = entry.getKey();
-            ServerConfig conf = entry.getValue();
-
-            container.getLabels().put("che:server:" + conf.getPort() + ":protocol", conf.getProtocol());
-            container.getLabels().put("che:server:" + conf.getPort() + ":ref", ref);
-
-            String path = conf.getPath();
-            if (!isNullOrEmpty(path)) {
-                container.getLabels().put("che:server:" + conf.getPort() + ":path", path);
-            }
-        }
+        container.getLabels().putAll(Labels.newSerializer()
+                                           .servers(servers)
+                                           .labels());
     }
 
     private void addEnv(DockerContainerConfig container, Map<String, String> properties) {

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -30,11 +30,12 @@ import java.util.regex.Pattern;
  */
 public final class Labels {
 
-    private static final String LABEL_PREFIX              = "org.eclipse.che.";
+    public static final String LABEL_PREFIX          = "org.eclipse.che.";
+    public static final String LABEL_WORKSPACE_ID    = LABEL_PREFIX + "workspace.id";
+    public static final String LABEL_WORKSPACE_ENV   = LABEL_PREFIX + "workspace.env";
+    public static final String LABEL_WORKSPACE_OWNER = LABEL_PREFIX + "workspace.owner";
+
     private static final String LABEL_MACHINE_NAME        = LABEL_PREFIX + "machine.name";
-    private static final String LABEL_WORKSPACE_ID        = LABEL_PREFIX + "workspace.id";
-    private static final String LABEL_WORKSPACE_ENV       = LABEL_PREFIX + "workspace.env";
-    private static final String LABEL_WORKSPACE_OWNER     = LABEL_PREFIX + "workspace.owner";
     private static final String SERVER_PORT_LABEL_FMT     = LABEL_PREFIX + "server.%s.port";
     private static final String SERVER_PROTOCOL_LABEL_FMT = LABEL_PREFIX + "server.%s.protocol";
     private static final String SERVER_PATH_LABEL_FMT     = LABEL_PREFIX + "server.%s.path";

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyChecker.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyChecker.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+
+import javax.inject.Singleton;
+import java.util.Map;
+
+/** Checks whether runtime is consistent with its configuration. */
+@Singleton
+class RuntimeConsistencyChecker {
+    void check(Environment environment, DockerInternalRuntime runtime) throws ValidationException {
+        Map<String, ? extends MachineConfig> configs = environment.getMachines();
+        Map<String, ? extends Machine> machines = runtime.getMachines();
+        if (configs.size() != machines.size()) {
+            throw new ValidationException("Runtime has '%d' machines while configuration defines '%d'." +
+                                          "Runtime machines: %s. Configuration machines: %s",
+                                          machines.size(), configs.size(),
+                                          machines.keySet(), configs.keySet());
+        }
+        if (!configs.keySet().containsAll(machines.keySet())) {
+            throw new ValidationException("Runtime has different set of machines than defined by configuration. " +
+                                          "Runtime machines: %s. Configuration machines: %s",
+                                          machines.keySet(), configs.keySet());
+        }
+    }
+}

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/EnvironmentNormalizer.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/EnvironmentNormalizer.java
@@ -53,7 +53,7 @@ public class EnvironmentNormalizer {
 
     public void normalize(Environment environment, DockerEnvironment dockerEnvironment, RuntimeIdentity identity)
             throws InfrastructureException {
-        String networkId = NameGenerator.generate(identity.getWorkspaceId() + "_", 16);
+        String networkId = identity.getWorkspaceId() + "_" + identity.getEnvName();
         dockerEnvironment.setNetwork(networkId);
 
         Map<String, DockerContainerConfig> containers = dockerEnvironment.getContainers();

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/ServerChecker.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/ServerChecker.java
@@ -75,6 +75,16 @@ public abstract class ServerChecker {
     }
 
     /**
+     * Checks server availability, throws {@link InfrastructureException}
+     * if the server is not available.
+     */
+    public void checkOnce() throws InfrastructureException {
+        if (!isAvailable()) {
+            throw new InfrastructureException(String.format("Server '%s' in machine '%s' not available.", serverRef, machineName));
+        }
+    }
+
+    /**
      * Shows whether the server is treated as available.
      *
      * @return true if server is available, false otherwise

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/strategy/ServersMapper.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/strategy/ServersMapper.java
@@ -54,8 +54,9 @@ public class ServersMapper {
         Map<String, List<String>> port2refs = new HashMap<>();
         for (Map.Entry<String, ServerConfig> entry : configs.entrySet()) {
             port2refs.compute(entry.getValue().getPort(), (port, list) -> {
-                if (list == null)
+                if (list == null) {
                     list = new ArrayList<>();
+                }
                 list.add(entry.getKey());
                 return list;
             });

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/strategy/ServersMapper.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/strategy/ServersMapper.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker.strategy;
+
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.plugin.docker.client.json.ContainerPort;
+import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
+import org.eclipse.che.plugin.docker.client.json.PortBinding;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Maps container ports bindings to machine servers. */
+public class ServersMapper {
+
+    private final String hostname;
+
+    /**
+     * Creates mapper using given {@code hostname} as
+     * hostname for all the servers urls produced by mapper.
+     */
+    public ServersMapper(String hostname) { this.hostname = hostname; }
+
+    /**
+     * Maps container ports to machine servers resolving references
+     * from the given configuration map.
+     *
+     * @param ports
+     *         container ports to map
+     * @param configs
+     *         servers configuration map used to resolve server references
+     * @return server reference -> server map. Note that if there is no server configuration
+     * for container bound port, port+type itself(like 4022/tpc) will be used as a reference
+     */
+    public Map<String, ServerImpl> map(ContainerPort[] ports, Map<String, ServerConfig> configs) {
+        if (ports == null || ports.length == 0) {
+            return Collections.emptyMap();
+        }
+
+        // 4011/tcp -> [ exec-agent-rest, exec-agent-ws ]
+        // 4012     -> [ terminal ]
+        Map<String, List<String>> port2refs = new HashMap<>();
+        for (Map.Entry<String, ServerConfig> entry : configs.entrySet()) {
+            port2refs.compute(entry.getValue().getPort(), (port, list) -> {
+                if (list == null)
+                    list = new ArrayList<>();
+                list.add(entry.getKey());
+                return list;
+            });
+        }
+
+        Map<String, ServerImpl> mapped = new HashMap<>();
+        for (ContainerPort port : ports) {
+            List<String> refs = null;
+
+            // configs which define port in format 'numPort/type' e.g. 4011/tcp
+            String rawPort = port.getPrivatePort() + "/" + port.getType();
+            if (port2refs.containsKey(rawPort)) {
+                refs = port2refs.get(rawPort);
+            }
+
+            // configs which define numPort in format 'numPort' e.g. 4011
+            String numPort = Integer.toString(port.getPrivatePort());
+            if (port2refs.containsKey(numPort)) {
+                if (refs == null) {
+                    refs = port2refs.get(numPort);
+                } else {
+                    refs.addAll(port2refs.get(numPort));
+                }
+            }
+
+            if (refs == null) {
+                mapped.put(rawPort, new ServerImpl(makeUrl(port, null, null)));
+            } else {
+                for (String ref : refs) {
+                    ServerConfig cfg = configs.get(ref);
+                    mapped.put(ref, new ServerImpl(makeUrl(port, cfg.getProtocol(), cfg.getPath())));
+                }
+            }
+        }
+        return mapped;
+    }
+
+    /**
+     * Maps ports in the same way {@link #map(ContainerPort[], Map)} method does, but
+     * for convenience allows to use port bindings in different format,
+     * like defined by {@link NetworkSettings#getPorts()}.
+     */
+    public Map<String, ServerImpl> map(Map<String, List<PortBinding>> ports, Map<String, ServerConfig> configs) {
+        if (ports == null) {
+            return Collections.emptyMap();
+        }
+        return map(ports.entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue().size() == 1)
+                        .map(entry -> toContainerPort(entry.getKey(), entry.getValue().get(0)))
+                        .toArray(ContainerPort[]::new),
+                   configs);
+    }
+
+    /**
+     * Makes url from given binding, protocol and path.
+     *
+     * <p>Examples:
+     * <pre>
+     * |------------------------------------------------------------------------|
+     * | binding           | protocol | path    | url                           |
+     * |------------------------------------------------------------------------|
+     * | 4011/tcp -> 32011 | http     | /api    | http://hostname:32011/api     |
+     * | 4012/tcp -> 32012 | wss      | connect | wss://hostname:32012/connect  |
+     * | 4013     -> 32013 | https    |         | https://hostname:32013        |
+     * | 4014/upd -> 32014 |          |         | upd://hostname:32014          |
+     * | 4015     -> 32015 |          |         | tcp://hostname:32015          |
+     * |------------------------------------------------------------------------|
+     * </pre>
+     */
+    private String makeUrl(ContainerPort port, String protocol, String path) {
+        if (protocol == null) {
+            if (port.getType() == null) {
+                protocol = "tcp";
+            } else {
+                protocol = port.getType();
+            }
+        }
+
+        // null -> "", "path" -> "/path"
+        if (path == null) {
+            path = "";
+        } else if (!path.startsWith("/")) {
+            path = '/' + path;
+        }
+
+        return protocol + "://" + hostname + ':' + port.getPublicPort() + path;
+    }
+
+    private ContainerPort toContainerPort(String rawPort, PortBinding binding) {
+        ContainerPort result = new ContainerPort();
+        result.setPublicPort(Integer.parseInt(binding.getHostPort()));
+        int slashIdx = rawPort.indexOf('/');
+        if (slashIdx != -1) {
+            result.setType(rawPort.substring(slashIdx + 1));
+            result.setPrivatePort(Integer.parseInt(rawPort.substring(0, slashIdx)));
+        } else {
+            result.setType("tcp");
+            result.setPrivatePort(Integer.parseInt(rawPort));
+        }
+        return result;
+    }
+}

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerContainersTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerContainersTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.RuntimeIdentityImpl;
+import org.eclipse.che.plugin.docker.client.DockerConnector;
+import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
+import org.eclipse.che.plugin.docker.client.json.ContainerListEntry;
+import org.eclipse.che.plugin.docker.client.params.ListContainersParams;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Arrays.asList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/** Tests {@link DockerContainers}. */
+@Listeners(MockitoTestNGListener.class)
+public class DockerContainersTest {
+
+    @Mock
+    private DockerConnector docker;
+
+    @InjectMocks
+    private DockerContainers containers;
+
+    @Test
+    public void findsIdentifiers() throws Exception {
+        RuntimeIdentity id1 = new RuntimeIdentityImpl("workspace123", "default", "test");
+        RuntimeIdentity id2 = new RuntimeIdentityImpl("workspace234", "default", "test");
+
+        List<ContainerListEntry> entries = asList(mockContainer(id1, "container1"), mockContainer(id2, "container2"));
+        when(docker.listContainers(ListContainersParams.create().withAll(false))).thenReturn(entries);
+
+        assertEquals(containers.findIdentities(), newHashSet(id1, id2));
+    }
+
+    @Test(expectedExceptions = InfrastructureException.class, expectedExceptionsMessageRegExp = "oops")
+    public void findsIdentitiesRethrowsIOExceptionThrownWhileListingContainersAsInternalInfraException() throws Exception {
+        when(docker.listContainers(ListContainersParams.create().withAll(false))).thenThrow(new IOException("oops"));
+
+        containers.findIdentities();
+    }
+
+    @Test
+    public void findContainers() throws Exception {
+        RuntimeIdentity id1 = new RuntimeIdentityImpl("workspace123", "default", "test");
+        ContainerListEntry entry1 = mockContainer(id1, "container1");
+        ContainerListEntry entry2 = mockContainer(id1, "container2");
+
+        RuntimeIdentity id2 = new RuntimeIdentityImpl("workspace234", "default", "test");
+        ContainerListEntry entry3 = mockContainer(id2, "container3");
+
+        List<ContainerListEntry> entries = asList(entry1, entry2, entry3);
+        when(docker.listContainers(ListContainersParams.create().withAll(false))).thenReturn(entries);
+
+        assertEquals(containers.find(id1)
+                               .stream()
+                               .map(ContainerListEntry::getId)
+                               .collect(Collectors.toSet()), newHashSet(entry1.getId(), entry2.getId()));
+        assertEquals(containers.find(id2)
+                               .stream()
+                               .map(ContainerListEntry::getId)
+                               .collect(Collectors.toSet()), newHashSet(entry3.getId()));
+    }
+
+    @Test(expectedExceptions = InternalInfrastructureException.class, expectedExceptionsMessageRegExp = "oops")
+    public void findContainersRethrowsIOExceptionThrownWhileListingContainersAsInternalInfraException() throws Exception {
+        when(docker.listContainers(ListContainersParams.create().withAll(false))).thenThrow(new IOException("oops"));
+
+        containers.find(new RuntimeIdentityImpl("workspace123", "default", "test"));
+    }
+
+    @Test(expectedExceptions = InternalInfrastructureException.class, expectedExceptionsMessageRegExp = "oops")
+    public void findContainersRethrowsIOExceptionThrownWhileInspectingContainersAsInternalInfraException() throws Exception {
+        RuntimeIdentity id = new RuntimeIdentityImpl("workspace123", "default", "test");
+        List<ContainerListEntry> entries = Collections.singletonList(mockContainer(id, "container"));
+        when(docker.listContainers(ListContainersParams.create().withAll(false))).thenReturn(entries);
+
+        when(docker.inspectContainer(anyString())).thenThrow(new IOException("oops"));
+
+        containers.find(id);
+    }
+
+    private ContainerListEntry mockContainer(RuntimeIdentity runtimeId, String containerId) throws IOException {
+        ContainerListEntry entry = new ContainerListEntry();
+        entry.setLabels(Labels.newSerializer().runtimeId(runtimeId).labels());
+        entry.setId(containerId);
+        return entry;
+    }
+}

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/InstallerConfigApplierTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/InstallerConfigApplierTest.java
@@ -84,9 +84,9 @@ public class InstallerConfigApplierTest {
 
         Map<String, String> labels = service.getLabels();
         assertEquals(labels.size(), 3);
-        assertEquals(labels.get("che:server:1111/udp:ref"), "a");
-        assertEquals(labels.get("che:server:1111/udp:protocol"), "http");
-        assertEquals(labels.get("che:server:1111/udp:path"), "b");
+        assertEquals(labels.get("org.eclipse.che.server.a.port"), "1111/udp");
+        assertEquals(labels.get("org.eclipse.che.server.a.protocol"), "http");
+        assertEquals(labels.get("org.eclipse.che.server.a.path"), "b");
     }
 
     @Test

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyCheckerTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyCheckerTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests {@link RuntimeConsistencyChecker}. */
+public class RuntimeConsistencyCheckerTest {
+
+    @Test(dataProvider = "consistentRuntimesProvider")
+    public void consistentRuntimes(Environment environment, DockerInternalRuntime runtime) throws ValidationException {
+        new RuntimeConsistencyChecker().check(environment, runtime);
+    }
+
+    @Test(dataProvider = "inconsistentRuntimesProvider", expectedExceptions = ValidationException.class)
+    public void inconsistentRuntimes(Environment environment, DockerInternalRuntime runtime) throws ValidationException {
+        new RuntimeConsistencyChecker().check(environment, runtime);
+    }
+
+    @DataProvider
+    private static Object[][] consistentRuntimesProvider() {
+        return new Object[][] {
+                { environment("a", "b"), runtime("b", "a") },
+                { environment("b", "a"), runtime("b", "a") }
+        };
+    }
+
+    @DataProvider
+    private static Object[][] inconsistentRuntimesProvider() {
+        return new Object[][] {
+                { environment("a", "b"), runtime("a") },
+                { environment("a", "b"), runtime("a", "c") },
+                { environment("a", "b"), runtime("a", "b", "c") },
+                { environment("a", "b"), runtime("a") },
+                { environment("a"),      runtime("a", "b") }
+        };
+    }
+
+    private static Environment environment(String... names) {
+        Map<String, MachineConfig> configs = new HashMap<>();
+        for (String name : names) {
+            configs.put(name, mock(MachineConfig.class));
+        }
+
+        Environment environment = mock(Environment.class);
+        doReturn(configs).when(environment).getMachines();
+        when(environment.toString()).thenReturn(Arrays.toString(names));
+        return environment;
+    }
+
+    private static DockerInternalRuntime runtime(String... names) {
+        Map<String, DockerMachine> machines = new HashMap<>();
+        for (String name : names) {
+            machines.put(name, mock(DockerMachine.class));
+        }
+
+        DockerInternalRuntime runtime = mock(DockerInternalRuntime.class);
+        doReturn(machines).when(runtime).getMachines();
+        when(runtime.toString()).thenReturn(Arrays.toString(names));
+        return runtime;
+    }
+}

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/ServerCheckerTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/ServerCheckerTest.java
@@ -104,6 +104,11 @@ public class ServerCheckerTest {
         }
     }
 
+    @Test(expectedExceptions = InfrastructureException.class)
+    public void checkOnceThrowsExceptionIfServerIsNotAvailable() throws InfrastructureException {
+        new TestServerChecker("test", "test", 1, 1, TimeUnit.SECONDS, null).checkOnce();
+    }
+
     private static class TestServerChecker extends ServerChecker {
         protected TestServerChecker(String machineName, String serverRef, long period, long timeout,
                                     TimeUnit timeUnit, Timer timer) {

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/strategy/ServersMapperTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/strategy/ServersMapperTest.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker.strategy;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
+import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
+import org.eclipse.che.plugin.docker.client.json.PortBinding;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toMap;
+import static org.testng.Assert.assertEquals;
+
+/** Tests {@link ServersMapper}. */
+public class ServersMapperTest {
+
+    private final String        hostname = "localhost";
+    private final ServersMapper mapper   = new ServersMapper(hostname);
+
+    @Test(dataProvider = "servers")
+    public void mapsServers(Map<String, String> dockerBindings,
+                            Map<String, ServerConfig> configs,
+                            Map<String, ServerImpl> expected) {
+        Map<String, List<PortBinding>> bindings = createBindings(dockerBindings);
+
+        Map<String, ServerImpl> result = mapper.map(bindings, configs);
+
+        assertEquals(result, expected);
+    }
+
+    @DataProvider(name = "servers")
+    private Object[][] serversProvider() {
+        return new Object[][] {
+                {
+                        ImmutableMap.of(
+                                "8080/tcp", "0.0.0.0:32080",
+                                "8081/tcp", "0.0.0.0:32081"
+                        ),
+                        ImmutableMap.of(
+                                "server1", new ServerConfigImpl("8080", "http", "no-slash-path"),
+                                "server2", new ServerConfigImpl("8081", "http", "/slash-path")
+                        ),
+                        ImmutableMap.of(
+                                "server1", new ServerImpl("http://" + hostname + ":32080/no-slash-path"),
+                                "server2", new ServerImpl("http://" + hostname + ":32081/slash-path")
+                        )
+                },
+                {
+                        ImmutableMap.of(
+                                "8080/tcp", "0.0.0.0:32080"
+                        ),
+                        ImmutableMap.of(
+                                "server1", new ServerConfigImpl("8080", "http", "http-endpoint"),
+                                "server2", new ServerConfigImpl("8080", "ws", "ws-endpoint")
+                        ),
+                        ImmutableMap.of(
+                                "server1", new ServerImpl("http://" + hostname + ":32080/http-endpoint"),
+                                "server2", new ServerImpl("ws://" + hostname + ":32080/ws-endpoint")
+                        )
+                },
+                {
+                        ImmutableMap.of(
+                                "8080/tcp", "0.0.0.0:32080"
+                        ),
+                        ImmutableMap.of(
+                                "server1", new ServerConfigImpl("8080", "http", "http-endpoint"),
+                                "server2", new ServerConfigImpl("8080/tcp", "ws", "ws-endpoint")
+                        ),
+                        ImmutableMap.of(
+                                "server1", new ServerImpl("http://" + hostname + ":32080/http-endpoint"),
+                                "server2", new ServerImpl("ws://" + hostname + ":32080/ws-endpoint")
+                        )
+                },
+                {
+                        ImmutableMap.of(
+                                "8080/tcp", "0.0.0.0:32080"
+                        ),
+                        ImmutableMap.of(),
+                        ImmutableMap.of("8080/tcp", new ServerImpl("tcp://" + hostname + ":32080"))
+                },
+                {
+                        ImmutableMap.of(
+                                "8080/tcp", "0.0.0.0:32080",
+                                "8081/udp", "0.0.0.0:32081",
+                                "8082", "0.0.0.0:32082"
+                        ),
+                        ImmutableMap.of(),
+                        ImmutableMap.of(
+                                "8080/tcp", new ServerImpl("tcp://" + hostname + ":32080"),
+                                "8081/udp", new ServerImpl("udp://" + hostname + ":32081"),
+                                "8082/tcp", new ServerImpl("tcp://" + hostname + ":32082")
+                        )
+                },
+                {
+                        ImmutableMap.of(
+                                "8000/tcp", "0.0.0.0:32000",
+                                "8080/tcp", "0.0.0.0:32080",
+                                "2288/udp", "0.0.0.0:32288",
+                                "4401/tcp", "0.0.0.0:32401"
+                        ),
+                        ImmutableMap.of(
+                                "ws-master",      new ServerConfigImpl("8080", "http", "/api"),
+                                "exec-agent-api", new ServerConfigImpl("4401", "http", "/process"),
+                                "exec-agent-ws",  new ServerConfigImpl("4401", "ws", "/connect")
+                        ),
+                        ImmutableMap.of(
+                                "ws-master",      new ServerImpl("http://" + hostname + ":32080/api"),
+                                "exec-agent-api", new ServerImpl("http://" + hostname + ":32401/process"),
+                                "exec-agent-ws",  new ServerImpl("ws://" + hostname + ":32401/connect"),
+                                "8000/tcp",       new ServerImpl("tcp://" + hostname + ":32000"),
+                                "2288/udp",       new ServerImpl("udp://" + hostname + ":32288")
+                        )
+                }
+        };
+    }
+
+    private static Map<String, List<PortBinding>> createBindings(Map<String, String> bindings) {
+        return bindings.entrySet()
+                       .stream()
+                       .collect(toMap(Map.Entry::getKey,
+                                      entry -> {
+                                          String[] split = entry.getValue().split(":");
+                                          PortBinding pb = new PortBinding(split[0], split[1]);
+                                          return singletonList(pb);
+                                      }));
+    }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftInternalRuntime.java
@@ -82,7 +82,7 @@ public class OpenshiftInternalRuntime extends InternalRuntime<OpenshiftRuntimeCo
                                     EventService eventService,
                                     OpenshiftBootstrapperFactory openshiftBootstrapperFactory,
                                     @Named("che.infra.openshift.machine_start_timeout_min") int machineStartTimeoutMin) {
-        super(context, urlRewriter);
+        super(context, urlRewriter, false);
         this.identity = identity;
         this.kubernetesEnvironment = openshiftEnvironment;
         this.clientFactory = clientFactory;

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerListEntry.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/ContainerListEntry.java
@@ -30,6 +30,7 @@ public class ContainerListEntry {
     private Map<String, String> labels;
     private int                 sizeRw;
     private int                 sizeRootFs;
+    private NetworkSettings     networkSettings;
 
     /**
      * Returns unique container identifier
@@ -144,7 +145,7 @@ public class ContainerListEntry {
     }
 
     /**
-     *  Returns the virtual size of the container
+     * Returns the virtual size of the container
      */
     public int getSizeRootFs() {
         return sizeRootFs;
@@ -152,6 +153,14 @@ public class ContainerListEntry {
 
     public void setSizeRootFs(int sizeRootFs) {
         this.sizeRootFs = sizeRootFs;
+    }
+
+    public NetworkSettings getNetworkSettings() {
+        return networkSettings;
+    }
+
+    public void setNetworkSettings(NetworkSettings networkSettings) {
+        this.networkSettings = networkSettings;
     }
 
     @Override
@@ -168,6 +177,7 @@ public class ContainerListEntry {
                ", labels=" + labels +
                ", sizeRw=" + sizeRw +
                ", sizeRootFs=" + sizeRootFs +
+               ", networkSettings=" + networkSettings +
                '}';
     }
 }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/Filters.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/Filters.java
@@ -24,6 +24,14 @@ import java.util.Map;
  * @author Alexander Garagatyi
  */
 public class Filters {
+
+    private static final String LABEL_FILTER = "label";
+
+    /** Creates filters with {@value #LABEL_FILTER} filter initialized to the given values. */
+    public static Filters label(String... values) {
+        return new Filters().withFilter(LABEL_FILTER, values);
+    }
+
     private final Map<String, List<String>> filters = new HashMap<>();
 
     public Map<String, List<String>> getFilters() {

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/PortBinding.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/PortBinding.java
@@ -15,6 +15,13 @@ public class PortBinding {
     private String hostIp;
     private String hostPort;
 
+    public PortBinding() {}
+
+    public PortBinding(String hostIp, String hostPort) {
+        this.hostIp = hostIp;
+        this.hostPort = hostPort;
+    }
+
     public String getHostIp() {
         return hostIp;
     }

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.json
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.json
@@ -11,9 +11,7 @@
     "wsagent": {
       "port": "4401/tcp",
       "protocol": "http",
-      "properties": {
-        "path": "/api"
-      }
+      "path" : "/api/"
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/MachineImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/MachineImpl.java
@@ -16,6 +16,9 @@ import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Data object for {@link Machine}.
@@ -27,10 +30,6 @@ public class MachineImpl implements Machine {
     private Map<String, String>     properties;
     private Map<String, ServerImpl> servers;
 
-    public static MachineRuntimeInfoImplBuilder builder() {
-        return new MachineRuntimeInfoImplBuilder();
-    }
-
     public MachineImpl(Machine machineRuntime) {
         this(machineRuntime.getProperties(), machineRuntime.getServers());
     }
@@ -38,16 +37,17 @@ public class MachineImpl implements Machine {
     public MachineImpl(Map<String, String> properties,
                        Map<String, ? extends Server> servers) {
 //        this.envVariables = new HashMap<>(envVariables);
+        this(servers);
         this.properties = new HashMap<>(properties);
+    }
+
+    public MachineImpl(Map<String, ? extends Server> servers) {
         if (servers != null) {
             this.servers = servers.entrySet()
                                   .stream()
-                                  .collect(HashMap::new,
-                                           (map, entry) -> map.put(entry.getKey(), new ServerImpl(entry.getValue())),
-                                           HashMap::putAll);
+                                  .collect(toMap(Map.Entry::getKey, entry -> new ServerImpl(entry.getValue().getUrl())));
         }
     }
-
 
 //    public Map<String, String> getEnvVariables() {
 //        if (envVariables == null) {
@@ -78,45 +78,12 @@ public class MachineImpl implements Machine {
         if (!(o instanceof MachineImpl)) return false;
         MachineImpl that = (MachineImpl)o;
         return //Objects.equals(getEnvVariables(), that.getEnvVariables()) &&
-               Objects.equals(getProperties(), that.getProperties()) &&
-               Objects.equals(getServers(), that.getServers());
+                Objects.equals(getProperties(), that.getProperties()) &&
+                Objects.equals(getServers(), that.getServers());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(/*getEnvVariables(),*/ getProperties(), getServers());
-    }
-
-    public static class MachineRuntimeInfoImplBuilder {
-        private Map<String, ? extends Server> servers;
-        private Map<String, String>           properties;
-//        private Map<String, String>           envVariables;
-
-        public MachineImpl build() {
-            return new MachineImpl(properties, servers);
-        }
-
-        public MachineRuntimeInfoImplBuilder setServers(Map<String, ? extends Server> servers) {
-            this.servers = servers;
-            return this;
-        }
-
-        public MachineRuntimeInfoImplBuilder setProperties(Map<String, String> properties) {
-            this.properties = properties;
-            return this;
-        }
-
-//        public MachineRuntimeInfoImplBuilder setEnvVariables(Map<String, String> envVariables) {
-//            this.envVariables = envVariables;
-//            return this;
-//        }
-    }
-
-    @Override
-    public String toString() {
-        return "MachineImpl{" +
-               "properties=" + properties +
-               ", servers=" + servers +
-               '}';
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerImpl.java
@@ -13,12 +13,14 @@ package org.eclipse.che.api.workspace.server.model.impl;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 
+import java.util.Objects;
+
 /**
  * @author gazarenkov
  */
 public class ServerImpl implements Server {
 
-    private String url;
+    private String       url;
     private ServerStatus status;
 
     public ServerImpl(String url) {
@@ -50,5 +52,31 @@ public class ServerImpl implements Server {
 
     public void setStatus(ServerStatus status) {
         this.status = status;
+    }
+
+    @Override
+    public String toString() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Server)) {
+            return false;
+        }
+        final Server that = (Server)obj;
+        return Objects.equals(url, that.getUrl())
+               && Objects.equals(status, that.getStatus());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + Objects.hashCode(url);
+        hash = 31 * hash + Objects.hashCode(status);
+        return hash;
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -45,9 +45,12 @@ public abstract class InternalRuntime <T extends RuntimeContext> implements Runt
     private final List<Warning>        warnings = new ArrayList<>();
     private       WorkspaceStatus      status;
 
-    public InternalRuntime(T context, URLRewriter urlRewriter) {
+    public InternalRuntime(T context, URLRewriter urlRewriter, boolean running) {
         this.context = context;
         this.urlRewriter = urlRewriter != null ? urlRewriter : new URLRewriter.NoOpURLRewriter();
+        if (running) {
+            status = WorkspaceStatus.RUNNING;
+        }
     }
 
     @Override
@@ -155,7 +158,7 @@ public abstract class InternalRuntime <T extends RuntimeContext> implements Runt
     /**
      * @return the Context
      */
-    public final RuntimeContext getContext() {
+    public final T getContext() {
         return context;
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeContext.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeContext.java
@@ -60,8 +60,10 @@ public abstract class RuntimeContext {
      * Context must return the Runtime object whatever its status is (STOPPED status including)
      *
      * @return Runtime object
+     * @throws InfrastructureException
+     *         when any error during runtime retrieving/creation
      */
-    public abstract InternalRuntime getRuntime();
+    public abstract InternalRuntime getRuntime() throws InfrastructureException;
 
     /**
      * Infrastructure should assign channel (usual WebSocket) to push long lived processes messages

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeInfrastructure.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeInfrastructure.java
@@ -101,24 +101,6 @@ public abstract class RuntimeInfrastructure {
     }
 
     /**
-     * An Infrastructure MAY track Runtimes. In this case the method should be overridden.
-     * <p>
-     * One of the reason for infrastructure to support this is ability to recover infrastructure
-     * after shutting down Master server.
-     *
-     * @param id
-     *         the RuntimeIdentityImpl
-     * @return the Runtime
-     * @throws UnsupportedOperationException
-     *         if implementation does not support runtimes tracking
-     * @throws InfrastructureException
-     *         if any other error occurred
-     */
-    public InternalRuntime getRuntime(RuntimeIdentity id) throws InfrastructureException {
-        throw new UnsupportedOperationException("The implementation does not track runtimes");
-    }
-
-    /**
      * Making Runtime is a two phase process.
      * On the first phase implementation MUST prepare RuntimeContext, this is supposedly "fast" method
      * On the second phase Runtime is created with RuntimeContext.start() which is supposedly "long" method

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
+import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
+import org.eclipse.che.api.workspace.server.spi.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.core.db.DBInitializer;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+/** Tests {@link WorkspaceRuntimes}. */
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceRuntimesTest {
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private WorkspaceDao workspaceDao;
+
+    @Mock
+    private DBInitializer dbInitializer;
+
+    @Mock
+    private WorkspaceSharedPool sharedPool;
+
+    private RuntimeInfrastructure infrastructure;
+    private WorkspaceRuntimes     runtimes;
+
+    @BeforeMethod
+    public void setUp() {
+        infrastructure = spy(new TestInfrastructure(eventService));
+
+        runtimes = new WorkspaceRuntimes(eventService,
+                                         Collections.singleton(infrastructure),
+                                         sharedPool,
+                                         workspaceDao,
+                                         dbInitializer);
+    }
+
+    @Test
+    public void runtimeIsRecovered() throws Exception {
+        RuntimeIdentity identity = new RuntimeIdentityImpl("workspace123", "my-env", "me");
+
+        mockWorkspace(identity);
+        RuntimeContext context = mockContext(identity);
+        when(context.getRuntime()).thenReturn(new TestInternalRuntime(context));
+        doReturn(context).when(infrastructure).prepare(eq(identity), anyObject());
+
+        // try recover
+        runtimes.recoverOne(infrastructure, identity);
+
+        WorkspaceImpl workspace = new WorkspaceImpl(identity.getWorkspaceId(), null, null);
+        runtimes.injectRuntime(workspace);
+        assertNotNull(workspace.getRuntime());
+    }
+
+    @Test
+    public void runtimeIsNotRecoveredIfNoWorkspaceFound() throws Exception {
+        RuntimeIdentity identity = new RuntimeIdentityImpl("workspace123", "my-env", "me");
+        when(workspaceDao.get(identity.getWorkspaceId())).thenThrow(new NotFoundException("no!"));
+
+        // try recover
+        runtimes.recoverOne(infrastructure, identity);
+
+        assertFalse(runtimes.hasRuntime(identity.getWorkspaceId()));
+    }
+
+    @Test
+    public void runtimeIsNotRecoveredIfNoEnvironmentFound() throws Exception {
+        RuntimeIdentity identity = new RuntimeIdentityImpl("workspace123", "my-env", "me");
+        WorkspaceImpl workspace = mockWorkspace(identity);
+        when(workspace.getConfig().getEnvironments()).thenReturn(Collections.emptyMap());
+
+        // try recover
+        runtimes.recoverOne(infrastructure, identity);
+
+        assertFalse(runtimes.hasRuntime(identity.getWorkspaceId()));
+    }
+
+    @Test
+    public void runtimeIsNotRecoveredIfInfraPreparationFailed() throws Exception {
+        RuntimeIdentity identity = new RuntimeIdentityImpl("workspace123", "my-env", "me");
+
+        EnvironmentImpl env = mockWorkspace(identity).getConfig().getEnvironments().get(identity.getEnvName());
+        doThrow(new InfrastructureException("oops!")).when(infrastructure).prepare(identity, env);
+
+        // try recover
+        runtimes.recoverOne(infrastructure, identity);
+
+        assertFalse(runtimes.hasRuntime(identity.getWorkspaceId()));
+    }
+
+    @Test
+    public void runtimeIsNotRecoveredIfAnotherRuntimeWithTheSameIdentityAlreadyExists() throws Exception {
+        RuntimeIdentity identity = new RuntimeIdentityImpl("workspace123", "my-env", "me");
+
+        mockWorkspace(identity);
+        RuntimeContext context = mockContext(identity);
+
+        // runtime 1(has 1 machine) must be successfully saved
+        Map<String, Machine> r1machines = ImmutableMap.of("m1", mock(Machine.class));
+        InternalRuntime runtime1 = spy(new TestInternalRuntime(context, r1machines));
+        when(context.getRuntime()).thenReturn(runtime1);
+        runtimes.recoverOne(infrastructure, identity);
+
+        // runtime 2 must not be saved
+        Map<String, Machine> r2machines = ImmutableMap.of("m1", mock(Machine.class), "m2", mock(Machine.class));
+        InternalRuntime runtime2 = new TestInternalRuntime(context, r2machines);
+        when(context.getRuntime()).thenReturn(runtime2);
+        runtimes.recoverOne(infrastructure, identity);
+
+        WorkspaceImpl workspace = new WorkspaceImpl(identity.getWorkspaceId(), null, null);
+        runtimes.injectRuntime(workspace);
+
+        assertNotNull(workspace.getRuntime());
+        assertEquals(workspace.getRuntime().getMachines().keySet(), r1machines.keySet());
+    }
+
+    private RuntimeContext mockContext(RuntimeIdentity identity) throws ValidationException, InfrastructureException {
+        RuntimeContext context = mock(RuntimeContext.class);
+        doReturn(context).when(infrastructure).prepare(eq(identity), anyObject());
+        when(context.getInfrastructure()).thenReturn(infrastructure);
+        when(context.getIdentity()).thenReturn(identity);
+        return context;
+    }
+
+    private WorkspaceImpl mockWorkspace(RuntimeIdentity identity) throws NotFoundException, ServerException {
+        EnvironmentImpl environment = mock(EnvironmentImpl.class);
+
+        WorkspaceConfigImpl config = mock(WorkspaceConfigImpl.class);
+        when(config.getEnvironments()).thenReturn(ImmutableMap.of(identity.getEnvName(), environment));
+
+        WorkspaceImpl workspace = mock(WorkspaceImpl.class);
+        when(workspace.getConfig()).thenReturn(config);
+        when(workspace.getId()).thenReturn(identity.getWorkspaceId());
+
+        when(workspaceDao.get(identity.getWorkspaceId())).thenReturn(workspace);
+
+        return workspace;
+    }
+
+    private static class TestInfrastructure extends RuntimeInfrastructure {
+        public TestInfrastructure(EventService eventService) {
+            super("test", Collections.singleton("test"), eventService);
+        }
+
+        @Override
+        public Environment estimate(Environment environment) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RuntimeContext prepare(RuntimeIdentity id, Environment environment) throws InfrastructureException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class TestInternalRuntime extends InternalRuntime<RuntimeContext> {
+        final Map<String, Machine> machines;
+
+        TestInternalRuntime(RuntimeContext context, Map<String, Machine> machines) {
+            super(context, null, false);
+            this.machines = machines;
+        }
+
+        TestInternalRuntime(RuntimeContext context) {
+            this(context, Collections.emptyMap());
+        }
+
+        @Override
+        protected Map<String, Machine> getInternalMachines() {
+            return machines;
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        protected void internalStop(Map stopOptions) throws InfrastructureException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void internalStart(Map startOptions) throws InfrastructureException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
@@ -175,7 +175,11 @@ public class CascadeRemovalTest {
 //                install(new MachineJpaModule());
                 bind(WorkspaceManager.class);
                 
-                WorkspaceRuntimes wR = spy(new WorkspaceRuntimes(mock(EventService.class), Collections.emptySet(), mock(WorkspaceSharedPool.class)));
+                WorkspaceRuntimes wR = spy(new WorkspaceRuntimes(mock(EventService.class),
+                                                                 Collections.emptySet(),
+                                                                 mock(WorkspaceSharedPool.class),
+                                                                 mock(WorkspaceDao.class),
+                                                                 mock(DBInitializer.class)));
                 when(wR.hasRuntime(anyString())).thenReturn(false);
                 bind(WorkspaceRuntimes.class).toInstance(wR);
                 bind(AccountManager.class);


### PR DESCRIPTION
The goal of the issue #5097 is to prove that SPI architecture allows recovering workspace runtimes.
This PR changes bring recovery functionality to the _spi_ branch and _Docker Infrastructure_ implementation which should be considered rather as _tracer bullets_ than tough implementation. Also, PR includes small docker infra refactorings and simple `ServersMapper` for mapping ports -> servers which allows multi-ref bindings.

#### Intro
Right now in the [spi](https://github.com/eclipse/che/tree/24b7163e816a4fd3f7b6155fdd93a289cbe30290) branch there are a few core routines:
```java
// identifies runtime
interface RuntimeIdentity {
  String getWorkspaceId();
  String getEnvName();
  String getOwner();
}

// provides runtime context specific values, 
// resolves recipes, contains configuration needed for runtime start & life
abstract class RuntimeContext {
  ...
  abstract InternalRuntime getRuntime();
  ...
}

// a functional instance of runtime which can be started/stopped etc
abstract class InternalRuntime<T extends RuntimeContext> implements Runtime { 
  ...
  T getContext() { ... }
  abstract void internalStart(Map<String, String> opts);
  abstract void internalStop(Map<String, String> opts);
  ...
}

// the infrastructure itself
abstract class RuntimeInfrastructure {
  ...
  abstract RuntimeContext prepare(RuntimeIdentity id, Environment env);
  // gets all the runtime identities managed by infra
  Set<RuntimeIdentity> getIdentities() { throw new UnsupportedOperationException(); }
  // gets consistent runtime managed by infra
  Runtime getRuntime(RuntimeIdentity id) { throw new UnsupportedOperationException(); }
  ...
}
```

Very simplified version of how runtimes could be recovered:
```java
RuntimeInfrastructure infra = ...
for (RuntimeIdentity identity: infra.getIdentities()) {
  Runtime runtime = infra.getRuntime(identity); 
  save(runtime);
}
```

#### Contract changes
I see a few consequences of using the approach described above. First, it is not clear how to get `RuntimeContext` back if there is no environment configuration, which means that there is no easy way to check runtime consistency. Second, there is a confusion between methods `RuntimeContext#getRuntime` &`RuntimeInfrastructure#getRuntime` it is not clear how they share their responsibility.

It was decided not to use ~~RuntimeInfrastructure#getRuntime~~ but use `RuntimeContext#getRuntime` instead. It implies that context will provide necessary information to check runtime consistency. 
So the simplified version of recovery becomes:
```java
RuntimeInfrastructure infra = ...
for (RuntimeIdentity identity: infra.getIdentities()) {
  Environment env = getEnvironmentFromDB(identity);
  Runtime runtime = infra.prepare(identity, env).getRuntime();
  save(runtime);
}
```

Created issues:
- Recover server logs streaming - #5675


