### PR TITLE
che #6500 - Removing optional 'che-ws-' prefix during tag creation on OpenShift

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtils.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtils.java
@@ -113,7 +113,6 @@ public final class KubernetesStringUtils {
             .replaceAll("che_.*", "")
             .replaceAll("_", "");
 
-    name = "che-ws-" + name;
     return getNormalizedString(name);
   }
 


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Removing optional 'che-ws-' prefix during tag creation OpenShift / k8s names / labels max length is 63 chars and removing optional prefix (7 chars) would allow creating multi-container workspaces on minishift

### What issues does this PR fix or reference?
hot fix for https://github.com/eclipse/che/issues/6500
docker image for testing `ibuziuk/che-server:chews`

<!-- #### Changelog -->
Removing optional 'che-ws-' prefix during tag creation OpenShift

#### Release Notes
N / A

#### Docs PR
N / A
