### PR TITLE
Fix unstable CheckBasicFunctionalityInCommandsExplorerTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/intelligent/CommandsExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/intelligent/CommandsExplorer.java
@@ -184,9 +184,10 @@ public class CommandsExplorer {
   }
 
   public void cloneCommandByName(String commandName) {
+    loader.waitOnClosed();
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
         .until(
-            ExpectedConditions.visibilityOfElementLocated(
+            ExpectedConditions.elementToBeClickable(
                 By.xpath(
                     "//div[@id='command_"
                         + commandName

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckBasicFunctionalityInCommandsExplorerTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckBasicFunctionalityInCommandsExplorerTest.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.nio.file.Paths;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestBuildConstants;
-import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
@@ -35,9 +34,7 @@ import org.testng.annotations.Test;
 /** @author Igor Ohrimenko */
 public class CheckBasicFunctionalityInCommandsExplorerTest {
 
-  @InjectTestWorkspace(memoryGb = 4)
-  private TestWorkspace testWorkspace;
-
+  @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
   @Inject private CommandsExplorer commandsExplorer;
   @Inject private CommandsEditor commandsEditor;


### PR DESCRIPTION
### What does this PR do?
We need to fix unstable CheckBasicFunctionalityInCommandsExplorerTest selenium test from intelligencecommand package:

**CheckBasicFunctionalityInCommandsExplorerTest** - sometimes(when starting on CI) the test fails while try to click on the duplicate command button.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6346