### PR TITLE
Adding assembly-ide-war `webapp` source folder as sources instead of resources to avoid duplicated files in final war

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -422,23 +422,9 @@
                             <sources>
                                 <source>${generated.sources.directory}</source>
                                 <source>src/main/java</source>
+                                <source>src/main/webapp</source>
                             </sources>
                         </configuration>
-                    </execution>
-                    <execution>
-                      <id>add-resource</id>
-                      <phase>generate-resources</phase>
-                      <goals>
-                        <goal>add-resource</goal>
-                      </goals>
-                      <configuration>
-                        <resources>
-                          <resource>
-                            <directory>src/main/webapp</directory>
-                            <targetPath></targetPath>
-                          </resource>
-                        </resources>
-                      </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Fix previous PR #5966