### PR TITLE
CHE-6046. Provide correct data for search results of Find text feature

### DIFF
--- a/wsagent/che-core-api-project/pom.xml
+++ b/wsagent/che-core-api-project/pom.xml
@@ -132,6 +132,10 @@
             <artifactId>wsagent-local</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.text</groupId>
+            <artifactId>org.eclipse.text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-websockets</artifactId>
         </dependency>
@@ -178,6 +182,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.equinox</groupId>
+            <artifactId>common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Scanner;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import org.apache.lucene.analysis.Analyzer;
@@ -65,6 +64,9 @@ import org.eclipse.che.api.vfs.search.QueryExpression;
 import org.eclipse.che.api.vfs.search.SearchResult;
 import org.eclipse.che.api.vfs.search.SearchResultEntry;
 import org.eclipse.che.api.vfs.search.Searcher;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -269,22 +271,20 @@ public abstract class LuceneSearcher implements Searcher {
 
               float res = queryScorer.getTokenScore();
               if (res > 0.0F && startOffset <= endOffset) {
-                String tokenText = txt.substring(startOffset, endOffset);
-                Scanner sc = new Scanner(txt);
-                int lineNum = 0;
-                long len = 0;
-                String foundLine = "";
-                while (sc.hasNextLine()) {
-                  foundLine = sc.nextLine();
-                  lineNum++;
-                  len += foundLine.length();
-                  if (len > startOffset) {
-                    break;
-                  }
+                try {
+                  IDocument document = new org.eclipse.jface.text.Document(txt);
+                  int lineNum = document.getLineOfOffset(startOffset);
+                  IRegion lineInfo = document.getLineInformation(lineNum);
+                  String foundLine = document.get(lineInfo.getOffset(), lineInfo.getLength());
+                  String tokenText = document.get(startOffset, endOffset - startOffset);
+
+                  offsetData.add(
+                      new OffsetData(
+                          tokenText, startOffset, endOffset, docId, res, lineNum, foundLine));
+                } catch (BadLocationException e) {
+                  LOG.error(e.getLocalizedMessage(), e);
+                  throw new ServerException("Can not provide data for token " + termAtt.toString());
                 }
-                offsetData.add(
-                    new OffsetData(
-                        tokenText, startOffset, endOffset, docId, res, lineNum, foundLine));
               }
             }
           }


### PR DESCRIPTION
### What does this PR do?
Use org.eclipse.jface.text.Document instead of java.util.Scanner to provide correct data for search results of Find text feature
### What issues does this PR fix or reference?
#6046 

#### Changelog
Provide correct data for search results of Find text feature

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>