### PR TITLE
Fix run command for Eclipse Vert.x stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2364,7 +2364,7 @@
           "goal": "Build"
         }
       }, {
-        "commandLine": "cd ${current.project.path} && scl enable rh-maven33 'java -jar target/*-fat.jar'",
+        "commandLine": "scl enable rh-maven33 'mvn vertx:run -f ${current.project.path}'",
         "name": "run",
         "type": "custom",
         "attributes": {


### PR DESCRIPTION
### What does this PR do?
Use command `mvn vertx:run` instead of `java -jar target/-fat.jar` as Run command for Vert.x stack

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/215

#### Changelog
Fixed run command for Eclipse Vert.x stack

#### Release Notes
Fixed run command for Eclipse Vert.x stack

#### Docs PR
n/a