### PR TITLE
Docker image testing : exit if any test failed to prevent pushing images

### DIFF
--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -8,6 +8,8 @@
 # Contributors:
 #   Marian Labuda - Initial Implementation
 
+set -e
+
 BATS_BASE_DIR=$(cd "$(dirname "$0")"/..; pwd)
 . "${BATS_BASE_DIR}"/build.include
 BATS_BASE_DIR=$(get_mount_path "${BATS_BASE_DIR}")

--- a/dockerfiles/ip/test.sh
+++ b/dockerfiles/ip/test.sh
@@ -9,6 +9,8 @@
 #   Florent Benoit - Initial Implementation
 #
 
+set -e
+
 # Name of the image to use to run the tests
 BASE_DIR=$(cd "$(dirname "$0")"/..; pwd)
 . $BASE_DIR/build.include


### PR DESCRIPTION
### What does this PR do?
add `set -e` instruction which will stop build if any test fail, today we still pushing images even tests failed

needed for https://github.com/eclipse/che/issues/6134

#### Changelog
stop and fail CLI tests if any test failed.
