### PR TITLE
CHE-5741:  Auto focus after selection terminal.

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/NewTerminalAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/NewTerminalAction.java
@@ -21,6 +21,7 @@ import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.machine.MachineResources;
 import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
+import org.eclipse.che.ide.terminal.TerminalOptionsJso;
 
 /**
  * Action to open new terminal for the selected machine.
@@ -79,7 +80,7 @@ public class NewTerminalAction extends AbstractPerspectiveAction
 
   @Override
   public void actionPerformed(ActionEvent event) {
-    processesPanelPresenter.newTerminal(this);
+    processesPanelPresenter.newTerminal(TerminalOptionsJso.createDefault());
   }
 
   @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -98,6 +98,7 @@ import org.eclipse.che.ide.processes.ProcessTreeNodeSelectedEvent;
 import org.eclipse.che.ide.processes.actions.ConsoleTreeContextMenu;
 import org.eclipse.che.ide.processes.actions.ConsoleTreeContextMenuFactory;
 import org.eclipse.che.ide.terminal.TerminalFactory;
+import org.eclipse.che.ide.terminal.TerminalOptionsJso;
 import org.eclipse.che.ide.terminal.TerminalPresenter;
 import org.eclipse.che.ide.ui.loaders.DownloadWorkspaceOutputEvent;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
@@ -363,11 +364,11 @@ public class ProcessesPanelPresenter extends BasePresenter
   }
 
   /** Opens new terminal for the selected machine. */
