### PR TITLE
che #6306: Using default config for OpenShiftClient creation if no properties specified

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -393,7 +393,7 @@ che.predefined.stacks.reload_on_start=false
 che.infra.openshift.master_url=
 che.infra.openshift.username=
 che.infra.openshift.password=
-che.infra.openshift.trust_certs=false
+che.infra.openshift.trust_certs=
 
 che.infra.openshift.machine_start_timeout_min=5
 

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -92,6 +92,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -17,6 +17,7 @@ import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /** @author Sergii Leshchenko */
 public class OpenShiftClientFactory {
@@ -24,10 +25,10 @@ public class OpenShiftClientFactory {
 
   @Inject
   public OpenShiftClientFactory(
-      @Named("che.infra.openshift.master_url") String masterUrl,
-      @Named("che.infra.openshift.username") String username,
-      @Named("che.infra.openshift.password") String password,
-      @Named("che.infra.openshift.trust_certs") boolean doTrustCerts) {
+      @Nullable @Named("che.infra.openshift.master_url") String masterUrl,
+      @Nullable @Named("che.infra.openshift.username") String username,
+      @Nullable @Named("che.infra.openshift.password") String password,
+      @Nullable @Named("che.infra.openshift.trust_certs") Boolean doTrustCerts) {
     config = new Config();
     if (!isNullOrEmpty(masterUrl)) {
       config.setMasterUrl(masterUrl);
@@ -41,7 +42,9 @@ public class OpenShiftClientFactory {
       config.setPassword(password);
     }
 
-    config.setTrustCerts(doTrustCerts);
+    if (doTrustCerts != null) {
+      config.setTrustCerts(doTrustCerts);
+    }
   }
 
   public OpenShiftClient create() {


### PR DESCRIPTION

### What does this PR do?
Using default config for OpenShiftClient creation if no properties specified


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6306

#### Changelog
N/A

#### Release Notes
N/A

#### Docs PR
N/A
