### PR TITLE
Change steps in the test and rework depended Page Object for increasing stability tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Menu.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Menu.java
@@ -85,18 +85,20 @@ public class Menu {
    * @param idCommandName
    */
   public void runAndWaitCommand(final String idTopMenuCommand, final String idCommandName) {
-    (new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC))
-        .until(
-            new ExpectedCondition<Boolean>() {
-              @Override
-              public Boolean apply(WebDriver driver) {
-                driver.findElement(By.id(idTopMenuCommand)).click();
-                return driver.findElement(By.id(idCommandName)).isDisplayed();
-              }
-            });
+    WebDriverWait waitOfMenusRedrawing =
+        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
+
+    waitOfMenusRedrawing.until(
+        new ExpectedCondition<Boolean>() {
+          @Override
+          public Boolean apply(WebDriver driver) {
+            driver.findElement(By.id(idTopMenuCommand)).click();
+            return driver.findElement(By.id(idCommandName)).isDisplayed();
+          }
+        });
     seleniumWebDriver.findElement(By.id(idCommandName)).click();
-    (new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC))
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(idCommandName)));
+    waitOfMenusRedrawing.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.id(idCommandName)));
   }
 
   /**
@@ -106,29 +108,33 @@ public class Menu {
    * @param idCommandName
    */
   public void runCommand(final String idTopMenuCommand, final String idCommandName) {
+    WebDriverWait redrawMenuItemsWait =
+        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     loader.waitOnClosed();
     try {
-      new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+      redrawMenuItemsWait
           .until(ExpectedConditions.visibilityOfElementLocated(By.id(idTopMenuCommand)))
           .click();
 
     } catch (WebDriverException ex) {
       LOG.error(ex.getLocalizedMessage(), ex);
       WaitUtils.sleepQuietly(REDRAW_UI_ELEMENTS_TIMEOUT_SEC, TimeUnit.MILLISECONDS);
-      new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+      redrawMenuItemsWait
           .until(ExpectedConditions.visibilityOfElementLocated(By.id(idTopMenuCommand)))
           .click();
     }
     try {
-      new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+      redrawMenuItemsWait
           .until(ExpectedConditions.visibilityOfElementLocated(By.id(idCommandName)))
           .click();
     } catch (TimeoutException e) {
       seleniumWebDriver.findElement(By.id(idTopMenuCommand)).click();
-      new WebDriverWait(seleniumWebDriver, MINIMUM_SEC)
+      redrawMenuItemsWait
           .until(ExpectedConditions.visibilityOfElementLocated(By.id(idCommandName)))
           .click();
     }
+    redrawMenuItemsWait.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.id(idCommandName)));
   }
 
   /**
@@ -141,30 +147,33 @@ public class Menu {
   public void runCommand(String idTopMenuCommand, String idCommandName, String idSubCommandName) {
     loader.waitOnClosed();
     clickOnCommand(idTopMenuCommand);
+    WebDriverWait redrawMenuItemsWait =
+        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     try {
-      new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
-          .until(ExpectedConditions.visibilityOfElementLocated(By.id(idCommandName)));
+      redrawMenuItemsWait.until(
+          ExpectedConditions.visibilityOfElementLocated(By.id(idCommandName)));
     } catch (TimeoutException e) {
       LOG.error(e.getLocalizedMessage(), e);
       clickOnCommand(idTopMenuCommand);
     }
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.elementToBeClickable(By.id(idCommandName)));
+    redrawMenuItemsWait.until(ExpectedConditions.elementToBeClickable(By.id(idCommandName)));
     actionsFactory
         .createAction(seleniumWebDriver)
         .moveToElement(seleniumWebDriver.findElement(By.id(idCommandName)))
         .perform();
     //if element If the element is not drawn in time, in the catch block call submenu again
     try {
-      new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-          .until(ExpectedConditions.visibilityOfElementLocated(By.id(idSubCommandName)));
+      redrawMenuItemsWait.until(
+          ExpectedConditions.visibilityOfElementLocated(By.id(idSubCommandName)));
     } catch (TimeoutException e) {
       WaitUtils.sleepQuietly(1);
       seleniumWebDriver.findElement(By.id(idCommandName)).click();
-      new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-          .until(ExpectedConditions.visibilityOfElementLocated(By.id(idSubCommandName)));
+      redrawMenuItemsWait.until(
+          ExpectedConditions.visibilityOfElementLocated(By.id(idSubCommandName)));
     }
     seleniumWebDriver.findElement(By.id(idSubCommandName)).click();
+    redrawMenuItemsWait.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.id(idCommandName)));
   }
 
   /**
@@ -176,33 +185,36 @@ public class Menu {
    */
   public void runCommandByXpath(
       String idTopMenuCommand, String idCommandName, String xpathSubCommandName) {
+    WebDriverWait waitOfMenusRedrawing =
+        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     loader.waitOnClosed();
     clickOnCommand(idTopMenuCommand);
     try {
-      new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
-          .until(ExpectedConditions.visibilityOfElementLocated(By.id(idCommandName)));
+      waitOfMenusRedrawing.until(
+          ExpectedConditions.visibilityOfElementLocated(By.id(idCommandName)));
     } catch (TimeoutException e) {
       LOG.error(e.getLocalizedMessage(), e);
       clickOnCommand(idTopMenuCommand);
     }
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.elementToBeClickable(By.id(idCommandName)));
+    waitOfMenusRedrawing.until(ExpectedConditions.elementToBeClickable(By.id(idCommandName)));
     actionsFactory
         .createAction(seleniumWebDriver)
         .moveToElement(seleniumWebDriver.findElement(By.id(idCommandName)))
         .perform();
     //if element If the element is not drawn in time, in the catch block call submenu again
     try {
-      new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-          .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpathSubCommandName)));
+      waitOfMenusRedrawing.until(
+          ExpectedConditions.visibilityOfElementLocated(By.xpath(xpathSubCommandName)));
     } catch (TimeoutException e) {
       LOG.error(e.getLocalizedMessage(), e);
       WaitUtils.sleepQuietly(MINIMUM_SEC);
       seleniumWebDriver.findElement(By.id(idCommandName)).click();
-      new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-          .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpathSubCommandName)));
+      waitOfMenusRedrawing.until(
+          ExpectedConditions.visibilityOfElementLocated(By.xpath(xpathSubCommandName)));
     }
     seleniumWebDriver.findElement(By.xpath(xpathSubCommandName)).click();
