### PR TITLE
CHE-6024: Add selenium test for git revert action

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/revert/RevertCommitViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/revert/RevertCommitViewImpl.java
@@ -116,7 +116,7 @@ public class RevertCommitViewImpl extends Window implements RevertCommitView {
         new Column<Revision, String>(new TextCell()) {
           @Override
           public String getValue(Revision revision) {
-            return revision.getId().substring(0, 8) + "...";
+            return revision.getId().substring(0, 8);
           }
         };
     Column<Revision, String> dateColumn =

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/revert/RevertCommitViewImpl.ui.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/revert/RevertCommitViewImpl.ui.xml
@@ -15,9 +15,9 @@
              xmlns:g='urn:import:com.google.gwt.user.client.ui'>
     <ui:with field='locale' type='org.eclipse.che.ide.ext.git.client.GitLocalizationConstant'/>
     <ui:with field='res' type='org.eclipse.che.ide.ext.git.client.GitResources'/>
-    <g:DockLayoutPanel unit="PX" width="750px" height="450px" debugId="git-revert-mainForm">
+    <g:DockLayoutPanel unit="PX" width="750px" height="400px" debugId="git-revert-mainForm">
         <g:center>
-            <g:ScrollPanel ui:field="revisionsPanel" />
+            <g:ScrollPanel ui:field="revisionsPanel" debugId="revert-commit-panel"/>
         </g:center>
     </g:DockLayoutPanel>
 </ui:UiBinder>

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/constant/TestMenuCommandsConstants.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/constant/TestMenuCommandsConstants.java
@@ -129,6 +129,7 @@ public interface TestMenuCommandsConstants {
     String PROJECT_GIT_URL = GIT_MENU_PREFFIX + "gitUrl";
     String INITIALIZE_REPOSITORY = GIT_MENU_PREFFIX + "gitInitRepository";
     String DELETE_REPOSITORY = GIT_MENU_PREFFIX + "gitDeleteRepository";
+    String REVERT_COMMIT = GIT_MENU_PREFFIX + "gitRevertCommit";
 
     interface Remotes {
       String REMOTES_TOP = "gwt-debug-topmenu/Git/gitRemoteGroup";

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/Git.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/Git.java
@@ -119,7 +119,7 @@ public class Git {
    */
   public void waitGitStatusBarWithMess(String expextedMess) {
     loader.waitOnClosed();
-    gitStatusBar.waitMesageIntoGitInfoPAnel(expextedMess);
+    gitStatusBar.waitMessageInGitTab(expextedMess);
   }
 
   /** wait and click on the 'navigate button' in the 'git console' */

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitRevertCommit.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitRevertCommit.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.pageobject.git;
+
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.pageobject.Loader;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/** @author Anatolii Bazko */
+@Singleton
+public class GitRevertCommit {
+  private static final String REVERT_COMMIT_PANEL = "gwt-debug-revert-commit-panel";
+  private static final String REVERT_BUTTON = "git-revert";
+  private static final String CANCEL_BUTTON = "git-revert-cancel";
+
+  private final SeleniumWebDriver seleniumWebDriver;
+  private final Loader loader;
+
+  @Inject
+  public GitRevertCommit(SeleniumWebDriver seleniumWebDriver, Loader loader) {
+    this.seleniumWebDriver = seleniumWebDriver;
+    this.loader = loader;
+    PageFactory.initElements(seleniumWebDriver, this);
+  }
+
+  @FindBy(id = REVERT_COMMIT_PANEL)
+  private WebElement revertPanel;
+
+  @FindBy(id = REVERT_BUTTON)
+  private WebElement revertButton;
+
+  @FindBy(id = CANCEL_BUTTON)
+  private WebElement cancelButton;
+
+  public void waitRevertPanelOpened() {
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOf(revertPanel));
+  }
+
+  public void waitRevertPanelClosed() {
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(REVERT_COMMIT_PANEL)));
+  }
+
+  public void clickRevertButton() {
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOf(revertButton))
+        .click();
+  }
+
+  public String getTopCommitRevision() {
+    loader.waitOnClosed();
+    return new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOf(revertPanel))
+        .getText()
+        .split("\n")[1]
+        .replaceAll("\\.", "");
+  }
+
+  public String getTopCommitComment() {
+    loader.waitOnClosed();
+    return new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOf(revertPanel))
+        .getText()
+        .split("\n")[4];
+  }
+
+  public String getTopCommitAuthor() {
+    loader.waitOnClosed();
+    return new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOf(revertPanel))
+        .getText()
+        .split("\n")[3];
+  }
+
+  public void selectRevision(String revision) {
+    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+        .until(
+            ExpectedConditions.visibilityOfElementLocated(
+                By.xpath("//*[contains(text(),'" + revision + "')]")))
+        .click();
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitStatusBar.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitStatusBar.java
@@ -17,7 +17,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -98,16 +97,10 @@ public class GitStatusBar {
   }
 
   /** wait expected message into the IDE git status bar */
-  public void waitMesageIntoGitInfoPAnel(final String message) {
+  public void waitMessageInGitTab(final String message) {
     waitGitStatusBarInfoPanel();
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            new ExpectedCondition<Boolean>() {
-              @Override
-              public Boolean apply(WebDriver webDriver) {
-                return getTextStatus().contains(message);
-              }
-            });
+        .until((ExpectedCondition<Boolean>) webDriver -> getTextStatus().contains(message));
   }
 
   /** wait and click on navigate button in the 'git console' */

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/RevertCommitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/RevertCommitTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.git;
+
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Git.GIT;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Git.REVERT_COMMIT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.selenium.core.client.TestGitHubServiceClient;
+import org.eclipse.che.selenium.core.client.TestSshServiceClient;
+import org.eclipse.che.selenium.core.client.TestUserPreferencesServiceClient;
+import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.workspace.TestWorkspace;
+import org.eclipse.che.selenium.pageobject.Ide;
+import org.eclipse.che.selenium.pageobject.Menu;
+import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.eclipse.che.selenium.pageobject.Wizard;
+import org.eclipse.che.selenium.pageobject.git.GitRevertCommit;
+import org.eclipse.che.selenium.pageobject.git.GitStatusBar;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/** @author Anatolii Bazko */
+public class RevertCommitTest {
+  private static final String PROJECT_NAME = NameGenerator.generate("project", 2);
+
+  @Inject private TestWorkspace ws;
+  @Inject private Ide ide;
+  @Inject private DefaultTestUser productUser;
+
+  @Inject
+  @Named("github.username")
+  private String gitHubUsername;
+
+  @Inject
+  @Named("github.password")
+  private String gitHubPassword;
+
+  @Inject private ProjectExplorer projectExplorer;
+  @Inject private Menu menu;
+  @Inject private org.eclipse.che.selenium.pageobject.git.Git git;
+  @Inject private TestSshServiceClient testSshServiceClient;
+  @Inject private TestUserPreferencesServiceClient testUserPreferencesServiceClient;
+  @Inject private TestGitHubServiceClient gitHubClientService;
+  @Inject private GitRevertCommit gitRevertCommit;
+  @Inject private GitStatusBar gitStatusBar;
+
+  @BeforeClass
+  public void prepare() throws Exception {
+    uploadSshKey();
+    testUserPreferencesServiceClient.addGitCommitter(gitHubUsername, productUser.getEmail());
+
+    ide.open(ws);
+
+    git.importJavaApp(
+        "git@github.com:" + gitHubUsername + "/testRepo-1.git",
+        PROJECT_NAME,
+        Wizard.TypeProject.MAVEN);
+
+    projectExplorer.waitProjectExplorer();
+    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.selectItem(PROJECT_NAME);
+  }
+
+  @Test
+  public void shouldRevertCommit() {
+    menu.runCommand(GIT, REVERT_COMMIT);
+
+    String revision = gitRevertCommit.getTopCommitRevision();
+    String comment = gitRevertCommit.getTopCommitComment();
+
+    gitRevertCommit.selectRevision(revision);
+    gitRevertCommit.clickRevertButton();
+
+    gitStatusBar.waitMessageInGitTab("Reverted commits: - " + revision);
+
+    menu.runCommand(GIT, REVERT_COMMIT);
+
+    assertEquals(gitRevertCommit.getTopCommitAuthor(), gitHubUsername);
+    assertTrue(gitRevertCommit.getTopCommitComment().contains("Revert \"" + comment + "\""));
+  }
+
+  private void uploadSshKey() throws Exception {
+    try {
+      String publicKey = testSshServiceClient.generateGithubKey();
+      gitHubClientService.uploadPublicKey(gitHubUsername, gitHubPassword, publicKey);
+    } catch (ConflictException ignored) {
+      // already generated
+    }
+  }
+}

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -287,6 +287,7 @@
                     <exclude name="pullConflictsTest"/>
                 </methods>
             </class>
+            <class name="org.eclipse.che.selenium.git.RevertCommitTest"/>
             <class name="org.eclipse.che.selenium.gwt.CheckSimpleGwtAppTest"/>
             <class name="org.eclipse.che.selenium.intelligencecommand.MacrosCommandsEditorTest"/>
             <class name="org.eclipse.che.selenium.intelligencecommand.AutocompleteCommandsEditorTest"/>


### PR DESCRIPTION
### What does this PR do?
Adds selenium test for git revert action

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6024

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
not required

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
not required

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
not required