### PR TITLE
Added label comment for issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
 <!--- 
 Replace this comment with a description of the problem.
 
-Please help us by providing all of the details listed below. A complete and thoughtful issue request with research on possible root causes and diagnostics goes a very long way in helping us rapidly get your issues resolved. 
+Please help us by providing all of the details listed below. A complete and thoughtful issue request with research on possible root causes and diagnostics goes a very long way in helping us rapidly get your issues resolved.
+
+COMMITTERS: please include labels on each issue. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind` and `status` labels.
 --> 
 
 **Reproduction Steps:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+### Description
 <!--- 
 Replace this comment with a description of the problem.
 
@@ -6,12 +7,10 @@ Please help us by providing all of the details listed below. A complete and thou
 COMMITTERS: please include labels on each issue. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind` and `status` labels.
 --> 
 
-**Reproduction Steps:**
+### Reproduction Steps
+<!-- Describe the issue in as much detail as possible including steps to reproduce. Screenshots are very helpful. -->
 
 **OS and version:**    
 
 **Diagnostics:** 
-<!-- Provide output of 'docker run <DOCKER_OPTIONS> eclipse/che info' -->
-
-<!-- If asked, provide a support bundle with 'docker run <DOCKER_OPTIONS> eclipse/che info --bundle' -->
-<!-- If asked, provide CLI debugging info by adding '--trace' to your commands -->
+<!-- Provide logs and any other relevant diagnostic information -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!-- Please review the following before submitting a PR:
 Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
 Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
+
+COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
 -->
 
 ### What does this PR do?


### PR DESCRIPTION
Added comment that labels are required and linked to the label definition file. Added "minimum" request for `kind` and `status` labels.

Signed-off-by: Brad Micklea <bmicklea@redhat.com>