### PR TITLE
Add PVC provisioner for ws projects to openshift infra

### DIFF
--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.eclipse.che</groupId>
             <artifactId>bootstrapper</artifactId>
-            <type>tar.gz</type>
+            <type>zip</type>
             <classifier>linux_amd64</classifier>
         </dependency>
         <dependency>

--- a/assembly/assembly-main/src/assembly/assembly.xml
+++ b/assembly/assembly-main/src/assembly/assembly.xml
@@ -86,9 +86,8 @@
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>true</unpack>
             <outputDirectory>lib/linux_amd64</outputDirectory>
-            <outputFileNameMapping>bootstrapper-linux_amd64</outputFileNameMapping>
             <includes>
-                <include>org.eclipse.che:bootstrapper:tar.gz:linux_amd64</include>
+                <include>org.eclipse.che:bootstrapper:zip:linux_amd64</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -401,3 +401,17 @@ che.infra.openshift.bootstrapper.binary_url=http://che-host:${CHE_PORT}/agent-bi
 che.infra.openshift.bootstrapper.timeout_min=10
 che.infra.openshift.bootstrapper.installer_timeout_sec=180
 che.infra.openshift.bootstrapper.server_check_period_sec=3
+
+# Defines whether use the Persistent Volume Claim for che workspace needs
+# e.g backup projects, logs etc or disable it.
+che.infra.openshift.pvc.enabled=true
+# Defines the name of Persistent Volume Claim for che workspace.
+che.infra.openshift.pvc.name=claim-che-workspace
+# Defines the size of Persistent Volume Claim of che workspace.
+# Format described here:
+# https://docs.openshift.com/container-platform/latest/dev_guide/compute_resources.html#dev-compute-resources
+che.infra.openshift.pvc.quantity=10Gi
+# Defines Persistent Volume Claim access mode.
+# Detailed information is described here:
+# https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/storage.html#pv-access-modes
+che.infra.openshift.pvc.access_mode=ReadWriteOnce

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -462,3 +462,20 @@ CHE_SINGLE_PORT=false
 #CHE_INFRA_OPENSHIFT_CHE__SERVER__ENDPOINT=http://che-host:${CHE_PORT}/wsmaster/api
 #CHE_INFRA_OPENSHIFT_CHE__SERVER__WEBSOCKET__ENDPOINT__BASE=ws://che-host:${CHE_PORT}/wsmaster
 #CHE_INFRA_OPENSHIFT_BOOTSTRAPPER_BINARY__URL=http://che-host:${CHE_PORT}/agent-binaries/linux_amd64/bootstrapper/bootstrapper
