### PR TITLE
Replace steps depended on toolbar menu for the test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/RemoveFilesWithActiveTabs.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/RemoveFilesWithActiveTabs.java
@@ -10,6 +10,10 @@
  */
 package org.eclipse.che.selenium.filewatcher;
 
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.DELETE;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.EDIT;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -38,7 +42,6 @@ import org.testng.annotations.Test;
  */
 public class RemoveFilesWithActiveTabs {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 6);
-
   @Inject private TestWorkspace ws;
 
   @InjectPageObject(driverId = 1)
@@ -105,13 +108,13 @@ public class RemoveFilesWithActiveTabs {
     String deletedClass = "AppController.java";
     String expectedMessage = "File '" + deletedClass + "' is removed";
     projectExplorer1.selectVisibleItem(deletedClass);
-    ideMainDockPanel1.clickDeleteIcon();
+    menu1.runCommand(EDIT, DELETE);
     projectExplorer2.openItemByVisibleNameInExplorer(deletedClass);
     editor2.waitActiveEditor();
 
     confirmDeletion();
 
-    events2.waitExpectedMessage(expectedMessage, 10);
+    events2.waitExpectedMessage(expectedMessage, LOAD_PAGE_TIMEOUT_SEC);
     editor2.waitTabIsNotPresent(deletedClass.replace(".java", ""));
     projectExplorer2.waitItemIsNotPresentVisibleArea(deletedClass);
   }
@@ -128,12 +131,12 @@ public class RemoveFilesWithActiveTabs {
     projectExplorer2.openItemByPath(PROJECT_NAME + "/" + nameFiletxt1);
     projectExplorer1.selectItem(PROJECT_NAME + "/" + nameReadmeFile);
     projectExplorer1.selectMultiFilesByCtrlKeys(PROJECT_NAME + "/" + nameFiletxt1);
-    ideMainDockPanel1.clickDeleteIcon();
+    menu1.runCommand(EDIT, DELETE);
 
     confirmDeletion();
 
-    events2.waitExpectedMessage(expectedMessage1, 10);
-    events2.waitExpectedMessage(expectedMessage2, 10);
+    events2.waitExpectedMessage(expectedMessage1, LOAD_PAGE_TIMEOUT_SEC);
+    events2.waitExpectedMessage(expectedMessage2, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer1.waitItemIsNotPresentVisibleArea(nameReadmeFile);
     projectExplorer1.waitItemIsNotPresentVisibleArea(nameFiletxt1);
     projectExplorer2.waitItemIsNotPresentVisibleArea(nameReadmeFile);
@@ -151,7 +154,7 @@ public class RemoveFilesWithActiveTabs {
 
     testProjectServiceClient.deleteResource(ws.getId(), PROJECT_NAME + "/" + nameFiletxt2);
 
-    events1.waitExpectedMessage(expectedMessage1, 10);
+    events1.waitExpectedMessage(expectedMessage1, LOAD_PAGE_TIMEOUT_SEC);
     editor1.waitTabIsNotPresent(nameFiletxt2);
     projectExplorer2.openItemByPath(PROJECT_NAME + "/" + nameFiletxt3);
     editor2.waitTabIsPresent(nameFiletxt3);
@@ -159,7 +162,7 @@ public class RemoveFilesWithActiveTabs {
     testProjectServiceClient.deleteResource(ws.getId(), PROJECT_NAME + "/" + nameFiletxt3);
 
     editor2.waitTabIsNotPresent(nameFiletxt2);
-    events2.waitExpectedMessage(expectedMessage2, 10);
+    events2.waitExpectedMessage(expectedMessage2, LOAD_PAGE_TIMEOUT_SEC);
   }
 
   /** Handles the IDE deletion dialog */


### PR DESCRIPTION
### What does this PR do?
Avoid using toolbar for deleting files, because the toolbar is disabled by default in CHE6

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7009
@tolusha @vparfonov @dmytro-ndp 