### PR TITLE
CHE-5881. Add ability to add a project folder to File watcher excludes

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
@@ -235,7 +235,11 @@ public class FileWatcherIgnoreFileTracker {
       Set<Path> projectExcludes =
           lines
               .filter(line -> !isNullOrEmpty(line.trim()))
-              .map(line -> projectPath.resolve(line.trim()))
+              .map(
+                  line -> {
+                    line = line.trim();
+                    return "/".equals(line) ? projectPath : projectPath.resolve(line);
+                  })
               .filter(excludePath -> exists(excludePath))
               .collect(toSet());
 
@@ -354,7 +358,11 @@ public class FileWatcherIgnoreFileTracker {
 
         Set<String> excludesToWrite =
             groupedExcludes.computeIfAbsent(ignoreFilePath, k -> new HashSet<>());
-        excludesToWrite.add(projectPath.relativize(pathToExclude).toString());
+        String excludeToWrite =
+            pathToExclude.equals(projectPath)
+                ? "/"
+                : projectPath.relativize(pathToExclude).toString();
+        excludesToWrite.add(excludeToWrite);
       }
     } catch (NotFoundException e) {
       String errorMessage = "Can not add path to File Watcher excludes: " + e.getLocalizedMessage();


### PR DESCRIPTION
### What does this PR do?
Add ability to add a project folder to File watcher excludes. 
fileWatcherIgnore file keeps file watcher excludes as relative paths to a project folder
So I propose to keep exclude for a project folder as "/". 
### What issues does this PR fix or reference?
#5881 

#### Changelog
Add ability to add a project folder to File watcher excludes

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>