### PR TITLE
CHE-6085: Add posibility to choose WS infra impl

### DIFF
--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
@@ -13,8 +13,6 @@ package org.eclipse.che.workspace.infrastructure.docker;
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
-import org.eclipse.che.api.workspace.server.hc.ServerCheckerFactory;
-import org.eclipse.che.api.workspace.server.hc.ServerCheckerFactoryImpl;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.plugin.docker.client.DockerRegistryDynamicAuthResolver;
 import org.eclipse.che.plugin.docker.client.NoOpDockerRegistryDynamicAuthResolverImpl;
@@ -33,6 +31,8 @@ import org.eclipse.che.workspace.infrastructure.docker.provisioner.priviliged.Pr
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.proxy.ProxySettingsProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.server.ServersEnvVarsProvisioningModule;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.volume.ExtraVolumesProvisioner;
+import org.eclipse.che.workspace.infrastructure.docker.snapshot.JpaSnapshotDao;
+import org.eclipse.che.workspace.infrastructure.docker.snapshot.SnapshotDao;
 
 /** @author Alexander Garagatyi */
 public class DockerInfraModule extends AbstractModule {
@@ -66,6 +66,6 @@ public class DockerInfraModule extends AbstractModule {
     install(new FactoryModuleBuilder().build(DockerBootstrapperFactory.class));
     install(new FactoryModuleBuilder().build(DockerRuntimeContextFactory.class));
 
-    bind(ServerCheckerFactory.class).to(ServerCheckerFactoryImpl.class);
+    bind(SnapshotDao.class).to(JpaSnapshotDao.class);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
+import org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.workspace.infrastructure.openshift.bootstrapper.OpenShiftBootstrapperFactory;
 
@@ -30,5 +31,6 @@ public class OpenShiftInfraModule extends AbstractModule {
     install(new FactoryModuleBuilder().build(OpenShiftRuntimeContextFactory.class));
     install(new FactoryModuleBuilder().build(OpenShiftRuntimeFactory.class));
     install(new FactoryModuleBuilder().build(OpenShiftBootstrapperFactory.class));
+    bind(WorkspaceFilesCleaner.class).to(WorkspaceFilesCleaner.NoOpCleaner.class);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceFilesCleaner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceFilesCleaner.java
@@ -28,4 +28,10 @@ public interface WorkspaceFilesCleaner {
    * @param workspace workspace to clean up files
    */
   void clear(Workspace workspace) throws IOException, ServerException;
+
+  /** An implementation which do nothing on workspace cleanup call. */
+  class NoOpCleaner implements WorkspaceFilesCleaner {
+    @Override
+    public void clear(Workspace workspace) throws IOException, ServerException {}
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Environment variable CHE_INFRASTRUCTURE_ACTIVE sets which
implementation of workspace runtime infrastructure is used in Che.
Notice that corresponding property does not work - only env var.

### What issues does this PR fix or reference?
Fixes #6085 

#### Changelog
Allow choosing workspace runtime infrastructure implementation with an environment variable.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
