### PR TITLE
Workaround for ImageStreamTags issue on OpenShift 3.6

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -433,6 +433,9 @@ public class OpenShiftConnector extends DockerConnector {
                                                           openShiftCheProjectName,
                                                           imageStreamTagPullSpec);
 
+        // Workaround for ImageStreamTags issue
+        dockerPullSpec = imageStreamTag.getTag().getFrom().getName();
+
         ContainerConfig containerConfig = createContainerParams.getContainerConfig();
         ImageConfig imageConfig = inspectImage(InspectImageParams.create(imageForDocker)).getConfig();
 


### PR DESCRIPTION
### What does this PR do?
Introduce a minor workaround for an ImageStreamTag issue on OpenShift 3.6+.

Currently, when Che attempts to delete a deployment, the Kubernetes client throws a NullPointerException and workspace cleanup fails. After some testing, it seems like the Deployment status is null only if the docker image specified for the deployment is an ImageStreamTag. If instead the Deployment is specified to use a docker image from e.g. the docker hub, the Deployment's status is not null and it is deleted successfully. 

This change replaces the docker pull spec we use for Deployments with the underlying image they refer to.

This is not meant to be a long-term fix. We need to decide if we want to keep trying to use ImageStreams and ImageStreamTags, or if we want to find a better solution.

### What issues does this PR fix or reference?
Failure to stop workspaces when running Che on OpenShift 3.6 and higher.

#### Changelog
(bugfix, OpenShift 3.6 support)

#### Release Notes
(bugfix, OpenShift 3.6 support)
