### PR TITLE
Add more quick starts for vert.x, spring boot, and wildfly swarm

### DIFF
--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -1587,5 +1587,135 @@
     "tags": [
       "Ceylon"
     ]
+  },
+  {
+    "name": "vertx-http-booster",
+    "displayName": "vertx-http-booster",
+    "path": "/vertx-http-booster",
+    "description": "HTTP Vert.x Booster",
+    "projectType": "maven",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/openshiftio-vertx-boosters/vertx-http-booster",
+      "parameters": {}
+    },
+    "commands": [],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Vert.x"
+    ]
+  },
+  {
+    "name": "vertx-health-checks-booster",
+    "displayName": "vertx-health-checks-booster",
+    "path": "/vertx-health-checks-booster",
+    "description": "Booster demonstrating health checks and recovery",
+    "projectType": "maven",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster",
+      "parameters": {}
+    },
+    "commands": [],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "vert.x"
+    ]
+  },
+  {
+    "name": "spring-boot-http-booster",
+    "displayName": "spring-boot-http-booster",
+    "path": "/spring-boot-http-booster",
+    "description": "Quickstart to expose a REST Greeting endpoint using SpringBoot and Apache Tomcat in embedded mode",
+    "projectType": "maven",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/snowdrop/spring-boot-http-booster",
+      "parameters": {}
+    },
+    "commands": [],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Spring Boot"
+    ]
+  },
+  {
+    "name": "spring-boot-health-check-booster",
+    "displayName": "spring-boot-health-check-booster",
+    "path": "/spring-boot-health-check-booster",
+    "description": "Quickstart to demonstrate OpenShift health probes working with Spring Boot Actuator",
+    "projectType": "maven",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/snowdrop/spring-boot-health-check-booster",
+      "parameters": {}
+    },
+    "commands": [],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "spring boot"
+    ]
+  },
+  {
+    "name": "wfswarm-rest-http",
+    "displayName": "wfswarm-rest-http",
+    "path": "/wfswarm-rest-http",
+    "description": "Quickstart to expose a REST Greeting endpoint using Wildfly Swarm",
+    "projectType": "maven",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http",
+      "parameters": {}
+    },
+    "commands": [],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "Wildfly Swarm"
+    ]
   }
 ]


### PR DESCRIPTION
Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds more quick starts for vert.x, spring boot, and wildfly swarm

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/310

#### Changelog
<!-- one line entry to be added to changelog -->
Added more quick starts for vert.x, spring boot, and wildfly swarm

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
