### PR TITLE
Reconnect to push-logs-endpoint if connection is lost

### DIFF
--- a/agents/go-agents/bootstrapper/booter/booter_test.go
+++ b/agents/go-agents/bootstrapper/booter/booter_test.go
@@ -1,0 +1,230 @@
+//
+// Copyright (c) 2012-2017 Codenvy, S.A.
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// which accompanies this distribution, and is available at
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// Contributors:
+//   Codenvy, S.A. - initial API and implementation
+//
+
+package booter
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+	"sync"
+
+	"github.com/eclipse/che/agents/go-agents/core/event"
+	"github.com/eclipse/che/agents/go-agents/core/jsonrpc"
+	"github.com/eclipse/che/agents/go-agents/core/jsonrpc/jsonrpctest"
+)
+
+var (
+	testRuntimeID = RuntimeID{
+		Workspace:   "my-workspace",
+		Environment: "my-env",
+		Owner:       "me",
+	}
+	testMachineName = "my-machine"
+
+	print10numbersInst = Installer{
+		ID:          "test-installer-1",
+		Description: "Installer for testing",
+		Version:     "1.0",
+		Script:      "printf \"1\n2\n3\n4\n5\n6\n7\n8\n9\n10\"",
+	}
+	echoTestInst = Installer{
+		ID:          "test-installer-2",
+		Description: "Installer for testing",
+		Version:     "1.0",
+		Script:      "echo test",
+	}
+)
+
+func TestBootstrap(t *testing.T) {
+	// configuring bootstrapper
+	runtimeID = testRuntimeID
+	machineName = testMachineName
+	installerTimeout = time.Second * 2
+	installers = []Installer{print10numbersInst, echoTestInst}
+
+	// configuring jsonrpc endpoint
+	tunnel, cr, rr := jsonrpctest.NewTmpTunnel(2 * time.Second)
+	defer tunnel.Close()
+	defer rr.Close()
+	PushStatuses(tunnel)
+	PushLogs(tunnel, nil)
+
+	startAndWaitInstallations(t)
+
+	expectedEvents := []event.E{
+		&StatusChangedEvent{Status: StatusStarting},
+
+		&InstallerStatusChangedEvent{Status: InstallerStatusStarting, Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "1", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "2", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "3", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "4", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "5", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "6", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "7", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "8", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "9", Installer: print10numbersInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "10", Installer: print10numbersInst.ID},
+		&InstallerStatusChangedEvent{Status: InstallerStatusDone, Installer: print10numbersInst.ID},
+
+		&InstallerStatusChangedEvent{Status: InstallerStatusStarting, Installer: echoTestInst.ID},
+		&InstallerLogEvent{Stream: StdoutStream, Text: "test", Installer: echoTestInst.ID},
+		&InstallerStatusChangedEvent{Status: InstallerStatusDone, Installer: echoTestInst.ID},
+
+		&StatusChangedEvent{Status: StatusDone},
+	}
+
+	if err := cr.WaitUntil(jsonrpctest.WriteCalledAtLeast(len(expectedEvents))); err != nil {
+		t.Fatal(err)
+	}
+	requests, err := cr.GetAllRequests()
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkEvents(t, requests, expectedEvents...)
+}
+
+func TestReconnect(t *testing.T) {
+	// create tunnel & close it immediately
+	closedTunnel := jsonrpc.NewManagedTunnel(jsonrpctest.NewConnRecorder())
+	closedTunnel.Close()
+
+	connector := newTestConnector()
+	defer connector.doClose()
+
+	tb := tunnelBroadcaster{
+		tunnel:          closedTunnel,
+		connector:       connector,
+		reconnectPeriod: time.Microsecond,
+		reconnectOnce:   &sync.Once{},
+	}
+	// force broadcaster to reconnect
+	tb.Accept(&InstallerLogEvent{Text: "test"})
+
+	// publish log events until stop is not published
+	stopPublishing := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-stopPublishing:
+				return
+			default:
+				bus.Pub(&InstallerLogEvent{Text: "test"})
+			}
+		}
+	}()
+
+	err := connector.connRec.WaitUntil(jsonrpctest.WriteCalledAtLeast(1))
+	stopPublishing <- true
+	if err != nil {
+		t.Fatal("Didn't reconnect in time")
+	}
+}
+
+func startAndWaitInstallations(t *testing.T) {
+	complete := make(chan bool, 1)
+	go func() {
+		Start()
+		complete <- true
+	}()
+	select {
+	case <-time.After(time.Second * 2):
+		t.Fatalf("Installation timeout is reached")
+	case <-complete:
+	}
+}
+
+func checkEvents(t *testing.T, requests []*jsonrpc.Request, expectedEvents ...event.E) {
+	if len(requests) != len(expectedEvents) {
+		t.Logf("Expected evens len is '%d' while published '%d'", len(expectedEvents), len(requests))
+		t.Logf("Received events:")
+		for _, req := range requests {
+			t.Log(req.Method)
+		}
+		t.FailNow()
+	}
+	for i := range requests {
+		request := requests[i]
+		expectedEvent := expectedEvents[i]
+		if request.Method != expectedEvent.Type() {
+			t.Fatalf("Even type '%s' != '%s'", requests[i].Method, expectedEvents[i].Type())
+		}
+
+		switch expectedEvent.Type() {
+		case StatusChangedEventType:
+			actual := &StatusChangedEvent{}
+			json.Unmarshal(request.Params, actual)
+			checkStatusEvent(t, actual, expectedEvent.(*StatusChangedEvent))
+		case InstallerStatusChangedEventType:
+			actual := &InstallerStatusChangedEvent{}
+			json.Unmarshal(request.Params, actual)
+			checkInstallerStatusEvent(t, actual, expectedEvent.(*InstallerStatusChangedEvent))
+		case InstallerLogEventType:
+			actual := &InstallerLogEvent{}
+			json.Unmarshal(request.Params, actual)
+			checkLogEvent(t, actual, expectedEvent.(*InstallerLogEvent))
+		}
+	}
+}
+
+func checkStatusEvent(t *testing.T, actual, expected *StatusChangedEvent) {
+	if expected.Status != actual.Status {
+		t.Fatalf("Expected bootstrapper status '%s' but got '%s'", expected.Status, actual.Status)
+	}
+}
+
+func checkInstallerStatusEvent(t *testing.T, actual, expected *InstallerStatusChangedEvent) {
+	if expected.Status != actual.Status {
+		t.Fatalf("Expected installer status '%s' but got '%s'", expected.Status, actual.Status)
+	}
+	if expected.Installer != actual.Installer {
+		t.Fatalf("Expected installer id '%s' but got '%s'", expected.Installer, actual.Installer)
+	}
+}
+
+func checkLogEvent(t *testing.T, actual, expected *InstallerLogEvent) {
+	if expected.Text != actual.Text {
+		t.Fatalf("Expected log text to be '%s' but got '%s'", expected.Text, actual.Text)
+	}
+	if expected.Stream != actual.Stream {
+		t.Fatalf(
+			"Expected stream '%s' for log message '%s' but got '%s'",
+			expected.Stream,
+			expected.Text,
+			actual.Stream,
+		)
+	}
+	if expected.Installer != actual.Installer {
+		t.Fatalf("Expected installer id '%s' but got '%s'", expected.Installer, actual.Installer)
+	}
+}
+
+func newTestConnector() *testConnector {
+	c := &testConnector{}
+	c.tunnel, c.connRec, c.reqRec = jsonrpctest.NewTmpTunnel(2 * time.Second)
+	return c
+}
+
+type testConnector struct {
+	connRec *jsonrpctest.ConnRecorder
+	reqRec  *jsonrpctest.ReqRecorder
+	tunnel  *jsonrpc.Tunnel
+}
+
+func (c *testConnector) Connect() (*jsonrpc.Tunnel, error) {
+	return c.tunnel, nil
+}
+
+func (c *testConnector) doClose() {
+	c.tunnel.Close()
+	c.reqRec.Close()
+}

