### PR TITLE
CHE-5379: fix wrong cursor placement for auto completion

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -215,6 +215,15 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
                 } else {
                     document.replace(cursorOffset - offset, offset, completionItem.getInsertText());
                 }
+                if (currentWordLength == 0) {
+                    TextPosition cursorPosition = document.getCursorPosition();
+                    if (cursorPosition == null) {
+                        return;
+                    }
+                    int line = cursorPosition.getLine();
+                    int character = cursorPosition.getCharacter();
+                    document.setCursorPosition(new TextPosition(line, character + completionItem.getLabel().length()));
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Change cursor position after applying code completion

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5379

#### Changelog
<!-- one line entry to be added to changelog -->
Fix wrong cursor placement for auto completion

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fix wrong cursor placement for auto completion

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
