### PR TITLE
Make error message clearer in the Keycloak s2i build...

### DIFF
--- a/dockerfiles/init/s2i/keycloak/assemble
+++ b/dockerfiles/init/s2i/keycloak/assemble
@@ -9,7 +9,10 @@
 set -e
 
 if [ "${CHE_SERVER_URL}" == "" ]; then
-    echo "the 'CHE_SERVER_URL' environment variable should be set to the external URL that gives access to CHE"
+    echo "The 'CHE_SERVER_URL' environment variable should be set to the external URL that gives access to CHE"
+    echo "However the build is expected to fail a first time just after deployment,"
+    echo "since the expected variable is added after deployment in a second step."
+    echo "As soon as the variable is added to the build configuration, a second build should start and succeed."
     exit 1
 fi
 


### PR DESCRIPTION
### What does this PR do?

This PR makes the error message clearer in the Keycloak s2i build (for OpenShift deployment) so that no-one tries to search for the reason of a failure that, in fact, is expected during the first build.

### What issues does this PR fix or reference?

There's no issue but @garagatyi notified about the unclear error message during multi-user sync meeting.