### PR TITLE
OpenShift Connector : Fix the issue when no exposed ports are defined in the docker image

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -331,8 +331,18 @@ public class OpenShiftConnector extends DockerConnector {
    */
   protected Set<String> getExposedPorts(ContainerConfig containerConfig, ImageConfig imageConfig) {
 
-    Set<String> containerExposedPorts = containerConfig.getExposedPorts().keySet();
-    Set<String> imageExposedPorts = imageConfig.getExposedPorts().keySet();
+    Map<String, Map<String, String>> containerExposedPortsMap = containerConfig.getExposedPorts();
+    if (containerExposedPortsMap == null) {
+      containerExposedPortsMap = Collections.emptyMap();
+    }
+    Map<String, org.eclipse.che.plugin.docker.client.json.ExposedPort> imageExposedPortsMap =
+        imageConfig.getExposedPorts();
+    if (imageExposedPortsMap == null) {
+      imageExposedPortsMap = Collections.emptyMap();
+    }
+
+    Set<String> containerExposedPorts = containerExposedPortsMap.keySet();
+    Set<String> imageExposedPorts = imageExposedPortsMap.keySet();
     return ImmutableSet.<String>builder()
         .addAll(containerExposedPorts)
         .addAll(imageExposedPorts)

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -17,6 +17,7 @@ import static org.testng.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
@@ -116,5 +117,19 @@ public class OpenShiftConnectorTest {
     Map<String, String> map = openShiftConnector.getLabels(containerConfig, imageConfig);
     assertNotNull(map);
     assertEquals(map.size(), 0);
+  }
+
+  /** Check that we return empty ports if no export ports and not a NPE */
+  @Test
+  public void checkWithNoExposedPorts() {
+    ContainerConfig containerConfig = Mockito.mock(ContainerConfig.class);
+    when(containerConfig.getExposedPorts()).thenReturn(null);
+
+    ImageConfig imageConfig = Mockito.mock(ImageConfig.class);
+    when(imageConfig.getExposedPorts()).thenReturn(null);
+
+    Set<String> mapPorts = openShiftConnector.getExposedPorts(containerConfig, imageConfig);
+    assertNotNull(mapPorts);
+    assertEquals(mapPorts.size(), 0);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fix the issue when no exposed ports are defined in the docker image

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/338


#### Release Notes
N/A


#### Docs PR
N/A
Change-Id: I76fa7b6aaff552043e1e8cf2934527f491631b2a
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

