### PR TITLE
allow additional hostname match

### DIFF
--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenter.java
@@ -55,10 +55,10 @@ public class GithubImporterPagePresenter extends AbstractWizardPage<MutableProje
   // the transport protocol
   private static final RegExp PROTOCOL = RegExp.compile("((http|https|git|ssh|ftp|ftps)://)");
   // the address of the remote server between // and /
-  private static final RegExp HOST1 = RegExp.compile("//([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+/");
+  private static final RegExp HOST1 = RegExp.compile("//([0-9a-zA-Z_\\.\\-]+)/");
   // the address of the remote server between @ and : or /
   private static final RegExp HOST2 =
-      RegExp.compile("@([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-:]+)+[:/]");
+      RegExp.compile("@([0-9a-zA-Z_\\.\\-]+)[:\\/]");
   // the repository name
   private static final RegExp REPO_NAME = RegExp.compile("/[A-Za-z0-9_.\\-]+$");
   // start with white space


### PR DESCRIPTION
the regex blocks hostnames that are added to /etc/hosts:
172.16.1.25    foo

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

This allows hostnames of foo in addition to #.#.#.# for adding a VCS git.

### What issues does this PR fix or reference?


#### Changelog

#### Release Notes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
