### PR TITLE
[CHE 6] Extend NavigateToFileTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NavigateToFile.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NavigateToFile.java
@@ -122,11 +122,13 @@ public class NavigateToFile {
   /**
    * wait expected text in the dropdawn list of the widget
    *
-   * @param text a text that should be into list
+   * @param nameFragment a text that should be into list
    */
-  public void waitListOfFilesNames(final String text) {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until((ExpectedCondition<Boolean>) webDriver -> suggestionPanel.getText().contains(text));
+  public Boolean isFilenameSuggested(final String nameFragment) {
+    return new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
+        .until(
+            (ExpectedCondition<Boolean>)
+                webDriver -> suggestionPanel.getText().contains(nameFragment));
   }
 
   public String getText() {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -832,7 +832,7 @@ public class ProjectExplorer {
     } catch (StaleElementReferenceException ex) {
       WaitUtils.sleepQuietly(1);
     }
-    navigateToFile.waitListOfFilesNames(file);
+    navigateToFile.isFilenameSuggested(file);
     navigateToFile.selectFileByName(file);
     navigateToFile.waitFormToClose();
     menu.runCommand(


### PR DESCRIPTION
### What does this PR do?
We need extend **NavigateToFile** selenium test to cover next use cases:

- Closing widget by ESC https://github.com/eclipse/che/issues/6230.
- Widget should not be found files from hidden folders https://github.com/eclipse/che/issues/3928.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6641