### PR TITLE
CHE-6033: Fix bug when Git status markers are not updated after commi…

### DIFF
--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitIndexChangedDetector.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitIndexChangedDetector.java
@@ -40,6 +40,8 @@ public class GitIndexChangedDetector {
 
   private static final String GIT_DIR = ".git";
   private static final String INDEX_FILE = "index";
+  private static final String COMMIT_MESSAGE_FILE = "COMMIT_EDITMSG";
+  private static final String ORIG_HEAD_FILE = "ORIG_HEAD";
   private static final String INCOMING_METHOD = "track/git-index";
   private static final String OUTGOING_METHOD = "event/git-index";
 
@@ -84,7 +86,12 @@ public class GitIndexChangedDetector {
   private PathMatcher matcher() {
     return it ->
         !isDirectory(it)
-            && INDEX_FILE.equals(it.getFileName().toString())
+            && (INDEX_FILE.equals(it.getFileName().toString())
+                /* When making a commit or 'reset to commit' with the help of the JGit,
+                it does not update Git status immediately after writing changes to 'index' file,
+                so need to additionally detect changes in 'COMMIT_EDITMSG' and 'ORIG_HEAD' files.*/
+                || COMMIT_MESSAGE_FILE.equals(it.getFileName().toString())
+                || ORIG_HEAD_FILE.equals(it.getFileName().toString()))
             && GIT_DIR.equals(it.getParent().getFileName().toString());
   }
 


### PR DESCRIPTION
…t and reset to commit

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix bug when Git status markers are not updated after commit and reset to commit

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/6033

#### Changelog
Fix bug when Git status markers are not updated after commit and reset to commit

#### Release Notes
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A