### PR TITLE
Fix name of test project in its config

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
@@ -58,9 +58,10 @@ public class TestProjectServiceClient {
     InputStream in = getClass().getResourceAsStream("/templates/project/" + template);
     String json = IoUtil.readAndCloseQuietly(in);
 
-    String url = getWsAgentUrl(workspaceId);
     ProjectConfigDto project = getInstance().createDtoFromJson(json, ProjectConfigDto.class);
+    project.setName(projectName);
 
+    String url = getWsAgentUrl(workspaceId);
     requestFactory
         .fromUrl(url + "/" + projectName)
         .usePutMethod()


### PR DESCRIPTION
### What does this PR do?
This request fixed configuration of project which is created by selenium tests. It fixes code to replace default name of project in template json **"replaced_name"** by actual name generated in test:
![screenshot from 2017-10-03 15 54 26](https://user-images.githubusercontent.com/1197777/31126053-2d48d048-a853-11e7-83a1-0b6679c3a7e0.png)