### PR TITLE
Add ability to run selenium tests for che launched on custom port.

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -62,7 +62,6 @@ readonly FAILSAFE_REPORT="target/site/failsafe-report.html"
 [[ -z ${CALLER+x} ]] && { CALLER=$(basename $0); }
 [[ -z ${CUR_DIR+x} ]] && { CUR_DIR=$(cd "$(dirname "$0")"; pwd); }
 
-[[ -z ${API_SUFFIX+x} ]] && { API_SUFFIX=":8080/api/"; }
 [[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/che-integration-tests/"; }
 
 MODE="grid"
@@ -175,6 +174,10 @@ applyCustomOptions() {
 
         elif [[ "$var" =~ --host=.* ]]; then
             PRODUCT_HOST=$(echo "$var" | sed -e "s/--host=//g")
+
+        elif [[ "$var" =~ --port=.* ]]; then
+            PRODUCT_PORT=$(echo "$var" | sed -e "s/--port=//g");
+            API_SUFFIX=":${PRODUCT_PORT}/api/";
 
         elif [[ "$var" =~ --threads=.* ]]; then
             THREADS=$(echo "$var" | sed -e "s/--threads=//g")
@@ -377,6 +380,7 @@ Options:
     --http                              Use 'http' protocol to connect to product
     --https                             Use 'https' protocol to connect to product
     --host=<PRODUCT_HOST>               Set host where product is deployed
+    --port=<PRODUCT_PORT>               Set port where product is deployed
 
 Modes (defines environment to run tests):
     local                               All tests will be run in a Web browser on the developer machine.
@@ -387,7 +391,7 @@ Modes (defines environment to run tests):
     --web-driver-port=<PORT>            To run WebDriver on the specific port, by default: "${WEBDRIVER_PORT}"
     --threads=<THREADS>                 Number of tests that will be run simultaneously. It also means the very same number of
                                         Web browsers will be opened on the developer machine.
-                                        Default value is in range [2,5] and depends on available RAM.                                        
+                                        Default value is in range [2,5] and depends on available RAM.
     --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
                                         Default value is 0, that means that test workspaces are created on demand.
 
@@ -454,6 +458,7 @@ printRunOptions() {
     echo "[TEST] ==================================================="
     echo "[TEST] Product Protocol    : "${PRODUCT_PROTOCOL}
     echo "[TEST] Product Host        : "${PRODUCT_HOST}
+    echo "[TEST] Product Port        : "${PRODUCT_PORT}
     echo "[TEST] Tests               : "${TESTS_SCOPE}
     echo "[TEST] Threads             : "${THREADS}
     echo "[TEST] Workspace pool size : "${WORKSPACE_POOL_SIZE}
@@ -690,6 +695,7 @@ runTests() {
     mvn clean verify -Pselenium-test \
                 ${TESTS_SCOPE} \
                 -Dhost=${PRODUCT_HOST} \
+                -Dport=${PRODUCT_PORT} \
                 -Dprotocol=${PRODUCT_PROTOCOL} \
                 -Ddocker.interface.ip=$(detectDockerInterfaceIp) \
                 -Ddriver.port=${WEBDRIVER_PORT} \

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -49,6 +49,7 @@ Options:
     --http                              Use 'http' protocol to connect to product
     --https                             Use 'https' protocol to connect to product
     --host=<PRODUCT_HOST>               Set host where product is deployed
+    --port=<PRODUCT_PORT>               Set port where product is deployed
     --multiuser                         Run tests of Multi User Che
 
 Modes (defines environment to run tests):

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestApiEndpointUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestApiEndpointUrlProvider.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.core.provider;
 
+import static java.lang.Integer.valueOf;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.net.MalformedURLException;
@@ -27,10 +29,14 @@ public class CheTestApiEndpointUrlProvider implements TestApiEndpointUrlProvider
   @Named("sys.host")
   private String host;
 
+  @Inject
+  @Named("sys.port")
+  private String port;
+
   @Override
   public URL get() {
     try {
-      return new URL(protocol, host, 8080, "/wsmaster/api/");
+      return new URL(protocol, host, valueOf(port), "/wsmaster/api/");
     } catch (MalformedURLException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestDashboardUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestDashboardUrlProvider.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.core.provider;
 
+import static java.lang.Integer.valueOf;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.net.MalformedURLException;
@@ -27,10 +29,14 @@ public class CheTestDashboardUrlProvider implements TestDashboardUrlProvider {
   @Named("sys.host")
   private String host;
 
+  @Inject
+  @Named("sys.port")
+  private String port;
+
   @Override
   public URL get() {
     try {
-      return new URL(protocol, host, 8080, "/dashboard/");
+      return new URL(protocol, host, valueOf(port), "/dashboard/");
     } catch (MalformedURLException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestIdeUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestIdeUrlProvider.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.core.provider;
 
+import static java.lang.Integer.valueOf;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.net.MalformedURLException;
@@ -27,10 +29,14 @@ public class CheTestIdeUrlProvider implements TestIdeUrlProvider {
   @Named("sys.host")
   private String host;
 
+  @Inject
+  @Named("sys.port")
+  private String port;
+
   @Override
   public URL get() {
     try {
-      return new URL(protocol, host, 8080, "/");
+      return new URL(protocol, host, valueOf(port), "/");
     } catch (MalformedURLException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/Dashboard.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/Dashboard.java
@@ -20,8 +20,7 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.Arrays;
-import java.util.List;
+import java.net.URL;
 import javax.annotation.PreDestroy;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.entrance.Entrance;
@@ -212,11 +211,10 @@ public class Dashboard {
   }
 
   public void logout() {
-    String apiEndpoint = testDashboardUrlProvider.get().toString();
-    List<String> api = Arrays.asList(apiEndpoint.split(":"));
-    String logoutApiEndpoint = api.get(0) + ":" + api.get(1);
+    URL apiEndpoint = testDashboardUrlProvider.get();
+    String logoutApiEndpoint = apiEndpoint.getProtocol() + "://" + apiEndpoint.getHost();
     String logoutURL = logoutApiEndpoint + ":5050/auth/realms/che/protocol/openid-connect/logout";
-    String redirectURL = logoutApiEndpoint + ":8080/dashboard/#/workspaces";
+    String redirectURL = apiEndpoint + "#/workspaces";
 
     seleniumWebDriver.navigate().to(logoutURL + "?redirect_uri=" + redirectURL);
   }


### PR DESCRIPTION
### What does this PR do?

<!-- #### Changelog -->
Add ability to run selenium tests for che launched on custom port.

#### Release Notes
Add ability to run selenium tests for che launched on custom port.

#### Docs PR

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

