### PR TITLE
Update IOUtil test to be compliant with java9

### DIFF
--- a/core/commons/che-core-commons-lang/src/test/java/org/eclipse/che/commons/lang/IoUtilTest.java
+++ b/core/commons/che-core-commons-lang/src/test/java/org/eclipse/che/commons/lang/IoUtilTest.java
@@ -48,8 +48,9 @@ public class IoUtilTest {
     URI codenvyDir = URI.create("jar:" + testJar + "!/");
 
     List<String> resources = new ArrayList<>();
-    IoUtil.listResources(codenvyDir, path -> resources.add(path.getFileName().toString()));
+    IoUtil.listResources(
+        codenvyDir, path -> resources.add(path.getFileName().toString().replace("/", "")));
 
-    assertTrue(resources.contains("codenvy/"));
+    assertTrue(resources.contains("codenvy"));
   }
 }


### PR DESCRIPTION
### What does this PR do?
Update test to work with java8 and Java9
it's because on Java9, file.getPath on directory is not containing last /

### What issues does this PR fix or reference?
#5326 

#### Release Notes
N/A

#### Docs PR
N/A
