### PR TITLE
Send events from server to client about project's changes

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ClientSubscriptionHandler.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ClientSubscriptionHandler.java
@@ -19,8 +19,8 @@ import javax.inject.Inject;
 /** A mechanism for handling subscription from the client and registered its endpointId. */
 @Singleton
 public class ClientSubscriptionHandler {
-  public static final String CHE_CLIENT_INITIALIZE_METHOD_NAME = "cheClient/initialize";
-  public static final String CHE_CLIENT_EXPIRE_METHOD_NAME = "cheClient/expire";
+  public static final String CLIENT_SUBSCRIBE_METHOD_NAME = "client/subscribe";
+  public static final String CLIENT_UNSUBSCRIBE_METHOD_NAME = "client/unsubscribe";
 
   private final Set<String> endpointIds = newConcurrentHashSet();
 
@@ -28,14 +28,14 @@ public class ClientSubscriptionHandler {
   private void configureHandlers(RequestHandlerConfigurator configurator) {
     configurator
         .newConfiguration()
-        .methodName(CHE_CLIENT_INITIALIZE_METHOD_NAME)
+        .methodName(CLIENT_SUBSCRIBE_METHOD_NAME)
         .noParams()
         .noResult()
         .withConsumer(endpointIds::add);
 
     configurator
         .newConfiguration()
-        .methodName(CHE_CLIENT_EXPIRE_METHOD_NAME)
+        .methodName(CLIENT_UNSUBSCRIBE_METHOD_NAME)
         .noParams()
         .noResult()
         .withConsumer(endpointIds::remove);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ClientSubscriptionHandler.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/ClientSubscriptionHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.jsonrpc.commons;
+
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+
+import com.google.inject.Singleton;
+import java.util.Set;
+import javax.inject.Inject;
+
+/** A mechanism for handling subscription from the client and registered its endpointId. */
+@Singleton
+public class ClientSubscriptionHandler {
+  public static final String CHE_CLIENT_INITIALIZE_METHOD_NAME = "cheClient/initialize";
+  public static final String CHE_CLIENT_EXPIRE_METHOD_NAME = "cheClient/expire";
+
+  private final Set<String> endpointIds = newConcurrentHashSet();
+
+  @Inject
+  private void configureHandlers(RequestHandlerConfigurator configurator) {
+    configurator
+        .newConfiguration()
+        .methodName(CHE_CLIENT_INITIALIZE_METHOD_NAME)
+        .noParams()
+        .noResult()
+        .withConsumer(endpointIds::add);
+
+    configurator
+        .newConfiguration()
+        .methodName(CHE_CLIENT_EXPIRE_METHOD_NAME)
+        .noParams()
+        .noResult()
+        .withConsumer(endpointIds::remove);
+  }
+
+  /** returns set of endpoint ids of all registered clients. */
+  public Set<String> getEndpointIds() {
+    return endpointIds;
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/JsonRpcModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/JsonRpcModule.java
@@ -55,5 +55,7 @@ public class JsonRpcModule extends AbstractGinModule {
 
     bind(RequestProcessor.class).to(ClientSideRequestProcessor.class);
     bind(TimeoutActionRunner.class).to(ClientSideTimeoutActionRunner.class);
+
+    bind(ServerSubscriptionBroadcaster.class).asEagerSingleton();
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ServerSubscriptionBroadcaster.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ServerSubscriptionBroadcaster.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.core;
+
+import static org.eclipse.che.api.core.jsonrpc.commons.ClientSubscriptionHandler.CHE_CLIENT_INITIALIZE_METHOD_NAME;
+import static org.eclipse.che.ide.projectimport.ProjectImportNotificationSubscriber.WS_AGENT_ENDPOINT;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+
+/** Broadcaster sends subscription event to the server when client has already started. */
+@Singleton
+public class ServerSubscriptionBroadcaster {
+  private boolean isSubscribed = false;
+
+  @Inject
+  private void subscribe(RequestTransmitter requestTransmitter) {
+    if (isSubscribed) {
+      return;
+    }
+
+    requestTransmitter
+        .newRequest()
+        .endpointId(WS_AGENT_ENDPOINT)
+        .methodName(CHE_CLIENT_INITIALIZE_METHOD_NAME)
+        .noParams()
+        .sendAndSkipResult();
+
+    isSubscribed = true;
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ServerSubscriptionBroadcaster.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/ServerSubscriptionBroadcaster.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.ide.core;
 
-import static org.eclipse.che.api.core.jsonrpc.commons.ClientSubscriptionHandler.CHE_CLIENT_INITIALIZE_METHOD_NAME;
+import static org.eclipse.che.api.core.jsonrpc.commons.ClientSubscriptionHandler.CLIENT_SUBSCRIBE_METHOD_NAME;
 import static org.eclipse.che.ide.projectimport.ProjectImportNotificationSubscriber.WS_AGENT_ENDPOINT;
 
 import com.google.inject.Inject;
@@ -31,7 +31,7 @@ public class ServerSubscriptionBroadcaster {
     requestTransmitter
         .newRequest()
         .endpointId(WS_AGENT_ENDPOINT)
-        .methodName(CHE_CLIENT_INITIALIZE_METHOD_NAME)
+        .methodName(CLIENT_SUBSCRIBE_METHOD_NAME)
         .noParams()
         .sendAndSkipResult();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/ProjectApiModule.java
@@ -76,5 +76,7 @@ public class ProjectApiModule extends AbstractGinModule {
     bind(PreSelectedProjectTypeManager.class)
         .to(PreSelectedProjectTypeManagerImpl.class)
         .in(Singleton.class);
+
+    bind(WorkspaceProjectsSyncer.class).asEagerSingleton();
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/WorkspaceProjectsSyncer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/WorkspaceProjectsSyncer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.project;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.resources.Container;
+
+/** Handles event about workspace updating from the server using JSON RPC. */
+@Singleton
+public class WorkspaceProjectsSyncer {
+  private static final String WORKSPACE_SYNCHRONIZE_METHOD_NAME = "workspace/synchronize";
+
+  private final AppContext appContext;
+
+  @Inject
+  public WorkspaceProjectsSyncer(AppContext appContext) {
+    this.appContext = appContext;
+  }
+
+  @Inject
+  private void configureHandlers(RequestHandlerConfigurator configurator) {
+    configurator
+        .newConfiguration()
+        .methodName(WORKSPACE_SYNCHRONIZE_METHOD_NAME)
+        .noParams()
+        .noResult()
+        .withConsumer(this::updateProjects);
+  }
+
+  private void updateProjects(String endpointId) {
+    Container workspaceRoot = appContext.getWorkspaceRoot();
+    if (workspaceRoot != null) {
+      workspaceRoot.synchronize();
+    }
+  }
+}

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/ProjectApiUtils.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/ProjectApiUtils.java
@@ -26,6 +26,7 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.project.server.ProjectRegistry;
 import org.eclipse.che.api.project.server.WorkspaceProjectsSyncer;
+import org.eclipse.che.api.project.server.WorkspaceSyncCommunication;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.importer.ProjectImporterRegistry;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
@@ -96,6 +97,7 @@ public class ProjectApiUtils {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             importerRegistry,

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/rest/JavaFormatterServiceTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/rest/JavaFormatterServiceTest.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.project.server.ProjectRegistry;
 import org.eclipse.che.api.project.server.RegisteredProject;
 import org.eclipse.che.api.project.server.WorkspaceProjectsSyncer;
+import org.eclipse.che.api.project.server.WorkspaceSyncCommunication;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.importer.ProjectImporterRegistry;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
@@ -114,6 +115,7 @@ public class JavaFormatterServiceTest {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             importerRegistry,

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/test/java/org/eclipse/che/plugin/java/plain/server/BaseTest.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/test/java/org/eclipse/che/plugin/java/plain/server/BaseTest.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.project.server.ProjectCreatedEvent;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.project.server.ProjectRegistry;
 import org.eclipse.che.api.project.server.WorkspaceProjectsSyncer;
+import org.eclipse.che.api.project.server.WorkspaceSyncCommunication;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.importer.ProjectImporterRegistry;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
@@ -115,6 +116,7 @@ public abstract class BaseTest {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             importerRegistry,

--- a/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/BaseTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/test/java/org/eclipse/che/plugin/maven/server/BaseTest.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.project.server.ProjectCreatedEvent;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.project.server.ProjectRegistry;
 import org.eclipse.che.api.project.server.WorkspaceProjectsSyncer;
+import org.eclipse.che.api.project.server.WorkspaceSyncCommunication;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.importer.ProjectImporterRegistry;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
@@ -154,6 +155,7 @@ public abstract class BaseTest {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             importerRegistry,

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/test/java/org/ecipse/che/plugin/testing/testng/server/BaseTest.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/test/java/org/ecipse/che/plugin/testing/testng/server/BaseTest.java
@@ -10,6 +10,8 @@
  */
 package org.ecipse.che.plugin.testing.testng.server;
 
+import static org.mockito.Mockito.mock;
+
 import java.io.File;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
@@ -24,6 +26,7 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.project.server.ProjectRegistry;
 import org.eclipse.che.api.project.server.WorkspaceProjectsSyncer;
+import org.eclipse.che.api.project.server.WorkspaceSyncCommunication;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
 import org.eclipse.che.api.project.server.importer.ProjectImporterRegistry;
 import org.eclipse.che.api.project.server.type.ProjectTypeDef;
@@ -134,6 +137,7 @@ public abstract class BaseTest {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             importerRegistry,

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -77,6 +77,7 @@ public class ProjectManager {
 
   private final VirtualFileSystem vfs;
   private final ProjectTypeRegistry projectTypeRegistry;
+  private final WorkspaceSyncCommunication workspaceSyncCommunication;
   private final ProjectRegistry projectRegistry;
   private final ProjectHandlerRegistry handlers;
   private final ProjectImporterRegistry importers;
@@ -92,6 +93,7 @@ public class ProjectManager {
   public ProjectManager(
       VirtualFileSystemProvider vfsProvider,
       ProjectTypeRegistry projectTypeRegistry,
+      WorkspaceSyncCommunication workspaceSyncCommunication,
       ProjectRegistry projectRegistry,
       ProjectHandlerRegistry handlers,
       ProjectImporterRegistry importers,
@@ -102,6 +104,7 @@ public class ProjectManager {
       throws ServerException {
     this.vfs = vfsProvider.getVirtualFileSystem();
     this.projectTypeRegistry = projectTypeRegistry;
+    this.workspaceSyncCommunication = workspaceSyncCommunication;
     this.projectRegistry = projectRegistry;
     this.handlers = handlers;
     this.importers = importers;
@@ -131,7 +134,7 @@ public class ProjectManager {
             projectPath -> {
               try {
                 projectRegistry.removeProjects(projectPath);
-                workspaceProjectsHolder.sync(projectRegistry);
+                workspaceProjectsHolder.sync(projectRegistry, workspaceSyncCommunication);
               } catch (ServerException e) {
                 LOG.error("Could not remove or synchronize  project: {}", projectPath);
               }
@@ -293,7 +296,7 @@ public class ProjectManager {
 
     final RegisteredProject project =
         projectRegistry.putProject(projectConfig, projectFolder, true, false);
-    workspaceProjectsHolder.sync(projectRegistry);
+    workspaceProjectsHolder.sync(projectRegistry, workspaceSyncCommunication);
     projectRegistry.fireInitHandlers(project);
 
     return project;
@@ -464,7 +467,7 @@ public class ProjectManager {
 
     final RegisteredProject project =
         projectRegistry.putProject(newConfig, baseFolder, true, false);
-    workspaceProjectsHolder.sync(projectRegistry);
+    workspaceProjectsHolder.sync(projectRegistry, workspaceSyncCommunication);
 
     projectRegistry.fireInitHandlers(project);
 
@@ -547,7 +550,7 @@ public class ProjectManager {
               registeredProject, asFolder(registeredProject.getPath()), true, false);
         }
         RegisteredProject rp = projectRegistry.putProject(project, folder, true, false);
-        workspaceProjectsHolder.sync(projectRegistry);
+        workspaceProjectsHolder.sync(projectRegistry, workspaceSyncCommunication);
         return rp;
       }
     }
@@ -558,7 +561,7 @@ public class ProjectManager {
             folder,
             true,
             false);
-    workspaceProjectsHolder.sync(projectRegistry);
+    workspaceProjectsHolder.sync(projectRegistry, workspaceSyncCommunication);
     return rp;
   }
 
@@ -637,7 +640,7 @@ public class ProjectManager {
     // delete child projects
     projectRegistry.removeProjects(apath);
 
-    workspaceProjectsHolder.sync(projectRegistry);
+    workspaceProjectsHolder.sync(projectRegistry, workspaceSyncCommunication);
   }
 
   /**

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/WorkspaceProjectsSyncer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/WorkspaceProjectsSyncer.java
@@ -26,9 +26,12 @@ public abstract class WorkspaceProjectsSyncer {
    * Synchronizes Project Config state on Agent and Master
    *
    * @param projectRegistry project registry
+   * @param workspaceSyncCommunication events sender about workspace synchronization to the client
    * @throws ServerException
    */
-  public final void sync(ProjectRegistry projectRegistry) throws ServerException {
+  public final void sync(
+      ProjectRegistry projectRegistry, WorkspaceSyncCommunication workspaceSyncCommunication)
+      throws ServerException {
 
     List<? extends ProjectConfig> remote = getProjects();
 
@@ -69,6 +72,7 @@ public abstract class WorkspaceProjectsSyncer {
         project.setSync();
       }
     }
+    workspaceSyncCommunication.synchronizeWorkspace();
   }
 
   /**

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/WorkspaceSyncCommunication.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/WorkspaceSyncCommunication.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.project.server;
+
+import com.google.inject.Singleton;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.jsonrpc.commons.ClientSubscriptionHandler;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+
+/** Sends event about workspace updating using JSON RPC to the all subscribed clients. */
+@Singleton
+public class WorkspaceSyncCommunication {
+  private static final String WORKSPACE_SYNCHRONIZE_METHOD_NAME = "workspace/synchronize";
+
+  private RequestTransmitter transmitter;
+  private ClientSubscriptionHandler clientSubscriptionHandler;
+
+  @Inject
+  public WorkspaceSyncCommunication(
+      RequestTransmitter transmitter, ClientSubscriptionHandler clientSubscriptionHandler) {
+    this.transmitter = transmitter;
+    this.clientSubscriptionHandler = clientSubscriptionHandler;
+  }
+
+  /** Sends workspace updating event */
+  public void synchronizeWorkspace() {
+    clientSubscriptionHandler
+        .getEndpointIds()
+        .forEach(
+            it ->
+                transmitter
+                    .newRequest()
+                    .endpointId(it)
+                    .methodName(WORKSPACE_SYNCHRONIZE_METHOD_NAME)
+                    .noParams()
+                    .sendAndSkipResult());
+  }
+}

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ExtensionCasesTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ExtensionCasesTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.project.server;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -66,6 +67,7 @@ public class ExtensionCasesTest extends WsAgentTestBase {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             null,

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerReadTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectManagerReadTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.project.server;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
@@ -78,6 +79,7 @@ public class ProjectManagerReadTest extends WsAgentTestBase {
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             projectHandlerRegistry,
             null,

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -257,6 +257,7 @@ public class ProjectServiceTest {
         new ProjectManager(
             vfsProvider,
             ptRegistry,
+            mock(WorkspaceSyncCommunication.class),
             projectRegistry,
             phRegistry,
             importerRegistry,

--- a/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/WsAgentTestBase.java
+++ b/wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/WsAgentTestBase.java
@@ -59,6 +59,8 @@ public class WsAgentTestBase {
 
   protected ProjectRegistry projectRegistry;
 
+  protected WorkspaceSyncCommunication workspaceSyncCommunication;
+
   protected FileWatcherNotificationHandler fileWatcherNotificationHandler;
 
   protected FileTreeWatcher fileTreeWatcher;
@@ -116,12 +118,14 @@ public class WsAgentTestBase {
     fileWatcherNotificationHandler = new DefaultFileWatcherNotificationHandler(vfsProvider);
     fileTreeWatcher = new FileTreeWatcher(root, new HashSet<>(), fileWatcherNotificationHandler);
     fileWatcherManager = mock(FileWatcherManager.class);
+    workspaceSyncCommunication = mock(WorkspaceSyncCommunication.class);
     TestWorkspaceHolder wsHolder = new TestWorkspaceHolder();
 
     pm =
         new ProjectManager(
             vfsProvider,
             projectTypeRegistry,
+            workspaceSyncCommunication,
             projectRegistry,
             projectHandlerRegistry,
             importerRegistry,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
WsAgent has an ability to communicate with clients if some changes were happened  with projects (create, update, import, delete). 
For example if the project was created by calling API request beyond the IDE, the server will send events to each registered clients that some changes in workspace was happened. 

How it works:
1. A client initialised then he sends an event to the server about that by using `ServerSubscriptionBroadcaster`;
2. The server (`ClientSubscriptionHandler`) saves client's endpoint id into some set;
3. When some changes were happened on the server, he (`WorkspaceSyncCommunication`) sends synchronization event to each registered endpointId;
4. Each client (`WorkspaceProjectsSyncer`) catches this event and updates the workspace. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6160

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A
