### PR TITLE
Ignore Routes in OpenShift recipe

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -17,77 +17,83 @@ import io.fabric8.openshift.api.model.Route;
 import java.util.HashMap;
 import java.util.Map;
 
-/** @author Sergii Leshchenko */
+/**
+ * Holds objects of OpenShift environment.
+ *
+ * @author Sergii Leshchenko
+ */
 public class OpenShiftEnvironment {
-  private Map<String, Pod> pods;
-  private Map<String, Service> services;
-  private Map<String, Route> routes;
-  private Map<String, PersistentVolumeClaim> persistentVolumeClaims;
 
-  public OpenShiftEnvironment() {}
+  private final Map<String, Pod> pods;
+  private final Map<String, Service> services;
+  private final Map<String, Route> routes;
+  private final Map<String, PersistentVolumeClaim> persistentVolumeClaims;
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private OpenShiftEnvironment(
+      Map<String, Pod> pods,
+      Map<String, Service> services,
+      Map<String, Route> routes,
+      Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
+    this.pods = pods;
+    this.services = services;
+    this.routes = routes;
+    this.persistentVolumeClaims = persistentVolumeClaims;
+  }
+
+  /** Returns pods that should be created when environment starts. */
   public Map<String, Pod> getPods() {
-    if (pods == null) {
-      pods = new HashMap<>();
-    }
     return pods;
   }
 
-  public void setPods(Map<String, Pod> pods) {
-    this.pods = pods;
-  }
-
-  public OpenShiftEnvironment withPods(Map<String, Pod> pods) {
-    this.pods = pods;
-    return this;
-  }
-
+  /** Returns services that should be created when environment starts. */
   public Map<String, Service> getServices() {
-    if (services == null) {
-      services = new HashMap<>();
-    }
     return services;
   }
 
-  public void setServices(Map<String, Service> services) {
-    this.services = services;
-  }
-
-  public OpenShiftEnvironment withServices(Map<String, Service> services) {
-    this.services = services;
-    return this;
-  }
-
+  /** Returns services that should be created when environment starts. */
   public Map<String, Route> getRoutes() {
-    if (routes == null) {
-      routes = new HashMap<>();
-    }
     return routes;
   }
 
-  public void setRoutes(Map<String, Route> routes) {
-    this.routes = routes;
-  }
-
-  public OpenShiftEnvironment withRoutes(Map<String, Route> routes) {
-    this.routes = routes;
-    return this;
-  }
-
+  /** Returns PVCs that should be created when environment starts. */
   public Map<String, PersistentVolumeClaim> getPersistentVolumeClaims() {
-    if (persistentVolumeClaims == null) {
-      persistentVolumeClaims = new HashMap<>();
-    }
     return persistentVolumeClaims;
   }
 
-  public void setPersistentVolumeClaims(Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
-    this.persistentVolumeClaims = persistentVolumeClaims;
-  }
+  public static class Builder {
+    private final Map<String, Pod> pods = new HashMap<>();
+    private final Map<String, Service> services = new HashMap<>();
+    private final Map<String, Route> routes = new HashMap<>();
+    private final Map<String, PersistentVolumeClaim> persistentVolumeClaims = new HashMap<>();
 
-  public OpenShiftEnvironment withPersistentVolumeClaims(
-      Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
-    this.persistentVolumeClaims = persistentVolumeClaims;
-    return this;
+    private Builder() {}
+
+    public Builder setPods(Map<String, Pod> pods) {
+      this.pods.putAll(pods);
+      return this;
+    }
+
+    public Builder setServices(Map<String, Service> services) {
+      this.services.putAll(services);
+      return this;
+    }
+
+    public Builder setRoutes(Map<String, Route> route) {
+      this.routes.putAll(route);
+      return this;
+    }
+
+    public Builder setPersistentVolumeClaims(Map<String, PersistentVolumeClaim> pvcs) {
+      this.persistentVolumeClaims.putAll(pvcs);
+      return this;
+    }
+
+    public OpenShiftEnvironment build() {
+      return new OpenShiftEnvironment(pods, services, routes, persistentVolumeClaims);
+    }
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposerTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.Test;
  * @author Sergii Leshchenko
  */
 public class ServerExposerTest {
+
   private static final String SERVER_PREFIX = "server";
 
   private ServerExposer serverExposer;
@@ -58,7 +59,8 @@ public class ServerExposerTest {
             .endSpec()
             .build();
 
-    openShiftEnvironment = new OpenShiftEnvironment().withPods(ImmutableMap.of("pod", pod));
+    openShiftEnvironment =
+        OpenShiftEnvironment.builder().setPods(ImmutableMap.of("pod", pod)).build();
     this.serverExposer = new ServerExposer("pod/main", container, openShiftEnvironment);
   }
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentParserTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentParserTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.workspace.infrastructure.openshift.environment;
 
 import static java.lang.String.format;
+import static java.util.Arrays.*;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentParser.DEFAULT_RESTART_POLICY;
 import static org.mockito.Matchers.any;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -32,6 +34,7 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
+import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -102,6 +105,20 @@ public class OpenShiftEnvironmentParserTest {
             format(
                 "Restart policy '%s' for pod '%s' is rewritten with %s",
                 ALWAYS_RESTART_POLICY, TEST_POD_NAME, DEFAULT_RESTART_POLICY)));
+  }
+
+  @Test
+  public void ignoreRoutesWhenRecipeContainsThem() throws Exception {
+    final List<HasMetadata> objects = asList(new Route(), new Route());
+    when(validatedObjects.getItems()).thenReturn(objects);
+
+    final OpenShiftEnvironment parsed = osEnvironmentParser.parse(internalEnvironment);
+
+    assertTrue(parsed.getRoutes().isEmpty());
+    verifyWarnings(
+        new WarningImpl(
+            OpenShiftEnvironmentParser.ROUTE_IGNORED_WARNING_CODE,
+            OpenShiftEnvironmentParser.ROUTES_IGNORED_WARNING_MESSAGE));
   }
 
   private void verifyWarnings(Warning... expectedWarnings) {


### PR DESCRIPTION
### What does this PR do?
Ignore Routes in OpenShift recipe.
Add warnings when OpenShift recipe contains Routes and they are ignored.

Note that warnings are not delivered to the clients yet. Because `InternalEnvironment` is not exposed by Rest API. It will be implemented later.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6216