### PR TITLE
Adapt che-in-che stack for Eclipse Che development

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -3,21 +3,15 @@
     "id": "che-in-che",
     "creator": "ide",
     "name": "Eclipse Che",
-    "description": "Utilities to build Che in Che with Docker, JDK 8, and Maven.",
+    "description": "Utilities to build Che in Che with JDK 8 and Maven.",
     "scope": "general",
     "tags": [
-      "Docker",
       "Java",
       "JDK",
       "Maven",
-      "Alpine",
       "Git"
     ],
     "components": [
-      {
-        "name": "Docker",
-        "version": "1.12.0"
-      },
       {
         "name": "JDK",
         "version": "1.8.0_92"
@@ -29,7 +23,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "codenvy/alpine_jdk8"
+      "origin": "eclipse/che-dev"
     },
     "workspaceConfig": {
       "environments": {
@@ -44,12 +38,12 @@
               ],
               "servers": {},
               "attributes": {
-                "memoryLimitBytes": "2147483648"
+                "memoryLimitBytes": "4294967296"
               }
             }
           },
           "recipe": {
-            "location": "codenvy/alpine_jdk8",
+            "location": "eclipse/che-dev",
             "type": "dockerimage"
           }
         }
@@ -59,31 +53,8 @@
       "description": null,
       "commands": [
         {
-          "commandLine": "sudo docker rename che-server che-host;sudo apk update; sudo apk add curl;export HOST_IP=$(curl -s https://4.ifcfg.me/)",
-          "name": "1. Setup Che in Che",
-          "type": "custom"
-        },
-        {
-          "commandLine": "mvn clean install -f /projects/che/assembly/assembly-main",
-          "name": "2. Build Che in Che",
-          "type": "custom"
-        },
-        {
-          "commandLine": "export CHE_BIN_PATH=$(ls -d /projects/che/assembly/assembly-main/target/eclipse-che-*/eclipse-che-*); sudo docker run -t -v /var/run/docker.sock:/var/run/docker.sock --env CHE_ASSEMBLY=${CHE_BIN_PATH//projects/'home/user/che/workspaces/che'} --env CHE_HOST_IP=$HOST_IP --env CHE_PORT=54321 eclipse/che-launcher start",
-          "name": "3. Run Che in Che",
-          "type": "custom",
-          "attributes": {
-            "previewUrl": "http://<host.ip>:54321/"
-          }
-        },
-        {
-          "commandLine": "sudo docker run -t -v /var/run/docker.sock:/var/run/docker.sock eclipse/che-launcher stop",
-          "name": "4. Stop Che in Che",
-          "type": "custom"
-        },
-        {
-          "commandLine": "sudo docker rm -f che-server",
-          "name": "** Kill Che in Che **",
+          "commandLine": "mvn clean install -f ${current.project.path}",
+          "name": "Build project",
           "type": "custom"
         }
       ]

--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -53,7 +53,7 @@
       "description": null,
       "commands": [
         {
-          "commandLine": "mvn clean install -f ${current.project.path}",
+          "commandLine": "mvn clean install -DskipIntegrationTests=true -Pnative -f ${current.project.path}",
           "name": "Build project",
           "type": "custom"
         }

--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -27,12 +27,13 @@
 # For Windows, replace $PWD with Che source code directory.
 #
 
-FROM codenvy/debian_jdk8
-ENV NODE_VERSION=4.8.0 \
+FROM eclipse/debian_jdk8
+ENV NODE_VERSION=6.11.2 \
+    GOLANG_VERSION=1.8.3 \
     NODE_PATH=/usr/local/lib/node_modules
 
 RUN sudo apt-get update && \
-    sudo apt-get -y install build-essential libssl-dev libkrb5-dev gcc make ruby-full rubygems && \
+    sudo apt-get -y install build-essential libkrb5-dev gcc make ruby-full rubygems && \
     sudo gem install sass compass && \
     sudo apt-get clean && \
     sudo apt-get -y autoremove && \
@@ -60,12 +61,12 @@ RUN sudo apt-get update && \
     && sudo rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
 EXPOSE 3000 5000 9000
-RUN sudo npm install -g npm@latest
-RUN sudo npm install --unsafe-perm -g gulp bower typings
+#RUN sudo npm install -g npm@lastest
+#RUN sudo npm install --unsafe-perm -g gulp bower typings
 RUN mkdir ~/gopath && \
-    cd /home/user && wget -q https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz && \
-    sudo tar -xvf go1.6.2.linux-amd64.tar.gz -C /opt/ && \
-    rm go1.6.2.linux-amd64.tar.gz
+    cd /home/user && wget -q https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz && \
+    sudo tar -xvf go$GOLANG_VERSION.linux-amd64.tar.gz -C /opt/ && \
+    rm go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOROOT=/opt/go
 ENV GOPATH=/home/user/gopath
 RUN echo "export PATH=$GOROOT/bin:$PATH" >> ~/.bashrc && \

--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -61,8 +61,7 @@ RUN sudo apt-get update && \
     && sudo rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
 EXPOSE 3000 5000 9000
-#RUN sudo npm install -g npm@lastest
-#RUN sudo npm install --unsafe-perm -g gulp bower typings
+
 RUN mkdir ~/gopath && \
     cd /home/user && wget -q https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz && \
     sudo tar -xvf go$GOLANG_VERSION.linux-amd64.tar.gz -C /opt/ && \


### PR DESCRIPTION

### What does this PR do?
- Use ```eclipse/che-dev```  image instead of  ```codenvy/alpine_jdk8```
- Add commands to build maven project and module
- Set up memory limit to 4G

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/6928


#### Release Notes
Adapt Che in Che stack for Che development.
