### PR TITLE
Add missing templates to the assembly

### DIFF
--- a/assembly/assembly-main/src/assembly/assembly.xml
+++ b/assembly/assembly-main/src/assembly/assembly.xml
@@ -99,6 +99,19 @@
                 <include>org.eclipse.che:exec-agent:tar.gz:linux_amd64</include>
             </includes>
         </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>true</unpack>
+            <outputDirectory>templates</outputDirectory>
+            <includes>
+                <include>org.eclipse.che.core:che-core-ide-templates</include>
+            </includes>
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/**</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet>
     </dependencySets>
     <fileSets>
         <fileSet>


### PR DESCRIPTION

### What does this PR do?
Add missing templates to the assembly. They were removed by mistake.