+    waitOfMenusRedrawing.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.id(idCommandName)));
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/intelligent/CommandsPalette.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/intelligent/CommandsPalette.java
@@ -158,11 +158,13 @@ public class CommandsPalette {
    * @param commandName name of the command
    */
   public void startCommandByDoubleClick(String commandName) {
-    actions
-        .doubleClick(
-            seleniumWebDriver.findElement(By.xpath(String.format(Locators.COMMANDS, commandName))))
-        .build()
-        .perform();
+    String locatorToCurrentCommand = String.format(Locators.COMMANDS, commandName);
+    WebElement currentCommand =
+        redrawUiElementTimeout.until(
+            ExpectedConditions.visibilityOfElementLocated(By.xpath(locatorToCurrentCommand)));
+    actions.doubleClick(currentCommand).perform();
+    redrawUiElementTimeout.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.xpath(locatorToCurrentCommand)));
   }
 
   /**
@@ -171,8 +173,17 @@ public class CommandsPalette {
    * @param commandName name of the command
    */
   public void startCommandByEnterKey(String commandName) {
-    seleniumWebDriver.findElement(By.xpath(String.format(Locators.COMMANDS, commandName))).click();
-    actionsFactory.createAction(seleniumWebDriver).sendKeys(Keys.ENTER.toString()).perform();
+    String locatorToCurrentCommand = String.format(Locators.COMMANDS, commandName);
+    WebElement currentCommand =
+        redrawUiElementTimeout.until(
+            ExpectedConditions.visibilityOfElementLocated(By.xpath(locatorToCurrentCommand)));
+    seleniumWebDriver.findElement(By.xpath(locatorToCurrentCommand)).click();
+    actionsFactory
+        .createAction(seleniumWebDriver)
+        .sendKeys(currentCommand, Keys.ENTER.toString())
+        .perform();
+    redrawUiElementTimeout.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.xpath(locatorToCurrentCommand)));
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/intelligent/CommandsPalette.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/intelligent/CommandsPalette.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.pageobject.intelligent;
 
