### PR TITLE
Skip github api requests in keycloak interceptor

### DIFF
--- a/dashboard/src/components/interceptor/keycloak-token-interceptor.ts
+++ b/dashboard/src/components/interceptor/keycloak-token-interceptor.ts
@@ -12,6 +12,8 @@
 
 import {HttpInterceptorBase} from './interceptor-base';
 
+const GITHUB_API = 'api.github.com';
+
 /**
  * @author Oleksii Kurinnyi
  */
@@ -40,6 +42,11 @@ export class KeycloakTokenInterceptor extends HttpInterceptorBase {
     if (this.keycloak && config.url.indexOf(this.keycloakConfig.url) > -1) {
       return config;
     }
+
+    if (config.url.indexOf(GITHUB_API) > -1) {
+      return config;
+    }
+
     if (this.keycloak && this.keycloak.token) {
       let deferred = this.$q.defer();
       this.keycloak.updateToken(5).success(() => {


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Skips the github.api.com requests in keycloak interceptor to avoid sending tokens to GitHub.

#### Release Notes
N/A

#### Docs PR
N/A
