### PR TITLE
#5791 save user preferences when window lost focus

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -24,6 +24,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
+import elemental.events.Event;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,6 +62,7 @@ import org.eclipse.che.ide.resources.ResourceManagerInitializer;
 import org.eclipse.che.ide.resources.impl.ResourceDeltaImpl;
 import org.eclipse.che.ide.resources.impl.ResourceManager;
 import org.eclipse.che.ide.statepersistance.AppStateManager;
+import org.eclipse.che.ide.util.dom.Elements;
 
 /**
  * Implementation of {@link AppContext}.
@@ -123,6 +125,12 @@ public class AppContextImpl
     eventBus.addHandler(ResourceChangedEvent.getType(), this);
     eventBus.addHandler(WindowActionEvent.TYPE, this);
     eventBus.addHandler(WorkspaceStoppedEvent.TYPE, this);
+
+    //in some cases IDE doesn't save preferences on window close
+    //so try to save if window lost focus
+    Elements.getWindow()
+        .addEventListener(
+            Event.BLUR, evt -> appStateManager.get().persistWorkspaceState(getWorkspaceId()));
   }
 
   private static native String masterFromIDEConfig() /*-{

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/multipart/EditorMultiPartStackViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/multipart/EditorMultiPartStackViewImpl.java
@@ -92,7 +92,9 @@ public class EditorMultiPartStackViewImpl extends ResizeComposite
       splitEditorPartView.removeFromParent();
     }
     if (splitEditorParts.size() == 0) {
+      contentPanel.remove(rootView);
       contentPanel.add(emptyEditorsPanel);
+      rootView = null;
     }
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -127,8 +127,13 @@ public class AppStateManager {
         Log.error(getClass(), e);
       }
     }
-    allWsState.put(wsId, settings);
-    return writeStateToPreferences(allWsState);
+    JsonObject olsSettings = allWsState.getObject(wsId);
+    if (olsSettings == null || !olsSettings.toJson().equals(settings.toJson())) {
+      allWsState.put(wsId, settings);
+      return writeStateToPreferences(allWsState);
+    } else {
+      return promises.resolve(null);
+    }
   }
 
   private Promise<Void> writeStateToPreferences(JsonObject state) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -127,8 +127,8 @@ public class AppStateManager {
         Log.error(getClass(), e);
       }
     }
-    JsonObject olsSettings = allWsState.getObject(wsId);
-    if (olsSettings == null || !olsSettings.toJson().equals(settings.toJson())) {
+    JsonObject oldSettings = allWsState.getObject(wsId);
+    if (oldSettings == null || !oldSettings.toJson().equals(settings.toJson())) {
       allWsState.put(wsId, settings);
       return writeStateToPreferences(allWsState);
     } else {


### PR DESCRIPTION
### What does this PR do?
When user switch workspaces in dashboard tab IDE doesn't have enough time  to save user preferences,
this pull enable save user preferences when window lost focus

### What issues does this PR fix or reference?
#5791

