### PR TITLE
Add a che.env/che.properties property to skip docker unused containers and networks cleanup

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -251,6 +251,8 @@ che.docker.namespace=NULL
 
 # Docker unused containers and networks cleanup period
 che.docker.cleanup_period_min=60
+# Skip docker unused containers and networks cleanup if the value is {true}.
+che.docker.cleanup_skip=false
 
 # Version number of the Docker API used within the Che implementation
 che.docker.api=1.20

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -381,6 +381,8 @@ CHE_SINGLE_PORT=false
 #     Unused containers and networks from Che and workspaces need to be cleaned up
 #     periodically.
 #CHE_DOCKER_CLEANUP__PERIOD__MIN=60
+#     Skip docker unused containers and networks cleanup if the value is {true}.
+#CHE_DOCKER_CLEANUP__SKIP=false
 
 
 

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/cleaner/DockerAbandonedResourcesCleaner.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/cleaner/DockerAbandonedResourcesCleaner.java
@@ -68,6 +68,10 @@ public class DockerAbandonedResourcesCleaner implements Runnable {
   private final WorkspaceRuntimes runtimes;
   private final Set<String> additionalNetworks;
 
+  @Inject(optional = true)
+  @Named("che.docker.cleanup_skip")
+  private String skipCleaningProperty;
+
   @Inject
   public DockerAbandonedResourcesCleaner(
       CheEnvironmentEngine environmentEngine,
@@ -89,6 +93,10 @@ public class DockerAbandonedResourcesCleaner implements Runnable {
   )
   @Override
   public void run() {
+    if (skipCleaningProperty != null && Boolean.parseBoolean(skipCleaningProperty)) {
+      LOG.info("Skipping che unused containers and network cleanup ...");
+      return;
+    }
     cleanContainers();
     cleanNetworks();
   }


### PR DESCRIPTION
### What does this PR do?
Add a che.env che.properties property to skip docker unused containers and networks cleanup. Can be useful in use cases where we want to run several che servers without having their workspaces being killed.
By default, cleanup will happen periodically.
To skip the cleanup, set the property to `true` in `che.env`

    CHE_DOCKER_CLEANUP__SKIP=true



### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6383