### PR TITLE
[CHE-6] - Provide ability to create user's workspaces in one OpenShift project

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -10,8 +10,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 import com.google.inject.assistedinject.Assisted;
 import java.net.URI;
 import javax.inject.Inject;
@@ -24,36 +22,32 @@ import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
-import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
-import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory;
 
 /** @author Sergii Leshchenko */
 public class OpenShiftRuntimeContext extends RuntimeContext {
-  private final OpenShiftClientFactory clientFactory;
+
   private final OpenShiftEnvironment openShiftEnvironment;
   private final OpenShiftRuntimeFactory runtimeFactory;
+  private final OpenShiftProjectFactory projectFactory;
   private final String websocketOutputEndpoint;
-  private final String projectName;
 
   @Inject
   public OpenShiftRuntimeContext(
+      @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
+      OpenShiftProjectFactory projectFactory,
+      OpenShiftRuntimeFactory runtimeFactory,
       @Assisted InternalEnvironment environment,
       @Assisted OpenShiftEnvironment openShiftEnvironment,
       @Assisted RuntimeIdentity identity,
-      @Assisted RuntimeInfrastructure infrastructure,
-      OpenShiftClientFactory clientFactory,
-      OpenShiftRuntimeFactory runtimeFactory,
-      @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
-      @Nullable @Named("che.infra.openshift.project") String projectName)
+      @Assisted RuntimeInfrastructure infrastructure)
       throws ValidationException, InfrastructureException {
-
     super(environment, identity, infrastructure);
-    this.clientFactory = clientFactory;
+    this.projectFactory = projectFactory;
     this.runtimeFactory = runtimeFactory;
     this.openShiftEnvironment = openShiftEnvironment;
     this.websocketOutputEndpoint = cheWebsocketEndpoint;
-    this.projectName = projectName;
   }
 
   /** Returns OpenShift environment which based on normalized context environment configuration. */
