### PR TITLE
Fix deploy che to openshift script

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -131,6 +131,7 @@ OPENSHIFT_FLAVOR=${OPENSHIFT_FLAVOR:-${DEFAULT_OPENSHIFT_FLAVOR}}
 # TODO move this env variable as a config map in the deployment config
 # as soon as the 'che-multiuser' branch is merged to master
 CHE_WORKSPACE_LOGS="/data/logs/machine/logs" \
+CHE_HOST="${OPENSHIFT_NAMESPACE_URL}"
 
 if [ "${OPENSHIFT_FLAVOR}" == "minishift" ]; then
   if [ -z "${MINISHIFT_IP}" ]; then
@@ -364,7 +365,9 @@ MULTI_USER_REPLACEMENT_STRING="          - name: \"CHE_WORKSPACE_LOGS\"
           - name: \"CHE_KEYCLOAK_REALM\"
             value: \"${CHE_KEYCLOAK_REALM}\"
           - name: \"CHE_KEYCLOAK_CLIENT__ID\"
-            value: \"${CHE_KEYCLOAK_CLIENT__ID}\""
+            value: \"${CHE_KEYCLOAK_CLIENT__ID}\"
+          - name: \"CHE_HOST\"
+            value: \"${CHE_HOST}\""
 
 # TODO When merging the multi-user work to master, this replacement string should
 # be replaced by the corresponding change in the fabric8 deployment descriptor


### PR DESCRIPTION
### What does this PR do?
after changes introduced here https://github.com/eclipse/che/pull/6534/files che server multiuser started to fail dueto unset `CHE_HOST` env so this PR adds env `CHE_HOST`

that was happened because this way `CheBootstrap` works https://github.com/eclipse/che/blob/master/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java#L146-L152
first it resolve props and then do override with envs