### PR TITLE
Allow to disable require update password for default admin user

### DIFF
--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -508,6 +508,7 @@ CHE_SINGLE_PORT=false
 #CHE_KEYCLOAK_REALM=che
 #CHE_KEYCLOAK_CLIENT__ID=che-public
 #CHE_KEYCLOAK_ALLOWED__CLOCK__SKEW__SEC=3
+#CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD=true
 
 
 ########################################################################################

--- a/dockerfiles/init/manifests/che.pp
+++ b/dockerfiles/init/manifests/che.pp
@@ -65,6 +65,8 @@ node default {
 
   $system_super_privileged_mode=getValue("SYSTEM_SUPER__PRIVILEGED__MODE", "false")
 
+  $che_keycloak_admin_require_update_password=getValue("CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD", "true")
+
   ###############################
   # Include base module
   include base

--- a/dockerfiles/init/modules/keycloak/templates/che-users-0.json.erb
+++ b/dockerfiles/init/modules/keycloak/templates/che-users-0.json.erb
@@ -23,7 +23,11 @@
       "config" : { }
     } ],
     "disableableCredentialTypes" : [ "password" ],
+    <% if scope.lookupvar('keycloak::che_keycloak_admin_require_update_password') == 'true' -%>
     "requiredActions" : [ "UPDATE_PASSWORD" ],
+    <% else -%>
+    "requiredActions" : [ ],
+    <% end -%>
     "groups" : [ ]
   } ]
 }


### PR DESCRIPTION
today we are not able to run selenium tests on che-multiuser automatically because existing by default user `admin` is not fully configured(by default due to security reasons default password is temporary). This PR introduce ENV var which allows to disable  forcing to change default password for testing purposes.


needed for: https://github.com/eclipse/che/issues/6770


NOTE: I;ve tried different ways to solve this but was not able to find any that works for CHE. If some one feels that it could be done in some other way please let me know in comments