### PR TITLE
Fix initialization change markers render

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -129,6 +129,7 @@ import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
 import org.eclipse.che.ide.api.resources.File;
+import org.eclipse.che.ide.api.resources.Project;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.ResourceChangedEvent;
 import org.eclipse.che.ide.api.resources.ResourceDelta;
@@ -1210,7 +1211,15 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
                       new OrionVcsChangeMarkersRuler(
                           orionExtRulerOverlay, editorWidget.getEditor());
 
-                  String vcsName = appContext.getRootProject().getAttribute("vcs.provider.name");
+                  VirtualFile file = input.getFile();
+                  Project project =
+                      file instanceof Resource ? ((Resource) file).getProject() : null;
+                  if (project == null) {
+                    resolve.apply(null);
+                    return;
+                  }
+
+                  String vcsName = project.getAttribute("vcs.provider.name");
                   VcsChangeMarkerRenderFactory vcsChangeMarkerRenderFactory =
                       vcsChangeMarkerRenderFactoryMap.get(vcsName);
                   if (vcsChangeMarkerRenderFactory != null) {


### PR DESCRIPTION
### What does this PR do?
Initialization of 'Change markers render' gets project info from app context at the moment.
It works perfect when we have selection in project tree or some opened editor.
But it doesn't work for use case when we open first Editor from the Find panel  - at this moment 
selection in the Find panel and we haven't active editor to provide current project.
So I suggest to get project info from resource which we open for initialization this render.

### What issues does this PR fix or reference?
#6687 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>