### PR TITLE
CHE-5862: Set right handler on double click in Git Compare window

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changeslist/ChangesListPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changeslist/ChangesListPresenter.java
@@ -60,7 +60,7 @@ public class ChangesListPresenter implements ChangesListView.ActionDelegate {
         this.view = view;
         this.notificationManager = notificationManager;
         this.changesPanelPresenter = changesPanelPresenter;
-        this.changesPanelPresenter.setOnFileNodeDoubleClickedHandler((path, status) -> this.onCompareClicked());
+        this.changesPanelPresenter.setFileNodeDoubleClickHandler((path, status) -> this.onCompareClicked());
         this.view.setDelegate(this);
 
         SelectionChangedHandler handler = event -> {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changeslist/ChangesListPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changeslist/ChangesListPresenter.java
@@ -60,6 +60,7 @@ public class ChangesListPresenter implements ChangesListView.ActionDelegate {
         this.view = view;
         this.notificationManager = notificationManager;
         this.changesPanelPresenter = changesPanelPresenter;
+        this.changesPanelPresenter.setOnFileNodeDoubleClickedHandler((path, status) -> this.onCompareClicked());
         this.view.setDelegate(this);
 
         SelectionChangedHandler handler = event -> {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelPresenter.java
@@ -39,7 +39,7 @@ public class ChangesPanelPresenter implements ChangesPanelView.ActionDelegate {
     private Map<String, Status> changedFiles;
     private ViewMode            viewMode;
 
-    private OnFileNodeDoubleClickedHandler onFileNodeDoubleClickedHandler;
+    private FileNodeDoubleClickHandler fileNodeDoubleClickHandler;
 
     @Inject
     public ChangesPanelPresenter(GitLocalizationConstant locale,
@@ -52,7 +52,7 @@ public class ChangesPanelPresenter implements ChangesPanelView.ActionDelegate {
         this.view.setDelegate(this);
         this.viewMode = TREE;
 
-        this.onFileNodeDoubleClickedHandler = (path, status) -> {
+        this.fileNodeDoubleClickHandler = (path, status) -> {
             appContext.getRootProject()
                       .getFile(path)
                       .then(file -> {
@@ -92,7 +92,7 @@ public class ChangesPanelPresenter implements ChangesPanelView.ActionDelegate {
 
     @Override
     public void onFileNodeDoubleClicked(String path, final Status status) {
-        onFileNodeDoubleClickedHandler.onFileNodeDoubleClicked(path, status);
+        fileNodeDoubleClickHandler.onFileNodeDoubleClicked(path, status);
     }
 
     @Override
@@ -118,12 +118,12 @@ public class ChangesPanelPresenter implements ChangesPanelView.ActionDelegate {
                                                             : locale.changeListGroupByDirectoryButtonText());
     }
 
-    public interface OnFileNodeDoubleClickedHandler {
+    public interface FileNodeDoubleClickHandler {
         void onFileNodeDoubleClicked(String path, final Status status);
     }
 
-    public void setOnFileNodeDoubleClickedHandler(OnFileNodeDoubleClickedHandler onFileNodeDoubleClickedHandler) {
-        this.onFileNodeDoubleClickedHandler = onFileNodeDoubleClickedHandler;
+    public void setFileNodeDoubleClickHandler(FileNodeDoubleClickHandler fileNodeDoubleClickHandler) {
+        this.fileNodeDoubleClickHandler = fileNodeDoubleClickHandler;
     }
 
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelPresenter.java
@@ -118,12 +118,15 @@ public class ChangesPanelPresenter implements ChangesPanelView.ActionDelegate {
                                                             : locale.changeListGroupByDirectoryButtonText());
     }
 
-    public interface FileNodeDoubleClickHandler {
-        void onFileNodeDoubleClicked(String path, final Status status);
-    }
-
     public void setFileNodeDoubleClickHandler(FileNodeDoubleClickHandler fileNodeDoubleClickHandler) {
         this.fileNodeDoubleClickHandler = fileNodeDoubleClickHandler;
+    }
+
+    /**
+     * Describes behaviour on double click action on a selected path.
+     */
+    public interface FileNodeDoubleClickHandler {
+        void onFileNodeDoubleClicked(String path, final Status status);
     }
 
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelPresenter.java
@@ -26,7 +26,7 @@ import static org.eclipse.che.ide.ext.git.client.compare.changespanel.ViewMode.L
 import static org.eclipse.che.ide.ext.git.client.compare.changespanel.ViewMode.TREE;
 
 /**
- * Presenter for displaying list of changed files.
+ * Presenter for displaying window with list of changed files.
  *
  * @author Igor Vinokur
  * @author Vlad Zhukovskyi


### PR DESCRIPTION
### What does this PR do?
Fixes bug when on double click on a changed file in Git Compare window always showed comparation with latest version instead of selected one.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5862

#### Changelog
Fixed Git Compare with non-latest version (before double-click would only compare to latest).

#### Release Notes
N/A

#### Docs PR
N/A