### PR TITLE
Need to force update presentation to correct display node in project explorer 

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/tree/ResourceNode.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/tree/ResourceNode.java
@@ -143,9 +143,11 @@ public abstract class ResourceNode<R extends Resource> extends AbstractTreeNode
       nodePresentation = new NodePresentation();
     }
 
-    if (update) {
-      updatePresentation(nodePresentation);
-    }
+    //need to force update presentation to correct display node in project explorer after restart
+    //workspace details https://github.com/eclipse/che/issues/6314
+    //problem reproduce randomly
+    updatePresentation(nodePresentation);
+
 
     return nodePresentation;
   }


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?
Added forced update presentation to correct display node in project explorer after restart workspace. Problem reproduce randomly so hard to detect real reason for this behavior

### What issues does this PR fix or reference?
#6314 

#### Changelog
N/A

#### Release Notes
N/A 


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
