### PR TITLE
Temporary workaround limit search result to 50 file

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
@@ -10,8 +10,19 @@
  */
 package org.eclipse.che.ide.api.project;
 
-import com.google.inject.Inject;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.gwt.http.client.RequestBuilder.DELETE;
+import static com.google.gwt.http.client.RequestBuilder.PUT;
+import static com.google.gwt.safehtml.shared.UriUtils.encodeAllowEscapes;
+import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
+import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
+import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
 
+import com.google.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.eclipse.che.api.project.shared.dto.CopyOptions;
 import org.eclipse.che.api.project.shared.dto.ItemReference;
 import org.eclipse.che.api.project.shared.dto.MoveOptions;
@@ -34,19 +45,6 @@ import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.rest.StringUnmarshaller;
 import org.eclipse.che.ide.rest.UrlBuilder;
 import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.gwt.http.client.RequestBuilder.DELETE;
-import static com.google.gwt.http.client.RequestBuilder.PUT;
-import static com.google.gwt.safehtml.shared.UriUtils.encodeAllowEscapes;
-import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
-import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
-import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
 
 /**
  * Implementation of {@link ProjectServiceClient}.
@@ -159,7 +157,8 @@ public class ProjectServiceClientImpl implements ProjectServiceClient {
       queryParameters.append("&text=").append(expression.getText());
     }
     if (expression.getMaxItems() == 0) {
-      expression.setMaxItems(100); //for avoiding block client by huge response until search not support pagination will limit result here
+      expression.setMaxItems(
+          100); //for avoiding block client by huge response until search not support pagination will limit result here
     }
     queryParameters.append("&maxItems=").append(expression.getMaxItems());
     if (expression.getSkipCount() != 0) {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/project/ProjectServiceClientImpl.java
@@ -10,19 +10,8 @@
  */
 package org.eclipse.che.ide.api.project;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.gwt.http.client.RequestBuilder.DELETE;
-import static com.google.gwt.http.client.RequestBuilder.PUT;
-import static com.google.gwt.safehtml.shared.UriUtils.encodeAllowEscapes;
-import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
-import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
-import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
-
 import com.google.inject.Inject;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
 import org.eclipse.che.api.project.shared.dto.CopyOptions;
 import org.eclipse.che.api.project.shared.dto.ItemReference;
 import org.eclipse.che.api.project.shared.dto.MoveOptions;
@@ -45,6 +34,19 @@ import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
 import org.eclipse.che.ide.rest.StringUnmarshaller;
 import org.eclipse.che.ide.rest.UrlBuilder;
 import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.gwt.http.client.RequestBuilder.DELETE;
+import static com.google.gwt.http.client.RequestBuilder.PUT;
+import static com.google.gwt.safehtml.shared.UriUtils.encodeAllowEscapes;
+import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
+import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
+import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
 
 /**
  * Implementation of {@link ProjectServiceClient}.
@@ -156,9 +158,10 @@ public class ProjectServiceClientImpl implements ProjectServiceClient {
     if (expression.getText() != null && !expression.getText().isEmpty()) {
       queryParameters.append("&text=").append(expression.getText());
     }
-    if (expression.getMaxItems() != 0) {
-      queryParameters.append("&maxItems=").append(expression.getMaxItems());
+    if (expression.getMaxItems() == 0) {
+      expression.setMaxItems(100); //for avoiding block client by huge response until search not support pagination will limit result here
     }
+    queryParameters.append("&maxItems=").append(expression.getMaxItems());
     if (expression.getSkipCount() != 0) {
       queryParameters.append("&skipCount=").append(expression.getSkipCount());
     }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Temporary workaround limit search result to 50 file for preventing freeze/crash  browser
Common solution will be provided in the https://github.com/eclipse/che/issues/6143 


### What issues does this PR fix or reference?
#6126 

