### PR TITLE
Provide ability to cancel the workspace start with docker backend

### DIFF
--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.docker;
+
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
+import org.eclipse.che.api.workspace.server.DtoConverter;
+import org.eclipse.che.api.workspace.server.URLRewriter;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.spi.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException;
+import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.workspace.infrastructure.docker.bootstrap.DockerBootstrapper;
+import org.eclipse.che.workspace.infrastructure.docker.bootstrap.DockerBootstrapperFactory;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+import org.eclipse.che.workspace.infrastructure.docker.monit.AbnormalMachineStopHandler;
+import org.eclipse.che.workspace.infrastructure.docker.server.ServerCheckerFactory;
+import org.eclipse.che.workspace.infrastructure.docker.snapshot.SnapshotDao;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.FAILED;
+import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.RUNNING;
+import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.STARTING;
+import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.STOPPED;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests {@link DockerInternalRuntime}.
+ *
+ * @author Anton Korneta
+ */
+public class DockerInternalRuntimeTest {
+
+    private static final RuntimeIdentity IDENTITY    = new RuntimeIdentityImpl("ws1", "env1", "usr1");
+    private static final String          DEV_MACHINE = "DEV_MACHINE";
+    private static final String          DB_MACHINE  = "DB_MACHINE";
+
+    @Mock
+    private DockerBootstrapperFactory bootstrapperFactory;
+    @Mock
+    private DockerRuntimeContext      runtimeContext;
+    @Mock
+    private EventService              eventService;
+    @Mock
+    private DockerMachineStarter      starter;
+    @Mock
+    private NetworkLifecycle          networks;
+    @Mock
+    private DockerBootstrapper        bootstrapper;
+
+    @Captor
+    private ArgumentCaptor<MachineStatusEvent> eventCaptor;
+
+    private DockerInternalRuntime dockerRuntime;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        final DockerContainerConfig config1 = new DockerContainerConfig();
+        final DockerContainerConfig config2 = new DockerContainerConfig();
+        final DockerEnvironment environment = new DockerEnvironment();
+        final InternalMachineConfig internalMachineCfg1 = mock(InternalMachineConfig.class);
+        when(internalMachineCfg1.getInstallers()).thenReturn(singletonList(newInstaller(1)));
+        final InternalMachineConfig internalMachineCfg2 = mock(InternalMachineConfig.class);
+        when(internalMachineCfg2.getInstallers()).thenReturn(singletonList(newInstaller(2)));
+        environment.setContainers(ImmutableMap.of(DEV_MACHINE, config1, DB_MACHINE, config2));
+
+        doNothing().when(networks).createNetwork(anyString());
+        when(runtimeContext.getIdentity()).thenReturn(IDENTITY);
+        when(runtimeContext.getDevMachineName()).thenReturn(DB_MACHINE);
+        when(runtimeContext.getDockerEnvironment()).thenReturn(environment);
+        final LinkedList<String> orderedContainers = new LinkedList<>();
+        orderedContainers.add(DEV_MACHINE);
+        orderedContainers.add(DB_MACHINE);
+        when(runtimeContext.getOrderedContainers()).thenReturn(orderedContainers);
+        when(runtimeContext.getMachineConfigs()).thenReturn(ImmutableMap.of(DEV_MACHINE, internalMachineCfg1,
+                                                                            DB_MACHINE, internalMachineCfg2));
+        dockerRuntime = new DockerInternalRuntime(runtimeContext,
+                                                  mock(URLRewriter.class),
+                                                  networks,
+                                                  starter,
+                                                  mock(SnapshotDao.class),
+                                                  mock(DockerRegistryClient.class),
+                                                  eventService,
+                                                  bootstrapperFactory,
+                                                  mock(ServerCheckerFactory.class),
+                                                  mock(MachineLoggersFactory.class));
+    }
+
+    @Test
+    public void startsDockerRuntimeAndPropagatesMachineStatusEvents() throws Exception {
+        mockInstallersBootstrap();
+        mockContainerStart();
+        dockerRuntime.start(emptyMap());
+
+        verify(starter, times(2)).startContainer(anyString(), anyString(), any(), any(), anyBoolean(), any());
+        verify(eventService, times(4)).publish(any(MachineStatusEvent.class));
+        verifyEventsOrder(newEvent(DEV_MACHINE, STARTING, null),
+                          newEvent(DEV_MACHINE, RUNNING, null),
+                          newEvent(DB_MACHINE, STARTING, null),
+                          newEvent(DB_MACHINE, RUNNING, null));
+    }
+
+    @Test(expectedExceptions = InfrastructureException.class)
+    public void throwsExceptionWhenOneMachineStartFailed() throws Exception {
+        final String msg = "container start failed";
+        mockInstallersBootstrap();
+        mockContainerStartFailed(new InfrastructureException(msg));
+
+        try {
+            dockerRuntime.start(emptyMap());
+        } catch (InfrastructureException ex) {
+            verify(starter, times(1)).startContainer(anyString(), anyString(), any(), any(), anyBoolean(), any());
+            verify(eventService, times(2)).publish(any(MachineStatusEvent.class));
+            verifyEventsOrder(newEvent(DEV_MACHINE, STARTING, null),
+                              newEvent(DEV_MACHINE, FAILED, msg));
+            throw ex;
+        }
+    }
+
+    @Test(expectedExceptions = InfrastructureException.class)
+    public void throwsExceptionWhenBootstrappingOfInstallersFailed() throws Exception {
+        mockInstallersBootstrapFailed(new InfrastructureException("bootstrap failed"));
+        mockContainerStart();
+        try {
+            dockerRuntime.start(emptyMap());
+        } catch (InfrastructureException ex) {
+            verify(starter, times(1)).startContainer(anyString(), anyString(), any(), any(), anyBoolean(), any());
+            verify(bootstrapper, times(1)).bootstrap();
+            verify(eventService, times(3)).publish(any(MachineStatusEvent.class));
+            verifyEventsOrder(newEvent(DEV_MACHINE, STARTING, null),
+                              newEvent(DEV_MACHINE, FAILED, "bootstrap failed"),
+                              newEvent(DEV_MACHINE, STOPPED, null));
+            throw ex;
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeStartInterruptedException.class)
+    public void throwsInterruptionExceptionWhenNetworkCreationInterrupted() throws Exception {
+        doThrow(RuntimeStartInterruptedException.class).when(networks).createNetwork(anyString());
+
+        try {
+            dockerRuntime.start(emptyMap());
+        } catch (InfrastructureException ex) {
+            verify(starter, never()).startContainer(anyString(), anyString(), any(), any(), anyBoolean(), any());
+            throw ex;
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeStartInterruptedException.class)
+    public void throwsInterruptionExceptionWhenContainerStartInterrupted() throws Exception {
+        mockInstallersBootstrap();
+        mockContainerStartFailed(new RuntimeStartInterruptedException(IDENTITY));
+
+        try {
+            dockerRuntime.start(emptyMap());
+        } catch (InfrastructureException ex) {
+            verify(starter, times(1)).startContainer(anyString(), anyString(), any(), any(), anyBoolean(), any());
+            throw ex;
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeStartInterruptedException.class)
+    public void throwsInterruptionExceptionWhenThreadInterruptedOnStarFailedBeforeDestroying() throws Exception {
+        final String msg = "container start failed";
+        mockInstallersBootstrap();
+        doAnswer(invocationOnMock -> {
+            Thread.currentThread().interrupt();
+            throw new InfrastructureException(msg);
+        }).when(starter).startContainer(anyString(),
+                                        anyString(),
+                                        any(DockerContainerConfig.class),
+                                        any(RuntimeIdentity.class),
+                                        anyBoolean(),
+                                        any(AbnormalMachineStopHandler.class));
+
+        try {
+            dockerRuntime.start(emptyMap());
+        } catch (InfrastructureException ex) {
+            verify(starter, times(1)).startContainer(anyString(), anyString(), any(), any(), anyBoolean(), any());
+            throw ex;
+        }
+    }
+
+    private void verifyEventsOrder(MachineStatusEvent... expectedEvents) {
+        final Iterator<MachineStatusEvent> actualEvents = captureEvents().iterator();
+        for (MachineStatusEvent expected : expectedEvents) {
+            if (!actualEvents.hasNext()) {
+                fail("It is expected to receive machine status events");
+            }
+            final MachineStatusEvent actual = actualEvents.next();
+            assertEquals(actual, expected);
+        }
+        if (actualEvents.hasNext()) {
+            fail("No more events expected");
+        }
+    }
+
+    private List<MachineStatusEvent> captureEvents() {
+        verify(eventService, atLeastOnce()).publish(eventCaptor.capture());
+        return eventCaptor.getAllValues();
+    }
+
+    private static MachineStatusEvent newEvent(String machineName,
+                                               MachineStatus status,
+                                               String error) {
+        return DtoFactory.newDto(MachineStatusEvent.class)
+                         .withIdentity(DtoConverter.asDto(IDENTITY))
+                         .withMachineName(machineName)
+                         .withEventType(status)
+                         .withError(error);
+    }
+
+    private void mockContainerStart() throws InfrastructureException {
+        when(starter.startContainer(anyString(),
+                                    anyString(),
+                                    any(DockerContainerConfig.class),
+                                    any(RuntimeIdentity.class),
+                                    anyBoolean(),
+                                    any(AbnormalMachineStopHandler.class))).thenReturn(mock(DockerMachine.class));
+    }
+
+    private void mockContainerStartFailed(InfrastructureException exception) throws InfrastructureException {
+        when(starter.startContainer(anyString(),
+                                    anyString(),
+                                    any(DockerContainerConfig.class),
+                                    any(RuntimeIdentity.class),
+                                    anyBoolean(),
+                                    any(AbnormalMachineStopHandler.class)))
+                .thenThrow(exception);
+    }
+
+    private void mockInstallersBootstrap() throws Exception {
+        final DockerBootstrapper bootstrapper = mock(DockerBootstrapper.class);
+        when(bootstrapperFactory.create(anyString(),
+                                        any(RuntimeIdentity.class),
+                                        anyListOf(InstallerImpl.class),
+                                        any(DockerMachine.class))).thenReturn(bootstrapper);
+        doNothing().when(bootstrapper).bootstrap();
+    }
+
+    private void mockInstallersBootstrapFailed(InfrastructureException exception) throws Exception {
+        when(bootstrapperFactory.create(anyString(),
+                                        any(RuntimeIdentity.class),
+                                        anyListOf(InstallerImpl.class),
+                                        any(DockerMachine.class))).thenReturn(bootstrapper);
+        doThrow(exception).when(bootstrapper).bootstrap();
+    }
+
+    private InstallerImpl newInstaller(int i) {
+        return new InstallerImpl("installer_" + i,
+                                 "installer_name" + i,
+                                 String.valueOf(i),
+                                 "test installer",
+                                 Collections.emptyList(),
+                                 emptyMap(),
+                                 "echo hello",
+                                 emptyMap());
+    }
+
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftInternalRuntime.java
@@ -124,7 +124,7 @@ public class OpenshiftInternalRuntime extends InternalRuntime<OpenshiftRuntimeCo
 
                 sendRunningEvent(machine.getName());
             }
-        } catch (RuntimeException e) {
+        } catch (RuntimeException | InterruptedException e) {
             LOG.error("Failed to start of openshift runtime. " + e.getMessage(), e);
             throw new InfrastructureException(e.getMessage(), e);
         }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -47,6 +47,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STOPPED_BY;
 
 /**
@@ -386,7 +387,7 @@ public class WorkspaceManager {
 
         requireNonNull(workspaceId, "Required non-null workspace id");
         final WorkspaceImpl workspace = normalizeState(workspaceDao.get(workspaceId), true);
-        checkWorkspaceIsRunning(workspace, "stop");
+        checkWorkspaceIsRunningOrStarting(workspace, "stop");
         stopAsync(workspace, options);
     }
 
@@ -538,8 +539,8 @@ public class WorkspaceManager {
         });
     }
 
-    private void checkWorkspaceIsRunning(WorkspaceImpl workspace, String operation) throws ConflictException {
-        if (workspace.getStatus() != RUNNING) {
+    private void checkWorkspaceIsRunningOrStarting(WorkspaceImpl workspace, String operation) throws ConflictException {
+        if (workspace.getStatus() != RUNNING && workspace.getStatus() != STARTING) {
             throw new ConflictException(format("Could not %s the workspace '%s/%s' because its status is '%s'.",
                                                operation,
                                                workspace.getNamespace(),

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
@@ -81,8 +81,10 @@ public abstract class AbstractBootstrapper {
      *         when bootstrapping failed
      * @throws InfrastructureException
      *         when any other error occurs while bootstrapping
+     * @throws InterruptedException
+     *         when the bootstrapping process was interrupted
      */
-    public void bootstrap() throws InfrastructureException {
+    public void bootstrap() throws InfrastructureException, InterruptedException {
         if (finishEventFuture != null) {
             throw new IllegalStateException("Bootstrap method must be called only once.");
         }
@@ -102,9 +104,6 @@ public abstract class AbstractBootstrapper {
             throw new InfrastructureException(e.getCause().getMessage(), e);
         } catch (TimeoutException e) {
             throw new InfrastructureException("Bootstrapping of machine " + machineName + " reached timeout");
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new InfrastructureException("Bootstrapping of machine " + machineName + " was interrupted");
         } finally {
             eventService.unsubscribe(bootstrapperStatusListener, BootstrapperStatusEvent.class);
         }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeStartInterruptedException.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeStartInterruptedException.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.workspace.server.spi;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+
+import static java.lang.String.format;
+
+/**
+ * Thrown when start of the runtime is interrupted.
+ *
+ * @author Anton Korneta
+ */
+public class RuntimeStartInterruptedException extends InfrastructureException {
+
+    public RuntimeStartInterruptedException(RuntimeIdentity identity) {
+        super(format("Runtime start for identity 'workspace: %s, environment: %s, owner: %s' is interrupted",
+                     identity.getWorkspaceId(),
+                     identity.getEnvName(),
+                     identity.getOwner()));
+    }
+}


### PR DESCRIPTION
Allows to cancel workspace start, it means that user is able to invoke stop of the workspace which status is `STARTING`.
Basically, a status map is the same as described [here](https://github.com/eclipse/che/issues/3743). 
