### PR TITLE
Add check whether keycloak refresh token is expired or not

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/KeycloakToken.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/KeycloakToken.java
@@ -23,7 +23,8 @@ public class KeycloakToken {
   @SerializedName("refresh_token")
   private String refreshToken;
 
-  private TokenDetails details;
+  private TokenDetails accessDetails;
+  private TokenDetails refreshDetails;
 
   public KeycloakToken() {}
 
@@ -51,12 +52,20 @@ public class KeycloakToken {
     this.refreshToken = refreshToken;
   }
 
-  public TokenDetails getDetails() {
-    return details;
+  public TokenDetails getAccessDetails() {
+    return accessDetails;
   }
 
-  public void setDetails(TokenDetails details) {
-    this.details = details;
+  public void setAccessDetails(TokenDetails accessDetails) {
+    this.accessDetails = accessDetails;
+  }
+
+  public TokenDetails getRefreshDetails() {
+    return refreshDetails;
+  }
+
+  public void setRefreshDetails(TokenDetails refreshDetails) {
+    this.refreshDetails = refreshDetails;
   }
 
   class TokenDetails {


### PR DESCRIPTION
### What does this PR do?
Adds check of keycloak refresh token lifetime. When the access token is expired and refresh token is not expired then proceed refreshing, in other cases will be relogin of the test user.

### What issues does this PR fix or reference?
Fixes the passage of selenium tests for che multiuser.
[ci-previous](https://ci.codenvycorp.com/view/qa/job/che-multiuser-integration-tests/11/)
[ci-this](https://ci.codenvycorp.com/view/qa/job/che-multiuser-integration-tests/13/)