### PR TITLE
Update entrypoint.sh

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -156,7 +156,7 @@ call_catalina () {
 
   ### Cannot add this in setenv.sh.
   ### We do the port mapping here, and this gets inserted into server.xml when tomcat boots
-  export JAVA_OPTS="${JAVA_OPTS} -Dport.http=${CHE_PORT} -Dche.home=${CHE_HOME}"
+  export JAVA_OPTS="${JAVA_OPTS} -Dche.docker.network=bridge -Dport.http=${CHE_PORT} -Dche.home=${CHE_HOME}"
   export SERVER_PORT=${CHE_PORT}
 
   # Launch the Che application server, passing in command line parameters
@@ -317,8 +317,6 @@ init() {
     cp -rf "${CHE_HOME}"/templates/* "${CHE_DATA}"/templates
   fi
 
-  # A che property, which names the Docker network used for che + ws to communicate
-  export JAVA_OPTS="${JAVA_OPTS} -Dche.docker.network=bridge"
 }
 
 get_che_data_from_host() {

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -149,9 +149,9 @@ call_catalina () {
 
   ### Initialize default JVM arguments to run che
   if [[ "${CHE_BLOCKING_ENTROPY}" == true ]]; then
-    [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m -Djava.security.egd=file:/dev/./urandom"
+    [ -z ${JAVA_OPTS} ] && JAVA_OPTS="-Xms256m -Xmx1024m -Djava.security.egd=file:/dev/./urandom"
   else
-    [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m"
+    [ -z ${JAVA_OPTS} ] && JAVA_OPTS="-Xms256m -Xmx1024m"
   fi
 
   ### Cannot add this in setenv.sh.

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -149,9 +149,9 @@ call_catalina () {
 
   ### Initialize default JVM arguments to run che
   if [[ "${CHE_BLOCKING_ENTROPY}" == true ]]; then
-    [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m"
-  else
     [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m -Djava.security.egd=file:/dev/./urandom"
+  else
+    [ -z "${JAVA_OPTS}" ] && JAVA_OPTS="-Xms256m -Xmx1024m"
   fi
 
   ### Cannot add this in setenv.sh.


### PR DESCRIPTION
JAVA_OPTS is set by line 321 `export JAVA_OPTS="${JAVA_OPTS} -Dche.docker.network=bridge"` to `export JAVA_OPTS=" -Dche.docker.network=bridge"` if JAVA_OPTS is empty. This causes 152 and 154 to never set JAVA_OPTS as it will always have a value. I propose to move line 321 to execute after lines 152/154.

### What does this PR do?
Allows JAVA_OPTS to be set in lines 152 and 154.

#### Changelog
Allow default values of JAVA_OPTS to be set in che-server container entrypoint script if no value is given to environment variable JAVA_OPTS by user or cli.

#### Release Notes
N/A

#### Docs PR
N/A

Signed-off-by: James Drummond james@devcomb.com