### PR TITLE
Clean up `org.eclipse.che.selenium.debugger` package

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebugExternalClassTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebugExternalClassTest.java
@@ -119,33 +119,6 @@ public class DebugExternalClassTest {
     editor.closeAllTabs();
   }
 
-  @Test
-  public void shouldDebugJreClass() {
-    // when
-    editor.setInactiveBreakpoint(19);
-    menu.runCommandByXpath(
-        TestMenuCommandsConstants.Run.RUN_MENU,
-        TestMenuCommandsConstants.Run.DEBUG,
-        debugConfig.getXpathToІRunDebugCommand(PROJECT));
-
-    notifications.waitExpectedMessageOnProgressPanelAndClosed("Remote debugger connected");
-    editor.waitAcitveBreakpoint(19);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.STEP_INTO);
-
-    // then
-    editor.waitActiveTabFileName("Logger"); // there should be class "Logger" opened
-    debugPanel.waitDebugHighlightedText(
-        "    "); // we can't rely on concrete code of external library which can be changed in future
-    debugPanel.waitTextInVariablesPanel(
-        "=\"Info from java logger\""); // there should be at least parameter with value "Info from java logger"
-
-    // when
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
-
-    // then
-    editor.waitActiveTabFileName("SimpleLogger");
-  }
-
   @Test(priority = 1)
   public void shouldDebugMavenArtifactClassWithSources() {
     // when

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
@@ -129,18 +129,6 @@ public class InnerClassAndLambdaDebuggingTest {
     debugPanel.waitTextInVariablesPanel("anonym=\"App anonym\"");
   }
 
-  @Test(priority = 1, enabled = false)
-  public void shouldDebugMethodLocalInnerClass() {
-    // when
-    editor.setCursorToLine(53);
-    editor.setBreakpoint(53);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
-
-    // then
-    editor.waitAcitveBreakpoint(53);
-    debugPanel.waitTextInVariablesPanel("methodValue=\"App method local inner test\"");
-  }
-
   @Test(priority = 2)
   public void shouldDebugInnerClass() {
     // when

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -99,29 +99,9 @@
                     <exclude name="shouldDebugCppProject"/>
                 </methods>
             </class>
-            <class name="org.eclipse.che.selenium.debugger.DebugExternalClassTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4636 -->
-                    <exclude name="shouldDebugJreClass"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.debugger.InnerClassAndLambdaDebuggingTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4211 -->
-                    <exclude name="shouldDebugInnerClass"/>
-                    <exclude name="shouldDebugMethodLocalInnerClass"/>
-                    <exclude name="shouldDebugStaticInnerClass"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.debugger.MultimoduleProjectDebuggingTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4268 -->
-                    <exclude name="shouldDebugStaticMethod"/>
-
-                    <!-- https://github.com/eclipse/che/issues/4286 -->
-                    <exclude name="shouldGoIntoConstructor"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.debugger.DebugExternalClassTest"/>
+            <class name="org.eclipse.che.selenium.debugger.InnerClassAndLambdaDebuggingTest"/>
+            <class name="org.eclipse.che.selenium.debugger.MultimoduleProjectDebuggingTest"/>
             <class name="org.eclipse.che.selenium.debugger.NodeJsDebugTest">
                 <methods>
                     <!-- https://github.com/eclipse/che/issues/4720 -->


### PR DESCRIPTION
Clean up `org.eclipse.che.selenium.debugger` package
```
[TEST] RESULTS ANALYSE:
[TEST]
[TEST] Command line: /home/tolusha/projects/che/selenium/che-selenium-test/selenium-tests.sh --test=org.eclipse.che.selenium.debugger.* --threads=2
[TEST]
[TEST] Local results:
[TEST] 	- Run: 	     24
[TEST] 	- Failed:     4
[TEST]
[TEST] REGRESSION (4):
[TEST] 	org.eclipse.che.selenium.debugger.CppProjectDebuggingTest.shouldDebugCppProject
[TEST] 	org.eclipse.che.selenium.debugger.CppProjectDebuggingTest.stopDebug
[TEST] 	org.eclipse.che.selenium.debugger.PhpProjectDebuggingTest.shouldDebugCliPhpScriptFromFirstLine
[TEST] 	org.eclipse.che.selenium.debugger.PhpProjectDebuggingTest.shouldDebugWebPhpScriptFromNonDefaultPortAndNotFromFirstLine
[TEST]
[TEST]
[TEST]
```