### PR TITLE
Sync dirty state for split editors

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditor.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditor.java
@@ -186,4 +186,12 @@ public interface TextEditor extends EditorPartPresenter {
    */
   @Nullable
   Position getWordAtOffset(int offset);
+
+  /**
+   * Update 'dirty' state of editor when state of editor content has changed
+   *
+   * @param dirty {@code true} when editor content has modified and {@code false} when editor
+   *     content has saved
+   */
+  void updateDirtyState(boolean dirty);
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorContentSynchronizerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorContentSynchronizerImpl.java
@@ -25,6 +25,8 @@ import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.EditorWithAutoSave;
 import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
+import org.eclipse.che.ide.api.event.EditorDirtyStateChangedEvent;
+import org.eclipse.che.ide.api.event.EditorDirtyStateChangedHandler;
 import org.eclipse.che.ide.api.parts.EditorPartStack;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.resources.ResourceChangedEvent;
@@ -42,7 +44,10 @@ import org.eclipse.che.ide.resource.Path;
  */
 @Singleton
 public class EditorContentSynchronizerImpl
-    implements EditorContentSynchronizer, ActivePartChangedHandler, ResourceChangedHandler {
+    implements EditorContentSynchronizer,
+        ActivePartChangedHandler,
+        ResourceChangedHandler,
+        EditorDirtyStateChangedHandler {
   final Map<Path, EditorGroupSynchronization> editorGroups;
   final Provider<EditorGroupSynchronization> editorGroupSyncProvider;
 
@@ -53,6 +58,7 @@ public class EditorContentSynchronizerImpl
     this.editorGroups = new HashMap<>();
     eventBus.addHandler(ActivePartChangedEvent.TYPE, this);
     eventBus.addHandler(ResourceChangedEvent.getType(), this);
+    eventBus.addHandler(EditorDirtyStateChangedEvent.TYPE, this);
   }
 
   /**
@@ -89,6 +95,20 @@ public class EditorContentSynchronizerImpl
     if (group.getSynchronizedEditors().isEmpty()) {
       group.unInstall();
       editorGroups.remove(path);
+    }
+  }
+
+  @Override
+  public void onEditorDirtyStateChanged(EditorDirtyStateChangedEvent event) {
+    EditorPartPresenter changedEditor = event.getEditor();
+    if (changedEditor == null || changedEditor.isDirty()) {
+      //we sync 'dirty' state of editors only for case when content of an active editor HAS SAVED
+      return;
+    }
+
+    Path changedEditorPath = changedEditor.getEditorInput().getFile().getLocation();
+    if (editorGroups.containsKey(changedEditorPath)) {
+      editorGroups.get(changedEditorPath).onEditorDirtyStateChanged(changedEditor);
     }
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronization.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronization.java
@@ -43,6 +43,9 @@ public interface EditorGroupSynchronization {
   /** Notify group that active editor has changed */
   void onActiveEditorChanged(@NotNull EditorPartPresenter activeEditor);
 
+  /** Notify group that editor dirty state has changed */
+  void onEditorDirtyStateChanged(@NotNull EditorPartPresenter changedEditor);
+
   /** Removes all editors from the group and stops to track changes of content for them. */
   void unInstall();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImpl.java
@@ -96,6 +96,25 @@ public class EditorGroupSynchronizationImpl
   }
 
   @Override
+  public void onEditorDirtyStateChanged(EditorPartPresenter changedEditor) {
+    boolean hasEditorsToSync = synchronizedEditors.keySet().size() > 1;
+    if (!hasEditorsToSync || groupLeaderEditor == null || groupLeaderEditor != changedEditor) {
+      //we sync 'dirty' state of editors when content of an ACTIVE editor has saved
+      return;
+    }
+
+    synchronizedEditors
+        .keySet()
+        .forEach(
+            editor -> {
+              if (editor != groupLeaderEditor && editor instanceof TextEditor) {
+                ((TextEditor) editor).getEditorWidget().markClean();
+                ((TextEditor) editor).updateDirtyState(false);
+              }
+            });
+  }
+
+  @Override
   public void removeEditor(EditorPartPresenter editor) {
     HandlerRegistration handlerRegistration = synchronizedEditors.remove(editor);
     if (handlerRegistration != null) {

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorContentSynchronizerImplTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorContentSynchronizerImplTest.java
@@ -27,7 +27,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.api.editor.EditorInput;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.EditorWithAutoSave;
-import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
+import org.eclipse.che.ide.api.event.EditorDirtyStateChangedEvent;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.ResourceChangedEvent;
 import org.eclipse.che.ide.api.resources.ResourceDelta;
@@ -56,7 +56,7 @@ public class EditorContentSynchronizerImplTest {
   @Mock private EditorInput editorInput;
   @Mock private VirtualFile virtualFile;
   @Mock private EditorGroupSynchronization editorGroupSynchronization;
-  @Mock private ActivePartChangedEvent activePartChangedEvent;
+  @Mock private EditorDirtyStateChangedEvent editorDirtyStateChangedEvent;
   private EditorPartPresenter activeEditor;
 
   @InjectMocks EditorContentSynchronizerImpl editorContentSynchronizer;
@@ -69,11 +69,12 @@ public class EditorContentSynchronizerImplTest {
     when(editorInput.getFile()).thenReturn(virtualFile);
     when(virtualFile.getLocation()).thenReturn(new Path(FILE_PATH));
     when(editorGroupSyncProvider.get()).thenReturn(editorGroupSynchronization);
+    when(editorDirtyStateChangedEvent.getEditor()).thenReturn(activeEditor);
   }
 
   @Test
   public void constructorShouldBeVerified() {
-    verify(eventBus, times(2)).addHandler(Matchers.<Event.Type<Object>>anyObject(), anyObject());
+    verify(eventBus, times(3)).addHandler(Matchers.<Event.Type<Object>>anyObject(), anyObject());
   }
 
   @Test
@@ -190,5 +191,51 @@ public class EditorContentSynchronizerImplTest {
 
     assertNull(oldGroup);
     assertNotNull(newGroup);
+  }
+
+  @Test
+  //we sync 'dirty' state of editors only for case when content of an active editor HAS SAVED
+  public void shouldSkipEditorDirtyStateChangedEventWhenEditorIsDirty() {
+    when(activeEditor.isDirty()).thenReturn(true);
+    EditorPartPresenter openedEditor1 = mock(EditorPartPresenter.class);
+    when(openedEditor1.getEditorInput()).thenReturn(editorInput);
+    editorContentSynchronizer.trackEditor(openedEditor1);
+    editorContentSynchronizer.trackEditor(activeEditor);
+
+    editorContentSynchronizer.onEditorDirtyStateChanged(editorDirtyStateChangedEvent);
+
+    EditorGroupSynchronization group =
+        editorContentSynchronizer.editorGroups.get(new Path(FILE_PATH));
+    verify(group, never()).onEditorDirtyStateChanged(activeEditor);
+  }
+
+  @Test
+  public void shouldSkipEditorDirtyStateChangedEventWhenEditorIsNull() {
+    when(editorDirtyStateChangedEvent.getEditor()).thenReturn(null);
+    EditorPartPresenter openedEditor1 = mock(EditorPartPresenter.class);
+    when(openedEditor1.getEditorInput()).thenReturn(editorInput);
+    editorContentSynchronizer.trackEditor(openedEditor1);
+    editorContentSynchronizer.trackEditor(activeEditor);
+
+    editorContentSynchronizer.onEditorDirtyStateChanged(editorDirtyStateChangedEvent);
+
+    EditorGroupSynchronization group =
+        editorContentSynchronizer.editorGroups.get(new Path(FILE_PATH));
+    verify(group, never()).onEditorDirtyStateChanged(activeEditor);
+  }
+
+  @Test
+  public void shouldNotifyGroupWhenEditorContentHasSaved() {
+    when(activeEditor.isDirty()).thenReturn(false);
+    EditorPartPresenter openedEditor1 = mock(EditorPartPresenter.class);
+    when(openedEditor1.getEditorInput()).thenReturn(editorInput);
+    editorContentSynchronizer.trackEditor(openedEditor1);
+    editorContentSynchronizer.trackEditor(activeEditor);
+
+    editorContentSynchronizer.onEditorDirtyStateChanged(editorDirtyStateChangedEvent);
+
+    EditorGroupSynchronization group =
+        editorContentSynchronizer.editorGroups.get(new Path(FILE_PATH));
+    verify(group).onEditorDirtyStateChanged(activeEditor);
   }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImplTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/editor/synchronization/EditorGroupSynchronizationImplTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.editor.synchronization;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -37,6 +38,7 @@ import org.eclipse.che.ide.api.editor.document.DocumentHandle;
 import org.eclipse.che.ide.api.editor.document.DocumentStorage;
 import org.eclipse.che.ide.api.editor.document.DocumentStorage.DocumentCallback;
 import org.eclipse.che.ide.api.editor.events.DocumentChangedEvent;
+import org.eclipse.che.ide.api.editor.texteditor.EditorWidget;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.event.FileContentUpdateEvent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
@@ -72,6 +74,9 @@ public class EditorGroupSynchronizationImplTest {
   @Mock private DocumentChangedEvent documentChangeEvent;
   @Mock private FileContentUpdateEvent fileContentUpdateEvent;
   @Mock private EditorInput editorInput;
+  @Mock private EditorWidget activeEditorWidget;
+  @Mock private EditorWidget editor_1_Widget;
+  @Mock private EditorWidget editor_2_Widget;
   @Captor private ArgumentCaptor<DocumentCallback> documentCallbackCaptor;
 
   private EditorPartPresenter activeEditor;
@@ -107,6 +112,10 @@ public class EditorGroupSynchronizationImplTest {
     when(((TextEditor) activeEditor).getDocument()).thenReturn(document);
     when(((TextEditor) openedEditor1).getDocument()).thenReturn(document);
     when(((TextEditor) openedEditor2).getDocument()).thenReturn(document);
+
+    when(((TextEditor) activeEditor).getEditorWidget()).thenReturn(activeEditorWidget);
+    when(((TextEditor) openedEditor1).getEditorWidget()).thenReturn(editor_1_Widget);
+    when(((TextEditor) openedEditor2).getEditorWidget()).thenReturn(editor_2_Widget);
 
     when(document.getContents()).thenReturn(FILE_CONTENT);
     when(openedEditor1.getEditorInput()).thenReturn(editorInput);
@@ -166,6 +175,50 @@ public class EditorGroupSynchronizationImplTest {
     documentCallbackCaptor.getValue().onDocumentReceived(FILE_NEW_CONTENT);
 
     verify(notificationManager).notify(anyString(), anyString(), eq(SUCCESS), eq(NOT_EMERGE_MODE));
+  }
+
+  @Test
+  public void shouldUpdateDirtyStateForEditors() {
+    addEditorsToGroup();
+
+    editorGroupSynchronization.onEditorDirtyStateChanged(activeEditor);
+
+    verify(editor_1_Widget).markClean();
+    verify(editor_2_Widget).markClean();
+    verify((TextEditor) openedEditor1).updateDirtyState(false);
+    verify((TextEditor) openedEditor2).updateDirtyState(false);
+    //we should not update 'dirty' state for the ACTIVE editor
+    verify(activeEditorWidget, never()).markClean();
+    verify((TextEditor) activeEditor, never()).updateDirtyState(false);
+  }
+
+  @Test
+  public void shouldSkipUpdatingDirtyStateWhenNotActiveEditorWasSaved() {
+    addEditorsToGroup();
+
+    editorGroupSynchronization.onEditorDirtyStateChanged(openedEditor1);
+
+    //we sync 'dirty' state of editors when content of an ACTIVE editor was saved
+    verify(editor_1_Widget, never()).markClean();
+    verify(editor_2_Widget, never()).markClean();
+    verify(activeEditorWidget, never()).markClean();
+    verify((TextEditor) openedEditor1, never()).updateDirtyState(anyBoolean());
+    verify((TextEditor) openedEditor2, never()).updateDirtyState(anyBoolean());
+    verify((TextEditor) activeEditor, never()).updateDirtyState(anyBoolean());
+  }
+
+  @Test
+  public void shouldSkipUpdatingDirtyStateWhenHasNotEditorsToSync() {
+    editorGroupSynchronization.addEditor(activeEditor);
+
+    editorGroupSynchronization.onEditorDirtyStateChanged(activeEditor);
+
+    verify(editor_1_Widget, never()).markClean();
+    verify(editor_2_Widget, never()).markClean();
+    verify(activeEditorWidget, never()).markClean();
+    verify((TextEditor) openedEditor1, never()).updateDirtyState(anyBoolean());
+    verify((TextEditor) openedEditor2, never()).updateDirtyState(anyBoolean());
+    verify((TextEditor) activeEditor, never()).updateDirtyState(anyBoolean());
   }
 
   @Test

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -437,7 +437,7 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
   }
 
   @Override
-  protected void updateDirtyState(boolean dirty) {
+  public void updateDirtyState(boolean dirty) {
     if (isReadOnly()) {
       dirtyState = false;
       return;


### PR DESCRIPTION
### What does this PR do?
Sync dirty state for split editors

PR for che6 branch: https://github.com/eclipse/che/pull/6860

### What issues does this PR fix or reference?
#5497 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>