### PR TITLE
CHE-5601: fix the bug with RAM spinner

### DIFF
--- a/dashboard/src/components/filter/change-memory-unit/change-memory-unit.filter.spec.ts
+++ b/dashboard/src/components/filter/change-memory-unit/change-memory-unit.filter.spec.ts
@@ -17,7 +17,7 @@ import {CheHttpBackend} from '../../api/test/che-http-backend';
  * @author Oleksii Kurinnyi
  */
 describe('ChangeMemoryUnitFilter', () => {
-  let $filter, unitFrom: string, unitTo: string;
+  let $filter, unitFrom: string;
 
   /**
    * Backend for handling http operations
@@ -105,6 +105,23 @@ describe('ChangeMemoryUnitFilter', () => {
 
       let result = $filter('changeMemoryUnit')(number, [unitFrom, unitTo]);
 
+      expect(result).toEqual(expectedResult);
+    });
+
+  });
+
+  describe(`bugfix https://github.com/eclipse/che/issues/5601 >`, () => {
+
+    it(`should round value in bytes >`, () => {
+      const number = 2.3,
+            unitFrom = 'GB',
+            unitTo = 'B',
+            notExpectedResult = 2469606195.2 + ' ' + unitTo,
+            expectedResult = 2469606195 + ' ' + unitTo;
+
+      const result = $filter('changeMemoryUnit')(number, [unitFrom, unitTo]);
+
+      expect(result).not.toEqual(notExpectedResult);
       expect(result).toEqual(expectedResult);
     });
 

--- a/dashboard/src/components/filter/change-memory-unit/change-memory-unit.filter.ts
+++ b/dashboard/src/components/filter/change-memory-unit/change-memory-unit.filter.ts
@@ -93,7 +93,7 @@ export class ChangeMemoryUnitFilter {
 
   castToBytes(number: number, unitFrom: string): number {
     const power = this.getPower(unitFrom);
-    number = this.castDown(number, power);
+    number = Math.round(this.castDown(number, power));
     return number;
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the bug with RAM spinner which causes workspace creation fail in case the decimal value is not 0.5

### What issues does this PR fix or reference?
fixes #5601

#### Changelog
<!-- one line entry to be added to changelog -->
Fixed the bug with RAM spinner which causes workspace creation fail in case the decimal value is not 0.5

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix
