### PR TITLE
Update Che Dev Dockerfile

### DIFF
--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -21,6 +21,7 @@
 #                  -Dfindbugs.skip=true
 #                  -Dgwt.compiler.localWorkers=2 -T 1C
 #                  -Dskip-validate-sources
+#                  -Pnative
 #              clean install
 #
 # For Windows, replace $HOME with maven repo directory.


### PR DESCRIPTION
Dashboard now builds with docker by default so `-Pnative` needs to be set. I also made this update at [https://github.com/eclipse/che/wiki/Development-Workflow](https://github.com/eclipse/che/wiki/Development-Workflow)

Signed-off-by: James Drummond james@devcomb.com