### PR TITLE
[wip] Update version of javassist to a Java9 compliant version (and update GWT Mockito for that version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <che.docs.version>6.0.0-M2-SNAPSHOT</che.docs.version>
         <che.lib.version>6.0.0-M2-SNAPSHOT</che.lib.version>
         <che.version>6.0.0-M2-SNAPSHOT</che.version>
+        <com.google.gwt.gwtmockito>1.1.7</com.google.gwt.gwtmockito>
         <org.javassist.version>3.22.0-GA</org.javassist.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <che.docs.version>6.0.0-M2-SNAPSHOT</che.docs.version>
         <che.lib.version>6.0.0-M2-SNAPSHOT</che.lib.version>
         <che.version>6.0.0-M2-SNAPSHOT</che.version>
+        <org.javassist.version>3.22.0-GA</org.javassist.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
note: this PR will be closed, it's only to verify with Che jenkins after it is working on my side.
Real PR will be at https://github.com/eclipse/che-dependencies/pull/68

### What does this PR do?
Update javassist to a java9 compliant version

### What issues does this PR fix or reference?
#5326 


#### Release Notes
N/A

#### Docs PR
N/A


Change-Id: I47e5937b1c681888dc6bc556c73b7539a358f77d
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

