### PR TITLE
Disable scheduling of methods annotated with @ScheduleRate/@ScheduleDelay if period/delay is negative

### DIFF
--- a/core/commons/che-core-commons-schedule/README.md
+++ b/core/commons/che-core-commons-schedule/README.md
@@ -133,6 +133,30 @@ public class RouterRulesRegistry {
        when statically configured value. Same for delay and delayParameterName.</p>
 </blockquote>
 
+### Disabling scheduling by rate or period
+If a scheduled method has been configured through `delayParameterName` or `periodParameterName`, it is possible to disable
+the scheduling by setting a non positive value to the parameter.
+
+Example: Disabling scheduling of this `registerRoutingRules` method:
+
+```java
+@Singleton // should be eager
+public class RouterRulesRegistry {
+
+    @ScheduleDelay(initialDelayParameterName = "router.rules.initialDelay",
+            delayParameterName = "router.rules.delay",
+            unit = TimeUnit.MINUTES)
+    private void registerRoutingRules() throws Exception {
+     ...
+    }
+```
+
+In che.properties:
+```
+router.rules.delay=-1
+```
+will disable the scheduling
+
 ### Run job according to the cron expression
 If you would like to execute some method according to the cron expression you can mark method with annotation @ScheduleCron
 Example 1 :  Send each Sunday at 1:00 AM.

--- a/core/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/ScheduleDelay.java
+++ b/core/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/ScheduleDelay.java
@@ -42,6 +42,9 @@ public @interface ScheduleDelay {
   /** @return - name of configuration parameter for initialDelay */
   String initialDelayParameterName() default "";
 
-  /** @return - name of configuration parameter for delay */
+  /**
+   * @return - name of configuration parameter for delay. A non positive delay value will disable
+   *     the scheduling of the method.
+   */
   String delayParameterName() default "";
 }

--- a/core/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/ScheduleRate.java
+++ b/core/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/ScheduleRate.java
@@ -46,6 +46,9 @@ public @interface ScheduleRate {
   /** @return - name of configuration parameter for initialDelay */
   String initialDelayParameterName() default "";
 
-  /** @return - name of configuration parameter for period */
+  /**
+   * @return - name of configuration parameter for period. A non positive period value will disable
+   *     the scheduling of the method.
+   */
   String periodParameterName() default "";
 }

--- a/core/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/executor/ThreadPullLauncher.java
+++ b/core/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/executor/ThreadPullLauncher.java
@@ -87,6 +87,16 @@ public class ThreadPullLauncher implements Launcher {
   @Override
   public void scheduleWithFixedDelay(
       Runnable runnable, long initialDelay, long delay, TimeUnit unit) {
+    if (delay <= 0) {
+      LOG.debug(
+          "Method {} has not been scheduled (delay <= 0). Initial delay {} delay {} unit {}",
+          runnable,
+          initialDelay,
+          delay,
+          unit);
+      return;
+    }
+
     service.scheduleWithFixedDelay(runnable, initialDelay, delay, unit);
     LOG.debug(
         "Schedule method {} with fixed initial delay {} delay {} unit {}",
@@ -99,6 +109,16 @@ public class ThreadPullLauncher implements Launcher {
   @Override
   public void scheduleAtFixedRate(
       Runnable runnable, long initialDelay, long period, TimeUnit unit) {
+    if (period <= 0) {
+      LOG.debug(
+          "Method {} with fixed rate has not been scheduled (period <= 0). Initial delay {} period {} unit {}",
+          runnable,
+          initialDelay,
+          period,
+          unit);
+      return;
+    }
+
     service.scheduleAtFixedRate(runnable, initialDelay, period, unit);
     LOG.debug(
         "Schedule method {} with fixed rate. Initial delay {} period {} unit {}",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Disable scheduling of methods annotated with @ScheduleRate/@ScheduleDelay if period/delay is negative

Thanks to this PR, we can fix #6383 by setting  `che.docker.cleanup_period_min=-1`
