### PR TITLE
Fix unstable selenium tests from dashboard package

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -20,6 +20,8 @@ import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestStacksConstants;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.pageobject.Loader;
+import org.eclipse.che.selenium.pageobject.MavenPluginStatusBar;
+import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
@@ -47,6 +49,8 @@ public class CreateAndDeleteProjectsTest {
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private DefaultTestUser defaultTestUser;
+  @Inject private NotificationsPopupPanel notificationsPopupPanel;
+  @Inject private MavenPluginStatusBar mavenPluginStatusBar;
 
   @BeforeClass
   public void setUp() {
@@ -85,6 +89,8 @@ public class CreateAndDeleteProjectsTest {
         DashboardProject.Template.CONSOLE_JAVA_SIMPLE.value(), PROJECT_FOLDER);
     explorer.waitFolderDefinedTypeOfFolderByPath(
         DashboardProject.Template.WEB_JAVA_SPRING.value(), PROJECT_FOLDER);
+    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    mavenPluginStatusBar.waitClosingInfoPanel();
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
@@ -17,6 +17,7 @@ import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace;
+import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace.StateWorkspace;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -53,6 +54,9 @@ public class RenameWorkspaceTest {
     dashboardWorkspace.selectTabInWorspaceMenu(DashboardWorkspace.TabNames.OVERVIEW);
     dashboardWorkspace.enterNameWorkspace(CHANGE_WORKSPACE_NAME);
     dashboardWorkspace.clickOnSaveBtn();
+    dashboardWorkspace.checkStateOfWorkspace(StateWorkspace.STOPPING);
+    dashboardWorkspace.checkStateOfWorkspace(StateWorkspace.STARTING);
+    dashboardWorkspace.checkStateOfWorkspace(StateWorkspace.RUNNING);
     dashboard.waitNotificationMessage("Workspace updated");
     dashboard.waitNotificationIsClosed();
     dashboardWorkspace.checkNameWorkspace(CHANGE_WORKSPACE_NAME);


### PR DESCRIPTION
### What does this PR do?
We need to fix unstable selenium tests from dashboard package:
- **RenameWorkspaceTest** sometimes fails because there is not enough time for waiting restarting a workspace after renaming. 
- In **CreateAndDeleteProjectsTest** need to add waiting for fully initialization projects in the IDE.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6433