### PR TITLE
Add capturing of a html dump after failing a test

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -10,30 +10,10 @@
  */
 package org.eclipse.che.selenium.core.inject;
 
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
-
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
-import javax.annotation.PreDestroy;
-import javax.inject.Named;
+
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.constant.TestBrowser;
@@ -57,6 +37,28 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.TestException;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Named;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 
 /**
  * Tests lifecycle handler.
@@ -203,8 +205,8 @@ public abstract class SeleniumTestHandler
   private void onTestFinish(ITestResult result) {
     if (result.getStatus() == ITestResult.FAILURE || result.getStatus() == ITestResult.SKIP) {
       ofNullable(result.getThrowable()).ifPresent(e -> LOG.error("" + e.getMessage(), e));
-
       captureScreenshot(result);
+      captureHtmlSource(result);
     }
   }
 
@@ -258,6 +260,12 @@ public abstract class SeleniumTestHandler
 
     collectInjectedWebDrivers(testInstance, webDrivers);
     webDrivers.forEach(webDriver -> captureScreenshot(result, webDriver));
+  }
+
+  private void captureHtmlSource(ITestResult result) {
+    Set<SeleniumWebDriver> webDrivers = new HashSet<>();
+    Object testInstance = result.getInstance();
+    collectInjectedWebDrivers(testInstance, webDrivers);
     webDrivers.forEach(webDriver -> dumpHtmlCodeFromTheCurrentPage(result, webDriver));
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -10,10 +10,30 @@
  */
 package org.eclipse.che.selenium.core.inject;
 
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import javax.annotation.PreDestroy;
+import javax.inject.Named;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.constant.TestBrowser;
@@ -37,28 +57,6 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.TestException;
-
-import javax.annotation.PreDestroy;
-import javax.inject.Named;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
-
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 
 /**
  * Tests lifecycle handler.

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -258,6 +258,7 @@ public abstract class SeleniumTestHandler
 
     collectInjectedWebDrivers(testInstance, webDrivers);
     webDrivers.forEach(webDriver -> captureScreenshot(result, webDriver));
+    webDrivers.forEach(webDriver -> dumpHtmlCodeFromTheCurrentPage(result, webDriver));
   }
 
   /**
@@ -307,17 +308,25 @@ public abstract class SeleniumTestHandler
     String filename = NameGenerator.generate(testName + "_", 8) + ".png";
 
     try {
-      String pageSource = webDriver.getPageSource();
-      Path dmpDirectory = Paths.get("target/htmldump", filename + ".html");
-      Files.createDirectories(dmpDirectory.getParent());
-      Files.write(dmpDirectory, pageSource.getBytes(), StandardOpenOption.CREATE);
-
       byte[] data = webDriver.getScreenshotAs(OutputType.BYTES);
       Path screenshot = Paths.get(screenshotDir, filename);
       Files.createDirectories(screenshot.getParent());
       Files.copy(new ByteArrayInputStream(data), screenshot);
     } catch (WebDriverException | IOException e) {
       LOG.error(format("Can't capture screenshot for test %s", testName), e);
+    }
+  }
+
+  private void dumpHtmlCodeFromTheCurrentPage(ITestResult result, SeleniumWebDriver webDriver) {
+    String testName = result.getTestClass().getName() + "." + result.getMethod().getMethodName();
+    String filename = NameGenerator.generate(testName + "_", 8) + ".html";
+    try {
+      String pageSource = webDriver.getPageSource();
+      Path dmpDirectory = Paths.get("target/htmldump", filename);
+      Files.createDirectories(dmpDirectory.getParent());
+      Files.write(dmpDirectory, pageSource.getBytes(), StandardOpenOption.CREATE);
+    } catch (WebDriverException | IOException e) {
+      LOG.error(format("Can't dump of html source for test %s", testName), e);
     }
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -306,9 +307,13 @@ public abstract class SeleniumTestHandler
     String filename = NameGenerator.generate(testName + "_", 8) + ".png";
 
     try {
+      String pageSource = webDriver.getPageSource();
+      Path dmpDirectory = Paths.get("target/htmldump", filename + ".html");
+      Files.createDirectories(dmpDirectory.getParent());
+      Files.write(dmpDirectory, pageSource.getBytes(), StandardOpenOption.CREATE);
+
       byte[] data = webDriver.getScreenshotAs(OutputType.BYTES);
       Path screenshot = Paths.get(screenshotDir, filename);
-
       Files.createDirectories(screenshot.getParent());
       Files.copy(new ByteArrayInputStream(data), screenshot);
     } catch (WebDriverException | IOException e) {


### PR DESCRIPTION
### What does this PR do?
Sometimes for investigating problems with failed tests the screenshots and exceptions may be not enough. This PR provides ability to capture html code from the current page for clarify of reasons of failing some specific usecases.