### PR TITLE
CHE-6072: fix bug when 'null' is used as a server path

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.api.core.model.workspace.config;
 
+import org.eclipse.che.commons.annotation.Nullable;
+
 /**
  * Configuration of server that can be started inside of machine.
  *
@@ -47,5 +49,6 @@ public interface ServerConfig {
   String getProtocol();
 
   /** Path used by server. */
+  @Nullable
   String getPath();
 }

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -94,7 +94,9 @@ public final class Labels {
     public Serializer server(String ref, ServerConfig server) {
       labels.put(String.format(SERVER_PORT_LABEL_FMT, ref), server.getPort());
       labels.put(String.format(SERVER_PROTOCOL_LABEL_FMT, ref), server.getProtocol());
-      labels.put(String.format(SERVER_PATH_LABEL_FMT, ref), server.getPath());
+      if (server.getPath() != null) {
+        labels.put(String.format(SERVER_PATH_LABEL_FMT, ref), server.getPath());
+      }
       return this;
     }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
@@ -70,15 +70,28 @@ public class ServerResolver {
                 (name, config) ->
                     servers.put(
                         name,
-                        new ServerImpl(
-                            config.getProtocol()
-                                + "://"
-                                + route.getSpec().getHost()
-                                + config.getPath(),
-                            ServerStatus.UNKNOWN)));
+                        newServer(
+                            config.getProtocol(), route.getSpec().getHost(), config.getPath())));
       }
     }
     return servers;
+  }
+
+  private ServerImpl newServer(String protocol, String host, String path) {
+    StringBuilder ub = new StringBuilder();
+    if (protocol != null) {
+      ub.append(protocol).append("://");
+    } else {
+      ub.append("tcp://");
+    }
+    ub.append(host);
+    if (path != null) {
+      if (!path.isEmpty() && !path.startsWith("/")) {
+        ub.append("/");
+      }
+      ub.append(path);
+    }
+    return new ServerImpl(ub.toString(), ServerStatus.UNKNOWN);
   }
 
   private List<Service> getMatchedServices(Pod pod, Container container) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -105,7 +105,7 @@ public class ServerConfigImpl implements ServerConfig {
     return Objects.equals(id, that.id)
         && Objects.equals(port, that.port)
         && Objects.equals(protocol, that.protocol)
-        && getPath().equals(that.getPath());
+        && Objects.equals(path, that.path);
   }
 
   @Override


### PR DESCRIPTION
### What does this PR do?
Fix server URL in case null was used as server config path.

### What issues does this PR fix or reference?
Fixes #6072 

#### Changelog
Fix bug when 'null' is used as a server path

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
