### PR TITLE
Make OpenShiftConnector add Cluster IP instead of Service name in workspace pods

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
@@ -65,6 +65,7 @@ public class OpenShiftPvcHelper {
     private static final String POD_PHASE_FAILED           = "Failed";
     private static final String[] MKDIR_WORKSPACE_COMMAND  = new String[] {"mkdir", "-p"};
     private static final String[] RMDIR_WORKSPACE_COMMAND  = new String[] {"rm", "-rf"};
+    private static final int JOB_TIMEOUT_SECONDS           = 120;
 
     private static final Set<String> createdWorkspaces = ConcurrentHashMap.newKeySet();
 
@@ -176,7 +177,7 @@ public class OpenShiftPvcHelper {
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()){
             openShiftClient.pods().inNamespace(projectNamespace).create(podSpec);
             boolean completed = false;
-            while(!completed) {
+            for(int waitCount = 0; (waitCount < JOB_TIMEOUT_SECONDS) && !completed; waitCount++) {
                 Pod pod = openShiftClient.pods().inNamespace(projectNamespace).withName(podName).get();
                 String phase = pod.getStatus().getPhase();
                 switch (phase) {

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
@@ -176,8 +176,9 @@ public class OpenShiftPvcHelper {
 
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()){
             openShiftClient.pods().inNamespace(projectNamespace).create(podSpec);
-            boolean completed = false;
-            for(int waitCount = 0; (waitCount < JOB_TIMEOUT_SECONDS) && !completed; waitCount++) {
+
+            int waitCount = 0;
+            while(waitCount < JOB_TIMEOUT_SECONDS) {
                 Pod pod = openShiftClient.pods().inNamespace(projectNamespace).withName(podName).get();
                 String phase = pod.getStatus().getPhase();
                 switch (phase) {
@@ -190,6 +191,7 @@ public class OpenShiftPvcHelper {
                     default:
                         Thread.sleep(1000);
                 }
+                waitCount++;
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
### What does this PR do?
Change OpenShiftConnector to be able to run workspaces in a separate namespace

- Make OpenShiftConnector override the `CHE_API` env variable before starting a workspace so that it uses che-host's cluster IP instead of service name. This is necessary since service names are namespaced, while cluster IP is accessible anywhere on the cluster.
- *Minor fix*: Add timeout to OpenShiftPvcHelper, to avoid stalling for a long time when an error occurs (e.g. when there is a PVC issue)

This PR only makes it possible to run workspaces in a separate namespace, it does not add the ability to do so without some customization. Since Che currently only supports one user, there is no way of knowing, within OpenShiftConnector, where the workspace should be started.

### What issues does this PR fix or reference?
Is a necessary step towards running a multitenant Che server on OpenShift. See https://github.com/redhat-developer/rh-che/issues/131.

#### Changelog
(Bug fix + no functional change)

#### Release Notes
(Bug fix; internal change only)