### PR TITLE
Do not scale down deployment before resource deletion. Removing watch pod logic (seems to be also broken after 3.6 osio update)

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftDeploymentCleaner.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftDeploymentCleaner.java
@@ -12,8 +12,6 @@ package org.eclipse.che.plugin.openshift.client;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javax.inject.Singleton;
 
@@ -23,16 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.DoneableDeployment;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -41,24 +32,12 @@ import io.fabric8.openshift.client.OpenShiftClient;
 public class OpenShiftDeploymentCleaner {
     private static final Logger LOG = LoggerFactory.getLogger(OpenShiftDeploymentCleaner.class);
     private static final int OPENSHIFT_POD_DELETION_TIMEOUT = 120;
+    private static final int OPENSHIFT_WAIT_POD_DELAY       = 1000;
+
 
     public void cleanDeploymentResources(final String deploymentName, final String namespace) throws IOException {
-        scaleDownDeployment(deploymentName, namespace);
         cleanUpWorkspaceResources(deploymentName, namespace);
         waitUntilWorkspacePodIsDeleted(deploymentName, namespace);
-    }
-
-    private void scaleDownDeployment(String deploymentName, final String namespace) throws OpenShiftException {
-        try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
-            ScalableResource<Deployment, DoneableDeployment> deployment = openShiftClient.extensions()
-                           .deployments()
-                           .inNamespace(namespace)
-                           .withName(deploymentName);
-
-            if (deployment != null) {
-                deployment.scale(0, true);
-            }
-        }
     }
 
     private void cleanUpWorkspaceResources(final String deploymentName, final String namespace) throws IOException {
@@ -92,50 +71,26 @@ public class OpenShiftDeploymentCleaner {
             }
         }
     }
-    
+
     private void waitUntilWorkspacePodIsDeleted(final String deploymentName, final String namespace) throws OpenShiftException {
         try (OpenShiftClient client = new DefaultOpenShiftClient()) {
-            FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> pods = client.pods()
-                                                                                              .inNamespace(namespace)
-                                                                                              .withLabel(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName);
+            for (int waitCount = 0; waitCount < OPENSHIFT_POD_DELETION_TIMEOUT; waitCount++) {
+                List<Pod> pods = client.pods().inNamespace(namespace)
+                                              .withLabel(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName)
+                                              .list()
+                                              .getItems();
 
-            int numberOfPodsToStop = pods.list().getItems().size();
-            LOG.info("Number of workspace pods to stop {}", numberOfPodsToStop);
-            if (numberOfPodsToStop > 0) {
-                final CountDownLatch podCount = new CountDownLatch(numberOfPodsToStop);
-                pods.watch(new Watcher<Pod>() {
-                    @Override
-                    public void eventReceived(Action action, Pod pod) {
-                        try {
-                            switch (action) {
-                                case ADDED:
-                                case MODIFIED:
-                                case ERROR:
-                                    break;
-                                case DELETED:
-                                    LOG.info("Pod {} deleted", pod.getMetadata().getName());
-                                    podCount.countDown();
-                                    break;
-                            }
-                        } catch (Exception e) {
-                            LOG.error("Failed to process {} on Pod {}. Error: ", action, pod, e);
-                        }
-                    }
-
-                    @Override
-                    public void onClose(KubernetesClientException ex) {
-                    }
-                });
-
-                try {
-                    LOG.info("Waiting for all pods to be deleted for deployment '{}'", deploymentName);
-                    podCount.await(OPENSHIFT_POD_DELETION_TIMEOUT, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    LOG.error("Exception while waiting for pods to be deleted", e);
-                    throw new OpenShiftException("Timeout while waiting for pods to terminate", e);
+                if (pods.size() == 0) {
+                    return;
                 }
+                Thread.sleep(OPENSHIFT_WAIT_POD_DELAY);
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.info("Thread interrupted while cleaning up workspace");
         }
+
+        throw new OpenShiftException("Timeout while waiting for pods to terminate");
     }
 
 }


### PR DESCRIPTION
### What does this PR do?
Do not scale down deployment before resource deletion
`deployment.scale(0, true);` hangs on osio after update to 3.6 version. Watching pods also seem to hang till timeout occurs.

#### Changelog
(bugfix, update to support OpenShift 3.6+)

#### Release Notes
N / A

#### Docs PR
N / A
