### PR TITLE
Make /system/status service public and use it as liveness check endpoint

### DIFF
--- a/dockerfiles/base/scripts/base/library.sh
+++ b/dockerfiles/base/scripts/base/library.sh
@@ -26,7 +26,7 @@ convert_posix_to_windows() {
 }
 
 get_boot_url() {
-  echo "$CHE_HOST:$CHE_PORT/api/"
+  echo "$CHE_HOST:$CHE_PORT/api/system/state"
 }
 
 get_display_url() {
@@ -66,7 +66,7 @@ server_is_booted() {
   PING_URL=$(get_boot_url)
   HTTP_STATUS_CODE=$(curl -I -k ${PING_URL} -s -o /dev/null --write-out '%{http_code}')
   log "${HTTP_STATUS_CODE}"
-  if [[ "${HTTP_STATUS_CODE}" = "200" ]] || [[ "${HTTP_STATUS_CODE}" = "302" ]] || [[ "${HTTP_STATUS_CODE}" = "403" ]]; then
+  if [[ "${HTTP_STATUS_CODE}" = "200" ]] || [[ "${HTTP_STATUS_CODE}" = "302" ]]; then
     return 0
   else
     return 1

--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -382,10 +382,6 @@ MULTI_USER_REPLACEMENT_STRING="          - name: \"CHE_WORKSPACE_LOGS\"
           - name: \"CHE_HOST\"
             value: \"${CHE_HOST}\""
 
-# TODO When merging the multi-user work to master, this replacement string should
-# be replaced by the corresponding change in the fabric8 deployment descriptor
-MULTI_USER_HEALTH_CHECK_REPLACEMENT_STRING="s|            path: /api/system/state|            path: /api|"
-
 echo
 if [ "${OPENSHIFT_FLAVOR}" == "minishift" ]; then
   echo "[CHE] Deploying Che on minishift (image ${CHE_IMAGE})"
@@ -418,7 +414,6 @@ cat "${CHE_DEPLOYMENT_FILE_PATH}" | \
     if [ "${CHE_INFRA_OPENSHIFT_PASSWORD+x}" ]; then sed "s|    CHE_INFRA_OPENSHIFT_PASSWORD:.*|    CHE_INFRA_OPENSHIFT_PASSWORD: ${CHE_INFRA_OPENSHIFT_PASSWORD}|"; else cat -;  fi | \
     if [ "${CHE_KEYCLOAK_DISABLED}" == "true" ]; then sed "s/    keycloak-disabled: \"false\"/    keycloak-disabled: \"true\"/" ; else cat -; fi | \
     if [ "${CHE_DEBUGGING_ENABLED}" == "true" ]; then sed "s/    remote-debugging-enabled: \"false\"/    remote-debugging-enabled: \"true\"/"; else cat -; fi | \
-    sed "$MULTI_USER_HEALTH_CHECK_REPLACEMENT_STRING" | \
     append_after_match "env:" "${MULTI_USER_REPLACEMENT_STRING}" | \
     oc apply --force=true -f -
 elif [ "${OPENSHIFT_FLAVOR}" == "osio" ]; then
@@ -439,7 +434,6 @@ cat "${CHE_DEPLOYMENT_FILE_PATH}" | \
     sed "s/          imagePullPolicy:.*/          imagePullPolicy: \"${IMAGE_PULL_POLICY}\"/" | \
     if [ "${CHE_KEYCLOAK_DISABLED}" == "true" ]; then sed "s/    keycloak-disabled: \"false\"/    keycloak-disabled: \"true\"/" ; else cat -; fi | \
     if [ "${CHE_DEBUGGING_ENABLED}" == "true" ]; then sed "s/    remote-debugging-enabled: \"false\"/    remote-debugging-enabled: \"true\"/"; else cat -; fi | \
-    sed "$MULTI_USER_HEALTH_CHECK_REPLACEMENT_STRING" | \
     append_after_match "env:" "${MULTI_USER_REPLACEMENT_STRING}" | \
     oc apply --force=true -f -
 else
@@ -470,7 +464,6 @@ cat "${CHE_DEPLOYMENT_FILE_PATH}" | \
     if [ "${ENABLE_SSL}" == "false" ]; then grep -v -e "tls:" -e "insecureEdgeTerminationPolicy: Redirect" -e "termination: edge" ; else cat -; fi | \
     if [ "${ENABLE_SSL}" == "false" ]; then sed "s/    che.docker.server_evaluation_strategy.custom.external.protocol: https/    che.docker.server_evaluation_strategy.custom.external.protocol: http/" ; else cat -; fi | \
     if [ "${K8S_VERSION_PRIOR_TO_1_6}" == "true" ]; then sed "s/    che-openshift-precreate-subpaths: \"false\"/    che-openshift-precreate-subpaths: \"true\"/"  ; else cat -; fi | \
-    sed "$MULTI_USER_HEALTH_CHECK_REPLACEMENT_STRING" | \
     append_after_match "env:" "${MULTI_USER_REPLACEMENT_STRING}" | \
     oc apply --force=true -f -
 fi

--- a/dockerfiles/init/modules/openshift/files/scripts/wait_until_che_is_available.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/wait_until_che_is_available.sh
@@ -46,11 +46,11 @@ elif [ ${SECONDS} -lt ${end} ]; then
   exit 1
 fi
 
-che_http_status=$(curl -s -o /dev/null -I -w "%{http_code}" "${CHE_API_ENDPOINT}/")
+che_http_status=$(curl -s -o /dev/null -I -w "%{http_code}" "${CHE_API_ENDPOINT}/system/state")
 if [ "${che_http_status}" == "200" ]; then  
   echo "[CHE] Che is up and running"
 else
-  echo "[CHE] [ERROR] Che is not reponding (HTTP status= ${che_http_status})"
+  echo "[CHE] [ERROR] Che is not responding (HTTP status= ${che_http_status})"
   exit 1
 fi
 

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -20,11 +20,11 @@ public class KeycloakServletModule extends ServletModule {
   protected void configureServlets() {
     bind(KeycloakAuthenticationFilter.class).in(Singleton.class);
 
-    // Not contains /docs/ (for swagger) and not ends with '/api/oauth/callback/' or
-    // '/keycloak/settings/'
-    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
+    // Not contains /docs/ (for swagger) and not ends with '/oauth/callback/' or
+    // '/keycloak/settings/' or '/system/state'
+    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/oauth/callback/?|/system/state/?)$).*")
         .through(KeycloakAuthenticationFilter.class);
-    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
+    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/oauth/callback/?|/system/state/?)$).*")
         .through(KeycloakEnvironmentInitalizationFilter.class);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Makes `/system/status service` public and fix cli to use it as a API liveneess check endpoint.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6533