### PR TITLE
Clean up test workspaces after the selenium tests execution

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestFactoryServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestFactoryServiceClient.java
@@ -10,14 +10,19 @@
  */
 package org.eclipse.che.selenium.core.client;
 
+import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.io.IOException;
 import java.util.List;
+import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonResponse;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestIdeUrlProvider;
 import org.slf4j.Logger;
@@ -66,21 +71,51 @@ public class TestFactoryServiceClient {
         responseDto.getName(),
         responseDto.getId());
 
-    return String.format("%sf?id=%s", ideUrl, responseDto.getId());
+    return format("%sf?id=%s", ideUrl, responseDto.getId());
   }
 
-  public String findFactoryIdByName(String name) throws Exception {
+  /**
+   * Search factory of certain name.
+   *
+   * @param name name of factory to find
+   * @return Factory DTO or null if factory wasn't found.
+   * @throws ApiException
+   * @throws IOException
+   */
+  @Nullable
+  public FactoryDto findFactory(String name) throws ApiException, IOException {
     String queryParamPrefix = "find?name=" + name;
-    HttpJsonResponse request =
-        requestFactory.fromUrl(factoryApiEndpoint + queryParamPrefix).request();
+    HttpJsonResponse request;
+    try {
+      request = requestFactory.fromUrl(factoryApiEndpoint + queryParamPrefix).request();
+    } catch (NotFoundException e) {
+      return null;
+    }
+
     List<FactoryDto> dtos = request.asList(FactoryDto.class);
-    return dtos.isEmpty() ? null : dtos.get(0).getId();
+    return dtos.isEmpty() ? null : dtos.get(0);
   }
 
-  public void deleteFactoryByName(String name) throws Exception {
-    String id = findFactoryIdByName(name);
-    if (id != null) {
-      requestFactory.fromUrl(factoryApiEndpoint + id).useDeleteMethod().request();
+  public void deleteFactory(String name) {
+    FactoryDto factory;
+    try {
+      factory = findFactory(name);
+    } catch (NotFoundException e) {
+      // ignore in case of there is no factory with certain name
+      return;
+    } catch (ApiException | IOException e) {
+      LOG.error(
+          format("Error of getting info about factory with name='%s': %s", name, e.getMessage()),
+          e);
+      return;
+    }
+
+    if (factory != null) {
+      try {
+        requestFactory.fromUrl(factoryApiEndpoint + factory.getId()).useDeleteMethod().request();
+      } catch (IOException | ApiException e) {
+        LOG.error(format("Error of deletion of factory with name='%s': %s", name, e.getMessage()), e);
+      }
     }
   }
 }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -283,4 +283,23 @@ public class TestWorkspaceServiceClient {
     }
     return calculatedValue;
   }
+
+  /**
+   * Delete workspaces which could be created from factory
+   *
+   * @param originalName name workspace which was used to create factory
+   * @param username
+   * @throws Exception
+   */
+  public void deleteFactoryWorkspaces(String originalName, String username) throws Exception {
+    String workspace2delete = originalName;
+    for (int i = 1; ; i++) {
+      if (!exists(workspace2delete, username)) {
+        break;
+      }
+
+      delete(workspace2delete, username);
+      workspace2delete = originalName + "_" + i;
+    }
+  }
 }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -132,7 +132,7 @@ public class TestWorkspaceServiceClient {
     requestFactory.fromUrl(getIdBasedUrl(workspace.getId())).useDeleteMethod().request();
 
     LOG.info(
-        "Workspace name='{}', id='{}' and of user with name='{}' is removed",
+        "Workspace name='{}', id='{}', username='{}' removed",
         workspaceName,
         workspace.getId(),
         userName);

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactory.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactory.java
@@ -57,26 +57,14 @@ public class TestFactory {
   }
 
   public void delete() throws Exception {
+    workspaceServiceClient.deleteFactoryWorkspaces(
+        factoryDto.getWorkspace().getName(), owner.getName());
     deleteFactory();
-    deleteWorkspaces();
   }
 
   private void deleteFactory() throws Exception {
     if (isNamedFactory()) {
-      testFactoryServiceClient.deleteFactoryByName(factoryDto.getName());
-    }
-  }
-
-  private void deleteWorkspaces() throws Exception {
-    String originalName = factoryDto.getWorkspace().getName();
-    String workspace2delete = originalName;
-    for (int i = 1; ; i++) {
-      if (!workspaceServiceClient.exists(workspace2delete, owner.getName())) {
-        break;
-      }
-
-      workspaceServiceClient.delete(workspace2delete, owner.getName());
-      workspace2delete = originalName + "_" + i;
+      testFactoryServiceClient.deleteFactory(factoryDto.getName());
     }
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactoryInitializer.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactoryInitializer.java
@@ -78,7 +78,6 @@ public class TestFactoryInitializer {
     HttpJsonRequest httpJsonRequest =
         requestFactory.fromUrl(apiEndpointProvider.get() + "factory/resolver");
     httpJsonRequest.setBody(singletonMap("url", url));
-    httpJsonRequest.setAuthorizationHeader(defaultUser.getAuthToken());
     HttpJsonResponse response = httpJsonRequest.request();
 
     FactoryDto factoryDto = response.asDto(FactoryDto.class);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/DashboardFactory.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/DashboardFactory.java
@@ -209,11 +209,11 @@ public class DashboardFactory {
   }
 
   /**
-   * wait the name of factory field and type the name
+   * wait on the factory name field visibility and enter the name
    *
-   * @param name
+   * @param name name of factory to enter
    */
-  public void setNameFactory(String name) {
+  public void setFactoryName(String name) {
     WebElement field =
         new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
             .until(ExpectedConditions.visibilityOf(factoryNameField));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
@@ -75,8 +75,8 @@ public class CheckOpenFileFeatureTest {
     dashboard.open();
     dashboard.selectFactoriesOnDashbord();
     dashboardFactory.clickOnAddFactoryBtn();
-    dashboardFactory.setFactoryName(FACTORY_NAME);
     dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
+    dashboardFactory.setFactoryName(FACTORY_NAME);
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.selectAction(OPEN_FILE);
     dashboardFactory.enterParamValue(OPEN_FILE_URL);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
@@ -17,7 +17,9 @@ import static org.eclipse.che.selenium.pageobject.Wizard.SamplesName.WEB_JAVA_SP
 import static org.eclipse.che.selenium.pageobject.dashboard.DashboardFactory.AddAction.OPEN_FILE;
 
 import com.google.inject.Inject;
+import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestFactoryServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -38,8 +40,7 @@ import org.testng.annotations.Test;
 public class CheckOpenFileFeatureTest {
   private static final String PROJECT_NAME = CheckOpenFileFeatureTest.class.getSimpleName();
   private static final String OPEN_FILE_URL = "/CheckOpenFileFeatureTest/pom.xml";
-
-  private String factoryWsName;
+  private static final String FACTORY_NAME = NameGenerator.generate("factory", 4);
 
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Dashboard dashboard;
@@ -54,6 +55,7 @@ public class CheckOpenFileFeatureTest {
   @Inject private DefaultTestUser user;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
+  @Inject private TestFactoryServiceClient factoryServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -62,9 +64,8 @@ public class CheckOpenFileFeatureTest {
 
   @AfterClass
   public void tearDown() throws Exception {
-    if (factoryWsName != null) {
-      workspaceServiceClient.delete(factoryWsName, user.getName());
-    }
+    workspaceServiceClient.deleteFactoryWorkspaces(testWorkspace.getName(), user.getName());
+    factoryServiceClient.deleteFactory(FACTORY_NAME);
   }
 
   @Test
@@ -74,11 +75,8 @@ public class CheckOpenFileFeatureTest {
     dashboard.open();
     dashboard.selectFactoriesOnDashbord();
     dashboardFactory.clickOnAddFactoryBtn();
-    dashboardFactory.clickWorkspacesTabOnSelectSource();
-
-    factoryWsName = testWorkspace.getName() + "_new";
-    dashboardFactory.selectWorkspaceForCreation(factoryWsName);
-
+    dashboardFactory.setFactoryName(FACTORY_NAME);
+    dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.selectAction(OPEN_FILE);
     dashboardFactory.enterParamValue(OPEN_FILE_URL);
@@ -90,7 +88,6 @@ public class CheckOpenFileFeatureTest {
     seleniumWebDriver.switchToNoneCurrentWindow(currentWin);
     loadingBehaviorPage.waitWhileLoadPageIsClosed();
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    factoryWsName = seleniumWebDriver.getWorkspaceNameFromBrowserUrl();
     projectExplorer.waitItem(PROJECT_NAME);
     editor.waitTabIsPresent("web-java-spring", ELEMENT_TIMEOUT_SEC);
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
@@ -50,14 +50,14 @@ public class CheckOpenFileFeatureTest {
   @Inject private Loader loader;
   @Inject private Wizard wizard;
   @Inject private Menu menu;
-  @Inject private TestWorkspace ws;
+  @Inject private TestWorkspace testWorkspace;
   @Inject private DefaultTestUser user;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
-    ide.open(ws);
+    ide.open(testWorkspace);
   }
 
   @AfterClass
@@ -75,7 +75,10 @@ public class CheckOpenFileFeatureTest {
     dashboard.selectFactoriesOnDashbord();
     dashboardFactory.clickOnAddFactoryBtn();
     dashboardFactory.clickWorkspacesTabOnSelectSource();
-    dashboardFactory.selectWorkspaceForCreation(ws.getName());
+
+    factoryWsName = testWorkspace.getName() + "_new";
+    dashboardFactory.selectWorkspaceForCreation(factoryWsName);
+
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.selectAction(OPEN_FILE);
     dashboardFactory.enterParamValue(OPEN_FILE_URL);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckRunCommandFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckRunCommandFeatureTest.java
@@ -52,7 +52,7 @@ public class CheckRunCommandFeatureTest {
   @Inject private Loader loader;
   @Inject private Wizard wizard;
   @Inject private Menu menu;
-  @Inject private TestWorkspace ws;
+  @Inject private TestWorkspace testWorkspace;
   @Inject private DefaultTestUser user;
   @Inject private Consoles consoles;
   @Inject private SeleniumWebDriver seleniumWebDriver;
@@ -60,7 +60,7 @@ public class CheckRunCommandFeatureTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    ide.open(ws);
+    ide.open(testWorkspace);
   }
 
   @AfterClass
@@ -79,7 +79,10 @@ public class CheckRunCommandFeatureTest {
     dashboard.selectFactoriesOnDashbord();
     dashboardFactory.clickOnAddFactoryBtn();
     dashboardFactory.clickWorkspacesTabOnSelectSource();
-    dashboardFactory.selectWorkspaceForCreation(ws.getName());
+
+    factoryWsName = testWorkspace.getName() + "_new";
+    dashboardFactory.selectWorkspaceForCreation(factoryWsName);
+
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.selectAction(RUN_COMMAND);
     dashboardFactory.enterParamValue(NAME_BUILD_COMMAND);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckRunCommandFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckRunCommandFeatureTest.java
@@ -18,7 +18,9 @@ import static org.eclipse.che.selenium.pageobject.dashboard.DashboardFactory.Add
 
 import com.google.inject.Inject;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestFactoryServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -40,8 +42,7 @@ import org.testng.annotations.Test;
 public class CheckRunCommandFeatureTest {
   private static final String PROJECT_NAME = CheckRunCommandFeatureTest.class.getSimpleName();
   private static final String NAME_BUILD_COMMAND = PROJECT_NAME + ": build and run";
-
-  private String factoryWsName;
+  private static final String FACTORY_NAME = NameGenerator.generate("factory", 4);
 
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Dashboard dashboard;
@@ -57,6 +58,7 @@ public class CheckRunCommandFeatureTest {
   @Inject private Consoles consoles;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
+  @Inject private TestFactoryServiceClient factoryServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -65,9 +67,8 @@ public class CheckRunCommandFeatureTest {
 
   @AfterClass
   public void tearDown() throws Exception {
-    if (factoryWsName != null) {
-      workspaceServiceClient.delete(factoryWsName, user.getName());
-    }
+    workspaceServiceClient.deleteFactoryWorkspaces(testWorkspace.getName(), user.getName());
+    factoryServiceClient.deleteFactory(FACTORY_NAME);
   }
 
   @Test
@@ -78,11 +79,8 @@ public class CheckRunCommandFeatureTest {
     dashboard.open();
     dashboard.selectFactoriesOnDashbord();
     dashboardFactory.clickOnAddFactoryBtn();
-    dashboardFactory.clickWorkspacesTabOnSelectSource();
-
-    factoryWsName = testWorkspace.getName() + "_new";
-    dashboardFactory.selectWorkspaceForCreation(factoryWsName);
-
+    dashboardFactory.setFactoryName(FACTORY_NAME);
+    dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.selectAction(RUN_COMMAND);
     dashboardFactory.enterParamValue(NAME_BUILD_COMMAND);
@@ -92,7 +90,6 @@ public class CheckRunCommandFeatureTest {
     seleniumWebDriver.switchToNoneCurrentWindow(currentWin);
     loadingBehaviorPage.waitWhileLoadPageIsClosed();
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    factoryWsName = seleniumWebDriver.getWorkspaceNameFromBrowserUrl();
     projectExplorer.waitItem(PROJECT_NAME);
     consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS);
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckRunCommandFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckRunCommandFeatureTest.java
@@ -79,8 +79,8 @@ public class CheckRunCommandFeatureTest {
     dashboard.open();
     dashboard.selectFactoriesOnDashbord();
     dashboardFactory.clickOnAddFactoryBtn();
-    dashboardFactory.setFactoryName(FACTORY_NAME);
     dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
+    dashboardFactory.setFactoryName(FACTORY_NAME);
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.selectAction(RUN_COMMAND);
     dashboardFactory.enterParamValue(NAME_BUILD_COMMAND);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
@@ -62,7 +62,7 @@ public class CreateFactoryFromUiWithKeepDirTest {
 
   @Inject private DefaultTestUser user;
   @Inject private CodenvyEditor editor;
-  @Inject private TestWorkspace workspace;
+  @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Menu menu;
@@ -79,13 +79,16 @@ public class CreateFactoryFromUiWithKeepDirTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    ide.open(workspace);
+    ide.open(testWorkspace);
   }
 
   @AfterClass
   public void tearDown() throws Exception {
     if (factoryWsName != null) {
       workspaceServiceClient.delete(factoryWsName, user.getName());
+    } else {
+      // workaround to remove test workspace for sure
+      workspaceServiceClient.delete(testWorkspace.getName() + "_1", user.getName());
     }
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
@@ -23,6 +23,7 @@ import com.google.inject.Inject;
 import java.io.IOException;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestFactoryServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.provider.TestIdeUrlProvider;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -57,8 +58,7 @@ public class CreateFactoryFromUiWithKeepDirTest {
   private static final String[] autocompleteContentAfterFirst = {
     "GreetingController()", "Greeting", "GreetingController", "Greeting() : void"
   };
-
-  private String factoryWsName;
+  private static final String FACTORY_NAME = NameGenerator.generate("keepFactory", 2);
 
   @Inject private DefaultTestUser user;
   @Inject private CodenvyEditor editor;
@@ -76,6 +76,7 @@ public class CreateFactoryFromUiWithKeepDirTest {
   @Inject private TestIdeUrlProvider ideUrlProvider;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
+  @Inject private TestFactoryServiceClient factoryServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -84,12 +85,8 @@ public class CreateFactoryFromUiWithKeepDirTest {
 
   @AfterClass
   public void tearDown() throws Exception {
-    if (factoryWsName != null) {
-      workspaceServiceClient.delete(factoryWsName, user.getName());
-    } else {
-      // workaround to remove test workspace for sure
-      workspaceServiceClient.delete(testWorkspace.getName() + "_1", user.getName());
-    }
+    workspaceServiceClient.deleteFactoryWorkspaces(testWorkspace.getName(), user.getName());
+    factoryServiceClient.deleteFactory(FACTORY_NAME);
   }
 
   @Test
@@ -126,14 +123,13 @@ public class CreateFactoryFromUiWithKeepDirTest {
     String currentWin = ide.driver().getWindowHandle();
     menu.runCommand(WORKSPACE, CREATE_FACTORY);
     factoryWidget.waitOpen();
-    factoryWidget.typeNameFactory(NameGenerator.generate("keepFactory", 2));
+    factoryWidget.typeNameFactory(FACTORY_NAME);
     factoryWidget.clickOnCreateBtn();
     factoryWidget.waitTextIntoFactoryField(ideUrlProvider.get().toString());
     factoryWidget.clickOnInvokeBtn();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWin);
     loadingBehaviorPage.waitWhileLoadPageIsClosed();
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    factoryWsName = seleniumWebDriver.getWorkspaceNameFromBrowserUrl();
     try {
       projectExplorer.waitProjectExplorer(80);
     } catch (org.openqa.selenium.TimeoutException ex) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
@@ -40,7 +40,8 @@ import org.testng.annotations.Test;
 /** @author Musienko Maxim */
 public class CreateNamedFactoryFromDashBoard {
   private static final String PROJECT_NAME = CreateNamedFactoryFromDashBoard.class.getSimpleName();
-  private static final String NEW_WORKSPACE_SUFFIX = "_1";
+
+  private String factoryWsName;
 
   @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
@@ -69,8 +70,9 @@ public class CreateNamedFactoryFromDashBoard {
 
   @AfterClass
   public void tearDown() throws Exception {
-    String newWorkspaceName = testWorkspace.getName() + NEW_WORKSPACE_SUFFIX;
-    workspaceServiceClient.delete(newWorkspaceName, user.getName());
+    if (factoryWsName != null) {
+      workspaceServiceClient.delete(factoryWsName, user.getName());
+    }
   }
 
   @Test
@@ -81,7 +83,10 @@ public class CreateNamedFactoryFromDashBoard {
     dashboardFactory.waitAllFactoriesPage();
     dashboardFactory.clickOnAddFactoryBtn();
     dashboardFactory.waitSelectSourceWidgetAndSelect(WORKSPACES.toString());
-    dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
+
+    factoryWsName = testWorkspace.getName() + "_new";
+    dashboardFactory.selectWorkspaceForCreation(factoryWsName);
+
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.waitJsonFactoryIsNotEmpty();
     dashboardFactory.setNameFactory(new SimpleDateFormat("yyyy_MM_dd_hh_mm_ss").format(new Date()));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
@@ -13,8 +13,6 @@ package org.eclipse.che.selenium.factory;
 import static org.eclipse.che.selenium.core.constant.TestGitConstants.CONFIGURING_PROJECT_AND_CLONING_SOURCE_CODE;
 
 import com.google.inject.Inject;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
@@ -82,11 +80,10 @@ public class CreateNamedFactoryFromDashBoard {
     dashboardFactory.selectFactoryOnNavBar();
     dashboardFactory.waitAllFactoriesPage();
     dashboardFactory.clickOnAddFactoryBtn();
-    dashboardFactory.setFactoryName(FACTORY_NAME);
     dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
+    dashboardFactory.setFactoryName(FACTORY_NAME);
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.waitJsonFactoryIsNotEmpty();
-    dashboardFactory.setFactoryName(new SimpleDateFormat("yyyy_MM_dd_hh_mm_ss").format(new Date()));
     dashboard.waitNotificationIsClosed();
     dashboardFactory.clickFactoryIDUrl();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWin);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
@@ -11,13 +11,14 @@
 package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.selenium.core.constant.TestGitConstants.CONFIGURING_PROJECT_AND_CLONING_SOURCE_CODE;
-import static org.eclipse.che.selenium.pageobject.dashboard.DashboardFactory.SourcesTypes.WORKSPACES;
 
 import com.google.inject.Inject;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestFactoryServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
@@ -40,8 +41,7 @@ import org.testng.annotations.Test;
 /** @author Musienko Maxim */
 public class CreateNamedFactoryFromDashBoard {
   private static final String PROJECT_NAME = CreateNamedFactoryFromDashBoard.class.getSimpleName();
-
-  private String factoryWsName;
+  private static final String FACTORY_NAME = NameGenerator.generate("factory", 4);
 
   @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
@@ -58,6 +58,7 @@ public class CreateNamedFactoryFromDashBoard {
   @Inject private Wizard wizard;
   @Inject private Menu menu;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
+  @Inject private TestFactoryServiceClient factoryServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -70,9 +71,8 @@ public class CreateNamedFactoryFromDashBoard {
 
   @AfterClass
   public void tearDown() throws Exception {
-    if (factoryWsName != null) {
-      workspaceServiceClient.delete(factoryWsName, user.getName());
-    }
+    workspaceServiceClient.deleteFactoryWorkspaces(testWorkspace.getName(), user.getName());
+    factoryServiceClient.deleteFactory(FACTORY_NAME);
   }
 
   @Test
@@ -82,14 +82,11 @@ public class CreateNamedFactoryFromDashBoard {
     dashboardFactory.selectFactoryOnNavBar();
     dashboardFactory.waitAllFactoriesPage();
     dashboardFactory.clickOnAddFactoryBtn();
-    dashboardFactory.waitSelectSourceWidgetAndSelect(WORKSPACES.toString());
-
-    factoryWsName = testWorkspace.getName() + "_new";
-    dashboardFactory.selectWorkspaceForCreation(factoryWsName);
-
+    dashboardFactory.setFactoryName(FACTORY_NAME);
+    dashboardFactory.selectWorkspaceForCreation(testWorkspace.getName());
     dashboardFactory.clickOnCreateFactoryBtn();
     dashboardFactory.waitJsonFactoryIsNotEmpty();
-    dashboardFactory.setNameFactory(new SimpleDateFormat("yyyy_MM_dd_hh_mm_ss").format(new Date()));
+    dashboardFactory.setFactoryName(new SimpleDateFormat("yyyy_MM_dd_hh_mm_ss").format(new Date()));
     dashboard.waitNotificationIsClosed();
     dashboardFactory.clickFactoryIDUrl();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWin);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
@@ -68,7 +68,7 @@ public class PullRequestPluginTest {
   private WebDriverWait webDriverWait;
   private String factoryWsName;
 
-  @Inject private TestWorkspace ws;
+  @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
   @Inject private DefaultTestUser productUser;
 
@@ -99,7 +99,7 @@ public class PullRequestPluginTest {
   @BeforeClass
   public void setUp() throws Exception {
     webDriverWait = new WebDriverWait(ide.driver(), LOAD_PAGE_TIMEOUT_SEC);
-    ide.open(ws);
+    ide.open(testWorkspace);
     // add committer info
     testUserPreferencesServiceClient.addGitCommitter(gitHubUsername, productUser.getEmail());
     // authorize application on GitHub
@@ -115,6 +115,9 @@ public class PullRequestPluginTest {
   public void tearDown() throws Exception {
     if (factoryWsName != null) {
       workspaceServiceClient.delete(factoryWsName, user.getName());
+    } else {
+      // workaround to remove test workspace for sure
+      workspaceServiceClient.delete(testWorkspace.getName() + "_1", user.getName());
     }
 
     List<String> listPullRequest =

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
@@ -113,12 +113,7 @@ public class PullRequestPluginTest {
 
   @AfterClass
   public void tearDown() throws Exception {
-    if (factoryWsName != null) {
-      workspaceServiceClient.delete(factoryWsName, user.getName());
-    } else {
-      // workaround to remove test workspace for sure
-      workspaceServiceClient.delete(testWorkspace.getName() + "_1", user.getName());
-    }
+    workspaceServiceClient.deleteFactoryWorkspaces(testWorkspace.getName(), user.getName());
 
     List<String> listPullRequest =
         gitHubClientService.getNumbersOfOpenedPullRequests(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -36,7 +36,7 @@ public class ProjectStateAfterRenameWorkspaceTest {
   private static final String PROJECT_NAME = NameGenerator.generate("ProjectAfterRenameWs", 4);
   private static final String WORKSPACE_NEW_NAME = NameGenerator.generate("rename_ws", 4);
 
-  @Inject private TestWorkspace workspace;
+  @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
@@ -53,16 +53,16 @@ public class ProjectStateAfterRenameWorkspaceTest {
     URL resource =
         ProjectStateAfterRenameWorkspaceTest.this.getClass().getResource("/projects/guess-project");
     testProjectServiceClient.importProject(
-        workspace.getId(),
+        testWorkspace.getId(),
         Paths.get(resource.toURI()),
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
-    ide.open(workspace);
+    ide.open(testWorkspace);
   }
 
   @AfterClass
   public void tearDown() throws Exception {
-    testWorkspaceServiceClient.delete(WORKSPACE_NEW_NAME, workspace.getOwner().getName());
+    testWorkspaceServiceClient.delete(WORKSPACE_NEW_NAME, testWorkspace.getOwner().getName());
   }
 
   @Test
@@ -84,7 +84,7 @@ public class ProjectStateAfterRenameWorkspaceTest {
     dashboard.waitDashboardToolbarTitle();
     dashboard.selectWorkspacesItemOnDashboard();
     dashboardWorkspace.waitToolbarTitleName("Workspaces");
-    dashboardWorkspace.selectWorkspaceItemName(workspace.getName());
+    dashboardWorkspace.selectWorkspaceItemName(testWorkspace.getName());
     dashboardWorkspace.enterNameWorkspace(WORKSPACE_NEW_NAME);
     dashboardWorkspace.clickOnSaveBtn();
     dashboardWorkspace.checkStateOfWorkspace(DashboardWorkspace.StateWorkspace.RUNNING);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
+import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestWorkspaceConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -26,6 +27,7 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,6 +46,7 @@ public class ProjectStateAfterRenameWorkspaceTest {
   @Inject private Events events;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestProjectServiceClient testProjectServiceClient;
+  @Inject private TestWorkspaceServiceClient testWorkspaceServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -55,6 +58,11 @@ public class ProjectStateAfterRenameWorkspaceTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(workspace);
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    testWorkspaceServiceClient.delete(WORKSPACE_NEW_NAME, workspace.getOwner().getName());
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Fixes clean up of test workspaces after execution of the next selenium tests:
- org.eclipse.che.selenium.factory.**CheckOpenFileFeatureTest**
- org.eclipse.che.selenium.factory.**CheckRunCommandFeatureTest**
- org.eclipse.che.selenium.factory.**CreateFactoryFromUiWithKeepDirTest**
- org.eclipse.che.selenium.factory.**CreateNamedFactoryFromDashBoard**
- org.eclipse.che.selenium.git.**PullRequestPluginTest**
- org.eclipse.che.selenium.workspaces.**ProjectStateAfterRenameWorkspaceTest**

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2397

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
