### PR TITLE
Che dockerfiles: apply chmod only to folders to fool COW

### DIFF
--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -40,4 +40,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 RUN mkdir /logs /data && \
     chmod 0777 /logs /data
 ADD eclipse-che.tar.gz /home/user/
-RUN chmod -R 0777 /home/user
+RUN find /home/user -type d -exec chmod 777 {} \;

--- a/dockerfiles/che/Dockerfile.centos
+++ b/dockerfiles/che/Dockerfile.centos
@@ -50,4 +50,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 RUN mkdir /logs /data && \
     chmod 0777 /logs /data
 ADD eclipse-che.tar.gz /home/user/
-RUN chmod -R 0777 /home/user
+RUN find /home/user -type d -exec chmod 777 {} \;


### PR DESCRIPTION
### What does this PR do?
Modify Che alpine and CentOS based Dockerfiles to apply chmod only to folders. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/6200#issuecomment-329418498: this single instruction at the end of the Dockerfile added a layer of ~185M
```Dockerfile
RUN chmod -R 0777 /home/user
```
That's because of copy on write: every file which permissions have been modified is duplicated in the new layer. To avoid that (and fool cow) we apply chmod only to folders:
```Dockerfile
RUN find /home/user -type d -exec chmod 777 {} \;
```
 
