### PR TITLE
Use docker to build dashboard app. (as alternative)

### DIFF
--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,27 @@
+Dockerfile
+node_modules
+bower_components
+target
+pom.xml
+./typings
+./tmp
+./codeverage
+
+# Eclipse  #
+###################
+
+*.launch
+.classpath
+.project
+.settings/
+bin/
+test-output/
+maven-eclipse.xml
+
+# Idea #
+##################
+*.iml
+*.ipr
+*.iws
+.idea/
+

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2012-2017 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# This is a Dockerfile allowing to build dashboard by using a docker container.
+# Build step: $ docker build -t eclipse-che-dashboard
+# It builds an archive file that can be used by doing later
+#  $ docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -
+FROM mhart/alpine-node:6
+
+RUN apk update && \
+    apk add --no-cache git
+COPY package.json /dashboard/
+RUN cd /dashboard && npm install
+COPY bower.json /dashboard/
+RUN cd /dashboard && ./node_modules/.bin/bower install --allow-root
+COPY . /dashboard/
+RUN cd /dashboard && npm run build && cd target/ && tar zcf /tmp/dashboard.tar.gz dist/
+
+CMD zcat /tmp/dashboard.tar.gz

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,11 +5,7 @@ Che Dashboard
 ==============
 
 #Requirements
-- Python `v2.7.x`(`v3.x.x`currently not supported)
-- Node.js `v4.x.x` (`v5.x.x` / `v6.x.x` are currently not supported)
-- npm
-
-Installation instructions for Node.js and npm can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). 
+- Docker
 
 #Quick start
 
