### PR TITLE
Use separate servers for ws/http endpoints

### DIFF
--- a/agents/exec/src/main/resources/org.eclipse.che.exec.json
+++ b/agents/exec/src/main/resources/org.eclipse.che.exec.json
@@ -5,9 +5,15 @@
   "dependencies": [],
   "properties": {},
   "servers": {
-    "exec-agent": {
+    "exec-agent/http": {
       "port": "4412/tcp",
-      "protocol": "http"
+      "protocol": "http",
+      "path" : "/process"
+    },
+    "exec-agent/ws": {
+      "port": "4412/tcp",
+      "protocol": "ws",
+      "path": "/connect"
     }
   }
 }

--- a/agents/terminal/src/main/resources/org.eclipse.che.terminal.json
+++ b/agents/terminal/src/main/resources/org.eclipse.che.terminal.json
@@ -7,7 +7,8 @@
   "servers": {
     "terminal": {
       "port": "4411/tcp",
-      "protocol": "http"
+      "protocol": "ws",
+      "path" : "/pty"
     }
   }
 }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
@@ -61,7 +61,7 @@ public class DockerMachineCreator {
     /** Creates new docker machine instance from the full container description. */
     public DockerMachine create(ContainerInfo container) {
         NetworkSettings networkSettings = container.getNetworkSettings();
-        String hostname = networkSettings.getIpAddress();
+        String hostname = networkSettings.getGateway();
         Map<String, ServerConfig> configs = Labels.newDeserializer(container.getConfig().getLabels()).servers();
 
         return new DockerMachine(container.getId(),

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -41,7 +41,7 @@ public final class Labels {
     private static final String SERVER_PATH_LABEL_FMT     = LABEL_PREFIX + "server.%s.path";
 
     /** Pattern that matches server labels e.g. "org.eclipse.che.server.exec-agent.port". */
-    private static final Pattern SERVER_LABEL_PATTERN = Pattern.compile("org\\.eclipse\\.che\\.server\\.(?<ref>[\\w-]+)\\..+");
+    private static final Pattern SERVER_LABEL_PATTERN = Pattern.compile("org\\.eclipse\\.che\\.server\\.(?<ref>[\\w-/]+)\\..+");
 
     /** Creates new label serializer. */
     public static Serializer newSerializer() { return new Serializer(); }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/ServersReadinessChecker.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/ServersReadinessChecker.java
@@ -17,7 +17,9 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 
 import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriBuilderException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,8 +39,8 @@ import java.util.function.Consumer;
 public class ServersReadinessChecker {
     // workaround to set correct paths for servers readiness checks
     // TODO replace with checks set in server config
-    private final static Map<String, String> LIVENESS_CHECKS_PATHS = ImmutableMap.of("wsagent", "/api/",
-                                                                                     "exec-agent", "/process",
+    private final static Map<String, String> LIVENESS_CHECKS_PATHS = ImmutableMap.of("wsagent/http", "/api/",
+                                                                                     "exec-agent/http", "/process",
                                                                                      "terminal", "/");
     private final String                  machineName;
     private final Map<String, ServerImpl> servers;
@@ -161,7 +163,9 @@ public class ServersReadinessChecker {
         // Create server readiness endpoint URL
         URL url;
         try {
-            url = UriBuilder.fromUri(server.getUrl())
+            // TODO: ws -> http is workaround used for terminal websocket server,
+            // should be removed after server checks added to model
+            url = UriBuilder.fromUri(server.getUrl().replaceFirst("^ws", "http"))
                             .replacePath(livenessCheckPath)
                             .build()
                             .toURL();

--- a/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
+++ b/infrastructures/docker/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
@@ -35,7 +35,7 @@ public class LabelsTest {
         Map<String, String> serialized = Labels.newSerializer()
                                                .machineName("dev-machine")
                                                .runtimeId(new RuntimeIdentityImpl("workspace123", "my-env", "owner"))
-                                               .server("my-server1", new ServerConfigImpl("8000/tcp", "http", "/api/info"))
+                                               .server("my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info"))
                                                .server("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect"))
                                                .labels();
         Map<String, String> expected =
@@ -44,9 +44,9 @@ public class LabelsTest {
                         .put("org.eclipse.che.workspace.id", "workspace123")
                         .put("org.eclipse.che.workspace.env", "my-env")
                         .put("org.eclipse.che.workspace.owner", "owner")
-                        .put("org.eclipse.che.server.my-server1.port", "8000/tcp")
-                        .put("org.eclipse.che.server.my-server1.protocol", "http")
-                        .put("org.eclipse.che.server.my-server1.path", "/api/info")
+                        .put("org.eclipse.che.server.my-server1/http.port", "8000/tcp")
+                        .put("org.eclipse.che.server.my-server1/http.protocol", "http")
+                        .put("org.eclipse.che.server.my-server1/http.path", "/api/info")
                         .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
                         .put("org.eclipse.che.server.my-server2.protocol", "ws")
                         .put("org.eclipse.che.server.my-server2.path", "/connect")
@@ -65,9 +65,9 @@ public class LabelsTest {
                         .put("org.eclipse.che.workspace.id", "workspace123")
                         .put("org.eclipse.che.workspace.env", "my-env")
                         .put("org.eclipse.che.workspace.owner", "owner")
-                        .put("org.eclipse.che.server.my-server1.port", "8000/tcp")
-                        .put("org.eclipse.che.server.my-server1.protocol", "http")
-                        .put("org.eclipse.che.server.my-server1.path", "/api/info")
+                        .put("org.eclipse.che.server.my-server1/http.port", "8000/tcp")
+                        .put("org.eclipse.che.server.my-server1/http.protocol", "http")
+                        .put("org.eclipse.che.server.my-server1/http.path", "/api/info")
                         .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
                         .put("org.eclipse.che.server.my-server2.protocol", "ws")
                         .put("org.eclipse.che.server.my-server2.path", "/connect")
@@ -83,7 +83,7 @@ public class LabelsTest {
         assertEquals(runtimeId.getOwner(), "owner", "workspace owner");
 
         Map<String, ServerConfig> servers = deserializer.servers();
-        ServerConfig server1 = servers.get("my-server1");
+        ServerConfig server1 = servers.get("my-server1/http");
         assertNotNull(server1, "first server");
         assertEquals(server1.getPort(), "8000/tcp");
         assertEquals(server1.getProtocol(), "http");

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.json
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.json
@@ -8,10 +8,15 @@
   ],
   "properties": {},
   "servers": {
-    "wsagent": {
+    "wsagent/http": {
       "port": "4401/tcp",
       "protocol": "http",
       "path" : "/api"
+    },
+    "wsagent/ws": {
+      "port": "4401/tcp",
+      "protocol": "ws",
+      "path" : "/wsagent"
     }
   }
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -72,12 +72,12 @@ public final class Constants {
     public static final String LINK_REL_ENVIRONMENT_STATUS_CHANNEL = "environment.status_channel";
     public static final String ENVIRONMENT_STATUS_CHANNEL_TEMPLATE = "workspace:%s:machines_statuses";
 
-    public static final String WSAGENT_REFERENCE                   = "wsagent";
+    public static final String WSAGENT_REFERENCE                   = "wsagent/http";
     public static final String WSAGENT_WEBSOCKET_REFERENCE         = "wsagent.websocket";
     public static final String WSAGENT_DEBUG_REFERENCE             = "wsagent.debug";
 
     public static final String TERMINAL_REFERENCE = "terminal";
-    public static final String EXEC_AGENT_REFERENCE = "exec-agent";
+    public static final String EXEC_AGENT_REFERENCE = "exec-agent/ws";
 
     public static final String WS_AGENT_PORT = "4401/tcp";
 


### PR DESCRIPTION
Use separate servers for _ws/http_ endpoints.
The example of API response:

```json
"servers": {
  "wsagent/ws": {
    "url": "ws://172.17.0.1:32838/wsagent",
    "status": "UNKNOWN"
  },
  "exec-agent/ws": {
    "url": "ws://172.17.0.1:32835/connect",
    "status": "UNKNOWN"
  },
  "wsagent/http": {
    "url": "http://172.17.0.1:32838/api",
    "status": "RUNNING"
  },
  "8080/tcp": {
    "url": "tcp://172.17.0.1:32833",
    "status": "UNKNOWN"
  },
  "exec-agent/http": {
    "url": "http://172.17.0.1:32835/process",
    "status": "RUNNING"
  },
  "ssh": {
    "url": "ssh://172.17.0.1:32839",
    "status": "UNKNOWN"
  },
  "9876/tcp": {
    "url": "tcp://172.17.0.1:32832",
    "status": "UNKNOWN"
  },
  "4403/tcp": {
    "url": "tcp://172.17.0.1:32837",
    "status": "UNKNOWN"
  },
  "8000/tcp": {
    "url": "tcp://172.17.0.1:32834",
    "status": "UNKNOWN"
  },
  "terminal": {
    "url": "ws://172.17.0.1:32836/pty",
    "status": "RUNNING"
  }
}
```

Resolves #5609 