### PR TITLE
Fixed issue where download outputs was returning null on workspace start

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -1357,7 +1357,7 @@ public class ProcessesPanelPresenter extends BasePresenter
             + DateTimeFormat.getFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
             + ".log";
 
-    download(fileName, getText(devMachine.getId()));
+    download(fileName, getText(devMachine.getConfig().getName()));
   }
 
   @Override


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR fixes an issue where download outputs would return null while starting a workspace.

![rh-che](https://user-images.githubusercontent.com/8839537/31142220-9f11784e-a847-11e7-9c67-8a93b7231e35.gif)

### What issues does this PR fix or reference?
I believe it would fix https://github.com/redhat-developer/rh-che/issues/360.
Additionally, it fixes eclipse/che behaviour but it does not have a created issue here.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
