### PR TITLE
Fix stack loading exception handling

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackLoader.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackLoader.java
@@ -106,15 +106,14 @@ public class StackLoader {
 
   protected void loadStack(StackImpl stack, Path imagePath) {
     setIconData(stack, imagePath);
-
     try {
-      stackDao.update(stack);
-    } catch (NotFoundException | ConflictException | ServerException e) {
       try {
+        stackDao.update(stack);
+      } catch (NotFoundException ex) {
         stackDao.create(stack);
-      } catch (Exception ex) {
-        LOG.error(format("Failed to load stack with id '%s' ", stack.getId()), ex);
       }
+    } catch (ServerException | ConflictException ex) {
+      LOG.warn(format("Failed to load stack with id '%s' ", stack.getId()), ex.getMessage());
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
@@ -92,13 +92,36 @@ public class StackLoaderTest {
   }
 
   @Test
-  public void predefinedStackWithValidJsonShouldBeCreated2() throws Exception {
+  public void doNotThrowExceptionWhenUpdateFailed() throws Exception {
     doThrow(new ServerException("Internal server error")).when(stackDao).update(any());
 
     stackLoader.start();
 
     verify(stackDao, times(5)).update(any());
+    verify(stackDao, never()).create(any());
+  }
+
+  @Test
+  public void doNotThrowExceptionWhenCreationFailed() throws Exception {
+    doThrow(new NotFoundException("Not found")).when(stackDao).update(any());
+    doThrow(new ServerException("Internal server error")).when(stackDao).create(any());
+
+    stackLoader.start();
+
+    verify(stackDao, times(5)).update(any());
     verify(stackDao, times(5)).create(any());
+  }
+
+  @Test
+  public void testOverrideStacksWithoutImages() throws Exception {
+    final Map<String, String> map = new HashMap<>();
+    map.put("stacks.json", null);
+    stackLoader = new StackLoader(true, map, stackDao, dbInitializer);
+
+    stackLoader.start();
+
+    verify(stackDao, times(5)).update(any());
+    verify(stackDao, never()).create(any());
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Changes handling of exception while stack loading, only if `NotFoundException` occurs, a new stack will be created.

### What issues does this PR fix or reference?
n/a