### PR TITLE
CHE-4952. Fix problems related to simultaneous opening files

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/EditorMultiPartStack.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/EditorMultiPartStack.java
@@ -16,7 +16,7 @@ import org.eclipse.che.ide.api.constraints.Constraints;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 
 /**
- * Multi Part Stack is layout element, containing {@code EditorPartStack}s and provides methods to
+ * Multi Part Stack is layout element, containing {@link EditorPartStack}s and provides methods to
  * control them.
  *
  * @author Roman Nikitenko
@@ -40,6 +40,16 @@ public interface EditorMultiPartStack extends PartStack {
    */
   @Nullable
   EditorPartStack getPartStackByPart(PartPresenter part);
+
+  /**
+   * Get {@link EditorPartStack} by given {@code tabId}
+   *
+   * @param tabId ID of editor tab to find part stack which contains corresponding editor part
+   * @return editor part stack which contains part with given {@code tabId} or null if this one is
+   *     not found in any {@link EditorPartStack}
+   */
+  @Nullable
+  EditorPartStack getPartStackByTabId(@NotNull String tabId);
 
   /**
    * Get editor part which associated with given {@code tabId}
@@ -84,6 +94,14 @@ public interface EditorMultiPartStack extends PartStack {
    * @return the first part stack
    */
   EditorPartStack createRootPartStack();
