### PR TITLE
Fix after PlainJavaProjectConfigureClasspathTest 

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/plainjava/PlainJavaProjectConfigureClasspathTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/plainjava/PlainJavaProjectConfigureClasspathTest.java
@@ -178,9 +178,9 @@ public class PlainJavaProjectConfigureClasspathTest {
     configureClasspath.addJarOrFolderToBuildPath(ConfigureClasspath.ADD_JAR);
     configureClasspath.waitSelectPathFormIsOpen();
     configureClasspath.openItemInSelectPathForm(LIB_PROJECT);
-    configureClasspath.selectItemInSelectPathForm("mockito-all-1.9.5.jar");
+    configureClasspath.selectItemInSelectPathForm("mockito-core-2.10.0.jar");
     configureClasspath.clickOkBtnSelectPathForm();
-    configureClasspath.waitExpectedTextJarsAndFolderArea("mockito-all-1.9.5.jar - /projects/lib");
+    configureClasspath.waitExpectedTextJarsAndFolderArea("mockito-core-2.10.0.jar - /projects/lib");
     configureClasspath.clickOnDoneBtnConfigureClasspath();
     projectExplorer.openItemByPath(PROJECT_NAME + "/src");
     projectExplorer.openItemByPath(PROJECT_NAME + "/src/com/company");


### PR DESCRIPTION
Fix after PlainJavaProjectConfigureClasspathTest [Move to mockito 2.10](https://github.com/eclipse/che/commit/9581a9bbeff36659a3f6a80a155379ff0116bd9e)

Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>
