### PR TITLE
Remove opacity from hex formatted colors

### DIFF
--- a/dockerfiles/init/modules/keycloak/files/che/email/html/footer.ftl
+++ b/dockerfiles/init/modules/keycloak/files/che/email/html/footer.ftl
@@ -1,5 +1,5 @@
 <div style="${msg("mailBannerStyle")}">
     <a href="${msg("eclipseCheMainSiteLink")}">
-        <img src="${msg("eclipseCheLogoLink")}" style="height: 32px;" alt=" " />
+        <img src="${msg("eclipseCheLogoLink")}" height="32" alt=" " />
     </a>
 </div>

--- a/dockerfiles/init/modules/keycloak/files/che/email/messages/messages_en.properties
+++ b/dockerfiles/init/modules/keycloak/files/che/email/messages/messages_en.properties
@@ -1,6 +1,6 @@
 product=Eclipse Che
 
-button=<p><span style="background-color: #fdb940ff; padding: 5px 20px; font-family: 'arial narrow'; font-weight: bold;"><a style="color: white; text-decoration: none;" href="{1}">{0}</a></span></p>
+button=<p><span style="background-color: #fdb940; padding: 5px 20px; font-family: 'arial narrow'; font-weight: bold;"><a style="color: white; text-decoration: none;" href="{1}">{0}</a></span></p>
 
 emailLinkExpirationText=Link will expire within {0} minutes.
 
@@ -47,5 +47,5 @@ robotoFontIncludeStyle=<style>@import url('https://fonts.googleapis.com/css?fami
 mailBodyStyle=width: 700px; margin: 0 auto; font-size: 16px; font-family: 'Roboto';
 productTitleStyle=font-size: 26px; color: #cccccc;
 mailTitleStyle=font-size: 24px; color: white;
-mailBannerStyle=background-color: #292c2fff; color: white; padding: 25px 10px;
+mailBannerStyle=background-color: #292c2f; color: white; padding: 25px 10px;
 mailContentStyle=padding: 10px;


### PR DESCRIPTION
### What does this PR do?
Removes opacity value from hex formatted colors in email styles. This is caused by some email senders (like GMail) which cannot send it correctly. To support wider range of senders we have to remove them.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6265