### PR TITLE
Fix URL with selenium test report on CI

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -503,7 +503,7 @@ fetchFailedTestsNumber() {
 
 detectLatestResultsUrl() {
     local job=$(curl -s ${BASE_ACTUAL_RESULTS_URL} | tr '\n' ' ' | sed 's/.*Last build (#\([0-9]\+\)).*/\1/')
-    echo ${BASE_ACTUAL_RESULTS_URL}${job}"/"
+    echo ${BASE_ACTUAL_RESULTS_URL}${job}"/testReport/"
 }
 
 # Fetches list of failed tests and failed configurations.
@@ -516,16 +516,14 @@ fetchActualResults() {
     if [[ ! ${job} =~ ^[0-9]+$ ]]; then
         ACTUAL_RESULTS_URL=$(detectLatestResultsUrl)
     else
-        ACTUAL_RESULTS_URL=${BASE_ACTUAL_RESULTS_URL}${job}"/"
+        ACTUAL_RESULTS_URL=${BASE_ACTUAL_RESULTS_URL}${job}"/testReport/"
     fi
 
-    # get list of failed tests from CI server
-    local actualResults=($(curl -s ${ACTUAL_RESULTS_URL} | \
+    # get list of failed tests from CI server, remove duplicates from it and sort
+    ACTUAL_RESULTS=$(echo $( curl -s ${ACTUAL_RESULTS_URL} | \
                            tr '>' '\n' | tr '<' '\n' | tr '"' '\n'  | \
-                           grep -A9999999 "Test Result" | \
-                           grep [a-z][a-z0-9_]*[.][a-z] | grep -v http | grep -v junit ))
-
-    ACTUAL_RESULTS=$(echo ${actualResults[*]} | tr ' ' '\n' | sort | uniq)
+                           grep --extended-regexp "^[a-z_$][a-z0-9_$.]*\.[A-Z_$][a-zA-Z0-9_$]*\.[a-z_$][a-zA-Z0-9_$]*$" | \
+                           tr ' ' '\n' | sort | uniq ))
 }
 
 findRegressions() {


### PR DESCRIPTION
### What does this PR do?
For comparing local selenium testing result with CI results this PR changes the page of Jenkins job, which is used for obtaining the list of failed tests, on **/testReport/** to avoid an error of comparing such a following, when we have 4 failed tests but only 3 names on page:

![screenshot from 2017-10-04 12 02 07](https://user-images.githubusercontent.com/1197777/31167769-e0e2e3c0-a8fb-11e7-8569-435e9da379d8.png)

### What issues does this PR fix or reference?
#6443 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
