### PR TITLE
Running integrations tests on centos/postgresql-96-centos7 image

### DIFF
--- a/multiuser/integration-tests/che-multiuser-postgresql-tck/pom.xml
+++ b/multiuser/integration-tests/che-multiuser-postgresql-tck/pom.xml
@@ -23,10 +23,12 @@
     <name>Che Multiuser :: PostgreSQL Tck</name>
     <properties>
         <db.image.name>centos/postgresql-96-centos7</db.image.name>
+        <jdbc.admin.name>postgres</jdbc.admin.name>
+        <jdbc.admin.password>che2</jdbc.admin.password>
         <jdbc.driver>org.postgresql.Driver</jdbc.driver>
-        <jdbc.password>che</jdbc.password>
         <jdbc.url>jdbc:postgresql://${docker.host.address}:${jdbc.port}/che</jdbc.url>
-        <jdbc.user>postgres</jdbc.user>
+        <jdbc.user.name>user</jdbc.user.name>
+        <jdbc.user.password>che1</jdbc.user.password>
     </properties>
     <dependencies>
         <dependency>
@@ -211,8 +213,8 @@
                             <systemPropertyVariables>
                                 <jdbc.driver>${jdbc.driver}</jdbc.driver>
                                 <jdbc.url>${jdbc.url}</jdbc.url>
