### PR TITLE
Capture screenshot when selenium test configuration method fails

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -200,7 +200,7 @@ public abstract class SeleniumTestHandler
 
   /** Is invoked when test or configuration is finished. */
   private void onTestFinish(ITestResult result) {
-    if (result.getStatus() == ITestResult.FAILURE) {
+    if (result.getStatus() == ITestResult.FAILURE || result.getStatus() == ITestResult.SKIP) {
       ofNullable(result.getThrowable()).ifPresent(e -> LOG.error("" + e.getMessage(), e));
 
       captureScreenshot(result);


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>

### What does this PR do?
It adds command to capture screenshot from **webdriver** instance after test configuration method fails.

### What issues does this PR fix or reference?
#6504

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
