### PR TITLE
openshift.io-798 Checking only first 20 chars of tag in 'getImageStreamTagFromRepo' for long tags

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -1105,7 +1105,7 @@ public class OpenShiftConnector extends DockerConnector {
     // Since repository + tag are limited to 63 chars, it's possible that the entire
     // tag name did not fit, so we have to match a substring.
     String imageTagTrimmed =
-        imageStreamTagName.length() > 30 ? imageStreamTagName.substring(0, 30) : imageStreamTagName;
+        imageStreamTagName.length() > 20 ? imageStreamTagName.substring(0, 20) : imageStreamTagName;
 
     // Note: ideally, ImageStreamTags could be identified with a label, but it seems like
     // ImageStreamTags do not support labels.


### PR DESCRIPTION
### What does this PR do?
After switching rhche stacks to`registry.devshift.net` ImageStream naming prefix has been significantly increased and creation of workspaces against some stacks (spring-boot) is started to fail. In order to fix it checking only first 20 chars of tag in 'getImageStreamTagFromRepo' for long tags is required

### What issues does this PR fix or reference?
https://github.com/openshiftio/openshift.io/issues/798

#### Changelog

#### Release Notes
N/A

#### Docs PR
N/A
