### PR TITLE
Clean up target directory at start of selenium tests

### DIFF
--- a/selenium/che-selenium-test/selenium-tests.sh
+++ b/selenium/che-selenium-test/selenium-tests.sh
@@ -14,7 +14,7 @@ export CALLER=$(basename $0)
 
 cd $CUR_DIR
 
-mvn dependency:unpack-dependencies \
+mvn clean dependency:unpack-dependencies \
     -DincludeArtifactIds=che-selenium-core \
     -DincludeGroupIds=org.eclipse.che.selenium \
     -Dmdep.unpack.includes=webdriver.sh \


### PR DESCRIPTION
### What does this PR do?
Clear target directory of selenium tests at start of test execution. It prevents us from having  of outdated result on CI.

### What issues does this PR fix or reference?
#6378

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
