### PR TITLE
use 9.6 tag of postgresql image instead of latest

### DIFF
--- a/dockerfiles/cli/version/5.19.0/images
+++ b/dockerfiles/cli/version/5.19.0/images
@@ -3,5 +3,5 @@ IMAGE_CHE=eclipse/che-server:5.19.0
 IMAGE_CHE_MULTIUSER=eclipse/che-server-multiuser:5.19.0
 IMAGE_COMPOSE=docker/compose:1.10.1
 IMAGE_TRAEFIK=traefik:v1.3.0-rc3
-IMAGE_POSTGRES=centos/postgresql-96-centos7
+IMAGE_POSTGRES=centos/postgresql-96-centos7:9.6
 IMAGE_KEYCLOACK=jboss/keycloak-openshift:3.3.0.CR2-2

--- a/dockerfiles/cli/version/latest/images
+++ b/dockerfiles/cli/version/latest/images
@@ -3,5 +3,5 @@ IMAGE_CHE=eclipse/che-server:latest
 IMAGE_CHE_MULTIUSER=eclipse/che-server-multiuser:latest
 IMAGE_COMPOSE=docker/compose:1.10.1
 IMAGE_TRAEFIK=traefik:v1.3.0-rc3
-IMAGE_POSTGRES=centos/postgresql-96-centos7
+IMAGE_POSTGRES=centos/postgresql-96-centos7:9.6
 IMAGE_KEYCLOACK=jboss/keycloak-openshift:3.3.0.CR2-2

--- a/dockerfiles/cli/version/nightly/images
+++ b/dockerfiles/cli/version/nightly/images
@@ -3,5 +3,5 @@ IMAGE_CHE=eclipse/che-server:nightly
 IMAGE_CHE_MULTIUSER=eclipse/che-server-multiuser:nightly
 IMAGE_COMPOSE=docker/compose:1.10.1
 IMAGE_TRAEFIK=traefik:v1.3.0-rc3
-IMAGE_POSTGRES=centos/postgresql-96-centos7
+IMAGE_POSTGRES=centos/postgresql-96-centos7:9.6
 IMAGE_KEYCLOACK=jboss/keycloak-openshift:3.3.0.CR2-2


### PR DESCRIPTION
we should not use `latest` tag to avoid unexpected updates of critical components