### PR TITLE
Use new (net.ltgt.gwt.maven) gwt-maven-plugin for compiling IDE app

### DIFF
--- a/assembly-multiuser/assembly-ide-war/pom.xml
+++ b/assembly-multiuser/assembly-ide-war/pom.xml
@@ -44,6 +44,11 @@
             <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-machine-authentication-ide</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -144,45 +149,22 @@
                     <outputDirectory>${generated.sources.directory}</outputDirectory>
                 </configuration>
             </plugin>
-            <!-- GWT Maven Plugin -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>net.ltgt.gwt.maven</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <goals>
                             <goal>compile</goal>
-                            <!--<goal>test</goal> -->
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-codeserver</artifactId>
-                        <version>${com.google.gwt.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-dev</artifactId>
-                        <version>${com.google.gwt.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-user</artifactId>
-                        <version>${com.google.gwt.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
-                    <gwtSdkFirstInClasspath>true</gwtSdkFirstInClasspath>
-                    <extraJvmArgs>${gwt.compiler.extraJvmArgs}</extraJvmArgs>
-                    <modules>
-                        <module>org.eclipse.che.ide.IDE</module>
-                    </modules>
-                    <!-- don' remove it we will use it then need to found 
-                        bug in compiled JS -->
-                    <!--style>DETAILED</style -->
-                    <logLevel>${gwt.compiler.logLevel}</logLevel>
+                    <moduleName>org.eclipse.che.ide.IDE</moduleName>
+                    <jvmArgs>
+                        <arg>${gwt.compiler.jvmArgs.Xss}</arg>
+                        <arg>${gwt.compiler.jvmArgs.Xmx}</arg>
+                    </jvmArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -216,6 +216,11 @@
             <artifactId>che-plugin-zend-debugger-ide</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
@@ -336,44 +341,22 @@
                     <outputDirectory>${generated.sources.directory}</outputDirectory>
                 </configuration>
             </plugin>
-            <!-- GWT Maven Plugin -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>net.ltgt.gwt.maven</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <goals>
                             <goal>compile</goal>
-                            <!--<goal>test</goal>-->
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-codeserver</artifactId>
-                        <version>${com.google.gwt.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-dev</artifactId>
-                        <version>${com.google.gwt.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-user</artifactId>
-                        <version>${com.google.gwt.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
-                    <gwtSdkFirstInClasspath>true</gwtSdkFirstInClasspath>
-                    <extraJvmArgs>${gwt.compiler.extraJvmArgs}</extraJvmArgs>
-                    <modules>
-                        <module>org.eclipse.che.ide.IDE</module>
-                    </modules>
-                    <!-- don' remove it we will use it then need to found bug in compiled JS -->
-                    <!--style>DETAILED</style-->
-                    <logLevel>${gwt.compiler.logLevel}</logLevel>
+                    <moduleName>org.eclipse.che.ide.IDE</moduleName>
+                    <jvmArgs>
+                        <arg>${gwt.compiler.jvmArgs.Xss}</arg>
+                        <arg>${gwt.compiler.jvmArgs.Xmx}</arg>
+                    </jvmArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Removes using legacy "mojo's" `org.codehaus.mojo:gwt-maven-plugin` for GWT compilation of IDE app and adds using new `net.ltgt.gwt.maven:gwt-maven-plugin` instead.
Also, this PR leads to using GWT 2.8.1 which is declared in [che-dependencies/che6](https://github.com/eclipse/che-dependencies/blob/che6/pom.xml#L42).

**Note**, once we merge this PR, the same branches in [che-parent](https://github.com/eclipse/che-parent/tree/che6) and [che-dependencies](https://github.com/eclipse/che-dependencies/tree/che6) projects must be used for building Che from che6 branch.

Related CQs have been approved:
- [x] `net.ltgt.gwt.maven:gwt-maven-plugin` - https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14390
- [x] GWT 2.8.1 - https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14117

### What issues does this PR fix or reference?
#6129 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
