### PR TITLE
Fixes for when maven plugins will be updated

### DIFF
--- a/assembly-multiuser/assembly-main/pom.xml
+++ b/assembly-multiuser/assembly-main/pom.xml
@@ -64,7 +64,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/assembly-multiuser/assembly-wsagent-server/pom.xml
+++ b/assembly-multiuser/assembly-wsagent-server/pom.xml
@@ -45,7 +45,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>ext-server-${project.version}</finalName>
                 </configuration>
             </plugin>

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-agent/pom.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-agent/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-ide/pom.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-ide/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-machine-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-model</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
+++ b/plugins/plugin-docker/che-plugin-docker-machine/pom.xml
@@ -95,6 +95,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/pom.xml
@@ -171,13 +171,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>2.14</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <!-- <forkMode>never</forkMode> -->
                     <excludes>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/ClasspathMacroTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/ClasspathMacroTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.che.ide.ext.java.shared.ClasspathEntryKind.LIBRARY;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -161,16 +160,6 @@ public class ClasspathMacroTest {
 
     verify(classpathResolver).resolveClasspathEntries(entries);
     assertEquals("/projects/name:", classpath);
-  }
-
-  @Test
-  public void returnEmptyClasspathIfProjectDoesNotSupportJava() throws Exception {
-    Map<String, List<String>> attributes = new HashMap<>();
-    attributes.put(Constants.LANGUAGE, singletonList("c"));
-
-    when(project.getAttributes()).thenReturn(attributes);
-
-    verify(classpathContainer, never()).getClasspathEntries(anyString());
   }
 
   @Test

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/SourcepathMacroTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/command/valueproviders/SourcepathMacroTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.ide.ext.java.client.command.valueproviders;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -106,12 +105,10 @@ public class SourcepathMacroTest {
   @Test
   public void defaultValueOfSourcepathShouldBeBuilt() throws Exception {
     List<ClasspathEntryDto> entries = new ArrayList<>();
-    Set<String> libs = new HashSet<>();
     Path projectsRoot = Path.valueOf("/projects");
 
     when(appContext.getProjectsRoot()).thenReturn(projectsRoot);
     when(classpathContainer.getClasspathEntries(anyString())).thenReturn(classpathEntriesPromise);
-    when(classpathResolver.getLibs()).thenReturn(libs);
 
     sourcepathMacro.expand();
 
@@ -120,16 +117,6 @@ public class SourcepathMacroTest {
 
     verify(classpathResolver).resolveClasspathEntries(entries);
     assertEquals("/projects/name", classpath);
-  }
-
-  @Test
-  public void returnEmptySourcepathIfProjectDoesNotSupportJava() throws Exception {
-    Map<String, List<String>> attributes = new HashMap<>();
-    attributes.put(Constants.LANGUAGE, singletonList("c"));
-
-    when(project.getAttributes()).thenReturn(attributes);
-
-    verify(classpathContainer, never()).getClasspathEntries(anyString());
   }
 
   @Test

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructurePresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructurePresenterTest.java
@@ -136,22 +136,6 @@ public class FileStructurePresenterTest {
   }
 
   @Test
-  public void binaryClassShouldBeOpenedIfMemberIsBinary() throws Exception {
-    when(member.isBinary()).thenReturn(true);
-    when(nodePromise.then(Matchers.<Operation<Node>>anyObject())).thenReturn(nodePromise);
-
-    presenter.show(editor);
-  }
-
-  @Test
-  public void selectMemberIfItIsNotBinary() throws Exception {
-    when(member.isBinary()).thenReturn(false);
-    when(nodePromise.then(Matchers.<Function<Node, Node>>anyObject())).thenReturn(nodePromise);
-
-    presenter.show(editor);
-  }
-
-  @Test
   public void cursorShouldBeReturnedInPreviousPositionAfterDialogClosingByEscapeButton() {
     presenter.show(editor);
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
@@ -155,6 +155,16 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/core/ImportOrganizeTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/core/ImportOrganizeTest.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.internal.corext.codemanipulation.OrganizeImportsOperation
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ImportOrganizeTest extends CoreTests {
@@ -2167,6 +2168,8 @@ public class ImportOrganizeTest extends CoreTests {
     assertEqualString(cu.getSource(), buf.toString());
   }
 
+  @Test
+  @Ignore
   public void testStaticImports_bug159424() throws Exception {
     IPackageFragmentRoot sourceFolder = JavaProjectHelper.addSourceContainer(fJProject1, "src");
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenamePackageTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenamePackageTest.java
@@ -969,7 +969,8 @@ public class RenamePackageTest extends RefactoringTest {
   //		ZipInputStream zis= new ZipInputStream(new BufferedInputStream(new FileInputStream(junitSrcArchive)));
   //		ZipTools.compareWithZipped(src, zis, JavaProjectHelper.JUNIT_SRC_ENCODING);
   //	}
-
+  @Test
+  @Ignore
   public void testFail1() throws Exception {
     printTestDisabledMessage("needs revisiting");
     //helper1(new String[]{"r.p1"}, new String[][]{{"A"}}, "r");
@@ -995,24 +996,32 @@ public class RenamePackageTest extends RefactoringTest {
     helper1();
   }
 
+  @Test
+  @Ignore
   public void testFail7() throws Exception {
     //printTestDisabledMessage("1GK90H4: ITPJCORE:WIN2000 - search: missing package reference");
     printTestDisabledMessage("corner case - name obscuring");
     //		helper1(new String[]{"r", "p1"}, new String[][]{{"A"}, {"A"}}, "fred");
   }
 
+  @Test
+  @Ignore
   public void testFail8() throws Exception {
     printTestDisabledMessage("corner case - name obscuring");
     //		helper1(new String[]{"r", "p1"}, new String[][]{{"A"}, {"A"}}, "fred");
   }
 
   //native method used r.A as a parameter
+  @Test
+  @Ignore
   public void testFail9() throws Exception {
     printTestDisabledMessage(
         "corner case - qualified name used  as a parameter of a native method");
     //helper1(new String[]{"r", "p1"}, new String[][]{{"A"}, {"A"}}, "fred");
   }
 
+  @Test
+  @Ignore
   public void testFail10() throws Exception {
     helper1(new String[] {"r.p1", "r"}, new String[][] {{"A"}, {"A"}}, "r");
   }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenameParametersTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenameParametersTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class RenameParametersTest extends RefactoringTest {
@@ -179,6 +180,8 @@ public class RenameParametersTest extends RefactoringTest {
     helper1(new String[] {"j"}, new String[] {"I"});
   }
 
+  @Test
+  @Ignore
   public void test11() throws Exception {
     printTestDisabledMessage("revisit in the context of anonymous types in type hierarchies");
     // helper1(new String[]{"j"}, new String[]{"I"});
@@ -254,6 +257,8 @@ public class RenameParametersTest extends RefactoringTest {
     helper1(new String[] {"j"}, new String[] {"I"});
   }
 
+  @Test
+  @Ignore
   public void test26() throws Exception {
     printTestDisabledMessage("revisit in the context of anonymous types in type hierarchies");
     //helper1(new String[]{"j"}, new String[]{"I"});
@@ -284,10 +289,14 @@ public class RenameParametersTest extends RefactoringTest {
     helper1(new String[] {"kk", "j"}, new String[] {"I", "I"});
   }
 
+  @Test
+  @Ignore
   public void test32() throws Exception {
     printTestDisabledMessage("must do - constructor params");
   }
 
+  @Test
+  @Ignore
   public void test33() throws Exception {
     printTestDisabledMessage("revisit - removed the 'no ref update' option");
     //		helper1(new String[]{"b"}, new String[]{"QA;"}, false);
@@ -299,6 +308,8 @@ public class RenameParametersTest extends RefactoringTest {
     helper1(new String[] {"test2"}, new String[] {"Z"});
   }
 
+  @Test
+  @Ignore
   public void test35() throws Exception {
     printTestDisabledMessage("regression test for bug#6224");
     //		helper1(new String[]{"j"}, new String[]{"I"});
@@ -312,6 +323,8 @@ public class RenameParametersTest extends RefactoringTest {
 
   // -----
 
+  @Test
+  @Ignore
   public void testFail0() throws Exception {
     printTestDisabledMessage("must fix - name collision with an instance var");
     //		helper2(new String[]{"j"}, new String[]{"I"});
@@ -342,21 +355,29 @@ public class RenameParametersTest extends RefactoringTest {
     helper2(new String[] {"j"}, new String[] {"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail6() throws Exception {
     printTestDisabledMessage("must fix - name collision with an instance var");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail7() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail8() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail9() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
@@ -372,16 +393,22 @@ public class RenameParametersTest extends RefactoringTest {
     helper2(new String[] {"j", "j"}, new String[] {"I", "I"});
   }
 
+  @Test
+  @Ignore
   public void testFail12() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail13() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail14() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"QA;"});
@@ -407,16 +434,22 @@ public class RenameParametersTest extends RefactoringTest {
     helper2(new String[] {"j"}, new String[] {"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail19() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail20() throws Exception {
     printTestDisabledMessage("waiting for better conflict detection story from DB");
     //		helper2(new String[]{"j"}, new String[]{"I"});
   }
 
+  @Test
+  @Ignore
   public void testFail21() throws Exception {
     printTestDisabledMessage("Disabled since 1.4 compliance level doesn't produce error message");
     // helper2(new String[]{"j"}, new String[]{"I"});

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenameStaticMethodTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenameStaticMethodTest.java
@@ -27,6 +27,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class RenameStaticMethodTest extends RefactoringTest {
@@ -299,6 +300,8 @@ public class RenameStaticMethodTest extends RefactoringTest {
         "invalid renaming in C", getFileContents(getOutputTestFileName("C")), cuA.getSource());
   }
 
+  @Test
+  @Ignore
   public void testStaticImport3() throws Exception {
     if (BUG_83332_SPLIT_SINGLE_IMPORT) {
       printTestDisabledMessage("BUG_83332_SPLIT_SINGLE_IMPORT");
@@ -312,6 +315,8 @@ public class RenameStaticMethodTest extends RefactoringTest {
     helper2();
   }
 
+  @Test
+  @Ignore
   public void testStaticImport5() throws Exception {
     if (BUG_83332_SPLIT_SINGLE_IMPORT) {
       printTestDisabledMessage("BUG_83332_SPLIT_SINGLE_IMPORT");

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenameVirtualMethodInClassTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/src/test/java/org/eclipse/che/plugin/java/server/jdt/refactoring/RenameVirtualMethodInClassTest.java
@@ -30,6 +30,7 @@ import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class RenameVirtualMethodInClassTest extends RefactoringTest {
@@ -581,6 +582,8 @@ public class RenameVirtualMethodInClassTest extends RefactoringTest {
     helper2();
   }
 
+  @Test
+  @Ignore
   public void test34() throws Exception {
     printTestDisabledMessage("test for bug#18553");
     //		helper2_0("A", "foo", new String[0], true, true);

--- a/plugins/plugin-svn/che-plugin-svn-ext-ide/pom.xml
+++ b/plugins/plugin-svn/che-plugin-svn-ext-ide/pom.xml
@@ -48,6 +48,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-urlfactory/pom.xml
+++ b/plugins/plugin-urlfactory/pom.xml
@@ -29,6 +29,12 @@
         <dependencies>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${org.eclipse.jetty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
                 <version>${org.eclipse.jetty.version}</version>
                 <scope>test</scope>
@@ -95,6 +101,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/samples/sample-plugin-json/che-sample-plugin-json-server/pom.xml
+++ b/samples/sample-plugin-json/che-sample-plugin-json-server/pom.xml
@@ -50,17 +50,4 @@
             <artifactId>che-sample-plugin-json-shared</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <usedDependencies>
-                        <param>org.eclipse.che.sample:che-sample-plugin-json-shared</param>
-                    </usedDependencies>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>

--- a/wsagent/agent/pom.xml
+++ b/wsagent/agent/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-machine-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-model</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
- [x] warning: first commit of this PR should be removed before merging

### What does this PR do?
Apply fixes on source code due to maven plugins update
- errorprone : ignore test methods that are using testxyz() pattern but are not annotated by @Test
- Remove  deprecated stuff (for example use descriptors/descriptor for maven-assembly plugin
- maven dependency plugin: new missing dependencies

### What issues does this PR fix or reference?
https://github.com/eclipse/che-parent/pull/31

#### Release Notes
N/A

#### Docs PR
N/A