### PR TITLE
Workspace start code cleanup

### DIFF
--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
@@ -154,8 +154,7 @@ public class DockerMachine implements Machine {
     try {
       docker.removeImage(RemoveImageParams.create(image).withForce(false));
     } catch (IOException e) {
-      // TODO make log level warning if we ignoring it or remove ignoring phrase
-      LOG.error("IOException during destroy(). Ignoring.", e);
+      LOG.warn("IOException during destroy(). Ignoring.", e);
     }
   }
 

--- a/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
+++ b/infrastructures/docker/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
@@ -67,7 +67,7 @@ public class DockerMachineCreator {
 
     return new DockerMachine(
         container.getId(),
-        container.getImage(),
+        container.getConfig().getImage(),
         docker,
         new ServersMapper(hostname).map(networkSettings.getPorts(), configs),
         registry,

--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -33,7 +33,6 @@ import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
-import org.eclipse.che.api.workspace.server.WorkspaceSharedPool;
 import org.eclipse.che.api.workspace.server.WorkspaceValidator;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
@@ -76,13 +75,12 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
       EventService eventService,
       AccountManager accountManager,
       WorkspaceValidator workspaceValidator,
-      WorkspaceSharedPool sharedPool,
       //own injects
       @Named("che.limits.workspace.env.ram") String maxRamPerEnv,
       EnvironmentRamCalculator environmentRamCalculator,
       ResourceUsageManager resourceUsageManager,
       ResourcesLocks resourcesLocks) {
-    super(workspaceDao, runtimes, eventService, accountManager, workspaceValidator, sharedPool);
+    super(workspaceDao, runtimes, eventService, accountManager, workspaceValidator);
     this.environmentRamCalculator = environmentRamCalculator;
     this.maxRamPerEnvMB = "-1".equals(maxRamPerEnv) ? -1 : Size.parseSizeToMegabytes(maxRamPerEnv);
     this.resourceUsageManager = resourceUsageManager;

--- a/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -274,7 +274,6 @@ public class LimitsCheckingWorkspaceManagerTest {
               null,
               null,
               null,
-              null,
               maxRamPerEnv,
               environmentRamCalculator,
               resourceUsageManager,

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
@@ -53,7 +53,7 @@ public abstract class AbstractBootstrapper {
           BootstrapperStatus status = event.getStatus();
           //skip starting status event
           if (status.equals(BootstrapperStatus.DONE) || status.equals(BootstrapperStatus.FAILED)) {
-            //check boostrapper belongs to current runtime and machine
+            //check bootstrapper belongs to current runtime and machine
             RuntimeIdentityDto runtimeId = event.getRuntimeId();
             if (event.getMachineName().equals(machineName)
                 && runtimeIdentity.getEnvName().equals(runtimeId.getEnvName())

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.workspace.server.spi;
 
 import static java.util.stream.Collectors.toMap;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +26,6 @@ import org.eclipse.che.api.workspace.server.URLRewriter;
 import org.eclipse.che.api.workspace.server.model.impl.MachineImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
-import org.slf4j.Logger;
 
 /**
  * Implementation of concrete Runtime
@@ -35,8 +33,6 @@ import org.slf4j.Logger;
  * @author gazarenkov
  */
 public abstract class InternalRuntime<T extends RuntimeContext> implements Runtime {
-
-  private static final Logger LOG = getLogger(InternalRuntime.class);
 
   private final T context;
   private final URLRewriter urlRewriter;
@@ -139,15 +135,9 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
 
     try {
       internalStop(stopOptions);
-    } catch (InternalInfrastructureException e) {
-      LOG.error(
-          "Error occurs on stop of workspace {}. Error: {}",
-          context.getIdentity().getWorkspaceId(),
-          e.getMessage());
-    } catch (InfrastructureException e) {
-      LOG.debug(e.getMessage(), e);
+    } finally {
+      status = WorkspaceStatus.STOPPED;
     }
-    status = WorkspaceStatus.STOPPED;
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -225,7 +225,10 @@ public class InternalRuntimeTest {
     // given
     setRunningRuntime();
     doThrow(new InfrastructureException("")).when(internalRuntime).internalStop(any());
-    internalRuntime.stop(emptyMap());
+    try {
+      internalRuntime.stop(emptyMap());
+    } catch (InfrastructureException ignore) {
+    }
 
     // when
     internalRuntime.start(emptyMap());


### PR DESCRIPTION
### What does this PR do?
Moved async operations from WorkspaceManager to WorkspaceRuntimes
to have an async facility in one place instead of two.
Moved workspace start/stop logging from WorkspaceManager
to WorkspaceRuntimes since WorkspaceManager can not correctly log
them.
Improved logging of workspace start/stop including the addition of new logs.
Fixed logging of exception thrown by RuntimeInfrastructure on runtime
start/stop.
Fix docker image deletion bug on stop of a workspace.

### What issues does this PR fix or reference?
Reopened #6639 since it was closed due to removal of the base branch

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
