### PR TITLE
Add ability to inject different webdrivers into the Entrance class

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -205,7 +205,7 @@ public abstract class SeleniumTestHandler
     Injector classInjector = injector.createChildInjector(childModules);
     classInjector.injectMembers(testInstance);
 
-    pageObjectsInjector.injectMembers(testInstance);
+    pageObjectsInjector.injectMembers(testInstance, classInjector);
   }
 
   /** Is invoked when test or configuration is finished. */

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -175,7 +175,7 @@
                                 </property>
                                 <property>
                                     <name>listener</name>
-                                    <value>org.eclipse.che.selenium.core.CheSeleniumTesHandler</value>
+                                    <value>org.eclipse.che.selenium.core.CheSeleniumTestHandler</value>
                                 </property>
                             </properties>
                         </configuration>

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -29,6 +29,7 @@ import org.eclipse.che.selenium.core.client.TestUserServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClientFactory;
 import org.eclipse.che.selenium.core.configuration.SeleniumTestConfiguration;
 import org.eclipse.che.selenium.core.configuration.TestConfiguration;
+import org.eclipse.che.selenium.core.pageobject.PageObjectsInjector;
 import org.eclipse.che.selenium.core.provider.CheTestApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.provider.CheTestDashboardUrlProvider;
 import org.eclipse.che.selenium.core.provider.CheTestIdeUrlProvider;
@@ -57,6 +58,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProviderImpl;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceUrlResolver;
+import org.eclipse.che.selenium.pageobject.PageObjectsInjectorImpl;
 
 /**
  * Guice module per suite.
@@ -97,6 +99,8 @@ public class CheSeleniumSuiteModule extends AbstractModule {
     install(new FactoryModuleBuilder().build(TestUserHttpJsonRequestFactoryCreator.class));
     install(new FactoryModuleBuilder().build(TestWorkspaceServiceClientFactory.class));
     install(new FactoryModuleBuilder().build(TestUserFactory.class));
+
+    bind(PageObjectsInjector.class).to(PageObjectsInjectorImpl.class);
 
     if (parseBoolean(System.getenv(CHE_MULTIUSER_VARIABLE))) {
       install(new CheSeleniumMultiUserModule());

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumTestHandler.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumTestHandler.java
@@ -16,7 +16,7 @@ import java.util.List;
 import org.eclipse.che.selenium.core.inject.SeleniumTestHandler;
 
 /** @author Anatolii Bazko */
-public class CheSeleniumTesHandler extends SeleniumTestHandler {
+public class CheSeleniumTestHandler extends SeleniumTestHandler {
   @Override
   public List<Module> getParentModules() {
     List<Module> modules = new ArrayList<>();

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/PageObjectsInjectorImpl.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/PageObjectsInjectorImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.pageobject;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.selenium.core.CheSeleniumWebDriverRelatedModule;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.entrance.Entrance;
+import org.eclipse.che.selenium.core.pageobject.PageObjectsInjector;
+import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
+
+/** @author Dmytro Nochevnov */
+@Singleton
+public class PageObjectsInjectorImpl extends PageObjectsInjector {
+
+  private static final String CHE_MULTIUSER = "che.multiuser";
+
+  @Inject private CheSeleniumWebDriverRelatedModule cheSeleniumWebDriverRelatedModule;
+
+  @Inject
+  @javax.inject.Named(CHE_MULTIUSER)
+  boolean isMultiuser;
+
+  public Map<Class<?>, Object> getDependenciesWithWebdriver(SeleniumWebDriver seleniumWebDriver) {
+    Map<Class<?>, Object> dependencies = new HashMap<>();
+    dependencies.put(
+        Entrance.class,
+        cheSeleniumWebDriverRelatedModule.getEntrance(
+            isMultiuser, new CheLoginPage(seleniumWebDriver), seleniumWebDriver));
+
+    return dependencies;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This requests fixes an error after implementing Entrance class for Multiuser Che propose:
```
1) Unable to create binding for org.eclipse.che.selenium.core.entrance.Entrance. It was already configured on one or more child injectors or private modules
    bound at org.eclipse.che.selenium.core.CheSeleniumWebDriverRelatedModule.getEntrance()
  If it was in a PrivateModule, did you forget to expose the binding?
  while locating org.eclipse.che.selenium.core.entrance.Entrance
```
The problem is the algorithm of implementing different webdrivers for different page objects by the class [PageObjectsInjector](https://github.com/eclipse/che/blob/5.18.0/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/pageobject/PageObjectsInjector.java) was broken because of we instantiating Entrance outside the PageObjectsInjector class by using injector class itself.

_The proposed solution_: to create entrance instances with different webdrivers in page objects on demand by using separate **PageObjectsInjectorImpl.getDependenciesWithWebdriver(webdriver)** method.

### What issues does this PR fix or reference?
#6661

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
