### PR TITLE
Do not set focus on project tree when 'Link with editor' feature is applied

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -178,7 +178,7 @@ public class EditorAgentImpl
         preferencesManager.getValue(LinkWithEditorAction.LINK_WITH_EDITOR);
     if (parseBoolean(isLinkedWithEditor)) {
       final VirtualFile file = activeEditor.getEditorInput().getFile();
-      eventBus.fireEvent(new RevealResourceEvent(file.getLocation()));
+      eventBus.fireEvent(new RevealResourceEvent(file.getLocation(), true, false));
     }
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/reveal/RevealResourceEvent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/reveal/RevealResourceEvent.java
@@ -58,6 +58,8 @@ public class RevealResourceEvent extends GwtEvent<RevealResourceEvent.RevealReso
   }
 
   private Path location;
+  private boolean isSelectionRequired = true;
+  private boolean isFocusRequired = true;
 
   public RevealResourceEvent(Resource resource) {
     this.location = checkNotNull(resource, "Resource should not be a null").getLocation();
@@ -68,6 +70,20 @@ public class RevealResourceEvent extends GwtEvent<RevealResourceEvent.RevealReso
   }
 
   /**
+   * Creates new event to reveal given resource.
+   *
+   * @param location the resource path which should be revealed
+   * @param isSelectionRequired whether corresponding node should be selected after reveal
+   * @param isFocusRequired whether corresponding node should be focused after reveal
+   */
+  public RevealResourceEvent(
+      Path location, boolean isSelectionRequired, final boolean isFocusRequired) {
+    this.location = checkNotNull(location, "Path should not be a null");
+    this.isSelectionRequired = isSelectionRequired;
+    this.isFocusRequired = isFocusRequired;
+  }
+
+  /**
    * Returns the resource path which should be revealed.
    *
    * @return the resource path
@@ -75,6 +91,26 @@ public class RevealResourceEvent extends GwtEvent<RevealResourceEvent.RevealReso
    */
   public Path getLocation() {
     return location;
+  }
+
+  /**
+   * Returns whether corresponding node should be selected after reveal
+   *
+   * @return {@code true} if corresponding node should be selected after reveal or {@code false}
+   *     otherwise
+   */
+  public boolean isSelectionRequired() {
+    return isSelectionRequired;
+  }
+
+  /**
+   * Returns whether corresponding node should be focused after reveal
+   *
+   * @return {@code true} if corresponding node should be focused after reveal or {@code false}
+   *     otherwise
+   */
+  public boolean isFocusRequired() {
+    return isFocusRequired;
   }
 
   /** {@inheritDoc} */

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/Tree.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/Tree.java
@@ -631,11 +631,24 @@ public class Tree extends FocusWidget
   }
 
   /**
-   * Scroll focus element into specific node.
+   * Scroll focus element into specific node and set focus on the tree. Use {@link
+   * #scrollIntoView(Node, boolean)} when setting focus is not required.
    *
    * @param node node to scroll
    */
   public void scrollIntoView(Node node) {
+    scrollIntoView(node, true);
+  }
+
+  /**
+   * Scroll focus element into specific node. Set focus on the tree when {@code isFocusRequired} is
+   * {@code true}. Does not perform any operations with focus when {@code isFocusRequired} is {@code
+   * false}
+   *
+   * @param node node to scroll
+   * @param isFocusRequired whether tree should take focus after scroll
+   */
+  public void scrollIntoView(Node node, boolean isFocusRequired) {
     checkNotNull(node, NULL_NODE_MSG);
     NodeDescriptor descriptor = getNodeDescriptor(node);
     if (descriptor == null) {
@@ -648,7 +661,10 @@ public class Tree extends FocusWidget
     container.scrollIntoView();
     focusEl.getStyle().setLeft((nodeStorage.getDepth(node) - 1) * 16, Style.Unit.PX);
     focusEl.getStyle().setTop(container.getOffsetTop(), Style.Unit.PX);
-    setFocus(true);
+
+    if (isFocusRequired) {
+      setFocus(true);
+    }
   }
 
   @Override


### PR DESCRIPTION
### What does this PR do?
- Add ability to reveal node in project tree without setting focus on the tree
- Do not set focus on project tree when 'Link with editor' feature is applied
### What issues does this PR fix or reference?
#6183 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>