### PR TITLE
Synchronize commands with rh-che stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2444,9 +2444,22 @@
       },
       "commands": [
         {
-          "commandLine": "scl enable rh-maven33 'mvn clean install -f ${current.project.path}'",
+          "commandLine": "scl enable rh-maven33 'mvn install -f ${current.project.path}'",
           "name": "build",
-          "type": "mvn"
+          "type": "mvn",
+          "attributes": {
+            "previewUrl": "",
+            "goal": "Build"
+          }
+        },
+        {
+          "commandLine": "scl enable rh-maven33 'mvn clean install -f ${current.project.path}'",
+          "name": "clean build",
+          "type": "mvn",
+          "attributes": {
+            "previewUrl": "",
+            "goal": "Build"
+          }
         },
         {
           "commandLine": "scl enable rh-maven33 'mvn compile spring-boot:run -f ${current.project.path}'",


### PR DESCRIPTION
### What does this PR do?

Sync for spring-boot commands
- add `clean build` command
- remove clean option of `build`
- specify the goal of the build commands

### What issues does this PR fix or reference?
https://github.com/openshiftio/openshift.io/issues/621

#### Changelog
Update che commands to be aligned with rh-che commands for spring boot stack

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: Ib5a95666484893736a492287b458865c4daa17d4
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

