### PR TITLE
Remove unneeded license checking excludes

### DIFF
--- a/core/che-core-api-core/pom.xml
+++ b/core/che-core-api-core/pom.xml
@@ -255,17 +255,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!-- Exclude files until #3281 is resolved -->
-                        <exclude>**/ServerIdleEvent.java</exclude>
-                        <!-- End excluded files -->
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/wsagent/che-core-api-languageserver-maven-plugin/pom.xml
+++ b/wsagent/che-core-api-languageserver-maven-plugin/pom.xml
@@ -54,7 +54,7 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
-                        <exclude>**/generator/**</exclude>
+                        <exclude>**/generator/EitherUtil.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ClientDtoGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ClientDtoGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ClientJsonImpl.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ClientJsonImpl.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ConversionGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ConversionGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/DtoGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/DtoGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/FromJsonGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/FromJsonGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/JsonImpl.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/JsonImpl.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ServerDtoGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ServerDtoGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ServerJsonImpl.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ServerJsonImpl.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ToDtoGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ToDtoGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ToJsonGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ToJsonGenerator.java
@@ -1,11 +1,12 @@
-/**
- * ***************************************************************************** Copyright (c) 2017
- * Red Hat. All rights reserved. This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
- * available at http://www.eclipse.org/legal/epl-v10.html
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * <p>Contributors: Red Hat - Initial Contribution
- * *****************************************************************************
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.che.api.languageserver.generator;
 


### PR DESCRIPTION
### What does this PR do?
Removes some unneeded excludes in license plugin configuration.
Fixes some weirdly formatted license headers.
I suppose there are more of such files that should not be excluded anymore and that have weird license headers.

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