@@ -17,11 +13,18 @@ Installation instructions for Node.js and npm can be found on the following [lin
 cd che/dashboard
 mvn clean install
 ```
-note: by default it will build dashboard using a docker image. If all required tools are installed locally, the native profile can be used by performing
-```
-`mvn -Pnative clean install
-```
 
+note: by default it will build dashboard using a docker image. If all required tools are installed locally, the native profile can be used by pe$
+
+```
+$ mvn -Pnative clean install
+```
+Required tools for native build:
+- Python `v2.7.x`(`v3.x.x`currently not supported)
+- Node.js `v4.x.x` (`v5.x.x` / `v6.x.x` are currently not supported)
+- npm
+
+Installation instructions for Node.js and npm can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). 
 
 ## Running
 In order to run the project, the serve command is used

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -17,6 +17,11 @@ Installation instructions for Node.js and npm can be found on the following [lin
 cd che/dashboard
 mvn clean install
 ```
+note: by default it will build dashboard using a docker image. If all required tools are installed locally, the native profile can be used by performing
+```
+`mvn -Pnative clean install
+```
+
 
 ## Running
 In order to run the project, the serve command is used

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -14,7 +14,8 @@ cd che/dashboard
 mvn clean install
 ```
 
-note: by default it will build dashboard using a docker image. If all required tools are installed locally, the native profile can be used by pe$
+note: by default it will build dashboard using a docker image.
+If all required tools are installed locally, the native profile can be used instead of the docker build by following command:
 
 ```sh
 $ mvn -Pnative clean install
@@ -22,7 +23,7 @@ $ mvn -Pnative clean install
 
 Required tools for native build:
 - Python `v2.7.x`(`v3.x.x`currently not supported)
-- Node.js `v4.x.x` (`v5.x.x` / `v6.x.x` are currently not supported)
+- Node.js `v4.x.x`, `v5.x.x` or `v6.x.x`
 - npm
 
 Installation instructions for Node.js and npm can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -4,10 +4,10 @@ Eclipse Che is a next generation Eclipse IDE and open source alternative to Inte
 Che Dashboard
 ==============
 
-#Requirements
+## Requirements
 - Docker
 
-#Quick start
+## Quick start
 
 ```sh
 cd che/dashboard
@@ -16,9 +16,10 @@ mvn clean install
 
 note: by default it will build dashboard using a docker image. If all required tools are installed locally, the native profile can be used by pe$
 
-```
+```sh
 $ mvn -Pnative clean install
 ```
+
 Required tools for native build:
 - Python `v2.7.x`(`v3.x.x`currently not supported)
 - Node.js `v4.x.x` (`v5.x.x` / `v6.x.x` are currently not supported)

--- a/dashboard/gulp/conf.js
+++ b/dashboard/gulp/conf.js
@@ -16,7 +16,7 @@ var gutil = require('gulp-util');
  */
 exports.paths = {
   src: 'src',
-  dist: 'dist',
+  dist: 'target/dist',
   tmp: '.tmp',
   e2e: 'e2e'
 };

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -36,71 +36,12 @@
         <finalName>dashboard-war</finalName>
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${basedir}/bower_components</directory>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                        <fileset>
-                            <directory>${basedir}/node_modules</directory>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                        <fileset>
-                            <directory>${basedir}/dist</directory>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <!-- Download NPM dependencies -->
-                                <exec dir="${basedir}" executable="npm" failonerror="true">
-                                    <arg value="install" />
-                                </exec>
-                                <!-- Change base HREF of the application that will be hosted on /dashboard -->
-                                <replace file="${basedir}/dist/index.html">
-                                    <replacetoken><![CDATA[<base href="/">]]></replacetoken>
-                                    <replacevalue><![CDATA[<base href="/dashboard/">]]></replacevalue>
-                                </replace>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>compilation</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target unless="skipTests">
-                                <!-- Run unit tests -->
-                                <exec dir="${basedir}" executable="gulp" failonerror="true">
-                                    <arg value="test" />
-                                </exec>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <webResources>
                         <resource>
-                            <directory>dist</directory>
+                            <directory>target/dist</directory>
                         </resource>
                     </webResources>
                     <webXml>${basedir}/src/webapp/WEB-INF/web.xml</webXml>
@@ -129,6 +70,134 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <!-- Docker build used by default, to use native build, use -Pnative -->
+            <id>docker</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-image</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- build user dashboard with maven -->
+                                        <exec dir="${basedir}" executable="docker" failonerror="true">
+                                            <arg value="build" />
+                                            <arg value="-t" />
+                                            <arg value="eclipse-che-dashboard" />
+                                            <arg value="." />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>unpack-docker-build</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- build user dashboard with docker -->
+                                        <exec executable="bash">
+                                            <arg value="-c" />
+                                            <arg value="docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>update-href</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- Change base HREF of the application that will be hosted on /dashboard -->
+                                        <replace file="${basedir}/target/dist/index.html">
+                                            <replacetoken><![CDATA[<base href="/">]]></replacetoken>
+                                            <replacevalue><![CDATA[<base href="/dashboard/">]]></replacevalue>
+                                        </replace>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${basedir}/bower_components</directory>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                                <fileset>
+                                    <directory>${basedir}/node_modules</directory>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-dashboard</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- build user dashboard -->
+                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                            <arg value="install" />
+                                        </exec>
+                                        <!-- Change base HREF of the application that will be hosted on /dashboard -->
+                                        <replace file="${basedir}/target/dist/index.html">
+                                            <replacetoken><![CDATA[<base href="/">]]></replacetoken>
+                                            <replacevalue><![CDATA[<base href="/dashboard/">]]></replacevalue>
+                                        </replace>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>compilation</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target unless="skipTests">
+                                        <!-- Run unit tests -->
+                                        <exec dir="${basedir}" executable="gulp" failonerror="true">
+                                            <arg value="test" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>qa</id>
             <build>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -110,7 +110,7 @@
                                         <!-- build user dashboard with docker -->
                                         <exec executable="bash">
                                             <arg value="-c" />
-                                            <arg value="docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -" />
+                                            <arg value="docker run --rm eclipse-che-dashboard | tar -C target/ -xf -" />
                                         </exec>
                                     </target>
                                 </configuration>


### PR DESCRIPTION
### What does this PR do?
Use docker to build dashboard app. (as alternative)
By using layer for package.json and bower.json file, it saves extra time to get npm or bower dependencies

Also, if dashboard files are not modified, the build is faster.

it targets as well issue #5127

By default :
 "$ mvn clean install" --> use docker
 "$ mvn clean install -Pnative" --> use native tools

as a side note, if all files are untouched, mvn clean  install of dashboard is taking less than 10 seconds instead of like 5mn+

### What issues does this PR fix or reference?
 #5127

#### Changelog
Allow to build dashboard app with docker.

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: Ia65161b58e8ae70f7799500750a3d87687e34819
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

