### PR TITLE
Remove implicit redirection from  `/api` to `/wsmaster/api` for all requests.

### DIFF
--- a/assembly-multiuser/assembly-wsmaster-war/src/main/webapp/META-INF/context.xml
+++ b/assembly-multiuser/assembly-wsmaster-war/src/main/webapp/META-INF/context.xml
@@ -11,7 +11,7 @@
       Red Hat, Inc. - initial API and implementation
 
 -->
-<Context allowCasualMultipartParsing="true" sessionCookiePath="/api">
+<Context allowCasualMultipartParsing="true">
 
     <Resource name="jdbc/che" auth="Container"
               type="javax.sql.DataSource"

--- a/assembly/assembly-ide-war/src/main/webapp/WEB-INF/rewrite.config
+++ b/assembly/assembly-ide-war/src/main/webapp/WEB-INF/rewrite.config
@@ -1,5 +1,4 @@
 
-RewriteRule ^/api/(.*)$     /wsmaster/api/$1    [L]
 RewriteRule ^/factory/resources/(.*)$     /_app/$1    [L]
 RewriteRule ^/factory$     /dashboard/#/load-factory/    [R,NE,QSA]
 RewriteRule ^/factory/$    /dashboard/#/load-factory/    [R,NE,QSA]

--- a/assembly/assembly-wsmaster-war/src/main/webapp/META-INF/context.xml
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/META-INF/context.xml
@@ -11,7 +11,7 @@
       Red Hat, Inc. - initial API and implementation
 
 -->
-<Context allowCasualMultipartParsing="true" sessionCookiePath="/api">
+<Context allowCasualMultipartParsing="true">
 
     <Resource name="jdbc/che" auth="Container"
               type="javax.sql.DataSource"

