### PR TITLE
Fix for the code validation is not available for language servers 

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpoint.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpoint.java
@@ -20,6 +20,13 @@ import javax.websocket.OnError;
 import javax.websocket.OnMessage;
 import javax.websocket.OnOpen;
 import javax.websocket.Session;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.eclipse.che.api.core.websocket.impl.WebsocketIdService.randomClientId;
 
 /**
  * Duplex WEB SOCKET endpoint, handles messages, errors, session open/close events.
@@ -48,7 +55,7 @@ abstract public class BasicWebSocketEndpoint {
 
     @OnOpen
     public void onOpen(Session session) {
-        String combinedEndpointId = getCombinedEndpointId(session);
+        String combinedEndpointId = getOrGenerateCombinedEndpointId(session);
 
         LOG.debug("Web socket session opened");
         LOG.debug("Endpoint: {}", combinedEndpointId);
@@ -61,35 +68,78 @@ abstract public class BasicWebSocketEndpoint {
 
     @OnMessage
     public void onMessage(String message, Session session) {
-        String combinedEndpointId = getCombinedEndpointId(session);
+        Optional<String> endpointIdOptional = registry.get(session);
 
-        LOG.debug("Receiving a web socket message.");
-        LOG.debug("Endpoint: {}", combinedEndpointId);
-        LOG.debug("Message: {}", message);
+        String combinedEndpointId;
+        if (endpointIdOptional.isPresent()) {
+            combinedEndpointId = endpointIdOptional.get();
 
+            LOG.debug("Receiving a web socket message.");
+            LOG.debug("Endpoint: {}", combinedEndpointId);
+            LOG.debug("Message: {}", message);
+
+        } else {
+            combinedEndpointId = getOrGenerateCombinedEndpointId(session);
+
+            LOG.warn("Processing messing within unidentified session");
+        }
         receiver.receive(combinedEndpointId, message);
     }
 
     @OnClose
     public void onClose(CloseReason closeReason, Session session) {
-        String combinedEndpointId = getCombinedEndpointId(session);
+        Optional<String> endpointIdOptional = registry.get(session);
 
-        LOG.debug("Web socket session closed");
-        LOG.debug("Endpoint: {}", combinedEndpointId);
-        LOG.debug("Close reason: {}:{}", closeReason.getReasonPhrase(), closeReason.getCloseCode());
+        String combinedEndpointId;
+        if (endpointIdOptional.isPresent()) {
+            combinedEndpointId = endpointIdOptional.get();
 
-        registry.remove(combinedEndpointId);
+            LOG.debug("Web socket session closed");
+            LOG.debug("Endpoint: {}", combinedEndpointId);
+            LOG.debug("Close reason: {}:{}", closeReason.getReasonPhrase(), closeReason.getCloseCode());
+
+            registry.remove(combinedEndpointId);
+        } else {
+            LOG.warn("Closing unidentified session");
+        }
     }
 
     @OnError
-    public void onError(Throwable t) {
-        LOG.debug("Web socket session error");
-        LOG.debug("Error: {}", t);
-    }
+    public void onError(Throwable t, Session session) {
+        Optional<String> endpointIdOptional = registry.get(session);
 
-    private String getCombinedEndpointId(Session session) {
-        return registry.get(session).orElseGet(() -> identificationService.getCombinedId(getEndpointId()));
+        String combinedEndpointId;
+        if (endpointIdOptional.isPresent()) {
+            combinedEndpointId = endpointIdOptional.get();
+
+            LOG.debug("Web socket session error");
+            LOG.debug("Endpoint: {}", combinedEndpointId);
+            LOG.debug("Error: {}", t);
+        } else {
+            LOG.warn("Web socket session error");
+            LOG.debug("Unidentified session");
+            LOG.debug("Error: {}", t);
+        }
     }
 
     protected abstract String getEndpointId();
+
+    private String getOrGenerateCombinedEndpointId(Session session) {
+        Map<String, String> queryParamsMap = getQueryParamsMap(session.getQueryString());
+        String clientId = queryParamsMap.getOrDefault("clientId", randomClientId());
+        return registry.get(session).orElse(identificationService.getCombinedId(getEndpointId(), clientId));
+    }
+
+    private Map<String, String> getQueryParamsMap(String queryParamsString) {
+        Map<String, String> queryParamsMap = new HashMap<>();
+
+        for (String queryParamsPair : Optional.ofNullable(queryParamsString).orElse("").split("&")) {
+            String[] pair = queryParamsPair.split("=");
+            if (pair.length == 2) {
+                queryParamsMap.put(pair[0], pair[1]);
+            }
+        }
+
+        return queryParamsMap.isEmpty() ? emptyMap() : unmodifiableMap(queryParamsMap);
+    }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebsocketIdService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebsocketIdService.java
@@ -10,12 +10,10 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.websocket.impl;
 
-import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.websocket.Session;
 import java.util.Random;
 
 /**
@@ -29,18 +27,10 @@ import java.util.Random;
  */
 @Singleton
 public class WebsocketIdService {
-    private static final String ERROR_MESSAGE = "No session is associated with provided endpoint id";
     private static final String SEPARATOR     = "<-:->";
     private static final Random GENERATOR     = new Random();
 
-    private final WebSocketSessionRegistry registry;
-
-    @Inject
-    public WebsocketIdService(WebSocketSessionRegistry registry) {
-        this.registry = registry;
-    }
-
-    private static String clientId() {
+    public static String randomClientId() {
         return String.valueOf(GENERATOR.nextInt(Integer.MAX_VALUE));
     }
 
@@ -51,23 +41,6 @@ public class WebsocketIdService {
                                   .noParams()
                                   .resultAsString()
                                   .withFunction(this::extractClientId);
-
-        requestHandlerConfigurator.newConfiguration()
-                                  .methodName("websocketIdService/setId")
-                                  .paramsAsString()
-                                  .noResult()
-                                  .withBiConsumer((oldCombinedId, newClientId) -> {
-                                      String endpointId = extractEndpointId(oldCombinedId);
-                                      String newCombinedId = getCombinedId(endpointId, newClientId);
-                                      Session session = registry.remove(oldCombinedId)
-                                                                .orElseThrow(() -> new JsonRpcException(-27000, ERROR_MESSAGE));
-
-                                      registry.add(newCombinedId, session);
-                                  });
-    }
-
-    public String getCombinedId(String endpointId) {
-        return clientId() + SEPARATOR + endpointId;
     }
 
     public String getCombinedId(String endpointId, String clientId) {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
@@ -29,10 +29,10 @@ import org.eclipse.che.ide.jsonrpc.JsonRpcInitializer;
 import org.eclipse.che.ide.util.loging.Log;
 
 import javax.inject.Singleton;
-import java.util.Collections;
-import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto.Type.START;
@@ -91,11 +91,12 @@ public class JsonRpcWebSocketAgentEventListener implements WsAgentStateHandler {
         DevMachine devMachine = appContext.getDevMachine();
         String devMachineId = devMachine.getId();
         String wsAgentWebSocketUrl = devMachine.getWsAgentWebSocketUrl();
-
         String wsAgentUrl = wsAgentWebSocketUrl.replaceFirst("api/ws", "wsagent");
         String execAgentUrl = devMachine.getExecAgentUrl();
+        String queryParams = appContext.getApplicationWebsocketId().map(clientId -> "?clientId=" + clientId).orElse("");
+        Set<Runnable> initActions = appContext.getApplicationWebsocketId().isPresent() ? emptySet() : singleton(this::processWsId);
 
-        initializer.initialize("ws-agent", singletonMap("url", wsAgentUrl), singleton(this::processWsId));
+        initializer.initialize("ws-agent", singletonMap("url", wsAgentUrl + queryParams), initActions);
         initializer.initialize(devMachineId, singletonMap("url", execAgentUrl));
 
         for (MachineEntity machineEntity : appContext.getActiveRuntime().getMachines()) {
@@ -121,21 +122,12 @@ public class JsonRpcWebSocketAgentEventListener implements WsAgentStateHandler {
     }
 
     private void processWsId() {
-        Optional<String> applicationWebsocketId = appContext.getApplicationWebsocketId();
-        if (applicationWebsocketId.isPresent()) {
-            requestTransmitter.newRequest()
-                              .endpointId("ws-agent")
-                              .methodName("websocketIdService/setId")
-                              .paramsAsString(applicationWebsocketId.get())
-                              .sendAndSkipResult();
-        } else {
-            requestTransmitter.newRequest()
-                              .endpointId("ws-agent")
-                              .methodName("websocketIdService/getId")
-                              .noParams()
-                              .sendAndReceiveResultAsString()
-                              .onSuccess(appContext::setApplicationWebsocketId);
-        }
+        requestTransmitter.newRequest()
+                          .endpointId("ws-agent")
+                          .methodName("websocketIdService/getId")
+                          .noParams()
+                          .sendAndReceiveResultAsString()
+                          .onSuccess(appContext::setApplicationWebsocketId);
     }
 
     private void initializeTreeExplorerFileWatcher() {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/event/ng/JsonRpcWebSocketAgentEventListener.java
@@ -93,7 +93,8 @@ public class JsonRpcWebSocketAgentEventListener implements WsAgentStateHandler {
         String wsAgentWebSocketUrl = devMachine.getWsAgentWebSocketUrl();
         String wsAgentUrl = wsAgentWebSocketUrl.replaceFirst("api/ws", "wsagent");
         String execAgentUrl = devMachine.getExecAgentUrl();
-        String queryParams = appContext.getApplicationWebsocketId().map(clientId -> "?clientId=" + clientId).orElse("");
+        String separator = wsAgentUrl.contains("?") ? "&" : "?";
+        String queryParams = appContext.getApplicationWebsocketId().map(id -> separator + "clientId=" + id).orElse("");
         Set<Runnable> initActions = appContext.getApplicationWebsocketId().isPresent() ? emptySet() : singleton(this::processWsId);
 
         initializer.initialize("ws-agent", singletonMap("url", wsAgentUrl + queryParams), initActions);

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/jsonrpc/WorkspaceMasterJsonRpcInitializer.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/jsonrpc/WorkspaceMasterJsonRpcInitializer.java
@@ -71,11 +71,12 @@ public class WorkspaceMasterJsonRpcInitializer {
         String protocol = "https:".equals(getProtocol()) ? "wss://" : "ws://";
         String host = getHost();
         String context = getWebsocketContext();
-        String queryParams = appContext.getApplicationWebsocketId().map(clientId -> "?clientId=" + clientId).orElse("");
-        String workspaceMasterUrl = protocol + host + context + queryParams;
+        String url = protocol + host + context;
+        String separator = url.contains("?") ? "&" : "?";
+        String queryParams = appContext.getApplicationWebsocketId().map(id -> separator + "clientId=" + id).orElse("");
         Set<Runnable> initActions = appContext.getApplicationWebsocketId().isPresent() ? emptySet() : singleton(this::processWsId);
 
-        initializer.initialize("ws-master", singletonMap("url", workspaceMasterUrl), initActions);
+        initializer.initialize("ws-master", singletonMap("url", url + queryParams), initActions);
     }
 
     private void processWsId() {

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/impl/BasicWebSocketEndpoint.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/impl/BasicWebSocketEndpoint.java
@@ -25,18 +25,22 @@ public class BasicWebSocketEndpoint implements WebSocketEndpoint {
     private final WebSocketConnectionSustainer sustainer;
     private final MessagesReSender             reSender;
     private final WebSocketDispatcher          dispatcher;
+    private final WebSocketActionManager       actionManager;
 
     @Inject
-    public BasicWebSocketEndpoint(WebSocketConnectionSustainer sustainer, MessagesReSender reSender, WebSocketDispatcher dispatcher) {
+    public BasicWebSocketEndpoint(WebSocketConnectionSustainer sustainer, MessagesReSender reSender, WebSocketDispatcher dispatcher,
+                                  WebSocketActionManager actionManager) {
         this.sustainer = sustainer;
         this.reSender = reSender;
         this.dispatcher = dispatcher;
+        this.actionManager = actionManager;
     }
 
     @Override
     public void onOpen(String url) {
         Log.debug(getClass(), "Session opened.");
 
+        actionManager.getOnOpenActions(url).forEach(Runnable::run);
         sustainer.reset(url);
         reSender.reSend(url);
     }
@@ -45,6 +49,7 @@ public class BasicWebSocketEndpoint implements WebSocketEndpoint {
     public void onClose(String url) {
         Log.debug(getClass(), "Session closed.");
 
+        actionManager.getOnCloseActions(url).forEach(Runnable::run);
         sustainer.sustain(url);
     }
 

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/impl/WebSocketActionManager.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/impl/WebSocketActionManager.java
@@ -45,7 +45,7 @@ public class WebSocketActionManager {
      *         url of a connection
      * @return set of actions
      */
-    public Set<Runnable> getOnEstablishActions(String url) {
+    public Set<Runnable> getOnOpenActions(String url) {
         return establishActions.getOrDefault(url, emptySet());
     }
 

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/impl/WebSocketConnectionManager.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/websocket/impl/WebSocketConnectionManager.java
@@ -27,14 +27,12 @@ import java.util.Map;
 @Singleton
 public class WebSocketConnectionManager {
     private final WebSocketFactory       webSocketFactory;
-    private final WebSocketActionManager actionManager;
 
     private final Map<String, WebSocketConnection> connectionsRegistry = new HashMap<>();
 
     @Inject
-    public WebSocketConnectionManager(WebSocketFactory webSocketFactory, WebSocketActionManager actionManager) {
+    public WebSocketConnectionManager(WebSocketFactory webSocketFactory) {
         this.webSocketFactory = webSocketFactory;
-        this.actionManager = actionManager;
     }
 
     /**
@@ -64,7 +62,6 @@ public class WebSocketConnectionManager {
         }
 
         webSocketConnection.open();
-        actionManager.getOnEstablishActions(url).forEach(Runnable::run);
 
         Log.debug(getClass(), "Opening connection. Url: " + url);
     }
@@ -85,7 +82,6 @@ public class WebSocketConnectionManager {
         }
 
         webSocketConnection.close();
-        actionManager.getOnCloseActions(url).forEach(Runnable::run);
 
         Log.debug(WebSocketConnectionManager.class, "Closing connection.");
     }

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/impl/BasicWebSocketEndpointTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/websocket/impl/BasicWebSocketEndpointTest.java
@@ -26,11 +26,14 @@ import static org.mockito.Mockito.verify;
 @RunWith(MockitoJUnitRunner.class)
 public class BasicWebSocketEndpointTest {
     @Mock
-    private  WebSocketConnectionSustainer sustainer;
+    private WebSocketConnectionSustainer sustainer;
     @Mock
-    private  MessagesReSender             reSender;
+    private MessagesReSender             reSender;
     @Mock
-    private  WebSocketDispatcher          dispatcher;
+    private WebSocketDispatcher          dispatcher;
+    @Mock
+    private WebSocketActionManager       actionManager;
+
     @InjectMocks
     private BasicWebSocketEndpoint        endpoint;
 
@@ -46,6 +49,20 @@ public class BasicWebSocketEndpointTest {
         endpoint.onOpen("url");
 
         verify(reSender).reSend("url");
+    }
+
+    @Test
+    public void shouldOnOpenActionsOnOpen(){
+        endpoint.onOpen("url");
+
+        verify(actionManager).getOnOpenActions("url");
+    }
+
+    @Test
+    public void shouldOnCloseActionsOnClose(){
+        endpoint.onClose("url");
+
+        verify(actionManager).getOnCloseActions("url");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Dmitry Kuleshov <dkuleshov@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The description of the origin and solution is [here](https://github.com/eclipse/che/issues/5818#issuecomment-318431161). Briefly the idea is to replace `wsIdService/setId` JSON-RPC method calls with query params in order to set websocket client identifier before any request is being processed (previously it only could be set in parallel with processing other JSON-RPC requests). So we may have several scenarios:
- Client has or has no websocket ID but it is not expected to have several websocket sessions - client simply establishes a connection, no extra work for client. ID is generated automatically on server side and is used internally, within a single websocket session client is identified.
- Client has no websocket ID while it is expected to have several websocket sessions - after websocket connection is established client calls `wsIdService/getId` (not necessarily right on session opening, obviously depends on business logics) and gets an ID that can be used further for cross-session identification.
- Client has websocket ID while it is expected to have several websocket sessions - it identifies itself (only) during initialization of a websocket session by setting `clientId` query param: `ws://host:port/websocket?clientId=1283719824`


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5818

#### Changelog
Fixed errors in LS diagnostics propagation over JSON-RPC by changing websocket client identification mechanism.