### PR TITLE
Add support to VS Code style snippets in code completion

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -12,12 +12,14 @@ package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
 
 import static org.eclipse.che.ide.api.theme.Style.theme;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Widget;
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedCompletionItem;
 import org.eclipse.che.api.promises.client.Promise;
@@ -29,8 +31,10 @@ import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.ide.filters.Match;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerResources;
+import org.eclipse.che.plugin.languageserver.ide.editor.quickassist.ApplyWorkspaceEditAction;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextEdit;
@@ -183,12 +187,12 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
     return documentServiceClient.resolveCompletionItem(completionItem);
   }
 
-  private static class CompletionImpl implements Completion {
-
+  @VisibleForTesting
+  static class CompletionImpl implements Completion {
     private CompletionItem completionItem;
     private String currentWord;
-    private String insertedText;
     private int offset;
+    private LinearRange lastSelection;
 
     public CompletionImpl(CompletionItem completionItem, String currentWord, int offset) {
       this.completionItem = completionItem;
@@ -198,44 +202,79 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
 
     @Override
     public void apply(Document document) {
+      List<TextEdit> edits = new ArrayList<>();
+      TextPosition cursorPosition = document.getCursorPosition();
       if (completionItem.getTextEdit() != null) {
-        Range range = completionItem.getTextEdit().getRange();
-        int startOffset =
-            document.getIndexFromPosition(
-                new TextPosition(range.getStart().getLine(), range.getStart().getCharacter()));
-        int endOffset =
-            offset
-                + document.getIndexFromPosition(
-                    new TextPosition(range.getEnd().getLine(), range.getEnd().getCharacter()));
-        document.replace(
-            startOffset, endOffset - startOffset, completionItem.getTextEdit().getNewText());
+        edits.add(adjustForOffset(completionItem.getTextEdit(), cursorPosition, offset));
+      } else if (completionItem.getInsertText() == null) {
+        edits.add(
+            new TextEdit(
+                newRange(
+                    cursorPosition.getLine(),
+                    cursorPosition.getCharacter() - currentWord.length(),
+                    cursorPosition.getLine(),
+                    cursorPosition.getCharacter()),
+                completionItem.getLabel()));
       } else {
-        int currentWordLength = currentWord.length();
-        int cursorOffset = document.getCursorOffset();
-        if (completionItem.getInsertText() == null) {
-          document.replace(
-              cursorOffset - currentWordLength, currentWordLength, completionItem.getLabel());
-          insertedText = completionItem.getLabel();
-        } else {
-          document.replace(cursorOffset - offset, offset, completionItem.getInsertText());
-          insertedText = completionItem.getInsertText();
-        }
+        edits.add(
+            new TextEdit(
+                newRange(
+                    cursorPosition.getLine(),
+                    cursorPosition.getCharacter() - offset,
+                    cursorPosition.getLine(),
+                    cursorPosition.getCharacter()),
+                completionItem.getInsertText()));
       }
+      if (completionItem.getAdditionalTextEdits() != null) {
+        completionItem
+            .getAdditionalTextEdits()
+            .forEach(e -> edits.add(adjustForOffset(e, cursorPosition, offset)));
+      }
+      ApplyWorkspaceEditAction.applyTextEdits(document, edits);
+      lastSelection = computeLastSelection(document, edits.get(0));
     }
 
-    @Override
-    public LinearRange getSelection(Document document) {
-      final TextEdit textEdit = completionItem.getTextEdit();
-      if (textEdit == null) {
-        return LinearRange.createWithStart(document.getCursorOffset() + insertedText.length())
-            .andLength(0);
-      }
+    private LinearRange computeLastSelection(Document document, TextEdit textEdit) {
       Range range = textEdit.getRange();
       TextPosition textPosition =
           new TextPosition(range.getStart().getLine(), range.getStart().getCharacter());
       int startOffset =
           document.getIndexFromPosition(textPosition) + textEdit.getNewText().length();
       return LinearRange.createWithStart(startOffset).andLength(0);
+    }
+
+    private Range newRange(int startLine, int startChar, int endLine, int endChar) {
+      return new Range(new Position(startLine, startChar), new Position(endLine, endChar));
+    }
+
+    private TextEdit adjustForOffset(TextEdit textEdit, TextPosition pos, int delta) {
+      Range range = textEdit.getRange();
+      int originalStart = pos.getCharacter() - delta;
+      if (range.getStart().getLine() != pos.getLine()
+          || textEdit.getRange().getEnd().getCharacter() < originalStart) {
+        return textEdit;
+      } else if (originalStart < range.getStart().getCharacter()) {
+        return new TextEdit(
+            newRange(
+                range.getStart().getLine(),
+                range.getStart().getCharacter() + delta,
+                range.getEnd().getLine(),
+                range.getEnd().getCharacter() + delta),
+            textEdit.getNewText());
+      } else {
+        return new TextEdit(
+            newRange(
+                range.getStart().getLine(),
+                range.getStart().getCharacter(),
+                range.getEnd().getLine(),
+                range.getEnd().getCharacter() + delta),
+            textEdit.getNewText());
+      }
+    }
+
+    @Override
+    public LinearRange getSelection(Document document) {
+      return lastSelection;
     }
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolver.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
 
 import java.util.HashMap;
@@ -7,10 +17,17 @@ import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet.VariableResolver;
 
+/**
+ * Resolves snippet variables against an editor document.
+ *
+ * @author thomas
+ */
 public class DocumentVariableResolver implements VariableResolver {
+  // variables are functions from a document and position to a value.
   private static final Map<String, BiFunction<Document, TextPosition, String>> VARIABLES;
 
   static {
+    // well known variables according to https://github.com/Microsoft/vscode/blob/0ebd01213a65231f0af8187acaf264243629e4dc/src/vs/editor/contrib/snippet/browser/snippet.md
     VARIABLES = new HashMap<>();
     VARIABLES.put("TM_SELECTED_TEXT", DocumentVariableResolver::getSelectedText);
     VARIABLES.put("TM_CURRENT_LINE", DocumentVariableResolver::getCurrentLine);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolver.java
@@ -1,0 +1,83 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
+import org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet.VariableResolver;
+
+public class DocumentVariableResolver implements VariableResolver {
+  private static final Map<String, BiFunction<Document, TextPosition, String>> VARIABLES;
+
+  static {
+    VARIABLES = new HashMap<>();
+    VARIABLES.put("TM_SELECTED_TEXT", DocumentVariableResolver::getSelectedText);
+    VARIABLES.put("TM_CURRENT_LINE", DocumentVariableResolver::getCurrentLine);
+    VARIABLES.put("TM_CURRENT_WORD", DocumentVariableResolver::getCurrentWord);
+    VARIABLES.put("TM_LINE_INDEX", DocumentVariableResolver::getCurrentLineIndex);
+    VARIABLES.put("TM_LINE_NUMBER", DocumentVariableResolver::getCurrentLineNumber);
+    VARIABLES.put("TM_FILENAME", DocumentVariableResolver::getFileName);
+    VARIABLES.put("TM_DIRECTORY", DocumentVariableResolver::getDirectory);
+    VARIABLES.put("TM_FILEPATH", DocumentVariableResolver::getPath);
+  }
+
+  private Document document;
+  private TextPosition position;
+
+  public DocumentVariableResolver(Document document, TextPosition position) {
+    this.document = document;
+    this.position = position;
+  }
+
+  @Override
+  public boolean isVar(String name) {
+    return VARIABLES.containsKey(name);
+  }
+
+  @Override
+  public String resolve(String name) {
+    return VARIABLES.get(name).apply(document, position);
+  }
+
+  private static String getSelectedText(Document doc, TextPosition pos) {
+    return doc.getContentRange(doc.getSelectedTextRange());
+  }
+
+  private static String getCurrentLine(Document doc, TextPosition pos) {
+    return doc.getLineContent(pos.getLine());
+  }
+
+  private static String getCurrentLineIndex(Document doc, TextPosition pos) {
+    return String.valueOf(pos.getLine());
+  }
+
+  private static String getCurrentLineNumber(Document doc, TextPosition pos) {
+    return String.valueOf(pos.getLine() + 1);
+  }
+
+  private static String getFileName(Document doc, TextPosition pos) {
+    return doc.getFile().getName();
+  }
+
+  private static String getDirectory(Document doc, TextPosition pos) {
+    return doc.getFile().getLocation().parent().toString();
+  }
+
+  private static String getPath(Document doc, TextPosition pos) {
+    return doc.getFile().getLocation().toString();
+  }
+
+  private static String getCurrentWord(Document doc, TextPosition pos) {
+    String line = doc.getLineContent(pos.getLine());
+    int start = pos.getCharacter();
+    while (start > 0 && !Character.isWhitespace(line.charAt(start))) {
+      start--;
+    }
+    int end = pos.getCharacter();
+    while (end < line.length() - 1 && !Character.isWhitespace(line.charAt(start))) {
+      end++;
+    }
+    return line.substring(start, end);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolver.java
@@ -70,12 +70,15 @@ public class DocumentVariableResolver implements VariableResolver {
 
   private static String getCurrentWord(Document doc, TextPosition pos) {
     String line = doc.getLineContent(pos.getLine());
+    if (line.length() == 0) {
+      return "";
+    }
     int start = pos.getCharacter();
-    while (start > 0 && !Character.isWhitespace(line.charAt(start))) {
+    int end = start;
+    while (start > 0 && !Character.isWhitespace(line.charAt(start - 1))) {
       start--;
     }
-    int end = pos.getCharacter();
-    while (end < line.length() - 1 && !Character.isWhitespace(line.charAt(start))) {
+    while (end < line.length() && !Character.isWhitespace(line.charAt(end))) {
       end++;
     }
     return line.substring(start, end);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LanguageServerCodeAssistProcessor.java
@@ -40,7 +40,7 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
   private final ServerCapabilities serverCapabilities;
   private final TextDocumentServiceClient documentServiceClient;
   private final FuzzyMatches fuzzyMatches;
-  private final LatestCompletionResult latestCompletionResult;
+  private LatestCompletionResult latestCompletionResult;
   private String lastErrorMessage;
 
   @Inject
@@ -57,7 +57,7 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
     this.imageProvider = imageProvider;
     this.serverCapabilities = serverCapabilities;
     this.fuzzyMatches = fuzzyMatches;
-    this.latestCompletionResult = new LatestCompletionResult();
+    this.latestCompletionResult = LatestCompletionResult.NO_RESULT;
   }
 
   @Override
@@ -84,7 +84,8 @@ public class LanguageServerCodeAssistProcessor implements CodeAssistProcessor {
           .completion(documentPosition)
           .then(
               list -> {
-                latestCompletionResult.update(documentId, offset, currentWord, list);
+                latestCompletionResult =
+                    new LatestCompletionResult(documentId, offset, currentWord, list);
                 computeProposals(currentWord, 0, callback);
               })
           .catchError(

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java
@@ -18,11 +18,32 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
  * @author Kaloyan Raev
  */
 public class LatestCompletionResult {
+  public static final LatestCompletionResult NO_RESULT =
+      new LatestCompletionResult(null, 0, null, null);
 
   private TextDocumentIdentifier documentId;
   private int offset;
   private String word;
   private ExtendedCompletionList completionList;
+
+  /**
+   * Construct a new LatestCompletionResult
+   *
+   * @param documentId a text document identifier
+   * @param offset an offset position in the document
+   * @param word the word at the current position in the document
+   * @param completionList a completion list
+   */
+  public LatestCompletionResult(
+      TextDocumentIdentifier documentId,
+      int offset,
+      String word,
+      ExtendedCompletionList completionList) {
+    this.documentId = documentId;
+    this.offset = offset;
+    this.word = word;
+    this.completionList = completionList;
+  }
 
   /**
    * Returns the identifier of document used to compute the latest completion result.
@@ -89,27 +110,9 @@ public class LatestCompletionResult {
   public boolean isGoodFor(TextDocumentIdentifier documentId, int offset, String word) {
     return completionList != null
         && !completionList.isInComplete()
+        && this.documentId != null
         && this.documentId.getUri().equals(documentId.getUri())
         && word.startsWith(this.word)
         && offset - this.offset == word.length() - this.word.length();
-  }
-
-  /**
-   * Updates the latest completion result.
-   *
-   * @param documentId a text document identifier
-   * @param offset an offset position in the document
-   * @param word the word at the current position in the document
-   * @param completionList a completion list
-   */
-  public void update(
-      TextDocumentIdentifier documentId,
-      int offset,
-      String word,
-      ExtendedCompletionList completionList) {
-    this.documentId = documentId;
-    this.offset = offset;
-    this.word = word;
-    this.completionList = completionList;
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Choice.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Choice.java
@@ -7,11 +7,16 @@ public class Choice extends SimpleExpression {
   private List<String> choices;
 
   public Choice(int startChar, int endChar, List<String> choices) {
-    super(startChar,endChar);
+    super(startChar, endChar);
     this.choices = choices;
   }
-  
+
   public List<String> getChoices() {
     return choices;
+  }
+
+  @Override
+  public void accept(ExpressionVisitor v) {
+    v.visit(this);
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Choice.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Choice.java
@@ -1,8 +1,18 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import java.util.List;
 
-public class Choice extends SimpleExpression {
+public class Choice extends Expression {
 
   private List<String> choices;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Choice.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Choice.java
@@ -1,0 +1,17 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import java.util.List;
+
+public class Choice extends SimpleExpression {
+
+  private List<String> choices;
+
+  public Choice(int startChar, int endChar, List<String> choices) {
+    super(startChar,endChar);
+    this.choices = choices;
+  }
+  
+  public List<String> getChoices() {
+    return choices;
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/DollarExpression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/DollarExpression.java
@@ -7,15 +7,20 @@ public class DollarExpression extends SimpleExpression {
 
   public DollarExpression(int startChar, int endChar, Expression value, boolean brace) {
     super(startChar, endChar);
-    this.value= value;
-    this.brace =  brace;
+    this.value = value;
+    this.brace = brace;
   }
- 
+
   public Expression getValue() {
     return value;
   }
-  
+
   public boolean isBrace() {
     return brace;
+  }
+
+  @Override
+  public void accept(ExpressionVisitor v) {
+    v.visit(this);
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/DollarExpression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/DollarExpression.java
@@ -1,0 +1,21 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public class DollarExpression extends SimpleExpression {
+
+  private Expression value;
+  private boolean brace;
+
+  public DollarExpression(int startChar, int endChar, Expression value, boolean brace) {
+    super(startChar, endChar);
+    this.value= value;
+    this.brace =  brace;
+  }
+ 
+  public Expression getValue() {
+    return value;
+  }
+  
+  public boolean isBrace() {
+    return brace;
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/DollarExpression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/DollarExpression.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
-public class DollarExpression extends SimpleExpression {
+/**
+ * Expression starting with a dollar sign. This expression type exists to facilitate parser
+ * implementation.
+ *
+ * @author Thomas Mäder
+ */
+public class DollarExpression extends Expression {
 
   private Expression value;
   private boolean brace;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Expression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Expression.java
@@ -1,35 +1,21 @@
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
-import java.lang.reflect.InvocationTargetException;
-
-import org.apache.commons.lang3.NotImplementedException;
-
 public abstract class Expression {
   private int startChar;
   private int endChar;
-  
+
   public Expression(int startChar, int endChar) {
     this.startChar = startChar;
     this.endChar = endChar;
   }
-  
+
   public int getStartChar() {
     return startChar;
   }
-  
+
   public int getEndChar() {
     return endChar;
   }
-  
-  public final void accept(ExpressionVisitor v) {
-    try {
-      try {
-        v.getClass().getMethod("visit", new Class[] {getClass()}).invoke(v, this);
-      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-        throw new RuntimeException(e);
-      }
-    } catch (NoSuchMethodException | SecurityException e) {
-      throw new NotImplementedException(e);
-    }
-  }
+
+  public abstract void accept(ExpressionVisitor v);
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Expression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Expression.java
@@ -1,5 +1,21 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
+/**
+ * Represents an expression in vscode snippet syntax. Start and end locations indicate first an last
+ * character index of the expression.
+ *
+ * @author Thomas Mäder
+ */
 public abstract class Expression {
   private int startChar;
   private int endChar;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Expression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Expression.java
@@ -1,0 +1,35 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+public abstract class Expression {
+  private int startChar;
+  private int endChar;
+  
+  public Expression(int startChar, int endChar) {
+    this.startChar = startChar;
+    this.endChar = endChar;
+  }
+  
+  public int getStartChar() {
+    return startChar;
+  }
+  
+  public int getEndChar() {
+    return endChar;
+  }
+  
+  public final void accept(ExpressionVisitor v) {
+    try {
+      try {
+        v.getClass().getMethod("visit", new Class[] {getClass()}).invoke(v, this);
+      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+        throw new RuntimeException(e);
+      }
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new NotImplementedException(e);
+    }
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionPrinter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionPrinter.java
@@ -1,0 +1,92 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+
+public class ExpressionPrinter implements ExpressionVisitor {
+  private Writer out;
+
+  public ExpressionPrinter(Writer out) {
+    this.out = out;
+  }
+
+  public static void iterate(Expression e, PrintWriter out) {
+    e.accept(new ExpressionPrinter(out));
+  }
+
+  @Override
+  public void visit(Choice e) {
+    try {
+      out.write('|');
+      boolean first = true;
+      for (String choice : e.getChoices()) {
+        if (first) {
+          first = false;
+        } else {
+          out.write(",");
+        }
+        out.write(choice);
+      }
+      out.write('|');
+    } catch (IOException e1) {
+      throw new RuntimeException(e1);
+    }
+  }
+
+  @Override
+  public void visit(Placeholder e) {
+    try {
+      out.write(String.valueOf(e.getId()));
+      if (e.getValue() != null) {
+        out.write(':');
+        e.getValue().accept(this);
+      }
+    } catch (IOException e1) {
+      throw new RuntimeException(e1);
+    }
+  }
+
+  @Override
+  public void visit(Snippet e) {
+    e.getExpressions().forEach(expr -> expr.accept(this));
+  }
+
+  @Override
+  public void visit(Text e) {
+    try {
+      out.write(e.getValue());
+    } catch (IOException e1) {
+      throw new RuntimeException(e1);
+    }
+  }
+
+  @Override
+  public void visit(Variable e) {
+    try {
+      out.write(e.getName());
+      if (e.getValue() != null) {
+        out.write(':');
+        e.getValue().accept(this);
+      }
+    } catch (IOException e1) {
+      throw new RuntimeException(e1);
+    }
+  }
+
+  @Override
+  public void visit(DollarExpression e) {
+    try {
+      out.write('$');
+      if (e.isBrace()) {
+        out.write('{');
+      }
+      e.getValue().accept(this);
+      if (e.isBrace()) {
+        out.write('}');
+      }
+    } catch (IOException e1) {
+      throw new RuntimeException(e1);
+    }
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionVisitor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionVisitor.java
@@ -1,5 +1,20 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
+/**
+ * Visitor pattern implementation for snippets.
+ *
+ * @author Thomas Mäder
+ */
 public interface ExpressionVisitor {
   void visit(DollarExpression e);
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionVisitor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionVisitor.java
@@ -2,10 +2,14 @@ package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 public interface ExpressionVisitor {
   void visit(DollarExpression e);
+
   void visit(Choice e);
+
   void visit(Placeholder e);
+
   void visit(Snippet e);
+
   void visit(Text e);
+
   void visit(Variable e);
-  
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionVisitor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionVisitor.java
@@ -1,0 +1,11 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public interface ExpressionVisitor {
+  void visit(DollarExpression e);
+  void visit(Choice e);
+  void visit(Placeholder e);
+  void visit(Snippet e);
+  void visit(Text e);
+  void visit(Variable e);
+  
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Placeholder.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Placeholder.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
-public class Placeholder extends SimpleExpression {
+/**
+ * Expression representing placeholders and tab stops.
+ *
+ * @author Thomas Mäder
+ */
+public class Placeholder extends Expression {
 
   private Expression value;
   private int id;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Placeholder.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Placeholder.java
@@ -1,0 +1,21 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public class Placeholder extends SimpleExpression {
+
+  private Expression value;
+  private int id;
+
+  public Placeholder(int startChar, int endChar, int id, Expression value) {
+    super(startChar, endChar);
+    this.id = id;
+    this.value = value;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public Expression getValue() {
+    return value;
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Placeholder.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Placeholder.java
@@ -18,4 +18,9 @@ public class Placeholder extends SimpleExpression {
   public Expression getValue() {
     return value;
   }
+
+  @Override
+  public void accept(ExpressionVisitor v) {
+    v.visit(this);
+  }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SimpleExpression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SimpleExpression.java
@@ -1,7 +1,0 @@
-package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
-
-public abstract class SimpleExpression extends Expression {
-  public SimpleExpression(int startChar, int endChar) {
-    super(startChar, endChar);
-  }
-}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SimpleExpression.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SimpleExpression.java
@@ -1,0 +1,7 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public abstract class SimpleExpression extends Expression {
+  public SimpleExpression(int startChar, int endChar) {
+    super(startChar, endChar);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Snippet.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Snippet.java
@@ -1,0 +1,17 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import java.util.List;
+
+public class Snippet extends Expression {
+
+  private List<Expression> expressions;
+
+  public Snippet(int startChar, int endChar, List<Expression> expressions) {
+    super(startChar, endChar);
+    this.expressions = expressions;
+  }
+
+  public List<Expression> getExpressions() {
+    return expressions;
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Snippet.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Snippet.java
@@ -14,4 +14,9 @@ public class Snippet extends Expression {
   public List<Expression> getExpressions() {
     return expressions;
   }
+
+  @Override
+  public void accept(ExpressionVisitor v) {
+    v.visit(this);
+  }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Snippet.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Snippet.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import java.util.List;
 
+/**
+ * The root expression of a snippet.
+ *
+ * @author Thomas Mäder
+ */
 public class Snippet extends Expression {
 
   private List<Expression> expressions;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParser.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import java.util.ArrayList;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParser.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParser.java
@@ -1,0 +1,207 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SnippetParser {
+  private enum Token {
+    DOLLAR,
+    OPEN_BRACE,
+    CLOSE_BRACE,
+    PIPE,
+    COMMA,
+    COLON,
+    DIGIT,
+    OTHER,
+    EOF
+  }
+
+  private static String escapeChars = "${}\\";
+  private static String choiceEscapeChars = escapeChars + "|,:";
+  private static String tokenChars = "${}|,:";
+
+  private String text;
+  private boolean inChoice;
+  private Token token;
+  private char value;
+  private int pos;
+
+  public SnippetParser(String snippetText) {
+    this.text = snippetText;
+  }
+
+  public Snippet parse() {
+    nextToken();
+    return snippet();
+  }
+
+  private Snippet snippet() {
+    int start = pos;
+    List<Expression> expressions = new ArrayList<>();
+    while (token != Token.EOF && token !=  Token.CLOSE_BRACE) {
+      expressions.add(any());
+    }
+    return new Snippet(start, pos, expressions);
+  }
+
+  private Expression any() {
+    if (token == Token.DOLLAR) {
+      nextToken();
+      return dollarExpression();
+    } else {
+      int start2 = pos;
+      StringBuilder b = new StringBuilder();
+      while (token != Token.EOF
+          && token != Token.DOLLAR
+          && token != Token.CLOSE_BRACE
+          && token != Token.OPEN_BRACE) {
+        // text
+        b.append(value);
+        nextToken();
+      } 
+      return new Text(start2, pos, b.toString());
+    }
+  }
+
+  private Expression dollarExpression() {
+    int start = pos;
+    if (token == Token.OPEN_BRACE) {
+      nextToken();
+      Expression e = bracedExpression();
+      nextToken(); // consume closing brace
+      return new DollarExpression(start, pos, e, true);
+    } else {
+      return new DollarExpression(start, pos, unbracedExpression(), false);
+    }
+  }
+
+  private Expression unbracedExpression() {
+    int start = pos;
+    if (token == Token.DIGIT) {
+      StringBuilder b = new StringBuilder();
+      // tabstop
+      b.append(value);
+      nextToken();
+      while (token == Token.DIGIT) {
+        b.append(value);
+        nextToken();
+      }
+      return new Placeholder(start, pos, Integer.valueOf(b.toString()), null);
+    } else if (Character.isLetter(value)) {
+      StringBuilder b = new StringBuilder();
+      b.append(value);
+      // var
+      nextToken();
+      while (token != Token.EOF && Character.isLetterOrDigit(value)) {
+        b.append(value);
+        nextToken();
+      }
+      return new Variable(start, pos, b.toString(), null);
+    } else {
+      throw new RuntimeException("unexpected");
+    }
+  }
+
+  private Expression bracedExpression() {
+    int start = pos;
+    if (token == Token.DIGIT) {
+      // tabstop
+      // placeholder
+      // choice
+      StringBuilder b = new StringBuilder();
+      // tabstop
+      b.append(value);
+      nextToken();
+      while (token != Token.EOF && token == Token.DIGIT) {
+        b.append(value);
+        nextToken();
+      }
+      if (token == Token.COLON) {
+        nextToken();
+        Expression value= null;
+        if (token == Token.PIPE) {
+          value = parseChoice();
+        } else {
+         value = snippet();
+        }
+        return new Placeholder(start, pos, Integer.valueOf(b.toString()), value);
+      } else {
+        return new Placeholder(start, pos, Integer.valueOf(b.toString()), null);
+      }
+    } else if (Character.isLetter(value)) {
+      // var
+      StringBuilder b = new StringBuilder();
+      b.append(value);
+      // var
+      nextToken();
+      while (token != Token.EOF && Character.isLetterOrDigit(value)) {
+        b.append(value);
+        nextToken();
+      }
+      Expression value = null;
+      if (token == Token.COLON) {
+        nextToken();
+        value = snippet();
+      }
+      return new Variable(start, pos, b.toString(), value);
+    } else {
+      throw new RuntimeException("unexpected");
+    }
+  }
+
+  private Choice parseChoice() {
+    int start = pos;
+    inChoice = true;
+    List<String> choices = new ArrayList<>();
+    nextToken(); // consume pipe token
+    StringBuilder b = new StringBuilder();
+    while (token != Token.EOF && token != Token.PIPE) {
+      if ( token == Token.COMMA || token == Token.PIPE) {
+        choices.add(b.toString());
+        b= new StringBuilder();
+        nextToken();
+      } else if (token != Token.EOF) {
+        b.append(value);
+        nextToken();
+      }
+    }
+    choices.add(b.toString());
+    inChoice = false; 
+    return new Choice(start, pos, choices);
+  }
+
+  private void nextToken() {
+    nextChar();
+    if (value == '\\') {
+      char nextChar = peekChar(pos + 1);
+      String esc = inChoice ? choiceEscapeChars : escapeChars;
+      int index = esc.indexOf(nextChar);
+      if (index >= 0) {
+        token = Token.values()[index];
+        nextChar();
+      }
+    } else {
+      int index = tokenChars.indexOf(value);
+      if (index >= 0) {
+        token = Token.values()[index];
+      } else if (Character.isDigit(value)) {
+        token = Token.DIGIT;
+      } else if (value == (char) -1) {
+        token = Token.EOF;
+      } else {
+        token = Token.OTHER;
+      }
+    }
+  }
+
+  private void nextChar() {
+    value = peekChar(pos++);
+  }
+
+  private char peekChar(int pos) {
+    if (pos >= text.length()) {
+      return (char) -1;
+    }
+    return text.charAt(pos);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
@@ -86,18 +86,25 @@ public class SnippetResolver {
 
           @Override
           public void visit(Placeholder e) {
+            int start = b.length();
             TabStop group = groups.get(e.getId());
             if (group == null) {
               group = new TabStop();
               groups.put(e.getId(), group);
-            }
-            int start = b.length();
-            currentGroup.push(group);
-            if (e.getValue() != null) {
-              e.getValue().accept(this);
+              currentGroup.push(group);
+              if (e.getValue() != null) {
+                e.getValue().accept(this);
+              }
+              currentGroup.pop();
+            } else {
+              Position firstOccurrence = group.getPositions().get(0);
+              String renderedText =
+                  b.substring(
+                      firstOccurrence.offset - startPosition,
+                      firstOccurrence.offset - startPosition + firstOccurrence.length);
+              b.append(renderedText);
             }
             group.addPosition(new Position(startPosition + start, b.length() - start));
-            currentGroup.pop();
           }
 
           @Override

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
@@ -1,0 +1,146 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import org.eclipse.che.ide.api.editor.link.HasLinkedMode;
+import org.eclipse.che.ide.api.editor.link.LinkedModel;
+import org.eclipse.che.ide.api.editor.link.LinkedModelData;
+import org.eclipse.che.ide.api.editor.link.LinkedModelGroup;
+import org.eclipse.che.ide.api.editor.text.Position;
+import org.eclipse.che.ide.util.Pair;
+
+public class SnippetResolver {
+
+  private static class TabStop {
+    List<Position> positions = new ArrayList<>();
+    List<String> values = new ArrayList<>();
+
+    public void addPosition(Position p) {
+      positions.add(p);
+    }
+
+    public List<Position> getPositions() {
+      return positions;
+    }
+
+    public void setValues(List<String> values) {
+      this.values = new ArrayList<>(values);
+    }
+
+    public List<String> getValues() {
+      return values;
+    }
+  }
+
+  public Pair<String, LinkedModel> resolve(
+      String snippetText, HasLinkedMode editor, int startPosition) {
+    StringBuilder b = new StringBuilder();
+    Snippet p = new SnippetParser(snippetText).parse();
+    Map<Integer, TabStop> groups = new HashMap<>();
+    p.accept(
+        new ExpressionVisitor() {
+          private int nextArtificialGroup = Integer.MAX_VALUE / 2;
+          private Stack<TabStop> currentGroup = new Stack<>();
+
+          @Override
+          public void visit(Variable e) {
+            if (isVar(e.getName())) {
+              String v = resolveVar(e.getName());
+              if (v == null) {
+                if (e.getValue() != null) {
+                  e.getValue().accept(this);
+                } else {
+                  b.append("");
+                }
+              } else {
+                b.append(v);
+              }
+            } else {
+              TabStop group = new TabStop();
+              group.addPosition(new Position(startPosition + b.length() - 1, e.getName().length()));
+              groups.put(nextArtificialGroup++, group);
+              b.append(e.getName());
+            }
+          }
+
+          @Override
+          public void visit(Text e) {
+            b.append(e.getValue());
+          }
+
+          @Override
+          public void visit(Snippet e) {
+            for (Expression expr : e.getExpressions()) {
+              expr.accept(this);
+            }
+          }
+
+          @Override
+          public void visit(Placeholder e) {
+            TabStop group = groups.get(e.getId());
+            if (group == null) {
+              group = new TabStop();
+              groups.put(e.getId(), group);
+            }
+            int start = b.length();
+            currentGroup.push(group);
+            if (e.getValue() != null) {
+              e.getValue().accept(this);
+            }
+            group.addPosition(new Position(startPosition + start, b.length() - start));
+            currentGroup.pop();
+          }
+
+          @Override
+          public void visit(Choice e) {
+            TabStop group = currentGroup.peek();
+            group.setValues(e.getChoices());
+          }
+
+          @Override
+          public void visit(DollarExpression e) {
+            e.getValue().accept(this);
+          }
+        });
+
+    if (!groups.isEmpty()) {
+      LinkedModel model = editor.createLinkedModel();
+      List<LinkedModelGroup> modeGroups = new ArrayList<>();
+      groups
+          .entrySet()
+          .stream()
+          .sorted((left, right) -> left.getKey() - right.getKey())
+          .forEach(
+              (entry) -> {
+                if (entry.getKey() == 0) {
+                  model.setEscapePosition(entry.getValue().getPositions().get(0).getOffset());
+                } else {
+                  LinkedModelGroup group = editor.createLinkedGroup();
+                  group.setPositions(entry.getValue().getPositions());
+                  LinkedModelData data = editor.createLinkedModelData();
+                  data.setType("link");
+                  data.setValues(entry.getValue().getValues());
+                  group.setData(data);
+                  modeGroups.add(group);
+                }
+              });
+      model.setGroups(modeGroups);
+      return Pair.of(b.toString(), model);
+    } else {
+      return Pair.of(b.toString(), null);
+    }
+  }
+
+  protected String resolveVar(String name) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  private boolean isVar(String name) {
+    // TODO Auto-generated method stub
+    return false;
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import java.util.ArrayList;
@@ -11,7 +21,11 @@ import org.eclipse.che.ide.api.editor.link.LinkedModelData;
 import org.eclipse.che.ide.api.editor.link.LinkedModelGroup;
 import org.eclipse.che.ide.api.editor.text.Position;
 import org.eclipse.che.ide.util.Pair;
-
+/**
+ * Resolve snippets, producing resolved text and a linked mode model for the editor
+ *
+ * @author Thomas Mäder
+ */
 public class SnippetResolver {
 
   private VariableResolver varResolver;
@@ -97,6 +111,7 @@ public class SnippetResolver {
               }
               currentGroup.pop();
             } else {
+              // if a placeholder id occurs twice, always use content from first occurrence
               Position firstOccurrence = group.getPositions().get(0);
               String renderedText =
                   b.substring(

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolver.java
@@ -14,6 +14,12 @@ import org.eclipse.che.ide.util.Pair;
 
 public class SnippetResolver {
 
+  private VariableResolver varResolver;
+
+  public SnippetResolver(VariableResolver varResolver) {
+    this.varResolver = varResolver;
+  }
+
   private static class TabStop {
     List<Position> positions = new ArrayList<>();
     List<String> values = new ArrayList<>();
@@ -47,8 +53,8 @@ public class SnippetResolver {
 
           @Override
           public void visit(Variable e) {
-            if (isVar(e.getName())) {
-              String v = resolveVar(e.getName());
+            if (varResolver.isVar(e.getName())) {
+              String v = varResolver.resolve(e.getName());
               if (v == null) {
                 if (e.getValue() != null) {
                   e.getValue().accept(this);
@@ -60,7 +66,7 @@ public class SnippetResolver {
               }
             } else {
               TabStop group = new TabStop();
-              group.addPosition(new Position(startPosition + b.length() - 1, e.getName().length()));
+              group.addPosition(new Position(startPosition + b.length(), e.getName().length()));
               groups.put(nextArtificialGroup++, group);
               b.append(e.getName());
             }
@@ -132,15 +138,5 @@ public class SnippetResolver {
     } else {
       return Pair.of(b.toString(), null);
     }
-  }
-
-  protected String resolveVar(String name) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  private boolean isVar(String name) {
-    // TODO Auto-generated method stub
-    return false;
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Text.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Text.java
@@ -6,10 +6,15 @@ public class Text extends SimpleExpression {
 
   public Text(int startChar, int endChar, String value) {
     super(startChar, endChar);
-    this.value= value;
+    this.value = value;
   }
-  
+
   public String getValue() {
     return value;
-  } 
+  }
+
+  @Override
+  public void accept(ExpressionVisitor v) {
+    v.visit(this);
+  }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Text.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Text.java
@@ -1,6 +1,16 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
-public class Text extends SimpleExpression {
+public class Text extends Expression {
 
   private String value;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Text.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Text.java
@@ -1,0 +1,15 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public class Text extends SimpleExpression {
+
+  private String value;
+
+  public Text(int startChar, int endChar, String value) {
+    super(startChar, endChar);
+    this.value= value;
+  }
+  
+  public String getValue() {
+    return value;
+  } 
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Variable.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Variable.java
@@ -1,0 +1,28 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public class Variable extends SimpleExpression{
+  private String name;
+  private Expression value;
+
+  public Variable(int startChar, int endChar, String name, Expression value) {
+    super(startChar, endChar);
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Expression getValue() {
+    return value;
+  }
+
+  public void setValue(Expression value) {
+    this.value = value;
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Variable.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Variable.java
@@ -1,6 +1,16 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
-public class Variable extends SimpleExpression {
+public class Variable extends Expression {
   private String name;
   private Expression value;
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Variable.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/Variable.java
@@ -1,6 +1,6 @@
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
-public class Variable extends SimpleExpression{
+public class Variable extends SimpleExpression {
   private String name;
   private Expression value;
 
@@ -24,5 +24,10 @@ public class Variable extends SimpleExpression{
 
   public void setValue(Expression value) {
     this.value = value;
+  }
+
+  @Override
+  public void accept(ExpressionVisitor v) {
+    v.visit(this);
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/VariableResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/VariableResolver.java
@@ -1,7 +1,34 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
+/**
+ * Resolves variable values when evaluating a snippet.
+ *
+ * @author Thomas Mäder
+ */
 public interface VariableResolver {
+  /**
+   * Whether the given variable is a variable this resolver can resolve
+   *
+   * @param name the name of the variable
+   * @return true if the name designates a known variable name.
+   */
   boolean isVar(String name);
 
+  /**
+   * Returns the value of the variable at this time.
+   *
+   * @param name the variable name
+   * @return the current value. Maybe null.
+   */
   String resolve(String name);
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/VariableResolver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/VariableResolver.java
@@ -1,0 +1,7 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+public interface VariableResolver {
+  boolean isVar(String name);
+
+  String resolve(String name);
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
@@ -149,23 +149,9 @@ public class ApplyWorkspaceEditAction extends Action {
         TextEditor textEditor = (TextEditor) editor;
         HandlesUndoRedo undoRedo = textEditor.getEditorWidget().getUndoRedo();
         undoRedo.beginCompoundChange();
-        Document document = textEditor.getDocument();
-        edits
-            .stream()
-            .sorted(COMPARATOR)
-            .forEach(
-                e -> {
-                  Range r = e.getRange();
-                  Position start = r.getStart();
-                  Position end = r.getEnd();
-                  document.replace(
-                      start.getLine(),
-                      start.getCharacter(),
-                      end.getLine(),
-                      end.getCharacter(),
-                      e.getNewText());
-                });
+        applyTextEdits(textEditor.getDocument(), edits);
         undoRedo.endCompoundChange();
+
         Supplier<Promise<Void>> value =
             () -> {
               return promiseProvider.create(
@@ -205,6 +191,24 @@ public class ApplyWorkspaceEditAction extends Action {
                       return null;
                     });
               };
+            });
+  }
+
+  public static void applyTextEdits(Document document, List<TextEdit> edits) {
+    edits
+        .stream()
+        .sorted(COMPARATOR)
+        .forEach(
+            e -> {
+              Range r = e.getRange();
+              Position start = r.getStart();
+              Position end = r.getEnd();
+              document.replace(
+                  start.getLine(),
+                  start.getCharacter(),
+                  end.getLine(),
+                  end.getCharacter(),
+                  e.getNewText());
             });
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposalTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposalTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedCompletionItem;
 import org.eclipse.che.ide.api.editor.codeassist.Completion;
 import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.link.HasLinkedMode;
 import org.eclipse.che.ide.api.editor.text.LinearRange;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.icon.Icon;
@@ -46,6 +47,7 @@ import org.mockito.Mock;
 @RunWith(GwtMockitoTestRunner.class)
 public class CompletionItemBasedCompletionProposalTest {
 
+  @Mock private HasLinkedMode editor;
   @Mock private TextDocumentServiceClient documentServiceClient;
   @Mock private LanguageServerResources resources;
   @Mock private Icon icon;
@@ -61,6 +63,7 @@ public class CompletionItemBasedCompletionProposalTest {
   public void setUp() throws Exception {
     proposal =
         new CompletionItemBasedCompletionProposal(
+            editor,
             completionItem,
             "",
             documentServiceClient,

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposalTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposalTest.java
@@ -13,11 +13,12 @@ package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -26,6 +27,7 @@ import org.eclipse.che.api.languageserver.shared.model.ExtendedCompletionItem;
 import org.eclipse.che.ide.api.editor.codeassist.Completion;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.LinearRange;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerResources;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
@@ -86,7 +88,7 @@ public class CompletionItemBasedCompletionProposalTest {
     when(serverCapabilities.getCompletionProvider()).thenReturn(completionOptions);
     when(completionOptions.getResolveProvider()).thenReturn(false);
 
-    when(document.getCursorOffset()).thenReturn(5);
+    when(document.getCursorPosition()).thenReturn(new TextPosition(0, 5));
     when(completion.getInsertText()).thenReturn("foo");
 
     Completion[] completions = new Completion[1];
@@ -94,9 +96,9 @@ public class CompletionItemBasedCompletionProposalTest {
 
     completions[0].apply(document);
 
-    verify(document).getCursorOffset();
-    verify(document, times(1)).replace(eq(5), eq(0), eq("foo"));
-    verifyNoMoreInteractions(document);
+    verify(document).getCursorPosition();
+    verify(document, times(1)).replace(eq(0), eq(5), eq(0), eq(5), eq("foo"));
+    verify(document, times(1)).replace(anyInt(), anyInt(), anyInt(), anyInt(), anyString());
   }
 
   @Test
@@ -104,7 +106,7 @@ public class CompletionItemBasedCompletionProposalTest {
     when(serverCapabilities.getCompletionProvider()).thenReturn(completionOptions);
     when(completionOptions.getResolveProvider()).thenReturn(false);
 
-    when(document.getCursorOffset()).thenReturn(5);
+    when(document.getCursorPosition()).thenReturn(new TextPosition(0, 5));
     when(completion.getInsertText()).thenReturn(null);
     when(completion.getLabel()).thenReturn("bar");
 
@@ -113,9 +115,9 @@ public class CompletionItemBasedCompletionProposalTest {
 
     completions[0].apply(document);
 
-    verify(document).getCursorOffset();
-    verify(document, times(1)).replace(eq(5), eq(0), eq("bar"));
-    verifyNoMoreInteractions(document);
+    verify(document).getCursorPosition();
+    verify(document, times(1)).replace(eq(0), eq(5), eq(0), eq(5), eq("bar"));
+    verify(document, times(1)).replace(anyInt(), anyInt(), anyInt(), anyInt(), anyString());
   }
 
   @Test
@@ -128,7 +130,7 @@ public class CompletionItemBasedCompletionProposalTest {
     when(serverCapabilities.getCompletionProvider()).thenReturn(completionOptions);
     when(completionOptions.getResolveProvider()).thenReturn(false);
 
-    when(document.getCursorOffset()).thenReturn(5);
+    when(document.getCursorPosition()).thenReturn(new TextPosition(0, 5));
     when(completion.getInsertText()).thenReturn("foo");
     when(completion.getLabel()).thenReturn("bar");
     when(completion.getTextEdit()).thenReturn(textEdit);
@@ -145,16 +147,13 @@ public class CompletionItemBasedCompletionProposalTest {
     when(endPosition.getLine()).thenReturn(1);
     when(endPosition.getCharacter()).thenReturn(5);
 
-    when(document.getIndexFromPosition(any())).thenReturn(5);
-
     Completion[] completions = new Completion[1];
     proposal.getCompletion(completion -> completions[0] = completion);
 
     completions[0].apply(document);
 
-    verify(document, times(2)).getIndexFromPosition(any());
-    verify(document, times(1)).replace(eq(5), eq(0), eq("fooBar"));
-    verifyNoMoreInteractions(document);
+    verify(document, times(1)).replace(eq(1), eq(5), eq(1), eq(5), eq("fooBar"));
+    verify(document, times(1)).replace(anyInt(), anyInt(), anyInt(), anyInt(), anyString());
   }
 
   @Test
@@ -167,7 +166,7 @@ public class CompletionItemBasedCompletionProposalTest {
     when(serverCapabilities.getCompletionProvider()).thenReturn(completionOptions);
     when(completionOptions.getResolveProvider()).thenReturn(false);
 
-    when(document.getCursorOffset()).thenReturn(5);
+    when(document.getCursorPosition()).thenReturn(new TextPosition(0, 5));
     when(completion.getInsertText()).thenReturn("foo");
     when(completion.getLabel()).thenReturn("bar");
     when(completion.getTextEdit()).thenReturn(textEdit);
@@ -202,7 +201,7 @@ public class CompletionItemBasedCompletionProposalTest {
     when(serverCapabilities.getCompletionProvider()).thenReturn(completionOptions);
     when(completionOptions.getResolveProvider()).thenReturn(false);
 
-    when(document.getCursorOffset()).thenReturn(5);
+    when(document.getCursorPosition()).thenReturn(new TextPosition(0, 5));
     when(completion.getInsertText()).thenReturn("foo");
 
     when(document.getIndexFromPosition(any())).thenReturn(5);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolverTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolverTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
 
 import static org.junit.Assert.*;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolverTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/DocumentVariableResolverTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.che.ide.api.editor.document.Document;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
+import org.junit.Test;
+
+public class DocumentVariableResolverTest {
+  @Test
+  public void currentWord() {
+    testCurrentWord(" CurrentWo   ", "CurrentWo", 3);
+    testCurrentWord("CurrentWo   ", "CurrentWo", 3);
+    testCurrentWord(" CurrentWo", "CurrentWo", 3);
+    testCurrentWord(" CurrentWo", "CurrentWo", 10);
+    testCurrentWord("CurrentWo   ", "CurrentWo", 0);
+    testCurrentWord(" CurrentWo", "", 0);
+  }
+
+  private void testCurrentWord(String line, String word, int pos) {
+    Document d = mock(Document.class);
+    when(d.getLineContent(anyInt())).thenReturn(line);
+
+    String resolver =
+        new DocumentVariableResolver(d, new TextPosition(0, pos)).resolve("TM_CURRENT_WORD");
+    assertEquals(word, resolver);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionPrinter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/ExpressionPrinter.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import java.io.IOException;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
@@ -6,77 +6,105 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Stack;
-
 import org.junit.Test;
 
 public class SnippetParsingTest {
   @Test
   public void simplePlaceHolder() {
-    testParseAndRender("$1", e(Snippet.class, e(Placeholder.class))); 
-    testParseAndRender("$1$3989$27", e(Snippet.class, e(Placeholder.class), e(Placeholder.class), e(Placeholder.class))); 
+    testParseAndRender("$1", e(Snippet.class, e(Placeholder.class)));
+    testParseAndRender(
+        "{\n$1\n}", e(Snippet.class, e(Text.class), e(Placeholder.class), e(Text.class)));
+    testParseAndRender(
+        "$1$3989$27",
+        e(Snippet.class, e(Placeholder.class), e(Placeholder.class), e(Placeholder.class)));
     testParseAndRender("$1:Gurke 2", e(Snippet.class, e(Placeholder.class), e(Text.class)));
-    testParseAndRender("$1$2   $3", e(Snippet.class, e(Placeholder.class), e(Placeholder.class), e(Text.class), e(Placeholder.class)));
+    testParseAndRender(
+        "$1$2   $3",
+        e(
+            Snippet.class,
+            e(Placeholder.class),
+            e(Placeholder.class),
+            e(Text.class),
+            e(Placeholder.class)));
   }
-  
+
   @Test
   public void simpleVariable() {
-    testParseAndRender("$foo", e(Snippet.class, e(Variable.class))); 
-    testParseAndRender("${foo:bar}", e(Snippet.class, e(Variable.class, e(Snippet.class, e(Text.class))))); 
-    testParseAndRender("${foo:$5233}", e(Snippet.class, e(Variable.class, e(Snippet.class, e(Placeholder.class))))); 
+    testParseAndRender("$foo", e(Snippet.class, e(Variable.class)));
+    testParseAndRender(
+        "${foo:bar}", e(Snippet.class, e(Variable.class, e(Snippet.class, e(Text.class)))));
+    testParseAndRender(
+        "${foo:$5233}",
+        e(Snippet.class, e(Variable.class, e(Snippet.class, e(Placeholder.class)))));
   }
-  
+
   @Test
   public void choice() {
-    testParseAndRender("${3:|foo,bar,zoz|}", e(Snippet.class, e(Placeholder.class, e(Choice.class)))); 
+    testParseAndRender(
+        "${3:|foo,bar,zoz|}", e(Snippet.class, e(Placeholder.class, e(Choice.class))));
   }
 
-  
   @Test
   public void nestedPlaceHolder() {
-    testParseAndRender("${1:Gurke $2}", e(Snippet.class, e(Placeholder.class, e(Snippet.class, e(Text.class), e(Placeholder.class)))));
-    testParseAndRender("$1:Gurke ${2:3}", e(Snippet.class, e(Placeholder.class), e(Text.class), e(Placeholder.class, e(Snippet.class, e(Text.class)))));
-  }
-  
-  @Test
-  public void nestedVariable() {
-    testParseAndRender("${1:${foo:$3}}", e(Snippet.class, e(Placeholder.class, e(Snippet.class, e(Variable.class, e(Snippet.class, e(Placeholder.class)))))));
+    testParseAndRender(
+        "${1:Gurke $2}",
+        e(
+            Snippet.class,
+            e(Placeholder.class, e(Snippet.class, e(Text.class), e(Placeholder.class)))));
+    testParseAndRender(
+        "$1:Gurke ${2:3}",
+        e(
+            Snippet.class,
+            e(Placeholder.class),
+            e(Text.class),
+            e(Placeholder.class, e(Snippet.class, e(Text.class)))));
   }
 
-  
+  @Test
+  public void nestedVariable() {
+    testParseAndRender(
+        "${1:${foo:$3}}",
+        e(
+            Snippet.class,
+            e(
+                Placeholder.class,
+                e(Snippet.class, e(Variable.class, e(Snippet.class, e(Placeholder.class)))))));
+  }
+
   private void testParseAndRender(String snippetText, TestExpression testExpression) {
     Snippet snippet = new SnippetParser(snippetText).parse();
     StringWriter out = new StringWriter();
     snippet.accept(new ExpressionPrinter(out));
-    System.out.println(out.toString()); 
+    System.out.println(out.toString());
     assertEquals(snippetText, out.toString());
     assertSame(testExpression, snippet);
   }
-  
+
   private static class TestExpression {
     private Class<?> type;
     private List<TestExpression> children;
-    
+
     public TestExpression(Class<?> type, List<TestExpression> children) {
       this.type = type;
       this.children = children;
     }
-    
+
     public Class<?> getType() {
       return type;
     }
-    
+
     public List<TestExpression> getChildren() {
       return children;
     }
   };
-  
+
   private static class ExpressionAsserter implements ExpressionVisitor {
-    private Stack<TestExpression> state= new Stack<>();
-    
+    private Stack<TestExpression> state = new Stack<>();
+
     public ExpressionAsserter(TestExpression expr) {
       state.push(expr);
     }
-    
+
     @Override
     public void visit(DollarExpression e) {
       e.getValue().accept(this);
@@ -102,7 +130,7 @@ public class SnippetParsingTest {
     public void visit(Snippet e) {
       TestExpression current = state.peek();
       assertEquals(Snippet.class, current.getType());
-      for (int i= 0; i < e.getExpressions().size(); i++) {
+      for (int i = 0; i < e.getExpressions().size(); i++) {
         state.push(current.getChildren().get(i));
         e.getExpressions().get(i).accept(this);
         state.pop();
@@ -126,13 +154,12 @@ public class SnippetParsingTest {
       }
     }
   }
-  
+
   public static void assertSame(TestExpression expected, Expression actual) {
     actual.accept(new ExpressionAsserter(expected));
   }
-  
-  private TestExpression e(Class<?> type, TestExpression...children) {
+
+  private TestExpression e(Class<?> type, TestExpression... children) {
     return new TestExpression(type, Arrays.asList(children));
   }
-  
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
@@ -39,9 +39,17 @@ public class SnippetParsingTest {
   }
 
   @Test
-  public void choice() {
+  public void testChoice() {
+    testParseAndRender("${3:|foo,bar,zoz|}", snippet(placeholder(choice())));
     testParseAndRender(
-        "${3:|foo,bar,zoz|}", e(Snippet.class, e(Placeholder.class, e(Choice.class))));
+        "{ ${1:somevalue}    ${2:|first,second,third|} ${3:some text $4}",
+        snippet(
+            text(),
+            placeholder(snippet(text())),
+            text(),
+            placeholder(choice()),
+            text(),
+            placeholder(snippet(text(), placeholder()))));
   }
 
   @Test
@@ -76,8 +84,8 @@ public class SnippetParsingTest {
     StringWriter out = new StringWriter();
     snippet.accept(new ExpressionPrinter(out));
     System.out.println(out.toString());
-    assertEquals(snippetText, out.toString());
     assertSame(testExpression, snippet);
+    assertEquals(snippetText, out.toString());
   }
 
   private static class TestExpression {
@@ -161,5 +169,25 @@ public class SnippetParsingTest {
 
   private TestExpression e(Class<?> type, TestExpression... children) {
     return new TestExpression(type, Arrays.asList(children));
+  }
+
+  private TestExpression snippet(TestExpression... children) {
+    return e(Snippet.class, children);
+  }
+
+  private TestExpression placeholder(TestExpression child) {
+    return e(Placeholder.class, child);
+  }
+
+  private TestExpression placeholder() {
+    return e(Placeholder.class);
+  }
+
+  private TestExpression text() {
+    return e(Text.class);
+  }
+
+  private TestExpression choice() {
+    return e(Choice.class);
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
@@ -1,0 +1,138 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Stack;
+
+import org.junit.Test;
+
+public class SnippetParsingTest {
+  @Test
+  public void simplePlaceHolder() {
+    testParseAndRender("$1", e(Snippet.class, e(Placeholder.class))); 
+    testParseAndRender("$1$3989$27", e(Snippet.class, e(Placeholder.class), e(Placeholder.class), e(Placeholder.class))); 
+    testParseAndRender("$1:Gurke 2", e(Snippet.class, e(Placeholder.class), e(Text.class)));
+    testParseAndRender("$1$2   $3", e(Snippet.class, e(Placeholder.class), e(Placeholder.class), e(Text.class), e(Placeholder.class)));
+  }
+  
+  @Test
+  public void simpleVariable() {
+    testParseAndRender("$foo", e(Snippet.class, e(Variable.class))); 
+    testParseAndRender("${foo:bar}", e(Snippet.class, e(Variable.class, e(Snippet.class, e(Text.class))))); 
+    testParseAndRender("${foo:$5233}", e(Snippet.class, e(Variable.class, e(Snippet.class, e(Placeholder.class))))); 
+  }
+  
+  @Test
+  public void choice() {
+    testParseAndRender("${3:|foo,bar,zoz|}", e(Snippet.class, e(Placeholder.class, e(Choice.class)))); 
+  }
+
+  
+  @Test
+  public void nestedPlaceHolder() {
+    testParseAndRender("${1:Gurke $2}", e(Snippet.class, e(Placeholder.class, e(Snippet.class, e(Text.class), e(Placeholder.class)))));
+    testParseAndRender("$1:Gurke ${2:3}", e(Snippet.class, e(Placeholder.class), e(Text.class), e(Placeholder.class, e(Snippet.class, e(Text.class)))));
+  }
+  
+  @Test
+  public void nestedVariable() {
+    testParseAndRender("${1:${foo:$3}}", e(Snippet.class, e(Placeholder.class, e(Snippet.class, e(Variable.class, e(Snippet.class, e(Placeholder.class)))))));
+  }
+
+  
+  private void testParseAndRender(String snippetText, TestExpression testExpression) {
+    Snippet snippet = new SnippetParser(snippetText).parse();
+    StringWriter out = new StringWriter();
+    snippet.accept(new ExpressionPrinter(out));
+    System.out.println(out.toString()); 
+    assertEquals(snippetText, out.toString());
+    assertSame(testExpression, snippet);
+  }
+  
+  private static class TestExpression {
+    private Class<?> type;
+    private List<TestExpression> children;
+    
+    public TestExpression(Class<?> type, List<TestExpression> children) {
+      this.type = type;
+      this.children = children;
+    }
+    
+    public Class<?> getType() {
+      return type;
+    }
+    
+    public List<TestExpression> getChildren() {
+      return children;
+    }
+  };
+  
+  private static class ExpressionAsserter implements ExpressionVisitor {
+    private Stack<TestExpression> state= new Stack<>();
+    
+    public ExpressionAsserter(TestExpression expr) {
+      state.push(expr);
+    }
+    
+    @Override
+    public void visit(DollarExpression e) {
+      e.getValue().accept(this);
+    }
+
+    @Override
+    public void visit(Choice e) {
+      assertEquals(Choice.class, state.peek().getType());
+    }
+
+    @Override
+    public void visit(Placeholder e) {
+      TestExpression current = state.peek();
+      assertEquals(Placeholder.class, current.getType());
+      if (e.getValue() != null) {
+        state.push(current.getChildren().get(0));
+        e.getValue().accept(this);
+        state.pop();
+      }
+    }
+
+    @Override
+    public void visit(Snippet e) {
+      TestExpression current = state.peek();
+      assertEquals(Snippet.class, current.getType());
+      for (int i= 0; i < e.getExpressions().size(); i++) {
+        state.push(current.getChildren().get(i));
+        e.getExpressions().get(i).accept(this);
+        state.pop();
+      }
+    }
+
+    @Override
+    public void visit(Text e) {
+      TestExpression current = state.peek();
+      assertEquals(Text.class, current.getType());
+    }
+
+    @Override
+    public void visit(Variable e) {
+      TestExpression current = state.peek();
+      assertEquals(Variable.class, current.getType());
+      if (e.getValue() != null) {
+        state.push(current.getChildren().get(0));
+        e.getValue().accept(this);
+        state.pop();
+      }
+    }
+  }
+  
+  public static void assertSame(TestExpression expected, Expression actual) {
+    actual.accept(new ExpressionAsserter(expected));
+  }
+  
+  private TestExpression e(Class<?> type, TestExpression...children) {
+    return new TestExpression(type, Arrays.asList(children));
+  }
+  
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetParsingTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import static org.junit.Assert.assertEquals;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolverTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolverTest.java
@@ -1,0 +1,56 @@
+package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.ide.api.editor.link.HasLinkedMode;
+import org.eclipse.che.ide.api.editor.link.LinkedModel;
+import org.eclipse.che.ide.api.editor.link.LinkedModelData;
+import org.eclipse.che.ide.api.editor.link.LinkedModelGroup;
+import org.eclipse.che.ide.util.Pair;
+import org.junit.Test;
+
+public class SnippetResolverTest {
+  private static class TestVarResolver implements VariableResolver {
+    private Map<String, String> valueMap = new HashMap<>();
+
+    @SafeVarargs
+    public TestVarResolver(Pair<String, String>... values) {
+      for (Pair<String, String> pair : values) {
+        valueMap.put(pair.first, pair.second);
+      }
+    }
+
+    @Override
+    public boolean isVar(String name) {
+      return valueMap.containsKey(name);
+    }
+
+    @Override
+    public String resolve(String name) {
+      return valueMap.get(name);
+    }
+  }
+
+  @Test
+  public void resolveVariables() {
+    HasLinkedMode linkedMode = mock(HasLinkedMode.class);
+    when(linkedMode.createLinkedModel()).thenReturn(mock(LinkedModel.class));
+    when(linkedMode.createLinkedGroup()).thenReturn(mock(LinkedModelGroup.class));
+    when(linkedMode.createLinkedModelData()).thenReturn(mock(LinkedModelData.class));
+    SnippetResolver snippetResolver =
+        new SnippetResolver(
+            new TestVarResolver(
+                Pair.of("foo", "bar"), Pair.of("lolo", "lala"), Pair.of("bla", null)));
+    Pair<String, LinkedModel> resolved = snippetResolver.resolve("${foo}", linkedMode, 25);
+    assertEquals("bar", resolved.first);
+    resolved = snippetResolver.resolve("${gogo}", linkedMode, 25);
+    assertEquals("gogo", resolved.first);
+    resolved = snippetResolver.resolve("${foo:dflt}", linkedMode, 25);
+    assertEquals("bar", resolved.first);
+    resolved = snippetResolver.resolve("${bla:dflt}", linkedMode, 25);
+    assertEquals("dflt", resolved.first);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolverTest.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/test/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/snippet/SnippetResolverTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
### What does this PR do?
Adds support for VS Code-style snippets in code completion.
See https://github.com/Microsoft/vscode/blob/0ebd01213a65231f0af8187acaf264243629e4dc/src/vs/editor/contrib/snippet/browser/snippet.md

### What issues does this PR fix or reference?
#5365 

#### Changelog
Add support for snippets in code completion.

#### Release Notes
This version introduces new capabilities in the support of [Language Server Protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md) in Eclipse Che, we are now supporting the VS Code-style snippets in code completion. 
Code snippets are small templates of reusable code that can make easier and faster to insert code in a file. Templates are particularly efficient for loop blocks, if-else blocks but not only depending the language you are using. When using the autocompletion `ctrl+space` you'll have the list of snippets suggested.  

The snippets syntax support:
- **Tabstops**: to move the editor's cursor inside a snippet.
- **Variables**: to insert value of a variable.
- **Placeholders**: to easily insert placeholder text which will be selected to be changed (placeholders are tabstops with values). 
- **Choices**: to replace a placeholder by a value from a given enumeration.

[Insert Animated gif for "choices"]

You can refer to the following [documentation]() to learn more. We are currently supporting the [VS-Code style syntax](https://github.com/Microsoft/vscode/blob/0ebd01213a65231f0af8187acaf264243629e4dc/src/vs/editor/contrib/snippet/browser/snippet.md) description.

#### Docs PR
https://github.com/eclipse/che-docs/pull/292