### PR TITLE
Provide Action interface, use DOM Element for Action image

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Action.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Action.java
@@ -8,97 +8,21 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.ide.api.action;
 
-import com.google.gwt.resources.client.ImageResource;
-import org.vectomatic.dom.svg.ui.SVGResource;
+package org.eclipse.che.ide.api.action;
 
 /**
  * Represents an entity that has a state, a presentation and can be performed.
  *
- * <p>For an action to be useful, you need to implement {@link Action#actionPerformed} and
- * optionally to override {@link Action#update}. By overriding the {@link Action#update} method you
- * can dynamically change action's presentation.
+ * <p>For an action to be useful, you need to implement {@link BaseAction#actionPerformed} and
+ * optionally to override {@link BaseAction#update}. By overriding the {@link BaseAction#update}
+ * method you can dynamically change action's presentation.
  *
  * <p>The same action can have various presentations.
  *
- * @author Evgen Vidolob
- * @author Dmitry Shnurenko
- * @author Vitaliy Guliy
+ * @author Yevhen Vydolob
  */
-public abstract class Action {
-
-  private final Presentation presentation = new Presentation();
-
-  /** Creates a new action with its text, description and icon set to <code>null</code>. */
-  public Action() {
-    this(null, null, null, null);
-  }
-
-  /**
-   * Creates a new action with the specified text. Description and icon are set to <code>null</code>
-   * .
-   *
-   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
-   *     when the presentation is a menu item.
-   */
-  public Action(String text) {
-    this(text, null, null, null);
-  }
-
-  /**
-   * Constructs a new action with the specified text, description.
-   *
-   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
-   *     when the presentation is a menu item
-   * @param description Describes current action, this description will appear on the status bar
-   *     when presentation has focus
-   */
-  public Action(String text, String description) {
-    this(text, description, null, null);
-  }
-
-  /**
-   * Constructs a new action with the specified text, description and icon.
-   *
-   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
-   *     when the presentation is a menu item
-   * @param description Describes current action, this description will appear on the status bar
-   *     when presentation has focus
-   * @param imageResource Action's icon
-   * @param svgResource Action's SVG icon
-   */
-  public Action(
-      String text, String description, ImageResource imageResource, SVGResource svgResource) {
-    presentation.setText(text);
-    presentation.setDescription(description);
-    presentation.setImageResource(imageResource);
-    presentation.setSVGResource(svgResource);
-  }
-
-  /**
-   * Constructs a new action with the specified text, description and icon.
-   *
-   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
-   *     when the presentation is a menu item
-   * @param description Describes current action, this description will appear on the status bar
-   *     when presentation has focus
-   * @param imageResource Action's icon
-   * @param svgResource Action's SVG icon
-   * @param htmlResource HTML representation of icon
-   */
-  public Action(
-      String text,
-      String description,
-      ImageResource imageResource,
-      SVGResource svgResource,
-      String htmlResource) {
-    presentation.setText(text);
-    presentation.setDescription(description);
-    presentation.setImageResource(imageResource);
-    presentation.setSVGResource(svgResource);
-    presentation.setHTMLResource(htmlResource);
-  }
+public interface Action {
 
   /**
    * Updates the state of the action. Default implementation does nothing. Override this method to
@@ -114,26 +38,19 @@ public abstract class Action {
    *
    * @param e Carries information on the invocation place and data available
    */
-  public void update(ActionEvent e) {}
+  void update(ActionEvent e);
 
   /**
    * Returns a template presentation that will be used as a template for created presentations.
    *
    * @return template presentation
    */
-  public final Presentation getTemplatePresentation() {
-    return presentation;
-  }
+  Presentation getTemplatePresentation();
 
   /**
    * Implement this method to provide your action handler.
    *
    * @param e Carries information on the invocation place
    */
-  public abstract void actionPerformed(ActionEvent e);
-
-  @Override
-  public String toString() {
-    return getTemplatePresentation().toString();
-  }
+  void actionPerformed(ActionEvent e);
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ActionEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ActionEvent.java
@@ -13,10 +13,9 @@ package org.eclipse.che.ide.api.action;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 
 /**
- * Container for the information necessary to execute or update an {@link Action}.
+ * Container for the information necessary to execute or update an {@link BaseAction}.
  *
  * @author Evgen Vidolob
  * @author Dmitry Shnurenko
@@ -24,7 +23,6 @@ import org.eclipse.che.ide.api.parts.PerspectiveManager;
 public class ActionEvent {
   private final ActionManager actionManager;
   private final Presentation presentation;
-  private final PerspectiveManager perspectiveManager;
   private final Map<String, String> parameters;
 
   /**
@@ -33,14 +31,9 @@ public class ActionEvent {
    * @param presentation the presentation which represents the action in the place from where it is
    *     invoked or updated
    * @param actionManager the manager for actions
-   * @param perspectiveManager perspective manager which contains information about current
-   *     perspective
    */
-  public ActionEvent(
-      @NotNull Presentation presentation,
-      @NotNull ActionManager actionManager,
-      @NotNull PerspectiveManager perspectiveManager) {
-    this(presentation, actionManager, perspectiveManager, null);
+  public ActionEvent(@NotNull Presentation presentation, @NotNull ActionManager actionManager) {
+    this(presentation, actionManager, null);
   }
 
   /**
@@ -49,18 +42,14 @@ public class ActionEvent {
    * @param presentation the presentation which represents the action in the place from where it is
    *     invoked or updated
    * @param actionManager the manager for actions
-   * @param perspectiveManager perspective manager which contains information about current
-   *     perspective
    * @param parameters the parameters with which the action is invoked or updated
    */
   public ActionEvent(
       @NotNull Presentation presentation,
       @NotNull ActionManager actionManager,
-      @NotNull PerspectiveManager perspectiveManager,
       @Nullable Map<String, String> parameters) {
     this.actionManager = actionManager;
     this.presentation = presentation;
-    this.perspectiveManager = perspectiveManager;
     this.parameters = parameters;
   }
 
@@ -72,10 +61,6 @@ public class ActionEvent {
    */
   public Presentation getPresentation() {
     return presentation;
-  }
-
-  public PerspectiveManager getPerspectiveManager() {
-    return perspectiveManager;
   }
 
   /**

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ActionGroup.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ActionGroup.java
@@ -10,11 +10,10 @@
  */
 package org.eclipse.che.ide.api.action;
 
-import com.google.gwt.resources.client.ImageResource;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 /** @author Evgen Vidolob */
-public abstract class ActionGroup extends Action {
+public abstract class ActionGroup extends BaseAction {
 
   private boolean popup;
 
@@ -37,8 +36,8 @@ public abstract class ActionGroup extends Action {
     setPopup(popup);
   }
 
-  public ActionGroup(String text, String description, ImageResource icon, SVGResource svgIcon) {
-    super(text, description, icon, svgIcon);
+  public ActionGroup(String text, String description, SVGResource svgIcon) {
+    super(text, description, svgIcon);
   }
 
   /** This method can be called in popup menus if {@link #canBePerformed()} is true */

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ActionManager.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ActionManager.java
@@ -21,7 +21,7 @@ import org.eclipse.che.ide.util.Pair;
  * easily fetch action by id and id by action.
  *
  * @author Evgen Vidolob
- * @see Action
+ * @see BaseAction
  */
 @SDK(title = "ide.api.ui.action")
 public interface ActionManager {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/AppCloseActionEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/AppCloseActionEvent.java
@@ -13,10 +13,9 @@ package org.eclipse.che.ide.api.action;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 
 /**
- * Container for the information necessary to execute {@link Action} and cancel closing of
+ * Container for the information necessary to execute {@link BaseAction} and cancel closing of
  * application.
  *
  * @author Sergii Leschenko
@@ -25,20 +24,15 @@ public class AppCloseActionEvent extends ActionEvent {
   private String cancelMessage;
 
   public AppCloseActionEvent(
-      @NotNull Presentation presentation,
-      @NotNull ActionManager actionManager,
-      @NotNull PerspectiveManager perspectiveManager) {
-
-    super(presentation, actionManager, perspectiveManager);
+      @NotNull Presentation presentation, @NotNull ActionManager actionManager) {
+    super(presentation, actionManager);
   }
 
   public AppCloseActionEvent(
       @NotNull Presentation presentation,
       @NotNull ActionManager actionManager,
-      @NotNull PerspectiveManager perspectiveManager,
       @Nullable Map<String, String> parameters) {
-
-    super(presentation, actionManager, perspectiveManager, parameters);
+    super(presentation, actionManager, parameters);
   }
 
   /**

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/BaseAction.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/BaseAction.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.api.action;
+
+import org.vectomatic.dom.svg.ui.SVGImage;
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+/**
+ * Represents an entity that has a state, a presentation and can be performed.
+ *
+ * <p>For an action to be useful, you need to implement {@link Action#actionPerformed} and
+ * optionally to override {@link Action#update}. By overriding the {@link Action#update} method you
+ * can dynamically change action's presentation.
+ *
+ * <p>The same action can have various presentations.
+ *
+ * @author Evgen Vidolob
+ * @author Dmitry Shnurenko
+ * @author Vitaliy Guliy
+ */
+public abstract class BaseAction implements Action {
+
+  private final Presentation presentation = new Presentation();
+
+  /** Creates a new action with its text, description and icon set to <code>null</code>. */
+  public BaseAction() {
+    this(null, null, null, null);
+  }
+
+  /**
+   * Creates a new action with the specified text. Description and icon are set to <code>null</code>
+   * .
+   *
+   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
+   *     when the presentation is a menu item.
+   */
+  public BaseAction(String text) {
+    this(text, null, null, null);
+  }
+
+  /**
+   * Constructs a new action with the specified text, description.
+   *
+   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
+   *     when the presentation is a menu item
+   * @param description Describes current action, this description will appear on the status bar
+   *     when presentation has focus
+   */
+  public BaseAction(String text, String description) {
+    this(text, description, null, null);
+  }
+
+  /**
+   * Constructs a new action with the specified text, description.
+   *
+   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
+   *     when the presentation is a menu item
+   * @param description Describes current action, this description will appear on the status bar
+   *     when presentation has focus
+   * @param svgResource Action's SVG icon
+   */
+  public BaseAction(String text, String description, SVGResource svgResource) {
+    this(text, description, svgResource, null);
+  }
+
+  /**
+   * Constructs a new action with the specified text, description.
+   *
+   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
+   *     when the presentation is a menu item
+   * @param description Describes current action, this description will appear on the status bar
+   *     when presentation has focus
+   * @param htmlResource HTML representation of icon
+   */
+  public BaseAction(String text, String description, String htmlResource) {
+    this(text, description, null, htmlResource);
+  }
+
+  /**
+   * Constructs a new action with the specified text, description and icon.
+   *
+   * @param text Serves as a tooltip when the presentation is a button and the name of the menu item
+   *     when the presentation is a menu item
+   * @param description Describes current action, this description will appear on the status bar
+   *     when presentation has focus
+   * @param svgResource Action's SVG icon
+   * @param htmlResource HTML representation of icon
+   */
+  public BaseAction(String text, String description, SVGResource svgResource, String htmlResource) {
+    presentation.setText(text);
+    presentation.setDescription(description);
+    if (svgResource != null) {
+      presentation.setImageElement(new SVGImage(svgResource).getElement());
+    }
+    presentation.setHTMLResource(htmlResource);
+  }
+
+  @Override
+  public void update(ActionEvent e) {}
+
+  @Override
+  public final Presentation getTemplatePresentation() {
+    return presentation;
+  }
+
+  @Override
+  public String toString() {
+    return getTemplatePresentation().toString();
+  }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/DefaultActionGroup.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/DefaultActionGroup.java
@@ -43,7 +43,7 @@ public class DefaultActionGroup extends ActionGroup {
 
   private ActionManager actionManager;
 
-  //TODO: think about removing this field
+  // TODO: think about removing this field
   private boolean needSorting = false;
 
   public DefaultActionGroup(ActionManager actionManager) {
@@ -193,7 +193,7 @@ public class DefaultActionGroup extends ActionGroup {
    *
    * @return An array of sorted actions
    */
-  //TODO: to complicate
+  // TODO: to complicate
   private Action[] getSortedActions() {
     List<Action> result = new ArrayList<>();
     Map<Action, Constraints> unsortedMap = new LinkedHashMap<>();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Presentation.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Presentation.java
@@ -10,13 +10,12 @@
  */
 package org.eclipse.che.ide.api.action;
 
-import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.dom.client.Element;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.util.ListenerManager;
-import org.vectomatic.dom.svg.ui.SVGResource;
 
 /**
  * The presentation of an action in a specific place in the user interface.
@@ -26,35 +25,23 @@ import org.vectomatic.dom.svg.ui.SVGResource;
  */
 public final class Presentation {
 
-  private Map<String, Object> userMap = new HashMap<>();
-
   /** Defines tool tip for button at tool bar or text for element at menu value: String */
   public static final String PROP_TEXT = "text";
-
   /** value: String */
   public static final String PROP_DESCRIPTION = "description";
-
   /** value: Icon */
   public static final String PROP_ICON = "icon";
-
   /** value: Boolean */
   public static final String PROP_VISIBLE = "visible";
-
   /** The actual value is a Boolean. */
   public static final String PROP_ENABLED = "enabled";
 
+  private Map<String, Object> userMap = new HashMap<>();
   private ListenerManager<PropertyChangeListener> myChangeSupport;
   private String text;
   private String myDescription;
 
-  /**
-   * Presentation Icon
-   *
-   * <p>Can be set using ImageResource, SVG Resource or directly HTML code.
-   */
-  private ImageResource imageResource;
-
-  private SVGResource svgResource;
+  private Element imageElement;
   private String htmlResource;
 
   private boolean visible;
@@ -100,21 +87,23 @@ public final class Presentation {
   }
 
   /**
-   * Returns icon image resource.
-   *
-   * @return image resource
-   */
-  public ImageResource getImageResource() {
-    return imageResource;
-  }
-
-  /**
    * Returns SVG image resource.
    *
    * @return svg image resource
    */
-  public SVGResource getSVGResource() {
-    return svgResource;
+  public Element getImageElement() {
+    return imageElement;
+  }
+
+  /**
+   * Sets icon image element.
+   *
+   * @param imageElement icon image element
+   */
+  public void setImageElement(Element imageElement) {
+    Element oldElement = this.imageElement;
+    this.imageElement = imageElement;
+    firePropertyChange(PROP_ICON, oldElement, imageElement);
   }
 
   /**
@@ -127,36 +116,14 @@ public final class Presentation {
   }
 
   /**
-   * Sets icon image resource.
-   *
-   * @param imageResource image resource
-   */
-  public void setImageResource(ImageResource imageResource) {
-    ImageResource oldImaheResource = imageResource;
-    this.imageResource = imageResource;
-    firePropertyChange(PROP_ICON, oldImaheResource, imageResource);
-  }
-
-  /**
-   * Sets icon SVG resource.
-   *
-   * @param svgResource icon SVG resource
-   */
-  public void setSVGResource(SVGResource svgResource) {
-    SVGResource oldSVGResource = svgResource;
-    this.svgResource = svgResource;
-    firePropertyChange(PROP_ICON, oldSVGResource, svgResource);
-  }
-
-  /**
    * Sets icon HTML resource.
    *
    * @param htmlResource html resource
    */
   public void setHTMLResource(String htmlResource) {
-    String oldHTMLRersource = htmlResource;
+    String oldHTMLResource = htmlResource;
     this.htmlResource = htmlResource;
-    firePropertyChange(PROP_ICON, oldHTMLRersource, htmlResource);
+    firePropertyChange(PROP_ICON, oldHTMLResource, htmlResource);
   }
 
   public boolean isVisible() {
@@ -215,13 +182,7 @@ public final class Presentation {
   public void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
     final PropertyChangeEvent event =
         new PropertyChangeEvent(this, propertyName, oldValue, newValue);
-    myChangeSupport.dispatch(
-        new ListenerManager.Dispatcher<PropertyChangeListener>() {
-          @Override
-          public void dispatch(PropertyChangeListener listener) {
-            listener.onPropertyChange(event);
-          }
-        });
+    myChangeSupport.dispatch(listener -> listener.onPropertyChange(event));
   }
 
   public Presentation clone() {
@@ -229,8 +190,7 @@ public final class Presentation {
     presentation.myDescription = myDescription;
     presentation.enabled = enabled;
     presentation.visible = visible;
-    presentation.imageResource = imageResource;
-    presentation.svgResource = svgResource;
+    presentation.imageElement = imageElement;
     presentation.htmlResource = htmlResource;
     return presentation;
   }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ProjectAction.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ProjectAction.java
@@ -20,7 +20,7 @@ import org.vectomatic.dom.svg.ui.SVGResource;
  *
  * @author Evgen Vidolob
  */
-public abstract class ProjectAction extends Action {
+public abstract class ProjectAction extends BaseAction {
 
   protected AppContext appContext;
 
@@ -35,7 +35,7 @@ public abstract class ProjectAction extends Action {
   }
 
   protected ProjectAction(String text, String description, SVGResource svgIcon) {
-    super(text, description, null, svgIcon);
+    super(text, description, svgIcon);
   }
 
   @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Separator.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Separator.java
@@ -15,13 +15,13 @@ package org.eclipse.che.ide.api.action;
  *
  * @author Evgen Vidolob
  */
-public class Separator extends Action {
+public class Separator extends BaseAction {
   private static final Separator ourInstance = new Separator();
 
   private String myText;
 
   public Separator() {
-    //It is necessary because otherwise we have some problems with myText==null after compiling GWT
+    // It is necessary because otherwise we have some problems with myText==null after compiling GWT
     this(null);
   }
 

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ToggleAction.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/ToggleAction.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.ide.api.action;
 
-import com.google.gwt.resources.client.ImageResource;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
@@ -21,7 +20,7 @@ import org.vectomatic.dom.svg.ui.SVGResource;
  * @author Evgen Vidolob
  * @author Vitaliy Guliy
  */
-public abstract class ToggleAction extends Action implements Toggleable {
+public abstract class ToggleAction extends BaseAction implements Toggleable {
 
   public ToggleAction(@Nullable final String text) {
     super(text);
@@ -30,16 +29,8 @@ public abstract class ToggleAction extends Action implements Toggleable {
   public ToggleAction(
       @Nullable final String text,
       @Nullable final String description,
-      @Nullable final ImageResource icon,
       @Nullable final SVGResource svgIcon) {
-    super(text, description, icon, svgIcon);
-  }
-
-  public ToggleAction(
-      @Nullable final String text,
-      @Nullable final String description,
-      @Nullable final SVGResource svgIcon) {
-    super(text, description, null, svgIcon);
+    super(text, description, svgIcon);
   }
 
   @Override

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/action/AbstractPerspectiveActionTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/action/AbstractPerspectiveActionTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.api.action;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.Arrays;
 import java.util.List;
 import javax.validation.constraints.NotNull;
@@ -22,36 +23,32 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 /** @author Dmitry Shnurenko */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class AbstractPerspectiveActionTest {
 
   private static final String SOME_TEXT = "someText";
 
   @Mock private PerspectiveManager manager;
-  @Mock private SVGResource icon;
   @Mock private ActionEvent event;
 
   private DummyAction dummyAction;
 
   @Before
   public void setUp() {
-    dummyAction = new DummyAction(Arrays.asList(SOME_TEXT), SOME_TEXT, SOME_TEXT, icon);
+    dummyAction = new DummyAction(Arrays.asList(SOME_TEXT), SOME_TEXT, SOME_TEXT, null);
   }
 
   @Test
   public void actionShouldBePerformed() {
     Presentation presentation = new Presentation();
-    when(event.getPerspectiveManager()).thenReturn(manager);
     when(event.getPresentation()).thenReturn(presentation);
     when(manager.getPerspectiveId()).thenReturn("123");
 
     dummyAction.update(event);
 
-    verify(event).getPerspectiveManager();
     verify(event).getPresentation();
     verify(manager).getPerspectiveId();
   }
@@ -63,7 +60,9 @@ public class AbstractPerspectiveActionTest {
         @NotNull String tooltip,
         @NotNull String description,
         @NotNull SVGResource icon) {
-      super(activePerspectives, tooltip, description, null, icon);
+      super(activePerspectives, tooltip, description, icon);
+      perspectiveManager = () -> AbstractPerspectiveActionTest.this.manager;
+      appContext = () -> null;
     }
 
     @Override

--- a/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/action/DefaultActionGroupTest.java
+++ b/ide/che-core-ide-api/src/test/java/org/eclipse/che/ide/api/action/DefaultActionGroupTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,23 +26,22 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 /** @author Mihail Kuznyetsov. */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class DefaultActionGroupTest {
 
-  @Mock Action firstAction;
+  @Mock BaseAction firstAction;
 
-  @Mock Action secondAction;
+  @Mock BaseAction secondAction;
 
-  @Mock Action thirdAction;
+  @Mock BaseAction thirdAction;
 
-  @Mock Action fourthAction;
+  @Mock BaseAction fourthAction;
 
-  @Mock Action fifthAction;
+  @Mock BaseAction fifthAction;
 
-  @Mock Action sixthAction;
+  @Mock BaseAction sixthAction;
 
   @Mock ActionManager actionManager;
 
@@ -54,7 +54,7 @@ public class DefaultActionGroupTest {
 
   @Test
   public void shouldNotAddSameActionTwice() {
-    Action action = mock(Action.class);
+    BaseAction action = mock(BaseAction.class);
 
     defaultActionGroup.add(action, new Constraints(AFTER, "someAction"));
     defaultActionGroup.add(action, new Constraints(BEFORE, "someAction"));
@@ -67,7 +67,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result)).isEmpty();
   }
 
@@ -86,7 +86,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -108,7 +108,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -130,7 +130,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -152,7 +152,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -174,7 +174,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -196,7 +196,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -260,7 +260,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(
@@ -282,7 +282,7 @@ public class DefaultActionGroupTest {
     // when
     Action[] result = defaultActionGroup.getChildren(mock(ActionEvent.class));
 
-    //then
+    // then
     assertThat(Arrays.asList(result))
         .hasSize(6)
         .containsExactly(

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionManagerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionManagerImpl.java
@@ -216,8 +216,7 @@ public class ActionManagerImpl implements ActionManager {
     final Action action;
     if (actionId != null && (action = getAction(actionId)) != null) {
       final Presentation presentation = presentationFactory.getPresentation(action);
-      final ActionEvent actionEvent =
-          new ActionEvent(presentation, this, managerProvider.get(), parameters);
+      final ActionEvent actionEvent = new ActionEvent(presentation, this, parameters);
 
       action.update(actionEvent);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/AddToFileWatcherExcludesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/AddToFileWatcherExcludesAction.java
@@ -52,9 +52,7 @@ public class AddToFileWatcherExcludesAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.addToFileWatcherExludesName(),
-        locale.addToFileWatcherExludesDescription(),
-        null,
-        null);
+        locale.addToFileWatcherExludesDescription());
     this.appContext = appContext;
     this.notificationManager = notificationManager;
     this.fileWatcherExcludesOperation = fileWatcherExcludesOperation;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CloseActiveEditorAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CloseActiveEditorAction.java
@@ -36,9 +36,7 @@ public class CloseActiveEditorAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.editorTabClose(),
-        locale.editorTabCloseDescription(),
-        null,
-        null);
+        locale.editorTabCloseDescription());
     this.editorAgent = editorAgent;
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CollapseAllAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CollapseAllAction.java
@@ -14,8 +14,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartPresenter;
@@ -27,7 +27,7 @@ import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
  * @author Vlad Zhukovskiy
  */
 @Singleton
-public class CollapseAllAction extends Action implements ActivePartChangedHandler {
+public class CollapseAllAction extends BaseAction implements ActivePartChangedHandler {
 
   private ProjectExplorerPresenter projectExplorer;
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ConvertFolderToProjectAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ConvertFolderToProjectAction.java
@@ -41,9 +41,7 @@ public class ConvertFolderToProjectAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.actionConvertFolderToProject(),
-        locale.actionConvertFolderToProjectDescription(),
-        null,
-        null);
+        locale.actionConvertFolderToProjectDescription());
     this.appContext = appContext;
     this.projectConfigWizard = projectConfigWizard;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CreateProjectAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CreateProjectAction.java
@@ -38,7 +38,6 @@ public class CreateProjectAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         "Create Project...",
         "Create new project",
-        null,
         resources.newProject());
     this.wizard = wizard;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DeleteResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DeleteResourceAction.java
@@ -66,7 +66,6 @@ public class DeleteResourceAction extends AbstractPerspectiveAction implements P
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.deleteItemActionText(),
         localization.deleteItemActionDescription(),
-        null,
         resources.delete());
     this.deleteResourceManager = deleteResourceManager;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadProjectAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadProjectAction.java
@@ -50,7 +50,6 @@ public class DownloadProjectAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.downloadProjectAsZipName(),
         locale.downloadProjectAsZipDescription(),
-        null,
         resources.downloadZip());
     this.appContext = appContext;
     this.downloadContainer = downloadContainer;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadResourceAction.java
@@ -48,9 +48,7 @@ public class DownloadResourceAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.downloadItemName(),
-        locale.downloadItemDescription(),
-        null,
-        null);
+        locale.downloadItemDescription());
     this.appContext = appContext;
     this.downloadContainer = downloadContainer;
     this.urlModifier = urlModifier;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadWsAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DownloadWsAction.java
@@ -48,7 +48,6 @@ public class DownloadWsAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.downloadProjectAsZipName(),
         locale.downloadProjectAsZipDescription(),
-        null,
         resources.downloadZip());
     this.appContext = appContext;
     this.wsAgentURLModifier = wsAgentURLModifier;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/EditFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/EditFileAction.java
@@ -40,7 +40,7 @@ public class EditFileAction extends AbstractPerspectiveAction {
 
   @Inject
   public EditFileAction(AppContext appContext, Resources resources, EditorAgent editorAgent) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), "Edit file", null, null, resources.defaultFile());
+    super(singletonList(PROJECT_PERSPECTIVE_ID), "Edit file", null, resources.defaultFile());
     this.appContext = appContext;
     this.editorAgent = editorAgent;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ExpandEditorAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ExpandEditorAction.java
@@ -24,8 +24,8 @@ import com.google.inject.Singleton;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.FontAwesome;
 import org.eclipse.che.ide.Resources;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.CustomComponentAction;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.parts.PartStack;
@@ -38,7 +38,7 @@ import org.eclipse.che.ide.api.parts.PerspectiveManager;
  * @author Dmitry Shnurenko
  */
 @Singleton
-public class ExpandEditorAction extends Action implements CustomComponentAction {
+public class ExpandEditorAction extends BaseAction implements CustomComponentAction {
 
   private final Resources resources;
   private final CoreLocalizationConstant constant;
@@ -52,7 +52,7 @@ public class ExpandEditorAction extends Action implements CustomComponentAction 
       Resources resources,
       PerspectiveManager perspectiveManager,
       CoreLocalizationConstant constant) {
-    super(constant.actionExpandEditorTitle(), null, null, null, FontAwesome.EXPAND);
+    super(constant.actionExpandEditorTitle(), null, FontAwesome.EXPAND);
     this.resources = resources;
     this.perspectiveManager = perspectiveManager;
     this.constant = constant;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/FormatterAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/FormatterAction.java
@@ -41,7 +41,6 @@ public class FormatterAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.formatName(),
         localization.formatDescription(),
-        null,
         resources.format());
     this.editorAgent = editorAgent;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/FullTextSearchAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/FullTextSearchAction.java
@@ -49,7 +49,6 @@ public class FullTextSearchAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.actionFullTextSearch(),
         locale.actionFullTextSearchDescription(),
-        null,
         resources.find());
     this.presenter = presenter;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/HotKeysListAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/HotKeysListAction.java
@@ -29,7 +29,7 @@ public class HotKeysListAction extends AbstractPerspectiveAction {
   @Inject
   public HotKeysListAction(
       HotKeysDialogPresenter hotKeysDialogPresenter, CoreLocalizationConstant locale) {
-    super(null, locale.keyBindingsActionName(), locale.keyBindingsActionDescription(), null, null);
+    super(null, locale.keyBindingsActionName(), locale.keyBindingsActionDescription());
     this.hotKeysDialogPresenter = hotKeysDialogPresenter;
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ImportProjectAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ImportProjectAction.java
@@ -42,7 +42,6 @@ public class ImportProjectAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.importProjectFromLocationName(),
         locale.importProjectFromLocationDescription(),
-        null,
         resources.importProjectFromLocation());
     this.presenter = presenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/NavigateToFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/NavigateToFileAction.java
@@ -44,7 +44,6 @@ public class NavigateToFileAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localizationConstant.actionNavigateToFileText(),
         localizationConstant.actionNavigateToFileDescription(),
-        null,
         resources.navigateToFile());
     this.navigateToFilePresenterProvider = navigateToFilePresenterProvider;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/OpenFileAction.java
@@ -26,8 +26,8 @@ import org.eclipse.che.api.promises.client.callback.CallbackPromiseHelper.Call;
 import org.eclipse.che.api.promises.client.js.JsPromiseError;
 import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.PromisableAction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
@@ -44,7 +44,7 @@ import org.eclipse.che.ide.util.loging.Log;
  * @author Vlad Zhukovskyi
  */
 @Singleton
-public class OpenFileAction extends Action implements PromisableAction {
+public class OpenFileAction extends BaseAction implements PromisableAction {
 
   /** ID of the parameter to specify file path to open. */
   public static final String FILE_PARAM_ID = "file";

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ProjectConfigurationAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ProjectConfigurationAction.java
@@ -52,7 +52,6 @@ public class ProjectConfigurationAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.actionProjectConfigurationTitle(),
         localization.actionProjectConfigurationDescription(),
-        null,
         resources.projectConfiguration());
     this.appContext = appContext;
     this.projectWizard = projectWizard;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RedoAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RedoAction.java
@@ -41,7 +41,6 @@ public class RedoAction extends AbstractPerspectiveAction {
         Arrays.asList(PROJECT_PERSPECTIVE_ID),
         localization.redoName(),
         localization.redoDescription(),
-        null,
         resources.redo());
     this.editorAgent = editorAgent;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RemoveFromFileWatcherExcludesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RemoveFromFileWatcherExcludesAction.java
@@ -52,9 +52,7 @@ public class RemoveFromFileWatcherExcludesAction extends AbstractPerspectiveActi
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.removeFromFileWatcherExludesName(),
-        locale.removeFromFileWatcherExludesDescription(),
-        null,
-        null);
+        locale.removeFromFileWatcherExludesDescription());
     this.appContext = appContext;
     this.notificationManager = notificationManager;
     this.fileWatcherExcludesOperation = fileWatcherExcludesOperation;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
@@ -77,7 +77,6 @@ public class RenameItemAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.renameItemActionText(),
         localization.renameItemActionDescription(),
-        null,
         resources.rename());
     this.localization = localization;
     this.renamingSupport = renamingSupport;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RunCommandAction.java
@@ -12,8 +12,8 @@ package org.eclipse.che.ide.actions;
 
 import com.google.inject.Inject;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandExecutor;
 import org.eclipse.che.ide.api.command.CommandManager;
@@ -25,7 +25,7 @@ import org.eclipse.che.ide.util.loging.Log;
  *
  * @author Max Shaposhnik
  */
-public class RunCommandAction extends Action {
+public class RunCommandAction extends BaseAction {
 
   public static final String NAME_PARAM_ID = "name";
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ShowHiddenFilesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ShowHiddenFilesAction.java
@@ -53,7 +53,6 @@ public class ShowHiddenFilesAction extends AbstractPerspectiveAction implements 
         singletonList(PROJECT_PERSPECTIVE_ID),
         localizationConstant.actionShowHiddenFilesTitle(),
         localizationConstant.actionShowHiddenFilesDescription(),
-        null,
         resources.showHiddenFiles());
     this.appContext = appContext;
     this.projectExplorerPresenter = projectExplorerPresenter;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ShowPreferencesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ShowPreferencesAction.java
@@ -34,7 +34,7 @@ public class ShowPreferencesAction extends AbstractPerspectiveAction {
   @Inject
   public ShowPreferencesAction(
       Resources resources, PreferencesPresenter presenter, AppContext appContext) {
-    super(null, "Preferences", "Preferences", null, resources.preferences());
+    super(null, "Preferences", "Preferences", resources.preferences());
     this.presenter = presenter;
     this.appContext = appContext;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ShowReferenceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ShowReferenceAction.java
@@ -15,8 +15,8 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.reference.ShowReferencePresenter;
@@ -26,7 +26,7 @@ import org.eclipse.che.ide.reference.ShowReferencePresenter;
  * @author Vlad Zhukovskyi
  */
 @Singleton
-public class ShowReferenceAction extends Action {
+public class ShowReferenceAction extends BaseAction {
 
   private final ShowReferencePresenter showReferencePresenter;
   private final AppContext appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/SignatureHelpAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/SignatureHelpAction.java
@@ -39,9 +39,7 @@ public class SignatureHelpAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         constant.signatureName(),
-        constant.signatureDescription(),
-        null,
-        null);
+        constant.signatureDescription());
     this.editorAgent = editorAgent;
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UndoAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UndoAction.java
@@ -41,7 +41,6 @@ public class UndoAction extends AbstractPerspectiveAction {
         Arrays.asList(PROJECT_PERSPECTIVE_ID),
         localization.undoName(),
         localization.undoDescription(),
-        null,
         resources.undo());
     this.editorAgent = editorAgent;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFileAction.java
@@ -49,7 +49,6 @@ public class UploadFileAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.uploadFileName(),
         locale.uploadFileDescription(),
-        null,
         resources.uploadFile());
     this.presenter = presenter;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFolderAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFolderAction.java
@@ -49,7 +49,6 @@ public class UploadFolderAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.uploadFolderFromZipName(),
         locale.uploadFolderFromZipDescription(),
-        null,
         resources.uploadFile());
     this.presenter = presenter;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/CollapseTreeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/CollapseTreeAction.java
@@ -12,8 +12,8 @@ package org.eclipse.che.ide.actions.common;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.smartTree.data.TreeExpander;
 
 /**
@@ -23,7 +23,7 @@ import org.eclipse.che.ide.ui.smartTree.data.TreeExpander;
  * @see TreeExpander
  * @since 5.0.0
  */
-public abstract class CollapseTreeAction extends Action {
+public abstract class CollapseTreeAction extends BaseAction {
 
   public abstract TreeExpander getTreeExpander();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/ExpandTreeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/ExpandTreeAction.java
@@ -12,8 +12,8 @@ package org.eclipse.che.ide.actions.common;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.smartTree.data.TreeExpander;
 
 /**
@@ -23,7 +23,7 @@ import org.eclipse.che.ide.ui.smartTree.data.TreeExpander;
  * @see TreeExpander
  * @since 5.0.0
  */
-public abstract class ExpandTreeAction extends Action {
+public abstract class ExpandTreeAction extends BaseAction {
 
   public abstract TreeExpander getTreeExpander();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/HidePartAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/HidePartAction.java
@@ -13,8 +13,8 @@ package org.eclipse.che.ide.actions.common;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartStack;
@@ -24,7 +24,7 @@ import org.eclipse.che.ide.api.parts.PartStack;
  *
  * @author Vitaliy Guliy
  */
-public class HidePartAction extends Action implements ActivePartChangedHandler {
+public class HidePartAction extends BaseAction implements ActivePartChangedHandler {
 
   private PartStack activePartStack;
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/MaximizePartAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/MaximizePartAction.java
@@ -14,8 +14,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartStack;
@@ -26,7 +26,7 @@ import org.eclipse.che.ide.api.parts.PartStack;
  * @author Vitaliy Guliy
  */
 @Singleton
-public class MaximizePartAction extends Action implements ActivePartChangedHandler {
+public class MaximizePartAction extends BaseAction implements ActivePartChangedHandler {
 
   private PartStack activePartStack;
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/RestorePartAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/RestorePartAction.java
@@ -13,8 +13,8 @@ package org.eclipse.che.ide.actions.common;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.parts.PartStack;
@@ -24,7 +24,7 @@ import org.eclipse.che.ide.api.parts.PartStack;
  *
  * @author Vitaliy Guliy
  */
-public class RestorePartAction extends Action implements ActivePartChangedHandler {
+public class RestorePartAction extends BaseAction implements ActivePartChangedHandler {
 
   private PartStack activePartStack;
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/find/FindActionAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/find/FindActionAction.java
@@ -35,7 +35,6 @@ public class FindActionAction extends AbstractPerspectiveAction {
         null,
         localization.actionFindActionDescription(),
         localization.actionFindActionTitle(),
-        null,
         resources.findActions());
     this.presenter = presenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/find/FindActionPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/find/FindActionPresenter.java
@@ -15,7 +15,6 @@ import static java.util.Collections.unmodifiableList;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -35,7 +34,6 @@ import org.eclipse.che.ide.api.action.IdeActions;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.action.Separator;
 import org.eclipse.che.ide.api.mvp.Presenter;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.ui.toolbar.PresentationFactory;
 import org.eclipse.che.ide.util.StringUtils;
 import org.eclipse.che.ide.util.UnicodeUtils;
@@ -51,7 +49,6 @@ public class FindActionPresenter implements Presenter, FindActionView.ActionDele
   private final PresentationFactory presentationFactory;
   private final FindActionView view;
   private final ActionManager actionManager;
-  private final Provider<PerspectiveManager> perspectiveManager;
   private final Map<Action, String> actionsMap;
   private final Comparator<Action> actionComparator =
       new Comparator<Action>() {
@@ -74,16 +71,20 @@ public class FindActionPresenter implements Presenter, FindActionView.ActionDele
       };
 
   @Inject
-  public FindActionPresenter(
-      FindActionView view,
-      ActionManager actionManager,
-      Provider<PerspectiveManager> perspectiveManager) {
+  public FindActionPresenter(FindActionView view, ActionManager actionManager) {
     this.view = view;
     this.actionManager = actionManager;
-    this.perspectiveManager = perspectiveManager;
     view.setDelegate(this);
     presentationFactory = new PresentationFactory();
     actionsMap = new TreeMap<>(actionComparator);
+  }
+
+  private static boolean containsOnlyUppercaseLetters(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (c != '*' && c != ' ' && !Character.isUpperCase(c)) return false;
+    }
+    return true;
   }
 
   @Override
@@ -196,9 +197,7 @@ public class FindActionPresenter implements Presenter, FindActionView.ActionDele
 
   @Override
   public void onActionSelected(Action action) {
-    ActionEvent e =
-        new ActionEvent(
-            presentationFactory.getPresentation(action), actionManager, perspectiveManager.get());
+    ActionEvent e = new ActionEvent(presentationFactory.getPresentation(action), actionManager);
     action.update(e);
     if (e.getPresentation().isEnabled() && e.getPresentation().isVisible()) {
       view.hide();
@@ -227,7 +226,8 @@ public class FindActionPresenter implements Presenter, FindActionView.ActionDele
       final char c = pattern.charAt(i);
       if (Character.isLetterOrDigit(c)
           || UnicodeUtils.regexpIdentifierOrWhitespace.test(String.valueOf(c))) {
-        // This logic allows to use uppercase letters only to catch the name like PDM for PsiDocumentManager
+        // This logic allows to use uppercase letters only to catch the name like PDM for
+        // PsiDocumentManager
         if (Character.isUpperCase(c) || Character.isDigit(c)) {
 
           if (!firstIdentifierLetter) {
@@ -274,14 +274,6 @@ public class FindActionPresenter implements Presenter, FindActionView.ActionDele
     }
 
     return buffer.toString();
-  }
-
-  private static boolean containsOnlyUppercaseLetters(String s) {
-    for (int i = 0; i < s.length(); i++) {
-      char c = s.charAt(i);
-      if (c != '*' && c != ' ' && !Character.isUpperCase(c)) return false;
-    }
-    return true;
   }
 
   private List<String> getExcludedActionIds(ActionManager actionManager) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/find/FindActionViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/find/FindActionViewImpl.java
@@ -22,11 +22,9 @@ import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import elemental.dom.Element;
 import elemental.dom.Node;
 import elemental.html.TableCellElement;
@@ -41,13 +39,12 @@ import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.editor.codeassist.AutoCompleteResources;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
+import org.eclipse.che.ide.ui.ElementWidget;
 import org.eclipse.che.ide.ui.list.SimpleList;
 import org.eclipse.che.ide.ui.toolbar.PresentationFactory;
 import org.eclipse.che.ide.ui.toolbar.ToolbarResources;
 import org.eclipse.che.ide.util.dom.Elements;
 import org.eclipse.che.ide.util.input.KeyMapUtil;
-import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * @author Evgen Vidolob
@@ -83,14 +80,10 @@ public class FindActionViewImpl extends PopupPanel implements FindActionView {
           TableCellElement group = Elements.createTDElement(css.proposalGroup());
 
           Presentation presentation = presentationFactory.getPresentation(itemData);
-          itemData.update(new ActionEvent(presentation, actionManager, perspectiveManager.get()));
+          itemData.update(new ActionEvent(presentation, actionManager));
 
-          if (presentation.getImageResource() != null) {
-            Image image = new Image(presentation.getImageResource());
-            icon.appendChild((Node) image.getElement());
-
-          } else if (presentation.getSVGResource() != null) {
-            SVGImage image = new SVGImage(presentation.getSVGResource());
+          if (presentation.getImageElement() != null) {
+            ElementWidget image = new ElementWidget(presentation.getImageElement());
             image.getElement().setAttribute("class", toolbarResources.toolbar().iconButtonIcon());
             image.getElement().getStyle().setMargin(0, Style.Unit.PX);
             icon.appendChild((Node) image.getElement());
@@ -143,7 +136,6 @@ public class FindActionViewImpl extends PopupPanel implements FindActionView {
 
   private SimpleList<Action> list;
   private Map<Action, String> actions;
-  private Provider<PerspectiveManager> perspectiveManager;
   private ToolbarResources toolbarResources;
 
   @Inject
@@ -152,13 +144,11 @@ public class FindActionViewImpl extends PopupPanel implements FindActionView {
       KeyBindingAgent keyBindingAgent,
       ActionManager actionManager,
       AutoCompleteResources autoCompleteResources,
-      Provider<PerspectiveManager> perspectiveManager,
       ToolbarResources toolbarResources,
       FindActionViewImplUiBinder uiBinder) {
     this.resources = resources;
     this.keyBindingAgent = keyBindingAgent;
     this.actionManager = actionManager;
-    this.perspectiveManager = perspectiveManager;
     this.toolbarResources = toolbarResources;
     this.presentationFactory = new PresentationFactory();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandAction.java
@@ -12,16 +12,17 @@ package org.eclipse.che.ide.command.execute;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.command.CommandExecutor;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandManager;
 import org.eclipse.che.ide.command.CommandUtils;
+import org.vectomatic.dom.svg.ui.SVGImage;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 /** Action for executing a {@link CommandImpl}. */
-class ExecuteCommandAction extends Action {
+class ExecuteCommandAction extends BaseAction {
 
   private final CommandImpl command;
   private final CommandExecutor commandExecutor;
@@ -41,7 +42,7 @@ class ExecuteCommandAction extends Action {
 
     final SVGResource commandIcon = commandUtils.getCommandTypeIcon(command.getType());
     if (commandIcon != null) {
-      getTemplatePresentation().setSVGResource(commandIcon);
+      getTemplatePresentation().setImageElement(new SVGImage(commandIcon).getElement());
     }
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/GoalPopUpGroup.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/GoalPopUpGroup.java
@@ -48,7 +48,7 @@ class GoalPopUpGroup extends DefaultActionGroup {
     // set icon
     final SVGResource commandTypeIcon = getCommandGoalIcon();
     if (commandTypeIcon != null) {
-      getTemplatePresentation().setSVGResource(commandTypeIcon);
+      getTemplatePresentation().setImageElement(new SVGImage(commandTypeIcon).getElement());
     }
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/palette/ShowCommandsPaletteAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/palette/ShowCommandsPaletteAction.java
@@ -12,8 +12,8 @@ package org.eclipse.che.ide.command.palette;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 
 /**
  * Action for opening Commands Palette.
@@ -21,13 +21,13 @@ import org.eclipse.che.ide.api.action.ActionEvent;
  * @author Artem Zatsarynnyi
  */
 @Singleton
-public class ShowCommandsPaletteAction extends Action {
+public class ShowCommandsPaletteAction extends BaseAction {
 
   private final CommandsPalettePresenter presenter;
 
   @Inject
   public ShowCommandsPaletteAction(PaletteMessages messages, CommandsPalettePresenter presenter) {
-    super(messages.actionShowPaletteTitle(), messages.actionShowPaletteDescription(), null, null);
+    super(messages.actionShowPaletteTitle(), messages.actionShowPaletteDescription());
 
     this.presenter = presenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/producer/CommandProducerAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/producer/CommandProducerAction.java
@@ -12,8 +12,8 @@ package org.eclipse.che.ide.command.producer;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.command.CommandExecutor;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandProducer;
@@ -24,7 +24,7 @@ import org.eclipse.che.ide.api.command.CommandProducer;
  * @author Artem Zatsarynnyi
  * @see CommandProducer
  */
-public class CommandProducerAction extends Action {
+public class CommandProducerAction extends BaseAction {
 
   private final CommandProducer commandProducer;
   private final CommandExecutor commandExecutor;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/producer/CommandProducerActionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/producer/CommandProducerActionManager.java
@@ -21,13 +21,14 @@ import com.google.web.bindery.event.shared.EventBus;
 import java.util.HashSet;
 import java.util.Set;
 import org.eclipse.che.ide.Resources;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.ide.api.command.CommandProducer;
 import org.eclipse.che.ide.api.constraints.Constraints;
 import org.eclipse.che.ide.bootstrap.BasicIDEInitializedEvent;
+import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * Manages actions for the commands.
@@ -75,7 +76,9 @@ public class CommandProducerActionManager {
     commandActionsPopUpGroup =
         new DefaultActionGroup(messages.actionCommandsTitle(), true, actionManager);
     actionManager.registerAction("commandActionsPopUpGroup", commandActionsPopUpGroup);
-    commandActionsPopUpGroup.getTemplatePresentation().setSVGResource(resources.compile());
+    commandActionsPopUpGroup
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.compile()).getElement());
     commandActionsPopUpGroup
         .getTemplatePresentation()
         .setDescription(messages.actionCommandsDescription());
@@ -100,7 +103,7 @@ public class CommandProducerActionManager {
 
   /** Creates actions for the given {@link CommandProducer}. */
   private void createActionsForProducer(CommandProducer producer) {
-    Action action = commandProducerActionFactory.create(producer.getName(), producer);
+    BaseAction action = commandProducerActionFactory.create(producer.getName(), producer);
 
     actionManager.registerAction(producer.getName(), action);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/commands/button/ExecuteCommandButton.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/commands/button/ExecuteCommandButton.java
@@ -20,9 +20,9 @@ import elemental.html.DivElement;
 import elemental.html.SpanElement;
 import java.util.Optional;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.command.CommandGoal;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.command.toolbar.ToolbarMessages;
@@ -121,7 +121,7 @@ public class ExecuteCommandButton extends MenuButton {
     tooltip = Tooltip.create((Element) getElement(), BOTTOM, MIDDLE, divElement);
   }
 
-  private class ExecuteDefaultCommandAction extends Action {
+  private class ExecuteDefaultCommandAction extends BaseAction {
 
     ExecuteDefaultCommandAction() {
       super("Execute default command of " + goal.getId() + " goal");

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -90,9 +90,9 @@ import org.eclipse.che.ide.actions.common.HidePartAction;
 import org.eclipse.che.ide.actions.common.MaximizePartAction;
 import org.eclipse.che.ide.actions.common.RestorePartAction;
 import org.eclipse.che.ide.actions.find.FindActionAction;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.ide.api.action.IdeActions;
 import org.eclipse.che.ide.api.constraints.Constraints;
@@ -144,6 +144,7 @@ import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.ide.util.input.KeyCodeMap;
 import org.eclipse.che.ide.workspace.StopWorkspaceAction;
 import org.eclipse.che.ide.xml.NewXmlFileAction;
+import org.vectomatic.dom.svg.ui.SVGImage;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 /**
@@ -477,7 +478,9 @@ public class StandardComponentInitializer {
 
     DefaultActionGroup newGroup = new DefaultActionGroup("New", true, actionManager);
     newGroup.getTemplatePresentation().setDescription("Create...");
-    newGroup.getTemplatePresentation().setSVGResource(resources.newResource());
+    newGroup
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.newResource()).getElement());
     actionManager.registerAction(GROUP_FILE_NEW, newGroup);
     projectGroup.add(newGroup);
 
@@ -492,7 +495,9 @@ public class StandardComponentInitializer {
     newGroup.addSeparator();
 
     actionManager.registerAction("newXmlFile", newXmlFileAction);
-    newXmlFileAction.getTemplatePresentation().setSVGResource(xmlFile.getImage());
+    newXmlFileAction
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(xmlFile.getImage()).getElement());
     newGroup.addAction(newXmlFileAction);
 
     actionManager.registerAction("uploadFile", uploadFileAction);
@@ -824,8 +829,8 @@ public class StandardComponentInitializer {
           (DefaultActionGroup) actionManager.getAction(GROUP_MAIN_MENU);
       mainMenu.add(windowMenu);
       for (Perspective perspective : perspectives.values()) {
-        final Action action =
-            new Action(perspective.getPerspectiveName()) {
+        final BaseAction action =
+            new BaseAction(perspective.getPerspectiveName()) {
               @Override
               public void actionPerformed(ActionEvent e) {
                 perspectiveManager.setPerspectiveId(perspective.getPerspectiveId());

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/action/CreateFactoryAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/action/CreateFactoryAction.java
@@ -30,10 +30,7 @@ public class CreateFactoryAction extends AbstractPerspectiveAction {
       CreateFactoryPresenter presenter, CoreLocalizationConstant localizationConstant) {
     super(
         Collections.singletonList("Project Perspective"),
-        localizationConstant.createFactoryActionTitle(),
-        null,
-        null,
-        null);
+        localizationConstant.createFactoryActionTitle());
     this.presenter = presenter;
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/json/ImportFromConfigAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/json/ImportFromConfigAction.java
@@ -13,13 +13,13 @@ package org.eclipse.che.ide.factory.json;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.ide.CoreLocalizationConstant;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.factory.FactoryResources;
 
 /** @author Sergii Leschenko */
 @Singleton
-public class ImportFromConfigAction extends Action {
+public class ImportFromConfigAction extends BaseAction {
 
   private final ImportFromConfigPresenter presenter;
 
@@ -31,7 +31,6 @@ public class ImportFromConfigAction extends Action {
     super(
         locale.importFromConfigurationName(),
         locale.importFromConfigurationDescription(),
-        null,
         resources.importConfig());
     this.presenter = presenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/welcome/OpenWelcomePageAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/factory/welcome/OpenWelcomePageAction.java
@@ -11,12 +11,12 @@
 package org.eclipse.che.ide.factory.welcome;
 
 import javax.inject.Inject;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.util.loging.Log;
 
 /** @author Sergii Leschenko */
-public class OpenWelcomePageAction extends Action {
+public class OpenWelcomePageAction extends BaseAction {
   private final GreetingPartPresenter greetingPart;
 
   @Inject

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/imageviewer/PreviewImageAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/imageviewer/PreviewImageAction.java
@@ -57,9 +57,7 @@ public class PreviewImageAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         constant.actionPreviewImageTitle(),
-        constant.actionPreviewImageDescription(),
-        null,
-        null);
+        constant.actionPreviewImageDescription());
     this.wsAgentURLModifier = wsAgentURLModifier;
     this.appContext = appContext;
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/KeyBindingManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/keybinding/KeyBindingManager.java
@@ -14,7 +14,6 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.AreaElement;
 import com.google.gwt.dom.client.InputElement;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import elemental.dom.Element;
 import elemental.events.Event;
 import elemental.events.EventListener;
@@ -31,7 +30,6 @@ import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.keybinding.Scheme;
 import org.eclipse.che.ide.api.keybinding.SchemeImpl;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.ui.toolbar.PresentationFactory;
 import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.ide.util.dom.Elements;
@@ -52,7 +50,6 @@ public class KeyBindingManager implements KeyBindingAgent {
   public static final String SCHEME_GLOBAL_ID = "ide.ui.keyBinding.global";
 
   private final PresentationFactory presentationFactory;
-  private final Provider<PerspectiveManager> perspectiveManager;
 
   private final Map<String, Scheme> schemes = new HashMap<>();
 
@@ -60,10 +57,8 @@ public class KeyBindingManager implements KeyBindingAgent {
   private ActionManager actionManager;
 
   @Inject
-  public KeyBindingManager(
-      ActionManager actionManager, Provider<PerspectiveManager> perspectiveManager) {
+  public KeyBindingManager(ActionManager actionManager) {
     this.actionManager = actionManager;
-    this.perspectiveManager = perspectiveManager;
 
     addScheme(new SchemeImpl(SCHEME_GLOBAL_ID, "Global"));
     addScheme(new SchemeImpl(SCHEME_ECLIPSE_ID, "Eclipse Scheme"));
@@ -139,9 +134,7 @@ public class KeyBindingManager implements KeyBindingAgent {
       if (action == null) {
         continue;
       }
-      ActionEvent e =
-          new ActionEvent(
-              presentationFactory.getPresentation(action), actionManager, perspectiveManager.get());
+      ActionEvent e = new ActionEvent(presentationFactory.getPresentation(action), actionManager);
       action.update(e);
 
       if (e.getPresentation().isEnabled() && e.getPresentation().isVisible()) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MainMenuViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MainMenuViewImpl.java
@@ -194,7 +194,7 @@ public class MainMenuViewImpl extends Composite
     final Action[] children = mainActionGroup.getChildren(null);
     for (final Action action : children) {
       final Presentation presentation = presentationFactory.getPresentation(action);
-      final ActionEvent e = new ActionEvent(presentation, actionManager, managerProvider.get());
+      final ActionEvent e = new ActionEvent(presentation, actionManager);
       action.update(e);
       if (presentation.isVisible()) { // add only visible items
         newVisibleActions.add(action);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MenuBarItem.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/MenuBarItem.java
@@ -74,8 +74,7 @@ public class MenuBarItem implements ActionSelectedHandler {
     Presentation presentation = presentationFactory.getPresentation(group);
     title = presentation.getText();
     element.setInnerText(presentation.getText());
-    setEnabled(
-        Utils.hasVisibleChildren(group, presentationFactory, actionManager, managerProvider.get()));
+    setEnabled(Utils.hasVisibleChildren(group, presentationFactory, actionManager));
   }
 
   /** Close opened Popup Menu. */
@@ -180,7 +179,6 @@ public class MenuBarItem implements ActionSelectedHandler {
   }
 
   public void update() {
-    setEnabled(
-        Utils.hasVisibleChildren(group, presentationFactory, actionManager, managerProvider.get()));
+    setEnabled(Utils.hasVisibleChildren(group, presentationFactory, actionManager));
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/StatusPanelGroupViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/StatusPanelGroupViewImpl.java
@@ -17,7 +17,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +30,6 @@ import org.eclipse.che.ide.api.action.CustomComponentAction;
 import org.eclipse.che.ide.api.action.IdeActions;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.action.Separator;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.ui.toolbar.CloseMenuHandler;
 import org.eclipse.che.ide.ui.toolbar.MenuLockLayer;
 import org.eclipse.che.ide.ui.toolbar.PresentationFactory;
@@ -45,7 +43,6 @@ import org.eclipse.che.ide.ui.toolbar.PresentationFactory;
 public class StatusPanelGroupViewImpl extends Composite
     implements StatusPanelGroupView, CloseMenuHandler, ActionSelectedHandler {
   private final MenuResources resources;
-  private final Provider<PerspectiveManager> perspectiveManager;
 
   private final PresentationFactory presentationFactory = new PresentationFactory();
 
@@ -72,13 +69,9 @@ public class StatusPanelGroupViewImpl extends Composite
 
   /** Create new {@link MainMenuViewImpl} */
   @Inject
-  public StatusPanelGroupViewImpl(
-      MenuResources resources,
-      ActionManager actionManager,
-      Provider<PerspectiveManager> perspectiveManager) {
+  public StatusPanelGroupViewImpl(MenuResources resources, ActionManager actionManager) {
     this.resources = resources;
     this.actionManager = actionManager;
-    this.perspectiveManager = perspectiveManager;
 
     initWidget(rootPanel);
 
@@ -183,7 +176,7 @@ public class StatusPanelGroupViewImpl extends Composite
     final Action[] children = mainActionGroup.getChildren(null);
     for (final Action action : children) {
       final Presentation presentation = presentationFactory.getPresentation(action);
-      final ActionEvent e = new ActionEvent(presentation, actionManager, perspectiveManager.get());
+      final ActionEvent e = new ActionEvent(presentation, actionManager);
       action.update(e);
       if (presentation.isVisible()) { // add only visible items
         newVisibleActions.add(action);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/newresource/AbstractNewResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/newresource/AbstractNewResourceAction.java
@@ -25,8 +25,8 @@ import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
@@ -42,9 +42,9 @@ import org.eclipse.che.ide.util.NameUtils;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 /**
- * Implementation of an {@link Action} that provides an ability to create new resource (e.g. file,
- * folder). After performing this action, it asks user for the resource's name and then creates
- * resource in the selected folder.
+ * Implementation of an {@link BaseAction} that provides an ability to create new resource (e.g.
+ * file, folder). After performing this action, it asks user for the resource's name and then
+ * creates resource in the selected folder.
  *
  * @author Artem Zatsarynnyi
  * @author Dmitry Shnurenko
@@ -72,7 +72,7 @@ public abstract class AbstractNewResourceAction extends AbstractPerspectiveActio
       AppContext appContext,
       NotificationManager notificationManager,
       Provider<EditorAgent> editorAgentProvider) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), title, description, null, svgIcon);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), title, description, svgIcon);
     this.dialogFactory = dialogFactory;
     this.coreLocalizationConstant = coreLocalizationConstant;
     this.eventBus = eventBus;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EmptyEditorsPanel.java
@@ -61,23 +61,16 @@ import org.vectomatic.dom.svg.ui.SVGResource;
 public class EmptyEditorsPanel extends Composite
     implements ResourceChangedEvent.ResourceChangedHandler {
 
-  interface EmptyEditorsPanelUiBinder extends UiBinder<Widget, EmptyEditorsPanel> {}
-
   private static EmptyEditorsPanelUiBinder uiBinder = GWT.create(EmptyEditorsPanelUiBinder.class);
-
   protected final AppContext appContext;
   private final ActionManager actionManager;
   private final Provider<PerspectiveManager> perspectiveManagerProvider;
   private final KeyBindingAgent keyBindingAgent;
   private final PresentationFactory presentationFactory;
   private final CoreLocalizationConstant localizationConstant;
-
   private final Map<String, Action> noFiles = new HashMap<>();
-
   private final Map<String, Action> noProjects = new HashMap<>();
-
   private final Map<String, Action> factoryActions = new HashMap<>();
-
   @UiField protected DivElement title;
   @UiField protected DivElement root;
   @UiField protected DivElement container;
@@ -118,8 +111,9 @@ public class EmptyEditorsPanel extends Composite
     factoryActions.put(
         navigateToFileAction.getTemplatePresentation().getText(), navigateToFileAction);
 
-    //Sometimes initialization of Create/Import Project actions are completed after the Empty editor page is rendered.
-    //In this case we need to wait when actions will be initialized.
+    // Sometimes initialization of Create/Import Project actions are completed after the Empty
+    // editor page is rendered.
+    // In this case we need to wait when actions will be initialized.
     Timer hoverToRenderTimer =
         new Timer() {
           @Override
@@ -223,8 +217,7 @@ public class EmptyEditorsPanel extends Composite
         new EventListener() {
           @Override
           public void handleEvent(Event evt) {
-            ActionEvent event =
-                new ActionEvent(presentation, actionManager, perspectiveManagerProvider.get());
+            ActionEvent event = new ActionEvent(presentation, actionManager);
             action.actionPerformed(event);
           }
         },
@@ -247,6 +240,8 @@ public class EmptyEditorsPanel extends Composite
     divElement.appendChild(hotKeyElement);
     return divElement;
   }
+
+  interface EmptyEditorsPanelUiBinder extends UiBinder<Widget, EmptyEditorsPanel> {}
 
   interface Css extends CssResource {
     String list();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/EditorAbstractAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/EditorAbstractAction.java
@@ -43,7 +43,7 @@ public abstract class EditorAbstractAction extends AbstractPerspectiveAction {
       SVGResource icon,
       EditorAgent editorAgent,
       EventBus eventBus) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), tooltip, description, null, icon);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), tooltip, description, icon);
     this.eventBus = eventBus;
     this.editorAgent = editorAgent;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/ClearRecentListAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/ClearRecentListAction.java
@@ -35,9 +35,7 @@ public class ClearRecentListAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.openRecentFileClearTitle(),
-        locale.openRecentFileClearDescription(),
-        null,
-        null);
+        locale.openRecentFileClearDescription());
 
     this.recentFileList = recentFileList;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesAction.java
@@ -35,9 +35,7 @@ public class OpenRecentFilesAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.openRecentFileTitle(),
-        locale.openRecentFileDescription(),
-        null,
-        null);
+        locale.openRecentFileDescription());
     this.recentFileList = recentFileList;
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileAction.java
@@ -34,12 +34,7 @@ public class RecentFileAction extends AbstractPerspectiveAction {
 
   @Inject
   public RecentFileAction(@Assisted File file, EditorAgent editorAgent) {
-    super(
-        singletonList(PROJECT_PERSPECTIVE_ID),
-        getShortPath(file.getLocation().toString()),
-        null,
-        null,
-        null);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), getShortPath(file.getLocation().toString()));
     this.file = file;
     this.editorAgent = editorAgent;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/NewTerminalAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/NewTerminalAction.java
@@ -46,7 +46,6 @@ public class NewTerminalAction extends AbstractPerspectiveAction
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.newTerminal(),
         locale.newTerminalDescription(),
-        null,
         machineResources.addTerminalIcon());
 
     this.processesPanelPresenter = processesPanelPresenter;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/AddTabMenu.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/AddTabMenu.java
@@ -18,10 +18,10 @@ import com.google.inject.Provider;
 import java.util.Map;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.FontAwesome;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionGroup;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.ide.api.action.IdeActions;
 import org.eclipse.che.ide.api.action.Separator;
@@ -102,7 +102,7 @@ public class AddTabMenu extends ContextMenu {
   }
 
   /** Action to add new Terminal tab. */
-  public class NewTerminalMenuAction extends Action {
+  public class NewTerminalMenuAction extends BaseAction {
 
     private String machineName;
 
@@ -111,7 +111,6 @@ public class AddTabMenu extends ContextMenu {
       super(
           locale.newTerminal(),
           locale.newTerminalDescription(),
-          null,
           machineResources.addTerminalIcon());
       this.machineName = machineName;
     }
@@ -123,12 +122,12 @@ public class AddTabMenu extends ContextMenu {
   }
 
   /** Action to add new SSH tab. */
-  public class AddSSHMenuAction extends Action {
+  public class AddSSHMenuAction extends BaseAction {
 
     private String machineName;
 
     public AddSSHMenuAction(String machineName) {
-      super("SSH", "SSH", null, null, FontAwesome.RETWEET);
+      super("SSH", "SSH", FontAwesome.RETWEET);
       this.machineName = machineName;
     }
 
@@ -139,7 +138,7 @@ public class AddTabMenu extends ContextMenu {
   }
 
   /** Action to display bound servers. */
-  public class ShowServersAction extends Action {
+  public class ShowServersAction extends BaseAction {
 
     private String machineName;
 
@@ -147,7 +146,6 @@ public class AddTabMenu extends ContextMenu {
       super(
           runtimeInfoLocalization.showInfoActionTitle(),
           runtimeInfoLocalization.showInfoActionDescription(),
-          null,
           machineResources.remote());
       this.machineName = machineName;
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/CloseConsoleAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/CloseConsoleAction.java
@@ -41,7 +41,6 @@ public class CloseConsoleAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.closeControlTitle(),
         locale.closeControlDescription(),
-        null,
         partStackUIResources.closeIcon());
     this.processesPanelPresenter = processesPanelPresenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/ReRunProcessAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/ReRunProcessAction.java
@@ -43,7 +43,6 @@ public class ReRunProcessAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.reRunControlTitle(),
         locale.reRunControlDescription(),
-        null,
         machineResources.reRunIcon());
     this.processesPanelPresenter = processesPanelPresenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/StopProcessAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/actions/StopProcessAction.java
@@ -43,7 +43,6 @@ public class StopProcessAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.stopControlTitle(),
         locale.stopControlDescription(),
-        null,
         machineResources.stopIcon());
     this.processesPanelPresenter = processesPanelPresenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/runtime/ShowRuntimeInfoAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/runtime/ShowRuntimeInfoAction.java
@@ -45,7 +45,6 @@ public class ShowRuntimeInfoAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.showInfoActionTitle(),
         locale.showInfoActionDescription(),
-        null,
         resources.remote());
     this.processesPanelPresenter = processesPanelPresenter;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CopyResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CopyResourceAction.java
@@ -57,7 +57,6 @@ public class CopyResourceAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.copyItemsActionText(),
         localization.copyItemsActionDescription(),
-        null,
         resources.copy());
     this.clipboardManager = clipboardManager;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CutResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/CutResourceAction.java
@@ -57,7 +57,6 @@ public class CutResourceAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.cutItemsActionText(),
         localization.cutItemsActionDescription(),
-        null,
         resources.cut());
     this.clipboardManager = clipboardManager;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/PasteResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/PasteResourceAction.java
@@ -56,7 +56,6 @@ public class PasteResourceAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.pasteItemsActionText(),
         localization.pasteItemsActionDescription(),
-        null,
         resources.paste());
     this.clipboardManager = clipboardManager;
     this.appContext = appContext;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/RevealResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/RevealResourceAction.java
@@ -45,7 +45,7 @@ public class RevealResourceAction extends AbstractPerspectiveAction {
 
   @Inject
   public RevealResourceAction(AppContext appContext, EventBus eventBus) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), "Reveal Resource", null, null, null);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), "Reveal Resource");
     this.appContext = appContext;
     this.eventBus = eventBus;
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/StopWorkspaceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/StopWorkspaceAction.java
@@ -36,12 +36,7 @@ public class StopWorkspaceAction extends AbstractPerspectiveAction {
       CoreLocalizationConstant locale,
       AppContext appContext,
       CurrentWorkspaceManager workspaceManager) {
-    super(
-        singletonList(PROJECT_PERSPECTIVE_ID),
-        locale.stopWsTitle(),
-        locale.stopWsDescription(),
-        null,
-        null);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), locale.stopWsTitle(), locale.stopWsDescription());
     this.appContext = appContext;
     this.workspaceManager = workspaceManager;
   }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/keybinding/KeyBindingManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/keybinding/KeyBindingManagerTest.java
@@ -34,7 +34,7 @@ public class KeyBindingManagerTest {
 
   @Before
   public void setUp() {
-    keyManager = new KeyBindingManager(null, null);
+    keyManager = new KeyBindingManager(null);
     testScheme = new SchemeImpl("org.eclipse.che.test.scheme", "Sample Description");
   }
 

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenterTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenterTest.java
@@ -40,6 +40,7 @@ import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.ide.actions.EditorActions;
 import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.AbstractEditorPresenter;
@@ -147,7 +148,7 @@ public class EditorPartStackPresenterTest {
     when(partPresenter3.getEditorInput()).thenReturn(editorInput3);
     when(editorInput3.getFile()).thenReturn(file3);
 
-    when(presentationFactory.getPresentation(nullable(Action.class))).thenReturn(presentation);
+    when(presentationFactory.getPresentation(nullable(BaseAction.class))).thenReturn(presentation);
 
     when(eventBus.addHandler(any(), any())).thenReturn(handlerRegistration);
 
@@ -197,7 +198,7 @@ public class EditorPartStackPresenterTest {
   public void constructorShouldBeVerified() {
     verify(view, times(2)).setDelegate(presenter);
     verify(view).addPaneMenuButton(editorPaneMenu);
-    verify(editorPaneMenuItemFactory, times(4)).createMenuItem(Matchers.<Action>anyObject());
+    verify(editorPaneMenuItemFactory, times(4)).createMenuItem(Matchers.<BaseAction>anyObject());
     verify(editorPaneMenu).addItem(Matchers.<PaneMenuActionItemWidget>anyObject(), eq(true));
     verify(editorPaneMenu, times(3)).addItem(Matchers.<PaneMenuActionItemWidget>anyObject());
   }
@@ -418,7 +419,7 @@ public class EditorPartStackPresenterTest {
 
   @Test
   public void onActionClickedTest() {
-    Action action = mock(Action.class);
+    Action action = mock(BaseAction.class);
     when(editorPaneActionMenuItem.getData()).thenReturn(action);
     presenter.addPart(partPresenter1);
     presenter.setActivePart(partPresenter1);

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/ElementWidget.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/ElementWidget.java
@@ -8,16 +8,19 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.plugin.debugger.ide.configuration;
+package org.eclipse.che.ide.ui;
 
-import org.eclipse.che.ide.api.action.BaseAction;
-import org.eclipse.che.ide.api.debug.DebugConfiguration;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
- * Factory for creating instances of {@link DebugConfigurationAction}.
+ * Simple wrapper to create GWT Widget from DOM Elemen
  *
- * @author Artem Zatsarynnyi
+ * @author Evgen Vidolob
  */
-public interface DebugConfigurationActionFactory {
-  BaseAction createAction(DebugConfiguration configuration);
+public class ElementWidget extends Widget {
+
+  public ElementWidget(Element element) {
+    setElement(element);
+  }
 }

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/ClosePaneAction.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/ClosePaneAction.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.ide.ui.multisplitpanel.actions;
 
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 import org.eclipse.che.ide.ui.multisplitpanel.WidgetToShow;
 
@@ -20,12 +20,12 @@ import org.eclipse.che.ide.ui.multisplitpanel.WidgetToShow;
  *
  * @author Artem Zatsarynnyi
  */
-public class ClosePaneAction extends Action {
+public class ClosePaneAction extends BaseAction {
 
   private final SubPanel subPanel;
 
   public ClosePaneAction(SubPanel subPanel) {
-    super("Close Pane", "Close Pane", null, null);
+    super("Close Pane", "Close Pane");
     this.subPanel = subPanel;
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/RemoveAllWidgetsInPaneAction.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/RemoveAllWidgetsInPaneAction.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.ide.ui.multisplitpanel.actions;
 
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 import org.eclipse.che.ide.ui.multisplitpanel.WidgetToShow;
 
@@ -20,12 +20,12 @@ import org.eclipse.che.ide.ui.multisplitpanel.WidgetToShow;
  *
  * @author Artem Zatsarynnyi
  */
-public class RemoveAllWidgetsInPaneAction extends Action {
+public class RemoveAllWidgetsInPaneAction extends BaseAction {
 
   private final SubPanel subPanel;
 
   public RemoveAllWidgetsInPaneAction(SubPanel subPanel) {
-    super("Close All Tabs In Pane", "Close All Tabs In Pane", null, null);
+    super("Close All Tabs In Pane", "Close All Tabs In Pane");
     this.subPanel = subPanel;
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/SplitHorizontallyAction.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/SplitHorizontallyAction.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.ide.ui.multisplitpanel.actions;
 
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 
 /**
@@ -19,12 +19,12 @@ import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
  *
  * @author Artem Zatsarynnyi
  */
-public class SplitHorizontallyAction extends Action {
+public class SplitHorizontallyAction extends BaseAction {
 
   private final SubPanel subPanel;
 
   public SplitHorizontallyAction(SubPanel subPanel) {
-    super("Split Pane In Two Rows", "Split Pane In Two Rows", null, null);
+    super("Split Pane In Two Rows", "Split Pane In Two Rows");
     this.subPanel = subPanel;
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/SplitVerticallyAction.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/actions/SplitVerticallyAction.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.ide.ui.multisplitpanel.actions;
 
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 
 /**
@@ -19,12 +19,12 @@ import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
  *
  * @author Artem Zatsarynnyi
  */
-public class SplitVerticallyAction extends Action {
+public class SplitVerticallyAction extends BaseAction {
 
   private final SubPanel subPanel;
 
   public SplitVerticallyAction(SubPanel subPanel) {
-    super("Split Pane In Two Columns", "Split Pane In Two Columns", null, null);
+    super("Split Pane In Two Columns", "Split Pane In Two Columns");
     this.subPanel = subPanel;
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/menu/MenuItemActionWidget.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/menu/MenuItemActionWidget.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.ide.ui.multisplitpanel.menu;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -20,8 +21,7 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 import org.eclipse.che.ide.api.action.Action;
-import org.vectomatic.dom.svg.ui.SVGImage;
-import org.vectomatic.dom.svg.ui.SVGResource;
+import org.eclipse.che.ide.ui.ElementWidget;
 
 /**
  * Implementation of {@link MenuItem} that represents {@link Action}.
@@ -43,9 +43,9 @@ public class MenuItemActionWidget extends Composite implements MenuItem<Action> 
     initWidget(UI_BINDER.createAndBindUi(this));
     this.action = action;
 
-    final SVGResource actionIcon = action.getTemplatePresentation().getSVGResource();
+    final Element actionIcon = action.getTemplatePresentation().getImageElement();
     if (actionIcon != null) {
-      iconPanel.add(new SVGImage(actionIcon));
+      iconPanel.add(new ElementWidget(actionIcon));
     }
 
     title.setText(action.getTemplatePresentation().getText());

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/panel/SubPanelViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/panel/SubPanelViewImpl.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.FontAwesome;
 import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ui.multisplitpanel.SubPanel;
 import org.eclipse.che.ide.ui.multisplitpanel.WidgetToShow;
 import org.eclipse.che.ide.ui.multisplitpanel.actions.ClosePaneAction;
@@ -335,7 +336,7 @@ public class SubPanelViewImpl extends Composite
         activateWidget(widget);
         delegate.onWidgetFocused(widget.getWidget());
       }
-    } else if (data instanceof Action) {
+    } else if (data instanceof BaseAction) {
       ((Action) data).actionPerformed(null);
     }
   }

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/ActionButton.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/ActionButton.java
@@ -22,7 +22,6 @@ import com.google.gwt.event.dom.client.MouseUpEvent;
 import com.google.gwt.event.dom.client.MouseUpHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Image;
 import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionGroup;
@@ -31,10 +30,9 @@ import org.eclipse.che.ide.api.action.CustomComponentAction;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.action.PropertyChangeEvent;
 import org.eclipse.che.ide.api.action.PropertyChangeListener;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
+import org.eclipse.che.ide.ui.ElementWidget;
 import org.eclipse.che.ide.ui.Tooltip;
 import org.eclipse.che.ide.ui.menu.PositionController;
-import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * Toolbar image button.
@@ -45,7 +43,6 @@ public class ActionButton extends Composite
     implements MouseOverHandler, MouseOutHandler, MouseDownHandler, MouseUpHandler, ClickHandler {
 
   private final Presentation presentation;
-  private final PerspectiveManager perspectiveManager;
 
   /** Command which will be executed when button was pressed. */
   protected Action action;
@@ -69,10 +66,8 @@ public class ActionButton extends Composite
       Action action,
       ActionManager actionManager,
       Presentation presentation,
-      PerspectiveManager perspectiveManager,
       ToolbarResources toolbarResources) {
     this.actionManager = actionManager;
-    this.perspectiveManager = perspectiveManager;
     this.toolbarResources = toolbarResources;
     panel = new FlowPanel();
 
@@ -127,13 +122,8 @@ public class ActionButton extends Composite
   private void renderImage() {
     panel.clear();
 
-    if (presentation.getImageResource() != null) {
-      Image img = new Image(presentation.getImageResource());
-      img.setStyleName(toolbarResources.toolbar().iconButtonIcon());
-      panel.add(img);
-
-    } else if (presentation.getSVGResource() != null) {
-      SVGImage image = new SVGImage(presentation.getSVGResource());
+    if (presentation.getImageElement() != null) {
+      ElementWidget image = new ElementWidget(presentation.getImageElement());
       image.getElement().setAttribute("class", toolbarResources.toolbar().iconButtonIcon());
       panel.add(image);
 
@@ -218,8 +208,8 @@ public class ActionButton extends Composite
       return;
     }
 
-    //todo handle popup group
-    ActionEvent e = new ActionEvent(presentation, actionManager, perspectiveManager);
+    // todo handle popup group
+    ActionEvent e = new ActionEvent(presentation, actionManager);
     if (action instanceof ActionGroup
         && !(action instanceof CustomComponentAction)
         && ((ActionGroup) action).isPopup()) {

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/ActionPopupButton.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/ActionPopupButton.java
@@ -14,7 +14,6 @@ import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.InlineLabel;
 import com.google.inject.Provider;
 import org.eclipse.che.ide.api.action.Action;
@@ -26,9 +25,9 @@ import org.eclipse.che.ide.api.action.PropertyChangeEvent;
 import org.eclipse.che.ide.api.action.PropertyChangeListener;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
+import org.eclipse.che.ide.ui.ElementWidget;
 import org.eclipse.che.ide.ui.Tooltip;
 import org.eclipse.che.ide.ui.menu.PositionController;
-import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * @author Evgen Vidolob
@@ -105,13 +104,8 @@ public class ActionPopupButton extends Composite
   private void renderImage() {
     panel.clear();
 
-    if (presentation.getImageResource() != null) {
-      Image image = new Image(presentationFactory.getPresentation(action).getImageResource());
-      image.setStyleName(toolbarResources.toolbar().popupButtonIcon());
-      panel.add(image);
-
-    } else if (presentation.getSVGResource() != null) {
-      SVGImage image = new SVGImage(presentation.getSVGResource());
+    if (presentation.getImageElement() != null) {
+      ElementWidget image = new ElementWidget(presentation.getImageElement());
       image.getElement().setAttribute("class", toolbarResources.toolbar().popupButtonIcon());
       panel.add(image);
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/PopupMenu.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/PopupMenu.java
@@ -30,7 +30,6 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.UIObject;
@@ -47,6 +46,7 @@ import org.eclipse.che.ide.api.action.Separator;
 import org.eclipse.che.ide.api.action.ToggleAction;
 import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
+import org.eclipse.che.ide.ui.ElementWidget;
 import org.eclipse.che.ide.ui.Tooltip;
 import org.eclipse.che.ide.util.input.KeyMapUtil;
 import org.vectomatic.dom.svg.ui.SVGImage;
@@ -221,8 +221,7 @@ public class PopupMenu extends Composite {
     this.actionSelectedHandler = actionSelectedHandler;
 
     List<Utils.VisibleActionGroup> visibleActionGroupList =
-        Utils.renderActionGroup(
-            actionGroup, presentationFactory, actionManager, managerProvider.get());
+        Utils.renderActionGroup(actionGroup, presentationFactory, actionManager);
 
     list = new ArrayList<>();
     for (Utils.VisibleActionGroup groupActions : visibleActionGroupList) {
@@ -314,13 +313,8 @@ public class PopupMenu extends Composite {
       } else {
         Presentation presentation = presentationFactory.getPresentation(menuItem);
 
-        if (presentation.getImageResource() != null) {
-          Image image = new Image(presentation.getImageResource());
-          table.setWidget(i, 0, image);
-
-        } else if (presentation.getSVGResource() != null) {
-          SVGImage image = new SVGImage(presentation.getSVGResource());
-          table.setWidget(i, 0, image);
+        if (presentation.getImageElement() != null) {
+          table.setWidget(i, 0, new ElementWidget(presentation.getImageElement()));
         } else if (presentation.getHTMLResource() != null) {
           table.setHTML(i, 0, presentation.getHTMLResource());
         }
@@ -338,10 +332,7 @@ public class PopupMenu extends Composite {
           if (menuItem instanceof ToggleAction) {
             ToggleAction toggleAction = (ToggleAction) menuItem;
             ActionEvent e =
-                new ActionEvent(
-                    presentationFactory.getPresentation(toggleAction),
-                    actionManager,
-                    managerProvider.get());
+                new ActionEvent(presentationFactory.getPresentation(toggleAction), actionManager);
 
             if (toggleAction.isSelected(e)) {
               // Temporary solution
@@ -413,10 +404,7 @@ public class PopupMenu extends Composite {
         if (menuItem instanceof ActionGroup
             && !(((ActionGroup) menuItem).canBePerformed()
                 && !Utils.hasVisibleChildren(
-                    (ActionGroup) menuItem,
-                    presentationFactory,
-                    actionManager,
-                    managerProvider.get()))) {
+                    (ActionGroup) menuItem, presentationFactory, actionManager))) {
           table.setWidget(i, work, new SVGImage(POPUP_RESOURCES.subMenu()));
           table
               .getCellFormatter()
@@ -465,9 +453,7 @@ public class PopupMenu extends Composite {
       Action action = list.get(i);
       if (action instanceof ToggleAction) {
 
-        ActionEvent e =
-            new ActionEvent(
-                presentationFactory.getPresentation(action), actionManager, managerProvider.get());
+        ActionEvent e = new ActionEvent(presentationFactory.getPresentation(action), actionManager);
         if (((ToggleAction) action).isSelected(e)) {
           return true;
         }
@@ -521,10 +507,7 @@ public class PopupMenu extends Composite {
     if (menuItem instanceof ActionGroup
         && !(((ActionGroup) menuItem).canBePerformed()
             && !Utils.hasVisibleChildren(
-                (ActionGroup) menuItem,
-                presentationFactory,
-                actionManager,
-                managerProvider.get()))) {
+                (ActionGroup) menuItem, presentationFactory, actionManager))) {
       openSubPopupTimer.schedule(300);
     } else {
       closeSubPopupTimer.cancel();
@@ -547,18 +530,13 @@ public class PopupMenu extends Composite {
     if (menuItem instanceof ActionGroup
         && (!((ActionGroup) menuItem).canBePerformed()
             && Utils.hasVisibleChildren(
-                (ActionGroup) menuItem,
-                presentationFactory,
-                actionManager,
-                managerProvider.get()))) {
+                (ActionGroup) menuItem, presentationFactory, actionManager))) {
       openSubPopup(tr);
     } else {
       if (actionSelectedHandler != null) {
         actionSelectedHandler.onActionSelected(menuItem);
       }
-      ActionEvent e =
-          new ActionEvent(
-              presentationFactory.getPresentation(menuItem), actionManager, managerProvider.get());
+      ActionEvent e = new ActionEvent(presentationFactory.getPresentation(menuItem), actionManager);
       menuItem.actionPerformed(e);
     }
   }

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/ToolbarViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/ToolbarViewImpl.java
@@ -38,30 +38,23 @@ import org.eclipse.che.ide.api.parts.PerspectiveManager;
 public class ToolbarViewImpl extends FlowPanel implements ToolbarView {
 
   public static final int DELAY_MILLIS = 1000;
-
+  private final Timer timer;
   private FlowPanel leftToolbar;
   private FlowPanel centerToolbar;
   private FlowPanel rightToolbar;
-
   private ActionGroup leftActionGroup;
   private ActionGroup centerActionGroup;
   private ActionGroup rightActionGroup;
   private ActionManager actionManager;
   private KeyBindingAgent keyBindingAgent;
-
   private List<Utils.VisibleActionGroup> leftVisibleGroupActions;
   private List<Utils.VisibleActionGroup> centerVisibleGroupActions;
   private List<Utils.VisibleActionGroup> rightVisibleGroupActions;
-
   private Provider<PerspectiveManager> managerProvider;
   private PresentationFactory presentationFactory;
   private boolean addSeparatorFirst;
-
   private ToolbarResources toolbarResources;
-
   private ActionDelegate delegate;
-
-  private final Timer timer;
 
   /** Create view with given instance of resources. */
   @Inject
@@ -133,8 +126,7 @@ public class ToolbarViewImpl extends FlowPanel implements ToolbarView {
   private void updateActions() {
     if (leftActionGroup != null) {
       List<Utils.VisibleActionGroup> newLeftVisibleGroupActions =
-          Utils.renderActionGroup(
-              leftActionGroup, presentationFactory, actionManager, managerProvider.get());
+          Utils.renderActionGroup(leftActionGroup, presentationFactory, actionManager);
       if (newLeftVisibleGroupActions != null
           && !leftVisibleGroupActions.equals(newLeftVisibleGroupActions)) {
         leftVisibleGroupActions = newLeftVisibleGroupActions;
@@ -144,8 +136,7 @@ public class ToolbarViewImpl extends FlowPanel implements ToolbarView {
     }
     if (centerActionGroup != null) {
       List<Utils.VisibleActionGroup> newCenterVisibleGroupActions =
-          Utils.renderActionGroup(
-              centerActionGroup, presentationFactory, actionManager, managerProvider.get());
+          Utils.renderActionGroup(centerActionGroup, presentationFactory, actionManager);
       if (newCenterVisibleGroupActions != null
           && !centerVisibleGroupActions.equals(newCenterVisibleGroupActions)) {
         centerVisibleGroupActions = newCenterVisibleGroupActions;
@@ -155,8 +146,7 @@ public class ToolbarViewImpl extends FlowPanel implements ToolbarView {
     }
     if (rightActionGroup != null) {
       List<Utils.VisibleActionGroup> newRightVisibleGroupActions =
-          Utils.renderActionGroup(
-              rightActionGroup, presentationFactory, actionManager, managerProvider.get());
+          Utils.renderActionGroup(rightActionGroup, presentationFactory, actionManager);
       if (newRightVisibleGroupActions != null
           && !rightVisibleGroupActions.equals(newRightVisibleGroupActions)) {
         rightVisibleGroupActions = newRightVisibleGroupActions;
@@ -236,11 +226,7 @@ public class ToolbarViewImpl extends FlowPanel implements ToolbarView {
    */
   private ActionButton createToolbarButton(Action action) {
     return new ActionButton(
-        action,
-        actionManager,
-        presentationFactory.getPresentation(action),
-        managerProvider.get(),
-        toolbarResources);
+        action, actionManager, presentationFactory.getPresentation(action), toolbarResources);
   }
 
   @Override

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/Utils.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/toolbar/Utils.java
@@ -20,7 +20,6 @@ import org.eclipse.che.ide.api.action.ActionGroup;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.action.Separator;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.util.loging.Log;
 
 /**
@@ -36,16 +35,14 @@ public class Utils {
    * @param group action group
    * @param presentationFactory presentation factory
    * @param actionManager action manager
-   * @param perspectiveManager perspective manager
    * @return list of visible action group
    */
   public static List<VisibleActionGroup> renderActionGroup(
       @NotNull ActionGroup group,
       PresentationFactory presentationFactory,
-      ActionManager actionManager,
-      PerspectiveManager perspectiveManager) {
+      ActionManager actionManager) {
     Presentation presentation = presentationFactory.getPresentation(group);
-    ActionEvent event = new ActionEvent(presentation, actionManager, perspectiveManager);
+    ActionEvent event = new ActionEvent(presentation, actionManager);
 
     if (!presentation.isVisible()) { // don't process invisible groups
       return null;
@@ -62,7 +59,7 @@ public class Utils {
       }
 
       presentation = presentationFactory.getPresentation(child);
-      child.update(new ActionEvent(presentation, actionManager, perspectiveManager));
+      child.update(new ActionEvent(presentation, actionManager));
 
       if (!presentation.isVisible()) { // don't create invisible items in the menu
         continue;
@@ -73,8 +70,7 @@ public class Utils {
         if (actionGroup.isPopup()) { // popup menu has its own presentation
           if (actionGroup.disableIfNoVisibleChildren()) {
             final boolean visibleChildren =
-                hasVisibleChildren(
-                    actionGroup, presentationFactory, actionManager, perspectiveManager);
+                hasVisibleChildren(actionGroup, presentationFactory, actionManager);
             if (actionGroup.hideIfNoVisibleChildren() && !visibleChildren) {
               continue;
             }
@@ -83,8 +79,7 @@ public class Utils {
           currentActionList.add(child);
         } else {
           List<VisibleActionGroup> newVisibleActionGroupList =
-              renderActionGroup(
-                  (ActionGroup) child, presentationFactory, actionManager, perspectiveManager);
+              renderActionGroup((ActionGroup) child, presentationFactory, actionManager);
           currentVisibleActionGroupList.addAll(newVisibleActionGroupList);
         }
       } else if (child instanceof Separator) {
@@ -108,16 +103,11 @@ public class Utils {
    * @param group action group
    * @param factory presentation factory
    * @param actionManager action manager
-   * @param perspectiveManager perspective manager
    * @return boolean
    */
   public static boolean hasVisibleChildren(
-      ActionGroup group,
-      PresentationFactory factory,
-      ActionManager actionManager,
-      PerspectiveManager perspectiveManager) {
-    ActionEvent event =
-        new ActionEvent(factory.getPresentation(group), actionManager, perspectiveManager);
+      ActionGroup group, PresentationFactory factory, ActionManager actionManager) {
+    ActionEvent event = new ActionEvent(factory.getPresentation(group), actionManager);
     for (Action anAction : group.getChildren(event)) {
       if (anAction == null) {
         Log.error(
@@ -130,7 +120,7 @@ public class Utils {
       }
 
       final Presentation presentation = factory.getPresentation(anAction);
-      anAction.update(new ActionEvent(presentation, actionManager, perspectiveManager));
+      anAction.update(new ActionEvent(presentation, actionManager));
       if (anAction instanceof ActionGroup) {
         ActionGroup childGroup = (ActionGroup) anAction;
 
@@ -141,7 +131,7 @@ public class Utils {
           }
         }
 
-        if (hasVisibleChildren(childGroup, factory, actionManager, perspectiveManager)) {
+        if (hasVisibleChildren(childGroup, factory, actionManager)) {
           return true;
         }
       } else if (presentation.isVisible()) {

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/signature/SignatureHelpView.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/signature/SignatureHelpView.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.editor.signature.ParameterInfo;
 import org.eclipse.che.ide.api.editor.signature.SignatureHelp;
 import org.eclipse.che.ide.api.editor.signature.SignatureInfo;
+import org.eclipse.che.ide.ui.ElementWidget;
 import org.eclipse.che.ide.util.Pair;
 import org.eclipse.che.ide.util.dom.Elements;
 

--- a/plugins/plugin-dashboard/che-plugin-ext-dashboard/src/main/java/org/eclipse/che/ide/ext/dashboard/client/RedirectToDashboardAction.java
+++ b/plugins/plugin-dashboard/che-plugin-ext-dashboard/src/main/java/org/eclipse/che/ide/ext/dashboard/client/RedirectToDashboardAction.java
@@ -21,8 +21,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.CustomComponentAction;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.app.AppContext;
@@ -35,7 +35,7 @@ import org.eclipse.che.ide.ui.Tooltip;
  *
  * @author Oleksii Orel
  */
-public class RedirectToDashboardAction extends Action
+public class RedirectToDashboardAction extends BaseAction
     implements CustomComponentAction, WorkspaceRunningEvent.Handler, WorkspaceStoppedEvent.Handler {
 
   private final DashboardLocalizationConstant constant;

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/ChangeVariableValueAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/ChangeVariableValueAction.java
@@ -41,7 +41,6 @@ public class ChangeVariableValueAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.changeVariableValue(),
         locale.changeVariableValueDescription(),
-        null,
         resources.changeVariableValue());
     this.changeValuePresenter = changeValuePresenter;
     this.debuggerPresenter = debuggerPresenter;

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebugAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebugAction.java
@@ -43,7 +43,6 @@ public class DebugAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         localizationConstants.debugActionTitle(),
         localizationConstants.debugActionDescription(),
-        null,
         resources.debug());
     this.localizationConstants = localizationConstants;
     this.configurationsManager = debugConfigurationsManager;

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DeleteAllBreakpointsAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DeleteAllBreakpointsAction.java
@@ -38,7 +38,6 @@ public class DeleteAllBreakpointsAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.deleteAllBreakpoints(),
         locale.deleteAllBreakpointsDescription(),
-        null,
         resources.deleteAllBreakpoints());
     this.breakpointManager = breakpointManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DisconnectDebuggerAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DisconnectDebuggerAction.java
@@ -38,7 +38,6 @@ public class DisconnectDebuggerAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.disconnectDebugger(),
         locale.disconnectDebuggerDescription(),
-        null,
         resources.disconnectDebugger());
     this.debuggerManager = debuggerManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/EditConfigurationsAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/EditConfigurationsAction.java
@@ -40,7 +40,6 @@ public class EditConfigurationsAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         localizationConstant.editDebugConfigurationsActionTitle(),
         localizationConstant.editDebugConfigurationsActionDescription(),
-        null,
         resources.editCommands());
     this.editCommandsPresenter = editDebugConfigurationsPresenter;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/EvaluateExpressionAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/EvaluateExpressionAction.java
@@ -44,7 +44,6 @@ public class EvaluateExpressionAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.evaluateExpression(),
         locale.evaluateExpressionDescription(),
-        null,
         resources.evaluateExpression());
     this.debuggerManager = debuggerManager;
     this.evaluateExpressionPresenter = evaluateExpressionPresenter;

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/ResumeExecutionAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/ResumeExecutionAction.java
@@ -39,7 +39,6 @@ public class ResumeExecutionAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.resumeExecution(),
         locale.resumeExecutionDescription(),
-        null,
         resources.resumeExecution());
     this.debuggerManager = debuggerManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/ShowHideDebuggerPanelAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/ShowHideDebuggerPanelAction.java
@@ -11,8 +11,8 @@
 package org.eclipse.che.plugin.debugger.ide.actions;
 
 import com.google.inject.Inject;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
 import org.eclipse.che.plugin.debugger.ide.debug.DebuggerPresenter;
 
@@ -21,14 +21,14 @@ import org.eclipse.che.plugin.debugger.ide.debug.DebuggerPresenter;
  *
  * @author Mykola Morhun
  */
-public class ShowHideDebuggerPanelAction extends Action {
+public class ShowHideDebuggerPanelAction extends BaseAction {
 
   private final DebuggerPresenter debuggerPresenter;
 
   @Inject
   public ShowHideDebuggerPanelAction(
       DebuggerPresenter debuggerPresenter, DebuggerLocalizationConstant locale) {
-    super(locale.showHideDebuggerPanel(), locale.showHideDebuggerPanelDescription(), null, null);
+    super(locale.showHideDebuggerPanel(), locale.showHideDebuggerPanelDescription());
 
     this.debuggerPresenter = debuggerPresenter;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/StepIntoAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/StepIntoAction.java
@@ -39,7 +39,6 @@ public class StepIntoAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.stepInto(),
         locale.stepIntoDescription(),
-        null,
         resources.stepInto());
     this.debuggerManager = debuggerManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/StepOutAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/StepOutAction.java
@@ -39,7 +39,6 @@ public class StepOutAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.stepOut(),
         locale.stepOutDescription(),
-        null,
         resources.stepOut());
     this.debuggerManager = debuggerManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/StepOverAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/StepOverAction.java
@@ -39,7 +39,6 @@ public class StepOverAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.stepOver(),
         locale.stepOverDescription(),
-        null,
         resources.stepOver());
     this.debuggerManager = debuggerManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/SuspendAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/SuspendAction.java
@@ -37,8 +37,6 @@ public class SuspendAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         locale.suspend(),
         locale.suspendDescription(),
-        null,
-        null,
         FontAwesome.PAUSE);
     this.debuggerManager = debuggerManager;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/configuration/DebugConfigurationAction.java
@@ -40,9 +40,7 @@ public class DebugConfigurationAction extends AbstractPerspectiveAction {
     super(
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         configuration.getName(),
-        localizationConstants.debugConfigurationActionDescription(),
-        null,
-        null);
+        localizationConstants.debugConfigurationActionDescription());
     configurationsManager = debugConfigurationsManager;
     this.configuration = configuration;
   }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/inject/DebuggerGinModule.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/inject/DebuggerGinModule.java
@@ -13,7 +13,7 @@ package org.eclipse.che.plugin.debugger.ide.inject;
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
 import com.google.inject.Singleton;
-import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.debug.DebugConfigurationsManager;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 import org.eclipse.che.ide.ui.toolbar.ToolbarPresenter;
@@ -57,7 +57,7 @@ public class DebuggerGinModule extends AbstractGinModule {
         .in(Singleton.class);
     install(
         new GinFactoryModuleBuilder()
-            .implement(Action.class, DebugConfigurationAction.class)
+            .implement(BaseAction.class, DebugConfigurationAction.class)
             .build(DebugConfigurationActionFactory.class));
 
     bind(ToolbarPresenter.class)

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitExtension.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitExtension.java
@@ -44,6 +44,7 @@ import org.eclipse.che.ide.ext.git.client.action.ShowBranchesAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowMergeAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowRemoteAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowStatusAction;
+import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * Extension add Git support to the IDE Application.
@@ -149,7 +150,9 @@ public class GitExtension {
     commandGroup.add(showMergeAction);
     DefaultActionGroup remoteGroup =
         new DefaultActionGroup(constant.remotesControlTitle(), true, actionManager);
-    remoteGroup.getTemplatePresentation().setSVGResource(resources.remote());
+    remoteGroup
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.remote()).getElement());
     actionManager.registerAction("gitRemoteGroup", remoteGroup);
     commandGroup.add(remoteGroup);
     actionManager.registerAction("gitResetFiles", resetFilesAction);

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithBranchAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithBranchAction.java
@@ -34,7 +34,7 @@ public class CompareWithBranchAction extends GitAction {
   @Inject
   public CompareWithBranchAction(
       BranchListPresenter presenter, AppContext appContext, GitLocalizationConstant locale) {
-    super(locale.compareWithBranchTitle(), locale.compareWithBranchTitle(), null, appContext);
+    super(locale.compareWithBranchTitle(), locale.compareWithBranchTitle(), appContext);
     this.presenter = presenter;
   }
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithLatestAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithLatestAction.java
@@ -56,7 +56,7 @@ public class CompareWithLatestAction extends GitAction {
       NotificationManager notificationManager,
       GitServiceClient service,
       GitLocalizationConstant constant) {
-    super(constant.compareWithLatestTitle(), constant.compareWithLatestTitle(), null, appContext);
+    super(constant.compareWithLatestTitle(), constant.compareWithLatestTitle(), appContext);
     this.comparePresenter = presenter;
     this.changesListPresenter = changesListPresenter;
     this.dialogFactory = dialogFactory;

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithRevisionAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/CompareWithRevisionAction.java
@@ -37,7 +37,7 @@ public class CompareWithRevisionAction extends GitAction {
   @Inject
   public CompareWithRevisionAction(
       RevisionListPresenter presenter, AppContext appContext, GitLocalizationConstant locale) {
-    super(locale.compareWithRevisionTitle(), locale.compareWithRevisionTitle(), null, appContext);
+    super(locale.compareWithRevisionTitle(), locale.compareWithRevisionTitle(), appContext);
     this.presenter = presenter;
   }
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/GitAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/GitAction.java
@@ -13,7 +13,6 @@ package org.eclipse.che.ide.ext.git.client.action;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
-import com.google.gwt.resources.client.ImageResource;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
@@ -31,14 +30,18 @@ public abstract class GitAction extends AbstractPerspectiveAction {
 
   protected final AppContext appContext;
 
-  public GitAction(String title, String description, Object icon, AppContext appContext) {
-    super(
-        singletonList(PROJECT_PERSPECTIVE_ID),
-        title,
-        description,
-        icon instanceof ImageResource ? (ImageResource) icon : null,
-        icon instanceof SVGResource ? (SVGResource) icon : null,
-        icon instanceof String ? String.valueOf(icon) : null);
+  public GitAction(String title, String description, SVGResource icon, AppContext appContext) {
+    super(singletonList(PROJECT_PERSPECTIVE_ID), title, description, icon);
+    this.appContext = appContext;
+  }
+
+  public GitAction(String title, String description, String icon, AppContext appContext) {
+    super(singletonList(PROJECT_PERSPECTIVE_ID), title, description, icon);
+    this.appContext = appContext;
+  }
+
+  public GitAction(String title, String description, AppContext appContext) {
+    super(singletonList(PROJECT_PERSPECTIVE_ID), title, description);
     this.appContext = appContext;
   }
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/NextDiffAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/NextDiffAction.java
@@ -12,13 +12,13 @@ package org.eclipse.che.ide.ext.git.client.action;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ext.git.client.compare.ComparePresenter;
 
 /** @author Mykola Morhun */
 @Singleton
-public class NextDiffAction extends Action {
+public class NextDiffAction extends BaseAction {
 
   private final ComparePresenter comparePresenter;
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/PreviousDiffAction.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/PreviousDiffAction.java
@@ -12,13 +12,13 @@ package org.eclipse.che.ide.ext.git.client.action;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ext.git.client.compare.ComparePresenter;
 
 /** @author Mykola Morhun */
 @Singleton
-public class PreviousDiffAction extends Action {
+public class PreviousDiffAction extends BaseAction {
 
   private final ComparePresenter comparePresenter;
 

--- a/plugins/plugin-help/che-plugin-help-ext-client/src/main/java/org/eclipse/che/ide/ext/help/client/RedirectToSupportAction.java
+++ b/plugins/plugin-help/che-plugin-help-ext-client/src/main/java/org/eclipse/che/ide/ext/help/client/RedirectToSupportAction.java
@@ -15,8 +15,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.ide.api.ProductInfoDataProvider;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.util.browser.BrowserUtils;
 
 /**
@@ -26,7 +26,7 @@ import org.eclipse.che.ide.util.browser.BrowserUtils;
  * @author Alexander Andrienko
  */
 @Singleton
-public class RedirectToSupportAction extends Action {
+public class RedirectToSupportAction extends BaseAction {
   private final ProductInfoDataProvider productInfoDataProvider;
 
   @Inject
@@ -37,7 +37,6 @@ public class RedirectToSupportAction extends Action {
     super(
         productInfoDataProvider.getSupportTitle(),
         locale.actionRedirectToSupportDescription(),
-        null,
         resources.getSupport());
     this.productInfoDataProvider = productInfoDataProvider;
   }

--- a/plugins/plugin-help/che-plugin-help-ext-client/src/main/java/org/eclipse/che/ide/ext/help/client/about/ShowAboutAction.java
+++ b/plugins/plugin-help/che-plugin-help-ext-client/src/main/java/org/eclipse/che/ide/ext/help/client/about/ShowAboutAction.java
@@ -12,8 +12,8 @@ package org.eclipse.che.ide.ext.help.client.about;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.ext.help.client.AboutResources;
 
 /**
@@ -22,14 +22,14 @@ import org.eclipse.che.ide.ext.help.client.AboutResources;
  * @author Ann Shumilova
  */
 @Singleton
-public class ShowAboutAction extends Action {
+public class ShowAboutAction extends BaseAction {
 
   private final AboutPresenter presenter;
 
   @Inject
   public ShowAboutAction(
       AboutPresenter presenter, AboutLocalizationConstant locale, AboutResources resources) {
-    super(locale.aboutControlTitle(), "Show about application", null, resources.about());
+    super(locale.aboutControlTitle(), "Show about application", resources.about());
     this.presenter = presenter;
   }
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/MarkDirAsSourceAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/MarkDirAsSourceAction.java
@@ -62,7 +62,6 @@ public class MarkDirAsSourceAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.markDirectoryAsSourceAction(),
         locale.markDirectoryAsSourceDescription(),
-        null,
         javaResources.sourceFolder());
 
     this.appContext = appContext;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/ProjectClasspathAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/ProjectClasspathAction.java
@@ -45,9 +45,7 @@ public class ProjectClasspathAction extends AbstractPerspectiveAction {
     super(
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         localization.projectClasspathTitle(),
-        localization.projectClasspathDescriptions(),
-        null,
-        null);
+        localization.projectClasspathDescriptions());
     this.projectClasspathPresenter = projectClasspathPresenter;
     this.appContext = appContext;
   }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/UnmarkDirAsSourceAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/UnmarkDirAsSourceAction.java
@@ -62,7 +62,6 @@ public class UnmarkDirAsSourceAction extends AbstractPerspectiveAction {
         singletonList(PROJECT_PERSPECTIVE_ID),
         locale.unmarkDirectoryAsSourceAction(),
         locale.unmarkDirectoryAsSourceDescription(),
-        null,
         javaResources.sourceFolder());
 
     this.appContext = appContext;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/CutJavaSourceAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/CutJavaSourceAction.java
@@ -17,8 +17,8 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.filetypes.FileTypeRegistry;
@@ -39,7 +39,7 @@ import org.eclipse.che.ide.ext.java.client.resource.SourceFolderMarker;
  * @author Valeriy Svydenko
  */
 @Singleton
-public class CutJavaSourceAction extends Action implements ActivePartChangedHandler {
+public class CutJavaSourceAction extends BaseAction implements ActivePartChangedHandler {
   private final MoveAction moveAction;
   private final FileTypeRegistry fileTypeRegistry;
   private final AppContext appContext;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyTextEditAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyTextEditAction.java
@@ -15,8 +15,8 @@ import com.google.inject.Singleton;
 import java.util.Comparator;
 import java.util.List;
 import org.eclipse.che.api.languageserver.shared.util.RangeComparator;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.document.Document;
@@ -32,7 +32,7 @@ import org.eclipse.lsp4j.TextEdit;
  * @author Thomas Mäder
  */
 @Singleton
-public class ApplyTextEditAction extends Action {
+public class ApplyTextEditAction extends BaseAction {
   private static final Comparator<TextEdit> COMPARATOR =
       RangeComparator.transform(new RangeComparator().reversed(), TextEdit::getRange);
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
@@ -28,8 +28,8 @@ import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.api.promises.client.js.Executor;
 import org.eclipse.che.api.promises.client.js.RejectFunction;
 import org.eclipse.che.api.promises.client.js.ResolveFunction;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.document.Document;
@@ -52,7 +52,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 @Singleton
-public class ApplyWorkspaceEditAction extends Action {
+public class ApplyWorkspaceEditAction extends BaseAction {
   private static final Comparator<TextEdit> COMPARATOR =
       RangeComparator.transform(new RangeComparator().reversed(), TextEdit::getRange);
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/LanguageServerQuickAssistProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/LanguageServerQuickAssistProcessor.java
@@ -34,7 +34,6 @@ import org.eclipse.che.ide.api.editor.text.LinearRange;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.editor.text.annotation.Annotation;
 import org.eclipse.che.ide.api.icon.Icon;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.plugin.languageserver.ide.editor.DiagnosticAnnotation;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 import org.eclipse.lsp4j.CodeActionContext;
@@ -54,62 +53,12 @@ public class LanguageServerQuickAssistProcessor implements QuickAssistProcessor 
 
   private TextDocumentServiceClient textDocumentService;
   private ActionManager actionManager;
-  private PerspectiveManager perspectiveManager;
-
-  private final class ActionCompletionProposal implements CompletionProposal {
-    private final Command command;
-    private final Action action;
-
-    private ActionCompletionProposal(Command command, Action action) {
-      this.command = command;
-      this.action = action;
-    }
-
-    @Override
-    public void getAdditionalProposalInfo(AsyncCallback<Widget> callback) {}
-
-    @Override
-    public String getDisplayString() {
-      return command.getTitle();
-    }
-
-    @Override
-    public Icon getIcon() {
-      return null;
-    }
-
-    @Override
-    public void getCompletion(CompletionCallback callback) {
-      callback.onCompletion(
-          new Completion() {
-
-            @Override
-            public LinearRange getSelection(Document document) {
-              return null;
-            }
-
-            @Override
-            public void apply(Document document) {
-              QuickassistActionEvent evt =
-                  new QuickassistActionEvent(
-                      new Presentation(),
-                      actionManager,
-                      perspectiveManager,
-                      command.getArguments());
-              action.actionPerformed(evt);
-            }
-          });
-    }
-  }
 
   @Inject
   public LanguageServerQuickAssistProcessor(
-      TextDocumentServiceClient textDocumentService,
-      ActionManager actionManager,
-      PerspectiveManager perspectiveManager) {
+      TextDocumentServiceClient textDocumentService, ActionManager actionManager) {
     this.textDocumentService = textDocumentService;
     this.actionManager = actionManager;
-    this.perspectiveManager = perspectiveManager;
   }
 
   @Override
@@ -174,5 +123,48 @@ public class LanguageServerQuickAssistProcessor implements QuickAssistProcessor 
             .withCallback(annotationCallback)
             .build();
     document.getDocumentHandle().getDocEventBus().fireEvent(event);
+  }
+
+  private final class ActionCompletionProposal implements CompletionProposal {
+    private final Command command;
+    private final Action action;
+
+    private ActionCompletionProposal(Command command, Action action) {
+      this.command = command;
+      this.action = action;
+    }
+
+    @Override
+    public void getAdditionalProposalInfo(AsyncCallback<Widget> callback) {}
+
+    @Override
+    public String getDisplayString() {
+      return command.getTitle();
+    }
+
+    @Override
+    public Icon getIcon() {
+      return null;
+    }
+
+    @Override
+    public void getCompletion(CompletionCallback callback) {
+      callback.onCompletion(
+          new Completion() {
+
+            @Override
+            public LinearRange getSelection(Document document) {
+              return null;
+            }
+
+            @Override
+            public void apply(Document document) {
+              QuickassistActionEvent evt =
+                  new QuickassistActionEvent(
+                      new Presentation(), actionManager, command.getArguments());
+              action.actionPerformed(evt);
+            }
+          });
+    }
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/QuickassistActionEvent.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/QuickassistActionEvent.java
@@ -14,7 +14,6 @@ import java.util.List;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.action.Presentation;
-import org.eclipse.che.ide.api.parts.PerspectiveManager;
 
 /**
  * An extension of {@link ActionEvent} to pass command paramenters as a list of Objects to the
@@ -27,11 +26,8 @@ public class QuickassistActionEvent extends ActionEvent {
   private List<Object> arguments;
 
   public QuickassistActionEvent(
-      Presentation presentation,
-      ActionManager actionManager,
-      PerspectiveManager perspectiveManager,
-      List<Object> arguments) {
-    super(presentation, actionManager, perspectiveManager);
+      Presentation presentation, ActionManager actionManager, List<Object> arguments) {
+    super(presentation, actionManager);
     this.arguments = arguments;
   }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/declaration/FindDefinitionAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/declaration/FindDefinitionAction.java
@@ -48,7 +48,7 @@ public class FindDefinitionAction extends AbstractPerspectiveAction {
       OpenLocationPresenterFactory presenterFactory,
       TextDocumentServiceClient client,
       DtoBuildHelper dtoBuildHelper) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), "Find Definition", "Find Definition", null, null);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), "Find Definition", "Find Definition");
     this.editorAgent = editorAgent;
     this.client = client;
     this.dtoBuildHelper = dtoBuildHelper;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/references/FindReferencesAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/references/FindReferencesAction.java
@@ -49,7 +49,7 @@ public class FindReferencesAction extends AbstractPerspectiveAction {
       OpenLocationPresenterFactory presenterFactory,
       TextDocumentServiceClient client,
       DtoFactory dtoFactory) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), "Find References", "Find References", null, null);
+    super(singletonList(PROJECT_PERSPECTIVE_ID), "Find References", "Find References");
     this.editorAgent = editorAgent;
     this.client = client;
     this.dtoFactory = dtoFactory;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/symbol/GoToSymbolAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/symbol/GoToSymbolAction.java
@@ -85,9 +85,7 @@ public class GoToSymbolAction extends AbstractPerspectiveAction
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.goToSymbolActionDescription(),
-        localization.goToSymbolActionTitle(),
-        null,
-        null);
+        localization.goToSymbolActionTitle());
     this.presenter = presenter;
     this.localization = localization;
     this.client = client;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/workspace/FindSymbolAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/workspace/FindSymbolAction.java
@@ -85,9 +85,7 @@ public class FindSymbolAction extends AbstractPerspectiveAction
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         localization.findSymbolActionTitle(),
-        localization.findSymbolActionTitle(),
-        null,
-        null);
+        localization.findSymbolActionTitle());
     this.editorHelper = editorHelper;
     this.presenter = presenter;
     this.workspaceServiceClient = workspaceServiceClient;

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenExtension.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/MavenExtension.java
@@ -35,6 +35,7 @@ import org.eclipse.che.plugin.maven.client.editor.ClassFileSourcesDownloader;
 import org.eclipse.che.plugin.maven.client.project.MavenModelImporter;
 import org.eclipse.che.plugin.maven.client.project.ResolvingMavenProjectStateHolder;
 import org.eclipse.che.plugin.maven.shared.MavenAttributes;
+import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * Maven extension entry point.
@@ -92,7 +93,9 @@ public class MavenExtension {
     DefaultActionGroup mavenContextMenuGroup =
         new DefaultActionGroup(MAVEN_GROUP_CONTEXT_MENU_NAME, true, actionManager);
     actionManager.registerAction(MAVEN_GROUP_CONTEXT_MENU_ID, mavenContextMenuGroup);
-    mavenContextMenuGroup.getTemplatePresentation().setSVGResource(resources.maven());
+    mavenContextMenuGroup
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.maven()).getElement());
 
     // add maven context menu to main context menu
     DefaultActionGroup mainContextMenuGroup =

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/actions/GetEffectivePomAction.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/actions/GetEffectivePomAction.java
@@ -61,7 +61,6 @@ public class GetEffectivePomAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         constant.actionGetEffectivePomTitle(),
         constant.actionGetEffectivePomDescription(),
-        null,
         mavenResources.maven());
     this.editorAgent = editorAgent;
     this.notificationManager = notificationManager;

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/actions/ReimportMavenDependenciesAction.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/actions/ReimportMavenDependenciesAction.java
@@ -60,7 +60,6 @@ public class ReimportMavenDependenciesAction extends AbstractPerspectiveAction {
         Collections.singletonList(PROJECT_PERSPECTIVE_ID),
         constant.actionReimportDependenciesTitle(),
         constant.actionReimportDependenciesDescription(),
-        null,
         resources.refresh());
     this.appContext = appContext;
     this.notificationManager = notificationManager;

--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/progressor/background/DependencyResolverAction.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/comunnication/progressor/background/DependencyResolverAction.java
@@ -13,8 +13,8 @@ package org.eclipse.che.plugin.maven.client.comunnication.progressor.background;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.CustomComponentAction;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.plugin.maven.client.MavenLocalizationConstant;
@@ -25,7 +25,7 @@ import org.eclipse.che.plugin.maven.client.MavenLocalizationConstant;
  * @author Valeriy Svydenko
  */
 @Singleton
-public class DependencyResolverAction extends Action implements CustomComponentAction {
+public class DependencyResolverAction extends BaseAction implements CustomComponentAction {
   private final BackgroundLoaderPresenter dependencyResolver;
 
   @Inject

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/JUnitTestActionGroup.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/JUnitTestActionGroup.java
@@ -13,7 +13,6 @@ package org.eclipse.che.plugin.testing.junit.ide.action;
 import com.google.inject.Inject;
 import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionManager;
-import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.plugin.testing.ide.action.TestAction;
 

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/JUnitTestActionGroup.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/JUnitTestActionGroup.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.plugin.testing.junit.ide.action;
 
 import com.google.inject.Inject;
+import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
@@ -20,8 +21,8 @@ import org.eclipse.che.plugin.testing.ide.action.TestAction;
 public class JUnitTestActionGroup implements TestAction {
   public static final String TEST_ACTION_RUN = "TestJUnitActionRun";
   public static final String TEST_ACTION_DEBUG = "TestJUnitActionDebug";
-  private final BaseAction runTestAction;
-  private final BaseAction debugTestAction;
+  private final Action runTestAction;
+  private final Action debugTestAction;
 
   @Inject
   public JUnitTestActionGroup(

--- a/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/JUnitTestActionGroup.java
+++ b/plugins/plugin-testing-java/plugin-testing-junit/che-plugin-testing-junit-ide/src/main/java/org/eclipse/che/plugin/testing/junit/ide/action/JUnitTestActionGroup.java
@@ -11,8 +11,8 @@
 package org.eclipse.che.plugin.testing.junit.ide.action;
 
 import com.google.inject.Inject;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.plugin.testing.ide.action.TestAction;
 
@@ -20,8 +20,8 @@ import org.eclipse.che.plugin.testing.ide.action.TestAction;
 public class JUnitTestActionGroup implements TestAction {
   public static final String TEST_ACTION_RUN = "TestJUnitActionRun";
   public static final String TEST_ACTION_DEBUG = "TestJUnitActionDebug";
-  private final Action runTestAction;
-  private final Action debugTestAction;
+  private final BaseAction runTestAction;
+  private final BaseAction debugTestAction;
 
   @Inject
   public JUnitTestActionGroup(

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/TestNgTestAction.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-ide/src/main/java/org/eclipse/che/plugin/testing/testng/ide/TestNgTestAction.java
@@ -11,8 +11,8 @@
 package org.eclipse.che.plugin.testing.testng.ide;
 
 import com.google.inject.Inject;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.plugin.testing.ide.action.TestAction;
 import org.eclipse.che.plugin.testing.testng.ide.action.DebugTestNgTestAction;
@@ -23,8 +23,8 @@ public class TestNgTestAction implements TestAction {
   public static final String TEST_ACTION_RUN = "TestNgActionRun";
   public static final String TEST_ACTION_DEBUG = "TestNgActionDebug";
 
-  private final Action runTestAction;
-  private final Action debugTestAction;
+  private final BaseAction runTestAction;
+  private final BaseAction debugTestAction;
 
   @Inject
   public TestNgTestAction(

--- a/plugins/plugin-testing-php/plugin-testing-phpunit/che-plugin-testing-phpunit-ide/src/main/java/org/eclipse/che/plugin/testing/phpunit/ide/action/PHPUnitTestActionGroup.java
+++ b/plugins/plugin-testing-php/plugin-testing-phpunit/che-plugin-testing-phpunit-ide/src/main/java/org/eclipse/che/plugin/testing/phpunit/ide/action/PHPUnitTestActionGroup.java
@@ -10,8 +10,8 @@
 package org.eclipse.che.plugin.testing.phpunit.ide.action;
 
 import com.google.inject.Inject;
-import org.eclipse.che.ide.api.action.Action;
 import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.BaseAction;
 import org.eclipse.che.ide.api.action.DefaultActionGroup;
 import org.eclipse.che.plugin.testing.ide.action.TestAction;
 
@@ -22,7 +22,7 @@ import org.eclipse.che.plugin.testing.ide.action.TestAction;
  */
 public class PHPUnitTestActionGroup implements TestAction {
 
-  private final Action runScriptTestAction;
+  private final BaseAction runScriptTestAction;
 
   @Inject
   public PHPUnitTestActionGroup(

--- a/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/action/RunDebugTestAbstractAction.java
+++ b/plugins/plugin-testing/che-plugin-testing-ide/src/main/java/org/eclipse/che/plugin/testing/ide/action/RunDebugTestAbstractAction.java
@@ -73,7 +73,7 @@ public abstract class RunDebugTestAbstractAction extends AbstractPerspectiveActi
       @NotNull String description,
       @NotNull String text,
       SVGResource icon) {
-    super(perspectives, text, description, null, icon);
+    super(perspectives, text, description, icon);
     this.testDetector = testDetector;
     this.testResultPresenter = testResultPresenter;
     this.testingHandler = testingHandler;

--- a/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/WebExtension.java
+++ b/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/WebExtension.java
@@ -32,6 +32,7 @@ import org.eclipse.che.ide.ext.web.html.PreviewHTMLAction;
 import org.eclipse.che.ide.ext.web.html.editor.HtmlEditorProvider;
 import org.eclipse.che.ide.ext.web.js.NewJavaScriptFileAction;
 import org.eclipse.che.ide.ext.web.js.editor.JsEditorProvider;
+import org.vectomatic.dom.svg.ui.SVGImage;
 
 /**
  * Extension add editing JavaScript, HTML, CSS css type support to the IDE Application. It provides
@@ -105,10 +106,18 @@ public class WebExtension {
     actionManager.registerAction("previewHTML", previewHTMLAction);
 
     // set icons
-    newCssFileAction.getTemplatePresentation().setSVGResource(resources.cssFile());
-    newLessFileAction.getTemplatePresentation().setSVGResource(resources.lessFile());
-    newHtmlFileAction.getTemplatePresentation().setSVGResource(resources.htmlFile());
-    newJavaScriptFileAction.getTemplatePresentation().setSVGResource(resources.jsFile());
+    newCssFileAction
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.cssFile()).getElement());
+    newLessFileAction
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.lessFile()).getElement());
+    newHtmlFileAction
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.htmlFile()).getElement());
+    newJavaScriptFileAction
+        .getTemplatePresentation()
+        .setImageElement(new SVGImage(resources.jsFile()).getElement());
 
     // add actions in main menu
     DefaultActionGroup newGroup = (DefaultActionGroup) actionManager.getAction(GROUP_FILE_NEW);

--- a/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/html/PreviewHTMLAction.java
+++ b/plugins/plugin-web/che-plugin-web-ext-web/src/main/java/org/eclipse/che/ide/ext/web/html/PreviewHTMLAction.java
@@ -43,9 +43,7 @@ public class PreviewHTMLAction extends AbstractPerspectiveAction {
     super(
         singletonList(PROJECT_PERSPECTIVE_ID),
         localizationConstants.previewHTMLActionTitle(),
-        localizationConstants.previewHTMLActionDescription(),
-        null,
-        null);
+        localizationConstants.previewHTMLActionDescription());
     this.wsAgentURLModifier = wsAgentURLModifier;
     this.appContext = appContext;
   }


### PR DESCRIPTION

### What does this PR do?
Add Action interface and declare all needed methods from absctract class Action in BaseAction class.
Replace ImageResorce and SVGResource with DOM Element.
Cleanup BaseAction constructors.
Remove PerspectiveManager from ActionEvent.

### What issues does this PR fix or reference?
#6788
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Action now interface, use abstract class BaseAction


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
