### PR TITLE
Use plexus metadata maven version from che-parent repository

### DIFF
--- a/plugins/plugin-maven/maven-server/maven-server-impl/pom.xml
+++ b/plugins/plugin-maven/maven-server/maven-server-impl/pom.xml
@@ -213,7 +213,6 @@
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>process-classes</id>


### PR DESCRIPTION
- [x] Warning: requires https://github.com/eclipse/che-parent/pull/32 to be merged first

### What does this PR do?
We should not define version of plugin that are used in che project but use instead versions defined in che-parent or che-dependencies project

### What issues does this PR fix or reference?
https://github.com/eclipse/che-parent/pull/32

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I3cf8dc6875c29b649328c92792214b2b447a1315
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

