### PR TITLE
Implement heartbeat mechanism with JSON RPC protocol for WS  Agent

### DIFF
--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -163,6 +163,10 @@
             <type>gwt-lib</type>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-wsagent-shared</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.lib</groupId>
             <artifactId>che-terminal-client</artifactId>
         </dependency>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -1231,4 +1231,16 @@ public interface CoreLocalizationConstant extends Messages {
 
   @Key("menu.loader.pullingImage")
   String menuLoaderPullingImage(String image);
+
+  @Key("ws.agent.lost.connection.dialog.title")
+  String wsAgentNotRespondingDialogTitle();
+
+  @Key("ws.agent.lost.connection.dialog.message")
+  String wsAgentNotRespondingDialogMessage();
+
+  @Key("ws.agent.lost.connection.dialog.restart")
+  String wsAgentNotRespondingDialogRestart();
+
+  @Key("ws.agent.lost.connection.dialog.close")
+  String wsAgentNotRespondingDialogClose();
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -181,6 +181,7 @@ public class StandardComponentInitializer {
   public static final String SHOW_REFERENCE = "showReference";
   public static final String SHOW_COMMANDS_PALETTE = "showCommandsPalette";
   public static final String NEW_TERMINAL = "newTerminal";
+  public static final String STOP_WORKSPACE = "stopWorkspace";
 
   public interface ParserResource extends ClientBundle {
     @Source("org/eclipse/che/ide/blank.svg")
@@ -612,7 +613,7 @@ public class StandardComponentInitializer {
     helpGroup.addSeparator();
 
     // Processes panel actions
-    actionManager.registerAction("stopWorkspace", stopWorkspaceAction);
+    actionManager.registerAction(STOP_WORKSPACE, stopWorkspaceAction);
     actionManager.registerAction("runCommand", runCommandAction);
     actionManager.registerAction("newTerminal", newTerminalAction);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/WebSocketModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/WebSocketModule.java
@@ -35,6 +35,8 @@ public class WebSocketModule extends AbstractGinModule {
     bind(WebSocketMessageTransmitter.class).to(BasicWebSocketMessageTransmitter.class);
     bind(WebSocketMessageReceiver.class).to(JsonRpcMessageReceiver.class);
 
+    bind(WsAgentWebSocketConnectionTracker.class).asEagerSingleton();
+
     install(
         new GinFactoryModuleBuilder()
             .implement(WebSocketConnection.class, DelayableWebSocketConnection.class)

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/WsAgentWebSocketConnectionTracker.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/WsAgentWebSocketConnectionTracker.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.core;
+
+import static java.util.Collections.emptyMap;
+import static org.eclipse.che.api.core.model.workspace.runtime.ServerStatus.RUNNING;
+import static org.eclipse.che.ide.api.jsonrpc.Constants.WS_AGENT_JSON_RPC_ENDPOINT_ID;
+import static org.eclipse.che.ide.core.StandardComponentInitializer.STOP_WORKSPACE;
+import static org.eclipse.che.ide.util.browser.BrowserUtils.reloadPage;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_HEARTBEAT;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_PERIOD_MILLISECONDS;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_SUBSCRIBE;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_UNSUBSCRIBE;
+
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Provider;
+import com.google.web.bindery.event.shared.EventBus;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.workspace.WsAgentServerUtil;
+import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.api.workspace.event.WsAgentServerRunningEvent;
+import org.eclipse.che.ide.api.workspace.event.WsAgentServerStoppedEvent;
+import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
+import org.eclipse.che.ide.bootstrap.BasicIDEInitializedEvent;
+import org.eclipse.che.ide.ui.dialogs.DialogFactory;
+
+/**
+ * Tracks web socket connection to control ws agent state. Notifies client side by {@link
+ * WsAgentServerStoppedEvent} when the connection is lost. Prompts to restart a workspace when
+ * connection is lost, but workspace is running.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class WsAgentWebSocketConnectionTracker {
+  private static final int HEART_BEAT_PERIOD =
+      3 * WS_AGENT_TRACK_CONNECTION_PERIOD_MILLISECONDS + 1_000;
+
+  private EventBus eventBus;
+  private AppContext appContext;
+  private DialogFactory dialogFactory;
+  private ActionManager actionManager;
+  private RequestTransmitter requestTransmitter;
+  private CoreLocalizationConstant localizationConstant;
+  private Provider<WsAgentServerUtil> wsAgentServerUtilProvider;
+
+  private final Timer heartBeatTimer =
+      new Timer() {
+        @Override
+        public void run() {
+          onWsAgentConnectionIsLost();
+        }
+      };
+
+  @Inject
+  public WsAgentWebSocketConnectionTracker(
+      EventBus eventBus,
+      AppContext appContext,
+      DialogFactory dialogFactory,
+      ActionManager actionManager,
+      RequestTransmitter transmitter,
+      RequestHandlerConfigurator requestHandler,
+      CoreLocalizationConstant localizationConstant,
+      Provider<WsAgentServerUtil> wsAgentServerUtilProvider) {
+    this.appContext = appContext;
+    this.eventBus = eventBus;
+    this.actionManager = actionManager;
+    this.requestTransmitter = transmitter;
+    this.dialogFactory = dialogFactory;
+    this.localizationConstant = localizationConstant;
+    this.wsAgentServerUtilProvider = wsAgentServerUtilProvider;
+
+    requestHandler
+        .newConfiguration()
+        .methodName(WS_AGENT_TRACK_CONNECTION_HEARTBEAT)
+        .paramsAsBoolean()
+        .resultAsBoolean()
+        .withFunction(
+            aBoolean -> {
+              restartTimer();
+              return true;
+            });
+
+    eventBus.addHandler(
+        BasicIDEInitializedEvent.TYPE,
+        event ->
+            wsAgentServerUtilProvider
+                .get()
+                .getWsAgentHttpServer()
+                .filter(server -> RUNNING == server.getStatus())
+                .ifPresent(
+                    server -> {
+                      subscribe();
+                      restartTimer();
+                    }));
+    eventBus.addHandler(
+        WsAgentServerRunningEvent.TYPE,
+        e -> {
+          subscribe();
+          restartTimer();
+        });
+    eventBus.addHandler(
+        WsAgentServerStoppedEvent.TYPE,
+        e -> {
+          unsubscribe();
+          heartBeatTimer.cancel();
+        });
+    eventBus.addHandler(
+        WorkspaceStoppedEvent.TYPE,
+        e -> {
+          unsubscribe();
+          heartBeatTimer.cancel();
+        });
+  }
+
+  private void restartTimer() {
+    heartBeatTimer.cancel();
+    heartBeatTimer.schedule(HEART_BEAT_PERIOD);
+  }
+
+  private void onWsAgentConnectionIsLost() {
+    WorkspaceImpl workspace = appContext.getWorkspace();
+    if (workspace.getStatus() != WorkspaceStatus.RUNNING) {
+      return;
+    }
+
+    wsAgentServerUtilProvider
+        .get()
+        .getWsAgentServerMachine()
+        .ifPresent(machine -> eventBus.fireEvent(new WsAgentServerStoppedEvent(machine.getName())));
+
+    dialogFactory
+        .createChoiceDialog(
+            localizationConstant.wsAgentNotRespondingDialogTitle(),
+            localizationConstant.wsAgentNotRespondingDialogMessage(),
+            localizationConstant.wsAgentNotRespondingDialogRestart(),
+            localizationConstant.wsAgentNotRespondingDialogClose(),
+            () -> {
+              eventBus.addHandler(WorkspaceStoppedEvent.TYPE, event -> reloadPage(false));
+              actionManager.performAction(STOP_WORKSPACE, emptyMap());
+            },
+            null)
+        .show();
+  }
+
+  private void subscribe() {
+    requestTransmitter
+        .newRequest()
+        .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
+        .methodName(WS_AGENT_TRACK_CONNECTION_SUBSCRIBE)
+        .noParams()
+        .sendAndSkipResult();
+  }
+
+  private void unsubscribe() {
+    requestTransmitter
+        .newRequest()
+        .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
+        .methodName(WS_AGENT_TRACK_CONNECTION_UNSUBSCRIBE)
+        .noParams()
+        .sendAndSkipResult();
+  }
+}

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -548,3 +548,9 @@ menu.loader.machineRunning = Machine <span style="color: #b069ef;">{0}</span> is
 menu.loader.workspaceStarted = <span style="color: #3aa461;">Workspace successfully started</span>
 menu.loader.waitingWorkspace = Waiting workspace machines to be booted...
 menu.loader.pullingImage = Pulling image <span style="color: #7699da;">{0}</span> ...
+
+##### Ws Agent Connection Tracker#####
+ws.agent.lost.connection.dialog.title=Workspace Agent is not responding
+ws.agent.lost.connection.dialog.message=Workspace agent is no longer responding. To fix the problem, restart the workspace.
+ws.agent.lost.connection.dialog.restart=Restart
+ws.agent.lost.connection.dialog.close=Close

--- a/pom.xml
+++ b/pom.xml
@@ -688,6 +688,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-wsagent-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
                 <artifactId>wsagent</artifactId>
                 <version>${che.version}</version>
             </dependency>

--- a/wsagent/che-wsagent-core/pom.xml
+++ b/wsagent/che-wsagent-core/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>guice-servlet</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -90,6 +94,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-git-impl-jgit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-wsagent-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
@@ -36,5 +36,6 @@ public class CheWsAgentModule extends AbstractModule {
     bind(String.class)
         .annotatedWith(Names.named("wsagent.endpoint"))
         .toProvider(WsAgentURLProvider.class);
+    bind(WsAgentWebSocketConnectionKeeper.class).asEagerSingleton();
   }
 }

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentWebSocketConnectionKeeper.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentWebSocketConnectionKeeper.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.wsagent.server;
+
+import static com.google.common.collect.ImmutableSet.copyOf;
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_CLEANUP_PERIOD_MINUTES;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_HEARTBEAT;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_PERIOD_MILLISECONDS;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_SUBSCRIBE;
+import static org.eclipse.che.wsagent.shared.Constants.WS_AGENT_TRACK_CONNECTION_UNSUBSCRIBE;
+
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.commons.schedule.ScheduleRate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sends requests to interested clients to confirm that connection isn't lost.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class WsAgentWebSocketConnectionKeeper {
+  private static final Logger LOG = LoggerFactory.getLogger(WsAgentWebSocketConnectionKeeper.class);
+  private final ScheduledExecutorService heartBeatScheduler = Executors.newScheduledThreadPool(1);
+  private final Set<String> endpointIds = newConcurrentHashSet();
+  private final Set<String> unresponsiveEndpointIds = newConcurrentHashSet();
+  private ScheduledFuture<?> keepingInTouchFuture;
+  private RequestTransmitter transmitter;
+  private RequestHandlerConfigurator configurator;
+
+  @Inject
+  public WsAgentWebSocketConnectionKeeper(
+      RequestTransmitter transmitter, RequestHandlerConfigurator configurator) {
+    this.transmitter = transmitter;
+    this.configurator = configurator;
+  }
+
+  @PostConstruct
+  public void initialize() {
+    configurator
+        .newConfiguration()
+        .methodName(WS_AGENT_TRACK_CONNECTION_SUBSCRIBE)
+        .noParams()
+        .noResult()
+        .withConsumer(endpointIds::add);
+
+    configurator
+        .newConfiguration()
+        .methodName(WS_AGENT_TRACK_CONNECTION_UNSUBSCRIBE)
+        .noParams()
+        .noResult()
+        .withConsumer(endpointIds::remove);
+
+    keepingInTouchFuture =
+        heartBeatScheduler.scheduleAtFixedRate(
+            this::sendRequest, 0, WS_AGENT_TRACK_CONNECTION_PERIOD_MILLISECONDS, MILLISECONDS);
+  }
+
+  private void sendRequest() {
+    if (endpointIds.isEmpty()) {
+      return;
+    }
+
+    Set<String> endpointsIdsCopy = copyOf(endpointIds);
+    endpointsIdsCopy.forEach(
+        endpointId ->
+            transmitter
+                .newRequest()
+                .endpointId(endpointId)
+                .methodName(WS_AGENT_TRACK_CONNECTION_HEARTBEAT)
+                .paramsAsBoolean(true)
+                .sendAndReceiveResultAsBoolean(3 * WS_AGENT_TRACK_CONNECTION_PERIOD_MILLISECONDS)
+                .onTimeout(() -> unresponsiveEndpointIds.add(endpointId))
+                .onSuccess(aBoolean -> unresponsiveEndpointIds.remove(endpointId))
+                .onFailure(
+                    jsonRpcError -> {
+                      unresponsiveEndpointIds.add(endpointId);
+                      LOG.error(
+                          format(
+                              "Tracking connection request to client with endpointId %s fail, the reason is %s",
+                              endpointId, jsonRpcError.getMessage()));
+                    }));
+  }
+
+  @ScheduleRate(period = WS_AGENT_TRACK_CONNECTION_CLEANUP_PERIOD_MINUTES, unit = MINUTES)
+  private void cleanUpEnpointIds() {
+    if (unresponsiveEndpointIds.isEmpty()) {
+      return;
+    }
+
+    Set<String> unresponsiveEndpointIdsCopy = copyOf(unresponsiveEndpointIds);
+    unresponsiveEndpointIds.clear();
+    endpointIds.removeAll(unresponsiveEndpointIdsCopy);
+  }
+
+  @PreDestroy
+  public void unInstall() {
+    keepingInTouchFuture.cancel(true);
+    endpointIds.clear();
+    unresponsiveEndpointIds.clear();
+  }
+}

--- a/wsagent/che-wsagent-shared/pom.xml
+++ b/wsagent/che-wsagent-shared/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-agent-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>6.0.0-M3-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-wsagent-shared</artifactId>
+    <name>Che Workspace Agent :: Shared</name>
+</project>

--- a/wsagent/che-wsagent-shared/src/main/java/org/eclipse/che/wsagent/shared/Constants.java
+++ b/wsagent/che-wsagent-shared/src/main/java/org/eclipse/che/wsagent/shared/Constants.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.wsagent.shared;
+
+/**
+ * Constants related to Workspace Agent
+ *
+ * @author Roman Nikitenko
+ */
+public final class Constants {
+  public static final String WS_AGENT_TRACK_CONNECTION_SUBSCRIBE =
+      "ws-agent/track/connection/subscribe";
+  public static final String WS_AGENT_TRACK_CONNECTION_UNSUBSCRIBE =
+      "ws-agent/track/connection/unsubscribe";
+  public static final String WS_AGENT_TRACK_CONNECTION_HEARTBEAT =
+      "ws-agent/track/connection/heartbeat";
+  public static final int WS_AGENT_TRACK_CONNECTION_PERIOD_MILLISECONDS = 3_000;
+  public static final int WS_AGENT_TRACK_CONNECTION_CLEANUP_PERIOD_MINUTES = 5;
+
+  private Constants() {}
+}

--- a/wsagent/pom.xml
+++ b/wsagent/pom.xml
@@ -43,5 +43,6 @@
         <module>che-core-api-testing-shared</module>
         <module>wsagent-local</module>
         <module>che-wsagent-core</module>
+        <module>che-wsagent-shared</module>
     </modules>
 </project>


### PR DESCRIPTION
### What does this PR do?
- Implement heartbeat mechanism with JSON RPC protocol for WS  Agent on server side
- Tracks web socket connection to control ws agent state on client side. 
- Notifies client side by [WsAgentServerStoppedEvent](https://github.com/eclipse/che/blob/6e9825c699d34eef6b8bf36fc0194ff871cbee84/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/event/WsAgentServerStoppedEvent.java#L22) when a connection is lost. 
- Prompts to restart a workspace when connection is lost, but workspace is running.

### What issues does this PR fix or reference?
#5935

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
