### PR TITLE
fix deploy to OS wait scripts

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/wait_until_postgres_is_available.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/wait_until_postgres_is_available.sh
@@ -27,7 +27,7 @@ while [ "${available}" != "\"True\"" ] && [ ${SECONDS} -lt ${end} ]; do
   sleep ${POLLING_INTERVAL_SEC}
 done
 
-if [ "${progressing}" == "\"True\"" ] && [ "${available}" == "\"True\"" ]; then
+if [ "${progressing}" == "\"True\"" ]; then
   echo "[CHE] Postgres deployed successfully"
 elif [ "${progressing}" == "False" ]; then
   echo "[CHE] [ERROR] Postgres deployment failed. Aborting. Run command 'oc rollout status postgres' to get more details."

--- a/dockerfiles/init/modules/openshift/files/scripts/wait_until_che_is_available.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/wait_until_che_is_available.sh
@@ -36,7 +36,7 @@ while [ "${available}" != "\"True\"" ] && [ ${SECONDS} -lt ${end} ]; do
   sleep ${POLLING_INTERVAL_SEC}
 done
 
-if [ "${progressing}" == "\"True\"" ] && [ "${available}" == "\"True\"" ]; then
+if [ "${progressing}" == "\"True\"" ]; then
   echo "[CHE] Che deployed successfully"
 elif [ "${progressing}" == "False" ]; then
   echo "[CHE] [ERROR] Che deployment failed. Aborting. Run command 'oc rollout status che' to get more details."


### PR DESCRIPTION
### What does this PR do?
sometimes deploy to ocp fails with:
```
imagestream "che-init" created
buildconfig "postgres-for-che" created
deploymentconfig "postgres" created
imagestream "postgres" created
persistentvolumeclaim "postgres-data" created
service "postgres" created
buildconfig "che-init-image-stream-build" created
imagestream "postgres-source" created
build "che-init-image-stream-build-1" started
[CHE] This script is going to wait until Postgres is deployed and available
[CHE] Deployment is in progress...(Available.status="False", Progressing.status=, Timeout in 119s)
[CHE] Deployment is in progress...(Available.status="False", Progressing.status=, Timeout in 114s)
[CHE] Deployment is in progress...(Available.status="False", Progressing.status="Unknown", Timeout in 108s)
[CHE] Deployment is in progress...(Available.status="False", Progressing.status="Unknown", Timeout in 103s)
[CHE] Deployment is in progress...(Available.status="True", Progressing.status="Unknown", Timeout in 97s)
[CHE] [ERROR] Deployment timeout. Aborting.
```

We didn't expected that during progressing status could be in "unknown" state for some time, so with these changes we will wait only for `Progressing.status=true`