### PR TITLE
Removes hardcoded path of ws-agent's API endpoint in IDE

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -408,7 +408,7 @@ public class AppContextImpl implements AppContext,
         Optional<ServerImpl> wsAgentServer = runtime.getWsAgentServer();
 
         if (wsAgentServer.isPresent()) {
-            return wsAgentServer.get().getUrl() + "/api"; // TODO (spi ide): remove path when it comes with server's URL
+            return wsAgentServer.get().getUrl();
         }
 
         throw new RuntimeException("ws-agent server doesn't exist");

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsAgentJsonRpcInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsAgentJsonRpcInitializer.java
@@ -77,8 +77,7 @@ public class WsAgentJsonRpcInitializer {
         }
 
         runtime.getWsAgentServer().ifPresent(server -> {
-            final String wsAgentBaseUrl = server.getUrl() + "/api"; // TODO (spi ide): remove path when it comes with URL
-            final String wsAgentWebSocketUrl = wsAgentBaseUrl.replaceFirst("http", "ws") + "/ws"; // TODO (spi ide): remove path when it comes with URL
+            final String wsAgentWebSocketUrl = server.getUrl().replaceFirst("http", "ws") + "/ws"; // TODO (spi ide): remove path when it comes with URL
             final String wsAgentUrl = wsAgentWebSocketUrl.replaceFirst("(api)(/)(ws)", "websocket" + "$2" + appContext.getAppId());
 
             initializer.initialize(WORKSPACE_AGENT_ENDPOINT_ID, singletonMap("url", wsAgentUrl));

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.json
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.json
@@ -11,7 +11,7 @@
     "wsagent": {
       "port": "4401/tcp",
       "protocol": "http",
-      "path" : "/api/"
+      "path" : "/api"
     }
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removes hardcoded path of ws-agent's API endpoint in IDE. Now path already included in server's URL.

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->
N/A

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A