### PR TITLE
Setup Traefik container to restart policy 'always'.

### DIFF
--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -70,4 +70,5 @@ traefik:
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     - '<%= scope.lookupvar('che::che_instance') -%>/config/traefik.toml:/etc/traefik/traefik.toml'
+  restart: always
 <% end -%>


### PR DESCRIPTION
As descibed in #6206, Traefik will not restart after rebooting the host OS.
So you will fail to reconnect to che-host. 

### What does this PR do?

Adding `restart: always` into docker-compose.yml

### What issues does this PR fix or reference?

#6206 

#### Changelog

Traefik restarts always.

#### Release Notes

Treafik restarts after the host OS was rebooted.
