### PR TITLE
CHE-5599: add improvements for Filters widget

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.controller.ts
@@ -43,9 +43,9 @@ export class ProjectSourceSelectorController {
    */
   private selectedSource: ProjectSource;
   /**
-   * button's values by Id.
+   * State of a button.
    */
-  private buttonValues: { [butonId: string]: boolean } = {};
+  private buttonState: { [buttonId: string]: boolean } = {};
   /**
    * Selected button's type.
    */
@@ -142,13 +142,13 @@ export class ProjectSourceSelectorController {
    */
   updateData({buttonState, buttonType, template = null}: { buttonState: boolean, buttonType: ButtonType, template?: che.IProjectTemplate }): void {
 
-    const buttonValue = template
+    const buttonId = template
       ? template.name
       : ButtonType[ButtonType.ADD_PROJECT];
 
     // leave only one selected button
-    this.buttonValues = {
-      [buttonValue]: true
+    this.buttonState = {
+      [buttonId]: true
     };
 
     if (!buttonState) {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.html
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.html
@@ -8,14 +8,13 @@
                           che-font-icon="material-design icon-ic_add_24px"
                           che-on-change="projectSourceSelectorController.updateData({buttonState: state, buttonType: projectSourceSelectorController.buttonType.ADD_PROJECT})"
                           ng-init="projectSourceSelectorController.selectedButtonType = projectSourceSelectorController.buttonType.ADD_PROJECT"
-                          che-value="projectSourceSelectorController.buttonValues['ADD_PROJECT']"></toggle-single-button>
+                          che-state="projectSourceSelectorController.buttonState['ADD_PROJECT']"></toggle-single-button>
     <toggle-single-button class="project-metadata"
                           ng-repeat="projectTemplate in projectSourceSelectorController.projectTemplates"
                           che-title="{{projectTemplate.name}}"
-                          che-state="false"
                           che-font-icon="chefont cheico-project"
                           che-on-change="projectSourceSelectorController.updateData({buttonState: state, buttonType: projectSourceSelectorController.buttonType.PROJECT_TEMPLATE, template: projectTemplate})"
-                          che-value="projectSourceSelectorController.buttonValues[projectTemplate.name]"
+                          che-state="projectSourceSelectorController.buttonState[projectTemplate.name]"
                           uib-tooltip="{{projectTemplate.name}}"></toggle-single-button>
   </div>
 

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-library-filter/che-stack-library-filter.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-library-filter/che-stack-library-filter.directive.ts
@@ -48,7 +48,7 @@ export class CheStackLibraryFilter implements ng.IDirective {
     };
 
     // select suggestion by keys
-    $element.bind('keypress keydown', (event: any) => {
+    $element.on('keypress keydown', (event: any) => {
       if (event.which === 38) {
         // on press 'up'
         // select prev suggestion
@@ -70,6 +70,16 @@ export class CheStackLibraryFilter implements ng.IDirective {
         }
         ctrl.selectSuggestion(ctrl.selectedIndex);
       }
+    });
+
+    // select suggestion by mouse click
+    $element.on('click', 'md-chip', (event: any) => {
+      const suggestions = ctrl.suggestions.map((suggestion: string) => {
+        return suggestion.toLowerCase();
+      });
+      const suggestionText = angular.element(event.currentTarget).find('.stack-library-filter-suggestion-text').text().toLowerCase();
+      ctrl.selectedIndex = suggestions.indexOf(suggestionText);
+      ctrl.selectSuggestion(ctrl.selectedIndex);
     });
   }
 }

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-library-filter/che-stack-library-filter.html
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-library-filter/che-stack-library-filter.html
@@ -35,8 +35,10 @@
                   class="stack-library-filter-suggestions"
                   readonly="true">
           <md-chip-template>
-            <div class="stack-library-filter-suggestion-text">{{$chip | uppercase}}</div>
-            <div class="stack-library-filter-suggestion-btn" ng-click="cheStackLibraryFilterCtrl.onSelectSuggestion($chip)">
+            <div class="stack-library-filter-suggestion-text"
+                 ng-dblclick="cheStackLibraryFilterCtrl.onSelectSuggestion($chip)">{{$chip | uppercase}}</div>
+            <div class="stack-library-filter-suggestion-btn"
+                 ng-click="cheStackLibraryFilterCtrl.onSelectSuggestion($chip)">
               <i class="fa fa-plus"></i>
             </div>
           </md-chip-template>

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.html
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.html
@@ -28,7 +28,8 @@
          layout-align="start center" layout-align-gt-md="end center">
       <toggle-button-popover button-title="Filters"
                              button-font-icon="fa fa-sliders"
-                             che-popover-trigger-outside-click="true">
+                             che-popover-trigger-outside-click="true"
+                             ng-class="{'stack-selector-active-tags-filter': stackSelectorController.selectedTags.length}">
         <che-stack-library-filter stack-tags="stackSelectorController.allStackTags"
                                   selected-tags="stackSelectorController.selectedTags"
                                   on-tags-changes="stackSelectorController.onTagsChanges(tags)">

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.html
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.html
@@ -27,7 +27,8 @@
          layout="row"
          layout-align="start center" layout-align-gt-md="end center">
       <toggle-button-popover button-title="Filters"
-                             button-font-icon="fa fa-sliders">
+                             button-font-icon="fa fa-sliders"
+                             che-popover-trigger-outside-click="true">
         <che-stack-library-filter stack-tags="stackSelectorController.allStackTags"
                                   selected-tags="stackSelectorController.selectedTags"
                                   on-tags-changes="stackSelectorController.onTagsChanges(tags)">

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.styl
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.styl
@@ -22,6 +22,9 @@
         md-icon
           font-size 28px
 
+  toggle-button-popover.stack-selector-active-tags-filter toggle-single-button md-icon
+    color $primary-color !important
+
   .stack-selector-list
     background-color $stack-selector-list-header-background
     border-top 1px solid $stack-selector-list-header-border

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.styl
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.styl
@@ -2,6 +2,9 @@
   $stack-selector-list-header-border = lighten($very-light-grey-color, 4%)
   $stack-selector-list-header-background = lighten($very-light-grey-color, 28%)
 
+  & *
+    outline none
+
   .stack-selector-buttons-right
     & > *
       margin 0

--- a/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.spec.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.spec.ts
@@ -63,6 +63,10 @@ describe('CheToggleButtonPopover >', () => {
 
   }));
 
+  afterEach(() => {
+    $timeout.verifyNoPendingTasks();
+  });
+
   function getCompiledElement() {
     const element = $compile(angular.element(
       `<div><toggle-button-popover button-title="model.popoverButtonTitle"
@@ -87,10 +91,16 @@ describe('CheToggleButtonPopover >', () => {
     });
 
     it('should have content hidden', () => {
+      // timeout should be flashed
+      $timeout.flush();
+
       expect(compiledDirective.html()).not.toContain($rootScope.model.popoverContent);
     });
 
     it('should have button disabled', () => {
+      // timeout should be flashed
+      $timeout.flush();
+
       expect(toggleSingleButton.get(0)).toBeTruthy();
       expect(toggleSingleButton.hasClass('toggle-single-button-disabled')).toBeTruthy();
     });
@@ -193,14 +203,16 @@ describe('CheToggleButtonPopover >', () => {
       });
 
       it('should make content hidden', () => {
-        // timeout should be flashed to get callback called and content visible
+        // timeout should be flashed to get callback called and content hidden
+        $timeout.flush();
         $timeout.flush();
 
         expect(compiledDirective.html()).not.toContain($rootScope.model.popoverContent);
       });
 
       it('should disable button', () => {
-        // timeout should be flashed to get callback called and content visible
+        // timeout should be flashed to get callback called and content hidden
+        $timeout.flush();
         $timeout.flush();
 
         expect(toggleSingleButton.hasClass('toggle-single-button-disabled')).toBeTruthy();
@@ -209,7 +221,8 @@ describe('CheToggleButtonPopover >', () => {
       it('should call the callback', () => {
         spyOn($rootScope.model, 'onChange');
 
-        // timeout should be flashed to get callback called and content visible
+        // timeout should be flashed to get callback called and content hidden
+        $timeout.flush();
         $timeout.flush();
 
         expect($rootScope.model.onChange).toHaveBeenCalledWith(false);
@@ -225,7 +238,7 @@ describe('CheToggleButtonPopover >', () => {
       });
 
       it('should make content hidden', () => {
-        // timeout should be flashed to get callback called and content visible
+        // timeout should be flashed to get callback called and content hidden
         $timeout.flush();
         $timeout.flush();
 
@@ -233,7 +246,8 @@ describe('CheToggleButtonPopover >', () => {
       });
 
       it('should disable button', () => {
-        // timeout should be flashed to get callback called and content visible
+        // timeout should be flashed to get callback called and content hidden
+        $timeout.flush();
         $timeout.flush();
 
         expect(toggleSingleButton.hasClass('toggle-single-button-disabled')).toBeTruthy();
@@ -242,7 +256,8 @@ describe('CheToggleButtonPopover >', () => {
       it('should call the callback', () => {
         spyOn($rootScope.model, 'onChange');
 
-        // timeout should be flashed to get callback called and content visible
+        // timeout should be flashed to get callback called and content hidden
+        $timeout.flush();
         $timeout.flush();
 
         expect($rootScope.model.onChange).toHaveBeenCalledWith(false);

--- a/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
@@ -13,7 +13,7 @@
 interface IPopoverScope extends ng.IScope {
   onChange: Function;
   isOpenPopover: boolean;
-  buttonInitState?: boolean;
+  buttonState?: boolean;
   buttonOnChange?: Function;
   buttonOnReset?: Function;
   chePopoverTriggerOutsideClick?: boolean;
@@ -33,13 +33,12 @@ interface IPopoverScope extends ng.IScope {
  * @param {string} button-font-icon button's icon CSS class
  * @param {expression=} button-state expression which defines state of button.
  * @param {Function} button-on-change callback on model change
- * @param {boolean} button-value button's state
  * @param {string=} che-popover-title popover's title
  * @param {string=} che-popover-placement popover's placement
  * @param {expression=} che-popover-close-outside-click if <code>true</close> then click outside of popover will close the it
  * @usage
  *   <toggle-button-popover button-title="Filter"
- *                          button-state="ctrl.filterInitState"
+ *                          button-state="ctrl.filterState"
  *                          button-on-change="ctrl.filterStateOnChange(state)"><div>My popover</div></toggle-button-popover>
  *
  * @author Oleksii Orel
@@ -51,8 +50,7 @@ export class CheToggleButtonPopover implements ng.IDirective {
     buttonTitle: '@',
     buttonFontIcon: '@',
     buttonOnChange: '&?buttonOnChange',
-    buttonInitState: '=?buttonState',
-    buttonValue: '=?',
+    buttonState: '=?buttonState',
     chePopoverTitle: '@?',
     chePopoverPlacement: '@?',
     chePopoverTriggerOutsideClick: '=?'
@@ -76,8 +74,7 @@ export class CheToggleButtonPopover implements ng.IDirective {
     return `<toggle-single-button che-title="{{buttonTitle}}"
                                   che-font-icon="{{buttonFontIcon}}"
                                   che-on-change="onChange(state)"
-                                  che-state="buttonInitState"
-                                  che-value="buttonValue"
+                                  che-state="buttonState"
                                   popover-title="{{chePopoverTitle ? chePopoverTitle : ''}}"
                                   popover-placement="{{chePopoverPlacement ? chePopoverPlacement : 'bottom'}}"
                                   popover-is-open="isOpenPopover"
@@ -103,10 +100,10 @@ export class CheToggleButtonPopover implements ng.IDirective {
       });
     };
 
-    if (!$scope.buttonInitState) {
-      $scope.buttonInitState = false;
+    if (!$scope.buttonState) {
+      $scope.buttonState = false;
     }
-    $scope.onChange($scope.buttonInitState);
+    $scope.onChange($scope.buttonState);
 
     // close popover on Esc is pressed
     $element.attr('tabindex', 0);
@@ -114,7 +111,7 @@ export class CheToggleButtonPopover implements ng.IDirective {
       if (event.which === 27) {
         // on press 'esc'
         $scope.$apply(() => {
-          $scope.buttonInitState = false;
+          $scope.buttonState = false;
         });
       }
     });
@@ -122,7 +119,7 @@ export class CheToggleButtonPopover implements ng.IDirective {
     if ($scope.chePopoverTriggerOutsideClick) {
       // update toggle single button state after popover is closed by outside click
       const watcher = $scope.$watch(() => { return $scope.isOpenPopover; }, (newVal: boolean) => {
-        $scope.buttonInitState = newVal;
+        $scope.buttonState = newVal;
       });
       $scope.$on('$destroy', () => {
         watcher();

--- a/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
@@ -40,7 +40,7 @@ interface IPopoverScope extends ng.IScope {
  *
  * @param {string} button-title button's title
  * @param {string} button-font-icon button's icon CSS class
- * @param {expression=} button-state expression which defines initial state of button.
+ * @param {expression=} button-state expression which defines state of button.
  * @param {Function} button-on-change callback on model change
  * @param {boolean} button-value button's state
  * @param {string=} che-popover-title popover's title
@@ -83,7 +83,7 @@ export class CheToggleButtonPopover implements ng.IDirective {
     return `<toggle-single-button che-title="{{buttonTitle}}"
                                   che-font-icon="{{buttonFontIcon}}"
                                   che-on-change="onChange(state)"
-                                  che-state="buttonInitState ? buttonInitState : false"
+                                  che-state="buttonInitState"
                                   che-value="buttonValue"
                                   popover-title="{{chePopoverTitle ? chePopoverTitle : ''}}"
                                   popover-placement="{{chePopoverPlacement ? chePopoverPlacement : 'bottom'}}"
@@ -108,6 +108,22 @@ export class CheToggleButtonPopover implements ng.IDirective {
         }
       });
     };
+
+    if (!$scope.buttonInitState) {
+      $scope.buttonInitState = false;
+    }
+    $scope.onChange($scope.buttonInitState);
+
+    // close popover on Esc is pressed
+    $element.attr('tabindex', 0);
+    $element.on('keypress keydown', (event: any) => {
+      if (event.which === 27) {
+        // on press 'esc'
+        $scope.$apply(() => {
+          $scope.buttonInitState = false;
+        });
+      }
+    });
 
   }
 }

--- a/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
@@ -10,22 +10,13 @@
  */
 'use strict';
 
-interface IPopoverAttrs extends ng.IAttributes {
-  buttonTitle: string;
-  buttonFontIcon: string;
-  buttonOnChange: string;
-  buttonState?: string;
-  buttonValue?: boolean;
-  chePopoverTitle?: string;
-  chePopoverPlacement?: string;
-}
-
 interface IPopoverScope extends ng.IScope {
   onChange: Function;
   isOpenPopover: boolean;
   buttonInitState?: boolean;
   buttonOnChange?: Function;
   buttonOnReset?: Function;
+  chePopoverTriggerOutsideClick?: boolean;
 }
 
 /**
@@ -45,6 +36,7 @@ interface IPopoverScope extends ng.IScope {
  * @param {boolean} button-value button's state
  * @param {string=} che-popover-title popover's title
  * @param {string=} che-popover-placement popover's placement
+ * @param {expression=} che-popover-close-outside-click if <code>true</close> then click outside of popover will close the it
  * @usage
  *   <toggle-button-popover button-title="Filter"
  *                          button-state="ctrl.filterInitState"
@@ -62,7 +54,8 @@ export class CheToggleButtonPopover implements ng.IDirective {
     buttonInitState: '=?buttonState',
     buttonValue: '=?',
     chePopoverTitle: '@?',
-    chePopoverPlacement: '@?'
+    chePopoverPlacement: '@?',
+    chePopoverTriggerOutsideClick: '=?'
   };
 
   private $timeout: ng.ITimeoutService;
@@ -88,10 +81,11 @@ export class CheToggleButtonPopover implements ng.IDirective {
                                   popover-title="{{chePopoverTitle ? chePopoverTitle : ''}}"
                                   popover-placement="{{chePopoverPlacement ? chePopoverPlacement : 'bottom'}}"
                                   popover-is-open="isOpenPopover"
+                                  popover-trigger="{{chePopoverTriggerOutsideClick ? 'outsideClick' : 'none'}}" 
                                   uib-popover-html="'<div class=\\'che-transclude\\'></div>'"></toggle-single-button>`;
   }
 
-  link($scope: IPopoverScope, $element: ng.IAugmentedJQuery, $attrs: IPopoverAttrs, ctrl: any, $transclude: ng.ITranscludeFunction): void {
+  link($scope: IPopoverScope, $element: ng.IAugmentedJQuery, $attrs: ng.IAttributes, ctrl: any, $transclude: ng.ITranscludeFunction): void {
 
     $scope.onChange = (state: boolean) => {
       this.$timeout(() => {
@@ -125,5 +119,16 @@ export class CheToggleButtonPopover implements ng.IDirective {
       }
     });
 
+    if ($scope.chePopoverTriggerOutsideClick) {
+      // update toggle single button state after popover is closed by outside click
+      const watcher = $scope.$watch(() => { return $scope.isOpenPopover; }, (newVal: boolean) => {
+        $scope.buttonInitState = newVal;
+      });
+      $scope.$on('$destroy', () => {
+        watcher();
+      });
+    }
+
   }
+
 }

--- a/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.spec.ts
+++ b/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.spec.ts
@@ -16,10 +16,10 @@ interface ITestScope extends ng.IRootScopeService {
 }
 
 /**
- * Test of the CheToggleButtonPopover directive.
+ * Test of the ToggleSingleButton directive.
  * @author Oleksii Kurinnyi
  */
-describe('CheToggleButtonPopover >', () => {
+describe('ToggleSingleButton >', () => {
 
   let $rootScope: ITestScope,
       $timeout: ng.ITimeoutService,
@@ -50,9 +50,8 @@ describe('CheToggleButtonPopover >', () => {
     httpBackend.when('OPTIONS', '/api/').respond({});
 
     $rootScope.model = {
-      title: 'Popover Button Title',
+      title: 'Toggle Single Button Title',
       state: false,
-      content: 'Simple popover content',
       onChange: (state: boolean) => {
         /* tslint:disable */
         const newState = state;
@@ -68,12 +67,10 @@ describe('CheToggleButtonPopover >', () => {
 
   function getCompiledElement() {
     const element = $compile(angular.element(
-      `<div><toggle-button-popover button-title="model.title"
-                                   button-state="model.state"
-                                   button-on-change="model.onChange(state)"
-                                   che-popover-placement="right-top">
-        <div>{{model.content}}</div>
-      </toggle-button-popover></div>`
+      `<div><toggle-single-button che-title="{{model.title}}"
+                                  che-state="model.state"
+                                  che-on-change="model.onChange(state)">
+      </toggle-single-button></div>`
     ))($rootScope);
     $rootScope.$digest();
     return element;
@@ -88,13 +85,6 @@ describe('CheToggleButtonPopover >', () => {
       toggleSingleButton = compiledDirective.find('button');
     });
 
-    it('should have content hidden', () => {
-      // timeout should be flashed
-      $timeout.flush();
-
-      expect(compiledDirective.html()).not.toContain($rootScope.model.content);
-    });
-
     it('should have button disabled', () => {
       // timeout should be flashed
       $timeout.flush();
@@ -105,19 +95,10 @@ describe('CheToggleButtonPopover >', () => {
 
     describe('click on button >', () => {
 
-      beforeEach(() => {
+      it('should enable button', () => {
         toggleSingleButton.click();
         $rootScope.$digest();
-      });
 
-      it('should make content visible', () => {
-        // timeout should be flashed to get callback called and content visible
-        $timeout.flush();
-
-        expect(compiledDirective.html()).toContain($rootScope.model.content);
-      });
-
-      it('should enable button', () => {
         // timeout should be flashed to get callback called and content visible
         $timeout.flush();
 
@@ -126,6 +107,9 @@ describe('CheToggleButtonPopover >', () => {
 
       it('should call the callback', () => {
         spyOn($rootScope.model, 'onChange');
+
+        toggleSingleButton.click();
+        $rootScope.$digest();
 
         // timeout should be flashed to get callback called and content visible
         $timeout.flush();
@@ -137,20 +121,9 @@ describe('CheToggleButtonPopover >', () => {
 
     describe(`change state of toggle button from outside of directive >`, () => {
 
-      beforeEach(() => {
+      it('should enable button', () => {
         $rootScope.model.state = true;
         $rootScope.$digest();
-      });
-
-      it('should make content visible', () => {
-        // timeout should be flashed to get callback called and content visible
-        $timeout.flush();
-
-        expect(compiledDirective.html()).toContain($rootScope.model.content);
-      });
-
-      it('should enable button', () => {
-        const toggleSingleButton = compiledDirective.find('button');
 
         // timeout should be flashed to get callback called and content visible
         $timeout.flush();
@@ -160,6 +133,9 @@ describe('CheToggleButtonPopover >', () => {
 
       it('should call the callback', () => {
         spyOn($rootScope.model, 'onChange');
+
+        $rootScope.model.state = true;
+        $rootScope.$digest();
 
         // timeout should be flashed to get callback called and content visible
         $timeout.flush();
@@ -183,10 +159,6 @@ describe('CheToggleButtonPopover >', () => {
       $timeout.flush();
     });
 
-    it('should have content visible', () => {
-      expect(compiledDirective.html()).toContain($rootScope.model.content);
-    });
-
     it('should have button enabled', () => {
       expect(toggleSingleButton.get(0)).toBeTruthy();
       expect(toggleSingleButton.hasClass('toggle-single-button-disabled')).toBeFalsy();
@@ -194,23 +166,9 @@ describe('CheToggleButtonPopover >', () => {
 
     describe('click on button >', () => {
 
-      beforeEach(() => {
+      it('should disable button', () => {
         toggleSingleButton.click();
         $rootScope.$digest();
-      });
-
-      it('should make content hidden', () => {
-        // timeout should be flashed to get callback called and content hidden
-        $timeout.flush();
-        $timeout.flush();
-
-        expect(compiledDirective.html()).not.toContain($rootScope.model.content);
-      });
-
-      it('should disable button', () => {
-        // timeout should be flashed to get callback called and content hidden
-        $timeout.flush();
-        $timeout.flush();
 
         expect(toggleSingleButton.hasClass('toggle-single-button-disabled')).toBeTruthy();
       });
@@ -218,9 +176,8 @@ describe('CheToggleButtonPopover >', () => {
       it('should call the callback', () => {
         spyOn($rootScope.model, 'onChange');
 
-        // timeout should be flashed to get callback called and content hidden
-        $timeout.flush();
-        $timeout.flush();
+        toggleSingleButton.click();
+        $rootScope.$digest();
 
         expect($rootScope.model.onChange).toHaveBeenCalledWith(false);
       });
@@ -229,23 +186,9 @@ describe('CheToggleButtonPopover >', () => {
 
     describe(`change state of toggle button from outside of directive >`, () => {
 
-      beforeEach(() => {
+      it('should disable button', () => {
         $rootScope.model.state = false;
         $rootScope.$digest();
-      });
-
-      it('should make content hidden', () => {
-        // timeout should be flashed to get callback called and content hidden
-        $timeout.flush();
-        $timeout.flush();
-
-        expect(compiledDirective.html()).not.toContain($rootScope.model.content);
-      });
-
-      it('should disable button', () => {
-        // timeout should be flashed to get callback called and content hidden
-        $timeout.flush();
-        $timeout.flush();
 
         expect(toggleSingleButton.hasClass('toggle-single-button-disabled')).toBeTruthy();
       });
@@ -253,9 +196,8 @@ describe('CheToggleButtonPopover >', () => {
       it('should call the callback', () => {
         spyOn($rootScope.model, 'onChange');
 
-        // timeout should be flashed to get callback called and content hidden
-        $timeout.flush();
-        $timeout.flush();
+        $rootScope.model.state = false;
+        $rootScope.$digest();
 
         expect($rootScope.model.onChange).toHaveBeenCalledWith(false);
       });

--- a/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
@@ -24,11 +24,12 @@
  * @param {expression=} che-multiline-title allows multi line title if attr exists
  * @param {string=} che-font-icon button's icon CSS class
  * @param {expression=} che-state expression which defines state of button.
+ * @param {expression=} che-value expression which defines value of button
  * @param {Function} che-on-change callback on model change
  * @usage
  *   <toggle-single-button che-title="Filter"
  *                         che-state="ctrl.filterInitState"
- *                         che-on-change="ctrl.filterStateOnChange(state)"></toggle-single-button>
+ *                         che-on-change="ctrl.filterStateOnChange(state, value)"></toggle-single-button>
  *
  * @author Oleksii Kurinnyi
  */
@@ -38,8 +39,8 @@ interface IToggleSingleButtonAttrs extends ng.IAttributes {
 }
 
 interface IToggleSingleButtonScope extends ng.IScope {
-  init?: boolean;
-  state?: boolean;
+  state: boolean;
+  changeState: () => void;
   onChange: (data: {state: boolean}) => void;
   multilineTitle?: string;
 }
@@ -64,39 +65,30 @@ export class ToggleSingleButton {
   constructor() {
     // scope values
     this.scope = {
-      init: '=?cheState',
-      state: '=?cheValue',
+      state: '=?cheState',
       title: '@cheTitle',
       multilineTitle: '=?cheMultilineTitle',
       fontIcon: '@?cheFontIcon',
-      onChange: '&cheOnChange'
+      onChange: '&?cheOnChange'
     };
 
   }
 
   link($scope: IToggleSingleButtonScope, $element: ng.IAugmentedJQuery, $attrs: IToggleSingleButtonAttrs): void {
+
     if (angular.isDefined($attrs.cheMultilineTitle)) {
       $scope.multilineTitle = 'true';
     }
 
-    const watcher1 = $scope.$watch(() => { return $scope.init; }, () => {
-      if ($scope.init === null) {
-        return;
-      }
-      $scope.state = !!$scope.init;
-      $scope.init = null;
-    });
-
-    const watcher2 = $scope.$watch(() => { return $scope.state; }, (newValue: boolean, oldValue: boolean) => {
+    const watcher = $scope.$watch(() => { return $scope.state; }, (newValue: boolean, oldValue: boolean) => {
       if (newValue === oldValue) {
         return;
       }
-      $scope.onChange({state: newValue});
+      $scope.onChange({state: $scope.state});
     });
 
     $scope.$on('$destroy', () => {
-      watcher1();
-      watcher2();
+      watcher();
     });
   }
 

--- a/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
@@ -23,7 +23,7 @@
  * @param {string} che-title button's title
  * @param {expression=} che-multiline-title allows multi line title if attr exists
  * @param {string=} che-font-icon button's icon CSS class
- * @param {expression=} che-state expression which defines initial state of button.
+ * @param {expression=} che-state expression which defines state of button.
  * @param {Function} che-on-change callback on model change
  * @usage
  *   <toggle-single-button che-title="Filter"
@@ -33,10 +33,15 @@
  * @author Oleksii Kurinnyi
  */
 
+interface IToggleSingleButtonAttrs extends ng.IAttributes {
+  cheMultilineTitle?: boolean;
+}
+
 interface IToggleSingleButtonScope extends ng.IScope {
   init?: boolean;
   state?: boolean;
   onChange: (data: {state: boolean}) => void;
+  multilineTitle?: string;
 }
 
 /**
@@ -69,23 +74,29 @@ export class ToggleSingleButton {
 
   }
 
-  link($scope: IToggleSingleButtonScope, $element: ng.IAugmentedJQuery, $attrs: ng.IAttributes): void {
+  link($scope: IToggleSingleButtonScope, $element: ng.IAugmentedJQuery, $attrs: IToggleSingleButtonAttrs): void {
     if (angular.isDefined($attrs.cheMultilineTitle)) {
       $scope.multilineTitle = 'true';
     }
 
-    if ($scope.init) {
-      $scope.state = $scope.init;
-      $scope.onChange({state: true});
-    }
-    const watcher = $scope.$watch(() => { return $scope.state; }, (newValue: boolean, oldValue: boolean) => {
+    const watcher1 = $scope.$watch(() => { return $scope.init; }, () => {
+      if ($scope.init === null) {
+        return;
+      }
+      $scope.state = !!$scope.init;
+      $scope.init = null;
+    });
+
+    const watcher2 = $scope.$watch(() => { return $scope.state; }, (newValue: boolean, oldValue: boolean) => {
       if (newValue === oldValue) {
         return;
       }
       $scope.onChange({state: newValue});
     });
+
     $scope.$on('$destroy', () => {
-      watcher();
+      watcher1();
+      watcher2();
     });
   }
 

--- a/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
@@ -24,12 +24,11 @@
  * @param {expression=} che-multiline-title allows multi line title if attr exists
  * @param {string=} che-font-icon button's icon CSS class
  * @param {expression=} che-state expression which defines state of button.
- * @param {expression=} che-value expression which defines value of button
  * @param {Function} che-on-change callback on model change
  * @usage
  *   <toggle-single-button che-title="Filter"
  *                         che-state="ctrl.filterInitState"
- *                         che-on-change="ctrl.filterStateOnChange(state, value)"></toggle-single-button>
+ *                         che-on-change="ctrl.filterStateOnChange(state)"></toggle-single-button>
  *
  * @author Oleksii Kurinnyi
  */


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- adds the possibility to close the popover by Esc button
- adds the possibility to close the popover by the left click outside it
- single left click on a suggestion makes it highlighted, double left click on a suggestion makes tag selected
- highlight the icon on Filters button with primary color when the filter is active and popover is closed

### What issues does this PR fix or reference?
fixes #5599 

#### Changelog
<!-- one line entry to be added to changelog -->
Added improvements for Filters widget.

#### Release Notes
n/a


#### Docs PR
n/a
