### PR TITLE
CHE-6025: Fix bug when Project wizard is not closed after importing m…

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerViewImpl.java
@@ -334,7 +334,9 @@ public class ProjectExplorerViewImpl extends BaseView<ProjectExplorerView.Action
                 element.setAttribute("path", resource.getLocation().toString());
 
                 Project project = resource.getProject();
-                element.setAttribute("project", project.getLocation().toString());
+                if (project != null) {
+                    element.setAttribute("project", project.getLocation().toString());
+                }
             }
 
             if (node instanceof HasAction) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add a check for variable to be not null to avoid `NullPointer` exception

### What issues does this PR fix or reference?
fixes #6025 

#### Changelog
Fix bug when Project wizard is not closed after importing maven project
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Bugfix N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
Bugfix N/A