### PR TITLE
Fix CheckRestoringOfSplitEditor selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/editor/split-editor-restore-exp-text.txt
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/editor/split-editor-restore-exp-text.txt
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,38 +7,27 @@
  *
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
- *******************************************************************************/
+ */
 package org.eclipse.qa.examples;
 
 import java.util.Random;
 
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.Controller;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-public class AppController implements Controller {
-    private static final String secretNum = Integer.toString(new Random().nextInt(10));
-
 ----split_line---
 Developer Workspace
 ----split_line---
-    @Override
-    public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
-        String numGuessByUser = request.getParameter("numGuess");
-        String result = "";
-
-        if (numGuessByUser != null && numGuessByUser.equals(secretNum)) {
-            result = "Congrats! The number is " + secretNum;
-        }
-
-        else if (numGuessByUser != null) {
-            result = "Sorry, you failed. Try again later!";
-        }
-
-        ModelAndView view = new ModelAndView("guess_num");
-        view.addObject("num", result);
-        return view;
-    }
-}
+    <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>3.0.5.RELEASE</version>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -53,6 +53,7 @@
                     <exclude name="renameNameWorkspaceTest"/>
                 </methods>
             </class>
+            <class name="org.eclipse.che.selenium.dashboard.WorkspaceDetailsTest"/>
             <class name="org.eclipse.che.selenium.debugger.ChangeVariableWithEvaluatingTest"/>
             <class name="org.eclipse.che.selenium.debugger.CheckBreakPointStateTest"/>
             <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest">
@@ -117,7 +118,7 @@
             <class name="org.eclipse.che.selenium.editor.autocomplete.QuickFixAndCodeAssistantFeaturesTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.ShowHintsCommandTest"/>
             <class name="org.eclipse.che.selenium.editor.CheckReplaceFeatureInEditorTest"/>
-            <class name="org.eclipse.che.selenium.editor.CheckRestoringOfSplitEditor">
+            <class name="org.eclipse.che.selenium.editor.CheckRestoringSplitEditorTest">
                 <methods>
                     <exclude name="checkRestoringStateSplittedEditor"/>
                 </methods>


### PR DESCRIPTION
We need fix **CheckRestoringOfSplitEditor** selenium test:
- change expected text in split-editor-restore-exp-text.txt resource file;
- change name of class to **CheckRestoringSplitEditorTest**;
- add checking that workspace restored properly after refresh.