### PR TITLE
[dashboard] Use `open` instead of `toggle`

### DIFF
--- a/dashboard/src/app/ide/ide-iframe/ide-iframe.service.ts
+++ b/dashboard/src/app/ide/ide-iframe/ide-iframe.service.ts
@@ -46,7 +46,7 @@ class IdeIFrameSvc {
 
       } else if ("show-navbar" === event.data) {
         $rootScope.hideNavbar = false;
-        $mdSidenav('left').toggle();
+        $mdSidenav('left').open();
 
       } else if ("hide-navbar" === event.data) {
         $rootScope.hideNavbar = true;


### PR DESCRIPTION
We should use open for symmetry reasons and also because it can otherwise turn the dashboard into a wrong state, when the dashboard was already open.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

It replaces a call to toggle() by one to open()

