### PR TITLE
Reverting #6019: Workaround for ImageStreamTags issue on OpenShift 3.6

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -433,9 +433,6 @@ public class OpenShiftConnector extends DockerConnector {
                                                           openShiftCheProjectName,
                                                           imageStreamTagPullSpec);
 
-        // Workaround for ImageStreamTags issue
-        dockerPullSpec = imageStreamTag.getTag().getFrom().getName();
-
         ContainerConfig containerConfig = createContainerParams.getContainerConfig();
         ImageConfig imageConfig = inspectImage(InspectImageParams.create(imageForDocker)).getConfig();
 
@@ -592,8 +589,6 @@ public class OpenShiftConnector extends DockerConnector {
 
         ImageStreamTag tag = getImageStreamTagFromRepo(tagName);
         ImageInfo imageInfo = getImageInfoFromTag(tag);
-
-
 
         Service svc = getCheServiceBySelector(OPENSHIFT_DEPLOYMENT_LABEL, deploymentName);
         if (svc == null) {


### PR DESCRIPTION
Reverting https://github.com/eclipse/che/pull/6019
On OSIO keep getting failure during workspace creation if there are more than one is presented: 

```

2017-08-17 11:02:10,307[aceSharedPool-6]  [ERROR] [o.e.c.a.w.s.WorkspaceManager 780]    - Multiple ImageStreamTags found for name latest
--
  | org.eclipse.che.api.core.ServerException: Multiple ImageStreamTags found for name latest
  | at org.eclipse.che.api.environment.server.CheEnvironmentEngine.startInstance(CheEnvironmentEngine.java:1012)
  | at org.eclipse.che.api.environment.server.CheEnvironmentEngine.startEnvironmentQueue(CheEnvironmentEngine.java:813)
  | at org.eclipse.che.api.environment.server.CheEnvironmentEngine.start(CheEnvironmentEngine.java:268)
  | at org.eclipse.che.api.workspace.server.WorkspaceRuntimes.startEnvironmentAndPublishEvents(WorkspaceRuntimes.java:712)
  | at org.eclipse.che.api.workspace.server.WorkspaceRuntimes.access$100(WorkspaceRuntimes.java:106)
  | at org.eclipse.che.api.workspace.server.WorkspaceRuntimes$StartTask.call(WorkspaceRuntimes.java:977)
  | at org.eclipse.che.api.workspace.server.WorkspaceRuntimes$StartTask.call(WorkspaceRuntimes.java:941)
  | at org.eclipse.che.commons.lang.concurrent.CopyThreadLocalCallable.call(CopyThreadLocalCallable.java:30)
  | at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  | at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  | at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  | at java.lang.Thread.run(Thread.java:748)
  | Caused by: org.eclipse.che.api.core.ServerException: Multiple ImageStreamTags found for name latest
  | at org.eclipse.che.plugin.docker.machine.MachineProviderImpl.startService(MachineProviderImpl.java:395)
  | at org.eclipse.che.api.environment.server.CheEnvironmentEngine.lambda$startEnvironmentQueue$6(CheEnvironmentEngine.java:785)
  | at org.eclipse.che.api.environment.server.CheEnvironmentEngine.startInstance(CheEnvironmentEngine.java:952)
  | ... 11 common frames omitted
  | Caused by: org.eclipse.che.plugin.openshift.client.exception.OpenShiftException: Multiple ImageStreamTags found for name latest
  | at org.eclipse.che.plugin.openshift.client.OpenShiftConnector.getImageStreamTagFromRepo(OpenShiftConnector.java:1083)
  | at org.eclipse.che.plugin.openshift.client.OpenShiftConnector.inspectContainer(OpenShiftConnector.java:593)
  | at org.eclipse.che.plugin.docker.machine.MachineProviderImpl.checkContainerIsRunning(MachineProviderImpl.java:701)
  | at org.eclipse.che.plugin.docker.machine.MachineProviderImpl.startService(MachineProviderImpl.java:350)
  | ... 13 common frames omitted


```