### PR TITLE
Fix logging when exception occurs on operations with workspaces' ssh …

### DIFF
--- a/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/WorkspaceSshKeys.java
+++ b/plugins/plugin-machine/che-plugin-machine-ext-server/src/main/java/org/eclipse/che/ide/ext/machine/server/ssh/WorkspaceSshKeys.java
@@ -113,8 +113,11 @@ public class WorkspaceSshKeys {
               final User user =
                   userManager.getByName(workspaceRemovedEvent.getWorkspace().getNamespace());
               userId = user.getId();
-            } catch (NotFoundException | ServerException e) {
-              LOG.error(
+            } catch (NotFoundException ignored) {
+              // namespace can be different from username
+              return;
+            } catch (ServerException e) {
+              LOG.warn(
                   "Unable to get owner of the workspace {} with namespace {}",
                   workspaceRemovedEvent.getWorkspace().getId(),
                   workspaceRemovedEvent.getWorkspace().getNamespace());
@@ -131,7 +134,7 @@ public class WorkspaceSshKeys {
                   workspaceRemovedEvent.getWorkspace().getConfig().getName(),
                   workspaceRemovedEvent.getWorkspace().getId());
             } catch (ServerException e) {
-              LOG.error(
+              LOG.warn(
                   "Error when trying to remove default ssh pair for the workspace {} (workspace ID {})",
                   workspaceRemovedEvent.getWorkspace().getConfig().getName(),
                   workspaceRemovedEvent.getWorkspace().getId());


### PR DESCRIPTION
### What does this PR do?
@skryzhny asked to change log level here to warn because actually, it is not an error at all and it may require attention. So this PR fixes logging when an exception occurs on operations with workspaces' ssh keys.

### What issues does this PR fix or reference?
N/A

#### Changelog
N/A

#### Release Notes
N/A