--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -93,7 +93,7 @@ const keycloakAuth = {
 initModule.constant('keycloakAuth', keycloakAuth);
 
 const promise = new Promise((resolve: IResolveFn<any>, reject: IRejectFn<any>) => {
-  angular.element.get('/api/keycloak/settings').then(resolve, reject);
+  angular.element.get('/wsmaster/api/keycloak/settings').then(resolve, reject);
 });
 promise.then((keycloakSettings: any) => {
   keycloakAuth.config = buildKeycloakConfig(keycloakSettings);

--- a/dashboard/src/app/organizations/organizations-config.service.spec.ts
+++ b/dashboard/src/app/organizations/organizations-config.service.spec.ts
@@ -171,7 +171,7 @@ describe('OrganizationsConfig >', () => {
       $rootScope.$digest();
 
       // make response for organizations list fail
-      $httpBackend.expect('GET', /\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
+      $httpBackend.expect('GET', /\/wsmaster\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
 
       const service = $injector.invoke(resolveBlock);
 
@@ -290,7 +290,7 @@ describe('OrganizationsConfig >', () => {
       $rootScope.$digest();
 
       // make response for organizations list fail
-      $httpBackend.expect('GET', /\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
+      $httpBackend.expect('GET', /\/wsmaster\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
 
       const service = $injector.invoke(resolveBlock);
 
@@ -382,7 +382,7 @@ describe('OrganizationsConfig >', () => {
       $rootScope.$digest();
 
       // make response for organizations list fail
-      $httpBackend.expect('GET', /\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
+      $httpBackend.expect('GET', /\/wsmaster\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
 
       const service = $injector.invoke(resolveBlock);
 

--- a/dashboard/src/app/projects/create-project/github/create-project-github.controller.ts
+++ b/dashboard/src/app/projects/create-project/github/create-project-github.controller.ts
@@ -107,7 +107,7 @@ export class CreateProjectGithubController {
       + this.$location.port()
       + this.$browser.baseHref()
       + 'gitHubCallback.html';
-    return this.githubPopup.open('/api/oauth/authenticate'
+    return this.githubPopup.open('/wsmaster/api/oauth/authenticate'
       + '?oauth_provider=github'
       + '&scope=' + ['user', 'repo', 'write:public_key'].join(',')
       + '&userId=' + this.currentUserId
@@ -125,12 +125,12 @@ export class CreateProjectGithubController {
   }
 
   getAndStoreRemoteToken()  {
-    return this.$http({method: 'GET', url: '/api/oauth/token?oauth_provider=github'}).then( (result) => {
+    return this.$http({method: 'GET', url: '/wsmaster/api/oauth/token?oauth_provider=github'}).then( (result) => {
       if (!result.data) {
         return false;
       }
       this.gitHubTokenStore.setToken(result.data.token);
-      this.$http({method: 'POST', url: '/api/github/ssh/generate'});
+      this.$http({method: 'POST', url: '/wsmaster/api/github/ssh/generate'});
       this.askLoad();
       return true;
     });

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
@@ -214,7 +214,7 @@ export class ImportGithubProjectController {
       + this.$location.port()
       + (this.$browser as any).baseHref()
       + 'gitHubCallback.html';
-    this.githubPopup.open('/api/oauth/authenticate'
+    this.githubPopup.open('/wsmaster/api/oauth/authenticate'
       + '?oauth_provider=github'
       + '&scope=' + ['user', 'repo', 'write:public_key'].join(',')
       + '&userId=' + this.importGithubProjectService.getCurrentUserId()

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
@@ -196,12 +196,12 @@ export class ImportGithubProjectService implements IEditingProgress {
    * @return {IPromise<any>}
    */
   getAndStoreRemoteToken(): ng.IPromise<any> {
-    return this.$http({method: 'GET', url: '/api/oauth/token?oauth_provider=github'}).then( (result: any) => {
+    return this.$http({method: 'GET', url: '/wsmaster/api/oauth/token?oauth_provider=github'}).then( (result: any) => {
       if (!result.data) {
         return false;
       }
       this.gitHubTokenStore.setToken(result.data.token);
-      this.$http({method: 'POST', url: '/api/github/ssh/generate'});
+      this.$http({method: 'POST', url: '/wsmaster/api/github/ssh/generate'});
       this.askLoad();
       return true;
     });

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-import/workspace-recipe-import.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-import/workspace-recipe-import.directive.spec.ts
@@ -38,7 +38,7 @@ describe('WorkspaceRecipeImport', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
 
     $rootScope.model = {
       recipeUrl: '',

--- a/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.spec.ts
@@ -52,7 +52,7 @@ describe('WorkspaceStatusButton >', () => {
 
     httpBackend = cheHttpBackend.getHttpBackend();
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
 
     $rootScope.model = {
       onStopWorkspace: angular.noop,

--- a/dashboard/src/components/api/che-agent.factory.ts
+++ b/dashboard/src/components/api/che-agent.factory.ts
@@ -31,8 +31,8 @@ export class CheAgent {
     this.agents = [];
 
     // remote call
-    this.remoteAgentAPI = this.$resource('/api/installer', {}, {
-      getAgents: { method: 'GET', url: '/api/installer', isArray: true }
+    this.remoteAgentAPI = this.$resource('/wsmaster/api/installer', {}, {
+      getAgents: { method: 'GET', url: '/wsmaster/api/installer', isArray: true }
     });
   }
 

--- a/dashboard/src/components/api/che-factory.factory.ts
+++ b/dashboard/src/components/api/che-factory.factory.ts
@@ -69,14 +69,14 @@ export class CheFactory {
     this.factoryPagesMap = new Map();
     this.pageInfo = {};
 
-    this.remoteFactoryAPI = <IFactoriesResource<any>>this.$resource('/api/factory/:factoryId', {factoryId: '@id'}, {
-      updateFactory: {method: 'PUT', url: '/api/factory/:factoryId'},
-      getFactoryContentFromWorkspace: {method: 'GET', url: '/api/factory/workspace/:workspaceId'},
-      getFactoryParameters: {method: 'POST', url: '/api/factory/resolver/'},
-      createFactoryByContent: {method: 'POST', url: '/api/factory'},
+    this.remoteFactoryAPI = <IFactoriesResource<any>>this.$resource('/wsmaster/api/factory/:factoryId', {factoryId: '@id'}, {
+      updateFactory: {method: 'PUT', url: '/wsmaster/api/factory/:factoryId'},
+      getFactoryContentFromWorkspace: {method: 'GET', url: '/wsmaster/api/factory/workspace/:workspaceId'},
+      getFactoryParameters: {method: 'POST', url: '/wsmaster/api/factory/resolver/'},
+      createFactoryByContent: {method: 'POST', url: '/wsmaster/api/factory'},
       getFactories: {
         method: 'GET',
-        url: '/api/factory/find?creator.userId=:userId&maxItems=:maxItems&skipCount=:skipCount',
+        url: '/wsmaster/api/factory/find?creator.userId=:userId&maxItems=:maxItems&skipCount=:skipCount',
         isArray: false,
         responseType: 'json',
         transformResponse: (data: any, headersGetter: Function) => {
@@ -85,7 +85,7 @@ export class CheFactory {
       },
       getFactoryByName: {
         method: 'GET',
-        url: '/api/factory/find?creator.userId=:userId&name=:factoryName',
+        url: '/wsmaster/api/factory/find?creator.userId=:userId&name=:factoryName',
         isArray: true
       }
     });
@@ -100,7 +100,7 @@ export class CheFactory {
         return {factories: data};
       }
       this.pageInfo.currentPageNumber = this.pageInfo.currentPageNumber ? this.pageInfo.currentPageNumber : 1;
-      let link = '/api/factory/find?creator.userId=' + user.id + '&maxItems=' + this.itemsPerPage;
+      let link = '/wsmaster/api/factory/find?creator.userId=' + user.id + '&maxItems=' + this.itemsPerPage;
       links.set('first', link + '&skipCount=0');
       if (data && data.length > 0) {
         links.set('next', link + '&skipCount=' + this.pageInfo.currentPageNumber * this.itemsPerPage);

--- a/dashboard/src/components/api/che-factory.spec.ts
+++ b/dashboard/src/components/api/che-factory.spec.ts
@@ -94,12 +94,12 @@ describe('CheFactory', () => {
       factory.fetchFactories(maxItem);
 
       // expecting GETs
-      httpBackend.expectGET('/api/user');
+      httpBackend.expectGET('/wsmaster/api/user');
 
-      httpBackend.expectGET('/api/factory/find?creator.userId=' + testUser.id + '&maxItems=' + maxItem + '&skipCount=' + skipCount);
-      httpBackend.expectGET('/api/factory/' + testFactory1.id);
-      httpBackend.expectGET('/api/factory/' + testFactory2.id);
-      httpBackend.expectGET('/api/factory/' + testFactory3.id);
+      httpBackend.expectGET('/wsmaster/api/factory/find?creator.userId=' + testUser.id + '&maxItems=' + maxItem + '&skipCount=' + skipCount);
+      httpBackend.expectGET('/wsmaster/api/factory/' + testFactory1.id);
+      httpBackend.expectGET('/wsmaster/api/factory/' + testFactory2.id);
+      httpBackend.expectGET('/wsmaster/api/factory/' + testFactory3.id);
 
       // flush command
       httpBackend.flush();
@@ -143,7 +143,7 @@ describe('CheFactory', () => {
       factory.fetchFactoryById(testFactory.id);
 
       // expecting GETs
-      httpBackend.expectGET('/api/factory/' + testFactory.id);
+      httpBackend.expectGET('/wsmaster/api/factory/' + testFactory.id);
 
       // flush command
       httpBackend.flush();
@@ -176,7 +176,7 @@ describe('CheFactory', () => {
       factory.deleteFactoryById(testFactory.id);
 
       // expecting GETs
-      httpBackend.expectDELETE('/api/factory/' + testFactory.id);
+      httpBackend.expectDELETE('/wsmaster/api/factory/' + testFactory.id);
 
       // flush command
       httpBackend.flush();
@@ -191,11 +191,11 @@ describe('CheFactory', () => {
       let testFactory2 = apiBuilder.getFactoryBuilder().withId('testId2').withName('testName2').withCreatorEmail('testEmail2').build();
       let factories = [testFactory1, testFactory2];
 
-      let test_link_1 = '/api/factory/find?creator.userId=testUserId&skipCount=0&maxItems=5';
+      let test_link_1 = '/wsmaster/api/factory/find?creator.userId=testUserId&skipCount=0&maxItems=5';
       let test_rel_1 = 'first';
-      let test_link_2 = '/api/factory/find?creator.userId=testUserId&skipCount=20&maxItems=5';
+      let test_link_2 = '/wsmaster/api/factory/find?creator.userId=testUserId&skipCount=20&maxItems=5';
       let test_rel_2 = 'last';
-      let test_link_3 = '/api/factory/find?creator.userId=testUserId&skipCount=5&maxItems=5';
+      let test_link_3 = '/wsmaster/api/factory/find?creator.userId=testUserId&skipCount=5&maxItems=5';
       let test_rel_3 = 'next';
 
       let headersLink = '\<' + test_link_1 + '\>' + '; rel="' + test_rel_1 + '",' +
@@ -223,7 +223,7 @@ describe('CheFactory', () => {
   it('Gets maxItems and skipCount from link params', () => {
       let skipCount = 20;
       let maxItems = 5;
-      let test_link = '/api/factory/find?creator.userId=testUserId&skipCount=' + skipCount + '&maxItems=' + maxItems;
+      let test_link = '/wsmaster/api/factory/find?creator.userId=testUserId&skipCount=' + skipCount + '&maxItems=' + maxItems;
 
       cheBackend.factoriesBackendSetup();
 

--- a/dashboard/src/components/api/che-git.spec.ts
+++ b/dashboard/src/components/api/che-git.spec.ts
@@ -86,7 +86,7 @@ describe('CheGit', function () {
     cheBackend.setup();
 
     workspace.fetchWorkspaceDetails(workspaceId);
-    httpBackend.expectGET('/api/workspace/' + workspaceId);
+    httpBackend.expectGET('/wsmaster/api/workspace/' + workspaceId);
 
 
     // flush command
@@ -153,7 +153,7 @@ describe('CheGit', function () {
     cheBackend.setup();
 
     workspace.fetchWorkspaceDetails(workspaceId);
-    httpBackend.expectGET('/api/workspace/' + workspaceId);
+    httpBackend.expectGET('/wsmaster/api/workspace/' + workspaceId);
 
     // flush command
     httpBackend.flush();
@@ -177,6 +177,5 @@ describe('CheGit', function () {
     // check
     expect(remoteArray.join()).toEqual(urlArray.join());
   });
-
 
 });

--- a/dashboard/src/components/api/che-invite.factory.ts
+++ b/dashboard/src/components/api/che-invite.factory.ts
@@ -50,10 +50,10 @@ export class CheInvite implements che.api.ICheInvite {
 
     this.teamInvitations = new Map();
 
-    this.remoteInviteAPI = <IInviteResource<any>>this.$resource('/api/invite', {}, {
-      invite: {method: 'POST', url: '/api/invite'},
-      getInvited: {method: 'GET', url: '/api/invite/:domain?instance=:instance', isArray: true},
-      remove: {method: 'DELETE', url: '/api/invite/:domain?instance=:instance&email=:email'}
+    this.remoteInviteAPI = <IInviteResource<any>>this.$resource('/wsmaster/api/invite', {}, {
+      invite: {method: 'POST', url: '/wsmaster/api/invite'},
+      getInvited: {method: 'GET', url: '/wsmaster/api/invite/:domain?instance=:instance', isArray: true},
+      remove: {method: 'DELETE', url: '/wsmaster/api/invite/:domain?instance=:instance&email=:email'}
     });
   }
 

--- a/dashboard/src/components/api/che-o-auth-provider.factory.ts
+++ b/dashboard/src/components/api/che-o-auth-provider.factory.ts
@@ -30,7 +30,7 @@ export class CheOAuthProvider {
       return this.providersPromise;
     }
 
-    let promise = this.$http.get('/api/oauth/');
+    let promise = this.$http.get('/wsmaster/api/oauth/');
     this.providersPromise = promise.then((providers) => {
       providers.data.forEach((provider) => {
         this.providersByName.set(provider.name, provider);

--- a/dashboard/src/components/api/che-organizations.factory.ts
+++ b/dashboard/src/components/api/che-organizations.factory.ts
@@ -19,7 +19,7 @@ interface IOrganizationsResource<T> extends ng.resource.IResourceClass<T> {
   fetchSubOrganizations(data: { id: string }): ng.resource.IResource<T>;
 }
 
-const MAIN_URL = '/api/organization';
+const MAIN_URL = '/wsmaster/api/organization';
 
 /**
  * This class is handling the interactions with Organization management API.

--- a/dashboard/src/components/api/che-permissions.factory.ts
+++ b/dashboard/src/components/api/che-permissions.factory.ts
@@ -71,11 +71,11 @@ export class ChePermissions implements che.api.IChePermissions {
       hasInstallationManagerService: false
     };
 
-    this.remotePermissionsAPI = <IPermissionsResource<any>>this.$resource('/api/permissions', {}, {
-      store: {method: 'POST', url: '/api/permissions'},
-      remove: {method: 'DELETE', url: '/api/permissions/:domain?instance=:instance&user=:user'},
-      getSystemPermissions: {method: 'GET', url: '/api/permissions/system'},
-      getPermissionsByInstance: {method: 'GET', url: '/api/permissions/:domain/all?instance=:instance', isArray: true}
+    this.remotePermissionsAPI = <IPermissionsResource<any>>this.$resource('/wsmaster/api/permissions', {}, {
+      store: {method: 'POST', url: '/wsmaster/api/permissions'},
+      remove: {method: 'DELETE', url: '/wsmaster/api/permissions/:domain?instance=:instance&user=:user'},
+      getSystemPermissions: {method: 'GET', url: '/wsmaster/api/permissions/system'},
+      getPermissionsByInstance: {method: 'GET', url: '/wsmaster/api/permissions/:domain/all?instance=:instance', isArray: true}
     });
   }
 

--- a/dashboard/src/components/api/che-preferences.factory.ts
+++ b/dashboard/src/components/api/che-preferences.factory.ts
@@ -31,7 +31,7 @@ export class ChePreferences {
     this.$http = $http;
 
     // remote call
-    this.remotePreferencesAPI = this.$resource('/api/preferences', {}, {});
+    this.remotePreferencesAPI = this.$resource('/wsmaster/api/preferences', {}, {});
 
     //registry array
     this.registries = [];
@@ -68,7 +68,7 @@ export class ChePreferences {
     // delete method doesn't send body when it is defined in $resources
     // that's why direct $http call is used.
     this.$http({
-      url: '/api/preferences',
+      url: '/wsmaster/api/preferences',
       method: 'DELETE',
       headers: {'Content-Type': 'application/json;charset=utf-8'},
       data: properties

--- a/dashboard/src/components/api/che-preferences.spec.ts
+++ b/dashboard/src/components/api/che-preferences.spec.ts
@@ -80,7 +80,7 @@ describe('ChePreferences', function () {
       factory.fetchPreferences();
 
       // expecting GETs
-      httpBackend.expectGET('/api/preferences');
+      httpBackend.expectGET('/wsmaster/api/preferences');
 
       // flush command
       httpBackend.flush();
@@ -120,7 +120,7 @@ describe('ChePreferences', function () {
       factory.addRegistry(registryUrl, userName, userPassword);
 
       // expecting POST
-      httpBackend.expectPOST('/api/preferences');
+      httpBackend.expectPOST('/wsmaster/api/preferences');
 
       // flush command
       httpBackend.flush();
@@ -154,7 +154,7 @@ describe('ChePreferences', function () {
       factory.updatePreferences(newPreferences);
 
       // expecting POST
-      httpBackend.expectPOST('/api/preferences');
+      httpBackend.expectPOST('/wsmaster/api/preferences');
 
       // flush command
       httpBackend.flush();
@@ -182,7 +182,7 @@ describe('ChePreferences', function () {
       factory.removePreferences(['pref1']);
 
       // expecting POST
-      httpBackend.expectDELETE('/api/preferences');
+      httpBackend.expectDELETE('/wsmaster/api/preferences');
 
       // flush command
       httpBackend.flush();

--- a/dashboard/src/components/api/che-profile.factory.ts
+++ b/dashboard/src/components/api/che-profile.factory.ts
@@ -51,10 +51,10 @@ export class CheProfile {
     this.$http = $http;
 
     // remote call
-    this.remoteProfileAPI = <IProfileResource<che.IProfile>>this.$resource('/api/profile', {}, {
-      getById: {method: 'GET', url: '/api/profile/:userId'},
-      setAttributes: {method: 'PUT', url: '/api/profile/attributes'},
-      setAttributesById: {method: 'PUT', url: '/api/profile/:userId/attributes'}
+    this.remoteProfileAPI = <IProfileResource<che.IProfile>>this.$resource('/wsmaster/api/profile', {}, {
+      getById: {method: 'GET', url: '/wsmaster/api/profile/:userId'},
+      setAttributes: {method: 'PUT', url: '/wsmaster/api/profile/attributes'},
+      setAttributesById: {method: 'PUT', url: '/wsmaster/api/profile/:userId/attributes'}
     });
 
     this.profileIdMap = new Map();

--- a/dashboard/src/components/api/che-profile.spec.ts
+++ b/dashboard/src/components/api/che-profile.spec.ts
@@ -74,7 +74,7 @@ describe('CheProfile', () => {
 
       factory.fetchProfile();
 
-      httpBackend.expectGET('/api/profile');
+      httpBackend.expectGET('/wsmaster/api/profile');
 
       httpBackend.flush();
 
@@ -99,7 +99,7 @@ describe('CheProfile', () => {
 
       factory.setAttributes(testProfile.atributes);
 
-      httpBackend.expectPUT('/api/profile/attributes');
+      httpBackend.expectPUT('/wsmaster/api/profile/attributes');
 
       httpBackend.flush();
     }
@@ -118,7 +118,7 @@ describe('CheProfile', () => {
 
       factory.setAttributes(testProfile.attributes, testProfile.userId);
 
-      httpBackend.expectPUT(`/api/profile/${testProfile.id}/attributes`);
+      httpBackend.expectPUT(`/wsmaster/api/profile/${testProfile.id}/attributes`);
 
       httpBackend.flush();
 

--- a/dashboard/src/components/api/che-project-template.factory.ts
+++ b/dashboard/src/components/api/che-project-template.factory.ts
@@ -40,7 +40,7 @@ export class CheProjectTemplate {
     this.templates = [];
 
     // remote call
-    this.remoteProjectTemplateAPI = <ng.resource.IResourceClass<any>> this.$resource('/api/project-template/all');
+    this.remoteProjectTemplateAPI = <ng.resource.IResourceClass<any>> this.$resource('/wsmaster/api/project-template/all');
   }
 
 

--- a/dashboard/src/components/api/che-project-template.spec.ts
+++ b/dashboard/src/components/api/che-project-template.spec.ts
@@ -109,7 +109,7 @@ describe('CheProjectTemplate', function(){
       factory.fetchTemplates();
 
       // expecting a GET
-      httpBackend.expectGET('/api/project-template/all');
+      httpBackend.expectGET('/wsmaster/api/project-template/all');
 
       // flush command
       httpBackend.flush();

--- a/dashboard/src/components/api/che-project-type.spec.ts
+++ b/dashboard/src/components/api/che-project-type.spec.ts
@@ -95,7 +95,7 @@ describe('CheProjectType', function(){
 
     // fetch runtime
     workspace.fetchWorkspaceDetails(workspaceId);
-    httpBackend.expectGET('/api/workspace/' + workspaceId);
+    httpBackend.expectGET('/wsmaster/api/workspace/' + workspaceId);
 
     // flush command
     httpBackend.flush();

--- a/dashboard/src/components/api/che-project.spec.ts
+++ b/dashboard/src/components/api/che-project.spec.ts
@@ -90,7 +90,7 @@ describe('CheProject', function () {
 
       // fetch runtime
       workspace.fetchWorkspaceDetails(testProjectDetails.workspaceId);
-      httpBackend.expectGET('/api/workspace/' + testProjectDetails.workspaceId);
+      httpBackend.expectGET('/wsmaster/api/workspace/' + testProjectDetails.workspaceId);
 
       // flush command
       httpBackend.flush();

--- a/dashboard/src/components/api/che-recipe.factory.ts
+++ b/dashboard/src/components/api/che-recipe.factory.ts
@@ -33,9 +33,9 @@ export class CheRecipe {
     this.recipes = [];
 
     // remote call
-    this.remoteRecipesAPI = this.$resource('/api/recipe',{}, {
-      create: {method: 'POST', url: '/api/recipe'},
-      getRecipes: {method: 'GET', url: '/api/recipe/list', isArray: true}});
+    this.remoteRecipesAPI = this.$resource('/wsmaster/api/recipe',{}, {
+      create: {method: 'POST', url: '/wsmaster/api/recipe'},
+      getRecipes: {method: 'GET', url: '/wsmaster/api/recipe/list', isArray: true}});
 
 
   }

--- a/dashboard/src/components/api/che-resources-distribution.factory.ts
+++ b/dashboard/src/components/api/che-resources-distribution.factory.ts
@@ -76,13 +76,13 @@ export class CheResourcesDistribution implements che.api.ICheResourcesDistributi
     this.organizationUsedResources = new Map();
     this.organizationAvailableResources = new Map();
 
-    this.remoteResourcesAPI = <IResourcesResource<any>>this.$resource('/api/organization/resource', {}, {
-      distribute: {method: 'POST', url: '/api/organization/resource/:organizationId/cap'},
-      getResources: {method: 'GET', url: '/api/organization/resource/:organizationId/cap', isArray: true},
-      getTotalResources: {method: 'GET', url: '/api/resource/:organizationId', isArray: true},
-      getUsedResources: {method: 'GET', url: '/api/resource/:organizationId/used', isArray: true},
-      getAvailableResources: {method: 'GET', url: '/api/resource/:organizationId/available', isArray: true},
-      updateFreeResources: {method: 'POST', url: '/api/resource/free'}
+    this.remoteResourcesAPI = <IResourcesResource<any>>this.$resource('/wsmaster/api/organization/resource', {}, {
+      distribute: {method: 'POST', url: '/wsmaster/api/organization/resource/:organizationId/cap'},
+      getResources: {method: 'GET', url: '/wsmaster/api/organization/resource/:organizationId/cap', isArray: true},
+      getTotalResources: {method: 'GET', url: '/wsmaster/api/resource/:organizationId', isArray: true},
+      getUsedResources: {method: 'GET', url: '/wsmaster/api/resource/:organizationId/used', isArray: true},
+      getAvailableResources: {method: 'GET', url: '/wsmaster/api/resource/:organizationId/available', isArray: true},
+      updateFreeResources: {method: 'POST', url: '/wsmaster/api/resource/free'}
     });
   }
 

--- a/dashboard/src/components/api/che-service.factory.ts
+++ b/dashboard/src/components/api/che-service.factory.ts
@@ -51,7 +51,7 @@ export class CheService {
       return this.servicesPromise;
     }
 
-    let promise = this.$http.get('/api/');
+    let promise = this.$http.get('/wsmaster/api/');
     this.servicesPromise = promise.then((response: any) => {
       this.services = [];
       response.data.rootResources.forEach((service: any) => {
@@ -82,7 +82,7 @@ export class CheService {
    * @returns {IHttpPromise<any>}
    */
   fetchServicesInfo(): ng.IPromise<any> {
-    let promise = this.$http({'method': 'OPTIONS', 'url': '/api/'});
+    let promise = this.$http({'method': 'OPTIONS', 'url': '/wsmaster/api/'});
     let infoPromise = promise.then((response: any) => {
       this.servicesInfo = response.data;
     });

--- a/dashboard/src/components/api/che-ssh.factory.ts
+++ b/dashboard/src/components/api/che-ssh.factory.ts
@@ -48,10 +48,10 @@ export class CheSsh {
     this.sshKeyPairs = new Map<string, any>();
 
     // remote call
-    this.remoteSshAPI = this.$resource('/api/ssh', {}, {
-      getKeyPair: { method: 'GET', url: '/api/ssh/:serviceId/find?name=:nameId'},
-      removeKey: { method: 'DELETE', url: '/api/ssh/:serviceId/?name=:nameId'},
-      generateKey: { method: 'POST', url: '/api/ssh/generate'},
+    this.remoteSshAPI = this.$resource('/wsmaster/api/ssh', {}, {
+      getKeyPair: { method: 'GET', url: '/wsmaster/api/ssh/:serviceId/find?name=:nameId'},
+      removeKey: { method: 'DELETE', url: '/wsmaster/api/ssh/:serviceId/?name=:nameId'},
+      generateKey: { method: 'POST', url: '/wsmaster/api/ssh/generate'},
     });
   }
 

--- a/dashboard/src/components/api/che-stack.factory.ts
+++ b/dashboard/src/components/api/che-stack.factory.ts
@@ -50,12 +50,12 @@ export class CheStack {
     this.usedStackNames = [];
 
     // remote call
-    this.remoteStackAPI = <IRemoteStackAPI<any>>this.$resource('/api/stack', {}, {
-      getStacks: {method: 'GET', url: '/api/stack?maxItems=50', isArray: true}, //TODO 50 items is temp solution while paging is not added
-      getStack: {method: 'GET', url: '/api/stack/:stackId'},
-      updateStack: {method: 'PUT', url: '/api/stack/:stackId'},
-      createStack: {method: 'POST', url: '/api/stack'},
-      deleteStack: {method: 'DELETE', url: '/api/stack/:stackId'}
+    this.remoteStackAPI = <IRemoteStackAPI<any>>this.$resource('/wsmaster/api/stack', {}, {
+      getStacks: {method: 'GET', url: '/wsmaster/api/stack?maxItems=50', isArray: true}, //TODO 50 items is temp solution while paging is not added
+      getStack: {method: 'GET', url: '/wsmaster/api/stack/:stackId'},
+      updateStack: {method: 'PUT', url: '/wsmaster/api/stack/:stackId'},
+      createStack: {method: 'POST', url: '/wsmaster/api/stack'},
+      deleteStack: {method: 'DELETE', url: '/wsmaster/api/stack/:stackId'}
     });
   }
 

--- a/dashboard/src/components/api/che-svn.spec.ts
+++ b/dashboard/src/components/api/che-svn.spec.ts
@@ -93,7 +93,7 @@ describe('CheSvn', function () {
     cheBackend.setup();
 
     workspace.fetchWorkspaceDetails(workspaceId);
-    httpBackend.expectGET('/api/workspace/' + workspaceId);
+    httpBackend.expectGET('/wsmaster/api/workspace/' + workspaceId);
 
     // flush command
     httpBackend.flush();

--- a/dashboard/src/components/api/che-team.factory.ts
+++ b/dashboard/src/components/api/che-team.factory.ts
@@ -86,8 +86,8 @@ export class CheTeam implements che.api.ICheTeam {
     this.cheOrganization = cheOrganization;
     this.cheResourcesDistribution = cheResourcesDistribution;
 
-    this.remoteTeamAPI = <ITeamsResource<any>>$resource('/api/organization', {}, {
-      findTeam: {method: 'GET', url: '/api/organization/find?name=:teamName'}
+    this.remoteTeamAPI = <ITeamsResource<any>>$resource('/wsmaster/api/organization', {}, {
+      findTeam: {method: 'GET', url: '/wsmaster/api/organization/find?name=:teamName'}
     });
 
     this.fetchTeamsDefer = this.$q.defer();

--- a/dashboard/src/components/api/che-user.factory.ts
+++ b/dashboard/src/components/api/che-user.factory.ts
@@ -52,30 +52,30 @@ export class CheUser {
     this.$cookies = $cookies;
 
     // remote call
-    this.remoteUserAPI = <IUsersResource<any>> this.$resource('/api/user', {}, {
-      findByID: {method: 'GET', url: '/api/user/:userId'},
-      findByAlias: {method: 'GET', url: '/api/user/find?email=:alias'},
-      findByName: {method: 'GET', url: '/api/user/find?name=:name'},
+    this.remoteUserAPI = <IUsersResource<any>> this.$resource('/wsmaster/api/user', {}, {
+      findByID: {method: 'GET', url: '/wsmaster/api/user/:userId'},
+      findByAlias: {method: 'GET', url: '/wsmaster/api/user/find?email=:alias'},
+      findByName: {method: 'GET', url: '/wsmaster/api/user/find?name=:name'},
       setPassword: {
-        method: 'POST', url: '/api/user/password', isArray: false,
+        method: 'POST', url: '/wsmaster/api/user/password', isArray: false,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
         }
       },
-      createUser: {method: 'POST', url: '/api/user'},
+      createUser: {method: 'POST', url: '/wsmaster/api/user'},
       getUsers: {
         method: 'GET',
-        url: '/api/admin/user?maxItems=:maxItems&skipCount=:skipCount',
+        url: '/wsmaster/api/admin/user?maxItems=:maxItems&skipCount=:skipCount',
         isArray: false,
         responseType: 'json',
         transformResponse: (data: any, headersGetter: any) => {
           return this._getPageFromResponse(data, headersGetter('link'));
         }
       },
-      removeUserById: {method: 'DELETE', url: '/api/user/:userId'}
+      removeUserById: {method: 'DELETE', url: '/wsmaster/api/user/:userId'}
     });
 
-    this.logoutAPI = this.$resource('/api/auth/logout', {});
+    this.logoutAPI = this.$resource('/wsmaster/api/auth/logout', {});
 
     // users by ID
     this.userIdMap = new Map();

--- a/dashboard/src/components/api/che-user.spec.ts
+++ b/dashboard/src/components/api/che-user.spec.ts
@@ -83,7 +83,7 @@ describe('CheUser', () => {
       factory.fetchUser(true);
 
       // expecting GETs
-      httpBackend.expectGET('/api/user');
+      httpBackend.expectGET('/wsmaster/api/user');
 
       // flush command
       httpBackend.flush();
@@ -118,7 +118,7 @@ describe('CheUser', () => {
       factory.fetchUserId(userId);
 
       // expecting GETs
-      httpBackend.expectGET('/api/user/' + userId);
+      httpBackend.expectGET('/wsmaster/api/user/' + userId);
 
       // flush command
       httpBackend.flush();
@@ -153,7 +153,7 @@ describe('CheUser', () => {
       factory.fetchUserByAlias(email);
 
       // expecting GETs
-      httpBackend.expectGET('/api/user/find?email=' + email);
+      httpBackend.expectGET('/wsmaster/api/user/find?email=' + email);
 
       // flush command
       httpBackend.flush();
@@ -181,7 +181,7 @@ describe('CheUser', () => {
       factory.setPassword(testPassword);
 
       // expecting a POST
-      httpBackend.expectPOST('/api/user/password', 'password=' + testPassword);
+      httpBackend.expectPOST('/wsmaster/api/user/password', 'password=' + testPassword);
 
       // flush command
       httpBackend.flush();
@@ -205,7 +205,7 @@ describe('CheUser', () => {
       factory.createUser(user.name, user.email, user.password);
 
       // expecting a POST
-      httpBackend.expectPOST('/api/user', user);
+      httpBackend.expectPOST('/wsmaster/api/user', user);
 
       // flush command
       httpBackend.flush();

--- a/dashboard/src/components/api/che-websocket.factory.ts
+++ b/dashboard/src/components/api/che-websocket.factory.ts
@@ -38,7 +38,7 @@ export class CheWebsocket {
 
     if (inDevMode) {
       // it handle then http and https
-      wsUrl = proxySettings.replace('http', 'ws') + '/api/ws';
+      wsUrl = proxySettings.replace('http', 'ws') + '/wsmaster/api/ws';
     } else {
 
       var wsProtocol;
@@ -48,7 +48,7 @@ export class CheWebsocket {
         wsProtocol = 'wss';
       }
 
-      wsUrl = wsProtocol + '://' + $location.host() + ':' + $location.port() + '/api/ws';
+      wsUrl = wsProtocol + '://' + $location.host() + ':' + $location.port() + '/wsmaster/api/ws';
     }
     let keycloakToken = keycloakAuth.isPresent ? '?token=' + keycloakAuth.keycloak.token : '';
     this.wsBaseUrl = wsUrl + keycloakToken;

--- a/dashboard/src/components/api/paging-resource/page-object.spec.ts
+++ b/dashboard/src/components/api/paging-resource/page-object.spec.ts
@@ -56,7 +56,7 @@ describe('PageObject >', () => {
 
     const maxItems = 15;
     const countObjects = 50;
-    const url = '/api/object';
+    const url = '/wsmaster/api/object';
 
     pageObjectResource = factory.createPageObjectResource(url);
     pageObjectMock = new PageObjectMock(pageObjectResource, maxItems, countObjects);

--- a/dashboard/src/components/api/remote/che-remote-login.ts
+++ b/dashboard/src/components/api/remote/che-remote-login.ts
@@ -25,7 +25,7 @@ export class CheRemoteLogin {
     this.$resource = $resource;
     this.url = url;
     this.remoteAuthAPI = this.$resource('', {}, {
-      auth: {method: 'POST', url: url + '/api/auth/login'}
+      auth: {method: 'POST', url: url + '/wsmaster/api/auth/login'}
     });
   }
 

--- a/dashboard/src/components/api/remote/che-remote-recipe.ts
+++ b/dashboard/src/components/api/remote/che-remote-recipe.ts
@@ -26,7 +26,7 @@ export class CheRemoteRecipe {
 
     // remote call
     this.remoteRecipesAPI = this.$resource('',{}, {
-      create: {method: 'POST', url: authData.url + '/api/recipe?token=' + authData.token},
+      create: {method: 'POST', url: authData.url + '/wsmaster/api/recipe?token=' + authData.token},
     });
 
   }

--- a/dashboard/src/components/api/remote/che-remote-workspace.ts
+++ b/dashboard/src/components/api/remote/che-remote-workspace.ts
@@ -42,10 +42,10 @@ export class CheRemoteWorkspace {
 
     // remote call
     this.remoteWorkspaceAPI = <IRemoteWorkspaceResource<any>>this.$resource('', {}, {
-        getDetails: {method: 'GET', url: authData.url + '/api/workspace/:workspaceId?token=' + authData.token},
-        getMachineToken: {method: 'GET', url: authData.url + '/api/machine/token/:workspaceId?token=' + authData.token},
-        create: {method: 'POST', url: authData.url + '/api/workspace?token=' + authData.token},
-        startWorkspace: {method: 'POST', url : authData.url + '/api/workspace/:workspaceId/runtime?environment=:envName&token=' + authData.token}
+        getDetails: {method: 'GET', url: authData.url + '/wsmaster/api/workspace/:workspaceId?token=' + authData.token},
+        getMachineToken: {method: 'GET', url: authData.url + '/wsmaster/api/machine/token/:workspaceId?token=' + authData.token},
+        create: {method: 'POST', url: authData.url + '/wsmaster/api/workspace?token=' + authData.token},
+        startWorkspace: {method: 'POST', url : authData.url + '/wsmaster/api/workspace/:workspaceId/runtime?environment=:envName&token=' + authData.token}
       }
     );
   }

--- a/dashboard/src/components/api/test/che-http-backend.ts
+++ b/dashboard/src/components/api/test/che-http-backend.ts
@@ -90,10 +90,10 @@ export class CheHttpBackend {
    * Setup all data that should be retrieved on calls
    */
   setup(): void {
-    this.httpBackend.when('OPTIONS', '/api/').respond({});
-    this.httpBackend.when('GET', '/api/').respond(200, {rootResources: []});
+    this.httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
+    this.httpBackend.when('GET', '/wsmaster/api/').respond(200, {rootResources: []});
 
-    this.httpBackend.when('GET', '/api/keycloak/settings').respond(404);
+    this.httpBackend.when('GET', '/wsmaster/api/keycloak/settings').respond(404);
 
     // add the remote call
     let workspaceReturn = [];
@@ -104,24 +104,24 @@ export class CheHttpBackend {
       this.addWorkspaceAgent(key, tmpWorkspace.runtime);
 
       // get by ID
-      this.httpBackend.when('GET', '/api/workspace/' + key).respond(200, tmpWorkspace);
+      this.httpBackend.when('GET', '/wsmaster/api/workspace/' + key).respond(200, tmpWorkspace);
       // get by namespace/workspaceName
-      this.httpBackend.when('GET', `/api/workspace/${tmpWorkspace.namespace}/${tmpWorkspace.config.name}`).respond(200, tmpWorkspace);
+      this.httpBackend.when('GET', `/wsmaster/api/workspace/${tmpWorkspace.namespace}/${tmpWorkspace.config.name}`).respond(200, tmpWorkspace);
 
-      this.httpBackend.when('DELETE', '/api/workspace/' + key).respond(200);
+      this.httpBackend.when('DELETE', '/wsmaster/api/workspace/' + key).respond(200);
     }
 
     let workspacSettings = {
       'che.workspace.auto_snapshot': this.isAutoSnapshot,
       'che.workspace.auto_restore': this.isAutoRestore
     };
-    this.httpBackend.when('GET', '/api/workspace/settings').respond(200, workspacSettings);
+    this.httpBackend.when('GET', '/wsmaster/api/workspace/settings').respond(200, workspacSettings);
 
-    this.httpBackend.when('GET', '/api/workspace/settings').respond({});
+    this.httpBackend.when('GET', '/wsmaster/api/workspace/settings').respond({});
 
-    this.httpBackend.when('GET', '/api/workspace').respond(workspaceReturn);
+    this.httpBackend.when('GET', '/wsmaster/api/workspace').respond(workspaceReturn);
 
-    this.httpBackend.when('GET', '/api/stack?maxItems=50').respond(this.stacks);
+    this.httpBackend.when('GET', '/wsmaster/api/stack?maxItems=50').respond(this.stacks);
 
     let projectTypeKeys = this.projectTypesWorkspaces.keys();
     for (let key of projectTypeKeys) {
@@ -129,15 +129,15 @@ export class CheHttpBackend {
     }
 
     // profiles
-    this.httpBackend.when('GET', '/api/profile').respond(this.defaultProfile);
+    this.httpBackend.when('GET', '/wsmaster/api/profile').respond(this.defaultProfile);
     let profileKeys = this.profilesMap.keys();
     for (let key of profileKeys) {
-      this.httpBackend.when('GET', '/api/profile/' + key).respond(this.profilesMap.get(key));
+      this.httpBackend.when('GET', '/wsmaster/api/profile/' + key).respond(this.profilesMap.get(key));
     }
 
     // preferences
-    this.httpBackend.when('GET', '/api/preferences').respond(this.defaultPreferences);
-    this.httpBackend.when('DELETE', '/api/preferences').respond(200, {});
+    this.httpBackend.when('GET', '/wsmaster/api/preferences').respond(this.defaultPreferences);
+    this.httpBackend.when('DELETE', '/wsmaster/api/preferences').respond(200, {});
 
     /// project details
     let projectDetailsKeys = this.projectDetailsMap.keys();
@@ -150,28 +150,28 @@ export class CheHttpBackend {
     // branding
     this.httpBackend.when('GET', 'assets/branding/product.json').respond(this.defaultBranding);
 
-    this.httpBackend.when('POST', '/api/analytics/log/session-usage').respond(200, {});
+    this.httpBackend.when('POST', '/wsmaster/api/analytics/log/session-usage').respond(200, {});
 
     // change password
-    this.httpBackend.when('POST', '/api/user/password').respond(() => {
+    this.httpBackend.when('POST', '/wsmaster/api/user/password').respond(() => {
       return [200, {success: true, errors: []}];
     });
 
     // create new user
-    this.httpBackend.when('POST', '/api/user').respond(() => {
+    this.httpBackend.when('POST', '/wsmaster/api/user').respond(() => {
       return [200, {success: true, errors: []}];
     });
 
-    this.httpBackend.when('GET', '/api/user').respond(this.defaultUser);
+    this.httpBackend.when('GET', '/wsmaster/api/user').respond(this.defaultUser);
 
     let userIdKeys = this.userIdMap.keys();
     for (let key of userIdKeys) {
-      this.httpBackend.when('GET', '/api/user/' + key).respond(this.userIdMap.get(key));
+      this.httpBackend.when('GET', '/wsmaster/api/user/' + key).respond(this.userIdMap.get(key));
     }
 
     let userEmailKeys = this.userEmailMap.keys();
     for (let key of userEmailKeys) {
-      this.httpBackend.when('GET', '/api/user/find?email=' + key).respond(this.userEmailMap.get(key));
+      this.httpBackend.when('GET', '/wsmaster/api/user/find?email=' + key).respond(this.userEmailMap.get(key));
     }
     this.httpBackend.when('GET', /\/_app\/compilation-mappings(\?.*$)?/).respond(200, '');
   }
@@ -310,7 +310,7 @@ export class CheHttpBackend {
    * @param preferences
    */
   setPreferences(preferences: any): void {
-    this.httpBackend.when('POST', '/api/preferences').respond(preferences);
+    this.httpBackend.when('POST', '/wsmaster/api/preferences').respond(preferences);
     this.defaultPreferences = preferences;
   }
 
@@ -330,11 +330,11 @@ export class CheHttpBackend {
    */
   setAttributes(attributes: che.IProfileAttributes, userId?: string): void {
     if (angular.isUndefined(userId)) {
-      this.httpBackend.when('PUT', '/api/profile/attributes').respond({attributes: attributes});
+      this.httpBackend.when('PUT', '/wsmaster/api/profile/attributes').respond({attributes: attributes});
       this.defaultProfile.attributes = attributes;
       return;
     }
-    this.httpBackend.when('PUT', `/api/profile/${userId}/attributes`).respond({userId: userId, attributes: attributes});
+    this.httpBackend.when('PUT', `/wsmaster/api/profile/${userId}/attributes`).respond({userId: userId, attributes: attributes});
   }
 
   /**
@@ -342,7 +342,7 @@ export class CheHttpBackend {
    * @param projectTemplates
    */
   addProjectTemplates(projectTemplates: any): void {
-    this.httpBackend.when('GET', '/api/project-template/all').respond(projectTemplates);
+    this.httpBackend.when('GET', '/wsmaster/api/project-template/all').respond(projectTemplates);
   }
 
   /**
@@ -465,15 +465,15 @@ export class CheHttpBackend {
     let factoriesKeys = this.factoriesMap.keys();
     for (let key of factoriesKeys) {
       let factory = this.factoriesMap.get(key);
-      this.httpBackend.when('GET', '/api/factory/' + factory.id).respond(factory);
-      this.httpBackend.when('DELETE', '/api/factory/' + factory.id).respond(() => {
+      this.httpBackend.when('GET', '/wsmaster/api/factory/' + factory.id).respond(factory);
+      this.httpBackend.when('DELETE', '/wsmaster/api/factory/' + factory.id).respond(() => {
         return [200, {success: true, errors: []}];
       });
       allFactories.push(factory);
     }
 
     if (this.defaultUser) {
-      this.httpBackend.when('GET', '/api/user').respond(this.defaultUser);
+      this.httpBackend.when('GET', '/wsmaster/api/user').respond(this.defaultUser);
 
       if (allFactories.length >  this.pageSkipCount) {
         if (allFactories.length > this.pageSkipCount + this.pageMaxItem) {
@@ -482,7 +482,7 @@ export class CheHttpBackend {
           pageFactories = allFactories.slice(this.pageSkipCount);
         }
       }
-      this.httpBackend.when('GET', '/api/factory/find?creator.userId=' + this.defaultUser.id + '&maxItems=' + this.pageMaxItem + '&skipCount=' + this.pageSkipCount).respond(pageFactories);
+      this.httpBackend.when('GET', '/wsmaster/api/factory/find?creator.userId=' + this.defaultUser.id + '&maxItems=' + this.pageMaxItem + '&skipCount=' + this.pageSkipCount).respond(pageFactories);
     }
   }
 
@@ -490,16 +490,16 @@ export class CheHttpBackend {
    * Setup all users
    */
   usersBackendSetup(): void {
-    this.httpBackend.when('GET', '/api/user').respond(this.defaultUser);
+    this.httpBackend.when('GET', '/wsmaster/api/user').respond(this.defaultUser);
 
     let userIdKeys = this.userIdMap.keys();
     for (let key of userIdKeys) {
-      this.httpBackend.when('GET', '/api/user/' + key).respond(this.userIdMap.get(key));
+      this.httpBackend.when('GET', '/wsmaster/api/user/' + key).respond(this.userIdMap.get(key));
     }
 
     let userEmailKeys = this.userEmailMap.keys();
     for (let key of userEmailKeys) {
-      this.httpBackend.when('GET', '/api/user/find?email=' + key).respond(this.userEmailMap.get(key));
+      this.httpBackend.when('GET', '/wsmaster/api/user/find?email=' + key).respond(this.userEmailMap.get(key));
     }
   }
 
@@ -560,14 +560,14 @@ export class CheHttpBackend {
     let teamsKeys = this.teamsMap.keys();
     for (let key of teamsKeys) {
       let team = this.teamsMap.get(key);
-      this.httpBackend.when('GET', '/api/organization/' + team.id).respond(team);
-      this.httpBackend.when('DELETE', '/api/organization/' + team.id).respond(() => {
+      this.httpBackend.when('GET', '/wsmaster/api/organization/' + team.id).respond(team);
+      this.httpBackend.when('DELETE', '/wsmaster/api/organization/' + team.id).respond(() => {
         return [200, {success: true, errors: []}];
       });
       allTeams.push(team);
     }
 
-    this.httpBackend.when('GET', /\/api\/organization(\?.*$)?/).respond(allTeams);
+    this.httpBackend.when('GET', /\/wsmaster\/api\/organization(\?.*$)?/).respond(allTeams);
   }
 
   /**
@@ -587,15 +587,15 @@ export class CheHttpBackend {
     const organizationKeys = this.organizationsMap.keys();
     for (let key of organizationKeys) {
       const organization = this.organizationsMap.get(key);
-      this.httpBackend.when('GET', '/api/organization/' + organization.id).respond(organization);
-      this.httpBackend.when('GET', '/api/organization/find?name=' + encodeURIComponent(organization.qualifiedName)).respond(organization);
-      this.httpBackend.when('DELETE', '/api/organization/' + organization.id).respond(() => {
+      this.httpBackend.when('GET', '/wsmaster/api/organization/' + organization.id).respond(organization);
+      this.httpBackend.when('GET', '/wsmaster/api/organization/find?name=' + encodeURIComponent(organization.qualifiedName)).respond(organization);
+      this.httpBackend.when('DELETE', '/wsmaster/api/organization/' + organization.id).respond(() => {
         return [200, {success: true, errors: []}];
       });
       allOrganizations.push(organization);
     }
-    this.httpBackend.when('GET', /^\/api\/organization\/find\?name=.*$/).respond(404, {}, {message: 'Organization is not found.'});
-    this.httpBackend.when('GET', /\/api\/organization(\?.*$)?/).respond(allOrganizations);
+    this.httpBackend.when('GET', /^\/wsmaster\/api\/organization\/find\?name=.*$/).respond(404, {}, {message: 'Organization is not found.'});
+    this.httpBackend.when('GET', /\/wsmaster\/api\/organization(\?.*$)?/).respond(allOrganizations);
   }
 
   /**
@@ -616,7 +616,7 @@ export class CheHttpBackend {
       const permissionsList = this.permissionsMap.get(domainInstanceKey);
       const {domainId, instanceId} = permissionsList[0];
 
-      this.httpBackend.when('GET', `/api/permissions/${domainId}/all?instance=${instanceId}`).respond(permissionsList);
+      this.httpBackend.when('GET', `/wsmaster/api/permissions/${domainId}/all?instance=${instanceId}`).respond(permissionsList);
     }
   }
 
@@ -646,13 +646,13 @@ export class CheHttpBackend {
       // distributed
       if (organizationResourcesMap.has('distributed')) {
         const resources = organizationResourcesMap.get('distributed');
-        this.httpBackend.when('GET', `/api/organization/resource/${organizationId}/cap`).respond(resources);
+        this.httpBackend.when('GET', `/wsmaster/api/organization/resource/${organizationId}/cap`).respond(resources);
       }
 
       // total
       if (organizationResourcesMap.has('total')) {
         const resources = organizationResourcesMap.get('total');
-        this.httpBackend.when('GET', `/api/resource/${organizationId}`).respond(resources);
+        this.httpBackend.when('GET', `/wsmaster/api/resource/${organizationId}`).respond(resources);
       }
     }
   }

--- a/dashboard/src/components/api/workspace/che-workspace.factory.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.factory.ts
@@ -117,19 +117,19 @@ export class CheWorkspace {
     this.statusDefers = {};
 
     // remote call
-    this.remoteWorkspaceAPI = <ICHELicenseResource<any>>this.$resource('/api/workspace', {}, {
+    this.remoteWorkspaceAPI = <ICHELicenseResource<any>>this.$resource('/wsmaster/api/workspace', {}, {
         // having 2 methods for creation to ensure namespace parameter won't be send at all if value is null or undefined
-        create: {method: 'POST', url: '/api/workspace'},
-        createWithNamespace: {method: 'POST', url: '/api/workspace?namespace=:namespace'},
-        deleteWorkspace: {method: 'DELETE', url: '/api/workspace/:workspaceId'},
-        updateWorkspace: {method: 'PUT', url: '/api/workspace/:workspaceId'},
-        addProject: {method: 'POST', url: '/api/workspace/:workspaceId/project'},
-        deleteProject: {method: 'DELETE', url: '/api/workspace/:workspaceId/project/:path'},
-        stopWorkspace: {method: 'DELETE', url: '/api/workspace/:workspaceId/runtime?create-snapshot=:createSnapshot'},
-        startWorkspace: {method: 'POST', url: '/api/workspace/:workspaceId/runtime?environment=:envName'},
-        startTemporaryWorkspace: {method: 'POST', url: '/api/workspace/runtime?temporary=true'},
-        addCommand: {method: 'POST', url: '/api/workspace/:workspaceId/command'},
-        getSettings: {method: 'GET', url: '/api/workspace/settings'}
+        create: {method: 'POST', url: '/wsmaster/api/workspace'},
+        createWithNamespace: {method: 'POST', url: '/wsmaster/api/workspace?namespace=:namespace'},
+        deleteWorkspace: {method: 'DELETE', url: '/wsmaster/api/workspace/:workspaceId'},
+        updateWorkspace: {method: 'PUT', url: '/wsmaster/api/workspace/:workspaceId'},
+        addProject: {method: 'POST', url: '/wsmaster/api/workspace/:workspaceId/project'},
+        deleteProject: {method: 'DELETE', url: '/wsmaster/api/workspace/:workspaceId/project/:path'},
+        stopWorkspace: {method: 'DELETE', url: '/wsmaster/api/workspace/:workspaceId/runtime?create-snapshot=:createSnapshot'},
+        startWorkspace: {method: 'POST', url: '/wsmaster/api/workspace/:workspaceId/runtime?environment=:envName'},
+        startTemporaryWorkspace: {method: 'POST', url: '/wsmaster/api/workspace/runtime?temporary=true'},
+        addCommand: {method: 'POST', url: '/wsmaster/api/workspace/:workspaceId/command'},
+        getSettings: {method: 'GET', url: '/wsmaster/api/workspace/settings'}
       }
     );
 
@@ -260,7 +260,7 @@ export class CheWorkspace {
    * @param namespace namespace
    */
   fetchWorkspacesByNamespace(namespace: string): ng.IPromise<any> {
-    let promise = this.$http.get('/api/workspace/namespace/' + namespace);
+    let promise = this.$http.get('/wsmaster/api/workspace/namespace/' + namespace);
     let resultPromise = promise.then((response: { data: che.IWorkspace[] }) => {
       const workspaces = this.getWorkspacesByNamespace(namespace);
 
@@ -346,7 +346,7 @@ export class CheWorkspace {
       return this.workspaceDetailsByKeyPromise.get(workspaceKey);
     }
     const defer = this.$q.defer();
-    const promise: ng.IHttpPromise<any> = this.$http.get('/api/workspace/' + workspaceKey);
+    const promise: ng.IHttpPromise<any> = this.$http.get('/wsmaster/api/workspace/' + workspaceKey);
     this.workspaceDetailsByKeyPromise.set(workspaceKey, promise);
 
     promise.then((response: ng.IHttpPromiseCallbackArg<che.IWorkspace>) => {

--- a/dashboard/src/components/api/workspace/che-workspace.spec.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.spec.ts
@@ -92,7 +92,7 @@ describe('CheWorkspace', () => {
         expect(listener.getWorkspaces().length).toEqual(0);
 
         // expecting a GET
-        httpBackend.expectGET('/api/workspace');
+        httpBackend.expectGET('/wsmaster/api/workspace');
 
         // providing request
         // add workspaces on Http backend

--- a/dashboard/src/components/attribute/multi-transclude/che-multi-transclude.directive.spec.ts
+++ b/dashboard/src/components/attribute/multi-transclude/che-multi-transclude.directive.spec.ts
@@ -43,7 +43,7 @@ describe('CheMultiTransclude >', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
   }));
 
   afterEach(() => {

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -60,7 +60,7 @@ const DEFAULT_DOCS_WORKSPACE = '/docs/getting-started/intro/index.html';
 const DEFAULT_WORKSPACE_PRIORITY_STACKS = ['Java', 'Java-MySQL', 'Blank'];
 const DEFAULT_WORKSPACE_DEFAULT_STACK = 'java-mysql';
 const DEFAULT_WORKSPACE_CREATION_LINK = '#/create-workspace';
-const DEFAULT_WEBSOCKET_CONTEXT = '/api/websocket';
+const DEFAULT_WEBSOCKET_CONTEXT = '/wsmaster/api/websocket';
 
 /**
  * This class is handling the branding data in Che.

--- a/dashboard/src/components/error-messages/che-error-messages.service.spec.ts
+++ b/dashboard/src/components/error-messages/che-error-messages.service.spec.ts
@@ -30,7 +30,7 @@ describe('CheErrorMessagesService', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
   }));
 
   describe('for each namespace', () => {

--- a/dashboard/src/components/filter/number-round/number-round.spec.ts
+++ b/dashboard/src/components/filter/number-round/number-round.spec.ts
@@ -67,7 +67,7 @@ describe('CheNumberRoundFilter', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
   }));
 
   testNumbers.forEach((entry: {number: number, precision: number, result: number}) => {

--- a/dashboard/src/components/validator/city-name-validator.spec.ts
+++ b/dashboard/src/components/validator/city-name-validator.spec.ts
@@ -66,7 +66,7 @@ describe('city-name-validator', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
   }));
 
   validNames.forEach((validName: string) => {

--- a/dashboard/src/components/validator/custom-validator.spec.ts
+++ b/dashboard/src/components/validator/custom-validator.spec.ts
@@ -32,7 +32,7 @@ describe('custom-validator', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
 
     $scope.validateFn = (value) => {
       return value % 2 === 0;

--- a/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.spec.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.spec.ts
@@ -46,7 +46,7 @@ describe('CheToggleButtonPopover >', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
 
     $rootScope.model = {
       title: 'Popover Button Title',

--- a/dashboard/src/components/widget/popover/che-toggle-popover.directive.spec.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-popover.directive.spec.ts
@@ -52,7 +52,7 @@ describe('CheTogglePopover >', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
 
     $rootScope.model = {
       buttonTitle: 'My Button',

--- a/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.spec.ts
+++ b/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.spec.ts
@@ -46,7 +46,7 @@ describe('ToggleSingleButton >', () => {
     httpBackend = cheHttpBackend.getHttpBackend();
     // avoid tracking requests from branding controller
     httpBackend.whenGET(/.*/).respond(200, '');
-    httpBackend.when('OPTIONS', '/api/').respond({});
+    httpBackend.when('OPTIONS', '/wsmaster/api/').respond({});
 
     $rootScope.model = {
       title: 'Toggle Single Button Title',

--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -26,7 +26,7 @@ convert_posix_to_windows() {
 }
 
 get_boot_url() {
-  echo "$CHE_HOST:$CHE_PORT/api/"
+  echo "$CHE_HOST:$CHE_PORT/wsmaster/api/"
 }
 
 get_display_url() {

--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -378,7 +378,7 @@ MULTI_USER_REPLACEMENT_STRING="          - name: \"CHE_WORKSPACE_LOGS\"
 
 # TODO When merging the multi-user work to master, this replacement string should
 # be replaced by the corresponding change in the fabric8 deployment descriptor
-MULTI_USER_HEALTH_CHECK_REPLACEMENT_STRING="s|            path: /api/system/state|            path: /api|"
+MULTI_USER_HEALTH_CHECK_REPLACEMENT_STRING="s|            path: /wsmaster/api/system/state|            path: /wsmaster/api|"
 
 echo
 if [ "${OPENSHIFT_FLAVOR}" == "minishift" ]; then

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -66,7 +66,7 @@ initVariables() {
     [[ -z ${CALLER+x} ]] && { CALLER=$(basename $0); }
     [[ -z ${CUR_DIR+x} ]] && { CUR_DIR=$(cd "$(dirname "$0")"; pwd); }
 
-    [[ -z ${API_SUFFIX+x} ]] && { API_SUFFIX="/api/"; }
+    [[ -z ${API_SUFFIX+x} ]] && { API_SUFFIX="/wsmaster/api/"; }
     [[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/che-integration-tests/"; }
 
     MODE="grid"


### PR DESCRIPTION
### What does this PR do?
Removes implicit redirection from `/api` to `/wsmaster/api` by Tomcat valve.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6481

#### Release Notes
Removed internall rewrite  `/api` to `/wsmaster/api` 

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/301/files

