### PR TITLE
Wrong version for `che-multiuser-personal-account`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -779,7 +779,7 @@
             <dependency>
                 <groupId>org.eclipse.che.multiuser</groupId>
                 <artifactId>che-multiuser-personal-account</artifactId>
-                <version>${project.version}</version>
+                <version>${che.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.multiuser</groupId>


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the Eclipse che build that might prevents other builds from depending on the  `org.eclipse.che.multiuser:che-multiuser-personal-account` artifact.
