### PR TITLE
Rename methods in AppContext interface

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/app/AppContext.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/app/AppContext.java
@@ -175,7 +175,7 @@ public interface AppContext {
     WorkspaceImpl getWorkspace();
 
     /** Returns URL of Che Master API endpoint. */
-    String getMasterEndpoint();
+    String getMasterApiEndpoint();
 
     /**
      * Returns URL of ws-agent server API endpoint.
@@ -183,7 +183,7 @@ public interface AppContext {
      * @throws RuntimeException
      *         if ws-agent server doesn't exist. Normally it may happen when workspace is stopped.
      */
-    String getDevAgentEndpoint();
+    String getWsAgentServerApiEndpoint();
 
     /**
      * Returns web application identifier. Most obvious use - to distinguish web applications

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/debug/DebuggerServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/debug/DebuggerServiceClientImpl.java
@@ -187,7 +187,7 @@ public class DebuggerServiceClientImpl implements DebuggerServiceClient {
     }
 
     private String getBaseUrl(String id) {
-        final String url = appContext.getDevAgentEndpoint() + "/debugger";
+        final String url = appContext.getWsAgentServerApiEndpoint() + "/debugger";
         if (id != null) {
             return url + "/" + id;
         }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/ssh/SshServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/ssh/SshServiceClientImpl.java
@@ -45,7 +45,7 @@ public class SshServiceClientImpl implements SshServiceClient {
         this.dtoFactory = dtoFactory;
         this.asyncRequestFactory = asyncRequestFactory;
         this.unmarshallerFactory = unmarshallerFactory;
-        this.sshApi = appContext.getMasterEndpoint() + "/ssh";
+        this.sshApi = appContext.getMasterApiEndpoint() + "/ssh";
     }
 
     /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadWsAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadWsAction.java
@@ -58,7 +58,7 @@ public class DownloadWsAction extends AbstractPerspectiveAction {
     /** {@inheritDoc} */
     @Override
     public void actionPerformed(ActionEvent e) {
-        downloadContainer.setUrl(wsAgentURLModifier.modify(appContext.getDevAgentEndpoint() + "/project/export/"));
+        downloadContainer.setUrl(wsAgentURLModifier.modify(appContext.getWsAgentServerApiEndpoint() + "/project/export/"));
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/CurrentUserInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/CurrentUserInitializer.java
@@ -92,7 +92,7 @@ class CurrentUserInitializer {
     }
 
     private Promise<ProfileDto> getUserProfile() {
-        return asyncRequestFactory.createGetRequest(appContext.getMasterEndpoint() + "/profile/")
+        return asyncRequestFactory.createGetRequest(appContext.getMasterApiEndpoint() + "/profile/")
                                   .header(ACCEPT, APPLICATION_JSON)
                                   .send(dtoUnmarshallerFactory.newUnmarshaller(ProfileDto.class));
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -398,12 +398,12 @@ public class AppContextImpl implements AppContext,
     }
 
     @Override
-    public String getMasterEndpoint() {
+    public String getMasterApiEndpoint() {
         return getMasterApiPathFromIDEConfig();
     }
 
     @Override
-    public String getDevAgentEndpoint() {
+    public String getWsAgentServerApiEndpoint() {
         RuntimeImpl runtime = getWorkspace().getRuntime();
         Optional<ServerImpl> wsAgentServer = runtime.getWsAgentServer();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/utils/FactoryProjectImporter.java
@@ -104,7 +104,7 @@ public class FactoryProjectImporter extends AbstractImporter {
         this.notificationManager = notificationManager;
         this.askCredentialsDialog = askCredentialsDialog;
         this.locale = locale;
-        this.restContext = appContext.getMasterEndpoint();
+        this.restContext = appContext.getMasterApiEndpoint();
         this.dialogFactory = dialogFactory;
         this.oAuth2AuthenticatorRegistry = oAuth2AuthenticatorRegistry;
         this.requestTransmitter = requestTransmitter;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/preferences/PreferencesManagerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/preferences/PreferencesManagerImpl.java
@@ -45,7 +45,7 @@ public class PreferencesManagerImpl implements PreferencesManager {
         this.persistedPreferences = new HashMap<>();
         this.changedPreferences = new HashMap<>();
 
-        PREFERENCES_SERVICE_ENDPOINT = appContext.getMasterEndpoint() + "/preferences";
+        PREFERENCES_SERVICE_ENDPOINT = appContext.getMasterApiEndpoint() + "/preferences";
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectServiceClient.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectServiceClient.java
@@ -38,12 +38,9 @@ import java.util.Map;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.gwt.http.client.RequestBuilder.DELETE;
-import static com.google.gwt.http.client.RequestBuilder.POST;
 import static com.google.gwt.http.client.RequestBuilder.PUT;
 import static org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper.createFromAsyncRequest;
-import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
 import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
-import static org.eclipse.che.ide.rest.HTTPHeader.CONTENTTYPE;
 import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
 
 /**
@@ -501,7 +498,7 @@ public class ProjectServiceClient {
      * @since 4.4.0
      */
     private String getBaseUrl() {
-        return appContext.getDevAgentEndpoint() + PROJECT;
+        return appContext.getWsAgentServerApiEndpoint() + PROJECT;
     }
 
     /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectImporter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/ProjectImporter.java
@@ -200,7 +200,7 @@ public class ProjectImporter extends AbstractImporter {
                     authenticator = oAuth2AuthenticatorRegistry.getAuthenticator("default");
                 }
 
-                authenticator.authenticate(OAuth2AuthenticatorUrlProvider.get(appContext.getMasterEndpoint(), authenticateUrl),
+                authenticator.authenticate(OAuth2AuthenticatorUrlProvider.get(appContext.getMasterApiEndpoint(), authenticateUrl),
                                            new AsyncCallback<OAuthStatus>() {
                                                @Override
                                                public void onFailure(Throwable caught) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/mainpage/MainPagePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/mainpage/MainPagePresenter.java
@@ -206,7 +206,7 @@ public class MainPagePresenter extends AbstractWizardPage<MutableProjectConfig> 
 
     /** Fetch project importers from the server. */
     private void fetchProjectImporters(AsyncRequestCallback<ProjectImporterData> callback) {
-        asyncRequestFactory.createGetRequest(appContext.getDevAgentEndpoint() + "/project-importers")
+        asyncRequestFactory.createGetRequest(appContext.getWsAgentServerApiEndpoint() + "/project-importers")
                            .header(HTTPHeader.CONTENT_TYPE, MimeType.APPLICATION_JSON)
                            .send(callback);
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/ProjectTemplateRegistryImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/ProjectTemplateRegistryImpl.java
@@ -69,7 +69,7 @@ public class ProjectTemplateRegistryImpl implements ProjectTemplateRegistry {
     }
 
     private Promise<List<ProjectTemplateDescriptor>> fetchTemplates() {
-        final String baseUrl = appContext.getMasterEndpoint() + "/project-template/all";
+        final String baseUrl = appContext.getMasterApiEndpoint() + "/project-template/all";
 
         return asyncRequestFactory.createGetRequest(baseUrl)
                                   .header(ACCEPT, APPLICATION_JSON)

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/ProjectTypeRegistryImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/ProjectTypeRegistryImpl.java
@@ -91,7 +91,7 @@ public class ProjectTypeRegistryImpl implements ProjectTypeRegistry {
     }
 
     private Promise<List<ProjectTypeDto>> fetchProjectTypes() {
-        final String url = appContext.getDevAgentEndpoint() + "/project-type";
+        final String url = appContext.getWsAgentServerApiEndpoint() + "/project-type";
 
         return asyncRequestFactory.createGetRequest(url)
                                   .header(ACCEPT, APPLICATION_JSON)

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -1168,7 +1168,7 @@ public final class ResourceManager {
     protected String getUrl(Resource resource) {
         checkArgument(!resource.getLocation().isRoot(), "Workspace root doesn't have export URL");
 
-        final String baseUrl = appContext.getDevAgentEndpoint() + "/project/export";
+        final String baseUrl = appContext.getWsAgentServerApiEndpoint() + "/project/export";
 
         if (resource.getResourceType() == FILE) {
             return baseUrl + "/file" + resource.getLocation();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/file/UploadFilePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/file/UploadFilePresenter.java
@@ -73,7 +73,7 @@ public class UploadFilePresenter implements UploadFileView.ActionDelegate {
     public void showDialog(Container container) {
         this.container = container;
         view.showDialog();
-        view.setAction(appContext.getDevAgentEndpoint() + "/project/uploadfile" + container.getLocation());
+        view.setAction(appContext.getWsAgentServerApiEndpoint() + "/project/uploadfile" + container.getLocation());
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/folder/UploadFolderFromZipPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/upload/folder/UploadFolderFromZipPresenter.java
@@ -58,7 +58,7 @@ public class UploadFolderFromZipPresenter implements UploadFolderFromZipView.Act
     public void showDialog(Container container) {
         this.container = container;
         view.showDialog();
-        view.setAction(appContext.getDevAgentEndpoint() + "/project/upload/zipfolder" + container.getLocation());
+        view.setAction(appContext.getWsAgentServerApiEndpoint() + "/project/upload/zipfolder" + container.getLocation());
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClient.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceServiceClient.java
@@ -54,7 +54,7 @@ public class WorkspaceServiceClient {
         this.dtoFactory = dtoFactory;
         this.asyncRequestFactory = asyncRequestFactory;
         this.loaderFactory = loaderFactory;
-        this.baseHttpUrl = appContext.getMasterEndpoint() + "/workspace";
+        this.baseHttpUrl = appContext.getMasterApiEndpoint() + "/workspace";
     }
 
     /**

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/DownloadWsActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/DownloadWsActionTest.java
@@ -65,7 +65,7 @@ public class DownloadWsActionTest {
     public void actionShouldBePerformed() throws Exception {
         String baseUrl = "baseUrl";
 
-        when(appContext.getDevAgentEndpoint()).thenReturn(baseUrl);
+        when(appContext.getWsAgentServerApiEndpoint()).thenReturn(baseUrl);
         when(wsAgentURLModifier.modify(anyString())).thenReturn(baseUrl);
 
         action.actionPerformed(actionEvent);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/project/ProjectServiceClientTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/project/ProjectServiceClientTest.java
@@ -59,7 +59,7 @@ public class ProjectServiceClientTest {
                                                         dtoFactory,
                                                         dtoUnmarshallerFactory,
                                                         appContext);
-        when(appContext.getDevAgentEndpoint()).thenReturn("");
+        when(appContext.getWsAgentServerApiEndpoint()).thenReturn("");
     }
 
     @Test

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitServiceClientImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitServiceClientImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.che.api.git.shared.BranchListMode;
 import org.eclipse.che.api.git.shared.CheckoutRequest;
 import org.eclipse.che.api.git.shared.CloneRequest;
 import org.eclipse.che.api.git.shared.CommitRequest;
-import org.eclipse.che.api.git.shared.Commiters;
 import org.eclipse.che.api.git.shared.DiffType;
 import org.eclipse.che.api.git.shared.FetchRequest;
 import org.eclipse.che.api.git.shared.LogResponse;
@@ -430,6 +429,6 @@ public class GitServiceClientImpl implements GitServiceClient {
     }
 
     private String getWsAgentBaseUrl() {
-        return appContext.getDevAgentEndpoint();
+        return appContext.getWsAgentServerApiEndpoint();
     }
 }

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/GitHubClientServiceImpl.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/GitHubClientServiceImpl.java
@@ -76,7 +76,7 @@ public class GitHubClientServiceImpl implements GitHubClientService {
 
 
     private String baseUrl() {
-        return appContext.getDevAgentEndpoint() + "/github";
+        return appContext.getWsAgentServerApiEndpoint() + "/github";
     }
 
     @Override

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/GitHubSshKeyUploader.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/GitHubSshKeyUploader.java
@@ -58,7 +58,7 @@ public class GitHubSshKeyUploader implements SshKeyUploader, OAuthCallback {
                                 DialogFactory dialogFactory,
                                 AppContext appContext) {
         this.gitHubService = gitHubService;
-        this.baseUrl = appContext.getMasterEndpoint();
+        this.baseUrl = appContext.getMasterApiEndpoint();
         this.constant = constant;
         this.notificationManager = notificationManager;
         this.productInfoDataProvider = productInfoDataProvider;

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/authenticator/GitHubAuthenticatorImpl.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/authenticator/GitHubAuthenticatorImpl.java
@@ -73,7 +73,7 @@ public class GitHubAuthenticatorImpl implements OAuth2Authenticator, OAuthCallba
         this.view = view;
         this.view.setDelegate(this);
         this.locale = locale;
-        this.baseUrl = appContext.getMasterEndpoint();
+        this.baseUrl = appContext.getMasterApiEndpoint();
         this.dialogFactory = dialogFactory;
         this.notificationManager = notificationManager;
         this.appContext = appContext;

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
@@ -84,7 +84,7 @@ public class GithubImporterPagePresenter extends AbstractWizardPage<MutableProje
                                        AppContext appContext,
                                        GitHubLocalizationConstant locale) {
         this.view = view;
-        this.baseUrl = appContext.getMasterEndpoint();
+        this.baseUrl = appContext.getMasterApiEndpoint();
         this.appContext = appContext;
         this.gitHubAuthenticator = gitHubAuthenticatorRegistry.getAuthenticator("github");
         this.gitHubClientService = gitHubClientService;

--- a/plugins/plugin-github/che-plugin-github-pullrequest/src/main/java/org/eclipse/che/plugin/pullrequest/client/GitHubHostingService.java
+++ b/plugins/plugin-github/che-plugin-github-pullrequest/src/main/java/org/eclipse/che/plugin/pullrequest/client/GitHubHostingService.java
@@ -83,7 +83,7 @@ public class GitHubHostingService implements VcsHostingService {
         this.dtoFactory = dtoFactory;
         this.gitHubClientService = gitHubClientService;
         this.templates = templates;
-        this.baseUrl = appContext.getMasterEndpoint();
+        this.baseUrl = appContext.getMasterApiEndpoint();
     }
 
     @Override

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/documentation/QuickDocPresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/documentation/QuickDocPresenter.java
@@ -78,7 +78,7 @@ public class QuickDocPresenter implements QuickDocumentation, QuickDocView.Actio
 
             final String fqn = JavaUtil.resolveFQN((Container)srcFolder.get(), resource);
 
-            final String docUrl = appContext.getDevAgentEndpoint() + "/java/javadoc/find?fqn=" + fqn + "&projectpath=" + project.get().getLocation() + "&offset=" + offset;
+            final String docUrl = appContext.getWsAgentServerApiEndpoint() + "/java/javadoc/find?fqn=" + fqn + "&projectpath=" + project.get().getLocation() + "&offset=" + offset;
 
             view.show(agentURLDecorator.modify(docUrl), coordinates.getX(), coordinates.getY());
         }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCodeAssistClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaCodeAssistClient.java
@@ -66,14 +66,14 @@ public class JavaCodeAssistClient {
     }
 
     public void computeProposals(String projectPath, String fqn, int offset, String contents, AsyncRequestCallback<Proposals> callback) {
-        String url = appContext.getDevAgentEndpoint() + CODE_ASSIST_URL_PREFIX + "/compute/completion" + "/?projectpath=" +
+        String url = appContext.getWsAgentServerApiEndpoint() + CODE_ASSIST_URL_PREFIX + "/compute/completion" + "/?projectpath=" +
                      projectPath + "&fqn=" + fqn + "&offset=" + offset;
         asyncRequestFactory.createPostRequest(url, null).data(contents).send(callback);
     }
 
     public void computeAssistProposals(String projectPath, String fqn, int offset, List<Problem> problems,
                                        AsyncRequestCallback<Proposals> callback) {
-        String url = appContext.getDevAgentEndpoint() + CODE_ASSIST_URL_PREFIX + "/compute/assist" + "/?projectpath=" +
+        String url = appContext.getWsAgentServerApiEndpoint() + CODE_ASSIST_URL_PREFIX + "/compute/assist" + "/?projectpath=" +
                      projectPath + "&fqn=" + fqn + "&offset=" + offset;
         List<Problem> prob = new ArrayList<>();
         prob.addAll(problems);
@@ -82,7 +82,7 @@ public class JavaCodeAssistClient {
 
 
     public void applyProposal(String sessionId, int index, boolean insert, final AsyncCallback<ProposalApplyResult> callback) {
-        String url = appContext.getDevAgentEndpoint() + CODE_ASSIST_URL_PREFIX + "/apply/completion/?sessionid=" +
+        String url = appContext.getWsAgentServerApiEndpoint() + CODE_ASSIST_URL_PREFIX + "/apply/completion/?sessionid=" +
                      sessionId + "&index=" + index + "&insert=" + insert;
         Unmarshallable<ProposalApplyResult> unmarshaller = unmarshallerFactory.newUnmarshaller(ProposalApplyResult.class);
         asyncRequestFactory.createGetRequest(url).send(new AsyncRequestCallback<ProposalApplyResult>(unmarshaller) {
@@ -99,7 +99,7 @@ public class JavaCodeAssistClient {
     }
 
     public String getProposalDocUrl(int id, String sessionId) {
-        return urlDecorator.modify(appContext.getDevAgentEndpoint() +
+        return urlDecorator.modify(appContext.getWsAgentServerApiEndpoint() +
                                    CODE_ASSIST_URL_PREFIX + "/compute/info?sessionid=" + sessionId +
                                    "&index=" + id);
     }
@@ -126,7 +126,7 @@ public class JavaCodeAssistClient {
     }
 
     private Promise<List<Change>> getFormatChanges(final int offset, final int length, final String content) {
-        final String baseUrl = appContext.getDevAgentEndpoint();
+        final String baseUrl = appContext.getWsAgentServerApiEndpoint();
         final String url = baseUrl + CODE_ASSIST_URL_PREFIX + "/format?offset=" + offset + "&length=" + length;
         return asyncRequestFactory.createPostRequest(url, null)
                                   .header(CONTENT_TYPE, MimeType.TEXT_PLAIN)
@@ -145,7 +145,7 @@ public class JavaCodeAssistClient {
      */
     public Promise<OrganizeImportResult> organizeImports(String projectPath, String fqn) {
         String url =
-                appContext.getDevAgentEndpoint() + CODE_ASSIST_URL_PREFIX + "/organize-imports?projectpath=" + projectPath +
+                appContext.getWsAgentServerApiEndpoint() + CODE_ASSIST_URL_PREFIX + "/organize-imports?projectpath=" + projectPath +
                 "&fqn=" + fqn;
         return asyncRequestFactory.createPostRequest(url, null)
                                   .loader(loader)
@@ -161,7 +161,7 @@ public class JavaCodeAssistClient {
      *         fully qualified name of the java file
      */
     public Promise<List<Change>> applyChosenImports(String projectPath, String fqn, ConflictImportDTO chosen) {
-        String url = appContext.getDevAgentEndpoint() + CODE_ASSIST_URL_PREFIX + "/apply-imports?projectpath=" + projectPath +
+        String url = appContext.getWsAgentServerApiEndpoint() + CODE_ASSIST_URL_PREFIX + "/apply-imports?projectpath=" + projectPath +
                      "&fqn=" + fqn;
         return asyncRequestFactory.createPostRequest(url, chosen)
                                   .loader(loader)

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcileClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcileClient.java
@@ -75,7 +75,7 @@ public class JavaReconcileClient {
     /** @deprecated in favor of {@link #reconcile(String, String)} */
     @Deprecated
     public void reconcile(String projectPath, String fqn, final ReconcileCallback callback) {
-        String url = appContext.getDevAgentEndpoint() + "/java/reconcile/?projectpath=" + projectPath + "&fqn=" + fqn;
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/reconcile/?projectpath=" + projectPath + "&fqn=" + fqn;
         asyncRequestFactory.createGetRequest(url)
                            .send(new AsyncRequestCallback<ReconcileResult>(dtoUnmarshallerFactory.newUnmarshaller(ReconcileResult.class)) {
                                @Override

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/service/JavaNavigationServiceImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/service/JavaNavigationServiceImpl.java
@@ -59,7 +59,7 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public void findDeclaration(String projectPath, String fqn, int offset, AsyncRequestCallback<OpenDeclarationDescriptor> callback) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/find-declaration" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/find-declaration" +
                      "?projectpath=" + projectPath.toString() + "&fqn=" + fqn + "&offset=" + offset;
         requestFactory.createGetRequest(url).send(callback);
     }
@@ -67,34 +67,34 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
     @Override
     public Promise<OpenDeclarationDescriptor> findDeclaration(Path project, String fqn, int offset) {
         String url =
-                appContext.getDevAgentEndpoint() + "/java/navigation/find-declaration?projectpath=" + project.toString() + "&fqn=" + fqn +
+                appContext.getWsAgentServerApiEndpoint() + "/java/navigation/find-declaration?projectpath=" + project.toString() + "&fqn=" + fqn +
                 "&offset=" + offset;
         return requestFactory.createGetRequest(url).send(unmarshallerFactory.newUnmarshaller(OpenDeclarationDescriptor.class));
     }
 
     public void getExternalLibraries(String projectPath, AsyncRequestCallback<List<Jar>> callback) {
         String url =
-                appContext.getDevAgentEndpoint() + "/java/navigation/libraries?projectpath=" + projectPath;
+                appContext.getWsAgentServerApiEndpoint() + "/java/navigation/libraries?projectpath=" + projectPath;
         requestFactory.createGetRequest(url).send(callback);
     }
 
     @Override
     public Promise<List<Jar>> getExternalLibraries(Path project) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/libraries?projectpath=" + project.toString();
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/libraries?projectpath=" + project.toString();
 
         return requestFactory.createGetRequest(url).send(unmarshallerFactory.newListUnmarshaller(Jar.class));
     }
 
     @Override
     public void getLibraryChildren(String projectPath, int libId, AsyncRequestCallback<List<JarEntry>> callback) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/lib/children" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/lib/children" +
                      "?projectpath=" + projectPath + "&root=" + libId;
         requestFactory.createGetRequest(url).send(callback);
     }
 
     @Override
     public Promise<List<JarEntry>> getLibraryChildren(Path project, int libId) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/lib/children?projectpath=" + project.toString() +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/lib/children?projectpath=" + project.toString() +
                      "&root=" + libId;
 
         return requestFactory.createGetRequest(url).send(unmarshallerFactory.newListUnmarshaller(JarEntry.class));
@@ -102,21 +102,21 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public void getChildren(String projectPath, int libId, String path, AsyncRequestCallback<List<JarEntry>> callback) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/children" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/children" +
                      "?projectpath=" + projectPath + "&root=" + libId + "&path=" + path;
         requestFactory.createGetRequest(url).send(callback);
     }
 
     @Override
     public Promise<List<JarEntry>> getChildren(Path project, int libId, Path path) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/children?projectpath=" + project.toString() + "&root=" + libId +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/children?projectpath=" + project.toString() + "&root=" + libId +
                      "&path=" + path.toString();
         return requestFactory.createGetRequest(url).send(unmarshallerFactory.newListUnmarshaller(JarEntry.class));
     }
 
     @Override
     public void getEntry(String projectPath, int libId, String path, AsyncRequestCallback<JarEntry> callback) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/entry" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/entry" +
                      "?projectpath=" + projectPath + "&root=" + libId + "&path=" + path;
         requestFactory.createGetRequest(url).send(callback);
     }
@@ -124,7 +124,7 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
     @Override
     public Promise<JarEntry> getEntry(Path project, int libId, String path) {
         String url =
-                appContext.getDevAgentEndpoint() + "/java/navigation/entry?projectpath=" + project.toString() + "&root=" + libId +
+                appContext.getWsAgentServerApiEndpoint() + "/java/navigation/entry?projectpath=" + project.toString() + "&root=" + libId +
                 "&path=" + path;
         return requestFactory.createGetRequest(url).send(unmarshallerFactory.newUnmarshaller(JarEntry.class));
     }
@@ -145,19 +145,19 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public void getContent(String projectPath, String fqn, AsyncRequestCallback<ClassContent> callback) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/contentbyfqn?projectpath=" + projectPath + "&fqn=" + fqn;
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/contentbyfqn?projectpath=" + projectPath + "&fqn=" + fqn;
         requestFactory.createGetRequest(url).send(callback);
     }
 
     @Override
     public Promise<ClassContent> getContent(Path project, String fqn) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/contentbyfqn?projectpath=" + project.toString() + "&fqn=" + fqn;
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/contentbyfqn?projectpath=" + project.toString() + "&fqn=" + fqn;
         return requestFactory.createGetRequest(url).send(unmarshallerFactory.newUnmarshaller(ClassContent.class));
     }
 
     @Override
     public Promise<ImplementationsDescriptorDTO> getImplementations(Path project, String fqn, int offset) {
-        final String url = appContext.getDevAgentEndpoint() + "/java/navigation/implementations" +
+        final String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/implementations" +
                            "?projectpath=" + project.toString() + "&fqn=" + fqn + "&offset=" + offset;
 
         return requestFactory.createGetRequest(url)
@@ -168,7 +168,7 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public Promise<CompilationUnit> getCompilationUnit(Path project, String fqn, boolean showInherited) {
-        final String url = appContext.getDevAgentEndpoint() + "/java/navigation/compilation-unit" +
+        final String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/compilation-unit" +
                            "?projectpath=" + project.toString() + "&fqn=" + fqn + "&showinherited=" + showInherited;
 
         return requestFactory.createGetRequest(url)
@@ -178,7 +178,7 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public Promise<List<JavaProject>> getProjectsAndPackages(boolean includePackage) {
-        final String url = appContext.getDevAgentEndpoint() + "/java/navigation/get/projects/and/packages"
+        final String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/get/projects/and/packages"
                            + "?includepackages=" + includePackage;
 
         return requestFactory.createGetRequest(url)
@@ -189,13 +189,13 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public String getContentUrl(String projectPath, int libId, String path) {
-        return appContext.getDevAgentEndpoint() + "/java/navigation/content" +
+        return appContext.getWsAgentServerApiEndpoint() + "/java/navigation/content" +
                "?projectpath=" + projectPath + "&root=" + libId + "&path=" + path;
     }
 
     @Override
     public Promise<List<MethodParameters>> getMethodParametersHints(String projectPath, String fqn, int offset, int lineStartOffset) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/parameters" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/parameters" +
                      "?projectpath=" + projectPath + "&fqn=" + fqn + "&offset=" + offset + "&lineStart=" + lineStartOffset;
 
         return requestFactory.createGetRequest(url)
@@ -206,7 +206,7 @@ public class JavaNavigationServiceImpl implements JavaNavigationService {
 
     @Override
     public Promise<List<MethodParameters>> getMethodParametersHints(Path project, String fqn, int offset, int lineStartOffset) {
-        String url = appContext.getDevAgentEndpoint() + "/java/navigation/parameters" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/navigation/parameters" +
                      "?projectpath=" + project.toString() + "&fqn=" + fqn + "&offset=" + offset + "&lineStart=" + lineStartOffset;
 
         return requestFactory.createGetRequest(url)

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/classpath/service/ClasspathServiceClientImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/classpath/service/ClasspathServiceClientImpl.java
@@ -52,7 +52,7 @@ public class ClasspathServiceClientImpl implements ClasspathServiceClient {
 
     @Override
     public Promise<List<ClasspathEntryDto>> getClasspath(String projectPath) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "?projectpath=" + projectPath;
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "?projectpath=" + projectPath;
 
         return asyncRequestFactory.createGetRequest(url)
                                   .loader(loader)

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/service/RefactoringServiceClientImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/service/RefactoringServiceClientImpl.java
@@ -71,7 +71,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<String> createMoveRefactoring(final CreateMoveRefactoring moveRefactoring) {
-        return asyncRequestFactory.createPostRequest(appContext.getDevAgentEndpoint() + pathToService + "move/create", moveRefactoring)
+        return asyncRequestFactory.createPostRequest(appContext.getWsAgentServerApiEndpoint() + pathToService + "move/create", moveRefactoring)
                                   .header(ACCEPT, TEXT_PLAIN)
                                   .header(CONTENT_TYPE, APPLICATION_JSON)
                                   .loader(loader)
@@ -81,7 +81,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<RenameRefactoringSession> createRenameRefactoring(final CreateRenameRefactoring settings) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "rename/create";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "rename/create";
         return asyncRequestFactory.createPostRequest(url, settings)
                                   .header(ACCEPT, APPLICATION_JSON)
                                   .header(CONTENT_TYPE, APPLICATION_JSON)
@@ -92,7 +92,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<RefactoringResult> applyLinkedModeRename(final LinkedRenameRefactoringApply refactoringApply) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "rename/linked/apply";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "rename/linked/apply";
         return asyncRequestFactory.createPostRequest(url, refactoringApply)
                                   .header(ACCEPT, APPLICATION_JSON)
                                   .header(CONTENT_TYPE, APPLICATION_JSON)
@@ -103,7 +103,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<RefactoringStatus> setDestination(final ReorgDestination destination) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "set/destination";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "set/destination";
 
         return asyncRequestFactory.createPostRequest(url, destination)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -115,7 +115,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> setMoveSettings(final MoveSettings settings) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "set/move/setting";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "set/move/setting";
 
         return asyncRequestFactory.createPostRequest(url, settings)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -127,7 +127,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<ChangeCreationResult> createChange(final RefactoringSession session) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "create/change";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "create/change";
 
         return asyncRequestFactory.createPostRequest(url, session)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -139,7 +139,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<RefactoringPreview> getRefactoringPreview(final RefactoringSession session) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "get/preview";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "get/preview";
 
         return asyncRequestFactory.createPostRequest(url, session)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -151,7 +151,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<RefactoringResult> applyRefactoring(final RefactoringSession session) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "apply";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "apply";
 
         return asyncRequestFactory.createPostRequest(url, session)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -163,7 +163,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> changeChangeEnabledState(final ChangeEnabledState state) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "change/enabled";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "change/enabled";
 
         return asyncRequestFactory.createPostRequest(url, state)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -175,7 +175,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<ChangePreview> getChangePreview(final RefactoringChange change) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "change/preview";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "change/preview";
 
         return asyncRequestFactory.createPostRequest(url, change)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -187,7 +187,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<RefactoringStatus> validateNewName(final ValidateNewName newName) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "rename/validate/name";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "rename/validate/name";
 
         return asyncRequestFactory.createPostRequest(url, newName)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -199,7 +199,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> setRenameSettings(final RenameSettings settings) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "set/rename/settings";
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "set/rename/settings";
 
         return asyncRequestFactory.createPostRequest(url, settings)
                                   .header(ACCEPT, APPLICATION_JSON)
@@ -210,7 +210,7 @@ final class RefactoringServiceClientImpl implements RefactoringServiceClient {
 
     @Override
     public Promise<Void> reindexProject(String projectPath) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "reindex?projectpath=" + projectPath;
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "reindex?projectpath=" + projectPath;
 
         return asyncRequestFactory.createGetRequest(url)
                                   .loader(loader)

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/JavaSearchServiceRest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/JavaSearchServiceRest.java
@@ -46,7 +46,7 @@ public class JavaSearchServiceRest implements JavaSearchService {
         this.asyncRequestFactory = asyncRequestFactory;
         this.unmarshallerFactory = unmarshallerFactory;
         this.loader = loaderFactory.newLoader();
-        this.pathToService = appContext.getDevAgentEndpoint() + "/jdt/search/";
+        this.pathToService = appContext.getWsAgentServerApiEndpoint() + "/jdt/search/";
     }
 
     @Override

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/settings/service/SettingsServiceClientImpl.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/settings/service/SettingsServiceClientImpl.java
@@ -44,7 +44,7 @@ public class SettingsServiceClientImpl implements SettingsServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Void> applyCompileParameters(@NotNull final Map<String, String> parameters) {
-        String url = appContext.getDevAgentEndpoint() + "/java/compiler-settings/set";
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/compiler-settings/set";
 
         JsonSerializable data = new JsonSerializable() {
             @Override
@@ -62,7 +62,7 @@ public class SettingsServiceClientImpl implements SettingsServiceClient {
     /** {@inheritDoc} */
     @Override
     public Promise<Map<String, String>> getCompileParameters() {
-        String url = appContext.getDevAgentEndpoint() + "/java/compiler-settings/all";
+        String url = appContext.getWsAgentServerApiEndpoint() + "/java/compiler-settings/all";
 
         return asyncRequestFactory.createGetRequest(url)
                                   .header(ACCEPT, APPLICATION_JSON)

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/service/ClasspathUpdaterServiceClientImpl.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-ide/src/main/java/org/eclipse/che/plugin/java/plain/client/service/ClasspathUpdaterServiceClientImpl.java
@@ -48,7 +48,7 @@ public class ClasspathUpdaterServiceClientImpl implements ClasspathUpdaterServic
 
     @Override
     public Promise<Void> setRawClasspath(String projectPath, List<ClasspathEntryDto> entries) {
-        final String url = appContext.getDevAgentEndpoint() + pathToService + "update?projectpath=" + projectPath;
+        final String url = appContext.getWsAgentServerApiEndpoint() + pathToService + "update?projectpath=" + projectPath;
         return asyncRequestFactory.createPostRequest(url, entries)
                                   .loader(loader)
                                   .send();

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/LanguageServerRegistryServiceClient.java
@@ -47,7 +47,7 @@ public class LanguageServerRegistryServiceClient {
      * @return all supported languages
      */
     public Promise<List<LanguageDescription>> getSupportedLanguages() {
-        String requestUrl = appContext.getDevAgentEndpoint() + BASE_URI + "/supported";
+        String requestUrl = appContext.getWsAgentServerApiEndpoint() + BASE_URI + "/supported";
         return asyncRequestFactory.createGetRequest(requestUrl)
                                   .header(ACCEPT, APPLICATION_JSON)
                                   .send(unmarshallerFactory.newListUnmarshaller(LanguageDescription.class));

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
@@ -54,7 +54,7 @@ public class WorkspaceServiceClient {
      * @return
      */
     public Promise<List<SymbolInformation>> symbol(WorkspaceSymbolParams params) {
-        String requestUrl = appContext.getDevAgentEndpoint() + "/languageserver/workspace/symbol";
+        String requestUrl = appContext.getWsAgentServerApiEndpoint() + "/languageserver/workspace/symbol";
         Unmarshallable<List<SymbolInformation>> unmarshaller = unmarshallerFactory.newListUnmarshaller(SymbolInformation.class);
         return asyncRequestFactory.createPostRequest(requestUrl, params)
                                   .header(ACCEPT, APPLICATION_JSON)

--- a/plugins/plugin-machine/che-plugin-machine-ssh-client/src/main/java/org/eclipse/che/ide/ext/ssh/client/upload/UploadSshKeyPresenter.java
+++ b/plugins/plugin-machine/che-plugin-machine-ssh-client/src/main/java/org/eclipse/che/ide/ext/ssh/client/upload/UploadSshKeyPresenter.java
@@ -46,7 +46,7 @@ public class UploadSshKeyPresenter implements UploadSshKeyView.ActionDelegate {
         this.view = view;
         this.view.setDelegate(this);
         this.constant = constant;
-        this.restContext = appContext.getMasterEndpoint();
+        this.restContext = appContext.getMasterApiEndpoint();
         this.notificationManager = notificationManager;
         this.appContext = appContext;
     }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/service/MavenServerServiceClientImpl.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/service/MavenServerServiceClientImpl.java
@@ -50,7 +50,7 @@ public class MavenServerServiceClientImpl implements MavenServerServiceClient {
 
     @Override
     public Promise<String> getEffectivePom(String projectPath) {
-        final String url = appContext.getDevAgentEndpoint() + servicePath + "effective/pom?projectpath=" + projectPath;
+        final String url = appContext.getWsAgentServerApiEndpoint() + servicePath + "effective/pom?projectpath=" + projectPath;
 
         return asyncRequestFactory.createGetRequest(url)
                                   .loader(loaderFactory.newLoader("Generating effective pom..."))
@@ -59,8 +59,8 @@ public class MavenServerServiceClientImpl implements MavenServerServiceClient {
 
     @Override
     public Promise<Boolean> downloadSources(String projectPath, String fqn) {
-        final String url = appContext.getDevAgentEndpoint() + servicePath +
-                           "download/sources?projectpath=" + projectPath +"&fqn=" + fqn;
+        final String url = appContext.getWsAgentServerApiEndpoint() + servicePath +
+                           "download/sources?projectpath=" + projectPath + "&fqn=" + fqn;
         return asyncRequestFactory.createGetRequest(url)
                                   .loader(loaderFactory.newLoader("Generating effective pom..."))
                                   .send(new Unmarshallable<Boolean>() {
@@ -83,7 +83,7 @@ public class MavenServerServiceClientImpl implements MavenServerServiceClient {
         for (String path : projectsPaths) {
             queryParameters.append("&projectPath=").append(path);
         }
-        final String url = appContext.getDevAgentEndpoint() + servicePath + "reimport" +
+        final String url = appContext.getWsAgentServerApiEndpoint() + servicePath + "reimport" +
                            queryParameters.toString().replaceFirst("&", "?");
 
         return asyncRequestFactory.createPostRequest(url, null).send();
@@ -91,7 +91,7 @@ public class MavenServerServiceClientImpl implements MavenServerServiceClient {
 
     @Override
     public Promise<Void> reconcilePom(String pomPath) {
-        final String url = appContext.getDevAgentEndpoint() + servicePath + "pom/reconcile?pompath=" + pomPath;
+        final String url = appContext.getWsAgentServerApiEndpoint() + servicePath + "pom/reconcile?pompath=" + pomPath;
         return asyncRequestFactory.createGetRequest(url).send();
     }
 }

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/SubversionClientServiceImpl.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/SubversionClientServiceImpl.java
@@ -88,7 +88,7 @@ public class SubversionClientServiceImpl implements SubversionClientService {
     }
 
     private String getBaseUrl() {
-        return appContext.getDevAgentEndpoint() + "/svn";
+        return appContext.getWsAgentServerApiEndpoint() + "/svn";
     }
 
     @Override

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/export/ExportPresenter.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/main/java/org/eclipse/che/plugin/svn/ide/export/ExportPresenter.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.plugin.svn.ide.export;
 
-import com.google.gwt.user.client.Window;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -166,7 +165,7 @@ public class ExportPresenter extends SubversionActionPresenter implements Export
             return;
         }
 
-        final StringBuilder url = new StringBuilder(appContext.getDevAgentEndpoint() + "/svn/"
+        final StringBuilder url = new StringBuilder(appContext.getWsAgentServerApiEndpoint() + "/svn/"
                                                     + devMachine.get().getName() + "/export" + project.toString());
         char separator = '?';
         if (!".".equals(exportPath.toString())) {

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/TestServiceClient.java
@@ -273,7 +273,7 @@ public class TestServiceClient {
                 sb.append(URL.encode(e.getKey())).append('=').append(URL.encode(e.getValue()));
             }
         }
-        String url = appContext.getDevAgentEndpoint() + "/che/testing/run/?projectPath=" + projectPath
+        String url = appContext.getWsAgentServerApiEndpoint() + "/che/testing/run/?projectPath=" + projectPath
                      + "&testFramework=" + testFramework + "&" + sb.toString();
         return asyncRequestFactory.createGetRequest(url).header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
                                   .send(dtoUnmarshallerFactory.newUnmarshaller(TestResult.class));
@@ -305,8 +305,8 @@ public class TestServiceClient {
                 sb.append(URL.encode(e.getKey())).append('=').append(URL.encode(e.getValue()));
             }
         }
-        String url = appContext.getDevAgentEndpoint() + "/che/testing/runtests/?testFramework=" + testFramework
-                + "&projectPath=" + projectPath + "&" + sb.toString();
+        String url = appContext.getWsAgentServerApiEndpoint() + "/che/testing/runtests/?testFramework=" + testFramework
+                     + "&projectPath=" + projectPath + "&" + sb.toString();
         return asyncRequestFactory.createGetRequest(url).header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
                 .send(dtoUnmarshallerFactory.newUnmarshaller(TestResultRootDto.class));
     }
@@ -317,8 +317,8 @@ public class TestServiceClient {
             params.append("&path" + i + '=');
             params.append(testResultsPath.get(i));
         }
-        String url = appContext.getDevAgentEndpoint() + "/che/testing/gettestresults/?testFramework="
-                + testFramework + params.toString();
+        String url = appContext.getWsAgentServerApiEndpoint() + "/che/testing/gettestresults/?testFramework="
+                     + testFramework + params.toString();
         return asyncRequestFactory.createGetRequest(url).header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
                 .send(dtoUnmarshallerFactory.newListUnmarshaller(TestResultDto.class));
     }

--- a/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/action/CountLinesAction.java
+++ b/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/action/CountLinesAction.java
@@ -68,7 +68,7 @@ public class CountLinesAction extends JsonExampleProjectAction {
     @Override
     public void actionPerformed(ActionEvent e) {
 
-        String url = appContext.getDevAgentEndpoint() + "/json-example/" +
+        String url = appContext.getWsAgentServerApiEndpoint() + "/json-example/" +
                      appContext.getWorkspaceId() +
                      appContext.getRootProject().getLocation();
 

--- a/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/editor/JsonExampleCodeAssistClient.java
+++ b/samples/sample-plugin-json/che-sample-plugin-json-ide/src/main/java/org/eclipse/che/plugin/jsonexample/ide/editor/JsonExampleCodeAssistClient.java
@@ -52,7 +52,7 @@ public class JsonExampleCodeAssistClient {
     }
 
     public void computeProposals(AsyncRequestCallback<List<String>> callback) {
-        String url = appContext.getDevAgentEndpoint() + "/json-example-completions/";
+        String url = appContext.getWsAgentServerApiEndpoint() + "/json-example-completions/";
         asyncRequestFactory
                 .createGetRequest(url, false)
                 .loader(loaderFactory.newLoader("Loading example completions..."))

--- a/samples/sample-plugin-serverservice/che-sample-plugin-serverservice-ide/src/main/java/org/eclipse/che/plugin/serverservice/ide/MyServiceClient.java
+++ b/samples/sample-plugin-serverservice/che-sample-plugin-serverservice-ide/src/main/java/org/eclipse/che/plugin/serverservice/ide/MyServiceClient.java
@@ -54,7 +54,7 @@ public class MyServiceClient {
      * @return a Promise containing the server response
      */
     public Promise<String> getHello(String name) {
-        return asyncRequestFactory.createGetRequest(appContext.getDevAgentEndpoint() + "/hello/" + name)
+        return asyncRequestFactory.createGetRequest(appContext.getWsAgentServerApiEndpoint() + "/hello/" + name)
                                   .loader(loaderFactory.newLoader("Waiting for hello..."))
                                   .send(new StringUnmarshaller());
     }

--- a/wsagent/che-core-ssh-key-ide/src/main/java/org/eclipse/che/plugin/ssh/key/client/upload/UploadSshKeyPresenter.java
+++ b/wsagent/che-core-ssh-key-ide/src/main/java/org/eclipse/che/plugin/ssh/key/client/upload/UploadSshKeyPresenter.java
@@ -46,7 +46,7 @@ public class UploadSshKeyPresenter implements UploadSshKeyView.ActionDelegate {
         this.view = view;
         this.view.setDelegate(this);
         this.constant = constant;
-        this.restContext = appContext.getMasterEndpoint();
+        this.restContext = appContext.getMasterApiEndpoint();
         this.notificationManager = notificationManager;
         this.appContext = appContext;
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Renames a couple of methods
`AppContext#getMasterEndpoint` -> `AppContext#getMasterApiEndpoint`
`AppContext#getDevAgentEndpoint` -> `AppContext#getWsAgentServerApiEndpoint`
in order to better reflect its purposes.

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->
Renamed a couple of methods in AppContext interface for better reflecting its purposes: getMasterEndpoint -> getMasterApiEndpoint, getDevAgentEndpoint -> getWsAgentServerApiEndpoint.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
