### PR TITLE
Fix CreateAndDeleteProjectsTest flow

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NotificationsPopupPanel.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NotificationsPopupPanel.java
@@ -68,13 +68,13 @@ public class NotificationsPopupPanel {
   /** wait progress Popup panel disappear */
   public void waitProgressPopupPanelClose() {
     new WebDriverWait(seleniumWebDriver, EXPECTED_MESS_IN_CONSOLE_SEC)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.xpath(PROGRESS_POPUP_PANEL_ID)));
+        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(PROGRESS_POPUP_PANEL_ID)));
   }
 
   /** wait progress Popup panel disappear after timeout defined by user */
   public void waitProgressPopupPanelClose(int userTimeout) {
     new WebDriverWait(seleniumWebDriver, userTimeout)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.xpath(PROGRESS_POPUP_PANEL_ID)));
+        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(PROGRESS_POPUP_PANEL_ID)));
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -85,12 +85,12 @@ public class CreateAndDeleteProjectsTest {
     loader.waitOnClosed();
     explorer.waitProjectExplorer();
     explorer.waitItem(DashboardProject.Template.CONSOLE_JAVA_SIMPLE.value());
+    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    mavenPluginStatusBar.waitClosingInfoPanel();
     explorer.waitFolderDefinedTypeOfFolderByPath(
         DashboardProject.Template.CONSOLE_JAVA_SIMPLE.value(), PROJECT_FOLDER);
     explorer.waitFolderDefinedTypeOfFolderByPath(
         DashboardProject.Template.WEB_JAVA_SPRING.value(), PROJECT_FOLDER);
-    notificationsPopupPanel.waitPopUpPanelsIsClosed();
-    mavenPluginStatusBar.waitClosingInfoPanel();
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();
 


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix CreateAndDeleteProjectsTest flow more reason start checking project state in prokectExplorere only after closing all popup windows and resolving progress


