### PR TITLE
Change license headers copyright owner on remaining files

### DIFF
--- a/dashboard/gulp/material-design-svgfont.js
+++ b/dashboard/gulp/material-design-svgfont.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulpfile.js
+++ b/dashboard/gulpfile.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/404.html
+++ b/dashboard/src/404.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/admin/plugins/plugins.html
+++ b/dashboard/src/app/admin/plugins/plugins.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/administration/administration.html
+++ b/dashboard/src/app/administration/administration.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/dashboard/dashboard.html
+++ b/dashboard/src/app/dashboard/dashboard.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/demo-components/demo-components.html
+++ b/dashboard/src/app/demo-components/demo-components.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/diagnostics/diagnostics-widget.html
+++ b/dashboard/src/app/diagnostics/diagnostics-widget.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/diagnostics/diagnostics.html
+++ b/dashboard/src/app/diagnostics/diagnostics.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.html
+++ b/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <div class="factory-from-file" layout="row" flex layout-align="start center">

--- a/dashboard/src/app/factories/create-factory/create-factory.html
+++ b/dashboard/src/app/factories/create-factory/create-factory.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <che-toolbar che-title="New Factory From"></che-toolbar>

--- a/dashboard/src/app/factories/create-factory/git/create-factory-git.html
+++ b/dashboard/src/app/factories/create-factory/git/create-factory-git.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.html
+++ b/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <div class="factory-from-template" layout="row" flex layout-align="start center">

--- a/dashboard/src/app/factories/create-factory/workspaces-tab/factory-from-workspace.html
+++ b/dashboard/src/app/factories/create-factory/workspaces-tab/factory-from-workspace.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <md-content class="factory-from-workspace" flex>

--- a/dashboard/src/app/factories/factory-details/factory-details.html
+++ b/dashboard/src/app/factories/factory-details/factory-details.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <che-toolbar

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <div class="factory-information" ng-if="factoryInformationController.copyOriginFactory">

--- a/dashboard/src/app/factories/last-factories/last-factories.html
+++ b/dashboard/src/app/factories/last-factories/last-factories.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <dashboard-panel panel-title="Recent Factories">

--- a/dashboard/src/app/factories/list-factories/factory-item/factory-item.html
+++ b/dashboard/src/app/factories/list-factories/factory-item/factory-item.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <che-list-item flex ng-mouseover="hover=true" ng-mouseout="hover=false">

--- a/dashboard/src/app/factories/list-factories/list-factories.html
+++ b/dashboard/src/app/factories/list-factories/list-factories.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <che-toolbar che-title="All factories" border-none></che-toolbar>

--- a/dashboard/src/app/factories/load-factory/load-factory.html
+++ b/dashboard/src/app/factories/load-factory/load-factory.html
@@ -1,20 +1,13 @@
 <!--
 
-    CODENVY CONFIDENTIAL
-    __________________
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-     [2015] - [2016] Red Hat, Inc.
-     All Rights Reserved.
-
-    NOTICE:  All information contained herein is, and remains
-    the property of Codenvy S.A. and its suppliers,
-    if any.  The intellectual and technical concepts contained
-    herein are proprietary to Codenvy S.A.
-    and its suppliers and may be covered by U.S. and Foreign Patents,
-    patents in process, and are protected by trade secret or copyright law.
-    Dissemination of this information or reproduction of this material
-    is strictly forbidden unless prior written permission is obtained
-    from Codenvy S.A..
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <div class="load-factory-main-container">

--- a/dashboard/src/app/ide/ide.html
+++ b/dashboard/src/app/ide/ide.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/navbar/navbar.html
+++ b/dashboard/src/app/navbar/navbar.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/navbar/navbar.styl
+++ b/dashboard/src/app/navbar/navbar.styl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/config-file/create-project-conf-file.html
+++ b/dashboard/src/app/projects/create-project/config-file/create-project-conf-file.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/create-project.html
+++ b/dashboard/src/app/projects/create-project/create-project.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/git/create-project-git.html
+++ b/dashboard/src/app/projects/create-project/git/create-project-git.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/github/create-project-github.html
+++ b/dashboard/src/app/projects/create-project/github/create-project-github.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/samples/create-project-samples.html
+++ b/dashboard/src/app/projects/create-project/samples/create-project-samples.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/workspaces/create-project-workspaces.html
+++ b/dashboard/src/app/projects/create-project/workspaces/create-project-workspaces.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/create-project/zip/create-project-zip.html
+++ b/dashboard/src/app/projects/create-project/zip/create-project-zip.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/list-projects/project-item/project-item.html
+++ b/dashboard/src/app/projects/list-projects/project-item/project-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/projects/project-details/repository/project-repository.html
+++ b/dashboard/src/app/projects/project-details/repository/project-repository.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/import-stack/import-stack.html
+++ b/dashboard/src/app/stacks/list-stacks/import-stack/import-stack.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/list-stacks.html
+++ b/dashboard/src/app/stacks/list-stacks/list-stacks.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.html
+++ b/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.html
+++ b/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/list-components/list-components.html
+++ b/dashboard/src/app/stacks/stack-details/list-components/list-components.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/select-template/select-template.html
+++ b/dashboard/src/app/stacks/stack-details/select-template/select-template.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/stack.html
+++ b/dashboard/src/app/stacks/stack-details/stack.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-item/workspace-item.html
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-item/workspace-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/environments.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/environments.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.html
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.html
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/components/widget/html-source/che-html-source.html
+++ b/dashboard/src/components/widget/html-source/che-html-source.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/components/widget/popup/che-modal-popup.html
+++ b/dashboard/src/components/widget/popup/che-modal-popup.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/components/widget/popup/che-popup.html
+++ b/dashboard/src/components/widget/popup/che-popup.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/gitHubCallback.html
+++ b/dashboard/src/gitHubCallback.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015 Red Hat, Inc.
+    Copyright (c) 2015-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/plugins/plugin-composer/che-plugin-composer-ide/pom.xml
+++ b/plugins/plugin-composer/che-plugin-composer-ide/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2016 Codenvy, S.A.
+    Copyright (c) 2016 Rogue Wave Software, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Rogue Wave Software, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/plugins/plugin-composer/che-plugin-composer-ide/src/main/resources/org/eclipse/che/plugin/composer/Composer.gwt.xml
+++ b/plugins/plugin-composer/che-plugin-composer-ide/src/main/resources/org/eclipse/che/plugin/composer/Composer.gwt.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2016 Codenvy, S.A.
+    Copyright (c) 2016 Rogue Wave Software, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Rogue Wave Software, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/workspace/test/.che/classpath
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/workspace/test/.che/classpath
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <classpath>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix remaining license headers (follow up to https://github.com/eclipse/che/pull/5964 and https://github.com/eclipse/che/pull/6032)

FIles that will not have their header changed:
https://github.com/eclipse/che/tree/master/wsmaster/che-core-sql-schema/src/main/resources/che-schema
(our Flyway DB Migration requires these file to be unchanged)
https://github.com/eclipse/che/tree/master/assembly/assembly-main/src/assembly/plugins
(Presumably old files, that need removal)
https://github.com/eclipse/che/tree/master/plugins/plugin-composer
(Need to find out the origin of files and their copyrigth owner with @kaloyan-raev )


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5891

#### Changelog
Changed copyright owner to "Red Hat, Inc." in license headers

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
