### PR TITLE
Don't wait 5 seconds for Language servers

### DIFF
--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/launcher/LanguageServerLauncherTemplate.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/launcher/LanguageServerLauncherTemplate.java
@@ -43,10 +43,14 @@ public abstract class LanguageServerLauncherTemplate implements LanguageServerLa
    * @throws LanguageServerException
    */
   private void waitCheckProcess(Process languageServerProcess) throws LanguageServerException {
+    long endTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(20);
+
     try {
-      TimeUnit.SECONDS.sleep(5);
+      while (!languageServerProcess.isAlive() && System.currentTimeMillis() < endTime) {
+        TimeUnit.MILLISECONDS.sleep(10);
+      }
     } catch (InterruptedException e) {
-      //ignore
+      Thread.currentThread().interrupt();
     }
     if (!languageServerProcess.isAlive()) {
       final String error;


### PR DESCRIPTION
### What does this PR do?
Change waiting for process startup to return early when LS is ready. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6091
