### PR TITLE
5485 apply workspace edit

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.ide.util.input.KeyCodeMap;
 import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConfiguration;
 import org.eclipse.che.plugin.languageserver.ide.editor.quickassist.ApplyTextEditAction;
+import org.eclipse.che.plugin.languageserver.ide.editor.quickassist.ApplyWorkspaceEditAction;
 import org.eclipse.che.plugin.languageserver.ide.navigation.declaration.FindDefinitionAction;
 import org.eclipse.che.plugin.languageserver.ide.navigation.references.FindReferencesAction;
 import org.eclipse.che.plugin.languageserver.ide.navigation.symbol.GoToSymbolAction;
@@ -61,12 +62,14 @@ public class LanguageServerExtension {
       FindSymbolAction findSymbolAction,
       FindDefinitionAction findDefinitionAction,
       FindReferencesAction findReferencesAction,
-      ApplyTextEditAction applyTextEditAction) {
+      ApplyTextEditAction applyTextEditAction,
+      ApplyWorkspaceEditAction applyWorkspaceEditAction) {
     actionManager.registerAction("LSGoToSymbolAction", goToSymbolAction);
     actionManager.registerAction("LSFindSymbolAction", findSymbolAction);
     actionManager.registerAction("LSFindDefinitionAction", findDefinitionAction);
     actionManager.registerAction("LSFindReferencesAction", findReferencesAction);
     actionManager.registerAction("lsp.applyTextEdit", applyTextEditAction);
+    actionManager.registerAction("lsp.applyWorkspaceEdit", applyWorkspaceEditAction);
 
     DefaultActionGroup assistantGroup =
         (DefaultActionGroup) actionManager.getAction(GROUP_ASSISTANT);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerLocalization.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerLocalization.java
@@ -24,6 +24,24 @@ public interface LanguageServerLocalization extends Messages {
   @Key("go.to.symbol.symbols")
   String goToSymbolSymbols(int num);
 
+  @Key("apply.workspace.edit.action.notification.title")
+  String applyWorkspaceActionNotificationTitle();
+
+  @Key("apply.workspace.edit.action.notification.done")
+  String applyWorkspaceActionNotificationDone();
+
+  @Key("apply.workspace.edit.action.notification.undoing")
+  String applyWorkspaceActionNotificationUndoing();
+
+  @Key("apply.workspace.edit.action.notification.undone")
+  String applyWorkspaceActionNotificationUndone();
+
+  @Key("apply.workspace.edit.action.notification.undo.failed")
+  String applyWorkspaceActionNotificationUndoFailed();
+
+  @Key("apply.workspace.edit.action.notification.modifying")
+  String applyWorkspaceActionNotificationModifying(String uri);
+
   @Key("modules.type")
   String modulesType(int p0);
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
@@ -1,0 +1,209 @@
+/**
+ * ***************************************************************************** Copyright (c)
+ * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: Red Hat, Inc. - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.che.plugin.languageserver.ide.editor.quickassist;
+
+import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.eclipse.che.api.languageserver.shared.dto.DtoClientImpls.FileEditParamsDto;
+import org.eclipse.che.api.languageserver.shared.model.FileEditParams;
+import org.eclipse.che.api.languageserver.shared.util.RangeComparator;
+import org.eclipse.che.api.promises.client.Function;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.api.promises.client.js.Executor;
+import org.eclipse.che.api.promises.client.js.RejectFunction;
+import org.eclipse.che.api.promises.client.js.ResolveFunction;
+import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.texteditor.HandlesUndoRedo;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
+import org.eclipse.che.ide.api.notification.Notification;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.notification.StatusNotification;
+import org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode;
+import org.eclipse.che.ide.api.notification.StatusNotification.Status;
+import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.plugin.languageserver.ide.LanguageServerLocalization;
+import org.eclipse.che.plugin.languageserver.ide.service.WorkspaceServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.PromiseHelper;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+
+public class ApplyWorkspaceEditAction extends Action {
+  private static final Comparator<TextEdit> COMPARATOR =
+      RangeComparator.transform(new RangeComparator().reversed(), TextEdit::getRange);
+
+  private EditorAgent editorAgent;
+  private DtoFactory dtoFactory;
+  private WorkspaceServiceClient workspaceService;
+  private PromiseHelper promiseHelper;
+  private LanguageServerLocalization localization;
+  private NotificationManager notificationManager;
+  private PromiseProvider promiseProvider;
+
+  @Inject
+  public ApplyWorkspaceEditAction(
+      EditorAgent editorAgent,
+      DtoFactory dtoFactory,
+      WorkspaceServiceClient workspaceService,
+      PromiseHelper promiseHelper,
+      LanguageServerLocalization localization,
+      NotificationManager notificationManager,
+      PromiseProvider promiseProvider) {
+    this.editorAgent = editorAgent;
+    this.dtoFactory = dtoFactory;
+    this.workspaceService = workspaceService;
+    this.promiseHelper = promiseHelper;
+    this.localization = localization;
+    this.notificationManager = notificationManager;
+    this.promiseProvider = promiseProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent evt) {
+    QuickassistActionEvent qaEvent = (QuickassistActionEvent) evt;
+    List<Object> arguments = qaEvent.getArguments();
+    WorkspaceEdit edit =
+        dtoFactory.createDtoFromJson(arguments.get(0).toString(), WorkspaceEdit.class);
+    List<Supplier<Promise<Void>>> undos = new ArrayList<>();
+
+    StatusNotification notification =
+        notificationManager.notify(
+            localization.applyWorkspaceActionNotificationTitle(),
+            Status.PROGRESS,
+            DisplayMode.FLOAT_MODE);
+
+    Map<String, List<TextEdit>> changes = null;
+    if (edit.getChanges() != null) {
+      changes = edit.getChanges();
+    } else if (edit.getDocumentChanges() != null) {
+      changes =
+          edit.getDocumentChanges()
+              .stream()
+              .collect(
+                  Collectors.toMap(
+                      (TextDocumentEdit e) -> e.getTextDocument().getUri(),
+                      TextDocumentEdit::getEdits));
+    }
+
+    Promise<Void> done =
+        promiseHelper.forEach(
+            changes.entrySet().iterator(),
+            (entry) -> handleFileChange(notification, entry.getKey(), entry.getValue()),
+            undos::add);
+
+    done.then(
+            (Void v) -> {
+              Log.debug(getClass(), "done applying changes");
+              notification.setStatus(Status.SUCCESS);
+              notification.setContent(localization.applyWorkspaceActionNotificationDone());
+            })
+        .catchError(
+            (error) -> {
+              Log.info(getClass(), "caught error applying changes", error);
+              notification.setStatus(Status.FAIL);
+              notification.setContent(localization.applyWorkspaceActionNotificationUndoing());
+              promiseHelper
+                  .forEach(undos.iterator(), (d) -> d.get(), (Void v) -> {})
+                  .then(
+                      (Void v) -> {
+                        notification.setContent(
+                            localization.applyWorkspaceActionNotificationUndone());
+                      })
+                  .catchError(
+                      e -> {
+                        Log.info(getClass(), "Error undoing changes", e);
+                        notification.setContent(
+                            localization.applyWorkspaceActionNotificationUndoFailed());
+                      });
+            });
+  }
+
+  private Promise<Supplier<Promise<Void>>> handleFileChange(
+      Notification notification, String uri, List<TextEdit> edits) {
+    for (EditorPartPresenter editor : editorAgent.getOpenedEditors()) {
+      if (editor instanceof TextEditor
+          && uri.endsWith(editor.getEditorInput().getFile().getLocation().toString())) {
+        notification.setContent(localization.applyWorkspaceActionNotificationModifying(uri));
+        TextEditor textEditor = (TextEditor) editor;
+        HandlesUndoRedo undoRedo = textEditor.getEditorWidget().getUndoRedo();
+        undoRedo.beginCompoundChange();
+        Document document = textEditor.getDocument();
+        edits
+            .stream()
+            .sorted(COMPARATOR)
+            .forEach(
+                e -> {
+                  Range r = e.getRange();
+                  Position start = r.getStart();
+                  Position end = r.getEnd();
+                  document.replace(
+                      start.getLine(),
+                      start.getCharacter(),
+                      end.getLine(),
+                      end.getCharacter(),
+                      e.getNewText());
+                });
+        undoRedo.endCompoundChange();
+        Supplier<Promise<Void>> value =
+            () -> {
+              return promiseProvider.create(
+                  Executor.create(
+                      (ResolveFunction<Void> resolve, RejectFunction reject) -> {
+                        try {
+                          undoRedo.undo();
+                          resolve.apply(null);
+                        } catch (Exception e) {
+                          reject.apply(
+                              new PromiseError() {
+                                public String getMessage() {
+                                  return "Error during undo";
+                                }
+
+                                public Throwable getCause() {
+                                  return e;
+                                }
+                              });
+                        }
+                      }));
+            };
+        return promiseProvider.resolve(value);
+      }
+    }
+    Promise<List<TextEdit>> undoPromise =
+        workspaceService.editFile(new FileEditParamsDto(new FileEditParams(uri, edits)));
+    return undoPromise.then(
+        (Function<List<TextEdit>, Supplier<Promise<Void>>>)
+            (List<TextEdit> undoEdits) -> {
+              return () -> {
+                Promise<List<TextEdit>> redoPromise =
+                    workspaceService.editFile(
+                        new FileEditParamsDto(new FileEditParams(uri, undoEdits)));
+                return redoPromise.then(
+                    (List<TextEdit> redo) -> {
+                      return null;
+                    });
+              };
+            });
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c)
- * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat, Inc. - initial API and implementation
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.plugin.languageserver.ide.editor.quickassist;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/LanguageServerQuickAssistProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/LanguageServerQuickAssistProcessor.java
@@ -120,6 +120,7 @@ public class LanguageServerQuickAssistProcessor implements QuickAssistProcessor 
     QueryAnnotationsEvent.QueryCallback annotationCallback =
         new QueryAnnotationsEvent.QueryCallback() {
 
+          @SuppressWarnings("ReturnValueIgnored")
           @Override
           public void respond(
               Map<Annotation, org.eclipse.che.ide.api.editor.text.Position> annotations) {

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ServiceUtil.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ServiceUtil.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c)
- * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat, Inc. - initial API and implementation
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.plugin.languageserver.ide.service;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ServiceUtil.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ServiceUtil.java
@@ -1,0 +1,32 @@
+/**
+ * ***************************************************************************** Copyright (c)
+ * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: Red Hat, Inc. - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.che.plugin.languageserver.ide.service;
+
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcError;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.promises.client.PromiseError;
+
+public class ServiceUtil {
+  private ServiceUtil() {}
+
+  public static PromiseError getPromiseError(JsonRpcError jsonRpcError) {
+    return new PromiseError() {
+      @Override
+      public String getMessage() {
+        return jsonRpcError.getMessage();
+      }
+
+      @Override
+      public Throwable getCause() {
+        return new JsonRpcException(jsonRpcError.getCode(), jsonRpcError.getMessage());
+      }
+    };
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c)
- * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat, Inc. - initial API and implementation
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.plugin.languageserver.ide.service;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/WorkspaceServiceClient.java
@@ -1,45 +1,35 @@
-/*
- * Copyright (c) 2012-2017 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+/**
+ * ***************************************************************************** Copyright (c)
+ * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * <p>Contributors: Red Hat, Inc. - initial API and implementation
+ * *****************************************************************************
  */
 package org.eclipse.che.plugin.languageserver.ide.service;
 
-import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
-import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
-import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
+import static org.eclipse.che.plugin.languageserver.ide.service.ServiceUtil.getPromiseError;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.languageserver.shared.model.FileEditParams;
 import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.rest.AsyncRequestFactory;
-import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
-import org.eclipse.che.ide.rest.Unmarshallable;
+import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 
 /** @author Evgen Vidolob */
 @Singleton
 public class WorkspaceServiceClient {
-  private final DtoUnmarshallerFactory unmarshallerFactory;
-  private final AppContext appContext;
-  private final AsyncRequestFactory asyncRequestFactory;
+  private RequestTransmitter requestTransmitter;
 
   @Inject
-  public WorkspaceServiceClient(
-      final DtoUnmarshallerFactory unmarshallerFactory,
-      final AppContext appContext,
-      final AsyncRequestFactory asyncRequestFactory) {
-    this.unmarshallerFactory = unmarshallerFactory;
-    this.appContext = appContext;
-    this.asyncRequestFactory = asyncRequestFactory;
+  public WorkspaceServiceClient(RequestTransmitter requestTransmitter) {
+    this.requestTransmitter = requestTransmitter;
   }
 
   /**
@@ -50,14 +40,28 @@ public class WorkspaceServiceClient {
    * @return
    */
   public Promise<List<SymbolInformation>> symbol(WorkspaceSymbolParams params) {
-    String requestUrl =
-        appContext.getDevMachine().getWsAgentBaseUrl() + "/languageserver/workspace/symbol";
-    Unmarshallable<List<SymbolInformation>> unmarshaller =
-        unmarshallerFactory.newListUnmarshaller(SymbolInformation.class);
-    return asyncRequestFactory
-        .createPostRequest(requestUrl, params)
-        .header(ACCEPT, APPLICATION_JSON)
-        .header(CONTENT_TYPE, APPLICATION_JSON)
-        .send(unmarshaller);
+    return Promises.create(
+        (resolve, reject) ->
+            requestTransmitter
+                .newRequest()
+                .endpointId("ws-agent")
+                .methodName("workspace/symbol")
+                .paramsAsDto(params)
+                .sendAndReceiveResultAsListOfDto(SymbolInformation.class)
+                .onSuccess(resolve::apply)
+                .onFailure(error -> reject.apply(getPromiseError(error))));
+  }
+
+  public Promise<List<TextEdit>> editFile(FileEditParams params) {
+    return Promises.create(
+        (resolve, reject) ->
+            requestTransmitter
+                .newRequest()
+                .endpointId("ws-agent")
+                .methodName("workspace/editFile")
+                .paramsAsDto(params)
+                .sendAndReceiveResultAsListOfDto(TextEdit.class)
+                .onSuccess(resolve::apply)
+                .onFailure(error -> reject.apply(getPromiseError(error))));
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/PromiseHelper.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/PromiseHelper.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c)
- * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat, Inc. - initial API and implementation
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.plugin.languageserver.ide.util;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/PromiseHelper.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/PromiseHelper.java
@@ -1,0 +1,43 @@
+/**
+ * ***************************************************************************** Copyright (c)
+ * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: Red Hat, Inc. - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.che.plugin.languageserver.ide.util;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Iterator;
+import java.util.function.Consumer;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+
+@Singleton
+public class PromiseHelper {
+  private PromiseProvider promiseProvider;
+
+  @Inject
+  PromiseHelper(PromiseProvider promiseProvider) {
+    this.promiseProvider = promiseProvider;
+  }
+
+  public <P, R> Promise<Void> forEach(
+      Iterator<P> elements,
+      java.util.function.Function<P, Promise<R>> promiseSource,
+      Consumer<R> resultConsumer) {
+    if (elements.hasNext()) {
+      Promise<R> elementPromise = promiseSource.apply(elements.next());
+      return elementPromise.thenPromise(
+          (R r) -> {
+            resultConsumer.accept(r);
+            return forEach(elements, promiseSource, resultConsumer);
+          });
+    } else {
+      return promiseProvider.resolve(null);
+    }
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/che/plugin/languageserver/ide/LanguageServerLocalization.properties
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/che/plugin/languageserver/ide/LanguageServerLocalization.properties
@@ -13,6 +13,12 @@
 go.to.symbol.action.title=Go To Symbol
 go.to.symbol.action.description= Go To Symbol
 find.symbol.action.title = Find Project Symbol
+apply.workspace.edit.action.notification.title=Apply Workspace Changes
+apply.workspace.edit.action.notification.done=Done
+apply.workspace.edit.action.notification.undoing=Undoing changes
+apply.workspace.edit.action.notification.undone=Changes undone
+apply.workspace.edit.action.notification.undo.failed=Undo failed
+apply.workspace.edit.action.notification.modifying=Modifying file: {0}
 
 # LIST
 go.to.symbol.symbols = symbols ({0})
@@ -24,3 +30,5 @@ function.type = functions ({0})
 property.type = properties ({0})
 variable.type = variables ({0})
 constructor.type = constructors ({0})
+
+#NOTIFICATIONS

--- a/wsagent/che-core-api-languageserver-shared/pom.xml
+++ b/wsagent/che-core-api-languageserver-shared/pom.xml
@@ -28,6 +28,11 @@
         <dependency>
             <groupId>org.eclipse.lsp4j</groupId>
             <artifactId>org.eclipse.lsp4j</artifactId>
+	    </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/FileEditParams.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/FileEditParams.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.shared.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.TextEdit;
+
+public class FileEditParams {
+  /** The workspace relative path of the file */
+  private String uri;
+  /** A list of TextEdits to be applied to the file */
+  private List<TextEdit> edits;
+
+  public FileEditParams() {}
+
+  public FileEditParams(String path, List<TextEdit> edits) {
+    this.uri = path;
+    this.edits = edits;
+  }
+
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+
+  public List<TextEdit> getEdits() {
+    return edits;
+  }
+
+  public void setEdits(List<TextEdit> edits) {
+    this.edits = new ArrayList<>(edits);
+  }
+}

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/CharStreamEditor.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/CharStreamEditor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package org.eclipse.che.api.languageserver.shared.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+
+public class CharStreamEditor {
+  private static final Comparator<TextEdit> COMPARATOR =
+      RangeComparator.transform(new RangeComparator(), TextEdit::getRange);
+  private ArrayList<TextEdit> edits;
+  private int currentReadLine = 0;
+  private int currentReadChar = 0;
+
+  private int currentWriteLine = 0;
+  private int currentWriteChar = 0;
+
+  private int ch;
+  private Supplier<Integer> source;
+  private Consumer<Integer> sink;
+  public static final Consumer<Integer> NULL = ch -> {};
+
+  public CharStreamEditor(
+      Collection<TextEdit> edits, Supplier<Integer> source, Consumer<Integer> dest) {
+    this.edits = new ArrayList<>(edits);
+    this.edits.sort(COMPARATOR);
+    this.source = source;
+    this.sink = ch -> writeAndCount(ch, dest);
+  }
+
+  public List<TextEdit> transform() {
+    List<TextEdit> inverse = new ArrayList<>();
+
+    Iterator<TextEdit> editIterator = edits.iterator();
+    ch = source.get();
+    while (editIterator.hasNext()) {
+      TextEdit edit = editIterator.next();
+
+      advanceTo(edit.getRange().getStart(), sink);
+      Position undoStart = new Position(currentWriteLine, currentWriteChar);
+      for (int i = 0; i < edit.getNewText().length(); i++) {
+        sink.accept((int) edit.getNewText().charAt(i));
+      }
+      StringBuilder replaced = new StringBuilder();
+      advanceTo(edit.getRange().getEnd(), forStringBuilder(replaced));
+      Position undoEnd = new Position(currentWriteLine, currentWriteChar);
+      inverse.add(new TextEdit(new Range(undoStart, undoEnd), replaced.toString()));
+    }
+    // all edits have been processed. Copy the rest of the chars.
+    while (ch >= 0) {
+      sink.accept(ch);
+      ch = source.get();
+    }
+    return inverse;
+  }
+
+  private void writeAndCount(int ch, Consumer<Integer> dest) {
+    dest.accept(ch);
+    if (ch == '\r') {
+      // we recognize \r\n, \n
+    } else if (ch == '\n') {
+      currentWriteLine++;
+      currentWriteChar = 0;
+    } else {
+      currentWriteChar++;
+    }
+  }
+
+  private void advanceTo(Position start, Consumer<Integer> dest) {
+    while (ch >= 0
+        && (currentReadLine < start.getLine() || currentReadChar < start.getCharacter())) {
+      dest.accept(ch);
+      if (ch == '\r') {
+        currentReadLine++;
+        currentReadChar = 0;
+        ch = source.get();
+        if (ch == '\n') {
+          dest.accept(ch);
+          ch = source.get();
+        }
+      } else if (ch == '\n') {
+        currentReadLine++;
+        currentReadChar = 0;
+        ch = source.get();
+      } else {
+        currentReadChar++;
+        ch = source.get();
+      }
+    }
+  }
+
+  public static Consumer<Integer> forStringBuilder(StringBuilder b) {
+    return new Consumer<Integer>() {
+      @Override
+      public void accept(Integer ch) {
+        b.append((char) ch.intValue());
+      }
+    };
+  }
+
+  public static Supplier<Integer> forReader(Reader reader) {
+    return new Supplier<Integer>() {
+      @Override
+      public Integer get() {
+        try {
+          return reader.read();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+
+  public static Consumer<Integer> forWriter(Writer w) {
+    return new Consumer<Integer>() {
+
+      @Override
+      public void accept(Integer ch) {
+        try {
+          w.write(ch);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+}

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/PositionComparator.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/PositionComparator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package org.eclipse.che.api.languageserver.shared.util;
+
+import java.util.Comparator;
+import org.eclipse.lsp4j.Position;
+
+public class PositionComparator implements Comparator<Position> {
+
+  @Override
+  public int compare(Position o1, Position o2) {
+    int lines = o1.getLine() - o2.getLine();
+    if (lines != 0) {
+      return lines;
+    }
+    return o1.getCharacter() - o2.getCharacter();
+  }
+}

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/RangeComparator.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/RangeComparator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package org.eclipse.che.api.languageserver.shared.util;
+
+import java.util.Comparator;
+import java.util.function.Function;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+public class RangeComparator implements Comparator<Range> {
+  Comparator<Position> positionComparator = new PositionComparator();
+
+  @Override
+  public int compare(Range o1, Range o2) {
+    int starts = positionComparator.compare(o1.getStart(), o2.getStart());
+    if (starts != 0) {
+      return starts;
+    }
+    return positionComparator.compare(o1.getEnd(), o2.getEnd());
+  }
+
+  public static <X, Y> Comparator<X> transform(Comparator<Y> comparator, Function<X, Y> f) {
+    return new Comparator<X>() {
+
+      @Override
+      public int compare(X o1, X o2) {
+        return comparator.compare(f.apply(o1), f.apply(o2));
+      }
+    };
+  }
+}

--- a/wsagent/che-core-api-languageserver-shared/src/test/java/org/eclipse/che/api/languageserver/shared/util/StreamEditorTest.java
+++ b/wsagent/che-core-api-languageserver-shared/src/test/java/org/eclipse/che/api/languageserver/shared/util/StreamEditorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.shared.util;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StreamEditorTest {
+
+  @Test
+  public void testInsertEmpty() {
+    runEdit("", "foobar", new TextEdit(newRange(0, 0, 0, 0), "foobar"));
+  }
+
+  @Test
+  public void testInsertTwo() {
+    runEdit(
+        "abcdef",
+        "afoobarbcbladef",
+        new TextEdit(newRange(0, 1, 0, 1), "foobar"),
+        new TextEdit(newRange(0, 3, 0, 3), "bla"));
+  }
+
+  @Test
+  public void testInsertNewLine() {
+    runEdit(
+        "abc\r\ndef",
+        "afoobarbc\r\ndblaef",
+        new TextEdit(newRange(0, 1, 0, 1), "foobar"),
+        new TextEdit(newRange(1, 1, 1, 1), "bla"));
+    runEdit(
+        "abc\ndef",
+        "afoobarbc\ndblaef",
+        new TextEdit(newRange(0, 1, 0, 1), "foobar"),
+        new TextEdit(newRange(1, 1, 1, 1), "bla"));
+  }
+
+  @Test
+  public void testInsertRemoveNewLine() {
+    runEdit(
+        "abc\r\ndef",
+        "ab\nlaefoobarf",
+        new TextEdit(newRange(0, 1, 1, 1), "b\nla"),
+        new TextEdit(newRange(1, 2, 1, 2), "foobar"));
+  }
+
+  @Test
+  public void testDeleteAll() {
+    runEdit("foo\nbar", "", new TextEdit(newRange(0, 0, 1, 3), ""));
+  }
+
+  @Test
+  public void testDeleteEnd() {
+    runEdit(
+        "abc\r\ndef",
+        "abc\r\ndxyz",
+        new TextEdit(newRange(1, 1, 1, 3), ""),
+        new TextEdit(newRange(1, 1, 1, 1), "xyz"));
+  }
+
+  private void runEdit(String originalContent, String editedContent, TextEdit... edits) {
+    StringBuilder output = new StringBuilder();
+    List<TextEdit> inverse =
+        new StringStreamEditor(Arrays.asList(edits), originalContent, output).transform();
+    Assert.assertEquals(editedContent, output.toString());
+
+    // now test that applying the inverse edits gives the original content.
+    StringBuilder inverseOutput = new StringBuilder();
+    new StringStreamEditor(inverse, output.toString(), inverseOutput).transform();
+    Assert.assertEquals(originalContent, inverseOutput.toString());
+  }
+
+  private Range newRange(int i, int j, int k, int l) {
+    return new Range(new Position(i, j), new Position(k, l));
+  }
+}

--- a/wsagent/che-core-api-languageserver-shared/src/test/java/org/eclipse/che/api/languageserver/shared/util/StringStreamEditor.java
+++ b/wsagent/che-core-api-languageserver-shared/src/test/java/org/eclipse/che/api/languageserver/shared/util/StringStreamEditor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.shared.util;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+import org.eclipse.lsp4j.TextEdit;
+
+public class StringStreamEditor extends CharStreamEditor {
+
+  public StringStreamEditor(Collection<TextEdit> edits, String contents, StringBuilder output) {
+    super(edits, StringStreamEditor.forString(contents), CharStreamEditor.forStringBuilder(output));
+  }
+
+  public static Supplier<Integer> forString(String text) {
+    return new Supplier<Integer>() {
+      int index = 0;
+
+      @Override
+      public Integer get() {
+        return (index >= text.length() ? -1 : text.charAt(index++));
+      }
+    };
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
@@ -35,9 +35,9 @@ public class LanguageServerModule extends AbstractModule {
     bind(LanguageServerRegistry.class).to(LanguageServerRegistryImpl.class);
     bind(ServerInitializer.class).to(ServerInitializerImpl.class);
     bind(LanguageRegistryService.class);
-    bind(WorkspaceService.class);
     Multibinder.newSetBinder(binder(), LanguageServerLauncher.class);
 
+    bind(WorkspaceService.class).asEagerSingleton();
     bind(TextDocumentService.class).asEagerSingleton();
     bind(PublishDiagnosticsParamsJsonRpcTransmitter.class).asEagerSingleton();
     bind(ShowMessageJsonRpcTransmitter.class).asEagerSingleton();

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/WorkspaceService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/WorkspaceService.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c)
- * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat, Inc. - initial API and implementation
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.service;
 

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/WorkspaceService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/WorkspaceService.java
@@ -1,12 +1,11 @@
-/*
- * Copyright (c) 2012-2017 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+/**
+ * ***************************************************************************** Copyright (c)
+ * 2012-2017 Red Hat, Inc. All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * <p>Contributors: Red Hat, Inc. - initial API and implementation
+ * *****************************************************************************
  */
 package org.eclipse.che.api.languageserver.service;
 
@@ -16,26 +15,40 @@ import static org.eclipse.che.api.languageserver.service.LanguageServiceUtils.tr
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import javax.annotation.PostConstruct;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.registry.InitializedLanguageServer;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistryImpl;
 import org.eclipse.che.api.languageserver.server.dto.DtoServerImpls.SymbolInformationDto;
+import org.eclipse.che.api.languageserver.server.dto.DtoServerImpls.TextEditDto;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedWorkspaceSymbolParams;
+import org.eclipse.che.api.languageserver.shared.model.FileEditParams;
+import org.eclipse.che.api.languageserver.shared.util.CharStreamEditor;
 import org.eclipse.che.api.languageserver.util.LSOperation;
 import org.eclipse.che.api.languageserver.util.OperationUtil;
+import org.eclipse.che.api.project.server.ProjectManager;
+import org.eclipse.che.api.project.server.VirtualFileEntry;
+import org.eclipse.che.api.vfs.VirtualFile;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextEdit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * REST API for the workspace/* services defined in
@@ -45,57 +58,126 @@ import org.eclipse.lsp4j.SymbolInformation;
  * @author Evgen Vidolob
  */
 @Singleton
-@Path("languageserver/workspace")
 public class WorkspaceService {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspaceService.class);
   private LanguageServerRegistry registry;
+  private ProjectManager projectManager;
+  private RequestHandlerConfigurator requestHandler;
 
   @Inject
-  public WorkspaceService(LanguageServerRegistry registry) {
+  public WorkspaceService(
+      LanguageServerRegistry registry,
+      ProjectManager projectManager,
+      RequestHandlerConfigurator requestHandler) {
     this.registry = registry;
+    this.projectManager = projectManager;
+    this.requestHandler = requestHandler;
   }
 
-  @POST
-  @Path("symbol")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
-  public List<? extends SymbolInformationDto> symbol(
-      ExtendedWorkspaceSymbolParams workspaceSymbolParams)
-      throws ExecutionException, InterruptedException, LanguageServerException {
+  @PostConstruct
+  public void configureMethods() {
+    requestHandler
+        .newConfiguration()
+        .methodName("workspace/symbol")
+        .paramsAsDto(ExtendedWorkspaceSymbolParams.class)
+        .resultAsListOfDto(SymbolInformationDto.class)
+        .withFunction(this::symbol);
+    requestHandler
+        .newConfiguration()
+        .methodName("workspace/editFile")
+        .paramsAsDto(FileEditParams.class)
+        .resultAsListOfDto(TextEditDto.class)
+        .withFunction(this::editFile);
+  }
+
+  /**
+   * Apply a list of text edits to a workspace file
+   *
+   * @param params the edit to be effected
+   * @return a list of text edits that will undo the effected change
+   */
+  @SuppressWarnings("deprecation")
+  private List<TextEditDto> editFile(FileEditParams params) {
+    try {
+      VirtualFileEntry child =
+          projectManager
+              .getProjectsRoot()
+              .getChild(LanguageServiceUtils.removePrefixUri(params.getUri()));
+      if (child != null) {
+        VirtualFile vf = child.getVirtualFile();
+        List<TextEdit> undo = new ArrayList<>();
+        vf.modifyContent(
+            new BiConsumer<InputStream, OutputStream>() {
+
+              @Override
+              public void accept(InputStream in, OutputStream out) {
+                OutputStreamWriter w = new OutputStreamWriter(out);
+                undo.addAll(
+                    new CharStreamEditor(
+                            params.getEdits(),
+                            CharStreamEditor.forReader(new InputStreamReader(in)),
+                            CharStreamEditor.forWriter(w))
+                        .transform());
+                try {
+                  w.flush();
+                } catch (IOException e) {
+                  throw new RuntimeException("failed to write tranformed file", e);
+                }
+              }
+            });
+        return undo.stream().map(e -> new TextEditDto(e)).collect(Collectors.toList());
+      } else {
+        LOG.error("did not find file " + params.getUri());
+        throw new JsonRpcException(-27000, "File not found for edit: " + params.getUri());
+      }
+    } catch (ServerException | ForbiddenException e) {
+      LOG.error("error editing file", e);
+      throw new JsonRpcException(-27000, e.getMessage());
+    }
+  }
+
+  private List<SymbolInformationDto> symbol(ExtendedWorkspaceSymbolParams workspaceSymbolParams) {
     List<SymbolInformationDto> result = new ArrayList<>();
-    List<InitializedLanguageServer> servers =
-        registry
-            .getApplicableLanguageServers(prefixURI(workspaceSymbolParams.getFileUri()))
-            .stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
-    OperationUtil.doInParallel(
-        servers,
-        new LSOperation<InitializedLanguageServer, List<? extends SymbolInformation>>() {
+    List<InitializedLanguageServer> servers;
+    try {
+      servers =
+          registry
+              .getApplicableLanguageServers(prefixURI(workspaceSymbolParams.getFileUri()))
+              .stream()
+              .flatMap(Collection::stream)
+              .collect(Collectors.toList());
+      OperationUtil.doInParallel(
+          servers,
+          new LSOperation<InitializedLanguageServer, List<? extends SymbolInformation>>() {
 
-          @Override
-          public boolean canDo(InitializedLanguageServer element) {
-            return truish(
-                element.getInitializeResult().getCapabilities().getWorkspaceSymbolProvider());
-          }
+            @Override
+            public boolean canDo(InitializedLanguageServer element) {
+              return truish(
+                  element.getInitializeResult().getCapabilities().getWorkspaceSymbolProvider());
+            }
 
-          @Override
-          public CompletableFuture<List<? extends SymbolInformation>> start(
-              InitializedLanguageServer element) {
-            return element.getServer().getWorkspaceService().symbol(workspaceSymbolParams);
-          }
+            @Override
+            public CompletableFuture<List<? extends SymbolInformation>> start(
+                InitializedLanguageServer element) {
+              return element.getServer().getWorkspaceService().symbol(workspaceSymbolParams);
+            }
 
-          @Override
-          public boolean handleResult(
-              InitializedLanguageServer element, List<? extends SymbolInformation> locations) {
-            locations.forEach(
-                o -> {
-                  o.getLocation().setUri(removePrefixUri(o.getLocation().getUri()));
-                  result.add(new SymbolInformationDto(o));
-                });
-            return true;
-          }
-        },
-        10000);
-    return result;
+            @Override
+            public boolean handleResult(
+                InitializedLanguageServer element, List<? extends SymbolInformation> locations) {
+              locations.forEach(
+                  o -> {
+                    o.getLocation().setUri(removePrefixUri(o.getLocation().getUri()));
+                    result.add(new SymbolInformationDto(o));
+                  });
+              return true;
+            }
+          },
+          10000);
+      return result;
+    } catch (LanguageServerException e) {
+      LOG.error("error getting symbol", e);
+      throw new JsonRpcException(-27000, e.getMessage());
+    }
   }
 }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFile.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/VirtualFile.java
@@ -12,8 +12,10 @@ package org.eclipse.che.api.vfs;
 
 import com.google.common.annotations.Beta;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.ServerException;
@@ -223,6 +225,35 @@ public interface VirtualFile extends Comparable<VirtualFile> {
    */
   VirtualFile updateContent(String content) throws ForbiddenException, ServerException;
 
+  /**
+   * Replaces the content read from the input stream parameter to the modifier with the bytes
+   * written to the output stream passed to the modifier.
+   *
+   * @param modifier
+   * @param lockToken lock token. This parameter is required if the file is locked otherwise might
+   *     be {@code null}
+   * @return VirtualFile after updating content
+   * @throws ForbiddenException if any of following conditions are met:
+   *     <ul>
+   *       <li>this item is not a file
+   *       <li>this item is locked file and {@code lockToken} is {@code null} or does not match
+   *     </ul>
+   *
+   * @throws ServerException if other error occurs
+   * @see #isFile()
+   */
+  VirtualFile modifyContent(BiConsumer<InputStream, OutputStream> modifier, String lockToken)
+      throws ForbiddenException, ServerException;
+
+  /**
+   * Equivalent to {@link #modifyContent(BiConsumer, null)
+   * @param modifier
+   * @return
+   * @throws ForbiddenException
+   * @throws ServerException
+   */
+  VirtualFile modifyContent(BiConsumer<InputStream, OutputStream> modifier)
+      throws ForbiddenException, ServerException;
   /**
    * Get length of content of the file. Always returns {@code 0} for folders.
    *

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/LocalVirtualFile.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/impl/file/LocalVirtualFile.java
@@ -17,9 +17,11 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.ServerException;
@@ -154,6 +156,19 @@ public class LocalVirtualFile implements VirtualFile {
   @Override
   public VirtualFile updateContent(String content) throws ForbiddenException, ServerException {
     return updateContent(content, null);
+  }
+
+  @Override
+  public VirtualFile modifyContent(BiConsumer<InputStream, OutputStream> modifier)
+      throws ForbiddenException, ServerException {
+    return modifyContent(modifier, null);
+  }
+
+  @Override
+  public VirtualFile modifyContent(BiConsumer<InputStream, OutputStream> modifier, String lockToken)
+      throws ForbiddenException, ServerException {
+    fileSystem.modifyContent(this, modifier, lockToken);
+    return this;
   }
 
   @Override


### PR DESCRIPTION
### What does this PR do?
Adds a "ApplyWorkspaceEditAction" that applies a LSP WorkspaceEdit to many files both open in and editor or not.

### What issues does this PR fix or reference?
#5485 

#### Changelog
Added "ApplyWorkspaceEditAction" to allow LSP code actions to edit multiple files at once. 
#### Release Notes
Added "ApplyWorkspaceEditAction" to allow LSP code actions to edit multiple files at once. 


#### Docs PR
https://github.com/eclipse/che-docs/pull/271