### PR TITLE
KubernetesStringUtils - Removing non-word-chars in the end of normilized strings

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtils.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtils.java
@@ -31,7 +31,9 @@ public final class KubernetesStringUtils {
    */
   public static String getNormalizedString(String input) {
     int end = Math.min(input.length(), MAX_CHARS - 1);
-    return input.substring(0, end);
+    String stringLessThan63chars = input.substring(0, end);
+    String normalizedString = removeSpecialCharactersInTheEnd(stringLessThan63chars);
+    return normalizedString;
   }
 
   /**
@@ -172,5 +174,10 @@ public final class KubernetesStringUtils {
       return null;
     }
     return pullSpec.replaceAll(".*:", "");
+  }
+
+  /** Removes non-word-characters at the end of the string */
+  private static String removeSpecialCharactersInTheEnd(final String input) {
+    return input.replaceAll("\\W+$", "");
   }
 }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtilsTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesStringUtilsTest.java
@@ -100,6 +100,18 @@ public class KubernetesStringUtilsTest {
   }
 
   @Test
+  public void getNormilizedStringWithoutDashInTheEnd() {
+    // Given
+    String input = RandomStringUtils.random(61, true, true) + "-";
+
+    // When
+    String output = KubernetesStringUtils.getNormalizedString(input);
+
+    // Then
+    assertTrue(!output.endsWith("-"), "Normalized string can not end with '-'");
+  }
+
+  @Test
   public void convertPullSpecToTagNameShouldLimitLength() {
     // Given
     String input = RandomStringUtils.random(100, true, false);


### PR DESCRIPTION
### What does this PR do?
Removing non-word-chars in the end of normilized strings in k8s util method

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6873

#### Release Notes
N / A

#### Docs PR
N / A
