### PR TITLE
CHE-6515 Added email notifications

### DIFF
--- a/assembly-multiuser/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/MultiUserCheWsMasterModule.java
+++ b/assembly-multiuser/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/MultiUserCheWsMasterModule.java
@@ -17,6 +17,8 @@ import org.eclipse.che.api.user.server.jpa.JpaUserDao;
 import org.eclipse.che.api.user.server.spi.PreferenceDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
 import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.mail.template.ST.STTemplateProcessorImpl;
+import org.eclipse.che.mail.template.TemplateProcessor;
 import org.eclipse.che.multiuser.api.permission.server.AdminPermissionInitializer;
 import org.eclipse.che.multiuser.api.permission.server.PermissionChecker;
 import org.eclipse.che.multiuser.api.permission.server.PermissionCheckerImpl;
@@ -32,6 +34,8 @@ public class MultiUserCheWsMasterModule extends AbstractModule {
 
   @Override
   protected void configure() {
+    bind(TemplateProcessor.class).to(STTemplateProcessorImpl.class);
+
     bind(DataSource.class).toProvider(org.eclipse.che.core.db.JndiDataSourceProvider.class);
     install(new org.eclipse.che.multiuser.api.permission.server.jpa.SystemPermissionsJpaModule());
     install(new org.eclipse.che.multiuser.api.permission.server.PermissionsModule());

--- a/assembly-multiuser/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly-multiuser/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -82,3 +82,19 @@ che.limits.organization.workspaces.count=-1
 #     organization will need to stop a running workspace to activate another.
 che.limits.organization.workspaces.run.count=-1
 
+# Address that will be used as from email for email notifications
+che.mail.from_email_address=che@noreply.com
+
+#####                     ORGANIZATIONS' NOTIFICATIONS SETTINGS                       #####
+
+che.organization.email.member_added_subject=You've been added to a Che Organization
+che.organization.email.member_added_template=st-html-templates/user_added_to_organization
+
+che.organization.email.member_removed_subject=You've been removed from a Che Organization
+che.organization.email.member_removed_template=st-html-templates/user_removed_from_organization
+
+che.organization.email.org_removed_subject=Che Organization deleted
+che.organization.email.org_removed_template=st-html-templates/organization_deleted
+
+che.organization.email.org_renamed_subject=Che Organization renamed
+che.organization.email.org_renamed_template=st-html-templates/organization_renamed

--- a/core/commons/che-core-commons-mail/pom.xml
+++ b/core/commons/che-core-commons-mail/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/EmailBean.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/EmailBean.java
@@ -21,6 +21,7 @@ import org.eclipse.che.commons.annotation.Nullable;
  * @author Alexander Garagatyi
  */
 public class EmailBean {
+
   private String from;
   private String to;
   private String replyTo;
@@ -153,8 +154,12 @@ public class EmailBean {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof EmailBean)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EmailBean)) {
+      return false;
+    }
     EmailBean emailBean = (EmailBean) o;
     return Objects.equals(getFrom(), emailBean.getFrom())
         && Objects.equals(getTo(), emailBean.getTo())

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/EmailBean.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/EmailBean.java
@@ -29,6 +29,36 @@ public class EmailBean {
   private String subject;
   private List<Attachment> attachments;
 
+  public EmailBean() {}
+
+  public EmailBean(EmailBean email) {
+    this(
+        email.getFrom(),
+        email.getTo(),
+        email.getReplyTo(),
+        email.getMimeType(),
+        email.getBody(),
+        email.getSubject(),
+        email.getAttachments());
+  }
+
+  public EmailBean(
+      String from,
+      String to,
+      String replyTo,
+      String mimeType,
+      String body,
+      String subject,
+      List<Attachment> attachments) {
+    this.from = from;
+    this.to = to;
+    this.replyTo = replyTo;
+    this.mimeType = mimeType;
+    this.body = body;
+    this.subject = subject;
+    this.attachments = attachments;
+  }
+
   public String getFrom() {
     return from;
   }

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/MailSessionProvider.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/MailSessionProvider.java
@@ -21,20 +21,23 @@ import javax.mail.Authenticator;
 import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
 import org.eclipse.che.inject.ConfigurationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Provider of {@link Session} */
 @Singleton
 public class MailSessionProvider implements Provider<Session> {
+  private static final Logger LOG = LoggerFactory.getLogger(MailSessionProvider.class);
 
   private final Session session;
+
   /**
-   * Configuration can be injected from container with help of {@lin ConfigurationProperties} class.
-   * In this case all properties that starts with 'che.mail.' will be used to create {@link
+   * Configuration can be injected from container with help of {@link ConfigurationProperties}
+   * class. In this case all properties that starts with 'che.mail.' will be used to create {@link
    * Session}. First 4 letters 'che.' from property names will be removed.
    */
   @Inject
   public MailSessionProvider(ConfigurationProperties configurationProperties) {
-
     this(
         configurationProperties
             .getProperties("che.mail.*")
@@ -70,6 +73,7 @@ public class MailSessionProvider implements Provider<Session> {
         this.session = Session.getInstance(props);
       }
     } else {
+      LOG.warn("Mail server is not configured. Sending of emails won't work.");
       this.session = null;
     }
   }
@@ -77,7 +81,7 @@ public class MailSessionProvider implements Provider<Session> {
   @Override
   public Session get() {
     if (session == null) {
-      throw new RuntimeException("SMTP is not configured");
+      throw new RuntimeException("Mail server is not configured");
     }
     return session;
   }

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/ST/STTemplateProcessorImpl.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/ST/STTemplateProcessorImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.mail.template.ST;
+
+import com.google.common.io.CharStreams;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+import javax.inject.Singleton;
+import org.eclipse.che.commons.lang.IoUtil;
+import org.eclipse.che.mail.template.Template;
+import org.eclipse.che.mail.template.TemplateProcessor;
+import org.eclipse.che.mail.template.exception.TemplateException;
+import org.eclipse.che.mail.template.exception.TemplateNotFoundException;
+import org.stringtemplate.v4.ST;
+
+/**
+ * {@link TemplateProcessor} implementation based on {@link ST}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class STTemplateProcessorImpl implements TemplateProcessor {
+
+  @Override
+  public String process(String templateName, Map<String, Object> variables)
+      throws TemplateException {
+    ST st = new ST(resolve(templateName));
+    variables.forEach(st::add);
+    return st.render();
+  }
+
+  @Override
+  public String process(Template template) throws TemplateException {
+    return process(template.getName(), template.getAttributes());
+  }
+
+  private String resolve(String template) throws TemplateNotFoundException {
+    try (Reader reader = new InputStreamReader(IoUtil.getResource(template))) {
+      return CharStreams.toString(reader);
+    } catch (IOException e) {
+      throw new TemplateNotFoundException(e.getMessage(), e);
+    }
+  }
+}

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/Template.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/Template.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.mail.template;
+
+import java.util.Map;
+
+/**
+ * Holds information that is required for template processing.
+ *
+ * @author Sergii Leshchenko
+ */
+public class Template {
+
+  private final String templateName;
+  private final Map<String, Object> attributes;
+
+  public Template(String templateName, Map<String, Object> attributes) {
+    this.templateName = templateName;
+    this.attributes = attributes;
+  }
+
+  /**
+   * Returns template name.
+   *
+   * @see ClassLoader#getResource(String)
+   */
+  public String getName() {
+    return templateName;
+  }
+
+  /** Returns attributes which will be used while template processing. */
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+}

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/TemplateProcessor.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/TemplateProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.mail.template;
+
+import java.util.Map;
+import org.eclipse.che.mail.template.exception.TemplateException;
+import org.eclipse.che.mail.template.exception.TemplateNotFoundException;
+
+/**
+ * Provides ability to process templates.
+ *
+ * <p>Note that variables definition format is implementation specific.
+ *
+ * @author Anton Korneta
+ * @author Sergii Leshchenko
+ */
+public interface TemplateProcessor {
+
+  /**
+   * Process specified template with given variables.
+   *
+   * @param templateName the template name which will be used for processing
+   * @param variables the variables to used while processing of the given template
+   * @return processed template as string
+   * @throws TemplateNotFoundException when given {@code template} not found
+   * @throws TemplateException when any another problem occurs during the template processing
+   * @see ClassLoader#getResource(String)
+   */
+  String process(String templateName, Map<String, Object> variables) throws TemplateException;
+
+  /**
+   * Process the specified template.
+   *
+   * @param template the template to process
+   * @return processed template as string
+   * @throws TemplateNotFoundException when given {@code template} not found
+   * @throws TemplateException when any another problem occurs during the template processing
+   */
+  String process(Template template) throws TemplateException;
+}

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/exception/TemplateException.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/exception/TemplateException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.mail.template.exception;
+
+/**
+ * Should be thrown when any exception occurs unable while template processing.
+ *
+ * @author Sergii Leshchenko
+ */
+public class TemplateException extends Exception {
+
+  public TemplateException(String message) {
+    super(message);
+  }
+
+  public TemplateException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/exception/TemplateNotFoundException.java
+++ b/core/commons/che-core-commons-mail/src/main/java/org/eclipse/che/mail/template/exception/TemplateNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.mail.template.exception;
+
+/**
+ * Should be thrown when unable to resolve template by given path.
+ *
+ * @author Anton Korneta
+ */
+public class TemplateNotFoundException extends TemplateException {
+
+  public TemplateNotFoundException(String message) {
+    super(message);
+  }
+
+  public TemplateNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/multiuser/api/che-multiuser-api-organization/pom.xml
+++ b/multiuser/api/che-multiuser-api-organization/pom.xml
@@ -95,6 +95,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
         </dependency>
         <dependency>

--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/OrganizationApiModule.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/OrganizationApiModule.java
@@ -20,6 +20,7 @@ import org.eclipse.che.multiuser.api.permission.shared.model.PermissionsDomain;
 import org.eclipse.che.multiuser.organization.api.listener.MemberEventsPublisher;
 import org.eclipse.che.multiuser.organization.api.listener.OrganizationEventsWebsocketBroadcaster;
 import org.eclipse.che.multiuser.organization.api.listener.RemoveOrganizationOnLastUserRemovedEventSubscriber;
+import org.eclipse.che.multiuser.organization.api.notification.OrganizationNotificationEmailSender;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationDomain;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationPermissionsFilter;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationResourceDistributionServicePermissionsFilter;
@@ -75,5 +76,7 @@ public class OrganizationApiModule extends AbstractModule {
             Names.named(SuperPrivilegesChecker.SUPER_PRIVILEGED_DOMAINS))
         .addBinding()
         .to(OrganizationDomain.class);
+
+    bind(OrganizationNotificationEmailSender.class).asEagerSingleton();
   }
 }

--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationEmailNotifications.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationEmailNotifications.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.organization.api.notification;
+
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.mail.EmailBean;
+import org.eclipse.che.mail.template.TemplateProcessor;
+import org.eclipse.che.mail.template.exception.TemplateException;
+
+/**
+ * Builds emails notification about organization changes.
+ *
+ * @author Sergii Leshchenko
+ */
+public class OrganizationEmailNotifications {
+
+  private final String mailFrom;
+  private final String memberAddedSubject;
+  private final String memberAddedTemplate;
+  private final String memberRemovedSubject;
+  private final String memberRemovedTemplate;
+  private final String orgRemovedSubject;
+  private final String orgRemovedTemplate;
+  private final String orgRenamedSubject;
+  private final String orgRenamedTemplate;
+  private final TemplateProcessor templateProcessor;
+
+  @Inject
+  public OrganizationEmailNotifications(
+      @Named("che.mail.from_email_address") String mailFrom,
+      @Named("che.organization.email.member_added_subject") String memberAddedSubject,
+      @Named("che.organization.email.member_added_template") String memberAddedTemplate,
+      @Named("che.organization.email.member_removed_subject") String memberRemovedSubject,
+      @Named("che.organization.email.member_removed_template") String memberRemovedTemplate,
+      @Named("che.organization.email.org_removed_subject") String orgRemovedSubject,
+      @Named("che.organization.email.org_removed_template") String orgRemovedTemplate,
+      @Named("che.organization.email.org_renamed_subject") String orgRenamedSubject,
+      @Named("che.organization.email.org_renamed_template") String orgRenamedTemplate,
+      TemplateProcessor templateProcessor) {
+    this.mailFrom = mailFrom;
+    this.memberAddedSubject = memberAddedSubject;
+    this.memberAddedTemplate = memberAddedTemplate;
+    this.memberRemovedSubject = memberRemovedSubject;
+    this.memberRemovedTemplate = memberRemovedTemplate;
+    this.orgRemovedSubject = orgRemovedSubject;
+    this.orgRemovedTemplate = orgRemovedTemplate;
+    this.orgRenamedSubject = orgRenamedSubject;
+    this.orgRenamedTemplate = orgRenamedTemplate;
+    this.templateProcessor = templateProcessor;
+  }
+
+  public EmailBean memberAdded(
+      String organizationName, String dashboardEndpoint, String orgQualifiedName, String initiator)
+      throws ServerException {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("organizationName", organizationName);
+    attributes.put("dashboardEndpoint", dashboardEndpoint);
+    attributes.put("orgQualifiedName", orgQualifiedName);
+    attributes.put("initiator", initiator);
+
+    return doBuildEmail(memberAddedSubject, memberAddedTemplate, attributes);
+  }
+
+  public EmailBean memberRemoved(String organizationName, String initiator) throws ServerException {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("organizationName", organizationName);
+    attributes.put("initiator", initiator);
+
+    return doBuildEmail(memberRemovedSubject, memberRemovedTemplate, attributes);
+  }
+
+  public EmailBean organizationRenamed(String oldName, String newName) throws ServerException {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("orgOldName", oldName);
+    attributes.put("orgNewName", newName);
+    return doBuildEmail(orgRenamedSubject, orgRenamedTemplate, attributes);
+  }
+
+  public EmailBean organizationRemoved(String organizationName) throws ServerException {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("organizationName", organizationName);
+    return doBuildEmail(orgRemovedSubject, orgRemovedTemplate, attributes);
+  }
+
+  protected EmailBean doBuildEmail(
+      String subject, String templatePath, Map<String, Object> attributes) throws ServerException {
+    try {
+      return new EmailBean()
+          .withSubject(subject)
+          .withBody(templateProcessor.process(templatePath, attributes))
+          .withFrom(mailFrom)
+          .withReplyTo(mailFrom)
+          .withMimeType(TEXT_HTML);
+    } catch (TemplateException e) {
+      throw new ServerException(e.getMessage());
+    }
+  }
+}

--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationNotificationEmailSender.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationNotificationEmailSender.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.organization.api.notification;
+
+import static org.eclipse.che.api.core.Pages.iterate;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.mail.EmailBean;
+import org.eclipse.che.mail.MailSender;
+import org.eclipse.che.multiuser.organization.api.OrganizationManager;
+import org.eclipse.che.multiuser.organization.api.event.MemberAddedEvent;
+import org.eclipse.che.multiuser.organization.api.event.MemberRemovedEvent;
+import org.eclipse.che.multiuser.organization.api.event.OrganizationRemovedEvent;
+import org.eclipse.che.multiuser.organization.api.event.OrganizationRenamedEvent;
+import org.eclipse.che.multiuser.organization.shared.event.OrganizationEvent;
+import org.eclipse.che.multiuser.organization.shared.model.Member;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Notify users about organization changes.
+ *
+ * @author Anton Korneta
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class OrganizationNotificationEmailSender implements EventSubscriber<OrganizationEvent> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OrganizationNotificationEmailSender.class);
+
+  private final String apiEndpoint;
+  private final MailSender mailSender;
+  private final OrganizationManager organizationManager;
+  private final UserManager userManager;
+  private final OrganizationEmailNotifications emails;
+
+  @Inject
+  public OrganizationNotificationEmailSender(
+      @Named("che.api") String apiEndpoint,
+      MailSender mailSender,
+      OrganizationManager organizationManager,
+      UserManager userManager,
+      OrganizationEmailNotifications emails) {
+    this.apiEndpoint = apiEndpoint;
+    this.mailSender = mailSender;
+    this.organizationManager = organizationManager;
+    this.userManager = userManager;
+    this.emails = emails;
+  }
+
+  @Inject
+  public void subscribe(EventService eventService) {
+    eventService.subscribe(this);
+  }
+
+  @Override
+  public void onEvent(OrganizationEvent event) {
+    try {
+      if (event.getInitiator() != null) {
+        if (event.getOrganization().getParent() == null) {
+          try {
+            userManager.getByName(event.getOrganization().getName());
+            return;
+          } catch (NotFoundException ex) {
+            //it is not personal organization
+          }
+        }
+        switch (event.getType()) {
+          case MEMBER_ADDED:
+            send((MemberAddedEvent) event);
+            break;
+          case MEMBER_REMOVED:
+            send((MemberRemovedEvent) event);
+            break;
+          case ORGANIZATION_REMOVED:
+            send((OrganizationRemovedEvent) event);
+            break;
+          case ORGANIZATION_RENAMED:
+            send((OrganizationRenamedEvent) event);
+        }
+      }
+    } catch (Exception ex) {
+      LOG.error("Failed to send email notification '{}' cause : '{}'", ex.getMessage());
+    }
+  }
+
+  private void send(MemberAddedEvent event) throws ServerException {
+    final String orgName = event.getOrganization().getName();
+    final String emailTo = event.getMember().getEmail();
+    final String initiator = event.getInitiator();
+    final String dashboardEndpoint = apiEndpoint.replace("api", "dashboard");
+    final String orgQualifiedName = event.getOrganization().getQualifiedName();
+    EmailBean memberAddedEmail =
+        emails.memberAdded(orgName, dashboardEndpoint, orgQualifiedName, initiator);
+    mailSender.sendAsync(memberAddedEmail.withTo(emailTo));
+  }
+
+  private void send(MemberRemovedEvent event) throws ServerException {
+    final String organizationName = event.getOrganization().getName();
+    final String initiator = event.getInitiator();
+    final String emailTo = event.getMember().getEmail();
+
+    EmailBean memberRemovedEmail = emails.memberRemoved(organizationName, initiator);
+    mailSender.sendAsync(memberRemovedEmail.withTo(emailTo));
+  }
+
+  private void send(OrganizationRemovedEvent event) throws ServerException, NotFoundException {
+    String organizationName = event.getOrganization().getName();
+    EmailBean orgRemovedEmail = emails.organizationRemoved(organizationName);
+    for (Member member : event.getMembers()) {
+      try {
+        final String emailTo = userManager.getById(member.getUserId()).getEmail();
+        mailSender.sendAsync(new EmailBean(orgRemovedEmail).withTo(emailTo));
+      } catch (Exception ignore) {
+      }
+    }
+  }
+
+  private void send(OrganizationRenamedEvent event) throws ServerException, NotFoundException {
+    EmailBean orgRenamedEmail = emails.organizationRenamed(event.getOldName(), event.getNewName());
+    for (Member member :
+        iterate(
+            (max, skip) ->
+                organizationManager.getMembers(event.getOrganization().getId(), max, skip))) {
+      try {
+        final String emailTo = userManager.getById(member.getUserId()).getEmail();
+        mailSender.sendAsync(new EmailBean(orgRenamedEmail).withTo(emailTo));
+      } catch (Exception ignore) {
+      }
+    }
+  }
+}

--- a/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/organization_deleted
+++ b/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/organization_deleted
@@ -1,0 +1,2 @@
+Hi,\<br>
+\<b><organizationName>\</b> organization has been deleted.

--- a/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/organization_renamed
+++ b/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/organization_renamed
@@ -1,0 +1,2 @@
+Hi,\<br>
+\<b><orgOldName>\</b> organization has been renamed to \<b><orgNewName>\</b>.

--- a/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/user_added_to_organization
+++ b/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/user_added_to_organization
@@ -1,0 +1,4 @@
+Hi,\<br>
+\<b><initiator>\</b> added you to a Che organization called \<b><organizationName>\</b>.\<br>
+Access the organization here \<a href="<dashboardEndpoint>/#/organization/<orgQualifiedName>">link\</a>.\<br>
+Enjoy!

--- a/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/user_removed_from_organization
+++ b/multiuser/api/che-multiuser-api-organization/src/main/resources/st-html-templates/user_removed_from_organization
@@ -1,0 +1,2 @@
+Hi,\<br>
+\<b><initiator>\</b> removed you from a Che organization called \<b><organizationName>\</b>.

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationEmailNotificationsTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationEmailNotificationsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.organization.api.notification;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Map;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.che.mail.EmailBean;
+import org.eclipse.che.mail.template.TemplateProcessor;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link OrganizationEmailNotifications}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OrganizationEmailNotificationsTest {
+
+  private static final String MAIL_FROM = "mail@from.com";
+  private static final String MEMBER_ADDED_SUBJECT = "Member Added";
+  private static final String MEMBER_ADDED_TEMPLATE = "/member-added";
+  private static final String MEMBER_REMOVED_SUBJECT = "Member Removed";
+  private static final String MEMBER_REMOVED_TEMPLATE = "/member-removed";
+  private static final String ORG_REMOVED_SUBJECT = "Org Removed";
+  private static final String ORG_REMOVED_TEMPLATE = "/org-removed";
+  private static final String ORG_RENAMED_SUBJECT = "Org Renamed";
+  private static final String ORG_RENAMED_TEMPLATE = "/org-renamed";
+
+  @Mock private TemplateProcessor templateProcessor;
+  @Captor private ArgumentCaptor<Map<String, Object>> attributesCaptor;
+
+  private OrganizationEmailNotifications emails;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    initMocks(this);
+
+    emails =
+        new OrganizationEmailNotifications(
+            MAIL_FROM,
+            MEMBER_ADDED_SUBJECT,
+            MEMBER_ADDED_TEMPLATE,
+            MEMBER_REMOVED_SUBJECT,
+            MEMBER_REMOVED_TEMPLATE,
+            ORG_REMOVED_SUBJECT,
+            ORG_REMOVED_TEMPLATE,
+            ORG_RENAMED_SUBJECT,
+            ORG_RENAMED_TEMPLATE,
+            templateProcessor);
+  }
+
+  @Test
+  public void shouldReturnMemberAddedEmail() throws Exception {
+    EmailBean email =
+        emails.memberAdded("SuperOrg", "localhost:8080/dashboard", "/superOrg/org", "admin");
+
+    assertEquals(email.getFrom(), MAIL_FROM);
+    assertEquals(email.getReplyTo(), MAIL_FROM);
+    assertEquals(email.getMimeType(), MediaType.TEXT_HTML);
+    assertEquals(email.getSubject(), MEMBER_ADDED_SUBJECT);
+
+    verify(templateProcessor).process(eq(MEMBER_ADDED_TEMPLATE), attributesCaptor.capture());
+    Map<String, Object> attributes = attributesCaptor.getValue();
+    assertEquals(attributes.get("organizationName"), "SuperOrg");
+    assertEquals(attributes.get("dashboardEndpoint"), "localhost:8080/dashboard");
+    assertEquals(attributes.get("orgQualifiedName"), "/superOrg/org");
+    assertEquals(attributes.get("initiator"), "admin");
+  }
+
+  @Test
+  public void shouldReturnMemberRemovedEmail() throws Exception {
+    EmailBean email = emails.memberRemoved("SuperOrg", "admin");
+
+    assertEquals(email.getFrom(), MAIL_FROM);
+    assertEquals(email.getReplyTo(), MAIL_FROM);
+    assertEquals(email.getMimeType(), MediaType.TEXT_HTML);
+    assertEquals(email.getSubject(), MEMBER_REMOVED_SUBJECT);
+
+    verify(templateProcessor).process(eq(MEMBER_REMOVED_TEMPLATE), attributesCaptor.capture());
+    Map<String, Object> attributes = attributesCaptor.getValue();
+    assertEquals(attributes.get("organizationName"), "SuperOrg");
+    assertEquals(attributes.get("initiator"), "admin");
+  }
+
+  @Test
+  public void shouldReturnOrgRenamedEmail() throws Exception {
+    EmailBean email = emails.organizationRenamed("Org", "SuperOrg");
+
+    assertEquals(email.getFrom(), MAIL_FROM);
+    assertEquals(email.getReplyTo(), MAIL_FROM);
+    assertEquals(email.getMimeType(), MediaType.TEXT_HTML);
+    assertEquals(email.getSubject(), ORG_RENAMED_SUBJECT);
+
+    verify(templateProcessor).process(eq(ORG_RENAMED_TEMPLATE), attributesCaptor.capture());
+    Map<String, Object> attributes = attributesCaptor.getValue();
+    assertEquals(attributes.get("orgOldName"), "Org");
+    assertEquals(attributes.get("orgNewName"), "SuperOrg");
+  }
+
+  @Test
+  public void shouldReturnOrgRemovedEmail() throws Exception {
+    EmailBean email = emails.organizationRemoved("Org");
+
+    assertEquals(email.getFrom(), MAIL_FROM);
+    assertEquals(email.getReplyTo(), MAIL_FROM);
+    assertEquals(email.getMimeType(), MediaType.TEXT_HTML);
+    assertEquals(email.getSubject(), ORG_REMOVED_SUBJECT);
+
+    verify(templateProcessor).process(eq(ORG_REMOVED_TEMPLATE), attributesCaptor.capture());
+    Map<String, Object> attributes = attributesCaptor.getValue();
+    assertEquals(attributes.get("organizationName"), "Org");
+  }
+}

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationNotificationEmailSenderTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/notification/OrganizationNotificationEmailSenderTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.organization.api.notification;
+
+import static java.util.Arrays.*;
+import static java.util.Collections.emptyList;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.Page;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.commons.test.mockito.answer.SelfReturningAnswer;
+import org.eclipse.che.mail.EmailBean;
+import org.eclipse.che.mail.MailSender;
+import org.eclipse.che.multiuser.organization.api.OrganizationManager;
+import org.eclipse.che.multiuser.organization.api.event.MemberAddedEvent;
+import org.eclipse.che.multiuser.organization.api.event.MemberRemovedEvent;
+import org.eclipse.che.multiuser.organization.api.event.OrganizationRemovedEvent;
+import org.eclipse.che.multiuser.organization.api.event.OrganizationRenamedEvent;
+import org.eclipse.che.multiuser.organization.shared.model.Member;
+import org.eclipse.che.multiuser.organization.spi.impl.MemberImpl;
+import org.eclipse.che.multiuser.organization.spi.impl.OrganizationImpl;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link OrganizationNotificationEmailSender}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OrganizationNotificationEmailSenderTest {
+
+  public static final String API_ENDPOINT = "http://localhost/api";
+  public static final String DASHBOARD_ENDPOINT = API_ENDPOINT.replace("/api", "/dashboard");
+  @Mock private MailSender mailSender;
+  @Mock private OrganizationManager organizationManager;
+  @Mock private UserManager userManager;
+  @Mock private OrganizationEmailNotifications emails;
+  @Mock private EventService eventService;
+
+  OrganizationNotificationEmailSender emailSender;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    emailSender =
+        new OrganizationNotificationEmailSender(
+            API_ENDPOINT, mailSender, organizationManager, userManager, emails);
+  }
+
+  @Test
+  public void shouldSelfSubscribe() {
+    //when
+    emailSender.subscribe(eventService);
+
+    //then
+    verify(eventService).subscribe(emailSender);
+  }
+
+  @Test
+  public void shouldSendNotificationAboutMembershipAdding() throws Exception {
+    //given
+    EmailBean email = mock(EmailBean.class, new SelfReturningAnswer());
+
+    when(emails.memberAdded(anyString(), anyString(), anyString(), anyString())).thenReturn(email);
+
+    //when
+    emailSender.onEvent(
+        new MemberAddedEvent(
+            "admin",
+            new UserImpl("id", "email", null),
+            new OrganizationImpl("id", "/parent/name", "parent")));
+
+    //then
+    verify(emails).memberAdded("name", DASHBOARD_ENDPOINT, "/parent/name", "admin");
+    verify(email).withTo("email");
+    verify(mailSender).sendAsync(email);
+  }
+
+  @Test
+  public void shouldSendNotificationAboutMembershipRemoving() throws Exception {
+    //given
+    EmailBean email = mock(EmailBean.class, new SelfReturningAnswer());
+
+    when(emails.memberRemoved(anyString(), anyString())).thenReturn(email);
+
+    //when
+    emailSender.onEvent(
+        new MemberRemovedEvent(
+            "admin",
+            new UserImpl("id", "email", null),
+            new OrganizationImpl("id", "/parent/name", "parent")));
+
+    //then
+    verify(emails).memberRemoved("name", "admin");
+    verify(email).withTo("email");
+    verify(mailSender).sendAsync(email);
+  }
+
+  @Test
+  public void shouldSendNotificationAboutOrganizationRenaming() throws Exception {
+    //given
+    MemberImpl member1 = new MemberImpl("user1", "org123", ImmutableList.of());
+    MemberImpl member2 = new MemberImpl("user2", "org123", ImmutableList.of());
+    doReturn(new Page<Member>(asList(member1, member2), 0, 2, 2))
+        .when(organizationManager)
+        .getMembers(anyString(), anyInt(), anyInt());
+
+    when(userManager.getById("user1"))
+        .thenReturn(new UserImpl("user1", "email1", null, null, emptyList()));
+    when(userManager.getById("user2"))
+        .thenReturn(new UserImpl("user2", "email2", null, null, emptyList()));
+
+    EmailBean email = new EmailBean().withBody("Org Remaned Notification");
+    when(emails.organizationRenamed(anyString(), anyString())).thenReturn(email);
+
+    //when
+    emailSender.onEvent(
+        new OrganizationRenamedEvent(
+            "admin",
+            "oldName",
+            "newName",
+            new OrganizationImpl("org123", "/parent/newName", "parent")));
+
+    //then
+    verify(emails).organizationRenamed("oldName", "newName");
+    verify(mailSender).sendAsync(new EmailBean(email).withTo("email1"));
+    verify(mailSender).sendAsync(new EmailBean(email).withTo("email2"));
+  }
+
+  @Test
+  public void
+      shouldDoNotBreakSendingOfNotificationAboutOrganizationRenamingWhenUnableToRetrieveAUser()
+          throws Exception {
+    //given
+    MemberImpl member1 = new MemberImpl("user1", "org123", emptyList());
+    MemberImpl member2 = new MemberImpl("user2", "org123", emptyList());
+    doReturn(new Page<Member>(asList(member1, member2), 0, 2, 2))
+        .when(organizationManager)
+        .getMembers(anyString(), anyInt(), anyInt());
+
+    when(userManager.getById("user1")).thenThrow(new NotFoundException(""));
+    when(userManager.getById("user2"))
+        .thenReturn(new UserImpl("user2", "email2", null, null, emptyList()));
+
+    EmailBean email = new EmailBean().withBody("Org Renamed Notification");
+    when(emails.organizationRenamed(anyString(), anyString())).thenReturn(email);
+
+    //when
+    emailSender.onEvent(
+        new OrganizationRenamedEvent(
+            "admin",
+            "oldName",
+            "newName",
+            new OrganizationImpl("org123", "/parent/newName", "parent")));
+
+    //then
+    verify(emails).organizationRenamed("oldName", "newName");
+    verify(mailSender).sendAsync(new EmailBean(email).withTo("email2"));
+  }
+
+  @Test
+  public void shouldSendNotificationAboutOrganizationRemoving() throws Exception {
+    //given
+    MemberImpl member1 = new MemberImpl("user1", "org123", emptyList());
+    MemberImpl member2 = new MemberImpl("user2", "org123", emptyList());
+
+    when(userManager.getById("user1"))
+        .thenReturn(new UserImpl("user1", "email1", null, null, emptyList()));
+    when(userManager.getById("user2"))
+        .thenReturn(new UserImpl("user2", "email2", null, null, emptyList()));
+
+    EmailBean email = new EmailBean().withBody("Org Removed Notification");
+    when(emails.organizationRemoved(anyString())).thenReturn(email);
+
+    //when
+    emailSender.onEvent(
+        new OrganizationRemovedEvent(
+            "admin", new OrganizationImpl("id", "/parent/q", "parent"), asList(member1, member2)));
+
+    //then
+    verify(emails).organizationRemoved("q");
+    verify(mailSender).sendAsync(new EmailBean(email).withTo("email1"));
+    verify(mailSender).sendAsync(new EmailBean(email).withTo("email2"));
+  }
+
+  @Test
+  public void
+      shouldDoNotBreakSendingOfNotificationAboutOrganizationRemovingWhenUnableToRetrieveAUser()
+          throws Exception {
+    //given
+    MemberImpl member1 = new MemberImpl("user1", "org123", emptyList());
+    MemberImpl member2 = new MemberImpl("user2", "org123", emptyList());
+
+    when(userManager.getById("user1")).thenThrow(new NotFoundException(""));
+    when(userManager.getById("user2"))
+        .thenReturn(new UserImpl("user2", "email2", null, null, emptyList()));
+
+    EmailBean email = new EmailBean().withBody("Org Removed Notification");
+    when(emails.organizationRemoved(anyString())).thenReturn(email);
+
+    //when
+    emailSender.onEvent(
+        new OrganizationRemovedEvent(
+            "admin", new OrganizationImpl("id", "/parent/q", "parent"), asList(member1, member2)));
+
+    //then
+    verify(emails).organizationRemoved("q");
+    verify(mailSender).sendAsync(new EmailBean(email).withTo("email2"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-commons-mail</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-commons-schedule</artifactId>
                 <version>${che.version}</version>
             </dependency>


### PR DESCRIPTION
### What does this PR do?
Adds template processor.
Adds warning on tomcat start when mail sender is not configured.
Adds sending of email notification when changes occur in an organization. Note that notifications are not styled. Styling will be made during this [issue](https://github.com/eclipse/che/issues/6546).

#### Organization Notifications:
##### Member added to an Organization
![added_to_org](https://user-images.githubusercontent.com/5887312/31122482-b9b1706c-a844-11e7-8d6c-725796f76d36.png)

##### Member Removed from an Organization
![removed_from_org](https://user-images.githubusercontent.com/5887312/31122499-d0d01f32-a844-11e7-8b71-fe3e3f90b189.png)

##### Organization Renamed
![org_remaned](https://user-images.githubusercontent.com/5887312/31122510-d9f93666-a844-11e7-9f9b-d4a5fd96427c.png)

##### Organization Removed
![org_deleted](https://user-images.githubusercontent.com/5887312/31122503-d3b36fa6-a844-11e7-850b-fc6b59db3933.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6515
