### PR TITLE
Add account page with readonly info

### DIFF
--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -38,6 +38,7 @@ import {RouteHistory} from '../components/routing/route-history.service';
 import {CheUIElementsInjectorService} from '../components/service/injector/che-ui-elements-injector.service';
 import {OrganizationsConfig} from './organizations/organizations-config';
 import {TeamsConfig} from './teams/teams-config';
+import {ProfileConfig} from './profile/profile-config';
 
 // init module
 const initModule = angular.module('userDashboard', ['ngAnimate', 'ngCookies', 'ngTouch', 'ngSanitize', 'ngResource', 'ngRoute',
@@ -411,4 +412,5 @@ new StacksConfig(instanceRegister);
 new FactoryConfig(instanceRegister);
 new OrganizationsConfig(instanceRegister);
 new TeamsConfig(instanceRegister);
+new ProfileConfig(instanceRegister);
 /* tslint:enable */

--- a/dashboard/src/app/navbar/navbar.controller.ts
+++ b/dashboard/src/app/navbar/navbar.controller.ts
@@ -28,7 +28,7 @@ export class CheNavBarController {
 
   accountItems = [
     {
-      name: 'Go to Profile',
+      name: 'Account',
       onclick: () => {
         this.gotoProfile();
       }
@@ -178,8 +178,7 @@ export class CheNavBarController {
    * Opens user profile in new browser page.
    */
   gotoProfile(): void {
-    const url = this.cheKeycloak.getProfileUrl();
-    this.$window.open(url);
+    this.$location.path('/account');
   }
 
   /**

--- a/dashboard/src/app/profile/profile-config.ts
+++ b/dashboard/src/app/profile/profile-config.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+import {ProfileController} from './profile.controller';
+
+export class ProfileConfig {
+
+  constructor(register: che.IRegisterService) {
+    register.controller('ProfileController', ProfileController);
+
+    let locationProvider = {
+      title: 'Account',
+      templateUrl: 'app/profile/profile.html',
+      controller: 'ProfileController',
+      controllerAs: 'profileController'
+    };
+
+    // config routes
+    register.app.config(function ($routeProvider) {
+      $routeProvider.accessWhen('/account', locationProvider);
+    });
+  }
+}

--- a/dashboard/src/app/profile/profile.controller.ts
+++ b/dashboard/src/app/profile/profile.controller.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+import {CheKeycloak} from '../../components/api/che-keycloak.factory';
+import {CheProfile} from '../../components/api/che-profile.factory';
+/**
+ * This class is handling the controller for the profile page.
+ *
+ * @author Anna Shumilova
+ */
+export class ProfileController {
+  private profileUrl: string;
+  private firstName: string;
+  private lastName: string;
+  private email: string;
+  private userName: string;
+  private $window: ng.IWindowService;
+
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor(cheKeycloak: CheKeycloak, cheProfile: CheProfile, $window: ng.IWindowService) {
+    this.$window = $window;
+
+    this.profileUrl = cheKeycloak.getProfileUrl();
+    let profile = cheProfile.getProfile();
+    this.firstName = <string>profile.attributes['given_name'];
+    this.lastName = <string>profile.attributes['family_name'];
+    this.email = profile.email;
+    this.userName = <string>profile.attributes['preferred_username'];
+  }
+
+  /**
+   * Edit profile - redirects to proper page.
+   */
+  editProfile(): void {
+    this.$window.open(this.profileUrl);
+  }
+}

--- a/dashboard/src/app/profile/profile.html
+++ b/dashboard/src/app/profile/profile.html
@@ -1,0 +1,57 @@
+<!--
+
+    Copyright (c) 2015-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<che-toolbar che-title="Account"></che-toolbar>
+<md-content id="dashboardAccountPage" layout="column" class="profileContent" md-scroll-y flex>
+  <!-- User Name -->
+  <che-label-container che-label-name="Login">
+    <che-input-box che-name="login_name"
+                   aria-label="Login name"
+                   che-place-holder=""
+                   ng-model="profileController.userName"
+                   che-readonly="true">
+    </che-input-box>
+  </che-label-container>
+  <!-- Email -->
+  <che-label-container che-label-name="Email">
+    <che-input-box che-name="email"
+                   aria-label="email"
+                   che-place-holder=""
+                   ng-model="profileController.email"
+                   che-readonly="true">
+    </che-input-box>
+  </che-label-container>
+  <!-- First Name -->
+  <che-label-container che-label-name="First Name">
+    <che-input-box che-name="first_name"
+                   aria-label="First name"
+                   che-place-holder=""
+                   ng-model="profileController.firstName"
+                   che-readonly="true">
+    </che-input-box>
+  </che-label-container>
+  <!-- Last Name -->
+  <che-label-container che-label-name="Last Name">
+    <che-input-box che-name="last_name"
+                   aria-label="Last name"
+                   che-place-holder=""
+                   ng-model="profileController.lastName"
+                   che-readonly="true">
+    </che-input-box>
+  </che-label-container>
+  <!-- Update Profile -->
+  <che-label-container che-label-name="">
+    <che-button-default class="prifile-add-button"
+                        che-button-title="Edit" name="editButton"
+                        ng-click="profileController.editProfile()"></che-button-default>
+  </che-label-container>
+</md-content>

--- a/dashboard/src/app/profile/profile.styl
+++ b/dashboard/src/app/profile/profile.styl
@@ -1,0 +1,7 @@
+.profileContent .che-label-container
+  border-bottom none
+  padding 0px
+  flex none
+
+.profileContent .che-label-container:first-of-type
+  margin-top 25px


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds account page with readonly information and edit button (which redirects to advanced profile editing)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5788

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
