### PR TITLE
Don't fail if SSH agent doesn't start

### DIFF
--- a/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncher.java
+++ b/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AbstractAgentLauncher.java
@@ -102,7 +102,14 @@ public abstract class AbstractAgentLauncher implements AgentLauncher {
               "Fail launching agent '%s' in '%s' workspace due to timeout",
               agent.getName(), machine.getWorkspaceId()));
 
-      process.kill();
+      if (this.shouldBlockMachineStartOnError()) {
+        LOG.info("Stopping workspace {}", machine.getWorkspaceId());
+        process.kill();
+      } else {
+        LOG.info(
+            "Continuing workspace bootstrap even if agent {} failed to start.", agent.getName());
+        return;
+      }
     } catch (MachineException e) {
       logAsErrorAgentStartLogs(machine, agent.getName(), agentLogger.getText());
       throw new ServerException(e.getServiceError());
@@ -171,5 +178,10 @@ public abstract class AbstractAgentLauncher implements AgentLauncher {
           machine.getId(),
           machine.getNode().getHost());
     }
+  }
+
+  @Override
+  public boolean shouldBlockMachineStartOnError() {
+    return true;
   }
 }

--- a/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AgentLauncher.java
+++ b/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/AgentLauncher.java
@@ -31,6 +31,12 @@ public interface AgentLauncher {
   String getMachineType();
 
   /**
+   * @return true if machine bootstrap should be interrupted when agent fail to launch, false
+   *     otherwise
+   */
+  boolean shouldBlockMachineStartOnError();
+
+  /**
    * Executes agents scripts over target machine. The machine should be started.
    *
    * @see Agent#getScript()

--- a/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/DefaultAgentLauncher.java
+++ b/agents/che-core-api-agent/src/main/java/org/eclipse/che/api/agent/server/launcher/DefaultAgentLauncher.java
@@ -78,4 +78,9 @@ public class DefaultAgentLauncher implements AgentLauncher {
   public String getMachineType() {
     return "any";
   }
+
+  @Override
+  public boolean shouldBlockMachineStartOnError() {
+    return true;
+  }
 }

--- a/agents/ssh/src/main/java/org/eclipse/che/api/agent/SshAgentLauncher.java
+++ b/agents/ssh/src/main/java/org/eclipse/che/api/agent/SshAgentLauncher.java
@@ -40,4 +40,9 @@ public class SshAgentLauncher extends AbstractAgentLauncher {
   public String getAgentId() {
     return "org.eclipse.che.ssh";
   }
+
+  @Override
+  public boolean shouldBlockMachineStartOnError() {
+    return false;
+  }
 }

--- a/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
+++ b/agents/ssh/src/main/resources/org.eclipse.che.ssh.script.sh
@@ -21,6 +21,11 @@ set_sudo_command() {
     if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
 }
 
+if ! is_current_user_root && ! is_current_user_sudoer; then
+  (>&2 echo "Current user is not a sudoer and cannot start SSH daemon. SSH service won't be available for this workspace")
+  exit 1
+fi
+
 set_sudo_command
 unset PACKAGES
 

--- a/wsagent/agent/src/main/java/org/eclipse/che/api/agent/WsAgentLauncher.java
+++ b/wsagent/agent/src/main/java/org/eclipse/che/api/agent/WsAgentLauncher.java
@@ -85,6 +85,11 @@ public class WsAgentLauncher implements AgentLauncher {
   }
 
   @Override
+  public boolean shouldBlockMachineStartOnError() {
+    return true;
+  }
+
+  @Override
   public void launch(Instance machine, Agent agent) throws ServerException {
     final String wsAgentPingUrl;
     try {


### PR DESCRIPTION
### What does this PR do?
In the case of a workspace run by an unprivileged user the bootstrap won't fail when the SSH agent fail to start. Failure of the SSH agent is not blocking a workspace creation anymore. That applies to SSH agent only, failures to other agents will result in aborting workspace creation.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/346

#### Release Notes
Workspaces can start even if SSH service is not started (e.g. if the workspace user is not a privileged user).
