### PR TITLE
Limit command output to fix problem with crashed browser tab

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/OutputConsoleViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/console/OutputConsoleViewImpl.java
@@ -317,6 +317,11 @@ public class OutputConsoleViewImpl extends Composite implements OutputConsoleVie
 
   @Override
   public void print(final String text, boolean carriageReturn, String color) {
+
+    if (consoleLines.getElement().getChildCount() > 500) {
+      consoleLines.getElement().getFirstChild().removeFromParent();
+    }
+
     if (this.carriageReturn) {
       Node lastChild = consoleLines.getElement().getLastChild();
       if (lastChild != null) {


### PR DESCRIPTION
### What does this PR do?
With help of @vitaliy-guliy  Limit command output to fix problem with crashed browser tab

### What issues does this PR fix or reference?
Fast fix discussed here https://github.com/eclipse/che/issues/7008#issuecomment-339650502
Now we can build che in che
<img width="1280" alt="2017-10-27 15 53 38" src="https://user-images.githubusercontent.com/1614429/32106327-fcaf9a54-bb33-11e7-90d6-1d6ca6d251a7.png">


<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Command output limited to 500 lines