+import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
@@ -143,13 +144,13 @@ public class CommandsPalette {
   public void commandIsExists(String commandName) {
     redrawUiElementTimeout.until(
         ExpectedConditions.visibilityOfElementLocated(
-            By.xpath(String.format(Locators.COMMANDS, commandName))));
+            By.xpath(format(Locators.COMMANDS, commandName))));
   }
 
   public void commandIsNotExists(String commandName) {
     redrawUiElementTimeout.until(
         ExpectedConditions.invisibilityOfElementLocated(
-            By.xpath(String.format(Locators.COMMANDS, commandName))));
+            By.xpath(format(Locators.COMMANDS, commandName))));
   }
 
   /**
@@ -158,7 +159,7 @@ public class CommandsPalette {
    * @param commandName name of the command
    */
   public void startCommandByDoubleClick(String commandName) {
-    String locatorToCurrentCommand = String.format(Locators.COMMANDS, commandName);
+    String locatorToCurrentCommand = format(Locators.COMMANDS, commandName);
     WebElement currentCommand =
         redrawUiElementTimeout.until(
             ExpectedConditions.visibilityOfElementLocated(By.xpath(locatorToCurrentCommand)));
@@ -173,7 +174,7 @@ public class CommandsPalette {
    * @param commandName name of the command
    */
   public void startCommandByEnterKey(String commandName) {
-    String locatorToCurrentCommand = String.format(Locators.COMMANDS, commandName);
+    String locatorToCurrentCommand = format(Locators.COMMANDS, commandName);
     WebElement currentCommand =
         redrawUiElementTimeout.until(
             ExpectedConditions.visibilityOfElementLocated(By.xpath(locatorToCurrentCommand)));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
@@ -10,6 +10,9 @@
  */
 package org.eclipse.che.selenium.debugger;
 
+import static org.eclipse.che.selenium.pageobject.debug.DebugPanel.DebuggerButtonsPanel.BTN_DISCONNECT;
+import static org.eclipse.che.selenium.pageobject.debug.DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID;
+
 import com.google.inject.Inject;
 import java.nio.file.Paths;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
@@ -113,8 +116,7 @@ public class InnerClassAndLambdaDebuggingTest {
   @AfterMethod
   public void stopDebug() {
     debugPanel.removeAllBreakpoints();
-    menu.runCommand(
-        TestMenuCommandsConstants.Run.RUN_MENU, TestMenuCommandsConstants.Run.END_DEBUG_SESSION);
+    debugPanel.clickOnButton(BTN_DISCONNECT);
   }
 
   @Test
@@ -122,7 +124,7 @@ public class InnerClassAndLambdaDebuggingTest {
     // when
     editor.setCursorToLine(37);
     editor.setBreakpoint(37);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(37);
@@ -134,7 +136,7 @@ public class InnerClassAndLambdaDebuggingTest {
     // when
     editor.setCursorToLine(53);
     editor.setBreakpoint(53);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(53);
@@ -146,7 +148,7 @@ public class InnerClassAndLambdaDebuggingTest {
     // when
     editor.setCursorToLine(64);
     editor.setBreakpoint(64);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(64);
@@ -158,7 +160,7 @@ public class InnerClassAndLambdaDebuggingTest {
     // when
     editor.setCursorToLine(72);
     editor.setBreakpoint(72);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(72);
@@ -171,21 +173,21 @@ public class InnerClassAndLambdaDebuggingTest {
     editor.setCursorToLine(79);
     editor.setBreakPointAndWaitActiveState(79);
     editor.setBreakPointAndWaitActiveState(87);
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(79);
     debugPanel.waitTextInVariablesPanel("j=1");
 
     // when
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(79);
     debugPanel.waitTextInVariablesPanel("j=2");
 
     // when
-    debugPanel.clickOnButton(DebugPanel.DebuggerButtonsPanel.RESUME_BTN_ID);
+    debugPanel.clickOnButton(RESUME_BTN_ID);
 
     // then
     editor.waitActiveBreakpoint(87);


### PR DESCRIPTION
### What does this PR do?
* Use in the @AfterMethod  stopDebug() the Debugger button for end of debug session. It allow to avoid potential problems in case of incorrect closing of the top menu.
* Use static imports in the test for more readability
* Add checks in the Menu PageObject on correct closing of menus after clicking


#### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6586

@tolusha, @vparfonov, @dmytro-ndp 