### PR TITLE
 Add ability to setup test workspace pool size in selenium tests

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -74,6 +74,7 @@ WEBDRIVER_VERSION=$(curl -s http://chromedriver.storage.googleapis.com/LATEST_RE
 WEBDRIVER_PORT="9515"
 NODE_CHROME_DEBUG_SUFFIX=
 THREADS=$(getRecommendedThreadCount)
+WORKSPACE_POOL_SIZE=0
 
 ACTUAL_RESULTS=()
 COMPARE_WITH_CI=false
@@ -96,7 +97,6 @@ unset DEBUG_OPTIONS
 unset MAVEN_OPTIONS
 unset TMP_SUITE_PATH
 unset ORIGIN_TESTS_SCOPE
-unset WORKSPACE_POOL_SIZE
 
 cleanUpEnvironment() {
     if [[ ${MODE} == "grid" ]]; then
@@ -145,7 +145,7 @@ checkParameters() {
         elif [[ "$var" =~ -P.* ]]; then :
         elif [[ "$var" == "--help" ]]; then :
         elif [[ "$var" == "--compare-with-ci" ]]; then :
-        elif [[ "$var" =~ --workspace-pool-size=[0-9]+$ ]]; then :
+        elif [[ "$var" =~ --workspace-pool-size=auto|[0-9]+$ ]]; then :
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
         else
             printHelp
@@ -382,23 +382,25 @@ Modes (defines environment to run tests):
     local                               All tests will be run in a Web browser on the developer machine.
                                         Recommended if test visualization is needed and for debugging purpose.
 
-        Options that go with 'local' mode:
-        --web-driver-version=<VERSION>  To use the specific version of the WebDriver, be default the latest will be used: "${WEBDRIVER_VERSION}"
-        --web-driver-port=<PORT>        To run WebDriver on the specific port, by default: "${WEBDRIVER_PORT}"
-        --threads=<THREADS>             Number of tests that will be run simultaneously. It also means the very same number of
+    Options that go with 'local' mode:
+    --web-driver-version=<VERSION>      To use the specific version of the WebDriver, be default the latest will be used: "${WEBDRIVER_VERSION}"
+    --web-driver-port=<PORT>            To run WebDriver on the specific port, by default: "${WEBDRIVER_PORT}"
+    --threads=<THREADS>                 Number of tests that will be run simultaneously. It also means the very same number of
                                         Web browsers will be opened on the developer machine.
-                                        Default value is in range [2,5] and depends on available RAM.
-                                        
-        --workspace-pool-size=<SIZE>    Size of test workspace pool.
-                                        Default value is 0, that means that test workspaces are created on demand;
+                                        Default value is in range [2,5] and depends on available RAM.                                        
+    --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
+                                        Default value is 0, that means that test workspaces are created on demand.
 
 
     grid (default)                      All tests will be run in parallel on several docker containers.
                                         One container per thread. Recommended to run test suite.
 
-        Options that go with 'grid' mode:
-            --threads=<THREADS>         Number of tests that will be run simultaneously.
+    Options that go with 'grid' mode:
+    --threads=<THREADS>                 Number of tests that will be run simultaneously.
                                         Default value is in range [2,5] and depends on available RAM.
+    --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
+                                        Default value is 0, that means that test workspaces are created on demand.
+
 
 Define tests scope:
     --all-tests                         Run all tests within the suite despite of <exclude>/<include> sections in the test suite.
@@ -450,14 +452,15 @@ printRunOptions() {
     echo "[TEST] Tests inclusion     : "${!TEST_INCLUSION_MSG}
     echo "[TEST] Rerun failing tests : "${RERUN}
     echo "[TEST] ==================================================="
-    echo "[TEST] Product Protocol : "${PRODUCT_PROTOCOL}
-    echo "[TEST] Product Host     : "${PRODUCT_HOST}
-    echo "[TEST] Tests            : "${TESTS_SCOPE}
-    echo "[TEST] Threads          : "${THREADS}
-    echo "[TEST] Web browser      : "${BROWSER}
-    echo "[TEST] Web driver ver   : "${WEBDRIVER_VERSION}
-    echo "[TEST] Web driver port  : "${WEBDRIVER_PORT}
-    echo "[TEST] Additional opts  : "${GRID_OPTIONS}" "${DEBUG_OPTIONS}" "${MAVEN_OPTIONS}
+    echo "[TEST] Product Protocol    : "${PRODUCT_PROTOCOL}
+    echo "[TEST] Product Host        : "${PRODUCT_HOST}
+    echo "[TEST] Tests               : "${TESTS_SCOPE}
+    echo "[TEST] Threads             : "${THREADS}
+    echo "[TEST] Workspace pool size : "${WORKSPACE_POOL_SIZE}
+    echo "[TEST] Web browser         : "${BROWSER}
+    echo "[TEST] Web driver ver      : "${WEBDRIVER_VERSION}
+    echo "[TEST] Web driver port     : "${WEBDRIVER_PORT}
+    echo "[TEST] Additional opts     : "${GRID_OPTIONS}" "${DEBUG_OPTIONS}" "${MAVEN_OPTIONS}
     echo "[TEST] ==================================================="
 }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/pageobject/PageObjectsInjector.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/pageobject/PageObjectsInjector.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.constant.TestBrowser;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -35,6 +36,8 @@ import org.slf4j.LoggerFactory;
  * @author Anatolii Bazko
  */
 public abstract class PageObjectsInjector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PageObjectsInjector.class);
 
   @Inject
   @Named("sys.browser")
@@ -64,19 +67,11 @@ public abstract class PageObjectsInjector {
       container.putAll(getDependenciesWithWebdriver(seleniumWebDriver));
 
       for (Field f : toInject.get(poIndex)) {
-        LoggerFactory.getLogger(this.getClass())
-            .info("Inject field {} into test {}.", f, testInstance);
-
         try {
           injectField(f, testInstance, container, injector);
         } catch (Exception e) {
-          LoggerFactory.getLogger(this.getClass())
-              .error(
-                  format(
-                      "Error of injection member '%s' into test '%s'. %s",
-                      f, testInstance, e.getMessage()),
-                  e);
-          throw e;
+          throw new RuntimeException(
+              format("Error of injection member '%s' into test '%s'. %s", f, testInstance), e);
         }
       }
     }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/pageobject/PageObjectsInjector.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/pageobject/PageObjectsInjector.java
@@ -71,7 +71,7 @@ public abstract class PageObjectsInjector {
           injectField(f, testInstance, container, injector);
         } catch (Exception e) {
           throw new RuntimeException(
-              format("Error of injection member '%s' into test '%s'. %s", f, testInstance), e);
+              format("Error of injection member '%s' into test '%s'.", f, testInstance), e);
         }
       }
     }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/site/CheLoginPage.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/site/CheLoginPage.java
