### PR TITLE
Add ability to check swagger with several workspaces in an account

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
@@ -18,6 +18,7 @@ import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.commons.json.JsonHelper;
 import org.eclipse.che.commons.json.JsonParseException;
@@ -107,7 +108,7 @@ public class Swagger {
    *
    * @return result search by key
    */
-  public String getWsNameFromWorkspacePage() {
+  public List<String> getWsNamesFromWorkspacePage() {
     expandWorkSpaceItem();
     clickElementByXpath(Locators.GET_WORKSPACES);
     clickTryItOutByXpath(Locators.TRY_IT_OUT);
@@ -117,7 +118,10 @@ public class Swagger {
             .getText();
     List<WorkspaceDto> workspaces =
         DtoFactory.getInstance().createListDtoFromJson(json, WorkspaceDto.class);
-    return workspaces.get(0).getConfig().getName();
+    return workspaces
+        .stream()
+        .map(workspaceDto -> workspaceDto.getConfig().getName())
+        .collect(Collectors.toList());
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
@@ -21,6 +21,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertTrue;
+
 /** @author Andrey Chizhikov */
 public class SwaggerTest {
 
@@ -42,6 +44,6 @@ public class SwaggerTest {
   @Test
   public void checkNameProjectTest() throws Exception {
     driver.navigate().to(swaggerUrl);
-    Assert.assertTrue(swagger.getWsNamesFromWorkspacePage().contains(workspace.getName()));
+    assertTrue(swagger.getWsNamesFromWorkspacePage().contains(workspace.getName()));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.swagger;
 
 import com.google.inject.Inject;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.provider.TestIdeUrlProvider;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Ide;
@@ -28,6 +29,7 @@ public class SwaggerTest {
   @Inject private TestWorkspace workspace;
   @Inject private Loader loader;
   @Inject private Swagger swagger;
+  @Inject private SeleniumWebDriver driver;
 
   private String swaggerUrl;
 
@@ -39,8 +41,7 @@ public class SwaggerTest {
 
   @Test
   public void checkNameProjectTest() throws Exception {
-    ide.driver().navigate().to(swaggerUrl);
-    String wsNameFromSwaggerPage = swagger.getWsNameFromWorkspacePage();
-    Assert.assertEquals(wsNameFromSwaggerPage, workspace.getName());
+    driver.navigate().to(swaggerUrl);
+    Assert.assertTrue(swagger.getWsNamesFromWorkspacePage().contains(workspace.getName()));
   }
 }


### PR DESCRIPTION
### What does this PR do?
Check that a current workspace present in the 'workspaces' part of the Swagger page, if the workspaces can be more than 1. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6532

@vparfonov, @tolusha 