### PR TITLE
Allow overriding the images used by the CLI

### DIFF
--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -120,10 +120,11 @@ list_versions(){
 ### define variables for all image name in the given list
 set_variables_images_list() {
   IFS=$'\n'
+  REPLACEMENT='s/\(.*\)=\(.*\)/\1=${\1:-\2}/g'
   for SINGLE_IMAGE in $1; do
-    INSTRUCTION=$(echo "${SINGLE_IMAGE}" | sed -e 's/\(.*\)=\(.*\)/\1=${\1:-\2}/g')
-    log "eval $INSTRUCTION "
-    eval $INSTRUCTION
+    INSTRUCTION="$(echo "${SINGLE_IMAGE}" | sed -e "${REPLACEMENT}")"
+    log "eval ${INSTRUCTION}"
+    eval "${INSTRUCTION}"
   done
 
 }

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -121,8 +121,9 @@ list_versions(){
 set_variables_images_list() {
   IFS=$'\n'
   for SINGLE_IMAGE in $1; do
-    log "eval $SINGLE_IMAGE"
-    eval $SINGLE_IMAGE
+  INSTRUCTION=$(echo "${SINGLE_IMAGE}" | sed -e 's/\(.*\)=\(.*\)/\1=${\1:-\2}/g')
+    log "eval $INSTRUCTION "
+    eval $INSTRUCTION
   done
 
 }

--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -121,7 +121,7 @@ list_versions(){
 set_variables_images_list() {
   IFS=$'\n'
   for SINGLE_IMAGE in $1; do
-  INSTRUCTION=$(echo "${SINGLE_IMAGE}" | sed -e 's/\(.*\)=\(.*\)/\1=${\1:-\2}/g')
+    INSTRUCTION=$(echo "${SINGLE_IMAGE}" | sed -e 's/\(.*\)=\(.*\)/\1=${\1:-\2}/g')
     log "eval $INSTRUCTION "
     eval $INSTRUCTION
   done

--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -31,7 +31,7 @@ fi
 #   The file has to be placed in tests folder in directory containing this script
 # (Optional) second argument is options for a docker run command.
 run_test_in_docker_container() {
-  docker_exec run --rm ${DOCKER_RUN_OPTIONS} \
+  docker_exec run --rm ${DOCKER_RUN_OPTIONS} $2 \
        -v "${BATS_BASE_DIR}":/dockerfiles \
        -e CLI_IMAGE="$ORGANIZATION/$PREFIX-cli:$TAG" \
        -e BATS_BASE_DIR="${BATS_BASE_DIR}" \

--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -31,7 +31,7 @@ fi
 #   The file has to be placed in tests folder in directory containing this script
 # (Optional) second argument is options for a docker run command.
 run_test_in_docker_container() {
-  docker_exec run --rm ${DOCKER_RUN_OPTIONS} $2 \
+  docker_exec run --rm ${DOCKER_RUN_OPTIONS} \
        -v "${BATS_BASE_DIR}":/dockerfiles \
        -e CLI_IMAGE="$ORGANIZATION/$PREFIX-cli:$TAG" \
        -e BATS_BASE_DIR="${BATS_BASE_DIR}" \
@@ -40,6 +40,8 @@ run_test_in_docker_container() {
 }
 
 echo "Running tests in container from image $IMAGE_NAME"
+echo "Running functionals bats tests for overriding images"
+run_test_in_docker_container override_image_tests.bats
 echo "Running functional bats tests for CLI prompts and usage"
 run_test_in_docker_container cli_prompts_usage_tests.bats ""
 echo "Running functionals bats tests for config command"

--- a/dockerfiles/cli/tests/override_image_tests.bats
+++ b/dockerfiles/cli/tests/override_image_tests.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   David Festal
+
+
+function log() {
+    echo ""
+}
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+source /dockerfiles/cli/tests/test_base.sh
+source /dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+
+@test "test overriding the CLI images" {
+  #GIVEN
+  IMAGES="IMAGE_INIT=eclipse/che-init:nightly"
+  IMAGE_INIT="dfestal/che-init:nightly"
+
+  #WHEN
+  set_variables_images_list "${IMAGES}"
+
+  #THEN
+  [[ "${IMAGE_INIT}" == ""dfestal/che-init:nightly"" ]]
+}
+
+@test "test not overriding the CLI images" {
+  #GIVEN
+  IMAGES="IMAGE_INIT=eclipse/che-init:nightly"
+
+  #WHEN
+  set_variables_images_list "${IMAGES}"
+
+  #THEN
+  [[ "${IMAGE_INIT}" == ""eclipse/che-init:nightly"" ]]
+}


### PR DESCRIPTION
### What does this PR do?

This PR allows overriding  the images used by the CLI to perform commands.
for example, the following command:

``` 
docker run ... -e IMAGE_INIT=dfestal/che-init:nightly eclipse/che-cli:nightly config
```

will run the `cli config` command, but when running it will use the `dfestal/che-init:nightly` init image, instead of the default `eclipse/che-init:nightly` image.

### What issues does this PR fix or reference?

This makes running specific version of some components with the standard CLI much easier, which can be a great help for development. 

#### Changelog

Allow overriding the images used by the CLI
