### PR TITLE
Adding debug commands for vertx & spring-boot stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2371,6 +2371,14 @@
           "previewUrl": "http://${server.port.8080}",
           "goal": "Run"
         }
+      }, {
+        "commandLine": "scl enable rh-maven33 'mvn vertx:debug -f ${current.project.path}'",
+        "name": "debug",
+        "type": "custom",
+        "attributes": {
+          "previewUrl": "http://${server.port.8080}",
+          "goal": "Debug"
+        }
       }]
     },
     "stackIcon": {
@@ -2447,6 +2455,15 @@
           "attributes": {
             "previewUrl": "http://${server.port.8080}",
             "goal": "Run"
+          }
+        },
+        {
+          "commandLine": "scl enable rh-maven33 'mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\" -f ${current.project.path}'",
+          "name": "debug",
+          "type": "custom",
+          "attributes": {
+            "previewUrl": "http://${server.port.8080}",
+            "goal": "Debug"
           }
         }
       ]


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Adds debug commands for 'vert.x' and 'spring-boot' stacks

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/238

#### Changelog
Adding debug commands for 'vert.x' and 'spring-boot' stacks

#### Release Notes
Debug commands for 'vert.x' and 'spring-boot' stacks

#### Docs PR
N / A
