### PR TITLE
CHE-5152: Apply pagination in Git Reset window

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryViewImpl.java
@@ -208,7 +208,9 @@ public class HistoryViewImpl extends Window implements HistoryView {
 
     @UiHandler("revisionsPanel")
     public void onPanelScrolled(ScrollEvent ignored) {
-        if (revisionsPanel.getVerticalScrollPosition() == revisionsPanel.getMaximumVerticalScrollPosition()) {
+        // We cannot rely on exact equality of scroll positions because GWT sometimes round such values
+        // and it is possible that the actual max scroll position is a pixel less then declared.
+        if (revisionsPanel.getMaximumVerticalScrollPosition() - revisionsPanel.getVerticalScrollPosition() <= 1) {
             // to avoid autoscrolling to selected item
             revisionsPanel.getElement().focus();
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitPresenter.java
@@ -25,9 +25,15 @@ import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.outputconsole.GitOutputConsole;
 import org.eclipse.che.ide.ext.git.client.outputconsole.GitOutputConsoleFactory;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
+import org.eclipse.che.ide.resource.Path;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.che.api.git.shared.Constants.DEFAULT_PAGE_SIZE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.util.ExceptionUtils.getErrorCode;
@@ -52,8 +58,10 @@ public class ResetToCommitPresenter implements ResetToCommitView.ActionDelegate 
     private final GitLocalizationConstant constant;
     private final NotificationManager     notificationManager;
 
-    private Revision selectedRevision;
-    private Project  project;
+    private Revision       selectedRevision;
+    private List<Revision> revisions;
+    private Project        project;
+    private int            skip;
 
     @Inject
     public ResetToCommitPresenter(ResetToCommitView view,
@@ -77,29 +85,10 @@ public class ResetToCommitPresenter implements ResetToCommitView.ActionDelegate 
 
     public void showDialog(final Project project) {
         this.project = project;
+        this.skip = 0;
+        this.revisions = new ArrayList<>();
 
-        service.log(project.getLocation(), null, -1, -1, false)
-               .then(log -> {
-                   view.setRevisions(log.getCommits());
-                   view.setMixMode(true);
-                   view.setEnableResetButton(selectedRevision != null);
-                   view.showDialog();
-
-                   project.synchronize();
-               })
-               .catchError(error -> {
-                   if (getErrorCode(error.getCause()) == ErrorCodes.INIT_COMMIT_WAS_NOT_PERFORMED) {
-                       dialogFactory.createMessageDialog(constant.resetCommitViewTitle(),
-                                                         constant.initCommitWasNotPerformed(),
-                                                         null).show();
-                       return;
-                   }
-                   String errorMessage = (error.getMessage() != null) ? error.getMessage() : constant.logFailed();
-                   GitOutputConsole console = gitOutputConsoleFactory.create(LOG_COMMAND_NAME);
-                   console.printError(errorMessage);
-                   consolesPanelPresenter.addCommandOutput(appContext.getDevMachine().getId(), console);
-                   notificationManager.notify(constant.logFailed(), FAIL, FLOAT_MODE);
-               });
+        fetchAndAddNextRevisions();
     }
 
     /**
@@ -126,6 +115,41 @@ public class ResetToCommitPresenter implements ResetToCommitView.ActionDelegate 
     public void onRevisionSelected(@NotNull Revision revision) {
         selectedRevision = revision;
         view.setEnableResetButton(selectedRevision != null);
+    }
+
+    @Override
+    public void onScrolledToBottom() {
+        fetchAndAddNextRevisions();
+    }
+
+    private void fetchAndAddNextRevisions() {
+        service.log(project.getLocation(), null, skip, DEFAULT_PAGE_SIZE, false)
+               .then(log -> {
+                   List<Revision> commits = log.getCommits();
+                   if (!commits.isEmpty()) {
+                       skip += commits.size();
+                       revisions.addAll(commits);
+                       view.setEnableResetButton(selectedRevision != null);
+                       view.setRevisions(revisions);
+                       view.setMixMode(true);
+                       view.showDialog();
+
+                       project.synchronize();
+                   }
+               })
+               .catchError(error -> {
+                   if (getErrorCode(error.getCause()) == ErrorCodes.INIT_COMMIT_WAS_NOT_PERFORMED) {
+                       dialogFactory.createMessageDialog(constant.resetCommitViewTitle(),
+                               constant.initCommitWasNotPerformed(),
+                               null).show();
+                       return;
+                   }
+                   String errorMessage = (error.getMessage() != null) ? error.getMessage() : constant.logFailed();
+                   GitOutputConsole console = gitOutputConsoleFactory.create(LOG_COMMAND_NAME);
+                   console.printError(errorMessage);
+                   consolesPanelPresenter.addCommandOutput(appContext.getDevMachine().getId(), console);
+                   notificationManager.notify(constant.logFailed(), FAIL, FLOAT_MODE);
+               });
     }
 
     /**

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitPresenter.java
@@ -25,7 +25,6 @@ import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.outputconsole.GitOutputConsole;
 import org.eclipse.che.ide.ext.git.client.outputconsole.GitOutputConsoleFactory;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
-import org.eclipse.che.ide.resource.Path;
 
 import javax.validation.constraints.NotNull;
 
@@ -33,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.eclipse.che.api.git.shared.Constants.DEFAULT_PAGE_SIZE;
-import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.util.ExceptionUtils.getErrorCode;

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitPresenter.java
@@ -85,6 +85,8 @@ public class ResetToCommitPresenter implements ResetToCommitView.ActionDelegate 
         this.project = project;
         this.skip = 0;
         this.revisions = new ArrayList<>();
+        this.selectedRevision = null;
+        this.view.resetRevisionSelection();
 
         fetchAndAddNextRevisions();
     }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitView.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitView.java
@@ -52,6 +52,11 @@ public interface ResetToCommitView extends View<ResetToCommitView.ActionDelegate
      */
     void setRevisions(@NotNull List<Revision> revisions);
 
+    /**
+     * Deselect active revision in the table of available revisions.
+     */
+    void resetRevisionSelection();
+
     /** @return <code>true</code> if soft mode is chosen, and <code>false</code> otherwise */
     boolean isSoftMode();
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitView.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitView.java
@@ -85,28 +85,6 @@ public interface ResetToCommitView extends View<ResetToCommitView.ActionDelegate
      */
     void setHardMode(boolean isHard);
 
-//    /** @return <code>true</code> if keep mode is chosen, and <code>false</code> otherwise */
-//    boolean isKeepMode();
-//
-//    /**
-//     * Select keep mode.
-//     *
-//     * @param isKeep
-//     *         <code>true</code> to select keep mode, <code>false</code> not to select
-//     */
-//    void setKeepMode(boolean isKeep);
-//
-//    /** @return <code>true</code> if merge mode is chosen, and <code>false</code> otherwise */
-//    boolean isMergeMode();
-//
-//    /**
-//     * Select merge mode.
-//     *
-//     * @param isMerge
-//     *         <code>true</code> to select merge mode, <code>false</code> not to select
-//     */
-//    void setMergeMode(boolean isMerge);
-
     /**IDEUI-166 No cursor in terminal
 
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitView.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitView.java
@@ -37,6 +37,11 @@ public interface ResetToCommitView extends View<ResetToCommitView.ActionDelegate
          *         selected revision
          */
         void onRevisionSelected(@NotNull Revision revision);
+
+        /**
+         * Occurs when the last entry in the list has been displayed.
+         */
+        void onScrolledToBottom();
     }
 
     /**

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.java
@@ -22,10 +22,12 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.client.DOM;
@@ -59,12 +61,10 @@ public class ResetToCommitViewImpl extends Window implements ResetToCommitView {
     RadioButton mixed;
     @UiField
     RadioButton hard;
-    //    @UiField
-//    RadioButton         keep;
-//    @UiField
-//    RadioButton         merge;
     Button btnReset;
     Button btnCancel;
+    @UiField
+    ScrollPanel revisionsPanel;
     @UiField(provided = true)
     CellTable<Revision> commits;
     @UiField(provided = true)
@@ -130,8 +130,6 @@ public class ResetToCommitViewImpl extends Window implements ResetToCommitView {
         addDescription(soft, locale.resetSoftTypeDescription());
         addDescription(mixed, locale.resetMixedTypeDescription());
         addDescription(hard, locale.resetHardTypeDescription());
-//        addDescription(keep, locale.resetKeepTypeDescription());
-//        addDescription(merge, locale.resetMergeTypeDescription());
     }
 
     /**
@@ -258,30 +256,6 @@ public class ResetToCommitViewImpl extends Window implements ResetToCommitView {
         hard.setValue(isHard);
     }
 
-//    /** {@inheritDoc} */
-//    @Override
-//    public boolean isKeepMode() {
-//        return keep.getValue();
-//    }
-//
-//    /** {@inheritDoc} */
-//    @Override
-//    public void setKeepMode(boolean isKeep) {
-//        keep.setValue(isKeep);
-//    }
-//
-//    /** {@inheritDoc} */
-//    @Override
-//    public boolean isMergeMode() {
-//        return merge.getValue();
-//    }
-//
-//    /** {@inheritDoc} */
-//    @Override
-//    public void setMergeMode(boolean isMerge) {
-//        merge.setValue(isMerge);
-//    }
-
     /** {@inheritDoc} */
     @Override
     public void setEnableResetButton(final boolean enabled) {
@@ -312,4 +286,13 @@ public class ResetToCommitViewImpl extends Window implements ResetToCommitView {
         this.delegate = delegate;
     }
 
+    @UiHandler("revisionsPanel")
+    public void onPanelScrolled(ScrollEvent ignored) {
+        if (revisionsPanel.getVerticalScrollPosition() == revisionsPanel.getMaximumVerticalScrollPosition()) {
+            // to avoid autoscrolling to selected item
+            revisionsPanel.getElement().focus();
+
+            delegate.onScrolledToBottom();
+        }
+    }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.java
@@ -288,7 +288,9 @@ public class ResetToCommitViewImpl extends Window implements ResetToCommitView {
 
     @UiHandler("revisionsPanel")
     public void onPanelScrolled(ScrollEvent ignored) {
-        if (revisionsPanel.getVerticalScrollPosition() == revisionsPanel.getMaximumVerticalScrollPosition()) {
+        // We cannot rely on exact equality of scroll positions because GWT sometimes round such values
+        // and it is possible that the actual max scroll position is a pixel less then declared.
+        if (revisionsPanel.getMaximumVerticalScrollPosition() - revisionsPanel.getVerticalScrollPosition() <= 1) {
             // to avoid autoscrolling to selected item
             revisionsPanel.getElement().focus();
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ext.git.client.reset.commit;
 
+import com.google.gwt.view.client.SelectionModel;
 import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.api.git.shared.Revision;
 import org.eclipse.che.ide.ext.git.client.GitResources;
@@ -212,12 +213,15 @@ public class ResetToCommitViewImpl extends Window implements ResetToCommitView {
     @Override
     public void setRevisions(@NotNull List<Revision> revisions) {
         // Wraps Array in java.util.List
-        List<Revision> list = new ArrayList<Revision>();
-        for (int i = 0; i < revisions.size(); i++) {
-            list.add(revisions.get(i));
-        }
+        List<Revision> list = new ArrayList<>();
+        list.addAll(revisions);
 
         this.commits.setRowData(list);
+    }
+
+    @Override
+    public void resetRevisionSelection() {
+        ((SingleSelectionModel) commits.getSelectionModel()).clear();
     }
 
     /** {@inheritDoc} */

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.ui.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/reset/commit/ResetToCommitViewImpl.ui.xml
@@ -47,18 +47,10 @@
                     <g:RadioButton ui:field="hard" name="type" addStyleNames="{res.gitCSS.textFont}" text="{locale.resetHardTypeTitle}"
                                    debugId="git-reset-hard"/>
                 </g:north>
-                <!--<g:north size="20">-->
-                    <!--<g:RadioButton ui:field="keep" name="type" visible="false" addStyleNames="{res.gitCSS.textFont}"-->
-                                   <!--text="{locale.resetKeepTypeTitle}" debugId="git-reset-keep"/>-->
-                <!--</g:north>-->
-                <!--<g:north size="20">-->
-                    <!--<g:RadioButton ui:field="merge" name="type" visible="false" addStyleNames="{res.gitCSS.textFont}"-->
-                                   <!--text="{locale.resetMergeTypeTitle}" debugId="git-reset-merge"/>-->
-                <!--</g:north>-->
             </g:DockLayoutPanel>
         </g:south>
         <g:center>
-            <g:ScrollPanel addStyleNames="{style.commits}">
+            <g:ScrollPanel ui:field="revisionsPanel" addStyleNames="{style.commits}">
                 <p1:CellTable width="100%" ui:field="commits" focus="false"/>
             </g:ScrollPanel>
         </g:center>


### PR DESCRIPTION
### What does this PR do?
Make load of commits history in git reset window by parts on demand (when a user scrolls to the last displayed one).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5152

#### Changelog
Added dynamic history loading in Git Reset window.

#### Release Notes
We've updated our Git Reset window to load commits in pages as you scroll. This significantly speeds up the UI and makes it easier to use.

#### Docs PR
N/A