### PR TITLE
There is no Java code inside the IDE.JSP so there is no need to have all JSP stuff

### DIFF
--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/IDEController.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/IDEController.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che;
+
+import java.io.IOException;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Defines a controller that is serving the IDE.html page.
+ *
+ * @author Florent Benoit
+ */
+public class IDEController extends HttpServlet {
+
+  /** Use the default dispatcher to serve the resource. */
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+
+    RequestDispatcher dispatcher = request.getRequestDispatcher("/_app/IDE.html");
+    dispatcher.forward(request, response);
+  }
+}

--- a/assembly/assembly-ide-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/assembly-ide-war/src/main/webapp/WEB-INF/web.xml
@@ -19,7 +19,7 @@
 
     <servlet>
         <servlet-name>IDE</servlet-name>
-        <jsp-file>/IDE.jsp</jsp-file>
+        <servlet-class>org.eclipse.che.IDEController</servlet-class>
     </servlet>
 
     <filter>

--- a/assembly/assembly-ide-war/src/main/webapp/_app/IDE.html
+++ b/assembly/assembly-ide-war/src/main/webapp/_app/IDE.html
@@ -1,4 +1,4 @@
-<%--
+<!--
 
     Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
@@ -9,7 +9,7 @@
     Contributors:
       Red Hat, Inc. - initial API and implementation
 
---%>
+-->
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
### What does this PR do?
Rename IDE.jsp to IDE.html as we only need to serve the html page.
so we can get rid of all the JSP libraries.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6169

#### Changelog
Avoid to use JSP for IDE html page that has no java code.

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I0c881fc37aedcc22f09fbbf16e49ce43f2dea334
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
