### PR TITLE
che-6284: Adding property for specifying project where workspaces will be created for OpenShift infrastructure

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -395,6 +395,10 @@ che.infra.openshift.username=
 che.infra.openshift.password=
 che.infra.openshift.trust_certs=
 
+# Defines OpenShift namespace in which all workspaces will be created.
+# If not set, every workspace will be created in a new project, where project name = workspace id
+che.infra.openshift.project=
+
 che.infra.openshift.machine_start_timeout_min=5
 
 che.infra.openshift.bootstrapper.binary_url=http://${CHE_HOST}:${CHE_PORT}/agent-binaries/linux_amd64/bootstrapper/bootstrapper

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -90,7 +90,6 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
   @Override
   protected void internalStart(Map<String, String> startOptions) throws InfrastructureException {
     try {
-      project.cleanUp();
 
       prepareOpenShiftPVCs(getContext().getOpenShiftEnvironment().getPersistentVolumeClaims());
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.google.inject.assistedinject.Assisted;
 import java.net.URI;
 import javax.inject.Inject;
@@ -22,6 +24,7 @@ import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
 
@@ -31,6 +34,7 @@ public class OpenShiftRuntimeContext extends RuntimeContext {
   private final OpenShiftEnvironment openShiftEnvironment;
   private final OpenShiftRuntimeFactory runtimeFactory;
   private final String websocketOutputEndpoint;
+  private final String projectName;
 
   @Inject
   public OpenShiftRuntimeContext(
@@ -40,7 +44,8 @@ public class OpenShiftRuntimeContext extends RuntimeContext {
       @Assisted RuntimeInfrastructure infrastructure,
       OpenShiftClientFactory clientFactory,
       OpenShiftRuntimeFactory runtimeFactory,
-      @Named("che.websocket.endpoint") String cheWebsocketEndpoint)
+      @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
+      @Nullable @Named("che.infra.openshift.project") String projectName)
       throws ValidationException, InfrastructureException {
 
     super(environment, identity, infrastructure);
@@ -48,6 +53,7 @@ public class OpenShiftRuntimeContext extends RuntimeContext {
     this.runtimeFactory = runtimeFactory;
     this.openShiftEnvironment = openShiftEnvironment;
     this.websocketOutputEndpoint = cheWebsocketEndpoint;
+    this.projectName = projectName;
   }
 
   /** Returns OpenShift environment which based on normalized context environment configuration. */
@@ -67,7 +73,8 @@ public class OpenShiftRuntimeContext extends RuntimeContext {
 
   @Override
   public InternalRuntime getRuntime() throws InfrastructureException {
-    return runtimeFactory.create(
-        this, new OpenShiftProject(getIdentity().getWorkspaceId(), clientFactory));
+    String name = isNullOrEmpty(projectName) ? getIdentity().getWorkspaceId() : projectName;
+    OpenShiftProject project = new OpenShiftProject(name, clientFactory);
+    return runtimeFactory.create(this, project);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adding property for specifying project where workspaces will be created for OpenShift infrastructure.
Once https://github.com/eclipse/che/issues/6284 is implemented it will be possible to pick strategy of workspace creation (new namespace / predefined namespace). However, now it would be really handy to have a posibility to deploy che from `spi` on clusters where project creation is not allowed (osio).

### What issues does this PR fix or reference?
temp solution of https://github.com/eclipse/che/issues/6284

#### Changelog
N / A

#### Release Notes
N / A 

#### Docs PR
N / A
