### PR TITLE
DTO TypeScript generator: Some DTO in Che are using "arguments" and this is a reserved keyword

### DIFF
--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
@@ -67,7 +67,14 @@ public class DTOHelper {
   public static String getFieldName(String type) {
     char[] c = type.toCharArray();
     c[0] = Character.toLowerCase(c[0]);
-    return new String(c);
+
+    String val = new String(c);
+
+    // replace reserved keyword
+    if ("arguments".equals(val)) {
+      val = "argumentsObj";
+    }
+    return val;
   }
 
   /** Extract field name from the getter method */

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyCustomDTO.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyCustomDTO.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.plugin.typescript.dto;
 
+import java.util.List;
 import java.util.Map;
 import org.eclipse.che.dto.shared.DTO;
 
@@ -40,4 +41,11 @@ public interface MyCustomDTO {
   void setCustomMap(Map<String, MyOtherDTO> map);
 
   MyCustomDTO withCustomMap(Map<String, MyOtherDTO> map);
+
+  // arguments is a reserved keyword for TypeScript
+  List<MyOtherDTO> getArguments();
+
+  void setArguments(List<MyOtherDTO> arguments);
+
+  MyCustomDTO withArguments(List<MyOtherDTO> arguments);
 }


### PR DESCRIPTION
so we need to adapt the field name

Change-Id: Ieb2f97499b4173a2b58c8c0565871aafef3b9ddc
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