-                                <jdbc.user>${jdbc.user}</jdbc.user>
-                                <jdbc.password>${jdbc.password}</jdbc.password>
+                                <jdbc.user>${jdbc.admin.name}</jdbc.user>
+                                <jdbc.password>${jdbc.admin.password}</jdbc.password>
                             </systemPropertyVariables>
                             <includes>
                                 <include>**/tck/**</include>
@@ -260,10 +262,10 @@
                                             <name>always</name>
                                         </restartPolicy>
                                         <env>
-                                            <POSTGRESQL_PASSWORD>password</POSTGRESQL_PASSWORD>
-                                            <POSTGRESQL_USER>user</POSTGRESQL_USER>
+                                            <POSTGRESQL_USER>${jdbc.user.name}</POSTGRESQL_USER>
+                                            <POSTGRESQL_PASSWORD>${jdbc.user.password}</POSTGRESQL_PASSWORD>
                                             <POSTGRESQL_DATABASE>che</POSTGRESQL_DATABASE>
-                                            <POSTGRESQL_ADMIN_PASSWORD>${jdbc.password}</POSTGRESQL_ADMIN_PASSWORD>
+                                            <POSTGRESQL_ADMIN_PASSWORD>${jdbc.admin.password}</POSTGRESQL_ADMIN_PASSWORD>
                                         </env>
                                     </run>
                                 </image>

--- a/multiuser/integration-tests/che-multiuser-postgresql-tck/pom.xml
+++ b/multiuser/integration-tests/che-multiuser-postgresql-tck/pom.xml
@@ -22,11 +22,11 @@
     <packaging>jar</packaging>
     <name>Che Multiuser :: PostgreSQL Tck</name>
     <properties>
-        <db.image.name>postgres:9.4</db.image.name>
+        <db.image.name>centos/postgresql-96-centos7</db.image.name>
         <jdbc.driver>org.postgresql.Driver</jdbc.driver>
-        <jdbc.password>multiuser</jdbc.password>
-        <jdbc.url>jdbc:postgresql://${docker.host.address}:${jdbc.port}/multiuser</jdbc.url>
-        <jdbc.user>multiuser</jdbc.user>
+        <jdbc.password>che</jdbc.password>
+        <jdbc.url>jdbc:postgresql://${docker.host.address}:${jdbc.port}/che</jdbc.url>
+        <jdbc.user>postgres</jdbc.user>
     </properties>
     <dependencies>
         <dependency>
@@ -253,15 +253,17 @@
                                             <port>jdbc.port:5432</port>
                                         </ports>
                                         <wait>
-                                            <log>database system is ready to accept connections</log>
-                                            <time>20000</time>
+                                            <log>server started</log>
+                                            <time>60000</time>
                                         </wait>
                                         <restartPolicy>
                                             <name>always</name>
                                         </restartPolicy>
                                         <env>
-                                            <POSTGRES_PASSWORD>${jdbc.password}</POSTGRES_PASSWORD>
-                                            <POSTGRES_USER>${jdbc.user}</POSTGRES_USER>
+                                            <POSTGRESQL_PASSWORD>password</POSTGRESQL_PASSWORD>
+                                            <POSTGRESQL_USER>user</POSTGRESQL_USER>
+                                            <POSTGRESQL_DATABASE>che</POSTGRESQL_DATABASE>
+                                            <POSTGRESQL_ADMIN_PASSWORD>${jdbc.password}</POSTGRESQL_ADMIN_PASSWORD>
                                         </env>
                                     </run>
                                 </image>

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -22,7 +22,7 @@
     <packaging>jar</packaging>
     <name>Integration Tests :: PostgreSQL</name>
     <properties>
-        <db.image.name>postgres:9.4</db.image.name>
+        <db.image.name>centos/postgresql-96-centos7</db.image.name>
         <jdbc.driver>org.postgresql.Driver</jdbc.driver>
         <jdbc.password>che</jdbc.password>
         <jdbc.url>jdbc:postgresql://${docker.host.address}:${jdbc.port}/che</jdbc.url>
@@ -251,8 +251,8 @@
                             <systemPropertyVariables>
                                 <jdbc.driver>${jdbc.driver}</jdbc.driver>
                                 <jdbc.url>${jdbc.url}</jdbc.url>
-                                <jdbc.user>${jdbc.user}</jdbc.user>
-                                <jdbc.password>${jdbc.password}</jdbc.password>
+                                <jdbc.user>postgres</jdbc.user>
+                                <jdbc.password>che22</jdbc.password>
                             </systemPropertyVariables>
                             <includes>
                                 <include>**/tck/**</include>
@@ -289,15 +289,17 @@
                                             <port>jdbc.port:5432</port>
                                         </ports>
                                         <wait>
-                                            <log>database system is ready to accept connections</log>
+                                            <log>server started</log>
                                             <time>60000</time>
                                         </wait>
                                         <restartPolicy>
                                             <name>always</name>
                                         </restartPolicy>
                                         <env>
-                                            <POSTGRES_PASSWORD>${jdbc.password}</POSTGRES_PASSWORD>
-                                            <POSTGRES_USER>${jdbc.user}</POSTGRES_USER>
+                                            <POSTGRESQL_PASSWORD>${jdbc.password}</POSTGRESQL_PASSWORD>
+                                            <POSTGRESQL_USER>${jdbc.user}</POSTGRESQL_USER>
+                                            <POSTGRESQL_DATABASE>che</POSTGRESQL_DATABASE>
+                                            <POSTGRESQL_ADMIN_PASSWORD>che22</POSTGRESQL_ADMIN_PASSWORD>
                                         </env>
                                     </run>
                                 </image>

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -26,7 +26,7 @@
         <jdbc.driver>org.postgresql.Driver</jdbc.driver>
         <jdbc.password>che</jdbc.password>
         <jdbc.url>jdbc:postgresql://${docker.host.address}:${jdbc.port}/che</jdbc.url>
-        <jdbc.user>che</jdbc.user>
+        <jdbc.user>postgres</jdbc.user>
     </properties>
     <dependencies>
         <dependency>
@@ -251,8 +251,8 @@
                             <systemPropertyVariables>
                                 <jdbc.driver>${jdbc.driver}</jdbc.driver>
                                 <jdbc.url>${jdbc.url}</jdbc.url>
-                                <jdbc.user>postgres</jdbc.user>
-                                <jdbc.password>che22</jdbc.password>
+                                <jdbc.user>${jdbc.user}</jdbc.user>
+                                <jdbc.password>${jdbc.password}</jdbc.password>
                             </systemPropertyVariables>
                             <includes>
                                 <include>**/tck/**</include>
@@ -296,10 +296,10 @@
                                             <name>always</name>
                                         </restartPolicy>
                                         <env>
-                                            <POSTGRESQL_PASSWORD>${jdbc.password}</POSTGRESQL_PASSWORD>
-                                            <POSTGRESQL_USER>${jdbc.user}</POSTGRESQL_USER>
+                                            <POSTGRESQL_PASSWORD>password</POSTGRESQL_PASSWORD>
+                                            <POSTGRESQL_USER>user</POSTGRESQL_USER>
                                             <POSTGRESQL_DATABASE>che</POSTGRESQL_DATABASE>
-                                            <POSTGRESQL_ADMIN_PASSWORD>che22</POSTGRESQL_ADMIN_PASSWORD>
+                                            <POSTGRESQL_ADMIN_PASSWORD>${jdbc.password}</POSTGRESQL_ADMIN_PASSWORD>
                                         </env>
                                     </run>
                                 </image>

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -23,10 +23,12 @@
     <name>Integration Tests :: PostgreSQL</name>
     <properties>
         <db.image.name>centos/postgresql-96-centos7</db.image.name>
+        <jdbc.admin.name>postgres</jdbc.admin.name>
+        <jdbc.admin.password>che2</jdbc.admin.password>
         <jdbc.driver>org.postgresql.Driver</jdbc.driver>
-        <jdbc.password>che</jdbc.password>
         <jdbc.url>jdbc:postgresql://${docker.host.address}:${jdbc.port}/che</jdbc.url>
-        <jdbc.user>postgres</jdbc.user>
+        <jdbc.user.name>user</jdbc.user.name>
+        <jdbc.user.password>che1</jdbc.user.password>
     </properties>
     <dependencies>
         <dependency>
@@ -251,8 +253,8 @@
                             <systemPropertyVariables>
                                 <jdbc.driver>${jdbc.driver}</jdbc.driver>
                                 <jdbc.url>${jdbc.url}</jdbc.url>
-                                <jdbc.user>${jdbc.user}</jdbc.user>
-                                <jdbc.password>${jdbc.password}</jdbc.password>
+                                <jdbc.user>${jdbc.admin.name}</jdbc.user>
+                                <jdbc.password>${jdbc.admin.password}</jdbc.password>
                             </systemPropertyVariables>
                             <includes>
                                 <include>**/tck/**</include>
@@ -296,10 +298,10 @@
                                             <name>always</name>
                                         </restartPolicy>
                                         <env>
-                                            <POSTGRESQL_PASSWORD>password</POSTGRESQL_PASSWORD>
-                                            <POSTGRESQL_USER>user</POSTGRESQL_USER>
+                                            <POSTGRESQL_USER>${jdbc.user.name}</POSTGRESQL_USER>
+                                            <POSTGRESQL_PASSWORD>${jdbc.user.password}</POSTGRESQL_PASSWORD>
                                             <POSTGRESQL_DATABASE>che</POSTGRESQL_DATABASE>
-                                            <POSTGRESQL_ADMIN_PASSWORD>${jdbc.password}</POSTGRESQL_ADMIN_PASSWORD>
+                                            <POSTGRESQL_ADMIN_PASSWORD>${jdbc.admin.password}</POSTGRESQL_ADMIN_PASSWORD>
                                         </env>
                                     </run>
                                 </image>


### PR DESCRIPTION


### What does this PR do?
Running integrations tests on centos/postgresql-96-centos7 image
Same image as we are using on che-multiuser assembly.
Because user that we are using to run che have privileges to install extension
https://github.com/eclipse/che/blob/che-multiuser/dockerfiles/init/modules/postgres/templates/init-che-user.sh.erb#L16 I've also changed the user in the test to superuser.  This is the same behavior as if we run official image https://hub.docker.com/_/postgres/

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5362

#### Release Notes
n/a


#### Docs PR
n/a
