### PR TITLE
Update to mockito 2.10

### DIFF
--- a/agents/che-core-api-agent/src/test/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncherTest.java
+++ b/agents/che-core-api-agent/src/test/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncherTest.java
@@ -10,11 +10,11 @@
  */
 package org.eclipse.che.api.agent.server.launcher;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -62,8 +62,9 @@ public class AbstractAgentLauncherTest {
     when(agent.getScript()).thenReturn("script content");
     doReturn(process)
         .when(launcher)
-        .start(any(Instance.class), any(Agent.class), any(LineConsumer.class));
-    when(agentChecker.isLaunched(any(Agent.class), any(InstanceProcess.class), any(Instance.class)))
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
+    when(agentChecker.isLaunched(
+            nullable(Agent.class), nullable(InstanceProcess.class), nullable(Instance.class)))
         .thenReturn(true);
     when(machine.getNode()).thenReturn(mock(InstanceNode.class));
   }
@@ -135,7 +136,7 @@ public class AbstractAgentLauncherTest {
     launcher = spy(new TestAgentLauncher(200, 100, agentChecker));
     doReturn(process)
         .when(launcher)
-        .start(any(Instance.class), any(Agent.class), any(LineConsumer.class));
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
     when(agentChecker.isLaunched(any(Agent.class), any(InstanceProcess.class), any(Instance.class)))
         .thenReturn(false)
         .thenReturn(false)
@@ -158,7 +159,7 @@ public class AbstractAgentLauncherTest {
     launcher = spy(new TestAgentLauncher(200, 10, agentChecker));
     doReturn(process)
         .when(launcher)
-        .start(any(Instance.class), any(Agent.class), any(LineConsumer.class));
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
     // record time of each check of agent state
     ArrayList<Long> checkTimestamps = new ArrayList<>(5);
     Answer<Boolean> recordTimestampAndReturnFalse =
@@ -253,8 +254,9 @@ public class AbstractAgentLauncherTest {
     String agentScript = "testAgentScript";
     when(agent.getId()).thenReturn(agentId);
     when(agent.getScript()).thenReturn(agentScript);
-    when(launcher.start(any(Instance.class), any(Agent.class), any(LineConsumer.class)))
-        .thenCallRealMethod();
+    doCallRealMethod()
+        .when(launcher)
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
 
     // when
     launcher.launch(machine, agent);
@@ -275,7 +277,7 @@ public class AbstractAgentLauncherTest {
 
     doReturn(process)
         .when(launcher)
-        .start(any(Instance.class), any(Agent.class), any(LineConsumer.class));
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
 
     // when
     try {
@@ -283,7 +285,9 @@ public class AbstractAgentLauncherTest {
       fail("Should throw AgentStartException");
     } catch (AgentStartException e) {
       // then
-      verify(launcher).logAsErrorAgentStartLogs(anyObject(), anyString(), anyString());
+      verify(launcher)
+          .logAsErrorAgentStartLogs(
+              nullable(Instance.class), nullable(String.class), nullable(String.class));
       // rethrow exception to verify message
       throw e;
     }
@@ -297,15 +301,17 @@ public class AbstractAgentLauncherTest {
     // given
     doThrow(new MachineException("An error on agent start"))
         .when(launcher)
-        .start(any(Instance.class), any(Agent.class), any(LineConsumer.class));
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
 
     // when
     try {
       launcher.launch(machine, agent);
       fail("Should throw ServerException");
+      verify(launcher)
+          .logAsErrorAgentStartLogs(
+              nullable(Instance.class), nullable(String.class), nullable(String.class));
     } catch (ServerException e) {
       // then
-      verify(launcher).logAsErrorAgentStartLogs(anyObject(), anyString(), anyString());
       // rethrow exception to verify message
       throw e;
     }
@@ -324,7 +330,7 @@ public class AbstractAgentLauncherTest {
 
     doReturn(process)
         .when(launcher)
-        .start(any(Instance.class), any(Agent.class), any(LineConsumer.class));
+        .start(nullable(Instance.class), nullable(Agent.class), nullable(LineConsumer.class));
     doThrow(new MachineException("An error on process kill")).when(process).kill();
 
     // when
@@ -333,7 +339,9 @@ public class AbstractAgentLauncherTest {
       fail("Should throw ServerException");
     } catch (ServerException e) {
       // then
-      verify(launcher).logAsErrorAgentStartLogs(anyObject(), anyString(), anyString());
+      verify(launcher)
+          .logAsErrorAgentStartLogs(
+              nullable(Instance.class), nullable(String.class), nullable(String.class));
       // rethrow exception to verify message
       throw e;
     }

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -300,7 +300,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/che-core-api-core/pom.xml
+++ b/core/che-core-api-core/pom.xml
@@ -154,11 +154,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiverTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiverTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -75,6 +76,8 @@ public class JsonRpcMessageReceiverTest {
     when(jsonRpcQualifier.isJsonRpcResponse(MESSAGE)).thenReturn(true);
     when(jsonRpcQualifier.isJsonRpcRequest(MESSAGE)).thenReturn(false);
     when(jsonRpcUnmarshaller.unmarshalArray(any())).thenReturn(singletonList(MESSAGE));
+    JsonRpcResponse jsonRpcResponse = Mockito.mock(JsonRpcResponse.class);
+    when(jsonRpcUnmarshaller.unmarshalResponse(any())).thenReturn(jsonRpcResponse);
 
     jsonRpcMessageReceiver.receive(ENDPOINT_ID, MESSAGE);
 

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
@@ -13,9 +13,8 @@ package org.eclipse.che.api.core.rest;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.core.util.LinksHelper.createLink;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -98,8 +97,13 @@ public class DefaultHttpJsonRequestTest {
     final DefaultHttpJsonRequest request = spy(new DefaultHttpJsonRequest(link));
     doReturn(new DefaultHttpJsonResponse("", 200))
         .when(request)
-        .doRequest(anyInt(), anyString(), anyString(), anyObject(), any(), anyString());
-
+        .doRequest(
+            anyInt(),
+            anyString(),
+            anyString(),
+            nullable(Object.class),
+            nullable(List.class),
+            nullable(String.class));
     request.request();
 
     verify(request).doRequest(0, DEFAULT_URL, "POST", null, null, null);
@@ -365,6 +369,12 @@ public class DefaultHttpJsonRequestTest {
   private void prepareResponse(String response) throws Exception {
     doReturn(new DefaultHttpJsonResponse(response, 200))
         .when(request)
-        .doRequest(anyInt(), anyString(), anyString(), anyObject(), any(), anyString());
+        .doRequest(
+            anyInt(),
+            anyString(),
+            anyString(),
+            nullable(Object.class),
+            nullable(List.class),
+            nullable(String.class));
   }
 }

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/util/lineconsumer/ConcurrentCompositeLineConsumerTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/util/lineconsumer/ConcurrentCompositeLineConsumerTest.java
@@ -32,6 +32,8 @@ import org.eclipse.che.commons.test.mockito.answer.WaitingAnswer;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;
 import org.mockito.testng.MockitoTestNGListener;
 import org.mockito.verification.VerificationMode;
@@ -260,8 +262,10 @@ public class ConcurrentCompositeLineConsumerTest {
    * verify(someMock, last()).someMethod();
    * </code></pre>
    */
-  private static VerificationMode last() {
-    return (verificationData) -> {
+  public static class Last implements VerificationMode {
+    public Last() {}
+
+    public void verify(VerificationData verificationData) {
       List<Invocation> invocations = verificationData.getAllInvocations();
       InvocationMatcher invocationMatcher = verificationData.getWanted();
 
@@ -276,6 +280,14 @@ public class ConcurrentCompositeLineConsumerTest {
       if (!invocationMatcher.matches(invocation)) {
         throw new MockitoException("\nWanted but not invoked:\n" + invocationMatcher);
       }
-    };
+    }
+
+    public VerificationMode description(String description) {
+      return VerificationModeFactory.description(this, description);
+    }
+  }
+
+  public static VerificationMode last() {
+    return new Last();
   }
 }

--- a/core/che-core-typescript-dto-maven-plugin/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/pom.xml
@@ -105,7 +105,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/commons/che-core-commons-inject/pom.xml
+++ b/core/commons/che-core-commons-inject/pom.xml
@@ -81,14 +81,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${org.mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${org.mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/commons/che-core-commons-lang/pom.xml
+++ b/core/commons/che-core-commons-lang/pom.xml
@@ -44,11 +44,6 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/ide/che-core-dyna-provider-generator-maven-plugin/pom.xml
+++ b/ide/che-core-dyna-provider-generator-maven-plugin/pom.xml
@@ -92,7 +92,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/action/DefaultActionGroupTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/action/DefaultActionGroupTest.java
@@ -362,7 +362,6 @@ public class DefaultActionGroupTest {
     when(actionManager.getId(eq(secondAction))).thenReturn("secondAction");
 
     defaultActionGroup.add(thirdAction, new Constraints(AFTER, "fourthAction"));
-    when(actionManager.getId(eq(thirdAction))).thenReturn("thirdAction");
 
     // verify order
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
@@ -371,7 +370,6 @@ public class DefaultActionGroupTest {
 
     // add other actions
     defaultActionGroup.add(fourthAction);
-    when(actionManager.getId(eq(thirdAction))).thenReturn("thirdAction");
 
     defaultActionGroup.add(fifthAction, Constraints.FIRST);
     when(actionManager.getId(eq(fifthAction))).thenReturn("fifthAction");

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/editor/changeintercept/changeintercept/CloseCStyleCommentChangeInterceptorTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/editor/changeintercept/changeintercept/CloseCStyleCommentChangeInterceptorTest.java
@@ -82,9 +82,7 @@ public class CloseCStyleCommentChangeInterceptorTest {
 
   @Test
   public void testStartNotEmptyLine() {
-    doReturn("whatever").when(document).getLineContent(0);
     doReturn("s/*").when(document).getLineContent(1);
-    doReturn(" *").when(document).getLineContent(2);
     final TextChange input =
         new TextChange.Builder()
             .from(new TextPosition(1, 3))
@@ -173,8 +171,6 @@ public class CloseCStyleCommentChangeInterceptorTest {
 
   @Test
   public void testPasteWholeCommentStart() {
-    doReturn("/**").when(document).getLineContent(0);
-    doReturn(" *").when(document).getLineContent(1);
     final TextChange input =
         new TextChange.Builder()
             .from(new TextPosition(0, 0))
@@ -187,8 +183,6 @@ public class CloseCStyleCommentChangeInterceptorTest {
 
   @Test
   public void testCloseComment() {
-    doReturn("/**").when(document).getLineContent(0);
-    doReturn(" *").when(document).getLineContent(1);
     final TextChange input =
         new TextChange.Builder()
             .from(new TextPosition(0, 0))

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/project/ProjectServiceClientImplTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/project/ProjectServiceClientImplTest.java
@@ -17,10 +17,12 @@ import static junit.framework.TestCase.assertEquals;
 import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
 import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
 import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -58,6 +60,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
@@ -111,11 +114,11 @@ public class ProjectServiceClientImplTest {
     when(devMachine.getWsAgentBaseUrl()).thenReturn("http://127.0.0.3/api");
 
     when(appContext.getDevMachine()).thenReturn(devMachine);
-    when(loaderFactory.newLoader(any())).thenReturn(messageLoader);
+    when(loaderFactory.newLoader(any(String.class))).thenReturn(messageLoader);
     when(asyncRequest.loader(messageLoader)).thenReturn(asyncRequest);
-    when(asyncRequest.data(any())).thenReturn(asyncRequest);
+    when(asyncRequest.data(any(String.class))).thenReturn(asyncRequest);
     when(asyncRequest.send(unmarshallableItemRef)).thenReturn(itemRefPromise);
-    when(asyncRequest.header(any(), any())).thenReturn(asyncRequest);
+    when(asyncRequest.header(any(String.class), any(String.class))).thenReturn(asyncRequest);
     when(unmarshaller.newUnmarshaller(ItemReference.class)).thenReturn(unmarshallableItemRef);
     when(unmarshaller.newListUnmarshaller(ProjectConfigDto.class))
         .thenReturn(unmarshallablePrjsConf);
@@ -128,13 +131,38 @@ public class ProjectServiceClientImplTest {
     when(unmarshaller.newUnmarshaller(TreeElement.class)).thenReturn(unmarshallableTreeElem);
     when(unmarshaller.newUnmarshaller(ProjectConfigDto.class)).thenReturn(unmarshallablePrjConf);
 
-    when(requestFactory.createGetRequest(anyString())).thenReturn(asyncRequest);
-    when(requestFactory.createPostRequest(anyString(), any(MimeType.class)))
+    when(requestFactory.createGetRequest(any(String.class))).thenReturn(asyncRequest);
+    when(requestFactory.createRequest(
+            any(RequestBuilder.Method.class),
+            any(String.class),
+            any(SourceStorageDto.class),
+            any(Boolean.class)))
         .thenReturn(asyncRequest);
     when(requestFactory.createRequest(
-            any(RequestBuilder.Method.class), anyString(), any(), anyBoolean()))
+            any(RequestBuilder.Method.class), any(String.class), anyList(), any(Boolean.class)))
         .thenReturn(asyncRequest);
-    when(requestFactory.createPostRequest(anyString(), any())).thenReturn(asyncRequest);
+    when(requestFactory.createRequest(
+            any(RequestBuilder.Method.class), any(String.class), any(), any(Boolean.class)))
+        .thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(any(String.class), anyList())).thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(any(String.class), any())).thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(
+            any(String.class), ArgumentMatchers.<List<NewProjectConfigDto>>any()))
+        .thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(any(String.class), nullable(MimeType.class)))
+        .thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(any(String.class), nullable(SourceStorageDto.class)))
+        .thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(any(String.class), nullable(CopyOptions.class)))
+        .thenReturn(asyncRequest);
+    when(requestFactory.createPostRequest(any(String.class), nullable(MoveOptions.class)))
+        .thenReturn(asyncRequest);
+    when(requestFactory.createRequest(
+            any(RequestBuilder.Method.class),
+            any(String.class),
+            any(CopyOptions.class),
+            any(Boolean.class)))
+        .thenReturn(asyncRequest);
   }
 
   @Test

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/wizard/AbstractWizardTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/wizard/AbstractWizardTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Testing {@link AbstractWizard}.
@@ -128,11 +128,9 @@ public class AbstractWizardTest {
   public void testCanCompleteWhenSomePageIsNotCompleted() throws Exception {
     when(page1.isCompleted()).thenReturn(true);
     when(page2.isCompleted()).thenReturn(false);
-    when(page3.isCompleted()).thenReturn(true);
 
     wizard.addPage(page1);
     wizard.addPage(page2);
-    wizard.addPage(page3);
 
     assertEquals(false, wizard.canComplete());
   }
@@ -189,16 +187,12 @@ public class AbstractWizardTest {
   /** In case the wizard has got 3 skipped pages and 1 not skipped page. */
   private void prepareTestCase1() {
     when(page1.canSkip()).thenReturn(false);
-    when(page1.isCompleted()).thenReturn(true);
 
     when(page2.canSkip()).thenReturn(false);
-    when(page2.isCompleted()).thenReturn(true);
 
     when(page3.canSkip()).thenReturn(true);
-    when(page3.isCompleted()).thenReturn(true);
 
     when(page4.canSkip()).thenReturn(false);
-    when(page4.isCompleted()).thenReturn(true);
 
     wizard.addPage(page1);
     wizard.addPage(page2);
@@ -250,16 +244,12 @@ public class AbstractWizardTest {
   /** In case the wizard has got 2 not skipped pages and 2 skipped page. */
   private void prepareTestCase2() {
     when(page1.canSkip()).thenReturn(false);
-    when(page1.isCompleted()).thenReturn(true);
 
     when(page2.canSkip()).thenReturn(false);
-    when(page2.isCompleted()).thenReturn(true);
 
     when(page3.canSkip()).thenReturn(true);
-    when(page3.isCompleted()).thenReturn(true);
 
     when(page4.canSkip()).thenReturn(true);
-    when(page4.isCompleted()).thenReturn(true);
 
     wizard.addPage(page1);
     wizard.addPage(page2);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/WorkspaceSnapshotNotifierTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/WorkspaceSnapshotNotifierTest.java
@@ -11,9 +11,7 @@
 package org.eclipse.che.ide.actions;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -61,7 +59,9 @@ public class WorkspaceSnapshotNotifierTest {
   @Before
   public void setup() throws Exception {
     when(notificationManager.notify(
-            anyString(), any(StatusNotification.Status.class), (DisplayMode) anyObject()))
+            nullable(String.class),
+            nullable(StatusNotification.Status.class),
+            nullable(DisplayMode.class)))
         .thenReturn(notification);
     when(notification.getStatus()).thenReturn(StatusNotification.Status.PROGRESS);
   }
@@ -71,7 +71,7 @@ public class WorkspaceSnapshotNotifierTest {
     snapshotCreator.creationStarted();
 
     verify(notificationManager)
-        .notify(anyString(), eq(StatusNotification.Status.PROGRESS), eq(FLOAT_MODE));
+        .notify(nullable(String.class), eq(StatusNotification.Status.PROGRESS), eq(FLOAT_MODE));
   }
 
   @Test

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/page/goal/GoalPageTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/page/goal/GoalPageTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.ide.command.editor.page.goal;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -137,14 +137,14 @@ public class GoalPageTest {
     // given
     InputDialog inputDialog = mock(InputDialog.class);
     when(dialogFactory.createInputDialog(
-            anyString(),
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
             eq(0),
             eq(0),
-            anyString(),
-            any(InputCallback.class),
-            any(CancelCallback.class)))
+            nullable(String.class),
+            nullable(InputCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(inputDialog);
     String newGoalId = "new goal";
 
@@ -155,14 +155,14 @@ public class GoalPageTest {
     ArgumentCaptor<InputCallback> inputCaptor = ArgumentCaptor.forClass(InputCallback.class);
     verify(dialogFactory)
         .createInputDialog(
-            anyString(),
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
             eq(0),
             eq(0),
-            anyString(),
+            nullable(String.class),
             inputCaptor.capture(),
-            isNull(CancelCallback.class));
+            isNull());
     verify(inputDialog).show();
     inputCaptor.getValue().accepted(newGoalId);
     verify(view).setGoal(eq(newGoalId));

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/explorer/CommandsExplorerPresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/explorer/CommandsExplorerPresenterTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.command.explorer;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -253,7 +254,10 @@ public class CommandsExplorerPresenterTest {
     // given
     ConfirmDialog confirmDialog = mock(ConfirmDialog.class);
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), any(ConfirmCallback.class), any(CancelCallback.class)))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
     ArgumentCaptor<ConfirmCallback> confirmCallbackCaptor =
         ArgumentCaptor.forClass(ConfirmCallback.class);
@@ -261,7 +265,7 @@ public class CommandsExplorerPresenterTest {
     CommandImpl command = mock(CommandImpl.class);
     String cmdName = "build";
     when(command.getName()).thenReturn(cmdName);
-    when(commandManager.removeCommand(anyString())).thenReturn(voidPromise);
+    when(commandManager.removeCommand(nullable(String.class))).thenReturn(voidPromise);
 
     // when
     presenter.onCommandRemove(command);
@@ -269,10 +273,10 @@ public class CommandsExplorerPresenterTest {
     // then
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
-            isNull(CancelCallback.class));
+            isNull());
     confirmCallbackCaptor.getValue().accepted();
     verify(confirmDialog).show();
     verify(commandManager).removeCommand(cmdName);
@@ -282,7 +286,10 @@ public class CommandsExplorerPresenterTest {
   public void shouldNotRemoveCommandWhenCancelled() throws Exception {
     ConfirmDialog confirmDialog = mock(ConfirmDialog.class);
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), any(ConfirmCallback.class), any(CancelCallback.class)))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
     CommandImpl command = mock(CommandImpl.class);
 
@@ -290,7 +297,10 @@ public class CommandsExplorerPresenterTest {
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(), anyString(), any(ConfirmCallback.class), isNull(CancelCallback.class));
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            isNull());
     verify(confirmDialog).show();
     verify(commandManager, never()).removeCommand(anyString());
   }
@@ -300,12 +310,15 @@ public class CommandsExplorerPresenterTest {
     // given
     ConfirmDialog confirmDialog = mock(ConfirmDialog.class);
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), any(ConfirmCallback.class), any(CancelCallback.class)))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
     ArgumentCaptor<ConfirmCallback> confirmCallbackCaptor =
         ArgumentCaptor.forClass(ConfirmCallback.class);
 
-    when(commandManager.removeCommand(anyString())).thenReturn(voidPromise);
+    when(commandManager.removeCommand(nullable(String.class))).thenReturn(voidPromise);
 
     // when
     presenter.onCommandRemove(mock(CommandImpl.class));
@@ -313,10 +326,11 @@ public class CommandsExplorerPresenterTest {
     // then
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
-            isNull(CancelCallback.class));
+            isNull());
+
     confirmCallbackCaptor.getValue().accepted();
 
     verify(voidPromise).catchError(errorOperationCaptor.capture());

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenterTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
@@ -146,10 +147,9 @@ public class EditorPartStackPresenterTest {
     when(partPresenter3.getEditorInput()).thenReturn(editorInput3);
     when(editorInput3.getFile()).thenReturn(file3);
 
-    when(presentationFactory.getPresentation((Action) anyObject())).thenReturn(presentation);
+    when(presentationFactory.getPresentation(nullable(Action.class))).thenReturn(presentation);
 
-    when(eventBus.addHandler((Event.Type<Object>) anyObject(), anyObject()))
-        .thenReturn(handlerRegistration);
+    when(eventBus.addHandler(any(), any())).thenReturn(handlerRegistration);
 
     when(actionManager.getAction(EditorActions.SPLIT_HORIZONTALLY))
         .thenReturn(splitHorizontallyAction);
@@ -159,15 +159,15 @@ public class EditorPartStackPresenterTest {
     when(closeAllTabsPaneAction.getTemplatePresentation()).thenReturn(presentation);
     when(splitHorizontallyAction.getTemplatePresentation()).thenReturn(presentation);
     when(splitVerticallyAction.getTemplatePresentation()).thenReturn(presentation);
-    when(editorPaneMenuItemFactory.createMenuItem((Action) anyObject()))
+    when(editorPaneMenuItemFactory.createMenuItem((Action) any()))
         .thenReturn(editorPaneActionMenuItem);
-    when(editorPaneMenuItemFactory.createMenuItem((TabItem) anyObject()))
+    when(editorPaneMenuItemFactory.createMenuItem((TabItem) any()))
         .thenReturn(editorPaneTabMenuItem);
 
     Container container = mock(Container.class);
     Promise promise = mock(Promise.class);
     when(appContext.getWorkspaceRoot()).thenReturn(container);
-    when(container.getFile(any(Path.class))).thenReturn(promise);
+    when(container.getFile(nullable(Path.class))).thenReturn(promise);
 
     when(appContext.getDevMachine()).thenReturn(mock(DevMachine.class));
 
@@ -437,6 +437,6 @@ public class EditorPartStackPresenterTest {
 
     presenter.paneMenuTabItemHandler.onCloseButtonClicked(editorPaneTabMenuItem);
 
-    verify(editorAgent).closeEditor(any(EditorPartPresenter.class));
+    verify(editorAgent).closeEditor(nullable(EditorPartPresenter.class));
   }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projectimport/wizard/ProjectImportOutputJsonRpcNotifierTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projectimport/wizard/ProjectImportOutputJsonRpcNotifierTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.projectimport.wizard;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -101,14 +102,15 @@ public class ProjectImportOutputJsonRpcNotifierTest {
   @Test
   public void testShouldUnSubscribeFromDisplayingNotification() throws Exception {
     //given
-    when(constant.importProjectMessageSuccess(anyString())).thenReturn("message");
+    when(constant.importProjectMessageSuccess(nullable(String.class))).thenReturn("message");
     final StatusNotification statusNotification = mock(StatusNotification.class);
-    when(notificationManager.notify(anyString(), any(Status.class), any(DisplayMode.class)))
+    when(notificationManager.notify(
+            nullable(String.class), nullable(Status.class), nullable(DisplayMode.class)))
         .thenReturn(statusNotification);
     final MethodNameConfigurator methodNameConfigurator = mock(MethodNameConfigurator.class);
     when(configurator.newConfiguration()).thenReturn(methodNameConfigurator);
     final ParamsConfigurator paramsConfigurator = mock(ParamsConfigurator.class);
-    when(methodNameConfigurator.methodName(anyString())).thenReturn(paramsConfigurator);
+    when(methodNameConfigurator.methodName(nullable(String.class))).thenReturn(paramsConfigurator);
     final ResultConfiguratorFromOne resultConfiguratorFromOne =
         mock(ResultConfiguratorFromOne.class);
     when(paramsConfigurator.paramsAsDto(any())).thenReturn(resultConfiguratorFromOne);
@@ -132,12 +134,13 @@ public class ProjectImportOutputJsonRpcNotifierTest {
 
     //given
     final StatusNotification statusNotification = mock(StatusNotification.class);
-    when(notificationManager.notify(anyString(), any(Status.class), any(DisplayMode.class)))
+    when(notificationManager.notify(
+            nullable(String.class), nullable(Status.class), nullable(DisplayMode.class)))
         .thenReturn(statusNotification);
     final MethodNameConfigurator methodNameConfigurator = mock(MethodNameConfigurator.class);
     when(configurator.newConfiguration()).thenReturn(methodNameConfigurator);
     final ParamsConfigurator paramsConfigurator = mock(ParamsConfigurator.class);
-    when(methodNameConfigurator.methodName(anyString())).thenReturn(paramsConfigurator);
+    when(methodNameConfigurator.methodName(nullable(String.class))).thenReturn(paramsConfigurator);
     final ResultConfiguratorFromOne resultConfiguratorFromOne =
         mock(ResultConfiguratorFromOne.class);
     when(paramsConfigurator.paramsAsDto(any())).thenReturn(resultConfiguratorFromOne);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projectimport/zip/ZipImporterPagePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projectimport/zip/ZipImporterPagePresenterTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.ide.projectimport.zip;
 
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -67,10 +67,10 @@ public class ZipImporterPagePresenterTest {
     presenter.go(container);
 
     verify(container).setWidget(eq(view));
-    verify(view).setProjectName(anyString());
-    verify(view).setProjectDescription(anyString());
-    verify(view).setProjectUrl(anyString());
-    verify(view).setSkipFirstLevel(anyBoolean());
+    verify(view).setProjectName(nullable(String.class));
+    verify(view).setProjectDescription(nullable(String.class));
+    verify(view).setProjectUrl(nullable(String.class));
+    verify(view).setSkipFirstLevel(nullable(Boolean.class));
     verify(view).setInputsEnableState(eq(true));
     verify(view).focusInUrlInput();
   }
@@ -82,7 +82,7 @@ public class ZipImporterPagePresenterTest {
 
     presenter.projectUrlChanged(INCORRECT_URL);
 
-    verify(view).showUrlError(anyString());
+    verify(view).showUrlError(nullable(String.class));
     verify(delegate).updateControls();
   }
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/search/FullTextSearchPresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/search/FullTextSearchPresenterTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.ide.search;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -84,11 +84,11 @@ public class FullTextSearchPresenterTest {
   public void searchShouldBeSuccessfullyFinished() throws Exception {
     when(view.getPathToSearch()).thenReturn("/search");
     when(appContext.getWorkspaceRoot()).thenReturn(workspaceRoot);
-    when(workspaceRoot.getContainer(any(Path.class))).thenReturn(optionalContainerPromise);
-    when(searchContainer.search(any(QueryExpression.class))).thenReturn(searchResultPromise);
-    when(searchContainer.createSearchQueryExpression(anyString(), anyString()))
+    when(workspaceRoot.getContainer(nullable(Path.class))).thenReturn(optionalContainerPromise);
+    when(searchContainer.search(nullable(QueryExpression.class))).thenReturn(searchResultPromise);
+    when(searchContainer.createSearchQueryExpression(
+            nullable(String.class), nullable(String.class)))
         .thenReturn(queryExpression);
-
     fullTextSearchPresenter.search(SEARCHED_TEXT);
 
     verify(optionalContainerPromise).then(optionalContainerCaptor.capture());
@@ -108,9 +108,10 @@ public class FullTextSearchPresenterTest {
     when(view.getPathToSearch()).thenReturn("/search");
     when(view.isWholeWordsOnly()).thenReturn(false);
     when(appContext.getWorkspaceRoot()).thenReturn(workspaceRoot);
-    when(workspaceRoot.getContainer(any(Path.class))).thenReturn(optionalContainerPromise);
-    when(searchContainer.search(any(QueryExpression.class))).thenReturn(searchResultPromise);
-    when(searchContainer.createSearchQueryExpression(anyString(), anyString()))
+    when(workspaceRoot.getContainer(nullable(Path.class))).thenReturn(optionalContainerPromise);
+    when(searchContainer.search(nullable(QueryExpression.class))).thenReturn(searchResultPromise);
+    when(searchContainer.createSearchQueryExpression(
+            nullable(String.class), nullable(String.class)))
         .thenReturn(queryExpression);
 
     final String search = NameGenerator.generate("test", 10);
@@ -124,7 +125,7 @@ public class FullTextSearchPresenterTest {
 
     verify(searchContainer).search(queryExpression);
     verify(view).isWholeWordsOnly();
-    verify(view, never()).showErrorMessage(anyString());
+    verify(view, never()).showErrorMessage(nullable(String.class));
     verify(view).close();
     verify(findResultPresenter).handleResponse(eq(searchResult), eq(queryExpression), eq(search));
   }
@@ -134,9 +135,10 @@ public class FullTextSearchPresenterTest {
     when(view.getPathToSearch()).thenReturn("/search");
     when(view.isWholeWordsOnly()).thenReturn(true);
     when(appContext.getWorkspaceRoot()).thenReturn(workspaceRoot);
-    when(workspaceRoot.getContainer(any(Path.class))).thenReturn(optionalContainerPromise);
-    when(searchContainer.search(any(QueryExpression.class))).thenReturn(searchResultPromise);
-    when(searchContainer.createSearchQueryExpression(anyString(), anyString()))
+    when(workspaceRoot.getContainer(nullable(Path.class))).thenReturn(optionalContainerPromise);
+    when(searchContainer.search(nullable(QueryExpression.class))).thenReturn(searchResultPromise);
+    when(searchContainer.createSearchQueryExpression(
+            nullable(String.class), nullable(String.class)))
         .thenReturn(queryExpression);
 
     final String search = NameGenerator.generate("test", 10);
@@ -159,7 +161,7 @@ public class FullTextSearchPresenterTest {
   public void searchHasDoneWithSomeError() throws Exception {
     when(view.getPathToSearch()).thenReturn("/search");
     when(appContext.getWorkspaceRoot()).thenReturn(workspaceRoot);
-    when(workspaceRoot.getContainer(any(Path.class))).thenReturn(optionalContainerPromise);
+    when(workspaceRoot.getContainer(nullable(Path.class))).thenReturn(optionalContainerPromise);
 
     fullTextSearchPresenter.search(SEARCHED_TEXT);
 
@@ -179,9 +181,10 @@ public class FullTextSearchPresenterTest {
 
     when(view.getPathToSearch()).thenReturn("/search");
     when(appContext.getWorkspaceRoot()).thenReturn(workspaceRoot);
-    when(workspaceRoot.getContainer(any(Path.class))).thenReturn(optionalContainerPromise);
-    when(searchContainer.search(any(QueryExpression.class))).thenReturn(searchResultPromise);
-    when(searchContainer.createSearchQueryExpression(anyString(), anyString()))
+    when(workspaceRoot.getContainer(nullable(Path.class))).thenReturn(optionalContainerPromise);
+    when(searchContainer.search(nullable(QueryExpression.class))).thenReturn(searchResultPromise);
+    when(searchContainer.createSearchQueryExpression(
+            nullable(String.class), nullable(String.class)))
         .thenReturn(queryExpression);
     List<SearchItemReference> result = Collections.emptyList();
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.ide.statepersistance;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
@@ -143,7 +143,7 @@ public class AppStateManagerTest {
     workspace.put("component1", comp1);
     comp1.put("key1", "value1");
 
-    when(promiseProvider.resolve(any(Void.class))).thenReturn(sequentialRestore);
+    when(promiseProvider.resolve(nullable(Void.class))).thenReturn(sequentialRestore);
 
     appStateManager.restoreWorkspaceState(WS_ID);
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspacePresenterTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.workspace.create;
 import static org.eclipse.che.ide.workspace.create.CreateWorkspacePresenter.MAX_COUNT;
 import static org.eclipse.che.ide.workspace.create.CreateWorkspacePresenter.RECIPE_TYPE;
 import static org.eclipse.che.ide.workspace.create.CreateWorkspacePresenter.SKIP_COUNT;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -62,7 +63,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /** @author Dmitry Shnurenko */
 @RunWith(MockitoJUnitRunner.class)
@@ -109,20 +110,9 @@ public class CreateWorkspacePresenterTest {
     workspaceConfigDto = mock(WorkspaceConfigDto.class, new SelfReturningAnswer());
     when(usersWorkspaceDto.getConfig()).thenReturn(workspaceConfigDto);
 
-    when(dtoFactory.createDto(MachineSourceDto.class)).thenReturn(machineSourceDto);
-    when(machineSourceDto.withType(anyString())).thenReturn(machineSourceDto);
-    when(machineSourceDto.withLocation(anyString())).thenReturn(machineSourceDto);
-
-    when(dtoFactory.createDto(MachineLimitsDto.class)).thenReturn(limitsDto);
-    when(limitsDto.withRam(anyInt())).thenReturn(limitsDto);
-
-    when(dtoFactory.createDto(MachineConfigDto.class)).thenReturn(machineConfigDto);
-
     when(dtoFactory.createDto(EnvironmentDto.class)).thenReturn(environmentDto);
-
     when(dtoFactory.createDto(WorkspaceConfigDto.class)).thenReturn(workspaceConfigDto);
 
-    when(dtoFactory.createDto(WorkspaceDto.class)).thenReturn(usersWorkspaceDto);
     environmentDto = mock(EnvironmentDto.class, new SelfReturningAnswer());
     when(dtoFactory.createDto(EnvironmentDto.class)).thenReturn(environmentDto);
     environmentRecipeDto = mock(EnvironmentRecipeDto.class, new SelfReturningAnswer());
@@ -147,7 +137,7 @@ public class CreateWorkspacePresenterTest {
     presenter.show(Collections.singletonList(usersWorkspaceDto), componentCallback);
 
     verify(browserAddress).getWorkspaceName();
-    verify(view).setWorkspaceName(anyString());
+    verify(view).setWorkspaceName(nullable(String.class));
 
     verify(view).show();
   }
@@ -274,11 +264,10 @@ public class CreateWorkspacePresenterTest {
   }
 
   private void clickOnCreateButton() {
-    when(workspaceClient.create(Matchers.<WorkspaceConfigDto>anyObject(), anyString()))
+    when(workspaceClient.create(Matchers.<WorkspaceConfigDto>any(), nullable(String.class)))
         .thenReturn(userWsPromise);
-    when(userWsPromise.then(Matchers.<Operation<WorkspaceDto>>anyObject()))
-        .thenReturn(userWsPromise);
-    when(userWsPromise.catchError(Matchers.<Operation<PromiseError>>anyObject()))
+    when(userWsPromise.then(Matchers.<Operation<WorkspaceDto>>any())).thenReturn(userWsPromise);
+    when(userWsPromise.catchError(Matchers.<Operation<PromiseError>>any()))
         .thenReturn(userWsPromise);
     when(recipeServiceClient.getAllRecipes()).thenReturn(recipesPromise);
 
@@ -287,7 +276,7 @@ public class CreateWorkspacePresenterTest {
     presenter.onCreateButtonClicked();
 
     verify(recipeServiceClient).getAllRecipes();
-    verify(recipesPromise).then(Matchers.<Operation<List<RecipeDescriptor>>>anyObject());
+    verify(recipesPromise).then(Matchers.<Operation<List<RecipeDescriptor>>>any());
 
     verify(view).show();
   }
@@ -306,8 +295,6 @@ public class CreateWorkspacePresenterTest {
 
   @Test
   public void workspaceShouldBeCreatedForDevMachine() throws Exception {
-    when(machineConfigDto.isDev()).thenReturn(true);
-
     callApplyCreateWorkspaceMethod();
 
     verify(wsComponentProvider).get();
@@ -318,9 +305,6 @@ public class CreateWorkspacePresenterTest {
     Map<String, EnvironmentDto> environments = new HashMap<>();
     environments.put("name", environmentDto);
 
-    when(workspaceConfigDto.getDefaultEnv()).thenReturn("name");
-    when(workspaceConfigDto.getEnvironments()).thenReturn(environments);
-
     clickOnCreateButton();
 
     verify(userWsPromise).then(workspaceOperation.capture());
@@ -329,8 +313,6 @@ public class CreateWorkspacePresenterTest {
 
   @Test
   public void workspaceShouldBeCreatedForNotDevMachine() throws Exception {
-    when(machineConfigDto.isDev()).thenReturn(false);
-
     callApplyCreateWorkspaceMethod();
 
     verify(workspaceComponent).startWorkspace(usersWorkspaceDto, componentCallback);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspaceViewImplTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/CreateWorkspaceViewImplTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +73,7 @@ public class CreateWorkspaceViewImplTest {
 
   @Test
   public void nameShouldBeSet() {
-    verify(view.wsName).setText(anyString());
+    verify(view.wsName).setText(nullable(String.class));
     verify(locale).createWsDefaultName();
   }
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/recipewidget/RecipeWidgetImplTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/workspace/create/recipewidget/RecipeWidgetImplTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.ide.workspace.create.recipewidget;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -57,8 +58,8 @@ public class RecipeWidgetImplTest {
     verify(descriptor).getName();
     verify(descriptor).getType();
 
-    verify(tag.tagName).setText(anyString());
-    verify(tag.type).setText(anyString());
+    verify(tag.tagName).setText(nullable(String.class));
+    verify(tag.type).setText(nullable(String.class));
 
     verify(resources).recipe();
     verify(tag.icon).getElement();

--- a/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenterTest.java
+++ b/ide/che-core-ide-ui/src/test/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenterTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.ide.ui.dialogs.input;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -74,7 +75,7 @@ public class InputDialogPresenterTest extends BaseTest {
 
     verify(view).closeDialog();
     verify(view).getValue();
-    verify(inputCallback).accepted(anyString());
+    verify(inputCallback).accepted(nullable(String.class));
   }
 
   @Test
@@ -153,7 +154,7 @@ public class InputDialogPresenterTest extends BaseTest {
 
     verify(view, never()).showErrorHint(anyString());
     verify(view).closeDialog();
-    verify(inputCallback).accepted(anyString());
+    verify(inputCallback).accepted(nullable(String.class));
   }
 
   @Test

--- a/multiuser/api/che-multiuser-api-authorization-impl/pom.xml
+++ b/multiuser/api/che-multiuser-api-authorization-impl/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/multiuser/api/che-multiuser-api-authorization/pom.xml
+++ b/multiuser/api/che-multiuser-api-authorization/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/OrganizationManagerTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/OrganizationManagerTest.java
@@ -249,7 +249,7 @@ public class OrganizationManagerTest {
     doReturn(new Page<>(singletonList(member1), 0, 1, 2))
         .doReturn(new Page<>(singletonList(member2), 1, 1, 2))
         .when(memberDao)
-        .getMembers(anyString(), anyInt(), anyInt());
+        .getMembers(anyString(), anyInt(), anyLong());
 
     manager.removeMembers("org1");
 
@@ -266,7 +266,7 @@ public class OrganizationManagerTest {
     doReturn(new Page<>(singletonList(subOrg1), 0, 1, 2))
         .doReturn(new Page<>(singletonList(subOrg2), 1, 1, 2))
         .when(organizationDao)
-        .getByParent(anyString(), anyInt(), anyInt());
+        .getByParent(anyString(), anyInt(), anyLong());
 
     manager.removeSuborganizations("org1");
 
@@ -326,7 +326,7 @@ public class OrganizationManagerTest {
   @Test
   public void shouldGetOrganizationsByParent() throws Exception {
     final OrganizationImpl toFetch = new OrganizationImpl("org321", "toFetchOrg", "org123");
-    when(organizationDao.getByParent(eq("org123"), anyInt(), anyInt()))
+    when(organizationDao.getByParent(eq("org123"), anyInt(), anyLong()))
         .thenReturn(new Page<>(singletonList(toFetch), 0, 1, 1));
 
     final Page<? extends Organization> organizations = manager.getByParent("org123", 30, 0);
@@ -339,7 +339,7 @@ public class OrganizationManagerTest {
   @Test
   public void shouldGetSuborganizations() throws Exception {
     final OrganizationImpl toFetch = new OrganizationImpl("org321", "parent/toFetchOrg", "org123");
-    when(organizationDao.getSuborganizations(eq("parent"), anyInt(), anyInt()))
+    when(organizationDao.getSuborganizations(eq("parent"), anyInt(), anyLong()))
         .thenReturn(new Page<>(singletonList(toFetch), 0, 1, 1));
 
     final Page<? extends Organization> organizations = manager.getSuborganizations("parent", 30, 0);
@@ -362,7 +362,7 @@ public class OrganizationManagerTest {
   @Test
   public void shouldGetOrganizationsByMember() throws Exception {
     final OrganizationImpl toFetch = new OrganizationImpl("org123", "toFetchOrg", "org321");
-    when(memberDao.getOrganizations(eq("org123"), anyInt(), anyInt()))
+    when(memberDao.getOrganizations(eq("org123"), anyInt(), anyLong()))
         .thenReturn(new Page<>(singletonList(toFetch), 0, 1, 1));
 
     final Page<? extends Organization> organizations = manager.getByMember("org123", 30, 0);

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/OrganizationServiceTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/OrganizationServiceTest.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.toList;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -260,7 +261,7 @@ public class OrganizationServiceTest {
 
     doReturn(new Page<>(singletonList(toFetch), 0, 1, 1))
         .when(orgManager)
-        .getByParent(anyString(), anyInt(), anyInt());
+        .getByParent(anyString(), anyInt(), anyLong());
 
     final Response response =
         given()

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationNotificationEmailSenderTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationNotificationEmailSenderTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.multiuser.organization.api.notification;
 
 import static java.util.Arrays.*;
 import static java.util.Collections.emptyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -123,7 +124,7 @@ public class OrganizationNotificationEmailSenderTest {
     MemberImpl member2 = new MemberImpl("user2", "org123", ImmutableList.of());
     doReturn(new Page<Member>(asList(member1, member2), 0, 2, 2))
         .when(organizationManager)
-        .getMembers(anyString(), anyInt(), anyInt());
+        .getMembers(anyString(), anyInt(), anyLong());
 
     when(userManager.getById("user1"))
         .thenReturn(new UserImpl("user1", "email1", null, null, emptyList()));
@@ -156,7 +157,7 @@ public class OrganizationNotificationEmailSenderTest {
     MemberImpl member2 = new MemberImpl("user2", "org123", emptyList());
     doReturn(new Page<Member>(asList(member1, member2), 0, 2, 2))
         .when(organizationManager)
-        .getMembers(anyString(), anyInt(), anyInt());
+        .getMembers(anyString(), anyInt(), anyLong());
 
     when(userManager.getById("user1")).thenThrow(new NotFoundException(""));
     when(userManager.getById("user2"))

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/resource/OrganizationalAccountAvailableResourcesProviderTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/resource/OrganizationalAccountAvailableResourcesProviderTest.java
@@ -41,7 +41,6 @@ import org.eclipse.che.multiuser.resource.api.exception.NoEnoughResourcesExcepti
 import org.eclipse.che.multiuser.resource.api.usage.ResourceUsageManager;
 import org.eclipse.che.multiuser.resource.model.Resource;
 import org.eclipse.che.multiuser.resource.spi.impl.ResourceImpl;
-import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -244,12 +243,6 @@ public class OrganizationalAccountAvailableResourcesProviderTest {
     doReturn(singletonList(availableResource))
         .when(availableResourcesProvider)
         .getAvailableOrganizationResources(
-            argThat(
-                new ArgumentMatcher<Organization>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return organizationId.equals(((Organization) argument).getId());
-                  }
-                }));
+            argThat(argument -> organizationId.equals(((Organization) argument).getId())));
   }
 }

--- a/multiuser/api/che-multiuser-api-permission/src/test/java/org/eclipse/che/multiuser/api/permission/server/AdminPermissionInitializerTest.java
+++ b/multiuser/api/che-multiuser-api-permission/src/test/java/org/eclipse/che/multiuser/api/permission/server/AdminPermissionInitializerTest.java
@@ -81,12 +81,8 @@ public class AdminPermissionInitializerTest {
     verify(permissionsManager)
         .storePermission(
             argThat(
-                new ArgumentMatcher<SystemPermissionsImpl>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((SystemPermissionsImpl) argument).getUserId().equals(NAME);
-                  }
-                }));
+                (ArgumentMatcher<SystemPermissionsImpl>)
+                    argument -> argument.getUserId().equals(NAME)));
   }
 
   @Test
@@ -112,12 +108,9 @@ public class AdminPermissionInitializerTest {
     verify(permissionsManager)
         .storePermission(
             argThat(
-                new ArgumentMatcher<SystemPermissionsImpl>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((SystemPermissionsImpl) argument).getUserId().equals(adminUser.getId());
-                  }
-                }));
+                (ArgumentMatcher<SystemPermissionsImpl>)
+                    argument ->
+                        ((SystemPermissionsImpl) argument).getUserId().equals(adminUser.getId())));
   }
 
   @Test

--- a/multiuser/api/che-multiuser-api-permission/src/test/java/org/eclipse/che/multiuser/api/permission/server/PermissionsManagerTest.java
+++ b/multiuser/api/che-multiuser-api-permission/src/test/java/org/eclipse/che/multiuser/api/permission/server/PermissionsManagerTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.multiuser.api.permission.server;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.multiuser.api.permission.server.AbstractPermissionsDomain.SET_PERMISSIONS;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -131,7 +132,7 @@ public class PermissionsManagerTest {
     doReturn(new Page<>(singletonList(foreignPermissions), 0, 1, 2))
         .doReturn(new Page<>(singletonList(ownPermissions), 1, 1, 2))
         .when(permissionsDao)
-        .getByInstance(anyString(), anyInt(), anyInt());
+        .getByInstance(nullable(String.class), nullable(Integer.class), nullable(Long.class));
 
     permissionsManager.storePermission(
         new TestPermissionsImpl("user", "test", "test123", singletonList("delete")));
@@ -150,7 +151,7 @@ public class PermissionsManagerTest {
     doReturn(new Page<>(singletonList(ownPermissions), 0, 30, 31))
         .doReturn(new Page<>(singletonList(foreignPermissions), 1, 30, 31))
         .when(permissionsDao)
-        .getByInstance(anyString(), anyInt(), anyInt());
+        .getByInstance(nullable(String.class), nullable(Integer.class), nullable(Long.class));
 
     permissionsManager.storePermission(
         new TestPermissionsImpl("user", "test", "test123", singletonList("delete")));
@@ -193,7 +194,7 @@ public class PermissionsManagerTest {
     doReturn(new Page<>(singletonList(firstPermissions), 0, 1, 2))
         .doReturn(new Page<>(singletonList(secondPermissions), 1, 1, 2))
         .when(permissionsDao)
-        .getByInstance(anyString(), anyInt(), anyInt());
+        .getByInstance(nullable(String.class), nullable(Integer.class), nullable(Long.class));
 
     permissionsManager.remove("user", "test", "test123");
   }
@@ -228,7 +229,7 @@ public class PermissionsManagerTest {
 
     doReturn(new Page<>(asList(firstPermissions, secondPermissions), 1, 2, 4))
         .when(permissionsDao)
-        .getByInstance(anyString(), anyInt(), anyInt());
+        .getByInstance(nullable(String.class), nullable(Integer.class), nullable(Long.class));
 
     final Page<AbstractPermissions> permissionsPage =
         permissionsManager.getByInstance("test", "test123", 2, 1);

--- a/multiuser/permission/che-multiuser-permission-factory/src/test/java/org/eclipse/che/multiuser/permission/factory/FactoryPermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-factory/src/test/java/org/eclipse/che/multiuser/permission/factory/FactoryPermissionsFilterTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDom
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -69,7 +70,7 @@ public class FactoryPermissionsFilterTest {
             .get(SECURE_PATH + "/factory/workspace/workspace123");
 
     assertEquals(response.getStatusCode(), 204);
-    verify(service).getFactoryJson(eq("workspace123"), anyString());
+    verify(service).getFactoryJson(eq("workspace123"), nullable(String.class));
     verify(subject).checkPermission(DOMAIN_ID, "workspace123", READ);
   }
 

--- a/multiuser/permission/che-multiuser-permission-machine/src/test/java/org/eclipse/che/multiuser/permission/machine/filters/RecipePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-machine/src/test/java/org/eclipse/che/multiuser/permission/machine/filters/RecipePermissionsFilterTest.java
@@ -17,9 +17,9 @@ import static org.eclipse.che.multiuser.permission.machine.recipe.RecipeDomain.U
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import java.lang.reflect.Method;
+import java.util.List;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.rest.ApiExceptionMapper;
 import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
@@ -188,7 +189,7 @@ public class RecipePermissionsFilterTest {
             .get(SECURE_PATH + "/recipe");
 
     assertEquals(response.getStatusCode(), 200);
-    verify(service).searchRecipes(anyListOf(String.class), anyString(), anyInt(), anyInt());
+    verify(service).searchRecipes(nullable(List.class), nullable(String.class), anyInt(), anyInt());
     verifyZeroInteractions(subject);
   }
 

--- a/multiuser/permission/che-multiuser-permission-resource/src/test/java/org/eclipse/che/multiuser/permission/resource/filters/FreeResourcesLimitServicePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-resource/src/test/java/org/eclipse/che/multiuser/permission/resource/filters/FreeResourcesLimitServicePermissionsFilterTest.java
@@ -14,9 +14,9 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -74,7 +74,9 @@ public class FreeResourcesLimitServicePermissionsFilterTest {
   public void setUp() throws Exception {
     filter = new FreeResourcesLimitServicePermissionsFilter();
 
-    when(subject.hasPermission(anyString(), anyString(), anyString())).thenReturn(true);
+    when(subject.hasPermission(
+            nullable(String.class), nullable(String.class), nullable(String.class)))
+        .thenReturn(true);
   }
 
   @Test
@@ -176,7 +178,9 @@ public class FreeResourcesLimitServicePermissionsFilterTest {
   @Test(dataProvider = "coveredPaths")
   public void shouldReturn403WhenUserDoesNotHaveRequiredPermission(String path, String method)
       throws Exception {
-    when(subject.hasPermission(anyString(), anyString(), anyString())).thenReturn(false);
+    when(subject.hasPermission(
+            nullable(String.class), nullable(String.class), nullable(String.class)))
+        .thenReturn(false);
 
     Response response =
         request(

--- a/multiuser/permission/che-multiuser-permission-resource/src/test/java/org/eclipse/che/multiuser/permission/resource/filters/ResourceUsageServicePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-resource/src/test/java/org/eclipse/che/multiuser/permission/resource/filters/ResourceUsageServicePermissionsFilterTest.java
@@ -14,8 +14,8 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -115,7 +115,7 @@ public class ResourceUsageServicePermissionsFilterTest {
         .when()
         .get(SECURE_PATH + "/resource/free/account123");
 
-    verify(freeResourcesLimitService).getFreeResourcesLimit(anyString());
+    verify(freeResourcesLimitService).getFreeResourcesLimit(nullable(String.class));
   }
 
   @Test
@@ -163,7 +163,9 @@ public class ResourceUsageServicePermissionsFilterTest {
   @Test(dataProvider = "coveredPaths")
   public void shouldDenyRequestWhenUserDoesNotHasPermissionsToSeeResources(String path)
       throws Exception {
-    doThrow(new ForbiddenException("Forbidden")).when(checker).checkPermissions(anyString(), any());
+    doThrow(new ForbiddenException("Forbidden"))
+        .when(checker)
+        .checkPermissions(nullable(String.class), any());
 
     given()
         .auth()
@@ -179,7 +181,9 @@ public class ResourceUsageServicePermissionsFilterTest {
   @Test(dataProvider = "coveredPaths")
   public void shouldNotCheckPermissionsOnAccountLevelWhenUserHasManageCodenvyPermission(String path)
       throws Exception {
-    when(subject.hasPermission(anyString(), anyString(), anyString())).thenReturn(true);
+    when(subject.hasPermission(
+            nullable(String.class), nullable(String.class), nullable(String.class)))
+        .thenReturn(true);
 
     given()
         .auth()

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/StackPermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/StackPermissionsFilterTest.java
@@ -19,11 +19,10 @@ import static org.eclipse.che.multiuser.permission.workspace.server.stack.StackD
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -40,6 +39,7 @@ import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.List;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.rest.ApiExceptionMapper;
@@ -172,7 +172,7 @@ public class StackPermissionsFilterTest {
             .get(SECURE_PATH + "/stack");
 
     assertEquals(response.getStatusCode(), 200);
-    verify(service).searchStacks(anyListOf(String.class), anyInt(), anyInt());
+    verify(service).searchStacks(nullable(List.class), anyInt(), anyInt());
     verifyZeroInteractions(subject);
   }
 
@@ -263,7 +263,9 @@ public class StackPermissionsFilterTest {
   @Test(dataProvider = "coveredPaths")
   public void shouldThrowForbiddenExceptionWhenUserDoesNotHavePermissionsForPerformOperation(
       String path, String method, String action) throws Exception {
-    when(subject.hasPermission(anyString(), anyString(), anyString())).thenReturn(false);
+    when(subject.hasPermission(
+            nullable(String.class), nullable(String.class), nullable(String.class)))
+        .thenReturn(false);
 
     Response response =
         request(
@@ -281,10 +283,12 @@ public class StackPermissionsFilterTest {
   @Test(dataProvider = "coveredPaths")
   public void shouldAllowToAdminPerformAnyActionWithPredefinedStack(
       String path, String method, String action) throws Exception {
-    when(subject.hasPermission(eq(DOMAIN_ID), anyString(), anyString())).thenReturn(false);
-    when(subject.hasPermission(eq(SystemDomain.DOMAIN_ID), anyString(), anyString()))
+    when(subject.hasPermission(eq(DOMAIN_ID), nullable(String.class), nullable(String.class)))
+        .thenReturn(false);
+    when(subject.hasPermission(
+            eq(SystemDomain.DOMAIN_ID), nullable(String.class), nullable(String.class)))
         .thenReturn(true);
-    doReturn(true).when(permissionsFilter).isStackPredefined(anyString());
+    doReturn(true).when(permissionsFilter).isStackPredefined(nullable(String.class));
 
     Response response =
         request(
@@ -301,10 +305,12 @@ public class StackPermissionsFilterTest {
   @Test(dataProvider = "coveredPaths")
   public void shouldNotAllowToAdminPerformAnyActionWithNonPredefinedStack(
       String path, String method, String action) throws Exception {
-    when(subject.hasPermission(eq(DOMAIN_ID), anyString(), anyString())).thenReturn(false);
-    when(subject.hasPermission(eq(SystemDomain.DOMAIN_ID), anyString(), anyString()))
+    when(subject.hasPermission(eq(DOMAIN_ID), nullable(String.class), nullable(String.class)))
+        .thenReturn(false);
+    when(subject.hasPermission(
+            eq(SystemDomain.DOMAIN_ID), nullable(String.class), nullable(String.class)))
         .thenReturn(true);
-    doReturn(false).when(permissionsFilter).isStackPredefined(anyString());
+    doReturn(false).when(permissionsFilter).isStackPredefined(nullable(String.class));
 
     Response response =
         request(
@@ -337,7 +343,8 @@ public class StackPermissionsFilterTest {
     final Page<AbstractPermissions> permissionsPage = mock(Page.class);
     when(permissionsPage.getItems()).thenReturn(Collections.singletonList(stackPermission));
 
-    when(permissionsManager.getByInstance(anyString(), anyString(), anyInt(), anyInt()))
+    when(permissionsManager.getByInstance(
+            nullable(String.class), nullable(String.class), anyInt(), anyLong()))
         .thenReturn(permissionsPage);
 
     assertTrue(permissionsFilter.isStackPredefined("stack123"));
@@ -351,7 +358,8 @@ public class StackPermissionsFilterTest {
     final Page<AbstractPermissions> permissionsPage = mock(Page.class);
     when(permissionsPage.getItems()).thenReturn(Collections.singletonList(stackPermission));
 
-    when(permissionsManager.getByInstance(anyString(), anyString(), anyInt(), anyInt()))
+    when(permissionsManager.getByInstance(
+            nullable(String.class), nullable(String.class), anyInt(), anyLong()))
         .thenReturn(permissionsPage);
 
     assertFalse(permissionsFilter.isStackPredefined("stack123"));
@@ -381,7 +389,8 @@ public class StackPermissionsFilterTest {
         .when(permissionsFilter)
         .getNextPermissionsPage(stackId, permissionsPage1);
     doReturn(null).when(permissionsFilter).getNextPermissionsPage(stackId, permissionsPage2);
-    when(permissionsManager.getByInstance(anyString(), anyString(), anyInt(), anyInt()))
+    when(permissionsManager.getByInstance(
+            nullable(String.class), nullable(String.class), anyInt(), anyLong()))
         .thenReturn(permissionsPage1);
 
     assertTrue(permissionsFilter.isStackPredefined(stackId));

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspacePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspacePermissionsFilterTest.java
@@ -14,6 +14,7 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -42,6 +43,7 @@ import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceService;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -224,7 +226,7 @@ public class WorkspacePermissionsFilterTest {
             .get(SECURE_PATH + "/workspace");
 
     assertEquals(response.getStatusCode(), 200);
-    verify(workspaceService).getWorkspaces(any(), anyInt(), anyString());
+    verify(workspaceService).getWorkspaces(any(), anyInt(), nullable(String.class));
     verify(permissionsFilter, never()).checkAccountPermissions(anyString(), any());
     verifyZeroInteractions(subject);
   }
@@ -284,7 +286,8 @@ public class WorkspacePermissionsFilterTest {
             .post(SECURE_PATH + "/workspace/{id}/runtime");
 
     assertEquals(response.getStatusCode(), 204);
-    verify(workspaceService).startById(eq("workspace123"), anyString(), any());
+    verify(workspaceService)
+        .startById(eq("workspace123"), nullable(String.class), nullable(Boolean.class));
     verify(subject).hasPermission(eq("workspace"), eq("workspace123"), eq("run"));
   }
 
@@ -507,7 +510,8 @@ public class WorkspacePermissionsFilterTest {
             .post(SECURE_PATH + "/workspace/{id}/environment");
 
     assertEquals(response.getStatusCode(), 204);
-    verify(workspaceService).addEnvironment(eq("workspace123"), any(), anyString());
+    verify(workspaceService)
+        .addEnvironment(eq("workspace123"), nullable(EnvironmentDto.class), nullable(String.class));
     verify(subject).hasPermission(eq("workspace"), eq("workspace123"), eq("configure"));
   }
 

--- a/multiuser/personal-account/pom.xml
+++ b/multiuser/personal-account/pom.xml
@@ -81,11 +81,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/BaseTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/BaseTest.java
@@ -25,14 +25,14 @@ import org.eclipse.che.ide.websocket.MessageBus;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Base test for java debugger extension.
  *
  * @author Artem Zatsarynnyi
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public abstract class BaseTest {
   public static final String HOST = "some.host";
   public static final int PORT = 8000;

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/actions/DebugActionTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/actions/DebugActionTest.java
@@ -18,7 +18,6 @@ import com.google.common.base.Optional;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.ide.api.debug.DebugConfiguration;
-import org.eclipse.che.ide.api.debug.DebugConfigurationType;
 import org.eclipse.che.ide.api.debug.DebugConfigurationsManager;
 import org.eclipse.che.ide.api.dialogs.DialogFactory;
 import org.eclipse.che.ide.debug.DebuggerManager;
@@ -52,13 +51,9 @@ public class DebugActionTest {
   @Test
   public void actionShouldBePerformed() {
     DebugConfiguration debugConfiguration = mock(DebugConfiguration.class);
-    when(debugConfiguration.getType()).thenReturn(mock(DebugConfigurationType.class));
-    when(debugConfiguration.getHost()).thenReturn("localhost");
-    when(debugConfiguration.getPort()).thenReturn(8000);
     Map<String, String> connectionProperties = new HashMap<>();
     connectionProperties.put("prop1", "val1");
     connectionProperties.put("prop2", "val2");
-    when(debugConfiguration.getConnectionProperties()).thenReturn(connectionProperties);
     Optional configurationOptional = mock(Optional.class);
     when(configurationOptional.isPresent()).thenReturn(Boolean.TRUE);
     when(configurationOptional.get()).thenReturn(debugConfiguration);

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImplTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationsManagerImplTest.java
@@ -10,9 +10,9 @@
  */
 package org.eclipse.che.plugin.debugger.ide.configuration;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -62,7 +62,8 @@ public class DebugConfigurationsManagerImplTest extends TestCase {
   @Test
   public void testShouldNotApplyConfigurationIfActiveDebuggerExists() throws Exception {
     when(debuggerManager.getActiveDebugger()).thenReturn(mock(Debugger.class));
-    when(dialogFactory.createMessageDialog(anyString(), anyString(), (ConfirmCallback) isNull()))
+    when(dialogFactory.createMessageDialog(
+            nullable(String.class), nullable(String.class), (ConfirmCallback) isNull()))
         .thenReturn(mock(MessageDialog.class));
 
     debugConfigurationsManager.apply(debugConfiguration);

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenterTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenterTest.java
@@ -12,9 +12,9 @@ package org.eclipse.che.plugin.debugger.ide.debug;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -44,11 +44,14 @@ import org.eclipse.che.plugin.debugger.ide.BaseTest;
 import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
 import org.eclipse.che.plugin.debugger.ide.DebuggerResources;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Testing {@link DebuggerPresenter} functionality.
@@ -56,6 +59,9 @@ import org.mockito.Mockito;
  * @author Dmytro Nochevnov
  */
 public class DebuggerPresenterTest extends BaseTest {
+
+  @Rule public MockitoRule mrule = MockitoJUnit.rule().silent();
+
   private static final long THREAD_ID = 1;
   private static final int FRAME_INDEX = 0;
 
@@ -89,7 +95,6 @@ public class DebuggerPresenterTest extends BaseTest {
   @Before
   public void setup() {
     when(debuggerManager.getActiveDebugger()).thenReturn(debugger);
-    when(debugger.isSuspended()).thenReturn(true);
     doReturn(true).when(debugger).isSuspended();
 
     presenter =
@@ -108,8 +113,6 @@ public class DebuggerPresenterTest extends BaseTest {
     Mockito.reset(view);
     when(view.getSelectedThreadId()).thenReturn(THREAD_ID);
     when(view.getSelectedFrameIndex()).thenReturn(FRAME_INDEX);
-
-    doNothing().when(presenter).showDebuggerPanel();
   }
 
   @Test
@@ -164,7 +167,7 @@ public class DebuggerPresenterTest extends BaseTest {
     operationThreadDumpCaptor.getValue().apply(threadDump);
     verify(presenter).updateStackFrameDump(THREAD_ID);
     verify(presenter).updateVariables(THREAD_ID, 0);
-    verify(view).setThreadDump(eq(threadDump), anyInt());
+    verify(view).setThreadDump(eq(threadDump), anyLong());
   }
 
   @Test
@@ -187,9 +190,9 @@ public class DebuggerPresenterTest extends BaseTest {
     doReturn(promiseVoid).when(promiseVoid).then((Operation<Void>) any());
     doNothing().when(presenter).showDebuggerPanel();
     when(notificationManager.notify(
-            anyString(),
-            any(StatusNotification.Status.class),
-            any(StatusNotification.DisplayMode.class)))
+            nullable(String.class),
+            nullable(StatusNotification.Status.class),
+            nullable(StatusNotification.DisplayMode.class)))
         .thenReturn(mock(StatusNotification.class));
 
     presenter.onDebuggerAttached(debuggerDescriptor, promiseVoid);

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -79,6 +80,7 @@ import org.eclipse.che.ide.util.storage.LocalStorage;
 import org.eclipse.che.ide.util.storage.LocalStorageProvider;
 import org.eclipse.che.plugin.debugger.ide.BaseTest;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -87,6 +89,8 @@ import org.mockito.Mock;
 import org.mockito.MockSettings;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.creation.MockSettingsImpl;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Testing {@link AbstractDebugger} functionality.
@@ -97,6 +101,8 @@ import org.mockito.internal.creation.MockSettingsImpl;
  */
 @RunWith(GwtMockitoTestRunner.class)
 public class DebuggerTest extends BaseTest {
+  @Rule public MockitoRule mrule = MockitoJUnit.rule().silent();
+
   private static final String DEBUG_INFO = "debug_info";
   private static final String SESSION_ID = "debugger_id";
   private static final long THREAD_ID = 1;
@@ -479,7 +485,7 @@ public class DebuggerTest extends BaseTest {
 
     SimpleValueDto simpleValueDto = mock(SimpleValueDto.class);
     doReturn(simpleValueDto).when(dtoFactory).createDto(SimpleValueDto.class);
-    doReturn(simpleValueDto).when(simpleValueDto).withString(anyString());
+    doReturn(simpleValueDto).when(simpleValueDto).withString(nullable(String.class));
 
     SimpleValue simpleValue = mock(SimpleValue.class);
     doReturn(simpleValue).when(variable).getValue();

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -13,6 +13,8 @@ package org.eclipse.che.plugin.docker.client;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -191,7 +193,7 @@ public class DockerConnectorTest {
   @BeforeMethod
   public void setup() throws IOException, URISyntaxException {
     dockerConnection = mock(DockerConnection.class, new SelfReturningAnswer());
-    when(dockerConnectionFactory.openConnection(any(URI.class))).thenReturn(dockerConnection);
+    when(dockerConnectionFactory.openConnection(nullable(URI.class))).thenReturn(dockerConnection);
     when(dockerConnection.request()).thenReturn(dockerResponse);
     when(dockerConnectorConfiguration.getAuthConfigs()).thenReturn(initialAuthConfig);
     when(dockerResponse.getStatus()).thenReturn(RESPONSE_SUCCESS_CODE);
@@ -221,7 +223,7 @@ public class DockerConnectorTest {
 
     SystemInfo returnedSystemInfo = dockerConnector.getSystemInfo();
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/info");
     verify(dockerConnection).request();
@@ -275,7 +277,7 @@ public class DockerConnectorTest {
 
     Version returnedVersion = dockerConnector.getVersion();
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/version");
     verify(dockerConnection).request();
@@ -310,7 +312,7 @@ public class DockerConnectorTest {
 
     List<Image> returnedImages = dockerConnector.listImages(listImagesParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/images/json");
     verify(dockerConnection).request();
@@ -366,7 +368,7 @@ public class DockerConnectorTest {
 
     List<ContainerListEntry> containers = dockerConnector.listContainers(listContainersParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/containers/json");
     verify(dockerConnection).query("all", 1);
@@ -462,7 +464,7 @@ public class DockerConnectorTest {
 
     ImageInfo returnedImageInfo = dockerConnector.inspectImage(inspectImageParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/images/" + inspectImageParams.getImage() + "/json");
     verify(dockerConnection).request();
@@ -508,7 +510,7 @@ public class DockerConnectorTest {
 
     dockerConnector.stopContainer(stopContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/containers/" + stopContainerParams.getContainer() + "/stop");
     verify(dockerConnection).request();
@@ -551,7 +553,7 @@ public class DockerConnectorTest {
 
     dockerConnector.killContainer(killContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/containers/" + killContainerParams.getContainer() + "/kill");
     verify(dockerConnection).request();
@@ -581,7 +583,7 @@ public class DockerConnectorTest {
 
     dockerConnector.removeContainer(removeContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_DELETE);
     verify(dockerConnection).path("/containers/" + removeContainerParams.getContainer());
     verify(dockerConnection).request();
@@ -630,7 +632,7 @@ public class DockerConnectorTest {
 
     int returnedExitCode = dockerConnector.waitContainer(waitContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/containers/" + waitContainerParams.getContainer() + "/wait");
     verify(dockerConnection).request();
@@ -683,7 +685,7 @@ public class DockerConnectorTest {
 
     ContainerInfo returnedContainerInfo = dockerConnector.inspectContainer(inspectContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/containers/" + inspectContainerParams.getContainer() + "/json");
     verify(dockerConnection).request();
@@ -732,7 +734,7 @@ public class DockerConnectorTest {
 
     dockerConnector.attachContainer(attachContainerParams, logMessageProcessor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection)
         .path("/containers/" + attachContainerParams.getContainer() + "/attach");
@@ -766,7 +768,7 @@ public class DockerConnectorTest {
 
     dockerConnector.getContainerLogs(getContainerLogsParams, logMessageProcessor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/containers/" + getContainerLogsParams.getContainer() + "/logs");
     verify(dockerConnection).query("stdout", 1);
@@ -819,7 +821,7 @@ public class DockerConnectorTest {
 
     Exec returnedExec = dockerConnector.createExec(createExecParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/containers/" + createExecParams.getContainer() + "/exec");
     verify(dockerConnection).header("Content-Type", MediaType.APPLICATION_JSON);
@@ -855,7 +857,7 @@ public class DockerConnectorTest {
 
     dockerConnector.startExec(startExecParams, logMessageProcessor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/exec/" + startExecParams.getExecId() + "/start");
     verify(dockerConnection).header("Content-Type", MediaType.APPLICATION_JSON);
@@ -923,7 +925,7 @@ public class DockerConnectorTest {
 
     ExecInfo returnedExecInfo = dockerConnector.getExecInfo(getExecInfoParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/exec/" + getExecInfoParams.getExecId() + "/json");
     verify(dockerConnection).request();
@@ -960,7 +962,7 @@ public class DockerConnectorTest {
 
     ContainerProcesses returnedContainerProcesses = dockerConnector.top(topParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/containers/" + topParams.getContainer() + "/top");
     verify(dockerConnection).request();
@@ -982,7 +984,7 @@ public class DockerConnectorTest {
 
     ContainerProcesses returnedContainerProcesses = dockerConnector.top(topParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/containers/" + topParams.getContainer() + "/top");
     verify(dockerConnection).query(eq("ps_args"), anyString());
@@ -1020,7 +1022,7 @@ public class DockerConnectorTest {
     String response =
         CharStreams.toString(new InputStreamReader(dockerConnector.getResource(getResourceParams)));
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/containers/" + getResourceParams.getContainer() + "/archive");
     verify(dockerConnection).query(eq("path"), eq(PATH_TO_FILE));
@@ -1059,12 +1061,12 @@ public class DockerConnectorTest {
 
     dockerConnector.putResource(putResourceParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_PUT);
     verify(dockerConnection).path("/containers/" + putResourceParams.getContainer() + "/archive");
     verify(dockerConnection).query(eq("path"), eq(PATH_TO_FILE));
     verify(dockerConnection).header("Content-Type", ExtMediaType.APPLICATION_X_TAR);
-    verify(dockerConnection).header(eq("Content-Length"), anyInt());
+    verify(dockerConnection).header(eq("Content-Length"), anyLong());
     verify(dockerConnection).entity(any(InputStream.class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
@@ -1098,7 +1100,7 @@ public class DockerConnectorTest {
 
     dockerConnector.getEvents(getEventsParams, eventMessageProcessor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/events");
     verify(dockerConnection).request();
@@ -1142,16 +1144,16 @@ public class DockerConnectorTest {
 
     String returnedImageId = dockerConnector.buildImage(buildImageParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/build");
 
     verify(dockerConnection).header("Content-Type", "application/x-compressed-tar");
-    verify(dockerConnection).header(eq("Content-Length"), anyInt());
+    verify(dockerConnection).header(eq("Content-Length"), anyLong());
     verify(dockerConnection).entity(any(InputStream.class));
     verify(dockerConnection, never()).header(eq("remote"), anyString());
 
-    verify(dockerConnection).header(eq("X-Registry-Config"), any(byte[].class));
+    verify(dockerConnection).header(eq("X-Registry-Config"), nullable(byte[].class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1181,7 +1183,7 @@ public class DockerConnectorTest {
 
     String returnedImageId = dockerConnector.buildImage(buildImageParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/build");
 
@@ -1190,7 +1192,7 @@ public class DockerConnectorTest {
     verify(dockerConnection, never()).header(eq("Content-Length"), anyInt());
     verify(dockerConnection, never()).entity(any(InputStream.class));
 
-    verify(dockerConnection).header(eq("X-Registry-Config"), any(byte[].class));
+    verify(dockerConnection).header(eq("X-Registry-Config"), nullable(byte[].class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1250,15 +1252,17 @@ public class DockerConnectorTest {
 
     String returnedImageId = dockerConnector.buildImage(buildImageParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/build");
 
     verify(dockerConnection).header("Content-Type", "application/x-compressed-tar");
-    verify(dockerConnection).header(eq("Content-Length"), anyInt());
+    verify(dockerConnection).header(eq("Content-Length"), anyLong());
     verify(dockerConnection).entity(any(InputStream.class));
+    verify(dockerConnection, never()).header(eq("remote"), anyString());
 
-    verify(dockerConnection).header(eq("X-Registry-Config"), any(byte[].class));
+    verify(dockerConnection).header(eq("X-Registry-Config"), nullable(byte[].class));
+
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1347,7 +1351,7 @@ public class DockerConnectorTest {
 
     dockerConnector.removeImage(removeImageParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_DELETE);
     verify(dockerConnection).path("/images/" + removeImageParams.getImage());
     verify(dockerConnection).request();
@@ -1375,7 +1379,7 @@ public class DockerConnectorTest {
 
     dockerConnector.tag(tagParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/images/" + tagParams.getImage() + "/tag");
     verify(dockerConnection).query("repo", tagParams.getRepository());
@@ -1409,10 +1413,10 @@ public class DockerConnectorTest {
 
     dockerConnector.push(pushParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/images/" + pushParams.getRepository() + "/push");
-    verify(dockerConnection).header(eq("X-Registry-Auth"), any(AuthConfig.class));
+    verify(dockerConnection).header(eq("X-Registry-Auth"), nullable(AuthConfig.class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1430,11 +1434,11 @@ public class DockerConnectorTest {
 
     dockerConnector.push(pushParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection)
         .path("/images/" + pushParams.getRegistry() + '/' + pushParams.getRepository() + "/push");
-    verify(dockerConnection).header(eq("X-Registry-Auth"), any(AuthConfig.class));
+    verify(dockerConnection).header(eq("X-Registry-Auth"), nullable(AuthConfig.class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1538,7 +1542,7 @@ public class DockerConnectorTest {
 
     String returnedImage = dockerConnector.commit(commitParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/commit");
     verify(dockerConnection).query("container", commitParams.getContainer());
@@ -1573,11 +1577,11 @@ public class DockerConnectorTest {
 
     dockerConnector.pull(pullParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/images/create");
     verify(dockerConnection).query("fromImage", pullParams.getImage());
-    verify(dockerConnection).header(eq("X-Registry-Auth"), any(AuthConfig.class));
+    verify(dockerConnection).header(eq("X-Registry-Auth"), nullable(AuthConfig.class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1592,12 +1596,12 @@ public class DockerConnectorTest {
 
     dockerConnector.pull(pullParams, progressMonitor);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/images/create");
     verify(dockerConnection)
         .query("fromImage", pullParams.getRegistry() + '/' + pullParams.getImage());
-    verify(dockerConnection).header(eq("X-Registry-Auth"), any(AuthConfig.class));
+    verify(dockerConnection).header(eq("X-Registry-Auth"), nullable(AuthConfig.class));
     verify(dockerConnection).request();
     verify(dockerResponse).getStatus();
     verify(dockerResponse).getInputStream();
@@ -1633,7 +1637,7 @@ public class DockerConnectorTest {
     ContainerCreated returnedContainerCreated =
         dockerConnector.createContainer(createContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/containers/create");
     verify(dockerConnection).header("Content-Type", MediaType.APPLICATION_JSON);
@@ -1668,7 +1672,7 @@ public class DockerConnectorTest {
 
     dockerConnector.startContainer(startContainerParams);
 
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/containers/" + startContainerParams.getContainer() + "/start");
     verify(dockerConnection).request();
@@ -1874,7 +1878,7 @@ public class DockerConnectorTest {
 
     // then
     assertEquals(actual, originNetworks);
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/networks");
     verify(dockerConnection).query(eq("filters"), anyObject());
@@ -1925,7 +1929,7 @@ public class DockerConnectorTest {
 
     // then
     assertEquals(actual, originNetwork);
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_GET);
     verify(dockerConnection).path("/networks/" + originNetwork.getId());
     verify(dockerConnection).request();
@@ -1963,7 +1967,7 @@ public class DockerConnectorTest {
 
     // then
     assertEquals(networkCreated, originNetworkCreated);
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/networks/create");
     verify(dockerConnection).header("Content-Type", MediaType.APPLICATION_JSON);
@@ -2023,7 +2027,7 @@ public class DockerConnectorTest {
     dockerConnector.connectContainerToNetwork(connectToNetworkParams);
 
     // then
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/networks/" + netId + "/connect");
     verify(dockerConnection).header("Content-Type", MediaType.APPLICATION_JSON);
@@ -2085,7 +2089,7 @@ public class DockerConnectorTest {
     dockerConnector.disconnectContainerFromNetwork(disconnectFromNetworkParams);
 
     // then
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_POST);
     verify(dockerConnection).path("/networks/" + netId + "/disconnect");
     verify(dockerConnection).header("Content-Type", MediaType.APPLICATION_JSON);
@@ -2140,7 +2144,7 @@ public class DockerConnectorTest {
     dockerConnector.removeNetwork(removeNetworkParams);
 
     // then
-    verify(dockerConnectionFactory).openConnection(any(URI.class));
+    verify(dockerConnectionFactory).openConnection(nullable(URI.class));
     verify(dockerConnection).method(REQUEST_METHOD_DELETE);
     verify(dockerConnection).path("/networks/" + netId);
     verify(dockerConnection).request();

--- a/plugins/plugin-docker/che-plugin-docker-compose/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-compose/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/test/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenterTest.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/test/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenterTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.plugin.gdb.ide.configuration;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -78,7 +78,7 @@ public class GdbConfigurationPagePresenterTest {
     verify(configuration, atLeastOnce()).getConnectionProperties();
     verify(pageView).setHost(eq(HOST));
     verify(pageView).setPort(eq(PORT));
-    verify(pageView).setBinaryPath(anyString());
+    verify(pageView).setBinaryPath(nullable(String.class));
     verify(pageView).setDevHost(eq(false));
     verify(pageView).setPortEnableState(eq(true));
     verify(pageView).setHostEnableState(eq(true));

--- a/plugins/plugin-gdb/che-plugin-gdb-server/pom.xml
+++ b/plugins/plugin-gdb/che-plugin-gdb-server/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/authenticator/GitHubAuthenticatorImplTest.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/authenticator/GitHubAuthenticatorImplTest.java
@@ -14,7 +14,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMod
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
 import static org.mockito.Mockito.mock;
@@ -89,8 +89,9 @@ public class GitHubAuthenticatorImplTest {
     sshPairDTOsPromise = createPromise();
     voidPromise = createPromise();
 
-    when(sshServiceClient.getPairs(anyString())).thenReturn(sshPairDTOsPromise);
-    when(sshServiceClient.deletePair(anyString(), anyString())).thenReturn(voidPromise);
+    when(sshServiceClient.getPairs(nullable(String.class))).thenReturn(sshPairDTOsPromise);
+    when(sshServiceClient.deletePair(nullable(String.class), nullable(String.class)))
+        .thenReturn(voidPromise);
   }
 
   private Promise createPromise() {
@@ -190,7 +191,7 @@ public class GitHubAuthenticatorImplTest {
     verify(view).isGenerateKeysSelected();
     verify(registry).getUploader(eq(GITHUB_HOST));
     verify(appContext).getCurrentUser();
-    verify(notificationManager).notify(anyString(), eq(SUCCESS), eq(FLOAT_MODE));
+    verify(notificationManager).notify(nullable(String.class), eq(SUCCESS), eq(FLOAT_MODE));
   }
 
   @Test
@@ -210,7 +211,7 @@ public class GitHubAuthenticatorImplTest {
     when(user.getProfile()).thenReturn(profile);
     when(profile.getUserId()).thenReturn(userId);
     when(dialogFactory.createMessageDialog(
-            anyString(), anyString(), Matchers.<ConfirmCallback>anyObject()))
+            nullable(String.class), nullable(String.class), Matchers.<ConfirmCallback>anyObject()))
         .thenReturn(messageDialog);
 
     gitHubAuthenticator.authenticate(null, getCallBack());
@@ -224,7 +225,8 @@ public class GitHubAuthenticatorImplTest {
     verify(registry).getUploader(eq(GITHUB_HOST));
     verify(appContext).getCurrentUser();
     verify(dialogFactory)
-        .createMessageDialog(anyString(), anyString(), Matchers.<ConfirmCallback>anyObject());
+        .createMessageDialog(
+            nullable(String.class), nullable(String.class), Matchers.<ConfirmCallback>anyObject());
     verify(messageDialog).show();
     verify(sshServiceClient).getPairs(eq(SshKeyManagerPresenter.VCS_SSH_SERVICE));
   }
@@ -248,7 +250,7 @@ public class GitHubAuthenticatorImplTest {
     when(user.getProfile()).thenReturn(profile);
     when(profile.getUserId()).thenReturn(userId);
     when(dialogFactory.createMessageDialog(
-            anyString(), anyString(), Matchers.<ConfirmCallback>anyObject()))
+            nullable(String.class), nullable(String.class), Matchers.<ConfirmCallback>anyObject()))
         .thenReturn(messageDialog);
     when(pair.getName()).thenReturn(GITHUB_HOST);
     when(pair.getService()).thenReturn(SshKeyManagerPresenter.VCS_SSH_SERVICE);
@@ -267,7 +269,8 @@ public class GitHubAuthenticatorImplTest {
     verify(registry).getUploader(eq(GITHUB_HOST));
     verify(appContext).getCurrentUser();
     verify(dialogFactory)
-        .createMessageDialog(anyString(), anyString(), Matchers.<ConfirmCallback>anyObject());
+        .createMessageDialog(
+            nullable(String.class), nullable(String.class), Matchers.<ConfirmCallback>anyObject());
     verify(messageDialog).show();
     verify(sshServiceClient).getPairs(eq(SshKeyManagerPresenter.VCS_SSH_SERVICE));
     verify(sshServiceClient)

--- a/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.plugin.github.ide.importer.page;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -126,8 +127,8 @@ public class GithubImporterPagePresenterTest {
                 locale));
     doReturn(Collections.singletonList(gitHubUser))
         .when(presenter)
-        .toOrgList(any(JsArrayMixed.class));
-    doReturn(Collections.emptyList()).when(presenter).toRepoList(any(JsArrayMixed.class));
+        .toOrgList(nullable(JsArrayMixed.class));
+    doReturn(Collections.emptyList()).when(presenter).toRepoList(nullable(JsArrayMixed.class));
     presenter.setUpdateDelegate(updateDelegate);
     presenter.init(dataObject);
   }
@@ -163,7 +164,7 @@ public class GithubImporterPagePresenterTest {
               }
             })
         .when(presenter)
-        .doRequest(any(Promise.class), any(Promise.class), any(Promise.class));
+        .doRequest(nullable(Promise.class), nullable(Promise.class), nullable(Promise.class));
     when(view.getAccountName()).thenReturn("AccountName");
 
     presenter.onLoadRepoClicked();
@@ -193,7 +194,7 @@ public class GithubImporterPagePresenterTest {
               }
             })
         .when(presenter)
-        .doRequest(any(Promise.class), any(Promise.class), any(Promise.class));
+        .doRequest(nullable(Promise.class), nullable(Promise.class), nullable(Promise.class));
 
     presenter.onLoadRepoClicked();
 
@@ -510,7 +511,7 @@ public class GithubImporterPagePresenterTest {
               }
             })
         .when(presenter)
-        .doRequest(any(Promise.class), any(Promise.class), any(Promise.class));
+        .doRequest(nullable(Promise.class), nullable(Promise.class), nullable(Promise.class));
     doReturn(exception).when(promiseError).getCause();
 
     presenter.onLoadRepoClicked();
@@ -550,7 +551,7 @@ public class GithubImporterPagePresenterTest {
               }
             })
         .when(presenter)
-        .doRequest(any(Promise.class), any(Promise.class), any(Promise.class));
+        .doRequest(nullable(Promise.class), nullable(Promise.class), nullable(Promise.class));
     final Throwable exception = mock(UnauthorizedException.class);
     String userId = "userId";
     CurrentUser user = mock(CurrentUser.class);

--- a/plugins/plugin-github/che-plugin-github-pullrequest/pom.xml
+++ b/plugins/plugin-github/che-plugin-github-pullrequest/pom.xml
@@ -107,7 +107,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>mockito-all</artifactId>
+                    <artifactId>mockito-core</artifactId>
                     <groupId>org.mockito</groupId>
                 </exclusion>
             </exclusions>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcilerStrategyTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/editor/JavaReconcilerStrategyTest.java
@@ -12,7 +12,7 @@ package org.eclipse.che.ide.ext.java.client.editor;
 
 import static org.eclipse.che.ide.project.ResolvingProjectStateHolder.ResolvingProjectState.IN_PROGRESS;
 import static org.eclipse.che.ide.project.ResolvingProjectStateHolder.ResolvingProjectState.RESOLVED;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -89,22 +89,21 @@ public class JavaReconcilerStrategyTest {
 
     when(editor.getEditorInput()).thenReturn(editorInput);
     when(editorInput.getFile()).thenReturn(file);
-    when(file.getName()).thenReturn(FILE_NAME);
     when(file.getProject()).thenReturn(project);
     when(file.getLocation()).thenReturn(Path.valueOf(FILE_PATH));
 
     when(project.getPath()).thenReturn(PROJECT_PATH);
-    when(file.getParentWithMarker(any())).thenReturn(srcFolder);
+    when(file.getParentWithMarker(nullable(String.class))).thenReturn(srcFolder);
     when(srcFolder.isPresent()).thenReturn(true);
     when(srcFolder.get()).thenReturn(startPoint);
     when(startPoint.getLocation()).thenReturn(Path.valueOf("some/path"));
 
-    when(resolvingProjectStateHolderRegistry.getResolvingProjectStateHolder(anyString()))
+    when(resolvingProjectStateHolderRegistry.getResolvingProjectStateHolder(nullable(String.class)))
         .thenReturn(resolvingProjectStateHolder);
     when(localizationConstant.codeAssistErrorMessageResolvingProject()).thenReturn("error");
 
     when(client.reconcile(anyString(), anyString())).thenReturn(reconcileResultPromise);
-    when(reconcileResultPromise.onSuccess(Matchers.<Consumer<ReconcileResult>>anyObject()))
+    when(reconcileResultPromise.onSuccess(Matchers.<Consumer<ReconcileResult>>any()))
         .thenReturn(reconcileResultPromise);
 
     javaReconcilerStrategy.setDocument(mock(Document.class));

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MovePresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MovePresenterTest.java
@@ -17,10 +17,10 @@ import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringSta
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.INFO;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.OK;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.WARNING;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -220,11 +220,11 @@ public class MovePresenterTest {
 
     presenter.onPreviewButtonClicked();
 
-    verify(moveSettings).setSessionId(anyString());
+    verify(moveSettings).setSessionId(nullable(String.class));
     verify(moveSettings).setUpdateReferences(anyBoolean());
     verify(moveSettings).setUpdateQualifiedNames(anyBoolean());
-    verify(moveSettings).setFilePatterns(anyString());
-    verify(session).setSessionId(anyString());
+    verify(moveSettings).setFilePatterns(nullable(String.class));
+    verify(session).setSessionId(nullable(String.class));
 
     verify(moveSettingsPromise).thenPromise(changeCreationFunction.capture());
     changeCreationFunction.getValue().apply(any());
@@ -232,7 +232,7 @@ public class MovePresenterTest {
 
     verify(changeCreationResultPromise).then(changeResultOperation.capture());
     changeResultOperation.getValue().apply(changeCreationResult);
-    verify(previewPresenter).show(anyString(), any());
+    verify(previewPresenter).show(nullable(String.class), any());
     verify(moveView).hide();
   }
 
@@ -245,7 +245,8 @@ public class MovePresenterTest {
 
     verify(locale).showPreviewError();
     verify(promiseError).getMessage();
-    verify(notificationManager).notify(anyString(), anyString(), eq(FAIL), eq(FLOAT_MODE));
+    verify(notificationManager)
+        .notify(nullable(String.class), nullable(String.class), eq(FAIL), eq(FLOAT_MODE));
   }
 
   @Test
@@ -255,11 +256,11 @@ public class MovePresenterTest {
 
     presenter.onPreviewButtonClicked();
 
-    verify(moveSettings).setSessionId(anyString());
+    verify(moveSettings).setSessionId(nullable(String.class));
     verify(moveSettings).setUpdateReferences(anyBoolean());
     verify(moveSettings).setUpdateQualifiedNames(anyBoolean());
-    verify(moveSettings).setFilePatterns(anyString());
-    verify(session).setSessionId(anyString());
+    verify(moveSettings).setFilePatterns(nullable(String.class));
+    verify(session).setSessionId(nullable(String.class));
 
     verify(moveSettingsPromise).thenPromise(changeCreationFunction.capture());
     changeCreationFunction.getValue().apply(any());
@@ -267,7 +268,7 @@ public class MovePresenterTest {
 
     verify(changeCreationResultPromise).then(changeResultOperation.capture());
     changeResultOperation.getValue().apply(changeCreationResult);
-    verify(previewPresenter, never()).show(anyString(), any());
+    verify(previewPresenter, never()).show(nullable(String.class), any());
     verify(moveView, never()).hide();
     verify(moveView).showStatusMessage(refactoringStatus);
   }
@@ -280,11 +281,11 @@ public class MovePresenterTest {
 
     presenter.onAcceptButtonClicked();
 
-    verify(moveSettings).setSessionId(anyString());
+    verify(moveSettings).setSessionId(nullable(String.class));
     verify(moveSettings).setUpdateReferences(anyBoolean());
     verify(moveSettings).setUpdateQualifiedNames(anyBoolean());
-    verify(moveSettings).setFilePatterns(anyString());
-    verify(session).setSessionId(anyString());
+    verify(moveSettings).setFilePatterns(nullable(String.class));
+    verify(session).setSessionId(nullable(String.class));
 
     verify(moveSettingsPromise).thenPromise(changeCreationFunction.capture());
     changeCreationFunction.getValue().apply(any());
@@ -305,7 +306,8 @@ public class MovePresenterTest {
 
     verify(locale).applyMoveError();
     verify(promiseError).getMessage();
-    verify(notificationManager).notify(anyString(), anyString(), eq(FAIL), eq(FLOAT_MODE));
+    verify(notificationManager)
+        .notify(nullable(String.class), nullable(String.class), eq(FAIL), eq(FLOAT_MODE));
   }
 
   @Test
@@ -323,11 +325,11 @@ public class MovePresenterTest {
 
     presenter.onAcceptButtonClicked();
 
-    verify(moveSettings).setSessionId(anyString());
+    verify(moveSettings).setSessionId(nullable(String.class));
     verify(moveSettings).setUpdateReferences(anyBoolean());
     verify(moveSettings).setUpdateQualifiedNames(anyBoolean());
-    verify(moveSettings).setFilePatterns(anyString());
-    verify(session).setSessionId(anyString());
+    verify(moveSettings).setFilePatterns(nullable(String.class));
+    verify(session).setSessionId(nullable(String.class));
 
     verify(moveSettingsPromise).thenPromise(changeCreationFunction.capture());
     changeCreationFunction.getValue().apply(any());
@@ -364,11 +366,11 @@ public class MovePresenterTest {
 
     presenter.onAcceptButtonClicked();
 
-    verify(moveSettings).setSessionId(anyString());
+    verify(moveSettings).setSessionId(nullable(String.class));
     verify(moveSettings).setUpdateReferences(anyBoolean());
     verify(moveSettings).setUpdateQualifiedNames(anyBoolean());
-    verify(moveSettings).setFilePatterns(anyString());
-    verify(session).setSessionId(anyString());
+    verify(moveSettings).setFilePatterns(nullable(String.class));
+    verify(session).setSessionId(nullable(String.class));
 
     verify(moveSettingsPromise).thenPromise(changeCreationFunction.capture());
     changeCreationFunction.getValue().apply(any());
@@ -397,7 +399,7 @@ public class MovePresenterTest {
     presenter.setMoveDestinationPath(DESTINATION, PROJECT_PATH);
 
     verify(destination).setType(ReorgDestination.DestinationType.PACKAGE);
-    verify(destination).setSessionId(anyString());
+    verify(destination).setSessionId(nullable(String.class));
     verify(destination).setProjectPath(PROJECT_PATH);
     verify(destination).setDestination(DESTINATION);
 
@@ -415,7 +417,7 @@ public class MovePresenterTest {
     presenter.setMoveDestinationPath(DESTINATION, PROJECT_PATH);
 
     verify(destination).setType(ReorgDestination.DestinationType.PACKAGE);
-    verify(destination).setSessionId(anyString());
+    verify(destination).setSessionId(nullable(String.class));
     verify(destination).setProjectPath(PROJECT_PATH);
     verify(destination).setDestination(DESTINATION);
 
@@ -433,7 +435,7 @@ public class MovePresenterTest {
     presenter.setMoveDestinationPath(DESTINATION, PROJECT_PATH);
 
     verify(destination).setType(ReorgDestination.DestinationType.PACKAGE);
-    verify(destination).setSessionId(anyString());
+    verify(destination).setSessionId(nullable(String.class));
     verify(destination).setProjectPath(PROJECT_PATH);
     verify(destination).setDestination(DESTINATION);
 
@@ -451,7 +453,7 @@ public class MovePresenterTest {
     presenter.setMoveDestinationPath(DESTINATION, PROJECT_PATH);
 
     verify(destination).setType(ReorgDestination.DestinationType.PACKAGE);
-    verify(destination).setSessionId(anyString());
+    verify(destination).setSessionId(nullable(String.class));
     verify(destination).setProjectPath(PROJECT_PATH);
     verify(destination).setDestination(DESTINATION);
 
@@ -472,7 +474,7 @@ public class MovePresenterTest {
     presenter.setMoveDestinationPath(DESTINATION, PROJECT_PATH);
 
     verify(destination).setType(ReorgDestination.DestinationType.PACKAGE);
-    verify(destination).setSessionId(anyString());
+    verify(destination).setSessionId(nullable(String.class));
     verify(destination).setProjectPath(PROJECT_PATH);
     verify(destination).setDestination(DESTINATION);
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/JavaRefactoringRenameTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/JavaRefactoringRenameTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringSta
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.OK;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.RefactoringStatus.WARNING;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyList;
@@ -219,8 +220,6 @@ public class JavaRefactoringRenameTest {
 
   @Test
   public void renameRefactoringShouldBeAppliedSuccessAndShowWizard() throws OperationException {
-    when(result.getSeverity()).thenReturn(OK);
-
     refactoringRename.refactor(textEditor);
     refactoringRename.refactor(textEditor);
 
@@ -235,7 +234,6 @@ public class JavaRefactoringRenameTest {
     PromiseError arg = Mockito.mock(PromiseError.class);
     MessageDialog dialog = Mockito.mock(MessageDialog.class);
 
-    when(result.getSeverity()).thenReturn(OK);
     when(locale.renameRename()).thenReturn("renameTitle");
     when(locale.renameOperationUnavailable()).thenReturn("renameBody");
     when(dialogFactory.createMessageDialog(anyString(), anyString(), anyObject()))
@@ -269,12 +267,12 @@ public class JavaRefactoringRenameTest {
     when(result.getSeverity()).thenReturn(ERROR);
 
     when(dialogFactory.createConfirmDialog(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyString(),
-            Matchers.<ConfirmCallback>anyObject(),
-            Matchers.<CancelCallback>anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     refactoringRename.refactor(textEditor);
@@ -300,10 +298,10 @@ public class JavaRefactoringRenameTest {
     verify(locale).buttonCancel();
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
             Matchers.<ConfirmCallback>anyObject(),
             Matchers.<CancelCallback>anyObject());
     verify(confirmDialog).show();
@@ -315,12 +313,12 @@ public class JavaRefactoringRenameTest {
 
     when(result.getSeverity()).thenReturn(WARNING);
     when(dialogFactory.createConfirmDialog(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyString(),
-            Matchers.<ConfirmCallback>anyObject(),
-            Matchers.<CancelCallback>anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     refactoringRename.refactor(textEditor);
@@ -346,10 +344,10 @@ public class JavaRefactoringRenameTest {
     verify(locale).buttonCancel();
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
             Matchers.<ConfirmCallback>anyObject(),
             Matchers.<CancelCallback>anyObject());
     verify(confirmDialog).show();

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/wizard/RenamePresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/wizard/RenamePresenterTest.java
@@ -13,10 +13,10 @@ package org.eclipse.che.ide.ext.java.client.refactoring.rename.wizard;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.CreateRenameRefactoring.RenameType.COMPILATION_UNIT;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.CreateRenameRefactoring.RenameType.JAVA_ELEMENT;
 import static org.eclipse.che.ide.ext.java.shared.dto.refactoring.CreateRenameRefactoring.RenameType.PACKAGE;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -216,7 +216,7 @@ public class RenamePresenterTest {
     renamePresenter.show(refactorInfo);
 
     verify(createRenameRefactoringDto).setRefactorLightweight(false);
-    verify(createRenameRefactoringDto).setPath(anyString());
+    verify(createRenameRefactoringDto).setPath(nullable(String.class));
     verify(createRenameRefactoringDto).setType(COMPILATION_UNIT);
     verify(createRenameRefactoringDto).setProjectPath(eq("/project"));
 
@@ -225,7 +225,10 @@ public class RenamePresenterTest {
     promiseErrorCaptor.getValue().apply(promiseError);
     verify(notificationManager)
         .notify(
-            anyString(), anyString(), any(StatusNotification.Status.class), any(DisplayMode.class));
+            nullable(String.class),
+            nullable(String.class),
+            any(StatusNotification.Status.class),
+            any(DisplayMode.class));
   }
 
   @Test
@@ -248,7 +251,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameCompilationUnitTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
     verify(view).setVisiblePatternsPanel(true);
     verify(view).setVisibleFullQualifiedNamePanel(true);
     verify(view).setVisibleSimilarlyVariablesPanel(true);
@@ -275,7 +278,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renamePackageTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
     verify(view).setVisiblePatternsPanel(true);
     verify(view).setVisibleFullQualifiedNamePanel(true);
     verify(view).setVisibleRenameSubpackagesPanel(true);
@@ -302,7 +305,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameTypeTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
     verify(view).setVisiblePatternsPanel(true);
     verify(view).setVisibleFullQualifiedNamePanel(true);
     verify(view).setVisibleSimilarlyVariablesPanel(true);
@@ -329,7 +332,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameFieldTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
     verify(view).setVisiblePatternsPanel(true);
 
     verify(view).show();
@@ -354,7 +357,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameEnumTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
     verify(view).setVisiblePatternsPanel(true);
 
     verify(view).show();
@@ -379,7 +382,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameTypeVariableTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
 
     verify(view).show();
   }
@@ -403,7 +406,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameMethodTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
     verify(view).setVisibleKeepOriginalPanel(true);
 
     verify(view).show();
@@ -427,7 +430,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameLocalVariableTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
 
     verify(view).show();
   }
@@ -439,7 +442,7 @@ public class RenamePresenterTest {
     renamePresenter.show((RefactorInfo) null);
 
     verify(createRenameRefactoringDto).setType(JAVA_ELEMENT);
-    verify(createRenameRefactoringDto).setPath(anyString());
+    verify(createRenameRefactoringDto).setPath(nullable(String.class));
     verify(createRenameRefactoringDto).setOffset(2);
 
     verify(refactorService).createRenameRefactoring(createRenameRefactoringDto);
@@ -449,7 +452,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameLocalVariableTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
 
     verify(view).show();
   }
@@ -476,7 +479,7 @@ public class RenamePresenterTest {
     verifyPreparingWizard();
 
     verify(locale).renameCompilationUnitTitle();
-    verify(view).setTitle(anyString());
+    verify(view).setTitle(nullable(String.class));
 
     verify(view).show();
   }
@@ -495,7 +498,7 @@ public class RenamePresenterTest {
 
   private void verifyPreparingRenameRefactoringDto() {
     verify(createRenameRefactoringDto).setRefactorLightweight(false);
-    verify(createRenameRefactoringDto).setPath(anyString());
+    verify(createRenameRefactoringDto).setPath(nullable(String.class));
     verify(createRenameRefactoringDto).setType(COMPILATION_UNIT);
     verify(createRenameRefactoringDto).setProjectPath(eq("/project"));
   }
@@ -545,7 +548,10 @@ public class RenamePresenterTest {
     verify(promiseError).getMessage();
     verify(notificationManager)
         .notify(
-            anyString(), anyString(), any(StatusNotification.Status.class), any(DisplayMode.class));
+            nullable(String.class),
+            nullable(String.class),
+            any(StatusNotification.Status.class),
+            any(DisplayMode.class));
   }
 
   @Test
@@ -677,7 +683,10 @@ public class RenamePresenterTest {
     verify(promiseError).getMessage();
     verify(notificationManager)
         .notify(
-            anyString(), anyString(), any(StatusNotification.Status.class), any(DisplayMode.class));
+            nullable(String.class),
+            nullable(String.class),
+            any(StatusNotification.Status.class),
+            any(DisplayMode.class));
   }
 
   @Test
@@ -703,7 +712,7 @@ public class RenamePresenterTest {
 
     verify(view).hide();
     verify(previewPresenter).show(SESSION_ID, refactorInfo);
-    verify(previewPresenter).setTitle(anyString());
+    verify(previewPresenter).setTitle(nullable(String.class));
   }
 
   @Test
@@ -718,10 +727,10 @@ public class RenamePresenterTest {
     when(refactoringStatus.getEntries()).thenReturn(entries);
     when(refactoringStatus.getSeverity()).thenReturn(2);
     when(dialogFactory.createConfirmDialog(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
             Matchers.<ConfirmCallback>anyObject(),
             Matchers.<CancelCallback>anyObject()))
         .thenReturn(dialog);
@@ -732,10 +741,10 @@ public class RenamePresenterTest {
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
             Matchers.<ConfirmCallback>anyObject(),
             Matchers.<CancelCallback>anyObject());
     verify(dialog).show();
@@ -781,7 +790,7 @@ public class RenamePresenterTest {
     verify(view).isUpdateReferences();
     verify(renameSettings).setUpdateQualifiedNames(true);
     verify(view, times(2)).isUpdateQualifiedNames();
-    verify(renameSettings).setFilePatterns(anyString());
+    verify(renameSettings).setFilePatterns(nullable(String.class));
     verify(renameSettings).setUpdateTextualMatches(anyBoolean());
     verify(view).isUpdateTextualOccurrences();
     verify(renameSettings).setUpdateSimilarDeclarations(true);

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/settings/compiler/JavaCompilerPreferencePresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/settings/compiler/JavaCompilerPreferencePresenterTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.che.ide.ext.java.client.settings.compiler.ErrorWarning
 import static org.eclipse.che.ide.ext.java.client.settings.compiler.ErrorWarningsOptions.USAGE_OF_RAW_TYPE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -224,7 +225,7 @@ public class JavaCompilerPreferencePresenterTest {
     operationCaptor.getValue().apply(getAllProperties());
 
     verify(propertyFactory, times(18)).create(Matchers.<ErrorWarningsOptions>anyObject());
-    verify(widget, times(18)).selectPropertyValue(anyString());
+    verify(widget, times(18)).selectPropertyValue(nullable(String.class));
     verify(widget, times(18)).setDelegate(presenter);
     verify(view, times(18)).addProperty(widget);
   }
@@ -244,6 +245,6 @@ public class JavaCompilerPreferencePresenterTest {
     errorOperationCaptor.getValue().apply(promiseError);
 
     verify(preferencesManager).loadPreferences();
-    verify(notificationManager).notify(anyString(), eq(FAIL), eq(FLOAT_MODE));
+    verify(notificationManager).notify(nullable(String.class), eq(FAIL), eq(FLOAT_MODE));
   }
 }

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/test/java/org/eclipse/che/plugin/maven/client/wizard/MavenPagePresenterTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/test/java/org/eclipse/che/plugin/maven/client/wizard/MavenPagePresenterTest.java
@@ -83,8 +83,6 @@ public class MavenPagePresenterTest {
 
     when(containerPromise.then(Matchers.<Operation<Optional<Container>>>anyObject()))
         .thenReturn(containerPromise);
-    when(containerPromise.catchError(Matchers.<Operation<PromiseError>>anyObject()))
-        .thenReturn(containerPromise);
   }
 
   @Test

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/src/test/java/org/eclipse/che/plugin/nodejsdbg/ide/configuration/NodeJsDebuggerConfigurationPagePresenterTest.java
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-ide/src/test/java/org/eclipse/che/plugin/nodejsdbg/ide/configuration/NodeJsDebuggerConfigurationPagePresenterTest.java
@@ -12,7 +12,7 @@ package org.eclipse.che.plugin.nodejsdbg.ide.configuration;
 
 import static org.eclipse.che.plugin.nodejsdbg.ide.NodeJsDebugger.ConnectionProperties.SCRIPT;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -52,9 +52,6 @@ public class NodeJsDebuggerConfigurationPagePresenterTest {
 
   @Before
   public void setUp() {
-    when(configuration.getHost()).thenReturn(HOST);
-    when(configuration.getPort()).thenReturn(PORT);
-
     pagePresenter.resetFrom(configuration);
   }
 
@@ -72,7 +69,7 @@ public class NodeJsDebuggerConfigurationPagePresenterTest {
 
     verify(container).setWidget(eq(pageView));
     verify(configuration, atLeastOnce()).getConnectionProperties();
-    verify(pageView).setScriptPath(anyString());
+    verify(pageView).setScriptPath(nullable(String.class));
   }
 
   @Test

--- a/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/pom.xml
+++ b/plugins/plugin-nodejs-debugger/che-plugin-nodejs-debugger-server/pom.xml
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-server/pom.xml
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-server/pom.xml
@@ -74,7 +74,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>mockito-all</artifactId>
+                    <artifactId>mockito-core</artifactId>
                     <groupId>org.mockito</groupId>
                 </exclusion>
             </exclusions>

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/src/test/java/org/eclipse/che/plugin/svn/ide/importer/SubversionProjectImporterPresenterTest.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/src/test/java/org/eclipse/che/plugin/svn/ide/importer/SubversionProjectImporterPresenterTest.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.plugin.svn.ide.importer;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -52,7 +52,6 @@ public class SubversionProjectImporterPresenterTest {
    */
   @Before
   public void setUp() throws Exception {
-    when(sourceStorage.getParameters()).thenReturn(parameters);
     when(dataObject.getSource()).thenReturn(sourceStorage);
     when(view.getProjectRelativePath()).thenReturn("");
 
@@ -69,8 +68,6 @@ public class SubversionProjectImporterPresenterTest {
   @Test
   public void testEmptyProjectName() throws Exception {
     final String projectName = "";
-
-    when(view.getProjectName()).thenReturn(projectName);
 
     presenter.onProjectNameChanged(projectName);
 
@@ -89,8 +86,6 @@ public class SubversionProjectImporterPresenterTest {
   public void testInvalidProjectName() throws Exception {
     final String projectName = "+subversion+";
 
-    when(view.getProjectName()).thenReturn(projectName);
-
     presenter.onProjectNameChanged(projectName);
 
     verify(dataObject).setName(eq(projectName));
@@ -107,8 +102,6 @@ public class SubversionProjectImporterPresenterTest {
   @Test
   public void testValidProjectName() throws Exception {
     final String projectName = "subversion";
-
-    when(view.getProjectName()).thenReturn(projectName);
 
     presenter.onProjectNameChanged(projectName);
 
@@ -165,8 +158,6 @@ public class SubversionProjectImporterPresenterTest {
   public void testProjectDescription() throws Exception {
     final String description = "Some description.";
 
-    when(view.getProjectDescription()).thenReturn(description);
-
     presenter.onProjectDescriptionChanged(description);
 
     verify(dataObject).setDescription(eq(description));
@@ -183,14 +174,12 @@ public class SubversionProjectImporterPresenterTest {
     final AcceptsOneWidget container = mock(AcceptsOneWidget.class);
     final ProjectImporterDescriptor projectImporter = mock(ProjectImporterDescriptor.class);
 
-    when(projectImporter.getDescription()).thenReturn(importerDescription);
-
     presenter.go(container);
 
     verify(container).setWidget(eq(view));
-    verify(view).setProjectName(anyString());
-    verify(view).setProjectDescription(anyString());
-    verify(view).setProjectUrl(anyString());
+    verify(view).setProjectName(nullable(String.class));
+    verify(view).setProjectDescription(nullable(String.class));
+    verify(view).setProjectUrl(nullable(String.class));
     verify(view).setInputsEnableState(eq(true));
   }
 }

--- a/plugins/plugin-svn/che-plugin-svn-ext-server/src/test/java/org/eclipse/che/plugin/svn/server/SubversionProjectImporterTest.java
+++ b/plugins/plugin-svn/che-plugin-svn-ext-server/src/test/java/org/eclipse/che/plugin/svn/server/SubversionProjectImporterTest.java
@@ -80,9 +80,6 @@ public class SubversionProjectImporterTest {
     VirtualFileSystem virtualFileSystem = TestUtils.createVirtualFileSystem();
     root = virtualFileSystem.getRoot();
 
-    // Create the test user
-    TestUtils.createTestUser(userProfileDao);
-
     // Create the Subversion repository
     repoRoot = TestUtils.createGreekTreeRepository();
 

--- a/plugins/plugin-traefik/plugin-traefik-docker/pom.xml
+++ b/plugins/plugin-traefik/plugin-traefik-docker/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -203,7 +203,7 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.mockito</groupId>
-                                    <artifactId>mockito-all</artifactId>
+                                    <artifactId>mockito-core</artifactId>
                                     <version>${org.mockito.version}</version>
                                     <type>jar</type>
                                 </artifactItem>

--- a/wsagent/agent/pom.xml
+++ b/wsagent/agent/pom.xml
@@ -76,11 +76,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/FSLuceneSearcherTest.java
@@ -33,7 +33,6 @@ import org.eclipse.che.api.vfs.search.QueryExpression;
 import org.eclipse.che.api.vfs.search.SearchResult;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.mockito.ArgumentMatcher;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -388,12 +387,6 @@ public class FSLuceneSearcherTest {
   }
 
   private static VirtualFile withName(String name) {
-    return argThat(
-        new ArgumentMatcher<VirtualFile>() {
-          @Override
-          public boolean matches(Object argument) {
-            return name.equals(((VirtualFile) argument).getName());
-          }
-        });
+    return argThat(argument -> name.equals((argument).getName()));
   }
 }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/MemoryLuceneSearcherTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/search/impl/MemoryLuceneSearcherTest.java
@@ -33,7 +33,6 @@ import org.eclipse.che.api.vfs.search.SearchResult;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 
 public class MemoryLuceneSearcherTest {
   private static final String[] TEST_CONTENT = {
@@ -303,12 +302,6 @@ public class MemoryLuceneSearcherTest {
   }
 
   private static VirtualFile withName(String name) {
-    return argThat(
-        new ArgumentMatcher<VirtualFile>() {
-          @Override
-          public boolean matches(Object argument) {
-            return name.equals(((VirtualFile) argument).getName());
-          }
-        });
+    return argThat(argument -> name.equals((argument).getName()));
   }
 }

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileWatcherServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/vfs/watcher/FileWatcherServiceTest.java
@@ -17,6 +17,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static org.apache.commons.io.FileUtils.write;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -138,7 +139,7 @@ public class FileWatcherServiceTest {
   public void shouldNotWatchUnRegisteredFolderForFileCreation() throws Exception {
     Path path = rootFolder.newFile(FILE_NAME).toPath();
 
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_CREATE);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_CREATE);
   }
 
   @Test
@@ -169,14 +170,14 @@ public class FileWatcherServiceTest {
 
     boolean deleted = file.delete();
     assertTrue(deleted);
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_DELETE);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_DELETE);
   }
 
   @Test
   public void shouldNotWatchUnRegisteredFolderForDirectoryCreation() throws Exception {
     Path path = rootFolder.newFolder(FOLDER_NAME).toPath();
 
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_CREATE);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_CREATE);
   }
 
   @Test
@@ -190,7 +191,7 @@ public class FileWatcherServiceTest {
     service.unRegister(rootFolder.getRoot().toPath());
 
     write(file, "");
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_MODIFY);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_MODIFY);
   }
 
   @Test
@@ -205,7 +206,7 @@ public class FileWatcherServiceTest {
 
     boolean deleted = file.delete();
     assertTrue(deleted);
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_DELETE);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_DELETE);
   }
 
   @Test
@@ -234,7 +235,7 @@ public class FileWatcherServiceTest {
 
     Path path = rootFolder.newFile(FILE_NAME).toPath();
 
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_CREATE);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_CREATE);
   }
 
   @Test
@@ -248,6 +249,6 @@ public class FileWatcherServiceTest {
     service.unRegister(rootFolder.getRoot().toPath());
 
     createDirectory(path.resolve(FILE_NAME));
-    verify(handler, timeout(TIMEOUT_VALUE).never()).handle(path, ENTRY_MODIFY);
+    verify(handler, after(TIMEOUT_VALUE).never()).handle(path, ENTRY_MODIFY);
   }
 }

--- a/wsagent/che-core-git-impl-jgit/pom.xml
+++ b/wsagent/che-core-git-impl-jgit/pom.xml
@@ -136,7 +136,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
+++ b/wsagent/che-core-git-impl-jgit/src/test/java/org/eclipse/che/git/impl/jgit/JGitConnectionTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.git.impl.jgit;
 
 import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -277,7 +278,11 @@ public class JGitConnectionTest {
     when(repository.getConfig()).thenReturn(mock(StoredConfig.class));
     doReturn(cloneCommand)
         .when(jGitConnection)
-        .executeRemoteCommand(anyString(), anyObject(), anyString(), anyString());
+        .executeRemoteCommand(
+            nullable(String.class),
+            nullable(TransportCommand.class),
+            nullable(String.class),
+            nullable(String.class));
 
     //when
     jGitConnection.clone(CloneParams.create("url").withWorkingDir("fakePath"));

--- a/wsagent/che-core-ssh-key-ide/src/test/java/org/eclipse/che/plugin/ssh/key/client/manage/SshKeyManagerPresenterTest.java
+++ b/wsagent/che-core-ssh-key-ide/src/test/java/org/eclipse/che/plugin/ssh/key/client/manage/SshKeyManagerPresenterTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.plugin.ssh.key.client.manage;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -57,6 +58,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Matchers;
@@ -167,15 +169,18 @@ public class SshKeyManagerPresenterTest {
     when(constant.deleteSshKeyQuestion(anyString())).thenReturn(safeHtml);
     when(safeHtml.asString()).thenReturn("");
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), (ConfirmCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     presenter.onDeleteClicked(sshPairDto);
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
             (CancelCallback) anyObject());
     ConfirmCallback confirmCallback = confirmCallbackCaptor.getValue();
@@ -190,19 +195,22 @@ public class SshKeyManagerPresenterTest {
   public void testOnDeleteClickedWhenDeleteKeyCanceled() {
     SafeHtml safeHtml = mock(SafeHtml.class);
     ConfirmDialog confirmDialog = mock(ConfirmDialog.class);
-    when(constant.deleteSshKeyQuestion(anyString())).thenReturn(safeHtml);
+    when(constant.deleteSshKeyQuestion(nullable(String.class))).thenReturn(safeHtml);
     when(safeHtml.asString()).thenReturn("");
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), (ConfirmCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     presenter.onDeleteClicked(sshPairDto);
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
-            (ConfirmCallback) anyObject(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
             cancelCallbackCaptor.capture());
     CancelCallback cancelCallback = cancelCallbackCaptor.getValue();
     cancelCallback.cancelled();
@@ -221,15 +229,18 @@ public class SshKeyManagerPresenterTest {
     when(constant.deleteSshKeyQuestion(anyString())).thenReturn(safeHtml);
     when(safeHtml.asString()).thenReturn("");
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), (ConfirmCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     presenter.onDeleteClicked(sshPairDto);
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
             (CancelCallback) anyObject());
     ConfirmCallback confirmCallback = confirmCallbackCaptor.getValue();
@@ -253,15 +264,18 @@ public class SshKeyManagerPresenterTest {
     when(constant.deleteSshKeyQuestion(anyString())).thenReturn(safeHtml);
     when(safeHtml.asString()).thenReturn("");
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), (ConfirmCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     presenter.onDeleteClicked(sshPairDto);
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
             (CancelCallback) anyObject());
     ConfirmCallback confirmCallback = confirmCallbackCaptor.getValue();
@@ -287,17 +301,20 @@ public class SshKeyManagerPresenterTest {
     when(constant.deleteSshKeyQuestion(anyString())).thenReturn(safeHtml);
     when(safeHtml.asString()).thenReturn("");
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), (ConfirmCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     presenter.onDeleteClicked(sshPairDto);
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
-            (CancelCallback) anyObject());
+            nullable(CancelCallback.class));
     ConfirmCallback confirmCallback = confirmCallbackCaptor.getValue();
     confirmCallback.accepted();
 
@@ -324,15 +341,18 @@ public class SshKeyManagerPresenterTest {
     when(constant.deleteSshKeyQuestion(anyString())).thenReturn(safeHtml);
     when(safeHtml.asString()).thenReturn("");
     when(dialogFactory.createConfirmDialog(
-            anyString(), anyString(), (ConfirmCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(ConfirmCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(confirmDialog);
 
     presenter.onDeleteClicked(sshPairDto);
 
     verify(dialogFactory)
         .createConfirmDialog(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             confirmCallbackCaptor.capture(),
             (CancelCallback) anyObject());
     ConfirmCallback confirmCallback = confirmCallbackCaptor.getValue();
@@ -350,7 +370,10 @@ public class SshKeyManagerPresenterTest {
     verify(service).getPairs(Matchers.eq(SshKeyManagerPresenter.VCS_SSH_SERVICE));
     verify(view, never()).setPairs(eq(sshPairDtoArray));
     verify(notificationManager)
-        .notify(anyString(), any(StatusNotification.Status.class), (DisplayMode) anyObject());
+        .notify(
+            nullable(String.class),
+            any(StatusNotification.Status.class),
+            (DisplayMode) anyObject());
   }
 
   @Test
@@ -390,14 +413,20 @@ public class SshKeyManagerPresenterTest {
   @Test
   public void testOnGenerateClickedWhenUserConfirmGenerateKey() {
     when(dialogFactory.createInputDialog(
-            anyString(), anyString(), (InputCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(InputCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(inputDialog);
 
     presenter.onGenerateClicked();
 
     verify(dialogFactory)
         .createInputDialog(
-            anyString(), anyString(), inputCallbackCaptor.capture(), (CancelCallback) anyObject());
+            nullable(String.class),
+            nullable(String.class),
+            inputCallbackCaptor.capture(),
+            (CancelCallback) anyObject());
     InputCallback inputCallback = inputCallbackCaptor.getValue();
     inputCallback.accepted(GITHUB_HOST);
 
@@ -408,14 +437,20 @@ public class SshKeyManagerPresenterTest {
   @Test
   public void testOnGenerateClickedWhenUserCancelGenerateKey() {
     when(dialogFactory.createInputDialog(
-            anyString(), anyString(), (InputCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(InputCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(inputDialog);
 
     presenter.onGenerateClicked();
 
     verify(dialogFactory)
         .createInputDialog(
-            anyString(), anyString(), (InputCallback) anyObject(), cancelCallbackCaptor.capture());
+            nullable(String.class),
+            nullable(String.class),
+            ArgumentMatchers.<InputCallback>any(),
+            cancelCallbackCaptor.capture());
     CancelCallback cancelCallback = cancelCallbackCaptor.getValue();
     cancelCallback.cancelled();
 
@@ -426,14 +461,17 @@ public class SshKeyManagerPresenterTest {
   @Test
   public void testOnGenerateClickedWhenGenerateKeyIsFailed() throws OperationException {
     when(dialogFactory.createInputDialog(
-            anyString(), anyString(), (InputCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(InputCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(inputDialog);
 
     presenter.onGenerateClicked();
 
     verify(dialogFactory)
         .createInputDialog(
-            anyString(), anyString(),
+            nullable(String.class), nullable(String.class),
             inputCallbackCaptor.capture(), cancelCallbackCaptor.capture());
     InputCallback inputCallback = inputCallbackCaptor.getValue();
     inputCallback.accepted(GITHUB_HOST);
@@ -447,8 +485,8 @@ public class SshKeyManagerPresenterTest {
     verify(view, never()).setPairs((List<SshPairDto>) anyObject());
     verify(notificationManager)
         .notify(
-            anyString(),
-            anyString(),
+            nullable(String.class),
+            nullable(String.class),
             any(StatusNotification.Status.class),
             (DisplayMode) anyObject());
   }
@@ -457,14 +495,17 @@ public class SshKeyManagerPresenterTest {
   public void testShouldRefreshKeysAfterSuccessfulGenerateKey() throws OperationException {
     List<SshPairDto> sshPairDtoArray = new ArrayList<>();
     when(dialogFactory.createInputDialog(
-            anyString(), anyString(), (InputCallback) anyObject(), (CancelCallback) anyObject()))
+            nullable(String.class),
+            nullable(String.class),
+            nullable(InputCallback.class),
+            nullable(CancelCallback.class)))
         .thenReturn(inputDialog);
 
     presenter.onGenerateClicked();
 
     verify(dialogFactory)
         .createInputDialog(
-            anyString(), anyString(),
+            nullable(String.class), nullable(String.class),
             inputCallbackCaptor.capture(), cancelCallbackCaptor.capture());
     InputCallback inputCallback = inputCallbackCaptor.getValue();
     inputCallback.accepted(GITHUB_HOST);

--- a/wsagent/wsagent-local/pom.xml
+++ b/wsagent/wsagent-local/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-account/pom.xml
+++ b/wsmaster/che-core-api-account/pom.xml
@@ -103,11 +103,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/wsmaster/che-core-api-system/pom.xml
+++ b/wsmaster/che-core-api-system/pom.xml
@@ -108,11 +108,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/filters/AddExecAgentInWorkspaceFilterTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/filters/AddExecAgentInWorkspaceFilterTest.java
@@ -21,10 +21,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -32,6 +29,7 @@ import static org.testng.Assert.assertEquals;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.Response;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.rest.ApiExceptionMapper;
 import org.eclipse.che.api.core.rest.CheJsonProvider;
@@ -71,9 +69,13 @@ public class AddExecAgentInWorkspaceFilterTest {
   @BeforeMethod
   public void setUp() throws Exception {
     when(workspaceService.create(
-            any(WorkspaceConfigDto.class), anyListOf(String.class), anyBoolean(), anyString()))
+            nullable(WorkspaceConfigDto.class),
+            nullable(List.class),
+            nullable(Boolean.class),
+            nullable(String.class)))
         .thenReturn(javax.ws.rs.core.Response.status(201).build());
-    when(workspaceService.startFromConfig(any(WorkspaceConfigDto.class), anyBoolean(), anyString()))
+    when(workspaceService.startFromConfig(
+            nullable(WorkspaceConfigDto.class), nullable(Boolean.class), nullable(String.class)))
         .thenReturn(newDto(WorkspaceDto.class));
   }
 
@@ -92,7 +94,11 @@ public class AddExecAgentInWorkspaceFilterTest {
 
     assertEquals(response.getStatusCode(), 201);
     verify(workspaceService)
-        .create(workspaceConfigCaptor.capture(), any(), anyBoolean(), anyString());
+        .create(
+            workspaceConfigCaptor.capture(),
+            nullable(List.class),
+            nullable(Boolean.class),
+            nullable(String.class));
     Map<String, EnvironmentDto> actualEnv = workspaceConfigCaptor.getValue().getEnvironments();
     assertEquals(actualEnv, expectedEnv);
   }
@@ -112,7 +118,8 @@ public class AddExecAgentInWorkspaceFilterTest {
 
     assertEquals(response.getStatusCode(), 200);
     verify(workspaceService)
-        .startFromConfig(workspaceConfigCaptor.capture(), anyBoolean(), anyString());
+        .startFromConfig(
+            workspaceConfigCaptor.capture(), nullable(Boolean.class), nullable(String.class));
     Map<String, EnvironmentDto> actualEnv = workspaceConfigCaptor.getValue().getEnvironments();
     assertEquals(actualEnv, expectedEnv);
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/TemporaryWorkspaceRemoverTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/TemporaryWorkspaceRemoverTest.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
-import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -48,40 +47,14 @@ public class TemporaryWorkspaceRemoverTest {
     // return 50 items when skip count is 200, and return empty list when skip count is 300.
     doReturn(createEntities(100))
         .when(workspaceDao)
-        .getWorkspaces(
-            eq(true),
-            intThat(
-                new ArgumentMatcher<Integer>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((int) argument) < 200;
-                  }
-                }),
-            anyInt());
+        .getWorkspaces(eq(true), intThat(integer -> integer.intValue() < 200), anyInt());
     doReturn(createEntities(50))
         .when(workspaceDao)
-        .getWorkspaces(
-            eq(true),
-            intThat(
-                new ArgumentMatcher<Integer>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((int) argument) == 200;
-                  }
-                }),
-            anyInt());
+        .getWorkspaces(eq(true), intThat(argument -> ((int) argument) == 200), anyInt());
     doReturn(Collections.emptyList())
         .when(workspaceDao)
         .getWorkspaces(
-            eq(true),
-            intThat(
-                new ArgumentMatcher<Integer>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((int) argument) > COUNT_OF_WORKSPACES;
-                  }
-                }),
-            anyInt());
+            eq(true), intThat(argument -> ((int) argument) > COUNT_OF_WORKSPACES), anyInt());
 
     remover.removeTemporaryWs();
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/event/MachineStateListenerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/event/MachineStateListenerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.workspace.server.event;
 
 import static org.eclipse.che.api.machine.shared.dto.event.MachineStatusEvent.EventType.DESTROYED;
 import static org.eclipse.che.api.machine.shared.dto.event.MachineStatusEvent.EventType.RUNNING;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -62,7 +63,7 @@ public class MachineStateListenerTest {
   public void workspaceShouldNotBeStoppedWhenItIsNotRunning() throws Exception {
     when(event.isDev()).thenReturn(true);
     when(event.getEventType()).thenReturn(DESTROYED);
-    when(workspaceManager.getWorkspace(anyString())).thenReturn(workspace);
+    when(workspaceManager.getWorkspace(nullable(String.class))).thenReturn(workspace);
     when(workspace.getStatus()).thenReturn(WorkspaceStatus.STOPPED);
 
     listener.onEvent(event);
@@ -74,11 +75,11 @@ public class MachineStateListenerTest {
   public void workspaceShouldBeStopped() throws Exception {
     when(event.isDev()).thenReturn(true);
     when(event.getEventType()).thenReturn(DESTROYED);
-    when(workspaceManager.getWorkspace(anyString())).thenReturn(workspace);
+    when(workspaceManager.getWorkspace(nullable(String.class))).thenReturn(workspace);
     when(workspace.getStatus()).thenReturn(WorkspaceStatus.RUNNING);
 
     listener.onEvent(event);
 
-    verify(workspaceManager).stopWorkspace(anyString());
+    verify(workspaceManager).stopWorkspace(nullable(String.class));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackServiceTest.java
@@ -23,9 +23,9 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -426,7 +426,8 @@ public class StackServiceTest {
     StackImpl stack2 = new StackImpl(stackImpl);
     stack2.setTags(singletonList("subversion"));
     List<StackImpl> stacks = asList(stackImpl, stack2);
-    when(stackDao.searchStacks(anyString(), anyList(), anyInt(), anyInt())).thenReturn(stacks);
+    when(stackDao.searchStacks(anyString(), nullable(List.class), anyInt(), anyInt()))
+        .thenReturn(stacks);
 
     Response response =
         given()
@@ -436,7 +437,7 @@ public class StackServiceTest {
             .get(SECURE_PATH + "/stack");
 
     assertEquals(response.getStatusCode(), 200);
-    verify(stackDao).searchStacks(anyString(), anyList(), anyInt(), anyInt());
+    verify(stackDao).searchStacks(anyString(), nullable(List.class), anyInt(), anyInt());
 
     List<StackDto> result = unwrapListDto(response, StackDto.class);
     assertEquals(result.size(), 2);

--- a/wsmaster/integration-tests/cascade-removal/pom.xml
+++ b/wsmaster/integration-tests/cascade-removal/pom.xml
@@ -148,11 +148,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/wsmaster/wsmaster-local/pom.xml
+++ b/wsmaster/wsmaster-local/pom.xml
@@ -138,11 +138,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
note : before merging, the versions of mockito needs to be removed from root pom.xml and moved to che-dependencies repository.

### What does this PR do?
Update Mockito to v2.10

Some changes are required like
 - `anySomething()` --> `nullable(Something.class)` for many tests as in fact we provide null values while any() expect a non-null value
 - add class for `VerificationMode` as there are more than one method now (can't use lambdas)
 - remove cast on `ArgumentMatcher` (now we can use lambdas as there is generics)
 - remove unecessary stubbing (mockito is now reporting un-needed stubs)
 - replace dependency `mockito-all` by` mockito-core` (it is no longer provided in 2.x)

### What issues does this PR fix or reference?
#5326 

#### Release Notes
N/A


#### Docs PR
N/A

Change-Id: Ifcddd24927a69cbbae1bd1dd97e35e900c94a5b3
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
 