### PR TITLE
#6479 - Create workspace with factory json for urls ending with .git

### DIFF
--- a/plugins/plugin-urlfactory/src/main/java/org/eclipse/che/plugin/urlfactory/URLFactoryBuilder.java
+++ b/plugins/plugin-urlfactory/src/main/java/org/eclipse/che/plugin/urlfactory/URLFactoryBuilder.java
@@ -40,7 +40,7 @@ import org.eclipse.che.dto.server.DtoFactory;
 public class URLFactoryBuilder {
 
   /** Default docker image (if repository has no dockerfile) */
-  protected static final String DEFAULT_DOCKER_IMAGE = "codenvy/ubuntu_jdk8";
+  protected static final String DEFAULT_DOCKER_IMAGE = "eclipse/ubuntu_jdk8";
 
   /** Default docker type (if repository has no dockerfile) */
   protected static final String MEMORY_LIMIT_BYTES = Long.toString(2000L * 1024L * 1024L);

--- a/plugins/plugin-urlfactory/src/main/java/org/eclipse/che/plugin/urlfactory/URLFetcher.java
+++ b/plugins/plugin-urlfactory/src/main/java/org/eclipse/che/plugin/urlfactory/URLFetcher.java
@@ -43,7 +43,7 @@ public class URLFetcher {
   protected static final long MAXIMUM_READ_BYTES = 30 * 1000;
 
   /** The Compiled REGEX PATTERN that can be used for http|https git urls */
-  final Pattern GIT_HTTP_URL_PATTERN = Pattern.compile("(^http[s]?://.*)(.git$)");
+  final Pattern GIT_HTTP_URL_PATTERN = Pattern.compile("(?<sanitized>^http[s]?://.*)\\.git$");
 
   /**
    * Fetch the url provided and return its content To prevent DOS attack, limit the amount of the
@@ -107,7 +107,7 @@ public class URLFetcher {
     if (url != null) {
       final Matcher matcher = GIT_HTTP_URL_PATTERN.matcher(url);
       if (matcher.find()) {
-        return matcher.group(1);
+        return matcher.group("sanitized");
       }
     }
     return url;

--- a/plugins/plugin-urlfactory/src/test/java/org/eclipse/che/plugin/urlfactory/URLFetcherTest.java
+++ b/plugins/plugin-urlfactory/src/test/java/org/eclipse/che/plugin/urlfactory/URLFetcherTest.java
@@ -66,6 +66,16 @@ public class URLFetcherTest {
     assertNull(result);
   }
 
+  /** Check Sanitizing of Git URL works */
+  @Test
+  public void checkDotGitRemovedFromURL() {
+    String result = URLFetcher.sanitized("https://github.com/acme/demo.git");
+    assertEquals("https://github.com/acme/demo", result);
+
+    result = URLFetcher.sanitized("http://github.com/acme/demo.git");
+    assertEquals("http://github.com/acme/demo", result);
+  }
+
   /** Check that when url doesn't exist */
   @Test
   public void checkMissingContent() {


### PR DESCRIPTION
Signed-off-by: Kamesh Sampath <kamesh.sampath@hotmail.com>

### What does this PR do?
* Change the default image from `codeenvy/ubuntu_jdk` to `eclipse/ubu…ntu_jdk8`
* Santize urls ending with .git to enable loading of factory files from git repos

### What issues does this PR fix or reference?
#6479 
