### PR TITLE
Add possibility to disable DockerInstanceStopDetector

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -255,6 +255,9 @@ che.docker.cleanup_period_min=60
 # Version number of the Docker API used within the Che implementation
 che.docker.api=1.20
 
+# Whether to enable component that detects failures of a machine caused by unexpected container stop
+che.docker.enable_container_stop_detector=true
+
 che.docker.network_driver=NULL
 
 che.docker.tcp_connection_timeout_ms=600000

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceStopDetector.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceStopDetector.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 public class DockerInstanceStopDetector {
   private static final Logger LOG = LoggerFactory.getLogger(DockerInstanceStopDetector.class);
 
-  private final boolean enableDetector;
+  private final boolean isEnabled;
   private EventService eventService;
   private DockerConnector dockerConnector;
   private ExecutorService executorService;
@@ -70,9 +70,9 @@ public class DockerInstanceStopDetector {
   public DockerInstanceStopDetector(
       EventService eventService,
       DockerConnectorProvider dockerConnectorProvider,
-      @Named("che.docker.enable_container_stop_detector") boolean enableDetector) {
-    this.enableDetector = enableDetector;
-    if (!enableDetector) {
+      @Named("che.docker.enable_container_stop_detector") boolean isEnabled) {
+    this.isEnabled = isEnabled;
+    if (!isEnabled) {
       return;
     }
     this.eventService = eventService;
@@ -97,7 +97,7 @@ public class DockerInstanceStopDetector {
    * @param workspaceId id of a workspace that owns machine
    */
   public void startDetection(String containerId, String machineId, String workspaceId) {
-    if (enableDetector) {
+    if (isEnabled) {
       instances.put(containerId, Pair.of(machineId, workspaceId));
     }
   }
@@ -108,14 +108,14 @@ public class DockerInstanceStopDetector {
    * @param containerId id of a container to start detection for
    */
   public void stopDetection(String containerId) {
-    if (enableDetector) {
+    if (isEnabled) {
       instances.remove(containerId);
     }
   }
 
   @PostConstruct
   private void detectContainersEvents() {
-    if (!enableDetector) {
+    if (!isEnabled) {
       return;
     }
     executorService.execute(

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceStopDetector.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceStopDetector.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.machine.server.event.InstanceStateEvent;
@@ -44,10 +45,11 @@ import org.slf4j.LoggerFactory;
 public class DockerInstanceStopDetector {
   private static final Logger LOG = LoggerFactory.getLogger(DockerInstanceStopDetector.class);
 
-  private final EventService eventService;
-  private final DockerConnector dockerConnector;
-  private final ExecutorService executorService;
-  private final Map<String, Pair<String, String>> instances;
+  private final boolean enableDetector;
+  private EventService eventService;
+  private DockerConnector dockerConnector;
+  private ExecutorService executorService;
+  private Map<String, Pair<String, String>> instances;
   /*
      Helps differentiate container main process OOM from other processes OOM
      Algorithm:
@@ -60,13 +62,19 @@ public class DockerInstanceStopDetector {
      That's why cache expires in X seconds.
      X was set as 10 empirically.
   */
-  private final Cache<String, String> containersOomTimestamps;
+  private Cache<String, String> containersOomTimestamps;
 
   private long lastProcessedEventDate = 0;
 
   @Inject
   public DockerInstanceStopDetector(
-      EventService eventService, DockerConnectorProvider dockerConnectorProvider) {
+      EventService eventService,
+      DockerConnectorProvider dockerConnectorProvider,
+      @Named("che.docker.enable_container_stop_detector") boolean enableDetector) {
+    this.enableDetector = enableDetector;
+    if (!enableDetector) {
+      return;
+    }
     this.eventService = eventService;
     this.dockerConnector = dockerConnectorProvider.get();
     this.instances = new ConcurrentHashMap<>();
@@ -89,7 +97,9 @@ public class DockerInstanceStopDetector {
    * @param workspaceId id of a workspace that owns machine
    */
   public void startDetection(String containerId, String machineId, String workspaceId) {
-    instances.put(containerId, Pair.of(machineId, workspaceId));
+    if (enableDetector) {
+      instances.put(containerId, Pair.of(machineId, workspaceId));
+    }
   }
 
   /**
@@ -98,11 +108,16 @@ public class DockerInstanceStopDetector {
    * @param containerId id of a container to start detection for
    */
   public void stopDetection(String containerId) {
-    instances.remove(containerId);
+    if (enableDetector) {
+      instances.remove(containerId);
+    }
   }
 
   @PostConstruct
   private void detectContainersEvents() {
+    if (!enableDetector) {
+      return;
+    }
     executorService.execute(
         () -> {
           //noinspection InfiniteLoopStatement


### PR DESCRIPTION
### What does this PR do?
It is needed for OpenShift infra where getting events
is not supported due to security limits.
To disable containers stop detector variable
CHE_DOCKER_ENABLE__CONTAINER__STOP__DETECTOR=false should be
defined.

### What issues does this PR fix or reference?


#### Changelog
Add possibility to disable DockerInstanceStopDetector

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