@@ -47,6 +47,7 @@ public class CheLoginPage implements LoginPage {
         new WebDriverWait(seleniumWebDriver, TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC);
   }
 
+  @Override
   public void login(String username, String password) {
     waitOnOpen();
     usernameInput.clear();
@@ -57,16 +58,7 @@ public class CheLoginPage implements LoginPage {
     waitOnClose();
   }
 
-  public void waitOnOpen() {
-    webDriverWait.until(ExpectedConditions.visibilityOf(loginButton));
-  }
-
-  public void waitOnClose() {
-    webDriverWait.until(
-        ExpectedConditions.invisibilityOfAllElements(
-            ImmutableList.of(loginButton, passwordInput, usernameInput)));
-  }
-
+  @Override
   public boolean isOpened() {
     try {
       waitOnOpen();
@@ -75,5 +67,15 @@ public class CheLoginPage implements LoginPage {
     }
 
     return true;
+  }
+
+  private void waitOnOpen() {
+    webDriverWait.until(ExpectedConditions.visibilityOf(loginButton));
+  }
+
+  private void waitOnClose() {
+    webDriverWait.until(
+        ExpectedConditions.invisibilityOfAllElements(
+            ImmutableList.of(loginButton, passwordInput, usernameInput)));
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix selenium tests to don't create test workspace pool by default, which allows to prevent unnecessary workspaces creation. To do so, it provides and implements new parameter of selenium tests:
```
 --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
                                     Default value is 0, that means that test workspaces are created on demand.
```

### What issues does this PR fix or reference?
#6238

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
