### PR TITLE
Move dependency declaration to che-deps repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <che.docs.version>5.19.0-SNAPSHOT</che.docs.version>
         <che.lib.version>5.19.0-SNAPSHOT</che.lib.version>
         <che.version>5.19.0-SNAPSHOT</che.version>
-        <com.dumbster.version>1.7.1</com.dumbster.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>
@@ -57,26 +56,6 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${version.jsr305.plugin}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt</artifactId>
-                <version>0.7.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-catalina</artifactId>
-                <version>${org.apache.tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-dbcp</artifactId>
-                <version>${org.apache.tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-servlet-api</artifactId>
-                <version>${org.apache.tomcat.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
@@ -1427,17 +1406,6 @@
                 <groupId>org.eclipse.che.selenium</groupId>
                 <artifactId>che-selenium-test</artifactId>
                 <version>${che.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${jdbc.postgresql-driver.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.kirviq</groupId>
-                <artifactId>dumbster</artifactId>
-                <version>${com.dumbster.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>


### PR DESCRIPTION


### What does this PR do?
Move dependency declaration to che-deps repo
related to https://github.com/eclipse/che-dependencies/pull/57
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5362

<!-- #### Changelog -->
n/a


#### Release Notes
n/a


#### Docs PR
n/a
