### PR TITLE
Fix GwtXmlGenerator classpath issue with Java9

### DIFF
--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IgnoreUnExistedResourcesReflectionConfigurationBuilder.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IgnoreUnExistedResourcesReflectionConfigurationBuilder.java
@@ -11,7 +11,11 @@
 package org.eclipse.che.util;
 
 import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.stream.Collectors;
+import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 
 /**
@@ -28,6 +32,11 @@ public final class IgnoreUnExistedResourcesReflectionConfigurationBuilder {
 
   static {
     configurationBuilder = ConfigurationBuilder.build();
+    Collection<URL> classpath = new ArrayList<>();
+    classpath.addAll(ClasspathHelper.forClassLoader());
+    classpath.addAll(ClasspathHelper.forJavaClassPath());
+    configurationBuilder.setUrls(classpath);
+
     configurationBuilder.setUrls(
         configurationBuilder
             .getUrls()


### PR DESCRIPTION
### What does this PR do?
Fix URLs finding when running with Java9
It's mainly because system classloader is not anymore a URLClassLoader

### What issues does this PR fix or reference?
#5326 

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I6f55020704b96d0c8335bded86fad6b8c6770622
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
