### PR TITLE
Fix postgres container freeze on stop

### DIFF
--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -110,8 +110,6 @@ services:
       - CHE_POSTGRES_USERNAME=<%= scope.lookupvar('postgres::che_pg_username') %>
       - CHE_POSTGRES_PASSWORD=<%= scope.lookupvar('postgres::che_pg_password') %>
       - CHE_POSTGRES_DATABASE=<%= scope.lookupvar('postgres::che_pg_database') %>
- 
-  
     volumes:
       - '<%= scope.lookupvar('che::che_instance') -%>/data/postgres:/var/lib/pgsql/data'
       - '<%= scope.lookupvar('che::che_instance') -%>/config/postgres/init-che-user.sh:/var/lib/pgsql/init-che-user.sh'

--- a/dockerfiles/init/modules/postgres/templates/init-che-user-and-run.sh.erb
+++ b/dockerfiles/init/modules/postgres/templates/init-che-user-and-run.sh.erb
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 $(dirname "$0")/init-che-user.sh
-run-postgresql
+exec run-postgresql


### PR DESCRIPTION
### What does this PR do?
Fixes postgres container freeze on stop. That is caused by wrong execution of main process of a container.
If entrypoint is a bash script which will invoke some other process that supposed to be main process of a container it should be invoked with `exec` which will exit the script and allow main process occupy pid `1`.

what we had before:
after sending term signal to PG container PG server was not stopped correctly because sigterm was received by bash script which was not handling sig terms
```
bash-4.2$ ps ax
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 /bin/bash /var/lib/pgsql/init-che-user-and-run.sh
   76 ?        S      0:00 postgres
   99 ?        Ss     0:00 postgres: logger process
  101 ?        Ss     0:00 postgres: checkpointer process
  102 ?        Ss     0:00 postgres: writer process
  103 ?        Ss     0:00 postgres: wal writer process
  104 ?        Ss     0:00 postgres: autovacuum launcher process
  105 ?        Ss     0:00 postgres: stats collector process
  966 pts/0    Ss     0:00 bash
  975 pts/0    R+     0:00 ps ax
```

after fix:
script is not running anymore and process `postgres` used pid `1`
```
bash-4.2$ ps ax
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 postgres
   98 ?        Ss     0:00 postgres: logger process
  100 ?        Ss     0:00 postgres: checkpointer process
  101 ?        Ss     0:00 postgres: writer process
  102 ?        Ss     0:00 postgres: wal writer process
  103 ?        Ss     0:00 postgres: autovacuum launcher process
  104 ?        Ss     0:00 postgres: stats collector process
  126 ?        Ss     0:00 postgres: pgche dbche 172.18.0.4(37704) idle
  138 ?        Ss     0:00 postgres: keycloak keycloak 172.18.0.3(38982) idle
  139 ?        Ss     0:00 postgres: keycloak keycloak 172.18.0.3(38984) idle
  141 ?        Ss     0:00 postgres: keycloak keycloak 172.18.0.3(38994) idle
  177 ?        Ss     0:00 postgres: pgche dbche 172.18.0.4(37766) idle
  183 pts/0    Ss     0:00 bash
  192 pts/0    R+     0:00 ps ax
```

PG container stop does not freeze anymore.

### What issues does this PR fix or reference?
fixes: https://github.com/eclipse/che/issues/6530
