### PR TITLE
Fix NavigateToFileTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NavigateToFile.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NavigateToFile.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 
@@ -17,6 +18,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.action.ActionsFactory;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
@@ -99,6 +101,7 @@ public class NavigateToFile {
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
         .until(ExpectedConditions.visibilityOf(fileNameInput));
     fileNameInput.clear();
+    WaitUtils.sleepQuietly(1); // timeout for waiting that input field is cleared
     fileNameInput.sendKeys(symbol);
   }
 
@@ -119,16 +122,18 @@ public class NavigateToFile {
         .until(ExpectedConditions.visibilityOf(suggestionPanel));
   }
 
+  public Boolean isFilenameSuggested(final String nameFragment) {
+    return suggestionPanel.getText().contains(nameFragment);
+  }
+
   /**
    * wait expected text in the dropdawn list of the widget
    *
-   * @param nameFragment a text that should be into list
+   * @param text a text that should be into list
    */
-  public Boolean isFilenameSuggested(final String nameFragment) {
-    return new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            (ExpectedCondition<Boolean>)
-                webDriver -> suggestionPanel.getText().contains(nameFragment));
+  public void waitListOfFilesNames(final String text) {
+    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
+        .until((ExpectedCondition<Boolean>) webDriver -> suggestionPanel.getText().contains(text));
   }
 
   public String getText() {
@@ -144,7 +149,7 @@ public class NavigateToFile {
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(
             ExpectedConditions.visibilityOfElementLocated(
-                By.xpath(String.format(Locators.FILE_NAME_LIST_SELECT_WITH_PATH, pathName))))
+                By.xpath(format(Locators.FILE_NAME_LIST_SELECT_WITH_PATH, pathName))))
         .click();
     actionsFactory.createAction(seleniumWebDriver).doubleClick().perform();
   }
@@ -158,7 +163,7 @@ public class NavigateToFile {
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(
             ExpectedConditions.visibilityOfElementLocated(
-                By.xpath(String.format(Locators.FILE_NAME_LIST_SELECT, nameOfFile))))
+                By.xpath(format(Locators.FILE_NAME_LIST_SELECT, nameOfFile))))
         .click();
     actionsFactory.createAction(seleniumWebDriver).doubleClick().perform();
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -834,7 +834,7 @@ public class ProjectExplorer {
     } catch (StaleElementReferenceException ex) {
       WaitUtils.sleepQuietly(1);
     }
-    navigateToFile.isFilenameSuggested(file);
+    navigateToFile.waitListOfFilesNames(file);
     navigateToFile.selectFileByName(file);
     navigateToFile.waitFormToClose();
     menu.runCommand(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
@@ -194,6 +194,7 @@ public class NavigateToFileTest {
         TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE);
     navigateToFile.waitFormToOpen();
     navigateToFile.typeSymbolInFileNameField("H");
+    loader.waitOnClosed();
     navigateToFile.waitFileNamePopUp();
     assertFalse(navigateToFile.isFilenameSuggested("HEAD (/NavigateFile/.git)"));
     navigateToFile.closeNavigateToFileForm();
@@ -211,7 +212,7 @@ public class NavigateToFileTest {
     loader.waitOnClosed();
     navigateToFile.waitFileNamePopUp();
     for (String listFiles : files) {
-      navigateToFile.isFilenameSuggested(listFiles);
+      navigateToFile.waitListOfFilesNames(listFiles);
     }
     navigateToFile.selectFileByFullName(pathName);
     navigateToFile.waitFormToClose();
@@ -228,7 +229,7 @@ public class NavigateToFileTest {
     loader.waitOnClosed();
     navigateToFile.waitFileNamePopUp();
     for (String listFiles : FILES_I_SYMBOL) {
-      navigateToFile.isFilenameSuggested(listFiles);
+      navigateToFile.waitListOfFilesNames(listFiles);
     }
     navigateToFile.selectFileByFullName(pathName);
     navigateToFile.waitFormToClose();
@@ -243,7 +244,7 @@ public class NavigateToFileTest {
     loader.waitOnClosed();
     navigateToFile.waitFileNamePopUp();
     for (String listFiles : FILES_R_SYMBOL) {
-      navigateToFile.isFilenameSuggested(listFiles);
+      navigateToFile.waitListOfFilesNames(listFiles);
     }
     navigateToFile.selectFileByFullName(pathName);
     navigateToFile.waitFormToClose();


### PR DESCRIPTION
### What does this PR do?
We need fix **NavigateToFileTest** selenium test:
- add timeout after clearing input field of Navigate To File form(sometimes, after clearing input field and then typing text very quickly, a pop-up window with a list of found files does not appear).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6641

