### PR TITLE
Fix CLI multiuser fail, fix CLI tests

### DIFF
--- a/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
+++ b/dockerfiles/base/scripts/base/startup_03_pre_networking.sh
@@ -87,15 +87,12 @@ get_image_manifest() {
 
   # Load images from file
   BOOTSTRAP_IMAGE_LIST=$(cat ${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}/images/images-bootstrap)
+  IMAGE_LIST=$(cat /version/$1/images)
   if [ -z "${CHE_SINGLE_PORT:-}" ]; then
-    IMAGE_LIST=$(cat /version/$1/images | sed '/IMAGE_TRAEFIK/d')
-  else
-    IMAGE_LIST=$(cat /version/$1/images)
+    IMAGE_LIST=$(echo "${IMAGE_LIST}" | sed '/IMAGE_TRAEFIK/d')
   fi
   if [ -z "${CHE_MULTIUSER:-}" ]; then
      IMAGE_LIST=$(echo "${IMAGE_LIST}" | sed '/IMAGE_KEY*/d; /IMAGE_POSTGRES/d; /IMAGE_CHE_MULTI_*/d')
-  else
-     IMAGE_LIST=$(echo "${IMAGE_LIST}" | sed '/IMAGE_CHE=/d')
   fi
   UTILITY_IMAGE_LIST=$(cat ${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}/images/images-utilities)
 

--- a/dockerfiles/cli/tests/cmd_offline_tests.bats
+++ b/dockerfiles/cli/tests/cmd_offline_tests.bats
@@ -34,11 +34,7 @@ source /dockerfiles/cli/tests/test_base.sh
   [[ -f $(ls "${container_tmp_path}"/backup/eclipse_che-init*.tar) ]]
   [[ -f $(ls "${container_tmp_path}"/backup/eclipse_che-ip*.tar) ]]
   [[ -f $(ls "${container_tmp_path}"/backup/eclipse_che-mount*.tar) ]]
-  [[ -f $(ls "${container_tmp_path}"/backup/eclipse_che-server-multiuser*.tar) ]]
   [[ -f $(ls "${container_tmp_path}"/backup/eclipse_che-test*.tar) ]]
-  [[ -f $(ls "${container_tmp_path}"/backup/traefik*.tar) ]]
-  [[ -f $(ls "${container_tmp_path}"/backup/jboss_keycloak-openshift*.tar) ]]
-  [[ -f $(ls "${container_tmp_path}"/backup/centos_postgresql-96-centos7*.tar) ]]
 }
 
 @test "test cli 'offline' command: include custom stack images" {

--- a/dockerfiles/lib/dto-pom.xml
+++ b/dockerfiles/lib/dto-pom.xml
@@ -17,13 +17,13 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.20.0-SNAPSHOT</version>
+        <version>6.0.0-M1-SNAPSHOT</version>
     </parent>
     <artifactId>dto-typescript</artifactId>
     <packaging>pom</packaging>
     <name>Che TypeScript DTO</name>
     <properties>
-        <che.version>5.20.0-SNAPSHOT</che.version>
+        <che.version>6.0.0-M1-SNAPSHOT</che.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
Fix CLI multiuser fail, fix CLI tests
after merge: https://github.com/eclipse/che/commit/a99ef73fcf46c8f589919510eb65874d8d81cb83

we have regression in CLI which is block using multi user mode due to this change
```
IMAGE_LIST=$(echo "${IMAGE_LIST}" | sed '/IMAGE_CHE=/d')
```
while $IMAGE_CHE  var is used even in multi user mode for some checks.

and CLI tests failures

fixes: https://github.com/eclipse/che/issues/6974