@@ -73,8 +67,6 @@ public class OpenShiftRuntimeContext extends RuntimeContext {
 
   @Override
   public InternalRuntime getRuntime() throws InfrastructureException {
-    String name = isNullOrEmpty(projectName) ? getIdentity().getWorkspaceId() : projectName;
-    OpenShiftProject project = new OpenShiftProject(name, clientFactory);
-    return runtimeFactory.create(this, project);
+    return runtimeFactory.create(this, projectFactory.create(getIdentity()));
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContextFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContextFactory.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import com.google.inject.assistedinject.Assisted;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
@@ -19,8 +18,8 @@ import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftE
 /** @author Sergii Leshchenko */
 public interface OpenShiftRuntimeContextFactory {
   OpenShiftRuntimeContext create(
-      @Assisted InternalEnvironment environment,
-      @Assisted OpenShiftEnvironment openShiftEnvironment,
-      @Assisted RuntimeIdentity identity,
-      @Assisted RuntimeInfrastructure infrastructure);
+      InternalEnvironment environment,
+      OpenShiftEnvironment openShiftEnvironment,
+      RuntimeIdentity identity,
+      RuntimeInfrastructure infrastructure);
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeFactory.java
@@ -10,11 +10,9 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import com.google.inject.assistedinject.Assisted;
 import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
 
 /** @author Sergii Leshchenko */
 public interface OpenShiftRuntimeFactory {
-  OpenShiftInternalRuntime create(
-      @Assisted OpenShiftRuntimeContext context, @Assisted OpenShiftProject openShiftProject);
+  OpenShiftInternalRuntime create(OpenShiftRuntimeContext context, OpenShiftProject namespace);
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentParser.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentParser.java
@@ -162,7 +162,7 @@ public class OpenShiftEnvironmentParser {
         if (machineConfig != null && !machineConfig.getServers().isEmpty()) {
           ServerExposer serverExposer =
               new ServerExposer(machineName, containerConfig, openShiftEnvironment);
-          serverExposer.expose("servers", machineConfig.getServers());
+          serverExposer.expose(machineConfig.getServers());
         }
       }
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftObjectUtil.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftObjectUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helps to work with OpenShift objects.
+ *
+ * @author Anton Korneta
+ */
+class OpenShiftObjectUtil {
+
+  /** Adds label to target OpenShift object. */
+  static void putLabel(HasMetadata target, String key, String value) {
+    ObjectMeta metadata = target.getMetadata();
+
+    if (metadata == null) {
+      target.setMetadata(metadata = new ObjectMeta());
+    }
+
+    Map<String, String> labels = metadata.getLabels();
+    if (labels == null) {
+      metadata.setLabels(labels = new HashMap<>());
+    }
+
+    labels.put(key, value);
+  }
+
+  /** Adds selector into target OpenShift service. */
+  static void putSelector(Service target, String key, String value) {
+    ServiceSpec spec = target.getSpec();
+
+    if (spec == null) {
+      target.setSpec(spec = new ServiceSpec());
+    }
+
+    Map<String, String> selector = spec.getSelector();
+    if (selector == null) {
+      spec.setSelector(selector = new HashMap<>());
+    }
+
+    selector.put(key, value);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -21,23 +21,25 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 
 /**
- * Defines an internal API for managing {@link Project} instance and objects inside it.
+ * Defines an internal API for managing subset of objects inside {@link Project} instance.
  *
  * @author Sergii Leshchenko
  */
 public class OpenShiftProject {
+
+  public static final String CHE_WORKSPACE_ID_LABEL = "CHE_WORKSPACE_ID";
+
   private final OpenShiftPods pods;
   private final OpenShiftServices services;
   private final OpenShiftRoutes routes;
   private final OpenShiftPersistentVolumeClaims pvcs;
 
-  public OpenShiftProject(String name, OpenShiftClientFactory clientFactory)
+  public OpenShiftProject(OpenShiftClientFactory clientFactory, String name, String workspaceId)
       throws InfrastructureException {
-    this.pods = new OpenShiftPods(name, clientFactory);
-    this.services = new OpenShiftServices(name, clientFactory);
-    this.routes = new OpenShiftRoutes(name, clientFactory);
+    this.pods = new OpenShiftPods(name, workspaceId, clientFactory);
+    this.services = new OpenShiftServices(name, workspaceId, clientFactory);
+    this.routes = new OpenShiftRoutes(name, workspaceId, clientFactory);
     this.pvcs = new OpenShiftPersistentVolumeClaims(name, clientFactory);
-
     try (OpenShiftClient client = clientFactory.create()) {
       if (get(name, client) == null) {
         create(name, client);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+
+/**
+ * Helps to create {@link OpenShiftProject} instances.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class OpenShiftProjectFactory {
+
+  private final String projectName;
+  private final OpenShiftClientFactory clientFactory;
+
+  @Inject
+  public OpenShiftProjectFactory(
+      @Nullable @Named("che.infra.openshift.project") String projectName,
+      OpenShiftClientFactory clientFactory) {
+    this.projectName = projectName;
+    this.clientFactory = clientFactory;
+  }
+
+  public OpenShiftProject create(RuntimeIdentity identity) throws InfrastructureException {
+    final String workspaceId = identity.getWorkspaceId();
+    final String projectName = firstNonNull(this.projectName, workspaceId);
+    return new OpenShiftProject(clientFactory, projectName, workspaceId);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftRoutes.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftRoutes.java
@@ -10,6 +10,9 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.project;
 
+import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.putLabel;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject.CHE_WORKSPACE_ID_LABEL;
+
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -25,10 +28,12 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
  */
 public class OpenShiftRoutes {
   private final String namespace;
+  private final String workspaceId;
   private final OpenShiftClientFactory clientFactory;
 
-  OpenShiftRoutes(String namespace, OpenShiftClientFactory clientFactory) {
+  OpenShiftRoutes(String namespace, String workspaceId, OpenShiftClientFactory clientFactory) {
     this.namespace = namespace;
+    this.workspaceId = workspaceId;
     this.clientFactory = clientFactory;
   }
 
@@ -40,6 +45,7 @@ public class OpenShiftRoutes {
    * @throws InfrastructureException when any exception occurs
    */
   public Route create(Route route) throws InfrastructureException {
+    putLabel(route, CHE_WORKSPACE_ID_LABEL, workspaceId);
     try (OpenShiftClient client = clientFactory.create()) {
       return client.routes().inNamespace(namespace).create(route);
     } catch (KubernetesClientException e) {
@@ -54,7 +60,12 @@ public class OpenShiftRoutes {
    */
   public List<Route> get() throws InfrastructureException {
     try (OpenShiftClient client = clientFactory.create()) {
-      return client.routes().inNamespace(namespace).list().getItems();
+      return client
+          .routes()
+          .inNamespace(namespace)
+          .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .list()
+          .getItems();
     } catch (KubernetesClientException e) {
       throw new InfrastructureException(e.getMessage(), e);
     }
@@ -67,7 +78,11 @@ public class OpenShiftRoutes {
    */
   public void delete() throws InfrastructureException {
     try (OpenShiftClient client = clientFactory.create()) {
-      client.routes().inNamespace(namespace).delete();
+      client
+          .routes()
+          .inNamespace(namespace)
+          .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .delete();
     } catch (KubernetesClientException e) {
       throw new InfrastructureException(e.getMessage(), e);
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemove.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemove.java
@@ -14,9 +14,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.fabric8.openshift.client.OpenShiftClient;
+import javax.inject.Named;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 
 /**
@@ -28,15 +30,21 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
 public class RemoveProjectOnWorkspaceRemove implements EventSubscriber<WorkspaceRemovedEvent> {
 
   private final OpenShiftClientFactory clientFactory;
+  private final String projectName;
 
   @Inject
-  public RemoveProjectOnWorkspaceRemove(OpenShiftClientFactory clientFactory) {
+  public RemoveProjectOnWorkspaceRemove(
+      @Nullable @Named("che.infra.openshift.project") String projectName,
+      OpenShiftClientFactory clientFactory) {
+    this.projectName = projectName;
     this.clientFactory = clientFactory;
   }
 
   @Inject
   public void subscribe(EventService eventService) {
-    eventService.subscribe(this);
+    if (projectName == null) {
+      eventService.subscribe(this);
+    }
   }
 
   @Override

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -133,13 +133,13 @@ public class OpenShiftInternalRuntimeTest {
     MockitoAnnotations.initMocks(this);
     internalRuntime =
         new OpenShiftInternalRuntime(
-            context,
-            project,
+            13,
             new URLRewriter.NoOpURLRewriter(),
             eventService,
             bootstrapperFactory,
             serverCheckerFactory,
-            13);
+            context,
+            project);
     when(context.getOpenShiftEnvironment()).thenReturn(osEnv);
     when(serverCheckerFactory.create(any(), anyString(), any())).thenReturn(serversChecker);
     when(context.getIdentity()).thenReturn(IDENTITY);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemoveTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemoveTest.java
@@ -42,7 +42,7 @@ public class RemoveProjectOnWorkspaceRemoveTest {
 
   @BeforeMethod
   public void setUp() {
-    removeProjectOnWorkspaceRemove = spy(new RemoveProjectOnWorkspaceRemove(null));
+    removeProjectOnWorkspaceRemove = spy(new RemoveProjectOnWorkspaceRemove(null, null));
 
     doNothing().when(removeProjectOnWorkspaceRemove).doRemoveProject(anyString());
 


### PR DESCRIPTION
### What does this PR do?
Provides another strategy for placing user's workspaces: _few workspaces inside one OpenShift project_. This strategy is used only in case when `che.infra.openshift.project` is specified, otherwise for each workspace the os project will be created with name that equal to workspace identifier.
Allows user run more than one workspace on os flavours, and also fixes the case of a stop che when the workspace is placed in the same os project with it.

### What issues does this PR fix or reference?
#6284 

#### Release Notes
Provide ability to create and run user's workspaces in one OpenShift project