### PR TITLE
Update CLI version files for future release

### DIFF
--- a/dockerfiles/cli/version/5.19.0/images
+++ b/dockerfiles/cli/version/5.19.0/images
@@ -1,4 +1,7 @@
 IMAGE_INIT=eclipse/che-init:5.19.0
 IMAGE_CHE=eclipse/che-server:5.19.0
-IMAGE_COMPOSE=docker/compose:1.8.1
+IMAGE_CHE_MULTIUSER=eclipse/che-server-multiuser:5.19.0
+IMAGE_COMPOSE=docker/compose:1.10.1
 IMAGE_TRAEFIK=traefik:v1.3.0-rc3
+IMAGE_POSTGRES=centos/postgresql-96-centos7
+IMAGE_KEYCLOACK=jboss/keycloak-openshift:3.3.0.CR2-2

--- a/dockerfiles/cli/version/5.19.0/images-stacks
+++ b/dockerfiles/cli/version/5.19.0/images-stacks
@@ -21,4 +21,3 @@ eclipse/ubuntu_jre
 eclipse/ubuntu_python
 eclipse/ubuntu_wildfly8
 registry.centos.org/che-stacks/vertx
-

--- a/dockerfiles/cli/version/latest/images-stacks
+++ b/dockerfiles/cli/version/latest/images-stacks
@@ -20,3 +20,4 @@ eclipse/ubuntu_jdk8
 eclipse/ubuntu_jre
 eclipse/ubuntu_python
 eclipse/ubuntu_wildfly8
+registry.centos.org/che-stacks/vertx


### PR DESCRIPTION
### What does this PR do?
After merge che-multiuser branch we've introduced new images in cli version files which should be also used in 5.19.0 tag version.

related to: https://github.com/eclipse/che/issues/6636