### PR TITLE
Changing deletion order during deployment cleaup (routes & services are going to be deleted first)

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftDeploymentCleaner.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftDeploymentCleaner.java
@@ -47,17 +47,6 @@ public class OpenShiftDeploymentCleaner {
         List<ReplicaSet> replicaSets = KubernetesResourceUtil.getReplicaSetByLabel(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName, namespace);
 
         try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
-
-            if (deployment != null) {
-                LOG.info("Removing OpenShift Deployment {}", deployment.getMetadata().getName());
-                openShiftClient.resource(deployment).delete();
-            }
-
-            if (replicaSets != null && replicaSets.size() > 0) {
-                LOG.info("Removing OpenShift ReplicaSets for deployment {}", deploymentName);
-                replicaSets.forEach(rs -> openShiftClient.resource(rs).delete());
-            }
-
             if (routes != null) {
                 for (Route route: routes) {
                     LOG.info("Removing OpenShift Route {}", route.getMetadata().getName());
@@ -69,6 +58,17 @@ public class OpenShiftDeploymentCleaner {
                 LOG.info("Removing OpenShift Service {}", service.getMetadata().getName());
                 openShiftClient.resource(service).delete();
             }
+
+            if (deployment != null) {
+                LOG.info("Removing OpenShift Deployment {}", deployment.getMetadata().getName());
+                openShiftClient.resource(deployment).delete();
+            }
+
+            if (replicaSets != null && replicaSets.size() > 0) {
+                LOG.info("Removing OpenShift ReplicaSets for deployment {}", deploymentName);
+                replicaSets.forEach(rs -> openShiftClient.resource(rs).delete());
+            }
+
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
Changes deletion order during deployment cleanup (routes & svc are deleted first)


#### Changelog
hot-fix for 3.6 OpenShift update

#### Release Notes
N/A

#### Docs PR
N/A
