### PR TITLE
Dashboard: loading and initialization of keycloak after DOM is ready

### DIFF
--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -92,27 +92,29 @@ const keycloakAuth = {
 };
 initModule.constant('keycloakAuth', keycloakAuth);
 
-const promise = new Promise((resolve: IResolveFn<any>, reject: IRejectFn<any>) => {
-  angular.element.get('/api/keycloak/settings').then(resolve, reject);
-});
-promise.then((keycloakSettings: any) => {
-  keycloakAuth.config = buildKeycloakConfig(keycloakSettings);
-
-  // load Keycloak
-  return keycloakLoad(keycloakSettings).then(() => {
-    // init Keycloak
-    return keycloakInit(keycloakAuth.config);
-  }).then((keycloak: any) => {
-    keycloakAuth.isPresent = true;
-    keycloakAuth.keycloak = keycloak;
-    /* tslint:disable */
-    window['_keycloak'] = keycloak;
-    /* tslint:enable */
+angular.element(document).ready(() => {
+  const promise = new Promise((resolve: IResolveFn<any>, reject: IRejectFn<any>) => {
+    angular.element.get('/api/keycloak/settings').then(resolve, reject);
   });
-}).catch((error: any) => {
-  console.error('Keycloak initialization failed with error: ', error);
-}).then(() => {
-  angular.resumeBootstrap();
+  promise.then((keycloakSettings: any) => {
+    keycloakAuth.config = buildKeycloakConfig(keycloakSettings);
+
+    // load Keycloak
+    return keycloakLoad(keycloakSettings).then(() => {
+      // init Keycloak
+      return keycloakInit(keycloakAuth.config);
+    }).then((keycloak: any) => {
+      keycloakAuth.isPresent = true;
+      keycloakAuth.keycloak = keycloak;
+      /* tslint:disable */
+      window['_keycloak'] = keycloak;
+      /* tslint:enable */
+    });
+  }).catch((error: any) => {
+    console.error('Keycloak initialization failed with error: ', error);
+  }).then(() => {
+    angular.resumeBootstrap();
+  });
 });
 
 // add a global resolve flag on all routes (user needs to be resolved first)


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
It makes loading and initialization of keycloak after DOM is ready to prevent failures of selenium tests on CI.
Сorresponding PR for `che6`: https://github.com/eclipse/che/pull/6924

### What issues does this PR fix or reference?
#6655

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>