### PR TITLE
Add utility class to serve request consumers

### DIFF
--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/RequestPromise.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/RequestPromise.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.util;
+
+import com.google.common.annotations.Beta;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Provider of the promise for the abstract operation. May hold success and failure consumer.
+ *
+ * @author Vlad Zhukovskyi
+ * @since 5.19.0
+ */
+@Beta
+public class RequestPromise<R> {
+
+  private Consumer<R> successConsumer;
+  private Consumer<Throwable> failureConsumer;
+
+  public Optional<Consumer<R>> getSuccessConsumer() {
+    return Optional.ofNullable(successConsumer);
+  }
+
+  public Optional<Consumer<Throwable>> getFailureConsumer() {
+    return Optional.ofNullable(failureConsumer);
+  }
+
+  public RequestPromise<R> onSuccess(Consumer<R> consumer) {
+    successConsumer = consumer;
+    return this;
+  }
+
+  public RequestPromise<R> onFailure(Consumer<Throwable> consumer) {
+    failureConsumer = consumer;
+    return this;
+  }
+}

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/RequestPromiseTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/RequestPromiseTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.util;
+
+import static org.junit.Assert.*;
+
+import java.util.function.Consumer;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link RequestPromise}.
+ *
+ * @author Vlad Zhukovskyi
+ */
+public class RequestPromiseTest {
+
+  @Test
+  public void testShouldReturnNonEmptyConsumers() throws Exception {
+    RequestPromise<Object> promise = new RequestPromise<>();
+
+    Consumer<Object> successConsumer = __ -> {};
+    Consumer<Throwable> failureConsumer = __ -> {};
+
+    promise.onSuccess(successConsumer).onFailure(failureConsumer);
+
+    assertTrue(promise.getSuccessConsumer().isPresent());
+    assertTrue(promise.getFailureConsumer().isPresent());
+    assertSame(promise.getSuccessConsumer().get(), successConsumer);
+    assertSame(promise.getFailureConsumer().get(), failureConsumer);
+  }
+
+  @Test
+  public void testShouldReturnEmptyConsumers() throws Exception {
+    RequestPromise<Object> promise = new RequestPromise<>();
+
+    assertFalse(promise.getSuccessConsumer().isPresent());
+    assertFalse(promise.getFailureConsumer().isPresent());
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Add utility class to serve request promises which works with consumers.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
Partially: #6672 

#### Release Notes
N/A

#### Docs PR
N/A
