### PR TITLE
Create .ssh if it does not exist

### DIFF
--- a/agents/git-credentials/src/main/resources/org.eclipse.che.git.script.sh
+++ b/agents/git-credentials/src/main/resources/org.eclipse.che.git.script.sh
@@ -11,6 +11,8 @@
 
 SCRIPT_FILE=~/.ssh/git.sh
 
+mkdir -p ~/.ssh
+
 token=$(if [ "$USER_TOKEN" != "dummy_token" ]; then echo "$USER_TOKEN"; fi)
 che_host=$(cat /etc/hosts | grep che-host | awk '{print $1;}')
 api_url=$(if [ "$CHE_API" != "http://che-host:8080/wsmaster/api" ]; then echo "$CHE_API"; else echo "$che_host:8080/api"; fi)


### PR DESCRIPTION
The git credentials agent will fail if the base image used doesn't already have an `.ssh` folder for the user. This PR will create one if it doesn't exist.