### PR TITLE
Deprecate WsConnectionListener

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java
@@ -25,7 +25,9 @@ import org.eclipse.che.ide.websocket.events.WebSocketClosedEvent;
 
 /**
  * @author Evgen Vidolob
+ * @deprecated within replacing everrest based Websocket calls with new RPC framework now it is considered as deprecated and will be removed
  */
+@Deprecated
 public class WsConnectionListener implements ConnectionClosedHandler, ConnectionOpenedHandler {
 
     private final EventBus                 eventBus;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -76,7 +76,6 @@ import org.eclipse.che.ide.api.parts.Perspective;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.command.editor.CommandEditorProvider;
 import org.eclipse.che.ide.command.palette.ShowCommandsPaletteAction;
-import org.eclipse.che.ide.connection.WsConnectionListener;
 import org.eclipse.che.ide.imageviewer.ImageViewerProvider;
 import org.eclipse.che.ide.imageviewer.PreviewImageAction;
 import org.eclipse.che.ide.machine.MachineResources;
@@ -479,8 +478,6 @@ public class StandardComponentInitializer {
     @Inject
     @Named("CommandFileType")
     private FileType              commandFileType;
-    @Inject
-    private WsConnectionListener  wsConnectionListener;
 
     @Inject
     private ProjectConfigSynchronized projectConfigSynchronized;


### PR DESCRIPTION
### What does this PR do?
Let's consider https://github.com/eclipse/che/blob/1efd83096307ac9dce376181c472a01d619ac705/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/connection/WsConnectionListener.java#L31-L31 as deprecated within replacing everrest based Websocket calls with new RPC framework #4459

#### Changelog
Deprecate WsConnectionListener

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
