### PR TITLE
Fix launchers to call to set_sudo_command

### DIFF
--- a/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
+++ b/agents/exec/src/main/resources/org.eclipse.che.exec.script.sh
@@ -22,6 +22,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 CURL_INSTALLED=false

--- a/agents/ls-csharp/src/main/resources/org.eclipse.che.ls.csharp.script.sh
+++ b/agents/ls-csharp/src/main/resources/org.eclipse.che.ls.csharp.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }

--- a/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
+++ b/agents/ls-json/src/main/resources/org.eclipse.che.ls.json.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }

--- a/agents/ls-php/src/main/resources/org.eclipse.che.ls.php.script.sh
+++ b/agents/ls-php/src/main/resources/org.eclipse.che.ls.php.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }

--- a/agents/ls-python/src/main/resources/org.eclipse.che.ls.python.script.sh
+++ b/agents/ls-python/src/main/resources/org.eclipse.che.ls.python.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 unset PYTHON_DEPS
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }

--- a/agents/ls-typescript/src/main/resources/org.eclipse.che.ls.typescript.script.sh
+++ b/agents/ls-typescript/src/main/resources/org.eclipse.che.ls.typescript.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }

--- a/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
+++ b/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 
 if [ -f /etc/centos-release ]; then

--- a/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/org.eclipse.che.terminal.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 CURL_INSTALLED=false

--- a/agents/unison/src/main/resources/org.eclipse.che.unison.script.sh
+++ b/agents/unison/src/main/resources/org.eclipse.che.unison.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 
 if [ -f /etc/centos-release ]; then

--- a/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/org.eclipse.che.ws-agent.script.sh
@@ -21,6 +21,7 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+set_sudo_command
 unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 CURL_INSTALLED=false


### PR DESCRIPTION
### What does this PR do?
Fix a bug introduced with https://github.com/eclipse/che/commit/a419690730908aac6ddf573e935722179615ddff: function `set_sudo_command` was never called