### PR TITLE
Fix spi-selenum tests according to latest changes

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -145,11 +145,11 @@ public class CodenvyEditor {
         "//div[@class='annotationLine currentLine' and @role='presentation']";
     public static final String ACTIVE_TAB_FILE_NAME = "//div[@active]/descendant::div[text()='%s']";
     public static final String TAB_FILE_NAME_XPATH =
-        "//div[@id='gwt-debug-editorPartStack-tabsPanel']//div[text()='%s']";
+        "//div[@id='gwt-debug-multiSplitPanel-tabsPanel']//div[text()='%s']";
     public static final String TAB_FILE_CLOSE_ICON =
-        "//div[@id='gwt-debug-editorPartStack-tabsPanel']//div[text()='%s']/following::div[1]";
+        "//div[@id='gwt-debug-multiSplitPanel-tabsPanel']//div[text()='%s']/following::div[1]";
     public static final String ALL_TABS_XPATH =
-        "//div[@id='gwt-debug-editorPartStack-tabsPanel']//div[string-length(text())>0]";
+        "//div[@id='gwt-debug-editorMultiPartStack-contentPanel']//div[@id='gwt-debug-multiSplitPanel-tabsPanel']//div[string-length(text())>0]";
     public static final String SELECTED_ITEM_IN_EDITOR =
         "//div[@contenteditable='true']//span[contains(text(), '%s')]";
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CommandsEditorTest.java
@@ -40,7 +40,7 @@ public class CommandsEditorTest {
   private static final String NAME_COMMAND = "runApp";
   private static final String COMMAND =
       "cd ${current.project.path}\n"
-          + "javac -classpath ${project.java.classpath} -sourcepath ${project.java.sourcepath} -d ${project.java.output.dir} src/com/company/nba/MainClass.java\n"
+          + "javac -classpath ${project.java.classpath} -sourcepath ${project.java.sourcepath} -d ${current.project.path} src/com/company/nba/MainClass.java\n"
           + "java -classpath ${project.java.classpath}${project.java.output.dir} com.company.nba.MainClass";
 
   @Inject private TestWorkspace testWorkspace;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
@@ -113,23 +113,25 @@ public class MacrosCommandsEditorTest {
     commandsEditor.setCursorToLine(1);
     commandsEditor.waitActiveEditor();
     commandsEditor.selectMacrosLinkInCommandsEditor(PREVIEW_MACROS_LINK);
-    commandsEditor.typeTextIntoSearchMacroField("server.22/");
-    commandsEditor.waitTextIntoSearchMacroField("server.22/");
+    commandsEditor.typeTextIntoSearchMacroField("server.");
+    commandsEditor.waitTextIntoSearchMacroField("server.");
     String[] macrosItems = {
-      "${server.22/tcp.hostname}",
-      "${server.22/tcp.port}",
-      "${server.22/tcp.protocol}",
-      "${server.22/tcp}",
-      "Returns hostname of a server registered by name",
-      "Returns port of a server registered by name",
-      "Returns protocol of a server registered by name",
-      "Returns protocol, hostname and port of an internal server"
+      "${server.4403/tcp}",
+      "${server.8000/tcp}",
+      "${server.8080/tcp}",
+      "${server.9876/tcp}",
+      "${server.exec-agent/http}",
+      "${server.exec-agent/ws}",
+      "${server.ssh}",
+      "${server.terminal}",
+      "${server.wsagent/http}",
+      "${server.wsagent/ws}"
     };
     for (String macrosItem : macrosItems) {
       commandsEditor.waitTextIntoMacrosContainer(macrosItem);
     }
-    commandsEditor.enterMacroCommandByEnter("${server.22/tcp.hostname}");
-    commandsEditor.waitTextIntoEditor("${server.22/tcp.hostname}");
+    commandsEditor.enterMacroCommandByEnter("${server.ssh}");
+    commandsEditor.waitTextIntoEditor("${server.ssh");
     commandsEditor.clickOnRunButton();
     consoles.waitExpectedTextIntoPreviewUrl("ssh");
     commandsEditor.setFocusIntoTypeCommandsEditor(PREVIEW_URL_EDITOR);
@@ -137,12 +139,12 @@ public class MacrosCommandsEditorTest {
     commandsEditor.selectLineAndDelete();
     commandsEditor.waitActiveEditor();
     commandsEditor.selectMacrosLinkInCommandsEditor(PREVIEW_MACROS_LINK);
-    commandsEditor.selectMacroCommand("${server.22/tcp}");
+    commandsEditor.selectMacroCommand("${server.ssh}");
     commandsEditor.typeTextIntoEditor(Keys.ARROW_UP.toString());
     commandsEditor.typeTextIntoEditor(Keys.SPACE.toString());
-    commandsEditor.waitMacroCommandIsSelected("${server.22/tcp.protocol}");
-    commandsEditor.enterMacroCommandByDoubleClick("${server.22/tcp.protocol}");
-    commandsEditor.waitTextIntoEditor("${server.22/tcp.protocol}");
+    commandsEditor.waitMacroCommandIsSelected("${server.ssh}");
+    commandsEditor.enterMacroCommandByDoubleClick("${server.ssh}");
+    commandsEditor.waitTextIntoEditor("${server.ssh}");
     commandsEditor.clickOnRunButton();
     consoles.waitExpectedTextIntoPreviewUrl("ssh");
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
@@ -51,6 +51,6 @@ public class CheckStopStartWsTest {
     toastLoader.waitExpectedTextInToastLoader("Starting workspace runtime.", 20);
     loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(20);
+    terminal.waitTerminalTab();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -18,6 +18,7 @@ import org.eclipse.che.selenium.core.constant.TestStacksConstants;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace;
@@ -40,6 +41,7 @@ public class CreateWorkspaceOnDashboardTest {
   @Inject private DashboardWorkspace dashboardWorkspace;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
+  @Inject private ToastLoader toastLoader;
 
   @AfterClass
   public void tearDown() throws Exception {
@@ -59,8 +61,9 @@ public class CreateWorkspaceOnDashboardTest {
     createWorkspace.setMachineRAM("2");
     createWorkspace.clickCreate();
     seleniumWebDriver.switchFromDashboardIframeToIde();
+    toastLoader.waitExpectedTextInToastLoader("Starting workspace runtime.", 60);
     projectExplorer.waitProjectExplorer();
     loader.waitOnClosed();
-    terminal.waitTerminalTab(20);
+    terminal.waitTerminalTab();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/SnapshotTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/SnapshotTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /** @author Andrey Chizhikov */
 public class SnapshotTest {
   private static final String PROJECT_NAME = SnapshotTest.class.getSimpleName();
-  private static final String PROJECT_PATH = "src/test/resources/projects/guess-project";
   private static final String USER_DIRECTORY = "cd ~/";
   private static final String CREATE_TEXT_FILE = ">" + PROJECT_NAME + ".txt";
   private static final String FILE_NAME = PROJECT_NAME + ".txt";
@@ -79,9 +78,10 @@ public class SnapshotTest {
         TestMenuCommandsConstants.Workspace.STOP_WORKSPACE);
     toastLoader.waitExpectedTextInToastLoader("Stopping the workspace");
     toastLoader.waitExpectedTextInToastLoader("Workspace is not running", 60);
-
     toastLoader.clickOnStartButton();
-    terminal.waitTerminalConsole();
+    toastLoader.waitExpectedTextInToastLoader("Starting workspace runtime.", 20);
+    projectExplorer.waitProjectExplorer();
+    terminal.waitTerminalTab();
     consoles.selectProcessByTabName("Terminal");
     terminal.typeIntoTerminal(USER_DIRECTORY);
     terminal.waitExpectedTextIntoTerminal(USER_DIRECTORY);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkspaceFromOfficialUbuntuImageStartTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkspaceFromOfficialUbuntuImageStartTest.java
@@ -33,8 +33,7 @@ public class WorkspaceFromOfficialUbuntuImageStartTest {
   @Test
   public void ensureWorkspaceStartsFromOfficialUbuntuImage() throws Exception {
     ide.open(testWorkspace);
-    toastLoader.waitExpectedTextInToastLoader("Starting workspace runtime.", 200);
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(20);
+    terminal.waitTerminalTab();
   }
 }


### PR DESCRIPTION
### What does this PR do?
* Fix locators for correct interactions with editor tabs in the IDE
* Fix syntax of macros commands for checking this in the MacrosCommandsEditorTest
* Change waiting of the terminal on default timeout in the CheckStopStartWsTest
* Return checking of the 'ToastLoader' widget in the related tests
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5996
fixed selenium tests
@tolusha, @vparfonov 