### PR TITLE
Fix for https://github.com/eclipse/che/issues/6891

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -404,8 +404,9 @@ if [ "${CHE_FABRIC8_MULTITENANT}" == "true" ]; then
           - name: \"CHE_WORKSPACE_CHE__SERVER__ENDPOINT\"
             value: \"\"
 $MULTI_USER_REPLACEMENT_STRING"
+
   MULTITENANT_CUSTOM_STRATEGY_REPLACEMENT="s/    che-server-evaluation-strategy: .*/    che-server-evaluation-strategy: always-external-custom/"
-  MULTITENANT_CUSTOM_TEMPLATE_REPLACEMENT="s/    che.docker.server_evaluation_strategy.custom.template: .*/    che.docker.server_evaluation_strategy.custom.template: <serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<if(workspacesRoutingSuffix)><user>-che.<workspacesRoutingSuffix><else><externalAddress><endif>/"
+  MULTITENANT_CUSTOM_TEMPLATE_REPLACEMENT="s/    che.docker.server_evaluation_strategy.custom.template: .*/    che.docker.server_evaluation_strategy.custom.template: <serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<if(workspacesRoutingSuffix)><workspacesRoutingSuffix><else><externalAddress><endif>/"
   MULTITENANT_IDLING_REPLACEMENT="s/    che-server-timeout-ms: .*/    che-server-timeout-ms: '0'/"
 fi
 

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
@@ -97,7 +97,7 @@ public class OpenShiftRouteCreator {
       final String cheWorkspacesRoutingSuffix,
       final String namespace) {
     if (cheWorkspacesRoutingSuffix != null) {
-      return routeName + "-" + namespace + "." + cheWorkspacesRoutingSuffix;
+      return routeName + "-" + cheWorkspacesRoutingSuffix;
     } else {
       return routeName + "-" + openShiftNamespaceExternalAddress;
     }


### PR DESCRIPTION
Make the `OpenshiftConnector` workspace route naming rule consistent
with custom server evaluation strategy in all cases (especially in case
of unexpected openshift.io user name).

### What does this PR do?

Make the `OpenshiftConnector` workspace route naming rule consistent
with custom server evaluation strategy in all cases (especially in case
of unexpected openshift.io user name).

This change is only relevant when using multi-tenancy (currently implemented in the `rh-che` distribution), and doesn't impact other use-cases.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/6891
