### PR TITLE
Update EclipseLink to v2.7.0

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -240,7 +240,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.everrest</groupId>

--- a/core/che-core-db-vendor-h2/pom.xml
+++ b/core/che-core-db-vendor-h2/pom.xml
@@ -31,7 +31,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/che-core-db-vendor-postgresql/pom.xml
+++ b/core/che-core-db-vendor-postgresql/pom.xml
@@ -27,7 +27,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/che-core-db/pom.xml
+++ b/core/che-core-db/pom.xml
@@ -47,11 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -60,6 +56,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/core/che-core-db/src/main/java/org/eclipse/che/core/db/DBInitializer.java
+++ b/core/che-core-db/src/main/java/org/eclipse/che/core/db/DBInitializer.java
@@ -19,7 +19,7 @@ import org.eclipse.che.core.db.jpa.JpaInitializer;
 import org.eclipse.che.core.db.jpa.eclipselink.GuiceEntityListenerInjectionManager;
 import org.eclipse.che.core.db.schema.SchemaInitializationException;
 import org.eclipse.che.core.db.schema.SchemaInitializer;
-import org.eclipse.persistence.sessions.server.ServerSession;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 
 /**
  * Initializes database components.
@@ -70,8 +70,8 @@ public class DBInitializer {
   @Inject
   public void setUpInjectionManager(
       GuiceEntityListenerInjectionManager injManager, EntityManagerFactory emFactory) {
-    final ServerSession session = emFactory.unwrap(ServerSession.class);
-    session.setEntityListenerInjectionManager(injManager);
+    final AbstractSession session = emFactory.unwrap(AbstractSession.class);
+    session.setInjectionManager(injManager);
   }
 
   /** Returns map of properties which represents state of database while initialization process */

--- a/core/che-core-db/src/main/java/org/eclipse/che/core/db/jpa/eclipselink/GuiceEntityListenerInjectionManager.java
+++ b/core/che-core-db/src/main/java/org/eclipse/che/core/db/jpa/eclipselink/GuiceEntityListenerInjectionManager.java
@@ -14,7 +14,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import javax.naming.NamingException;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
-import org.eclipse.persistence.internal.sessions.cdi.EntityListenerInjectionManager;
+import org.eclipse.persistence.internal.sessions.cdi.InjectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Yevhenii Voevodin
  */
-public class GuiceEntityListenerInjectionManager implements EntityListenerInjectionManager {
+public class GuiceEntityListenerInjectionManager implements InjectionManager {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(GuiceEntityListenerInjectionManager.class);
@@ -51,7 +51,7 @@ public class GuiceEntityListenerInjectionManager implements EntityListenerInject
   @Inject private Injector injector;
 
   @Override
-  public Object createEntityListenerAndInjectDependancies(Class entityListenerClass)
+  public Object createManagedBeanAndInjectDependencies(Class entityListenerClass)
       throws NamingException {
     try {
       return injector.getInstance(entityListenerClass);

--- a/core/commons/che-core-commons-test/pom.xml
+++ b/core/commons/che-core-commons-test/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/wsmaster/che-core-api-account/pom.xml
+++ b/wsmaster/che-core-api-account/pom.xml
@@ -53,11 +53,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -94,6 +89,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-sql-schema</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-factory/pom.xml
+++ b/wsmaster/che-core-api-factory/pom.xml
@@ -165,7 +165,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-machine/pom.xml
+++ b/wsmaster/che-core-api-machine/pom.xml
@@ -154,7 +154,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-ssh/pom.xml
+++ b/wsmaster/che-core-api-ssh/pom.xml
@@ -84,6 +84,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.gwt.gwtmockito</groupId>
@@ -122,7 +123,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-user/pom.xml
+++ b/wsmaster/che-core-api-user/pom.xml
@@ -128,7 +128,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-workspace/pom.xml
+++ b/wsmaster/che-core-api-workspace/pom.xml
@@ -144,12 +144,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>javax.persistence</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -180,6 +180,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-sql-schema</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/integration-tests/cascade-removal/pom.xml
+++ b/wsmaster/integration-tests/cascade-removal/pom.xml
@@ -52,6 +52,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-account</artifactId>
             <scope>test</scope>
@@ -129,6 +134,16 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -149,12 +149,17 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>javax.persistence</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/wsmaster-local/pom.xml
+++ b/wsmaster/wsmaster-local/pom.xml
@@ -111,12 +111,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>javax.persistence</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What does this PR do?
Update to the newer EclipseLink version
Packages have been refactored since previous version, adapting the classes.

note: some dependencies have been updated (avoid `eclipselink` dependencies as it contains some API of `javax.persistence` package)
then, when tests are running, Java runtime complains about siganture mismatch between `eclipse-link` jar and `javax-persistence.jar` (same package but with two origins)

By using `org.eclipse.persistence.core` and `org.eclipse.persistence.jpa` artifacts,  the dependencies are more explicit and we select only required dependencies.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I4752a79e1badb2bf36594a3f7c1928569200d2a5
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
