### PR TITLE
Fix top line position at restoring editors

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMod
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.parts.PartStackType.EDITING;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -743,6 +744,7 @@ public class EditorAgentImpl
 
                   promiseCallback.onSuccess(null);
                   openEditorCallback.onEditorOpened(editor);
+                  openEditorCallback.onEditorActivated(editor);
 
                   eventBus.fireEvent(new EditorOpenedEvent(file, editor));
                 }
@@ -844,7 +846,7 @@ public class EditorAgentImpl
     @Override
     public void onEditorActivated(EditorPartPresenter editor) {
       if (editor instanceof TextEditor) {
-        ((TextEditor) editor).setTopLine(topLine);
+        Scheduler.get().scheduleDeferred(() -> ((TextEditor) editor).setTopLine(topLine));
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?
At the moment after refresh IDE we have cursor position in a correct place, but not top line position.
So this PR fix top line position at restoring editors 

### What issues does this PR fix or reference?
The fix is related to https://github.com/eclipse/che/issues/4167

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>