+
+# Defines whether use the Persistent Volume Claim for che workspace needs
+# e.g backup projects, logs etc or disable it.
+#CHE_INFRA_OPENSHIFT_PVC_ENABLED=true
+
+# Defines the name of Persistent Volume Claim for che workspace.
+#CHE_INFRA_OPENSHIFT_PVC_NAME=claim-che-workspace
+
+# Defines the size of Persistent Volume Claim of che workspace.
+# Format described here:
+# https://docs.openshift.com/container-platform/latest/dev_guide/compute_resources.html#dev-compute-resources
+#CHE_INFRA_OPENSHIFT_PVC_QUANTITY=10Gi
+
+# Defines Persistent Volume Claim access mode.
+# Detailed information is described here:
+# https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/storage.html#pv-access-modes
+#CHE_INFRA_OPENSHIFT_PVC_ACCESS__MODE=ReadWriteOnce

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructureProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructureProvisioner.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.openshift;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.installer.InstallerConfigProvisioner;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.PersistentVolumeClaimProvisioner;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Applies the set of configurations to the OpenShift environment and environment configuration
+ * with the desired order, which corresponds to the needs of the OpenShift infrastructure.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class OpenShiftInfrastructureProvisioner {
+
+    private final InstallerConfigProvisioner       installerConfigProvisioner;
+    private final PersistentVolumeClaimProvisioner persistentVolumeClaimProvisioner;
+
+    @Inject
+    public OpenShiftInfrastructureProvisioner(InstallerConfigProvisioner installerConfigProvisioner,
+                                              PersistentVolumeClaimProvisioner projectVolumeProvisioner) {
+        this.installerConfigProvisioner = installerConfigProvisioner;
+        this.persistentVolumeClaimProvisioner = projectVolumeProvisioner;
+    }
+
+    public void provision(EnvironmentImpl environment,
+                          OpenShiftEnvironment osEnv,
+                          RuntimeIdentity identity) throws InfrastructureException {
+        installerConfigProvisioner.provision(environment, osEnv, identity);
+        persistentVolumeClaimProvisioner.provision(environment, osEnv, identity);
+    }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.workspace.infrastructure.openshift.environment;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
@@ -21,9 +22,10 @@ import java.util.Map;
  * @author Sergii Leshchenko
  */
 public class OpenShiftEnvironment {
-    private Map<String, Pod>     pods;
-    private Map<String, Service> services;
-    private Map<String, Route>   routes;
+    private Map<String, Pod>                   pods;
+    private Map<String, Service>               services;
+    private Map<String, Route>                 routes;
+    private Map<String, PersistentVolumeClaim> persistentVolumeClaims;
 
     public OpenShiftEnvironment() {
     }
@@ -73,6 +75,22 @@ public class OpenShiftEnvironment {
 
     public OpenShiftEnvironment withRoutes(Map<String, Route> routes) {
         this.routes = routes;
+        return this;
+    }
+
+    public Map<String, PersistentVolumeClaim> getPersistentVolumeClaims() {
+        if (persistentVolumeClaims == null) {
+            persistentVolumeClaims = new HashMap<>();
+        }
+        return persistentVolumeClaims;
+    }
+
+    public void setPersistentVolumeClaims(Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
+        this.persistentVolumeClaims = persistentVolumeClaims;
+    }
+
+    public OpenShiftEnvironment withPersistentVolumeClaims(Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
+        this.persistentVolumeClaims = persistentVolumeClaims;
         return this;
     }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentParser.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentParser.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -91,6 +92,7 @@ public class OpenShiftEnvironmentParser {
         Map<String, Pod> pods = new HashMap<>();
         Map<String, Service> services = new HashMap<>();
         Map<String, Route> routes = new HashMap<>();
+        Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
         for (HasMetadata object : list.getItems()) {
             if (object instanceof DeploymentConfig) {
                 throw new ValidationException("Supporting of deployment configs is not implemented yet.");
@@ -103,6 +105,9 @@ public class OpenShiftEnvironmentParser {
             } else if (object instanceof Route) {
                 Route route = (Route)object;
                 routes.put(route.getMetadata().getName(), route);
+            } else if (object instanceof PersistentVolumeClaim) {
+                PersistentVolumeClaim pvc = (PersistentVolumeClaim)object;
+                pvcs.put(pvc.getMetadata().getName(), pvc);
             } else {
                 throw new ValidationException(String.format("Found unknown object type '%s'", object.getMetadata()));
             }
@@ -110,7 +115,8 @@ public class OpenShiftEnvironmentParser {
 
         OpenShiftEnvironment openShiftEnvironment = new OpenShiftEnvironment().withPods(pods)
                                                                               .withServices(services)
-                                                                              .withRoutes(routes);
+                                                                              .withRoutes(routes)
+                                                                              .withPersistentVolumeClaims(pvcs);
         normalizeEnvironment(openShiftEnvironment, environment);
 
         return openShiftEnvironment;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/ConfigurationProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/ConfigurationProvisioner.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftInfrastructure;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+
+/**
+ * Modifies workspace environment configuration and OpenShift environment
+ * with everything needed for some logical part of {@link OpenShiftInfrastructure}.
+ *
+ * @author Anton Korneta
+ */
+public interface ConfigurationProvisioner {
+
+    /**
+     * Configures the OpenShift environment and workspace environment
+     * with infrastructure needs.
+     *
+     * @param environment
+     *         configuration of environment
+     * @param osEnv
+     *         OpenShift environment
+     * @param identity
+     *         runtime identity
+     * @throws InfrastructureException
+     *         when any error occurs
+     */
+    void provision(EnvironmentImpl environment,
+                   OpenShiftEnvironment osEnv,
+                   RuntimeIdentity identity) throws InfrastructureException;
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisioner.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.openshift.provision.volume;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.shared.Utils;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.ConfigurationProvisioner;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Provides persistent volume claim into OpenShift environment.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class PersistentVolumeClaimProvisioner implements ConfigurationProvisioner {
+
+    private final boolean pvcEnable;
+    private final String  pvcName;
+    private final String  pvcQuantity;
+    private final String  pvcAccessMode;
+    private final String  projectFolderPath;
+
+    @Inject
+    public PersistentVolumeClaimProvisioner(@Named("che.infra.openshift.pvc.enabled") boolean pvcEnable,
+                                            @Named("che.infra.openshift.pvc.name") String pvcName,
+                                            @Named("che.infra.openshift.pvc.quantity") String pvcQuantity,
+                                            @Named("che.infra.openshift.pvc.access_mode") String pvcAccessMode,
+                                            @Named("che.workspace.projects.storage") String projectFolderPath) {
+        this.pvcEnable = pvcEnable;
+        this.pvcName = pvcName;
+        this.pvcQuantity = pvcQuantity;
+        this.pvcAccessMode = pvcAccessMode;
+        this.projectFolderPath = projectFolderPath;
+    }
+
+    @Override
+    public void provision(EnvironmentImpl environment,
+                          OpenShiftEnvironment osEnv,
+                          RuntimeIdentity runtimeIdentity) throws InfrastructureException {
+        if (pvcEnable) {
+            osEnv.getPersistentVolumeClaims()
+                 .put(pvcName, new PersistentVolumeClaimBuilder()
+                         .withNewMetadata()
+                             .withName(pvcName)
+                         .endMetadata()
+                         .withNewSpec()
+                             .withAccessModes(pvcAccessMode)
+                             .withNewResources()
+                                 .withRequests(ImmutableMap.of("storage", new Quantity(pvcQuantity)))
+                             .endResources()
+                         .endSpec()
+                         .build());
+            final String devMachineName = Utils.getDevMachineName(environment);
+            for (Pod pod : osEnv.getPods().values()) {
+                for (Container container : pod.getSpec().getContainers()) {
+                    final String machineName = pod.getMetadata().getName() + "/" + container.getName();
+                    if (devMachineName != null && devMachineName.equals(machineName)) {
+                        final VolumeMount volumeMount = new VolumeMountBuilder()
+                                .withMountPath(projectFolderPath)
+                                .withName(pvcName)
+                                .build();
+                        container.getVolumeMounts().add(volumeMount);
+                        final PersistentVolumeClaimVolumeSource pvcs = new PersistentVolumeClaimVolumeSourceBuilder()
+                                .withClaimName(pvcName)
+                                .build();
+                        final Volume volume = new VolumeBuilder().withPersistentVolumeClaim(pvcs)
+                                                                 .withName(pvcName)
+                                                                 .build();
+                        pod.getSpec().getVolumes().add(volume);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructureProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructureProvisionerTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.openshift;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.installer.InstallerConfigProvisioner;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.PersistentVolumeClaimProvisioner;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
+
+/**
+ * Tests {@link OpenShiftInfrastructureProvisioner}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OpenShiftInfrastructureProvisionerTest {
+
+    @Mock
+    private InstallerConfigProvisioner       installerProvisioner;
+    @Mock
+    private PersistentVolumeClaimProvisioner pvcProvisioner;
+    @Mock
+    private EnvironmentImpl                  environment;
+    @Mock
+    private OpenShiftEnvironment             osEnv;
+    @Mock
+    private RuntimeIdentity                  runtimeIdentity;
+
+    private OpenShiftInfrastructureProvisioner osInfraProvisioner;
+
+    private InOrder provisionOrder;
+
+    @BeforeMethod
+    public void setUp() {
+        osInfraProvisioner = new OpenShiftInfrastructureProvisioner(installerProvisioner, pvcProvisioner);
+        provisionOrder = inOrder(installerProvisioner, pvcProvisioner);
+    }
+
+    @Test
+    public void performsOrderedProvisioning() throws Exception {
+        osInfraProvisioner.provision(environment, osEnv, runtimeIdentity);
+
+        provisionOrder.verify(installerProvisioner)
+                      .provision(eq(environment), eq(osEnv), eq(runtimeIdentity));
+        provisionOrder.verify(pvcProvisioner)
+                      .provision(eq(environment), eq(osEnv), eq(runtimeIdentity));
+        provisionOrder.verifyNoMoreInteractions();
+    }
+
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/installer/InstallerConfigProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/installer/InstallerConfigProvisionerTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.openshift.provision.installer;
+
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.installer.server.InstallerRegistry;
+import org.eclipse.che.api.installer.server.exception.InstallerException;
+import org.eclipse.che.api.installer.shared.model.Installer;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.workspace.shared.Utils.WSAGENT_INSTALLER;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests {@link InstallerConfigProvisioner}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class InstallerConfigProvisionerTest {
+
+    private static final String CHE_SERVER_ENDPOINT = "localhost:8080";
+
+    @Mock
+    private InstallerRegistry    registry;
+    @Mock
+    private EnvironmentImpl      environment;
+    @Mock
+    private OpenShiftEnvironment osEnv;
+    @Mock
+    private RuntimeIdentity      runtimeIdentity;
+
+    private InstallerConfigProvisioner installerConfigProvisioner;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        installerConfigProvisioner = new InstallerConfigProvisioner(registry, CHE_SERVER_ENDPOINT);
+    }
+
+    @Test
+    public void provisionInstallerConfig() throws Exception {
+        final String podName = "test";
+        final Container container = mockContainer("machine");
+        final Pod pod = mockPod(podName, singletonList(container));
+        when(osEnv.getPods()).thenReturn(ImmutableMap.of(podName, pod));
+        final MachineConfigImpl devMachine = mock(MachineConfigImpl.class);
+        final Map<String, MachineConfigImpl> machines = ImmutableMap.of("test/machine", devMachine);
+        when(environment.getMachines()).thenReturn(machines);
+        final List<String> installerIds = singletonList(WSAGENT_INSTALLER);
+        when(devMachine.getInstallers()).thenReturn(installerIds);
+        final Installer installer = mock(Installer.class);
+        when(registry.getOrderedInstallers(installerIds)).thenReturn(singletonList(installer));
+        final Map<String, String> envVars = ImmutableMap.of("environment", "CHE_HOST=localhost");
+        when(installer.getProperties()).thenReturn(envVars);
+        final List<EnvVar> envVariables = new ArrayList<>();
+        when(container.getEnv()).thenReturn(envVariables);
+        when(installer.getServers()).thenReturn(emptyMap());
+
+        installerConfigProvisioner.provision(environment, osEnv, runtimeIdentity);
+
+        verify(osEnv, times(1)).getPods();
+        verify(runtimeIdentity, atLeast(1)).getWorkspaceId();
+        verify(environment, times(1)).getMachines();
+        assertTrue(envVariables.size() == 3);
+    }
+
+    @Test(expectedExceptions = InfrastructureException.class)
+    public void throwsInfrastructureExceptionWhenInstallerExceptionOccurs() throws Exception {
+        final String podName = "test";
+        final Pod pod = mockPod(podName, "machine");
+        when(osEnv.getPods()).thenReturn(ImmutableMap.of(podName, pod));
+        when(environment.getMachines()).thenReturn(ImmutableMap.of("test/machine", mock(MachineConfigImpl.class)));
+        when(registry.getOrderedInstallers(any())).thenThrow(new InstallerException("not found"));
+
+        installerConfigProvisioner.provision(environment, osEnv, runtimeIdentity);
+    }
+
+    private static Pod mockPod(String podName, List<Container> containers) {
+        final Pod pod = mock(Pod.class);
+        final ObjectMeta podMeta = mock(ObjectMeta.class);
+        when(pod.getMetadata()).thenReturn(podMeta);
+        when(podMeta.getName()).thenReturn(podName);
+        final PodSpec podSpec = mock(PodSpec.class);
+        when(pod.getSpec()).thenReturn(podSpec);
+        when(podSpec.getContainers()).thenReturn(containers);
+        return pod;
+    }
+
+    private static Pod mockPod(String podName, String... containerNames) {
+        final List<Container> containers = new ArrayList<>();
+        for (String containerName : containerNames) {
+            containers.add(mockContainer(containerName));
+        }
+        return mockPod(podName, containers);
+    }
+
+    private static Container mockContainer(String name) {
+        final Container container = mock(Container.class);
+        when(container.getName()).thenReturn(name);
+        return container;
+    }
+
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisionerTest.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.workspace.infrastructure.openshift.provision.volume;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.workspace.shared.Utils.WSAGENT_INSTALLER;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+
+/**
+ * Tests {@link PersistentVolumeClaimProvisioner}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class PersistentVolumeClaimProvisionerTest {
+
+    @Mock
+    private EnvironmentImpl      environment;
+    @Mock
+    private OpenShiftEnvironment osEnv;
+    @Mock
+    private RuntimeIdentity      runtimeIdentity;
+
+    private PersistentVolumeClaimProvisioner pvcProvisioner;
+
+    @Test
+    public void doNothingWhenPVCDisabled() throws Exception {
+        pvcProvisioner = new PersistentVolumeClaimProvisioner(false,
+                                                              "claim-che-workspace",
+                                                              "10Gi",
+                                                              "ReadWriteOnce",
+                                                              "/projects");
+
+        pvcProvisioner.provision(environment, osEnv, runtimeIdentity);
+
+        verify(osEnv, never()).getPersistentVolumeClaims();
+        verify(environment, never()).getMachines();
+    }
+
+    @Test
+    public void provisionPVC() throws Exception {
+        pvcProvisioner = new PersistentVolumeClaimProvisioner(true,
+                                                              "claim-che-workspace",
+                                                              "10Gi",
+                                                              "ReadWriteOnce",
+                                                              "/projects");
+        final Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
+        when(osEnv.getPersistentVolumeClaims()).thenReturn(pvcs);
+        final MachineConfigImpl devMachine = mock(MachineConfigImpl.class);
+        when(environment.getMachines()).thenReturn(ImmutableMap.of("test/machine", devMachine));
+        when(devMachine.getInstallers()).thenReturn(singletonList(WSAGENT_INSTALLER));
+        final String podName = "test";
+        final Pod pod = mock(Pod.class);
+        final PodSpec podSpec = mock(PodSpec.class);
+        final ObjectMeta podMeta = mock(ObjectMeta.class);
+        final Container container = mock(Container.class);
+        when(pod.getSpec()).thenReturn(podSpec);
+        when(pod.getMetadata()).thenReturn(podMeta);
+        when(podMeta.getName()).thenReturn(podName);
+        when(podSpec.getContainers()).thenReturn(singletonList(container));
+        final List<Volume> volumes = new ArrayList<>();
+        when(podSpec.getVolumes()).thenReturn(volumes);
+        when(container.getName()).thenReturn("machine");
+        final List<VolumeMount> volumeMounts = new ArrayList<>();
+        when(container.getVolumeMounts()).thenReturn(volumeMounts);
+        when(osEnv.getPods()).thenReturn(ImmutableMap.of(podName, pod));
+
+        pvcProvisioner.provision(environment, osEnv, runtimeIdentity);
+
+        verify(osEnv, times(1)).getPersistentVolumeClaims();
+        verify(environment, times(1)).getMachines();
+        assertFalse(pvcs.isEmpty());
+        assertFalse(volumes.isEmpty());
+        assertFalse(volumeMounts.isEmpty());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,13 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
+                <artifactId>bootstrapper</artifactId>
+                <version>${che.version}</version>
+                <type>zip</type>
+                <classifier>linux_amd64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
                 <artifactId>exec-agent</artifactId>
                 <version>${che.version}</version>
             </dependency>

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Utils.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Utils.java
@@ -36,11 +36,24 @@ public class Utils {
     public static String getDevMachineName(Environment envConfig) {
         for (Map.Entry<String, ? extends MachineConfig> entry : envConfig.getMachines().entrySet()) {
             // TODO should we use server ref instead of installers?
-            List<String> installers = entry.getValue().getInstallers();
-            if (installers != null && installers.contains(WSAGENT_INSTALLER)) {
+            if (isDev(entry.getValue())) {
                 return entry.getKey();
             }
         }
         return null;
     }
+
+    /**
+     * Checks whether given machine installers contains 'ws-agent' installer.
+     *
+     * @param machineConf
+     *         given machine config
+     * @return true if given machine config contains ws-agent installer
+     * otherwise false will be returned
+     */
+    public static boolean isDev(MachineConfig machineConf) {
+        final List<String> installers = machineConf.getInstallers();
+        return installers != null && installers.contains(WSAGENT_INSTALLER);
+    }
+
 }


### PR DESCRIPTION
Adds provision mechanism for adjusting environment in accordance with infra needs.
Provides persistent volume claims for workspace projects, volume bindings, and volume mounts into Pod and container respectively.
Also added:
- property for disable PVC provisioning:
`CHE_INFRA_OPENSHIFT_WORKSPACE_PVC_ENABLE` with default value `true`
- property for define quantity of PVC:
`CHE_INFRA_OPENSHIFT_WORKSPACE_PVC_QUANTITY` with default value `10Gi`