### PR TITLE
CHE-5235: Fix step into when source cannot be obtained

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -215,6 +215,16 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
     }
 
     private void openCurrentFile() {
+        if (currentLocation.getResourcePath() == null) {
+            for (DebuggerObserver observer : observers) {
+                observer.onBreakpointStopped(currentLocation.getTarget(),
+                                             currentLocation.getTarget(),
+                                             currentLocation.getLineNumber());
+            }
+
+            return;
+        }
+
         //todo we need add possibility to handle few files
         activeFileHandler.openFile(currentLocation,
                                    new AsyncCallback<VirtualFile>() {

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -215,6 +215,8 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
     }
 
     private void openCurrentFile() {
+        // Handle the situation when resource isn't found in the workspace
+        // It means that it is impossible to open it.
         if (currentLocation.getResourcePath() == null) {
             for (DebuggerObserver observer : observers) {
                 observer.onBreakpointStopped(currentLocation.getTarget(),

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/JavaDebugger.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/JavaDebugger.java
@@ -596,7 +596,12 @@ public class JavaDebugger implements EventsHandler, Debugger {
         setCurrentThread(event.thread());
         com.sun.jdi.Location jdiLocation = event.location();
 
-        Location location = debuggerUtil.getLocation(jdiLocation);
+        Location location;
+        try {
+            location = debuggerUtil.getLocation(jdiLocation);
+        } catch (DebuggerException de) {
+            location = new LocationImpl(jdiLocation.declaringType().name(), jdiLocation.lineNumber());
+        }
         debuggerCallback.onEvent(new SuspendEventImpl(location));
         return false;
     }


### PR DESCRIPTION
### What does this PR do?
Fixes the Java debugger behaviour when Step Into is performed into a location which source cannot be obtained in the current environment.
Before this fix, the Java debugger performed Resume instead of Step Into.
Now, the Java debugger works as expected, but source file hasn't shown to user, because it cannot be obtained in the current environment, but a user can see current position and local variables in the debugger panel.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5235

#### Changelog
Fix the Java debugger Step Into functionality when the target source cannot be obtained.

#### Release Notes
Fix the Java debugger Step Into functionality when the target source cannot be obtained. In such cases a user can operate with the debugger as usual, but without source code in the editor.

#### Docs PR
N/A