### PR TITLE
Map system state API to login filter

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/wait_until_che_is_available.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/wait_until_che_is_available.sh
@@ -44,7 +44,7 @@ elif [ ${SECONDS} -lt ${end} ]; then
   exit 1
 fi
 
-che_http_status=$(curl -s -o /dev/null -I -w "%{http_code}" "${CHE_API_ENDPOINT}/system/state")
+che_http_status=$(curl -s -o /dev/null -I -w "%{http_code}" "${CHE_API_ENDPOINT}/")
 if [ "${che_http_status}" == "200" ]; then  
   echo "[CHE] Che is up and running"
 else

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -20,12 +20,12 @@ public class KeycloakServletModule extends ServletModule {
   protected void configureServlets() {
     bind(KeycloakAuthenticationFilter.class).in(Singleton.class);
 
-    // Not contains '/websocket', /docs/ (for swagger) and not ends with '/ws' or '/eventbus' or '/settings/' or '/api/system/state'
+    // Not contains '/websocket', /docs/ (for swagger) and not ends with '/ws' or '/eventbus' or '/settings/'
     filterRegex(
-            "^(?!.*(/websocket/?|/docs/))(?!.*(/ws/?|/eventbus/?|/settings/?|/api/oauth/callback/?|/api/system/state/?)$).*")
+            "^(?!.*(/websocket/?|/docs/))(?!.*(/ws/?|/eventbus/?|/settings/?|/api/oauth/callback/?)$).*")
         .through(KeycloakAuthenticationFilter.class);
     filterRegex(
-            "^(?!.*(/websocket/?|/docs/))(?!.*(/ws/?|/eventbus/?|/settings/?|/api/oauth/callback/?|/api/system/state/?)$).*")
+            "^(?!.*(/websocket/?|/docs/))(?!.*(/ws/?|/eventbus/?|/settings/?|/api/oauth/callback/?)$).*")
         .through(KeycloakEnvironmentInitalizationFilter.class);
   }
 }


### PR DESCRIPTION
### What does this PR do?
It is needed since it is secured by permissions system which requires
an authenticated user.
Also, use base API endpoint for checking Che in OpenShift deploy script since system state API which was used before is secured now.


### What issues does this PR fix or reference?
Fixes #5893 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
