### PR TITLE
Remove '/ws' and '/websocket/' parts from KeycloakAuthenticationFilter binding

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -20,12 +20,11 @@ public class KeycloakServletModule extends ServletModule {
   protected void configureServlets() {
     bind(KeycloakAuthenticationFilter.class).in(Singleton.class);
 
-    // Not contains '/websocket', /docs/ (for swagger) and not ends with '/ws' or '/eventbus' or '/settings/'
-    filterRegex(
-            "^(?!.*(/websocket/?|/docs/))(?!.*(/ws/?|/eventbus/?|/settings/?|/api/oauth/callback/?)$).*")
+    // Not contains /docs/ (for swagger) and not ends with '/api/oauth/callback/' or
+    // '/keycloak/settings/'
+    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
         .through(KeycloakAuthenticationFilter.class);
-    filterRegex(
-            "^(?!.*(/websocket/?|/docs/))(?!.*(/ws/?|/eventbus/?|/settings/?|/api/oauth/callback/?)$).*")
+    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
         .through(KeycloakEnvironmentInitalizationFilter.class);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Binds `KeycloakAuthenticationFilter` on paths which contains: _`/websocket/`_ or ends with _`/ws`_