### PR TITLE
Workspace start code cleanup

### DIFF
--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
@@ -154,8 +154,7 @@ public class DockerMachine implements Machine {
     try {
       docker.removeImage(RemoveImageParams.create(image).withForce(false));
     } catch (IOException e) {
-      // TODO make log level warning if we ignoring it or remove ignoring phrase
-      LOG.error("IOException during destroy(). Ignoring.", e);
+      LOG.warn("IOException during destroy(). Ignoring.", e);
     }
   }
 

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
@@ -67,7 +67,7 @@ public class DockerMachineCreator {
 
     return new DockerMachine(
         container.getId(),
-        container.getImage(),
+        container.getConfig().getImage(),
         docker,
         new ServersMapper(hostname).map(networkSettings.getPorts(), configs),
         registry,

--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -33,7 +33,6 @@ import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
-import org.eclipse.che.api.workspace.server.WorkspaceSharedPool;
 import org.eclipse.che.api.workspace.server.WorkspaceValidator;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
@@ -76,13 +75,12 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
       EventService eventService,
       AccountManager accountManager,
       WorkspaceValidator workspaceValidator,
-      WorkspaceSharedPool sharedPool,
       //own injects
       @Named("che.limits.workspace.env.ram") String maxRamPerEnv,
       EnvironmentRamCalculator environmentRamCalculator,
       ResourceUsageManager resourceUsageManager,
       ResourcesLocks resourcesLocks) {
-    super(workspaceDao, runtimes, eventService, accountManager, workspaceValidator, sharedPool);
+    super(workspaceDao, runtimes, eventService, accountManager, workspaceValidator);
     this.environmentRamCalculator = environmentRamCalculator;
     this.maxRamPerEnvMB = "-1".equals(maxRamPerEnv) ? -1 : Size.parseSizeToMegabytes(maxRamPerEnv);
     this.resourceUsageManager = resourceUsageManager;

--- a/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -274,7 +274,6 @@ public class LimitsCheckingWorkspaceManagerTest {
               null,
               null,
               null,
-              null,
               maxRamPerEnv,
               environmentRamCalculator,
               resourceUsageManager,

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -10,12 +10,14 @@
  */
 package org.eclipse.che.api.workspace.server;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPING;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STOPPED_BY;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -63,8 +65,6 @@ import org.eclipse.che.core.db.DBInitializer;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-// TODO: spi: deal with exceptions
 
 /**
  * Defines an internal API for managing {@link RuntimeImpl} instances.
@@ -167,15 +167,13 @@ public class WorkspaceRuntimes {
    * Starts all machines from specified workspace environment, creates workspace runtime instance
    * based on that environment.
    *
-   * <p>
-   *
    * <p>During the start of the workspace its runtime is visible with {@link
    * WorkspaceStatus#STARTING} status.
    *
    * @param workspace workspace which environment should be started
    * @param envName the name of the environment to start
    * @param options whether machines should be recovered(true) or not(false)
-   * @return the workspace runtime instance with machines set.
+   * @return completable future of start execution.
    * @throws ConflictException when workspace is already running
    * @throws ConflictException when start is interrupted
    * @throws NotFoundException when any not found exception occurs during environment start
@@ -237,32 +235,18 @@ public class WorkspaceRuntimes {
         throw new ConflictException(
             "Could not start workspace '" + workspaceId + "' because it is not in 'STOPPED' state");
       }
-      eventService.publish(
-          DtoFactory.newDto(WorkspaceStatusEvent.class)
-              .withWorkspaceId(workspaceId)
-              .withStatus(STARTING)
-              .withPrevStatus(STOPPED));
+      LOG.info(
+          "Starting workspace '{}/{}' with id '{}' by user '{}'",
+          workspace.getNamespace(),
+          workspace.getConfig().getName(),
+          workspace.getId(),
+          sessionUserNameOr("undefined"));
+
+      publishWorkspaceStatusEvent(workspaceId, STARTING, STOPPED, null);
+
       return CompletableFuture.runAsync(
-          ThreadLocalPropagateContext.wrap(
-              () -> {
-                try {
-                  runtime.start(options);
-                  runtimes.replace(workspaceId, new RuntimeState(runtime, RUNNING));
-                  eventService.publish(
-                      DtoFactory.newDto(WorkspaceStatusEvent.class)
-                          .withWorkspaceId(workspaceId)
-                          .withStatus(RUNNING)
-                          .withPrevStatus(STARTING));
-                } catch (InfrastructureException e) {
-                  runtimes.remove(workspaceId);
-                  if (!(e instanceof RuntimeStartInterruptedException)) {
-                    publishWorkspaceStoppedEvent(workspaceId, STARTING, e.getMessage());
-                  }
-                  throw new RuntimeException(e);
-                }
-              }),
+          ThreadLocalPropagateContext.wrap(new StartRuntimeTask(workspace, options, runtime)),
           sharedPool.getExecutor());
-      //TODO made complete rework of exceptions.
     } catch (ValidationException e) {
       LOG.error(e.getLocalizedMessage(), e);
       throw new ConflictException(e.getLocalizedMessage());
@@ -272,23 +256,74 @@ public class WorkspaceRuntimes {
     }
   }
 
+  private class StartRuntimeTask implements Runnable {
+    private final Workspace workspace;
+    private final Map<String, String> options;
+    private final String workspaceId;
+    private final InternalRuntime runtime;
+
+    public StartRuntimeTask(
+        Workspace workspace, Map<String, String> options, InternalRuntime runtime) {
+      this.workspace = workspace;
+      this.options = options;
+      this.workspaceId = workspace.getId();
+      this.runtime = runtime;
+    }
+
+    @Override
+    public void run() {
+      try {
+        runtime.start(options);
+        runtimes.replace(workspaceId, new RuntimeState(runtime, RUNNING));
+
+        LOG.info(
+            "Workspace '{}:{}' with id '{}' started by user '{}'",
+            workspace.getNamespace(),
+            workspace.getConfig().getName(),
+            workspace.getId(),
+            sessionUserNameOr("undefined"));
+        publishWorkspaceStatusEvent(workspaceId, RUNNING, STARTING, null);
+      } catch (InfrastructureException e) {
+        runtimes.remove(workspaceId);
+        String failureCause = "failed";
+        if (e instanceof RuntimeStartInterruptedException) {
+          failureCause = "interrupted";
+          publishWorkspaceStatusEvent(workspaceId, STOPPED, STARTING, e.getMessage());
+        }
+        LOG.info(
+            "Workspace '{}:{}' with id '{}' start {}",
+            workspace.getNamespace(),
+            workspace.getConfig().getName(),
+            workspace.getId(),
+            failureCause);
+        // InfrastructureException is supposed to be an exception that can't be solved
+        // by Che admin, so should not be logged (but not InternalInfrastructureException).
+        // It will prevent bothering the admin when user made a mistake in WS configuration.
+        if (e instanceof InternalInfrastructureException) {
+          LOG.error(e.getLocalizedMessage(), e);
+        }
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
   /**
-   * Stops running workspace runtime.
-   *
-   * <p>
+   * Stops running workspace runtime asynchronously.
    *
    * <p>Stops environment in an implementation specific way. During the stop of the workspace its
    * runtime is accessible with {@link WorkspaceStatus#STOPPING stopping} status. Workspace may be
-   * stopped only if its status is {@link WorkspaceStatus#RUNNING}.
+   * stopped only if its status is {@link WorkspaceStatus#RUNNING} or {@link
+   * WorkspaceStatus#STARTING}.
    *
-   * @param workspaceId identifier of workspace which should be stopped
+   * @param workspace workspace which runtime should be stopped
    * @throws NotFoundException when workspace with specified identifier does not have runtime
    * @throws ConflictException when running workspace status is different from {@link
-   *     WorkspaceStatus#RUNNING}
+   *     WorkspaceStatus#RUNNING} or {@link WorkspaceStatus#STARTING}
    * @see WorkspaceStatus#STOPPING
    */
-  public void stop(String workspaceId, Map<String, String> options)
+  public CompletableFuture<Void> stopAsync(Workspace workspace, Map<String, String> options)
       throws NotFoundException, ConflictException {
+    String workspaceId = workspace.getId();
     RuntimeState state = runtimes.get(workspaceId);
     if (state == null) {
       throw new NotFoundException("Workspace with id '" + workspaceId + "' is not running.");
@@ -305,25 +340,75 @@ public class WorkspaceRuntimes {
       throw new ConflictException(
           format("Could not stop workspace '%s' because its state is '%s'", workspaceId, status));
     }
-    eventService.publish(
-        DtoFactory.newDto(WorkspaceStatusEvent.class)
-            .withWorkspaceId(workspaceId)
-            .withPrevStatus(state.status)
-            .withStatus(STOPPING));
+    String stoppedBy =
+        firstNonNull(
+            sessionUserNameOr(workspace.getAttributes().get(WORKSPACE_STOPPED_BY)), "undefined");
+    LOG.info(
+        "Workspace '{}/{}' with id '{}' is being stopped by user '{}'",
+        workspace.getNamespace(),
+        workspace.getConfig().getName(),
+        workspace.getId(),
+        stoppedBy);
+    publishWorkspaceStatusEvent(workspaceId, STOPPING, state.status, null);
 
-    try {
-      state.runtime.stop(options);
+    return CompletableFuture.runAsync(
+        ThreadLocalPropagateContext.wrap(new StopRuntimeTask(workspace, options, stoppedBy, state)),
+        sharedPool.getExecutor());
+  }
 
-      // remove before firing an event to have consistency between state and the event
-      runtimes.remove(workspaceId);
-      publishWorkspaceStoppedEvent(workspaceId, STOPPING, null);
-    } catch (InfrastructureException e) {
-      // remove before firing an event to have consistency between state and the event
-      runtimes.remove(workspaceId);
-      publishWorkspaceStoppedEvent(
-          workspaceId,
-          STOPPING,
-          "Error occurs on workspace runtime stop. Error: " + e.getMessage());
+  private class StopRuntimeTask implements Runnable {
+    private final Workspace workspace;
+    private final Map<String, String> options;
+    private final String stoppedBy;
+    private final String workspaceId;
+    private final RuntimeState state;
+
+    public StopRuntimeTask(
+        Workspace workspace, Map<String, String> options, String stoppedBy, RuntimeState state) {
+      this.workspace = workspace;
+      this.options = options;
+      this.stoppedBy = stoppedBy;
+      this.workspaceId = workspace.getId();
+      this.state = state;
+    }
+
+    @Override
+    public void run() {
+      try {
+        state.runtime.stop(options);
+
+        // remove before firing an event to have consistency between state and the event
+        runtimes.remove(workspaceId);
+        LOG.info(
+            "Workspace '{}/{}' with id '{}' stopped by user '{}'",
+            workspace.getNamespace(),
+            workspace.getConfig().getName(),
+            workspace.getId(),
+            stoppedBy);
+        publishWorkspaceStatusEvent(workspaceId, STOPPED, STOPPING, null);
+      } catch (InfrastructureException e) {
+        // remove before firing an event to have consistency between state and the event
+        runtimes.remove(workspaceId);
+        LOG.info(
+            "Error occurs on workspace '{}/{}' with id '{}' stopped by user '{}'. Error: {}",
+            workspace.getNamespace(),
+            workspace.getConfig().getName(),
+            workspace.getId(),
+            stoppedBy,
+            e);
+        publishWorkspaceStatusEvent(
+            workspaceId,
+            STOPPED,
+            STOPPING,
+            "Error occurs on workspace runtime stop. Error: " + e.getMessage());
+        // InfrastructureException is supposed to be an exception that can't be solved
+        // by Che admin, so should not be logged (but not InternalInfrastructureException).
+        // It will prevent bothering the admin when user made a mistake in WS configuration.
+        if (e instanceof InternalInfrastructureException) {
+          LOG.error(e.getLocalizedMessage(), e);
+        }
+        throw new RuntimeException(e);
+      }
     }
   }
 
@@ -350,8 +435,9 @@ public class WorkspaceRuntimes {
         LOG.warn("Not recoverable infrastructure: '{}'", infra.getName());
       } catch (InternalInfrastructureException x) {
         LOG.error(
-            "An error occurred while attempted to recover runtimes using infrastructure '{}'. Reason: '{}'",
-            infra.getName(),
+            format(
+                "An error occurred while attempted to recover runtimes using infrastructure '%s'",
+                infra.getName()),
             x);
       } catch (ServerException | InfrastructureException x) {
         LOG.error(
@@ -419,14 +505,14 @@ public class WorkspaceRuntimes {
     eventService.subscribe(new CleanupRuntimeOnAbnormalRuntimeStop());
   }
 
-  private void publishWorkspaceStoppedEvent(
-      String workspaceId, WorkspaceStatus previous, String errorMsg) {
+  private void publishWorkspaceStatusEvent(
+      String workspaceId, WorkspaceStatus status, WorkspaceStatus previous, String errorMsg) {
     eventService.publish(
         DtoFactory.newDto(WorkspaceStatusEvent.class)
             .withWorkspaceId(workspaceId)
             .withPrevStatus(previous)
             .withError(errorMsg)
-            .withStatus(STOPPED));
+            .withStatus(status));
   }
 
   private static EnvironmentImpl copyEnv(Workspace workspace, String envName) {
@@ -484,18 +570,25 @@ public class WorkspaceRuntimes {
     return Optional.of(state.runtime.getContext());
   }
 
+  private String sessionUserNameOr(String nameIfNoUser) {
+    final Subject subject = EnvironmentContext.getCurrent().getSubject();
+    if (!subject.isAnonymous()) {
+      return subject.getUserName();
+    }
+    return nameIfNoUser;
+  }
+
   private class CleanupRuntimeOnAbnormalRuntimeStop implements EventSubscriber<RuntimeStatusEvent> {
     @Override
     public void onEvent(RuntimeStatusEvent event) {
       if (event.isFailed()) {
         RuntimeState state = runtimes.remove(event.getIdentity().getWorkspaceId());
         if (state != null) {
-          eventService.publish(
-              DtoFactory.newDto(WorkspaceStatusEvent.class)
-                  .withWorkspaceId(state.runtime.getContext().getIdentity().getWorkspaceId())
-                  .withPrevStatus(RUNNING)
-                  .withStatus(STOPPED)
-                  .withError("Error occurs on workspace runtime stop. Error: " + event.getError()));
+          publishWorkspaceStatusEvent(
+              state.runtime.getContext().getIdentity().getWorkspaceId(),
+              STOPPED,
+              RUNNING,
+              "Error occurs on workspace runtime stop. Error: " + event.getError());
         }
       }
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
@@ -53,7 +53,7 @@ public abstract class AbstractBootstrapper {
           BootstrapperStatus status = event.getStatus();
           //skip starting status event
           if (status.equals(BootstrapperStatus.DONE) || status.equals(BootstrapperStatus.FAILED)) {
-            //check boostrapper belongs to current runtime and machine
+            //check bootstrapper belongs to current runtime and machine
             RuntimeIdentityDto runtimeId = event.getRuntimeId();
             if (event.getMachineName().equals(machineName)
                 && runtimeIdentity.getEnvName().equals(runtimeId.getEnvName())

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.workspace.server.spi;
 
 import static java.util.stream.Collectors.toMap;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +26,6 @@ import org.eclipse.che.api.workspace.server.URLRewriter;
 import org.eclipse.che.api.workspace.server.model.impl.MachineImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
-import org.slf4j.Logger;
 
 /**
  * Implementation of concrete Runtime
@@ -35,8 +33,6 @@ import org.slf4j.Logger;
  * @author gazarenkov
  */
 public abstract class InternalRuntime<T extends RuntimeContext> implements Runtime {
-
-  private static final Logger LOG = getLogger(InternalRuntime.class);
 
   private final T context;
   private final URLRewriter urlRewriter;
@@ -139,15 +135,9 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
 
     try {
       internalStop(stopOptions);
-    } catch (InternalInfrastructureException e) {
-      LOG.error(
-          "Error occurs on stop of workspace {}. Error: {}",
-          context.getIdentity().getWorkspaceId(),
-          e.getMessage());
-    } catch (InfrastructureException e) {
-      LOG.debug(e.getMessage(), e);
+    } finally {
+      status = WorkspaceStatus.STOPPED;
     }
-    status = WorkspaceStatus.STOPPED;
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -225,7 +225,10 @@ public class InternalRuntimeTest {
     // given
     setRunningRuntime();
     doThrow(new InfrastructureException("")).when(internalRuntime).internalStop(any());
-    internalRuntime.stop(emptyMap());
+    try {
+      internalRuntime.stop(emptyMap());
+    } catch (InfrastructureException ignore) {
+    }
 
     // when
     internalRuntime.start(emptyMap());


### PR DESCRIPTION
### What does this PR do?
Moved async operations from WorkspaceManager to WorkspaceRuntimes
to have an async facility in one place instead of two.
Moved workspace start/stop logging from WorkspaceManager
to WorkspaceRuntimes since WorkspaceManager can not correctly log
them.
Improved logging of workspace start/stop including the addition of new logs.

### What issues does this PR fix or reference?
n/a
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
