### PR TITLE
In `deploy_che.sh`, the keycloack route should be `https` when the che server is `https`

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/configure_and_start_keycloak.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/configure_and_start_keycloak.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-# append_after_match allows to append content after matching line
+# append_before_match allows to append content before matching line
 # this is needed to append content of yaml files
 # first arg is mathing string, second string to insert before match
 append_before_match() {

--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/configure_and_start_keycloak.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/configure_and_start_keycloak.sh
@@ -8,7 +8,31 @@
 
 set -e
 
+# append_after_match allows to append content after matching line
+# this is needed to append content of yaml files
+# first arg is mathing string, second string to insert before match
+append_before_match() {
+    while IFS= read -r line
+    do
+      if [[ "$line" == *"$1"* ]];then
+          printf '%s\n' "$2"
+      fi
+      printf '%s\n' "$line"
+    done < /dev/stdin
+}
+
 COMMAND_DIR=$(dirname "$0")
+
+TLS_SETTINGS="  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Allow"
+
+CHE_SERVER_ROUTE_TLS=$(oc get route che -o jsonpath='{.spec.tls}' || echo "")
+if [ "${CHE_SERVER_ROUTE_TLS}" != "" ]; then
+  oc get route/keycloak -o yaml | \
+  append_before_match "wildcardPolicy:" "${TLS_SETTINGS}" | \
+  oc replace -f -
+fi
 
 if [ "${CHE_SERVER_URL}" == "" ]; then
   CHE_SERVER_ROUTE_HOST=$(oc get route che -o jsonpath='{.spec.host}' || echo "")
@@ -16,7 +40,6 @@ if [ "${CHE_SERVER_URL}" == "" ]; then
     echo "[CHE] **ERROR**: The Che server route should exist before configuring the Keycloak web origins"
     exit 1
   fi
-  PROTOCOL=CHE_SERVER_ROUTE_TLS=$(oc get route che -o jsonpath='{.spec.tls}' || echo "")
   if [ "${CHE_SERVER_ROUTE_TLS}" == "" ]; then
     CHE_SERVER_URL="http://${CHE_SERVER_ROUTE_HOST}"
   else 


### PR DESCRIPTION
### What does this PR do?

This PR allows the route of the deployed dedicated keycloack server to be `https` when the deployed che server route is `https`

### What issues does this PR fix or reference?

This PR fixes issue #6666 
