### PR TITLE
CHE-5687 Add usage of configured installers

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftRuntimeContext.java
@@ -55,6 +55,11 @@ public class OpenshiftRuntimeContext extends RuntimeContext {
         this.websocketEndpointBase = websocketEndpointBase;
     }
 
+    /** Returns openshift environment which based on normalized context environment configuration. */
+    public OpenshiftEnvironment getOpenshiftEnvironment() {
+        return openshiftEnvironment;
+    }
+
     @Override
     public URI getOutputChannel() throws InfrastructureException {
         try {
@@ -69,6 +74,6 @@ public class OpenshiftRuntimeContext extends RuntimeContext {
 
     @Override
     public InternalRuntime getRuntime() {
-        return runtimeFactory.create(environment, openshiftEnvironment, identity, this);
+        return runtimeFactory.create(this);
     }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftRuntimeFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenshiftRuntimeFactory.java
@@ -20,8 +20,5 @@ import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenshiftE
  * @author Sergii Leshchenko
  */
 public interface OpenshiftRuntimeFactory {
-    OpenshiftInternalRuntime create(@Assisted Environment environment,
-                                    @Assisted OpenshiftEnvironment openshiftEnvironment,
-                                    @Assisted RuntimeIdentity identity,
-                                    @Assisted OpenshiftRuntimeContext context);
+    OpenshiftInternalRuntime create(@Assisted OpenshiftRuntimeContext context);
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenshiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenshiftEnvironment.java
@@ -14,8 +14,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,32 +26,53 @@ public class OpenshiftEnvironment {
     private Map<String, Route>   routes;
 
     public OpenshiftEnvironment() {
-        routes = new HashMap<>();
-        services = new HashMap<>();
-        pods = new HashMap<>();
     }
 
     public Map<String, Pod> getPods() {
-        return ImmutableMap.copyOf(pods);
+        if (pods == null) {
+            pods = new HashMap<>();
+        }
+        return pods;
     }
 
-    public void addPod(Pod pod) {
-        pods.put(pod.getMetadata().getName(), pod);
+    public void setPods(Map<String, Pod> pods) {
+        this.pods = pods;
+    }
+
+    public OpenshiftEnvironment withPods(Map<String, Pod> pods) {
+        this.pods = pods;
+        return this;
     }
 
     public Map<String, Service> getServices() {
+        if (services == null) {
+            services = new HashMap<>();
+        }
         return services;
     }
 
-    public void addService(Service service) {
-        services.put(service.getMetadata().getName(), service);
+    public void setServices(Map<String, Service> services) {
+        this.services = services;
+    }
+
+    public OpenshiftEnvironment withServices(Map<String, Service> services) {
+        this.services = services;
+        return this;
     }
 
     public Map<String, Route> getRoutes() {
+        if (routes == null) {
+            routes = new HashMap<>();
+        }
         return routes;
     }
 
-    public void addRoute(Route route) {
-        routes.put(route.getMetadata().getName(), route);
+    public void setRoutes(Map<String, Route> routes) {
+        this.routes = routes;
+    }
+
+    public OpenshiftEnvironment withRoutes(Map<String, Route> routes) {
+        this.routes = routes;
+        return this;
     }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
@@ -90,12 +90,8 @@ public abstract class AbstractBootstrapper {
 
         eventService.subscribe(bootstrapperStatusListener, BootstrapperStatusEvent.class);
         try {
-            LOG.info("Launching bootstrapper");
-
             doBootstrapAsync(installerEndpoint + ENDPOINT_IDS.getAndIncrement(),
                              outputEndpoint + ENDPOINT_IDS.getAndIncrement());
-
-            LOG.info("Launched bootstrapper. Waiting for Done event");
 
             //waiting for DONE or FAILED bootstrapper status event
             BootstrapperStatusEvent resultEvent = finishEventFuture.get(bootstrappingTimeoutMinutes, TimeUnit.MINUTES);


### PR DESCRIPTION
### What does this PR do?
Add usage of configured installers instead of hard coded ones.
Move resolving of servers from InternalRuntime to Machine.
Add retrieving all required information for InternalRuntime from Сontext instead of setting it while InternalRuntime instance creation.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5687