### PR TITLE
CHE-5878. Provide output for importing project notification

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectApiModule.java
@@ -15,6 +15,7 @@ import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
 import com.google.gwt.inject.client.multibindings.GinMultibinder;
 import com.google.inject.Singleton;
 
+import org.eclipse.che.ide.projectimport.wizard.ProjectImportOutputJsonRpcNotifier;
 import org.eclipse.che.ide.resources.ProjectTreeStateNotificationOperation;
 import org.eclipse.che.ide.api.project.type.ProjectTemplateRegistry;
 import org.eclipse.che.ide.api.project.type.ProjectTypeRegistry;
@@ -63,7 +64,7 @@ public class ProjectApiModule extends AbstractGinModule {
 
         bind(ProjectNotificationSubscriber.class).to(ProjectNotificationSubscriberImpl.class).in(Singleton.class);
         install(new GinFactoryModuleBuilder()
-                        .implement(ProjectNotificationSubscriber.class, ProjectNotificationSubscriberImpl.class)
+                        .implement(ProjectNotificationSubscriber.class, ProjectImportOutputJsonRpcNotifier.class)
                         .build(ImportProjectNotificationSubscriberFactory.class));
 
         bind(ProjectImportNotificationSubscriber.class).asEagerSingleton();


### PR DESCRIPTION
### What does this PR do?
- Use ProjectImportOutputJsonRpcNotifier instead of ProjectNotificationSubscriberImpl to provide output for importing project notification.
- Fix displaying output for importing project notification for case when user imports project after refreshing a page.
- Fix status of importing project notification

### What issues does this PR fix or reference?
#5878 

#### Changelog
Provide output for importing project notification

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
![import_status](https://user-images.githubusercontent.com/5676062/29416086-b2b7166e-836d-11e7-8e44-3e02f122b92c.gif)

![import_output](https://user-images.githubusercontent.com/5676062/29416115-c76496c2-836d-11e7-86c7-9f1ea3e52260.gif)
