### PR TITLE
Add maven dependency on tools.jar automatically but only if JDK is < 1.9 (che6)

### DIFF
--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
@@ -101,12 +101,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>sun.jdt</groupId>
-            <artifactId>tools</artifactId>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>
@@ -287,6 +281,20 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>java8-tools</id>
+            <activation>
+                <jdk>(,1.9)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>sun.jdt</groupId>
+                    <artifactId>tools</artifactId>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
### What does this PR do?
Add dependency on tools.jar automatically but only if JDK is < 1.9
after 1.8 the tools.jar is not required

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326
https://github.com/eclipse/che-lib/pull/44

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I1b19ed8f5a5f1ed5de5f2727f6baa020ad72bfcd
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

