### PR TITLE
Avoid NPE by checking if map are null and not only empty in OpenShift connector

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -351,9 +351,15 @@ public class OpenShiftConnector extends DockerConnector {
 
     // first, get labels defined in the container configuration
     Map<String, String> containerLabels = containerConfig.getLabels();
+    if (containerLabels == null) {
+      containerLabels = Collections.emptyMap();
+    }
 
     // Also, get labels from the image itself
     Map<String, String> imageLabels = imageConfig.getLabels();
+    if (imageLabels == null) {
+      imageLabels = Collections.emptyMap();
+    }
 
     // Now merge all labels
     final Map<String, String> allLabels = new HashMap<>(containerLabels);

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -13,17 +13,22 @@ package org.eclipse.che.plugin.openshift.client;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.util.Map;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
 import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
 import org.eclipse.che.plugin.docker.client.connection.DockerConnectionFactory;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
+import org.eclipse.che.plugin.docker.client.json.ImageConfig;
 import org.eclipse.che.plugin.docker.client.params.CreateContainerParams;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -55,15 +60,8 @@ public class OpenShiftConnectorTest {
 
   private OpenShiftConnector openShiftConnector;
 
-  @Test
-  public void shouldGetWorkspaceIDWhenAValidOneIsProvidedInCreateContainerParams()
-      throws IOException {
-    //Given
-    String expectedWorkspaceID = "abcd1234";
-    ContainerConfig containerConfig = mock(ContainerConfig.class);
-    CreateContainerParams createContainerParams = CreateContainerParams.create(containerConfig);
-
-    when(containerConfig.getEnv()).thenReturn(CONTAINER_ENV_VARIABLES);
+  @BeforeMethod
+  private void setup() {
 
     //When
     openShiftConnector =
@@ -88,9 +86,35 @@ public class OpenShiftConnectorTest {
             null,
             SECURE_ROUTES,
             CREATE_WORKSPACE_DIRS);
+  }
+
+  @Test
+  public void shouldGetWorkspaceIDWhenAValidOneIsProvidedInCreateContainerParams()
+      throws IOException {
+    //Given
+    String expectedWorkspaceID = "abcd1234";
+    ContainerConfig containerConfig = mock(ContainerConfig.class);
+    CreateContainerParams createContainerParams = CreateContainerParams.create(containerConfig);
+
+    when(containerConfig.getEnv()).thenReturn(CONTAINER_ENV_VARIABLES);
+
     String workspaceID = openShiftConnector.getCheWorkspaceId(createContainerParams);
 
     //Then
     assertEquals(workspaceID, expectedWorkspaceID);
+  }
+
+  /** Check that we return empty map if no labels and not a NPE */
+  @Test
+  public void checkWithNoLabels() {
+    ContainerConfig containerConfig = Mockito.mock(ContainerConfig.class);
+    when(containerConfig.getLabels()).thenReturn(null);
+
+    ImageConfig imageConfig = Mockito.mock(ImageConfig.class);
+    when(imageConfig.getLabels()).thenReturn(null);
+
+    Map<String, String> map = openShiftConnector.getLabels(containerConfig, imageConfig);
+    assertNotNull(map);
+    assertEquals(map.size(), 0);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Avoid NPE by checking if map are null and not only empty in OpenShift connector

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/338

#### Release Notes
N/A

#### Docs PR
N/A
