### PR TITLE
Reverting changes in OpenShiftDeploymentCleaner that had to de done due to OpenShift  3.6 bugs

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftDeploymentCleaner.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftDeploymentCleaner.java
@@ -11,14 +11,23 @@
 package org.eclipse.che.plugin.openshift.client;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.DoneableDeployment;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Singleton;
 import org.eclipse.che.plugin.openshift.client.exception.OpenShiftException;
 import org.eclipse.che.plugin.openshift.client.kubernetes.KubernetesResourceUtil;
@@ -29,12 +38,28 @@ import org.slf4j.LoggerFactory;
 public class OpenShiftDeploymentCleaner {
   private static final Logger LOG = LoggerFactory.getLogger(OpenShiftDeploymentCleaner.class);
   private static final int OPENSHIFT_POD_DELETION_TIMEOUT = 120;
-  private static final int OPENSHIFT_WAIT_POD_DELAY = 1000;
 
   public void cleanDeploymentResources(final String deploymentName, final String namespace)
       throws IOException {
+    scaleDownDeployment(deploymentName, namespace);
     cleanUpWorkspaceResources(deploymentName, namespace);
     waitUntilWorkspacePodIsDeleted(deploymentName, namespace);
+  }
+
+  private void scaleDownDeployment(String deploymentName, final String namespace)
+      throws OpenShiftException {
+    try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
+      ScalableResource<Deployment, DoneableDeployment> deployment =
+          openShiftClient
+              .extensions()
+              .deployments()
+              .inNamespace(namespace)
+              .withName(deploymentName);
+
+      if (deployment != null) {
+        deployment.scale(0, true);
+      }
+    }
   }
 
   private void cleanUpWorkspaceResources(final String deploymentName, final String namespace)
@@ -51,6 +76,16 @@ public class OpenShiftDeploymentCleaner {
             OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName, namespace);
 
     try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
+      if (deployment != null) {
+        LOG.info("Removing OpenShift Deployment {}", deployment.getMetadata().getName());
+        openShiftClient.resource(deployment).delete();
+      }
+
+      if (replicaSets != null && replicaSets.size() > 0) {
+        LOG.info("Removing OpenShift ReplicaSets for deployment {}", deploymentName);
+        replicaSets.forEach(rs -> openShiftClient.resource(rs).delete());
+      }
+
       if (routes != null) {
         for (Route route : routes) {
           LOG.info("Removing OpenShift Route {}", route.getMetadata().getName());
@@ -62,41 +97,54 @@ public class OpenShiftDeploymentCleaner {
         LOG.info("Removing OpenShift Service {}", service.getMetadata().getName());
         openShiftClient.resource(service).delete();
       }
-
-      if (deployment != null) {
-        LOG.info("Removing OpenShift Deployment {}", deployment.getMetadata().getName());
-        openShiftClient.resource(deployment).delete();
-      }
-
-      if (replicaSets != null && replicaSets.size() > 0) {
-        LOG.info("Removing OpenShift ReplicaSets for deployment {}", deploymentName);
-        replicaSets.forEach(rs -> openShiftClient.resource(rs).delete());
-      }
     }
   }
 
   private void waitUntilWorkspacePodIsDeleted(final String deploymentName, final String namespace)
       throws OpenShiftException {
     try (OpenShiftClient client = new DefaultOpenShiftClient()) {
-      for (int waitCount = 0; waitCount < OPENSHIFT_POD_DELETION_TIMEOUT; waitCount++) {
-        List<Pod> pods =
-            client
-                .pods()
-                .inNamespace(namespace)
-                .withLabel(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName)
-                .list()
-                .getItems();
+      FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> pods =
+          client
+              .pods()
+              .inNamespace(namespace)
+              .withLabel(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName);
 
-        if (pods.size() == 0) {
-          return;
+      int numberOfPodsToStop = pods.list().getItems().size();
+      LOG.info("Number of workspace pods to stop {}", numberOfPodsToStop);
+      if (numberOfPodsToStop > 0) {
+        final CountDownLatch podCount = new CountDownLatch(numberOfPodsToStop);
+        pods.watch(
+            new Watcher<Pod>() {
+              @Override
+              public void eventReceived(Action action, Pod pod) {
+                try {
+                  switch (action) {
+                    case ADDED:
+                    case MODIFIED:
+                    case ERROR:
+                      break;
+                    case DELETED:
+                      LOG.info("Pod {} deleted", pod.getMetadata().getName());
+                      podCount.countDown();
+                      break;
+                  }
+                } catch (Exception e) {
+                  LOG.error("Failed to process {} on Pod {}. Error: ", action, pod, e);
+                }
+              }
+
+              @Override
+              public void onClose(KubernetesClientException ex) {}
+            });
+
+        try {
+          LOG.info("Waiting for all pods to be deleted for deployment '{}'", deploymentName);
+          podCount.await(OPENSHIFT_POD_DELETION_TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          LOG.error("Exception while waiting for pods to be deleted", e);
+          throw new OpenShiftException("Timeout while waiting for pods to terminate", e);
         }
-        Thread.sleep(OPENSHIFT_WAIT_POD_DELAY);
       }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      LOG.info("Thread interrupted while cleaning up workspace");
     }
-
-    throw new OpenShiftException("Timeout while waiting for pods to terminate");
   }
 }


### PR DESCRIPTION
### What does this PR do?
Reverting changes in OpenShiftDeploymentCleaner that had to de done due to OpenShift  3.6 bugs
Original PR - https://github.com/eclipse/che/pull/5766/

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CHE-220

<!-- #### Changelog -->
Enhances OpenShift resource deletion for workspaces (scaling down deployment before deleting resources)

#### Release Notes
N/A

#### Docs PR
N/A