+
+  /**
+   * Remove given part stack. Note: All opened parts will be closed, use {@link
+   * EditorPartStack#getParts()} to avoid removing not empty part stack
+   *
+   * @param partStackToRemove part stack to remove
+   */
+  void removePartStack(EditorPartStack partStackToRemove);
 
   /**
    * Split part stack

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -430,6 +430,9 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("messages.unableOpenResource")
   String unableOpenResource(String path);
 
+  @Key("messages.canNotOpenFileInSplitMode")
+  String canNotOpenFileInSplitMode(String path);
+
   @Key("messages.canNotOpenFileWithoutParams")
   String canNotOpenFileWithoutParams();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionApiModule.java
@@ -32,7 +32,7 @@ public class ActionApiModule extends AbstractGinModule {
 
     bind(StartUpActionsProcessor.class).in(Singleton.class);
     GinMapBinder.newMapBinder(binder(), String.class, WsAgentComponent.class)
-        .addBinding("Start-up actions processor")
+        .addBinding("ZZ Start-up actions processor")
         .to(StartUpActionsProcessor.class);
 
     bind(FindActionView.class).to(FindActionViewImpl.class).in(Singleton.class);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/WorkspaceStateRestorer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/WorkspaceStateRestorer.java
@@ -38,7 +38,12 @@ public class WorkspaceStateRestorer implements WsAgentComponent {
 
   @Override
   public void start(Callback<WsAgentComponent, Exception> callback) {
-    managerProvider.get().restoreWorkspaceState(appContextProvider.get().getWorkspaceId());
-    callback.onSuccess(this);
+    managerProvider
+        .get()
+        .restoreWorkspaceState(appContextProvider.get().getWorkspaceId())
+        .then(
+            arg -> {
+              callback.onSuccess(WorkspaceStateRestorer.this);
+            });
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -13,6 +13,8 @@ package org.eclipse.che.ide.editor;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.Boolean.parseBoolean;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.parts.PartStackType.EDITING;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -25,8 +27,10 @@ import elemental.json.JsonObject;
 import elemental.util.ArrayOf;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
@@ -60,6 +64,7 @@ import org.eclipse.che.ide.api.event.WindowActionEvent;
 import org.eclipse.che.ide.api.event.WindowActionHandler;
 import org.eclipse.che.ide.api.filetypes.FileType;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
+import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.parts.EditorMultiPartStack;
 import org.eclipse.che.ide.api.parts.EditorMultiPartStackState;
 import org.eclipse.che.ide.api.parts.EditorPartStack;
@@ -76,6 +81,7 @@ import org.eclipse.che.ide.part.editor.multipart.EditorMultiPartStackPresenter;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.resources.reveal.RevealResourceEvent;
+import org.eclipse.che.ide.util.loging.Log;
 
 /**
  * Default implementation of {@link EditorAgent}.
@@ -101,10 +107,12 @@ public class EditorAgentImpl
   private final EditorMultiPartStack editorMultiPartStack;
 
   private final List<EditorPartPresenter> openedEditors;
+  private final Map<EditorPartStack, Set<Path>> openingEditorsPathsToStacks;
   private final Map<EditorPartPresenter, String> openedEditorsToProviders;
   private final EditorContentSynchronizer editorContentSynchronizer;
   private final PromiseProvider promiseProvider;
   private final ResourceProvider resourceProvider;
+  private final NotificationManager notificationManager;
   private List<EditorPartPresenter> dirtyEditors;
   private EditorPartPresenter activeEditor;
   private PartPresenter activePart;
@@ -120,7 +128,8 @@ public class EditorAgentImpl
       EditorMultiPartStackPresenter editorMultiPartStack,
       EditorContentSynchronizer editorContentSynchronizer,
       PromiseProvider promiseProvider,
-      ResourceProvider resourceProvider) {
+      ResourceProvider resourceProvider,
+      NotificationManager notificationManager) {
     this.eventBus = eventBus;
     this.fileTypeRegistry = fileTypeRegistry;
     this.preferencesManager = preferencesManager;
@@ -131,7 +140,9 @@ public class EditorAgentImpl
     this.editorContentSynchronizer = editorContentSynchronizer;
     this.promiseProvider = promiseProvider;
     this.resourceProvider = resourceProvider;
+    this.notificationManager = notificationManager;
     this.openedEditors = newArrayList();
+    this.openingEditorsPathsToStacks = new HashMap<>();
     this.openedEditorsToProviders = new HashMap<>();
 
     eventBus.addHandler(ActivePartChangedEvent.TYPE, this);
@@ -190,12 +201,37 @@ public class EditorAgentImpl
 
   @Override
   public void openEditor(@NotNull final VirtualFile file) {
-    doOpen(file, new OpenEditorCallbackImpl(), null);
+    openEditor(file, new OpenEditorCallbackImpl());
   }
 
   @Override
   public void openEditor(@NotNull VirtualFile file, Constraints constraints) {
-    doOpen(file, new OpenEditorCallbackImpl(), constraints);
+    if (constraints == null) {
+      openEditor(file);
+      return;
+    }
+
+    EditorPartStack relativeEditorPartStack =
+        editorMultiPartStack.getPartStackByTabId(constraints.relativeId);
+    if (relativeEditorPartStack == null) {
+      String errorMessage =
+          coreLocalizationConstant.canNotOpenFileInSplitMode(file.getLocation().toString());
+      notificationManager.notify(errorMessage, FAIL, EMERGE_MODE);
+      Log.error(getClass(), errorMessage + ": relative part stack is not found");
+      return;
+    }
+
+    EditorPartStack editorPartStackConsumer =
+        editorMultiPartStack.split(relativeEditorPartStack, constraints, -1);
+    if (editorPartStackConsumer == null) {
+      String errorMessage =
+          coreLocalizationConstant.canNotOpenFileInSplitMode(file.getLocation().toString());
+      notificationManager.notify(errorMessage, FAIL, EMERGE_MODE);
+      Log.error(getClass(), errorMessage + ": split part stack is not found");
+      return;
+    }
+
+    doOpen(file, editorPartStackConsumer, new OpenEditorCallbackImpl());
   }
 
   @Override
@@ -248,20 +284,30 @@ public class EditorAgentImpl
 
   @Override
   public void openEditor(@NotNull VirtualFile file, @NotNull OpenEditorCallback callback) {
-    doOpen(file, callback, null);
+    Path path = file.getLocation();
+    EditorPartStack activeEditorPartStack = editorMultiPartStack.getActivePartStack();
+    if (activeEditorPartStack != null) {
+      PartPresenter openedPart = activeEditorPartStack.getPartByPath(path);
+      if (openedPart != null) {
+        editorMultiPartStack.setActivePart(openedPart);
+        callback.onEditorActivated((EditorPartPresenter) openedPart);
+        return;
+      }
+
+      if (isFileOpening(path, activeEditorPartStack)) {
+        return;
+      }
+    } else {
+      activeEditorPartStack = editorMultiPartStack.createRootPartStack();
+    }
+
+    doOpen(file, activeEditorPartStack, callback);
   }
 
   private void doOpen(
-      final VirtualFile file, final OpenEditorCallback callback, final Constraints constraints) {
-    EditorPartStack activePartStack = editorMultiPartStack.getActivePartStack();
-    if (constraints == null && activePartStack != null) {
-      PartPresenter partPresenter = activePartStack.getPartByPath(file.getLocation());
-      if (partPresenter != null) {
-        workspaceAgent.setActivePart(partPresenter, EDITING);
-        callback.onEditorActivated((EditorPartPresenter) partPresenter);
-        return;
-      }
-    }
+      VirtualFile file, EditorPartStack editorPartStackConsumer, OpenEditorCallback callback) {
+
+    addToOpeningFilesList(file.getLocation(), editorPartStackConsumer);
 
     final FileType fileType = fileTypeRegistry.getFileTypeByFile(file);
     final EditorProvider editorProvider = editorRegistry.getEditor(fileType);
@@ -270,33 +316,33 @@ public class EditorAgentImpl
       Promise<EditorPartPresenter> promise = provider.createEditor(file);
       if (promise != null) {
         promise.then(
-            new Operation<EditorPartPresenter>() {
-              @Override
-              public void apply(EditorPartPresenter arg) throws OperationException {
-                initEditor(file, callback, fileType, arg, constraints, editorProvider);
-              }
+            editor -> {
+              initEditor(file, callback, fileType, editor, editorPartStackConsumer, editorProvider);
             });
         return;
       }
     }
 
     final EditorPartPresenter editor = editorProvider.getEditor();
-    initEditor(file, callback, fileType, editor, constraints, editorProvider);
+    initEditor(file, callback, fileType, editor, editorPartStackConsumer, editorProvider);
   }
 
   private void initEditor(
-      final VirtualFile file,
-      final OpenEditorCallback openEditorCallback,
+      VirtualFile file,
+      OpenEditorCallback openEditorCallback,
       FileType fileType,
-      final EditorPartPresenter editor,
-      final Constraints constraints,
+      EditorPartPresenter editor,
+      EditorPartStack editorPartStack,
       EditorProvider editorProvider) {
     OpenEditorCallback initializeCallback =
         new OpenEditorCallbackImpl() {
           @Override
           public void onEditorOpened(EditorPartPresenter editor) {
-            workspaceAgent.openPart(editor, EDITING, constraints);
-            workspaceAgent.setActivePart(editor);
+            editorPartStack.addPart(editor);
+            editorMultiPartStack.setActivePart(editor);
+
+            openedEditors.add(editor);
+            removeFromOpeningFilesList(file.getLocation(), editorPartStack);
 
             openEditorCallback.onEditorOpened(editor);
           }
@@ -304,6 +350,13 @@ public class EditorAgentImpl
           @Override
           public void onInitializationFailed() {
             openEditorCallback.onInitializationFailed();
+
+            removeFromOpeningFilesList(file.getLocation(), editorPartStack);
+
+            if (!openingEditorsPathsToStacks.containsKey(editorPartStack)
+                && editorPartStack.getParts().isEmpty()) {
+              editorMultiPartStack.removePartStack(editorPartStack);
+            }
           }
         };
 
@@ -313,7 +366,6 @@ public class EditorAgentImpl
 
   private void finalizeInit(
       VirtualFile file, EditorPartPresenter editor, EditorProvider editorProvider) {
-    openedEditors.add(editor);
     openedEditorsToProviders.put(editor, editorProvider.getId());
 
     editor.addCloseHandler(this);
@@ -332,6 +384,30 @@ public class EditorAgentImpl
             eventBus.fireEvent(new EditorOpenedEvent(file, editor));
           }
         });
+  }
+
+  private boolean isFileOpening(Path path, EditorPartStack editorPartStack) {
+    Set<Path> openingFiles = openingEditorsPathsToStacks.get(editorPartStack);
+    return openingFiles != null && openingFiles.contains(path);
+  }
+
+  private void addToOpeningFilesList(Path path, EditorPartStack editorPartStack) {
+    if (editorPartStack == null) {
+      return;
+    }
+
+    Set<Path> openingFiles =
+        openingEditorsPathsToStacks.computeIfAbsent(editorPartStack, k -> new HashSet<>());
+    openingFiles.add(path);
+  }
+
+  private void removeFromOpeningFilesList(Path path, EditorPartStack editorPartStack) {
+    if (editorPartStack == null || !openingEditorsPathsToStacks.containsKey(editorPartStack)) {
+      return;
+    }
+
+    Set<Path> openingFiles = openingEditorsPathsToStacks.get(editorPartStack);
+    openingFiles.remove(path);
   }
 
   @Override
@@ -480,9 +556,13 @@ public class EditorAgentImpl
   public Promise<Void> loadState(@NotNull final JsonObject state) {
     if (state.hasKey("FILES")) {
       JsonObject files = state.getObject("FILES");
-      EditorPartStack partStack = editorMultiPartStack.createRootPartStack();
+      EditorPartStack editorPartStackConsumer = editorMultiPartStack.getActivePartStack();
+      if (editorPartStackConsumer == null) {
+        editorPartStackConsumer = editorMultiPartStack.createRootPartStack();
+      }
+
       final Map<EditorPartPresenter, EditorPartStack> activeEditors = new HashMap<>();
-      List<Promise<Void>> restore = restore(files, partStack, activeEditors);
+      List<Promise<Void>> restore = restore(files, editorPartStackConsumer, activeEditors);
       Promise<ArrayOf<?>> promise =
           promiseProvider.all2(restore.toArray(new Promise[restore.size()]));
       promise.then(
@@ -558,9 +638,16 @@ public class EditorAgentImpl
         new AsyncPromiseHelper.RequestCall<Void>() {
           @Override
           public void makeCall(final AsyncCallback<Void> callback) {
-            String path = file.getString("PATH");
+            String location = file.getString("PATH");
+            Path path = Path.valueOf(location);
+            if (isFileOpening(path, editorPartStack)) {
+              callback.onSuccess(null);
+              return;
+            }
+
+            addToOpeningFilesList(path, editorPartStack);
             resourceProvider
-                .getResource(path)
+                .getResource(location)
                 .then(
                     new Operation<java.util.Optional<VirtualFile>>() {
                       @Override
@@ -650,6 +737,9 @@ public class EditorAgentImpl
                 public void onEditorOpened(EditorPartPresenter editor) {
                   editorPartStack.addPart(editor);
 
+                  openedEditors.add(editor);
+                  removeFromOpeningFilesList(file.getLocation(), editorPartStack);
+
                   promiseCallback.onSuccess(null);
                   openEditorCallback.onEditorOpened(editor);
                 }
@@ -659,6 +749,12 @@ public class EditorAgentImpl
                   promiseCallback.onFailure(
                       new Exception("Can not initialize editor for " + file.getLocation()));
                   openEditorCallback.onInitializationFailed();
+                  removeFromOpeningFilesList(file.getLocation(), editorPartStack);
+
+                  if (!openingEditorsPathsToStacks.containsKey(editorPartStack)
+                      && editorPartStack.getParts().isEmpty()) {
+                    editorMultiPartStack.removePartStack(editorPartStack);
+                  }
                 }
               };
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/multipart/EditorMultiPartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/multipart/EditorMultiPartStackPresenter.java
@@ -186,10 +186,13 @@ public class EditorMultiPartStackPresenter
     }
   }
 
-  private void removePartStack(EditorPartStack editorPartStack) {
+  @Override
+  public void removePartStack(EditorPartStack editorPartStack) {
     if (activeEditorPartStack == editorPartStack) {
       activeEditorPartStack = null;
     }
+
+    editorPartStack.getParts().forEach(editorPartStack::removePart);
 
     view.removePartStack(editorPartStack);
     partStackPresenters.remove(editorPartStack);
@@ -239,7 +242,7 @@ public class EditorMultiPartStackPresenter
   }
 
   @Nullable
-  private EditorPartStack getPartStackByTabId(@NotNull String tabId) {
+  public EditorPartStack getPartStackByTabId(@NotNull String tabId) {
     for (EditorPartStack editorPartStack : partStackPresenters) {
       PartPresenter editorPart = editorPartStack.getPartByTabId(tabId);
       if (editorPart != null) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -83,13 +83,14 @@ public class AppStateManager {
     }
   }
 
-  public void restoreWorkspaceState(String wsId) {
+  public Promise<Void> restoreWorkspaceState(String wsId) {
     if (allWsState.hasKey(wsId)) {
-      restoreState(allWsState.getObject(wsId));
+      return restoreState(allWsState.getObject(wsId));
     }
+    return promises.resolve(null);
   }
 
-  private void restoreState(JsonObject settings) {
+  private Promise<Void> restoreState(JsonObject settings) {
     try {
       if (settings.hasKey(WORKSPACE)) {
         JsonObject workspace = settings.getObject(WORKSPACE);
@@ -108,10 +109,12 @@ public class AppStateManager {
                     ignored -> component.loadState(workspace.getObject(key)));
           }
         }
+        return sequentialRestore;
       }
     } catch (JsonException e) {
       Log.error(getClass(), e);
     }
+    return promises.resolve(null);
   }
 
   public Promise<Void> persistWorkspaceState(String wsId) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/PersistenceApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/PersistenceApiModule.java
@@ -30,7 +30,7 @@ public class PersistenceApiModule extends AbstractGinModule {
   @Override
   protected void configure() {
     GinMapBinder.newMapBinder(binder(), String.class, WsAgentComponent.class)
-        .addBinding("ZZ Restore Workspace State")
+        .addBinding("ZY Restore Workspace State")
         .to(WorkspaceStateRestorer.class);
 
     GinMultibinder<StateComponent> stateComponents =

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -226,6 +226,7 @@ messages.someFilesCanNotBeSaved = Failed to save all files
 messages.saveChanges = {0} has been modified. Save changes?
 messages.promptSaveChanges = Some data has been modified. Save changes?
 messages.unableOpenResource = Unable to open {0}.
+messages.canNotOpenFileInSplitMode=Can not open file {0} in split mode
 messages.canNotOpenFileWithoutParams=Can not open file without parameters
 messages.fileToOpenIsNotSpecified=File to open is not specified
 messages.fileToOpenLineIsNotANumber=Line specified for the file to open is not a number


### PR DESCRIPTION
### What does this PR do?
Change order of starting ws agent components -  [StartUpActionsProcessor](https://github.com/eclipse/che/blob/5b373e6cf5bfeb16f278c4d750fe64361445eeb4/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/StartUpActionsProcessor.java#L29) and [WorkspaceStateRestorer](https://github.com/eclipse/che/blob/7efb473ba6f5f514935024f44d2ec3319310f6f9/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/WorkspaceStateRestorer.java#L27), the new behavior:  StartUpActionsProcessor will start after WorkspaceStateRestorer.

Fix problems related to simultaneous opening files, like:
- avoid opening the same file a few times in the same editor part stack (for example, case when editor agent gets a few requests on opening the same file);
- avoid problems related to restoring editors and opening file by 'OpenFileAction' for example at the same time
- fix collapsing project tree when file is opened by [StartUpActionsProcessor](https://github.com/eclipse/che/blob/5b373e6cf5bfeb16f278c4d750fe64361445eeb4/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/client/StartUpActionsProcessor.java#L29), like this
![tree](https://user-images.githubusercontent.com/5676062/30957970-5f0bea06-a444-11e7-9f0e-b6afecc68267.png)

### What issues does this PR fix or reference?
#4952

#### Changelog
Fix problems related to simultaneous opening files

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>