### PR TITLE
Changing image pull policy to  in template that is used for spi deployment on minishift

### DIFF
--- a/dockerfiles/cli/scripts/openshift/che-spi-openshift.yml
+++ b/dockerfiles/cli/scripts/openshift/che-spi-openshift.yml
@@ -367,7 +367,7 @@ items:
                 key: che-workspace-auto-snapshot
                 name: che
           image: rhche/che-server:96acc83-fabric8-87a202e
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /api/system/state


### PR DESCRIPTION
### What does this PR do?
Changing image pull policy to  in template that is used for spi deployment on minishift. 
IMO, having `IfNotPresent` by default is much more handy for local development where new image can be built after using `eval $(minishift docker-env)` (switching to minishift docker environment) - No need to push / pull images for constant deployment on minishift 

### What issues does this PR fix or reference?
N/A

#### Changelog
N/A

#### Release Notes
N/A


#### Docs PR
N/A

