### PR TITLE
Delete the 'CreatePackagesAndFilesWithHelpIconCreateTest' from suite

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -434,7 +434,6 @@
             <class name="org.eclipse.che.selenium.projectexplorer.CreateNewNotJavaFilesTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateNewPackageFromContextMenuTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateNewPackagesWithHelpCreationJavaClassTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.CreatePackagesAndFilesWithHelpIconCreateTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectInSelectedFolderTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectsForArtikPluginTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectTest"/>


### PR DESCRIPTION
***What does this PR do?***
* Remove unused selenium test 'CreatePackagesAndFilesWithHelpIconCreateTest' from the test suite 'CheSuite.xml' in spi-branch


