### PR TITLE
CHE-5600: show notification when the creation of workspace failed

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.html
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.html
@@ -31,15 +31,13 @@
                        custom-validator="createWorkspaceController.isNameUnique($value)"
                        ng-minlength="3"
                        ng-maxlength="20"
-                       ng-pattern="/^[A-Za-z0-9_\-\.]+$/">
-          <che-error-messages>
-            <div ng-message="required">A name is required.</div>
-            <div ng-message="pattern">The name should not contain special characters like space, dollar, etc.
-            </div>
-            <div ng-message="minlength">The name has to be more than 3 characters long.</div>
-            <div ng-message="maxlength">The name has to be less than 20 characters long.</div>
-            <div ng-message="customValidator">This workspace name is already used.</div>
-          </che-error-messages>
+                       ng-pattern="/^[a-z\d][a-z\d-.]+[a-z\d]$/i">
+          <div ng-message="required">A name is required.</div>
+          <div ng-message="pattern">The name should not contain special characters like space, dollar, etc. and should start and end only with digits, latin letters or underscores.
+          </div>
+          <div ng-message="minlength">The name has to be more than 3 characters long.</div>
+          <div ng-message="maxlength">The name has to be less than 20 characters long.</div>
+          <div ng-message="customValidator">This workspace name is already used.</div>
         </che-input-box>
       </ng-form>
     </che-label-container>
@@ -55,7 +53,6 @@
     <che-label-container che-label-name="Select Stack"
                          che-label-description="Choose your workspace runtime environment used to build and run your projects.">
       <stack-selector on-stack-select="createWorkspaceController.onStackSelected(stackId)"></stack-selector>
-      <!--<stack-selector></stack-selector>-->
     </che-label-container>
 
     <!-- RAM Settings-->


### PR DESCRIPTION



<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- show notification when the creation of workspace failed
- fix pattern for WS name input to avoid leading and trailing dots and dashes

### What issues does this PR fix or reference?
fixes #5600
fixes #5647 

#### Changelog
<!-- one line entry to be added to changelog -->
[UD] show notification when the creation of workspace failed.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix
