### PR TITLE
CHE-5617. Set editor as active part when this one has initialized

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -286,7 +286,9 @@ public class EditorAgentImpl implements EditorAgent,
         editor.addCloseHandler(this);
 
         workspaceAgent.openPart(editor, EDITING, constraints);
-        finalizeInit(file, callback, editor, editorProvider);
+        finalizeInit(file, callback, editor, editorProvider).then(arg -> {
+            workspaceAgent.setActivePart(editor);
+        });
     }
 
     private Promise<Void> finalizeInit(final VirtualFile file,
@@ -297,7 +299,6 @@ public class EditorAgentImpl implements EditorAgent,
             openedEditors.add(editor);
             openedEditorsToProviders.put(editor, editorProvider.getId());
 
-            workspaceAgent.setActivePart(editor);
             editor.addPropertyListener((source, propId) -> {
                 if (propId == EditorPartPresenter.PROP_INPUT) {
                     promiseCallback.onSuccess(null);


### PR DESCRIPTION
### What does this PR do?
In many places on client side we have some logic that is executed when active part is changed. 
In case when active part is editor - we need to get some info from editor part to handle this logic. So we need to set active part when editor has initialized. 

### What issues does this PR fix or reference?
#5617 
#### Changelog
Set editor as active part when this one has initialized
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>