### PR TITLE
Fix TypeScript DTO Generator for newly float type introduced

### DIFF
--- a/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
+++ b/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
@@ -23,11 +23,12 @@ class DTOBuilder {
     static MY_SIMPLE_ID : number = 2503;
     static MY_SIMPLE_BOOLEAN : boolean = true;
     static MY_SIMPLE_DOUBLE : number = 19.79;
+    static MY_SIMPLE_FLOAT : number = 3.14;
 
 
     static buildSimpleDto() : org.eclipse.che.plugin.typescript.dto.MySimpleDTO {
         let mySimpleDTO : org.eclipse.che.plugin.typescript.dto.MySimpleDTO = new org.eclipse.che.plugin.typescript.dto.MySimpleDTOImpl();
-        mySimpleDTO.withId(DTOBuilder.MY_SIMPLE_ID).withBoolean(DTOBuilder.MY_SIMPLE_BOOLEAN).withDouble(DTOBuilder.MY_SIMPLE_DOUBLE);
+        mySimpleDTO.withId(DTOBuilder.MY_SIMPLE_ID).withBoolean(DTOBuilder.MY_SIMPLE_BOOLEAN).withDouble(DTOBuilder.MY_SIMPLE_DOUBLE).withFloat(DTOBuilder.MY_SIMPLE_FLOAT);
         return mySimpleDTO;
     }
 
@@ -55,6 +56,7 @@ describe("DTO serialization tests", () => {
         expect(myCustomDTO.getId()).to.eql(DTOBuilder.MY_SIMPLE_ID);
         expect(myCustomDTO.getBoolean()).to.eql(DTOBuilder.MY_SIMPLE_BOOLEAN);
         expect(myCustomDTO.getDouble()).to.eql(DTOBuilder.MY_SIMPLE_DOUBLE);
+        expect(myCustomDTO.getFloat()).to.eql(DTOBuilder.MY_SIMPLE_FLOAT);
 
     });
 

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
@@ -129,7 +129,7 @@ public class DTOHelper {
         } else if (String.class.equals(type) || (type instanceof Class && ((Class)type).isEnum())) {
             // Maybe find a better enum type for typescript
             return "string";
-        } else if (Integer.class.equals(type) || Integer.TYPE.equals(type) || Long.class.equals(type) || Long.TYPE.equals(type) || Double.class.equals(type) || Double.TYPE.equals(type)) {
+        } else if (Integer.class.equals(type) || Integer.TYPE.equals(type) || Long.class.equals(type) || Long.TYPE.equals(type) || Double.class.equals(type) || Double.TYPE.equals(type) || Float.TYPE.equals(type)) {
             return "number";
         } else if (Boolean.class.equals(type)) {
             return "boolean";

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MySimpleDTO.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MySimpleDTO.java
@@ -26,4 +26,8 @@ public interface MySimpleDTO {
 
     double getDouble();
     MySimpleDTO withDouble(double d);
+
+    float getFloat();
+    MySimpleDTO withFloat(float f);
+
 }


### PR DESCRIPTION
### What does this PR do?

Float was introduced on DTO by :https://github.com/eclipse/che/blob/0cada6bc983448a1e6619249d4c9f6c18c74db84/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/SearchOccurrenceDto.java#L28 )


### What issues does this PR fix or reference?

It wasn't handled by typescript dto generator, it was failing as float is not a TypeScript type.
add test case and handle it now.

Note: without this fix it's impossible to generate all che docker images.

#### Changelog
handle float type in DTO for TypeScript DTO generator


#### Release Notes
N/A bug

#### Docs PR
N/A bug

Change-Id: I63a634cdd8822b8908ad84816f75b25a122d45d3
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>






