### PR TITLE
Fix DockerInternalRuntime test that is not throwing an expected checked exception

### DIFF
--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
@@ -46,6 +46,7 @@ import org.eclipse.che.api.workspace.server.hc.ServersCheckerFactory;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
@@ -182,9 +183,10 @@ public class DockerInternalRuntimeTest {
     }
   }
 
-  @Test(expectedExceptions = RuntimeStartInterruptedException.class)
-  public void throwsInterruptionExceptionWhenNetworkCreationInterrupted() throws Exception {
-    doThrow(RuntimeStartInterruptedException.class)
+  @Test(expectedExceptions = InternalInfrastructureException.class)
+  public void throwsInternalInfrastructureExceptionWhenNetworkCreationInterrupted()
+      throws Exception {
+    doThrow(InternalInfrastructureException.class)
         .when(networks)
         .createNetwork(nullable(String.class));
 


### PR DESCRIPTION
### What does this PR do?

RuntimeStartInterruptedException is a checked exception that can't be thrown by createNetwork method
It is reported with new version of Mockito 

Replacing then the checked exception by the exception that createNetwork method can throw (which is InternalInfrastructureException)

note: I can change the code to what you'll expect, it's just that current code is not possible.

### What issues does this PR fix or reference?
#5326 

#### Release Notes
N/A

#### Docs PR
N/A


Change-Id: Icccf451ef5570494441c583495f41382246e10f1
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
