### PR TITLE
CHE-5643. Add ability to select items in the quick fix window using keyboard

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/popup/PopupKeyDownListener.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/popup/PopupKeyDownListener.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ui.popup;
 
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.util.dom.Elements;
+
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.dom.client.KeyCodes;
@@ -81,6 +83,7 @@ public class PopupKeyDownListener implements EventListener {
         if (current.getParentElement().isEqualNode(listElement)) {
             final Element next = current.getNextElementSibling();
             if (next != null) {
+                select(next);
                 next.focus();
             } else {
                 focusFirst();
@@ -100,6 +103,7 @@ public class PopupKeyDownListener implements EventListener {
         if (current.getParentElement().isEqualNode(listElement)) {
             final Element prev = current.getPreviousElementSibling();
             if (prev != null) {
+                select(prev);
                 prev.focus();
             } else {
                 focusLast();
@@ -114,8 +118,10 @@ public class PopupKeyDownListener implements EventListener {
      * Focus the first item in the list (if any).
      */
     private void focusFirst() {
-        if (this.listElement.hasChildNodes()) {
-            this.listElement.getFirstElementChild().focus();
+        if (listElement.hasChildNodes()) {
+            Element firstElement = listElement.getFirstElementChild();
+            select(firstElement);
+            firstElement.focus();
         }
     }
 
@@ -123,8 +129,10 @@ public class PopupKeyDownListener implements EventListener {
      * Focus the last item in the list (if any).
      */
     private void focusLast() {
-        if (this.listElement.hasChildNodes()) {
-            this.listElement.getLastElementChild().focus();
+        if (listElement.hasChildNodes()) {
+            Element lastElement = listElement.getLastElementChild();
+            select(lastElement);
+            lastElement.focus();
         }
     }
 
@@ -136,5 +144,35 @@ public class PopupKeyDownListener implements EventListener {
         if (current.getParentElement().isEqualNode(listElement)) {
             this.popupWidget.validateItem(current);
         }
+    }
+
+    private void select(Element elementToSelect) {
+        if (elementToSelect == null) {
+            return;
+        }
+
+        Element currentSelectedElement = getSelectedElement();
+        if (currentSelectedElement == null) {
+            elementToSelect.setAttribute("selected", "true");
+            return;
+        }
+
+        if (currentSelectedElement.isEqualNode(elementToSelect)) {
+            return;
+        }
+
+        currentSelectedElement.removeAttribute("selected");
+        elementToSelect.setAttribute("selected", "true");
+    }
+
+    /**
+     * Returns current selected element when we have an item in focus or {@code null} otherwise
+     *
+     * @return current selected element or {@code null} when we have no any items in focus
+     */
+    @Nullable
+    private Element getSelectedElement() {
+        Element selectedElement = Elements.getDocument().getActiveElement();
+        return selectedElement.getParentElement().isEqualNode(listElement) ? selectedElement : null;
     }
 }

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/popup/PopupWidget.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/popup/PopupWidget.java
@@ -164,7 +164,9 @@ public abstract class PopupWidget<T> {
         if (needsFocus()) {
             // save previous focus and set focus in popup
             previousFocus = Elements.getDocument().getActiveElement();
-            listElement.getFirstElementChild().focus();
+            Element elementToFocus = listElement.getFirstElementChild();
+            elementToFocus.setAttribute("selected", "true");
+            elementToFocus.focus();
         }
 
         // add key event listener on popup

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCompletionProposal.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCompletionProposal.java
@@ -121,7 +121,7 @@ public class JavaCompletionProposal implements CompletionProposal, CompletionPro
 
                 if (file instanceof Resource) {
                     final ChangeInfo changeInfo = result.getChangeInfo();
-                    if (changeInfo != null) {
+                    if (changeInfo != null && changeInfo.getName() != null) {
                         refactoringUpdater.updateAfterRefactoring(singletonList(changeInfo));
                     }
                 }


### PR DESCRIPTION
### What does this PR do?
Add ability to select items in the quick fix window using keyboard

### What issues does this PR fix or reference?
#5643

#### Changelog
Add ability to select items in the quick fix window using keyboard

![quick_fix_window](https://user-images.githubusercontent.com/5676062/28421954-53df9350-6d6f-11e7-98c9-05cf8d24cc63.gif)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>