### PR TITLE
Fix an erroneous change of vertx and spring boot stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2364,7 +2364,7 @@
           "goal": "Build"
         }
       }, {
-        "commandLine": "cd ${current.project.path} && scl enable rh-maven33 'java -jar target/*-fat.jar'",
+        "commandLine": "scl enable rh-maven33 'mvn compile vertx:run -f ${current.project.path}'",
         "name": "run",
         "type": "custom",
         "attributes": {
@@ -2441,7 +2441,7 @@
           "type": "mvn"
         },
         {
-          "commandLine": "java -jar ${current.project.path}/target/*.jar",
+          "commandLine": "scl enable rh-maven33 'mvn compile spring-boot:run -f ${current.project.path}'",
           "name": "run",
           "type": "custom",
           "attributes": {


### PR DESCRIPTION
### What does this PR do?

It fixes an erroneous change of vertx and spring boot stacks in [this
commit](https://github.com/eclipse/che/pull/5844/commits/cbc86776372c7557f7c5a62d4549a93466019c7c)
