### PR TITLE
Fix unexpected interuption of environment clean up in selenium tests

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -105,7 +105,7 @@ public abstract class SeleniumTestHandler
 
   private final Map<Long, Object> runningTests = new ConcurrentHashMap<>();
 
-  private static AtomicBoolean isCleanUpFinished = new AtomicBoolean(false);
+  private static AtomicBoolean isCleanUpCompleted = new AtomicBoolean();
 
   @Override
   public void onTestStart(ITestResult result) {}
@@ -352,7 +352,7 @@ public abstract class SeleniumTestHandler
 
   /** Cleans up test environment. */
   public void shutdown() {
-    if (isCleanUpFinished.get()) {
+    if (isCleanUpCompleted.get()) {
       return;
     }
 
@@ -370,7 +370,7 @@ public abstract class SeleniumTestHandler
       defaultTestUser.delete();
     }
 
-    isCleanUpFinished.set(true);
+    isCleanUpCompleted.set(true);
   }
 
   /** Returns list of parent modules */

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import javax.annotation.PreDestroy;
 import javax.inject.Named;
@@ -104,6 +105,8 @@ public abstract class SeleniumTestHandler
 
   private final Map<Long, Object> runningTests = new ConcurrentHashMap<>();
 
+  private static AtomicBoolean isCleanUpFinished = new AtomicBoolean(false);
+
   @Override
   public void onTestStart(ITestResult result) {}
 
@@ -157,7 +160,9 @@ public abstract class SeleniumTestHandler
   }
 
   @Override
-  public void onFinish(ISuite suite) {}
+  public void onFinish(ISuite suite) {
+    shutdown();
+  }
 
   @Override
   public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
@@ -346,7 +351,11 @@ public abstract class SeleniumTestHandler
   }
 
   /** Cleans up test environment. */
-  private void shutdown() {
+  public void shutdown() {
+    if (isCleanUpFinished.get()) {
+      return;
+    }
+
     LOG.info("Cleaning up test environment...");
 
     for (Object testInstance : runningTests.values()) {
@@ -360,6 +369,8 @@ public abstract class SeleniumTestHandler
     if (defaultTestUser != null) {
       defaultTestUser.delete();
     }
+
+    isCleanUpFinished.set(true);
   }
 
   /** Returns list of parent modules */

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProviderImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProviderImpl.java
@@ -141,7 +141,7 @@ public class TestWorkspaceProviderImpl implements TestWorkspaceProvider {
       LOG.info("Workspace threads pool is terminated");
     }
     LOG.info("Destroy remained workspaces: {}.", extractWorkspaceInfo());
-    testWorkspaceQueue.forEach(TestWorkspace::delete);
+    testWorkspaceQueue.parallelStream().forEach(TestWorkspace::delete);
 
     if (isInterrupted) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
### What does this PR do?
It fixes unexpected interruption of selenium tests environment clean up, like the follow:
```
2017-09-19 12:56:50,709[Thread-0]         [INFO ] [.e.c.s.c.i.SeleniumTestHandler 321]  - Cleaning up test environment...
2017-09-19 12:56:50,710[Thread-0]         [INFO ] [.e.c.s.c.i.SeleniumTestHandler 212]  - Processing @PreDestroy annotation in org.eclipse.che.selenium.miscellaneous.DialogAboutTest

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```
It leads to leaving test workspaces in the product after the test execution.

### What issues does this PR fix or reference?
#6362

**Che 6 PR**: https://github.com/eclipse/che/pull/6994