### PR TITLE
Increase login page load timeout in selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/site/CheLoginPage.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/site/CheLoginPage.java
@@ -44,7 +44,7 @@ public class CheLoginPage implements LoginPage {
     PageFactory.initElements(seleniumWebDriver, this);
 
     webDriverWait =
-        new WebDriverWait(seleniumWebDriver, TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
+        new WebDriverWait(seleniumWebDriver, TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC);
   }
 
   public void login(String username, String password) {


### PR DESCRIPTION
### What does this PR do?
It increases timeout of waiting on Che login page load in selenium tests from 5 to 10 seconds. 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