--- a/agents/go-agents/bootstrapper/cfg/cfg.go
+++ b/agents/go-agents/bootstrapper/cfg/cfg.go
@@ -44,6 +44,9 @@ var (
 
 	// CheckServersPeriodSec how much time(seconds) is between servers checks for one installer.
 	CheckServersPeriodSec int
+
+	// LogsEndpointReconnectPeriodSec how much time(seconds) is between logs endpoint reconnect attempts.
+	LogsEndpointReconnectPeriodSec int
 )
 
 func init() {
@@ -95,8 +98,16 @@ func init() {
 		`Time(in seconds) between servers availability checks.
 	Once servers for one installer available - checks stopped`,
 	)
+	flag.IntVar(
+		&LogsEndpointReconnectPeriodSec,
+		"logs-endpoint-reconnect-period",
+		10,
+		`Time(in seconds) between attempts to reconnect to push-logs-endpoint.
+	Bootstrapper tries to reconnect to push-logs-endpoint when previously established connection lost`,
+	)
 }
 
+// Parse parses configuration.
 func Parse() {
 	flag.Parse()
 
@@ -140,7 +151,7 @@ func Parse() {
 func Print() {
 	log.Print("Bootstrapper configuration")
 	log.Printf("  Push endpoint: %s", PushStatusesEndpoint)
-	log.Printf("  Push logs Endpoint: %s", PushLogsEndpoint)
+	log.Printf("  Push logs endpoint: %s", PushLogsEndpoint)
 	log.Print("  Runtime ID:")
 	log.Printf("    Workspace: %s", RuntimeID.Workspace)
 	log.Printf("    Environment: %s", RuntimeID.Environment)
@@ -148,6 +159,7 @@ func Print() {
 	log.Printf("  Machine name: %s", MachineName)
 	log.Printf("  Installer timeout: %dseconds", InstallerTimeoutSec)
 	log.Printf("  Check servers period: %dseconds", CheckServersPeriodSec)
+	log.Printf("  Push logs endpoint reconnect period: %dseconds", LogsEndpointReconnectPeriodSec)
 }
 
 // ReadInstallersConfig reads content of file by path cfg.FilePath,

--- a/agents/go-agents/core/jsonrpc/jsonrpctest/tunnel.go
+++ b/agents/go-agents/core/jsonrpc/jsonrpctest/tunnel.go
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2012-2017 Codenvy, S.A.
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// which accompanies this distribution, and is available at
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// Contributors:
+//   Codenvy, S.A. - initial API and implementation
+//
+
+package jsonrpctest
+
+import (
+	"time"
+
+	"github.com/eclipse/che/agents/go-agents/core/jsonrpc"
+)
+
+// NewTmpTunnel creates a new running jsonrpc.Tunnel based on test connection
+// and test request dispatcher which will be automatically closed after specified timeout.
+func NewTmpTunnel(t time.Duration) (*jsonrpc.Tunnel, *ConnRecorder, *ReqRecorder) {
+	connRecorder := NewConnRecorder()
+	connRecorder.CloseAfter(t)
+	reqRecorder := NewReqRecorder()
+	reqRecorder.CloseAfter(t)
+	tunnel := jsonrpc.NewTunnel(connRecorder, reqRecorder)
+	tunnel.Go()
+	return tunnel, connRecorder, reqRecorder
+}

--- a/agents/go-agents/core/jsonrpc/registry.go
+++ b/agents/go-agents/core/jsonrpc/registry.go
@@ -78,8 +78,8 @@ func (reg *TunnelRegistry) GetTunnels() []*Tunnel {
 
 // Get returns tunnel with a given id.
 func (reg *TunnelRegistry) Get(id string) (*Tunnel, bool) {
-	reg.Lock()
-	defer reg.Unlock()
+	reg.RLock()
+	defer reg.RUnlock()
 	tun, ok := reg.tunnels[id]
 	return tun, ok
 }

--- a/agents/go-agents/core/jsonrpc/tunnel_test.go
+++ b/agents/go-agents/core/jsonrpc/tunnel_test.go
@@ -24,8 +24,7 @@ func TestChannelSaysHello(t *testing.T) {
 	beforeConnected := time.Now()
 
 	// initialization routine
-	tunnel, connRecorder, reqRecorder := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, reqRecorder := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 	defer reqRecorder.Close()
 
@@ -55,8 +54,7 @@ func TestChannelSaysHello(t *testing.T) {
 
 // X Notification -> X'
 func TestSendingNotification(t *testing.T) {
-	tunnel, connRecorder, reqRecorder := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, reqRecorder := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 	defer reqRecorder.Close()
 
@@ -89,8 +87,7 @@ func TestSendingNotification(t *testing.T) {
 
 // X Request -> X'
 func TestSendingRequest(t *testing.T) {
-	tunnel, connRecorder, _ := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, _ := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 
 	method := "domain.doSomething"
@@ -124,8 +121,7 @@ func TestSendingRequest(t *testing.T) {
 
 // X' Request -> X
 func TestReceivingRequest(t *testing.T) {
-	tunnel, connRecorder, reqRecorder := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, reqRecorder := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 	defer reqRecorder.Close()
 
@@ -155,8 +151,7 @@ func TestReceivingRequest(t *testing.T) {
 // X' Request  -> X
 // X' <- Response X
 func TestSendingResponseBack(t *testing.T) {
-	tunnel, connRecorder, reqRecorder := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, reqRecorder := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 	defer reqRecorder.Close()
 
@@ -211,8 +206,7 @@ func TestSendingResponseBack(t *testing.T) {
 // X Request  -> X'
 // X <- Response X'
 func TestRequestResponseHandling(t *testing.T) {
-	tunnel, connRecorder, reqRecorder := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, reqRecorder := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 	defer reqRecorder.Close()
 
@@ -255,8 +249,7 @@ func TestRequestResponseHandling(t *testing.T) {
 }
 
 func TestSendingBrokenData(t *testing.T) {
-	tunnel, connRecorder, reqRecorder := newTestTunnel()
-	tunnel.Go()
+	tunnel, connRecorder, reqRecorder := jsonrpctest.NewTmpTunnel(2*time.Second)
 	defer tunnel.Close()
 	defer reqRecorder.Close()
 
@@ -290,13 +283,4 @@ func TestSendingBrokenData(t *testing.T) {
 
 type testStruct struct {
 	Data string `json:"data"`
-}
-
-func newTestTunnel() (*jsonrpc.Tunnel, *jsonrpctest.ConnRecorder, *jsonrpctest.ReqRecorder) {
-	connRecorder := jsonrpctest.NewConnRecorder()
-	reqRecorder := jsonrpctest.NewReqRecorder()
-	tunnel := jsonrpc.NewTunnel(connRecorder, reqRecorder)
-	connRecorder.CloseAfter(2 * time.Second)
-	reqRecorder.CloseAfter(2 * time.Second)
-	return tunnel, connRecorder, reqRecorder
 }

--- a/agents/go-agents/exec-agent/main.go
+++ b/agents/go-agents/exec-agent/main.go
@@ -74,7 +74,6 @@ func main() {
 							return err
 						}
 						tunnel := jsonrpc.NewManagedTunnel(conn)
-						tunnel.Go()
 						tunnel.SayHello()
 						return nil
 					},


### PR DESCRIPTION
Added ability to reconnect to logs endpoint if previously established connection is lost.
Default reconnect period is _10sec_ but it can be configured with cli parameter:
```
  -logs-endpoint-reconnect-period int
        Time(in seconds) between attempts to reconnect to push-logs-endpoint.
        Bootstrapper tries to reconnect to push-logs-endpoint when previously 
        established connection lost (default 10)
```
It partly resolves #5675.
Another part should be resolved by #5814.


