### PR TITLE
CHE-5274. Do not skip setting focus on element when window is displayed

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
@@ -224,6 +224,7 @@ public abstract class Window implements IsWidget {
         setBlocked(false);
 
         if (isShowing) {
+            setFocusOn(selectAndFocusElement);//the window is displayed but focus for the element may be lost
             return;
         }
 
@@ -247,11 +248,19 @@ public abstract class Window implements IsWidget {
                 public void execute() {
                     // The popup may have been hidden before this timer executes.
                     view.setShowing(true);
-                    if (selectAndFocusElement != null) {
-                        selectAndFocusElement.setFocus(true);
-                    }
+                    setFocusOn(selectAndFocusElement);
                 }
             });
+        }
+    }
+
+    /**
+     * Sets focus on the given element.
+     * If {@code elementToFocus} is {@code null}, no element will be given focus
+     */
+    private void setFocusOn(@Nullable Focusable elementToFocus) {
+        if (elementToFocus != null) {
+            elementToFocus.setFocus(true);
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
We skip some logic for Window#show(Focusable) [here](https://github.com/eclipse/che/blob/master/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java#L227) when window is displayed.
But we can have use cases when window is displayed but focus for the target element is lost.
One of these is described in the issue #5274: 
- We display File Structure widget by pressing Ctrl+F12 
- We display extended info when user press Ctrl+F12 again 

So I think we shouldn't skip setting focus on element when window is displayed

### What issues does this PR fix or reference?
#5274 

#### Changelog
Do not skip setting focus on element when window is displayed

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>