-  public void newTerminal(Object source) {
+  public void newTerminal(TerminalOptionsJso options) {
     final ProcessTreeNode selectedTreeNode = view.getSelectedTreeNode();
     final MachineEntity devMachine = appContext.getDevMachine();
     if (selectedTreeNode == null && devMachine != null) {
-      onAddTerminal(devMachine.getId(), source);
+      onAddTerminal(devMachine.getId(), options);
       return;
     }
 
@@ -380,14 +381,14 @@ public class ProcessesPanelPresenter extends BasePresenter
 
     if (selectedTreeNode.getType() == MACHINE_NODE) {
       MachineEntity machine = (MachineEntity) selectedTreeNode.getData();
-      onAddTerminal(machine.getId(), source);
+      onAddTerminal(machine.getId(), options);
       return;
     }
 
     ProcessTreeNode parent = selectedTreeNode.getParent();
     if (parent != null && parent.getType() == MACHINE_NODE) {
       MachineEntity machine = (MachineEntity) parent.getData();
-      onAddTerminal(machine.getId(), source);
+      onAddTerminal(machine.getId(), options);
     }
   }
 
@@ -429,7 +430,7 @@ public class ProcessesPanelPresenter extends BasePresenter
    * @param machineId id of machine in which the terminal will be added
    */
   @Override
-  public void onAddTerminal(final String machineId, Object source) {
+  public void onAddTerminal(final String machineId, TerminalOptionsJso options) {
     final MachineEntity machine = getMachine(machineId);
     if (machine == null) {
       notificationManager.notify(
@@ -442,7 +443,7 @@ public class ProcessesPanelPresenter extends BasePresenter
     }
 
     final ProcessTreeNode machineTreeNode = provideMachineNode(machine, false);
-    final TerminalPresenter newTerminal = terminalFactory.create(machine, source);
+    final TerminalPresenter newTerminal = terminalFactory.create(machine, options);
     final IsWidget terminalWidget = newTerminal.getView();
     final String terminalName = getUniqueTerminalName(machineTreeNode);
     final ProcessTreeNode terminalNode =
@@ -1057,7 +1058,8 @@ public class ProcessesPanelPresenter extends BasePresenter
     }
 
     selectDevMachine();
-    newTerminal(this);
+    TerminalOptionsJso options = TerminalOptionsJso.createDefault().withFocusOnOpen(false);
+    newTerminal(options);
   }
 
   private void restoreState(final MachineEntity machine) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelView.java
@@ -16,6 +16,7 @@ import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.mvp.View;
 import org.eclipse.che.ide.api.parts.base.BaseActionDelegate;
 import org.eclipse.che.ide.processes.ProcessTreeNode;
+import org.eclipse.che.ide.terminal.TerminalOptionsJso;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
@@ -109,9 +110,9 @@ public interface ProcessesPanelView extends View<ProcessesPanelView.ActionDelega
      * Will be called when user clicks 'Add new terminal' button
      *
      * @param machineId id of machine in which the terminal will be added
-     * @param source source object that called current method
+     * @param options context creation terminal. @see {@link TerminalOptionsJso}
      */
-    void onAddTerminal(String machineId, Object source);
+    void onAddTerminal(String machineId, TerminalOptionsJso options);
 
     /**
      * Will be called when user clicks 'Preview Ssh' button

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelViewImpl.java
@@ -43,6 +43,7 @@ import org.eclipse.che.ide.processes.ProcessDataAdapter;
 import org.eclipse.che.ide.processes.ProcessTreeNode;
 import org.eclipse.che.ide.processes.ProcessTreeRenderer;
 import org.eclipse.che.ide.processes.StopProcessHandler;
+import org.eclipse.che.ide.terminal.TerminalOptionsJso;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanelFactory;
 import org.eclipse.che.ide.ui.multisplitpanel.WidgetToShow;
@@ -107,7 +108,8 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
     processWidgets = new HashMap<>();
     widget2TreeNodes = new HashMap<>();
 
-    renderer.addAddTerminalClickHandler(machineId -> delegate.onAddTerminal(machineId, this));
+    renderer.addAddTerminalClickHandler(
+        machineId -> delegate.onAddTerminal(machineId, TerminalOptionsJso.createDefault()));
     renderer.addPreviewSshClickHandler(machineId -> delegate.onPreviewSsh(machineId));
     renderer.addStopProcessHandler(
         new StopProcessHandler() {
@@ -158,6 +160,12 @@ public class ProcessesPanelViewImpl extends BaseView<ProcessesPanelView.ActionDe
           @Override
           public void onNodeSelected(TreeNodeElement<ProcessTreeNode> node, SignalEvent event) {
             delegate.onTreeNodeSelected(node.getData());
+
+            WidgetToShow widgetToFocus = processWidgets.get(node.getData().getId());
+            if (widgetToFocus != null) {
+              SubPanel panelToFocus = widget2Panels.get(widgetToFocus);
+              focusGained(panelToFocus, widgetToFocus.getWidget());
+            }
           }
 
           @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/CustomKeyDownTerminalHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/CustomKeyDownTerminalHandler.java
@@ -26,17 +26,13 @@ public class CustomKeyDownTerminalHandler extends JavaScriptObject {
             var V = 86;
             if (ev.ctrlKey && !(ev.shiftKey || ev.metaKey || ev.altKey)) {
 
-                //handle Ctrl + V
+                // handle Ctrl + V
                 if (ev.keyCode === V) {
                     return false;
                 }
 
-                var selection = this.document.getSelection(),
-                    collapsed = selection.isCollapsed,
-                    isRange = typeof collapsed === 'boolean' ? !collapsed : selection.type === 'Range';
-
-                //handle Ctrl + C
-                if (ev.keyCode === C && isRange) {
+                // handle Ctrl + C. Notice: scope "this" it's a terminal scope.
+                if (ev.keyCode === C && this.hasSelection()) {
                     return false;
                 }
             }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalFactory.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.che.ide.api.machine.MachineEntity;
  * Special factory for creating {@link TerminalPresenter} instances.
  *
  * @author Dmitry Shnurenko
+ * @author Alexander Andrienko
  */
 public interface TerminalFactory {
 
@@ -25,7 +26,9 @@ public interface TerminalFactory {
    * Creates terminal for current machine.
    *
    * @param machine machine for which terminal will be created
+   * @param options options for new terminal
    * @return an instance of {@link TerminalPresenter}
    */
-  TerminalPresenter create(@NotNull @Assisted MachineEntity machine, Object source);
+  TerminalPresenter create(
+      @NotNull @Assisted MachineEntity machine, @Assisted TerminalOptionsJso options);
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalJso.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalJso.java
@@ -59,10 +59,14 @@ class TerminalJso extends JavaScriptObject {
     }-*/;
 
   public final native void focus() /*-{
-        this.element.focus();
+        this.focus();
     }-*/;
 
   public final native void blur() /*-{
-        this.element.blur();
+        this.blur();
+    }-*/;
+
+  public final native boolean hasSelection() /*-{
+      return this.hasSelection();
     }-*/;
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalOptionsJso.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalOptionsJso.java
@@ -13,7 +13,7 @@ package org.eclipse.che.ide.terminal;
 import org.eclipse.che.ide.collections.Jso;
 
 /** @author Evgen Vidolob */
-class TerminalOptionsJso extends Jso {
+public class TerminalOptionsJso extends Jso {
   protected TerminalOptionsJso() {}
 
   public static native TerminalOptionsJso createDefault() /*-{
@@ -21,11 +21,12 @@ class TerminalOptionsJso extends Jso {
             cols: 80,
             rows: 24,
             screenKeys: true,
-            focusOnOpen: false
+            focusOnOpen: true
         }
     }-*/;
 
   public final native TerminalOptionsJso withFocusOnOpen(boolean focusOnOpen) /*-{
         this.focusOnOpen = focusOnOpen;
+        return this;
     }-*/;
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalView.java
@@ -23,6 +23,13 @@ import org.eclipse.che.ide.api.mvp.View;
 interface TerminalView extends View<TerminalView.ActionDelegate> {
 
   interface ActionDelegate {
+
+    /**
+     * Set terminal size
+     *
+     * @param x amount of terminal columns
+     * @param y amount of terminal rows
+     */
     void setTerminalSize(int x, int y);
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/terminal/TerminalViewImpl.java
@@ -16,6 +16,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ResizeLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -26,7 +27,7 @@ import javax.validation.constraints.NotNull;
  *
  * @author Dmitry Shnurenko
  */
-final class TerminalViewImpl extends Composite implements TerminalView {
+final class TerminalViewImpl extends Composite implements TerminalView, Focusable {
 
   interface TerminalViewImplUiBinder extends UiBinder<Widget, TerminalViewImpl> {}
 
@@ -106,4 +107,34 @@ final class TerminalViewImpl extends Composite implements TerminalView {
 
     delegate.setTerminalSize(x, y);
   }
+
+  @Override
+  public int getTabIndex() {
+    return 0;
+  }
+
+  @Override
+  public void setAccessKey(char key) {}
+
+  private Timer focusTimer =
+      new Timer() {
+        @Override
+        public void run() {
+          terminal.focus();
+        }
+      };
+
+  @Override
+  public void setFocus(boolean focused) {
+    if (terminal == null || terminal.getElement() == null) {
+      return;
+    }
+
+    if (focused && !terminal.hasSelection()) {
+      focusTimer.schedule(10);
+    }
+  }
+
+  @Override
+  public void setTabIndex(int index) {}
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/processes/NewTerminalActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/processes/NewTerminalActionTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.ide.processes;
 
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -49,6 +49,6 @@ public class NewTerminalActionTest {
   public void actionShouldBePerformed() throws Exception {
     action.actionPerformed(actionEvent);
 
-    verify(processesPanelPresenter).newTerminal(eq(action));
+    verify(processesPanelPresenter).newTerminal(any());
   }
 }


### PR DESCRIPTION
### What does this PR do?
Auto focus after selection terminal:
1. Set focus when user clicks on the terminal tab.
2. Set focus when user clicks on the terminal tree node.
3. Set focus after creation new terminal by hotkey "Alt + F12" or by click on the "New terminal" button.
4. Set focus when user selected terminal  from list of the Split panel.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5741

#### Changelog
Auto focus after selection terminal.

#### Release Notes
Auto focus after selection terminal.

#### Docs PR
Don't need, it's a bug fix.
