### PR TITLE
CHE-4509: Fix project name validator for rename action

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
@@ -254,31 +254,29 @@ public class RenameItemAction extends AbstractPerspectiveAction {
         }
     }
 
-    private class ProjectNameValidator extends AbstractNameValidator {
+	private class ProjectNameValidator extends AbstractNameValidator {
 
-        public ProjectNameValidator(String selfName) {
-            super(selfName);
-        }
+		public ProjectNameValidator(String selfName) {
+			super(selfName);
+		}
 
-        @Override
-        public Violation isValidName(String value) {
-            final String correctValue = value.contains(" ") ? value.replaceAll(" ", "-") : null;
-            final String errormessage = !NameUtils.checkFileName(value) ? localization.invalidName() : null;
-            if (correctValue != null || errormessage != null) {
-                return new Violation() {
-                    @Override
-                    public String getMessage() {
-                        return errormessage;
-                    }
+		@Override
+		public Violation isValidName(String value) {
+			return new Violation() {
+				@Override
+				public String getMessage() {
+					return localization.invalidName();
+				}
 
-                    @Nullable
-                    @Override
-                    public String getCorrectedValue() {
-                        return correctValue;
-                    }
-                };
-            }
-            return null;
-        }
-    }
+				@Nullable
+				@Override
+				public String getCorrectedValue() {
+					if (NameUtils.checkProjectName(value)) {
+						return value.contains(" ") ? value.replaceAll(" ", "-") : value;
+					}
+					return null;
+				}
+			};
+		}
+	}
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
@@ -254,29 +254,29 @@ public class RenameItemAction extends AbstractPerspectiveAction {
         }
     }
 
-	private class ProjectNameValidator extends AbstractNameValidator {
+    private class ProjectNameValidator extends AbstractNameValidator {
 
-		public ProjectNameValidator(String selfName) {
-			super(selfName);
-		}
+        public ProjectNameValidator(String selfName) {
+            super(selfName);
+        }
 
-		@Override
-		public Violation isValidName(String value) {
-			return new Violation() {
-				@Override
-				public String getMessage() {
-					return localization.invalidName();
-				}
+        @Override
+        public Violation isValidName(String value) {
+            return new Violation() {
+                @Override
+                public String getMessage() {
+                    return localization.invalidName();
+                }
 
-				@Nullable
-				@Override
-				public String getCorrectedValue() {
-					if (NameUtils.checkProjectName(value)) {
-						return value.contains(" ") ? value.replaceAll(" ", "-") : value;
-					}
-					return null;
-				}
-			};
-		}
-	}
+                @Nullable
+                @Override
+                public String getCorrectedValue() {
+                    if (NameUtils.checkProjectName(value)) {
+                        return value.contains(" ") ? value.replaceAll(" ", "-") : value;
+                    }
+                    return null;
+                }
+            };
+        }
+    }
 }


### PR DESCRIPTION
Signed-off-by: Dmitrii Bocharov <dbocharo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes the validation of the project name during rename process

### What issues does this PR fix or reference?
#4509

#### Changelog
`ProjectNameValidator` had incorrect `isValidName` implementation. It said `true` for almost all values.