### PR TITLE
Fix for #7058 ...

### DIFF
--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/AlwaysExternalCustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/AlwaysExternalCustomServerEvaluationStrategy.java
@@ -14,6 +14,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import java.util.Map;
 import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.plugin.docker.client.WorkspacesRoutingSuffixProvider;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
@@ -55,5 +56,20 @@ public class AlwaysExternalCustomServerEvaluationStrategy extends BaseServerEval
   protected Map<String, String> getInternalAddressesAndPorts(
       ContainerInfo containerInfo, String internalHost) {
     return super.getExternalAddressesAndPorts(containerInfo, internalHost);
+  }
+
+  @Override
+  protected ServerImpl updateServer(ServerImpl server) {
+    super.updateServer(server);
+    ServerPropertiesImpl properties = (ServerPropertiesImpl) server.getProperties();
+    String url = properties.getInternalUrl();
+    String externalProtocol = server.getProtocol();
+    if (url != null && externalProtocol != null) {
+      int internalUrlProtocolEnd = url.indexOf(':');
+      if (internalUrlProtocolEnd > 0) {
+        properties.setInternalUrl(externalProtocol.concat(url.substring(internalUrlProtocolEnd)));
+      }
+    }
+    return server;
   }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/AlwaysExternalCustomServerEvaluationStrategy.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/AlwaysExternalCustomServerEvaluationStrategy.java
@@ -61,6 +61,11 @@ public class AlwaysExternalCustomServerEvaluationStrategy extends BaseServerEval
   @Override
   protected ServerImpl updateServer(ServerImpl server) {
     super.updateServer(server);
+    setExternalProtocolForInternalUrl(server);
+    return server;
+  }
+
+  private void setExternalProtocolForInternalUrl(ServerImpl server) {
     ServerPropertiesImpl properties = (ServerPropertiesImpl) server.getProperties();
     String url = properties.getInternalUrl();
     String externalProtocol = server.getProtocol();
@@ -70,6 +75,5 @@ public class AlwaysExternalCustomServerEvaluationStrategy extends BaseServerEval
         properties.setInternalUrl(externalProtocol.concat(url.substring(internalUrlProtocolEnd)));
       }
     }
-    return server;
   }
 }

--- a/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/AlwaysExternalCustomServerEvaluationStrategyTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/AlwaysExternalCustomServerEvaluationStrategyTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.docker.machine;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.machine.server.model.impl.ServerConfImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerImpl;
+import org.eclipse.che.api.machine.server.model.impl.ServerPropertiesImpl;
+import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
+import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
+import org.eclipse.che.plugin.docker.client.json.NetworkSettings;
+import org.eclipse.che.plugin.docker.client.json.PortBinding;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class AlwaysExternalCustomServerEvaluationStrategyTest {
+
+  private static final String CHE_DOCKER_IP_EXTERNAL = "container-host-ext.com";
+  private static final String ALL_IP_ADDRESS = "0.0.0.0";
+  private static final String CONTAINERCONFIG_HOSTNAME = "che-ws-y6jwknht0efzczit-4086112300-fm0aj";
+  private static final String WORKSPACE_ID = "79rfwhqaztq2ru2k";
+
+  private static final String WORKSPACE_ID_VALUE = WORKSPACE_ID;
+  private static final String WORKSPACE_ID_PROPERTY = "CHE_WORKSPACE_ID=" + WORKSPACE_ID_VALUE;
+
+  private static final String MACHINE_NAME_VALUE = "myMachine";
+  private static final String MACHINE_NAME_PROPERTY = "CHE_MACHINE_NAME=" + MACHINE_NAME_VALUE;
+
+  private static final String IS_DEV_MACHINE_VALUE = "true";
+  private static final String IS_DEV_MACHINE_PROPERTY =
+      "CHE_IS_DEV_MACHINE=" + IS_DEV_MACHINE_VALUE;
+
+  private static final String CHE_DOCKER_SERVER_EVALUATION_STRATEGY_CUSTOM_TEMPLATE =
+      "<serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<externalAddress>";
+
+  @Mock private ContainerInfo containerInfo;
+  @Mock private ContainerConfig containerConfig;
+  @Mock private NetworkSettings networkSettings;
+
+  private ServerEvaluationStrategy strategy;
+
+  private Map<String, ServerConfImpl> serverConfs;
+
+  private Map<String, List<PortBinding>> ports;
+
+  private Map<String, String> labels;
+
+  private String[] env;
+
+  private String[] envContainerConfig;
+
+  @BeforeMethod
+  public void setUp() {
+
+    serverConfs = new HashMap<>();
+    serverConfs.put(
+        "4301/tcp", new ServerConfImpl("sysServer1-tcp", "4301/tcp", "http", "/some/path1"));
+    serverConfs.put(
+        "4305/udp", new ServerConfImpl("devSysServer1-udp", "4305/udp", null, "some/path4"));
+
+    ports = new HashMap<>();
+    ports.put(
+        "4301/tcp",
+        Collections.singletonList(
+            new PortBinding().withHostIp(ALL_IP_ADDRESS).withHostPort("32100")));
+    ports.put(
+        "4305/udp",
+        Collections.singletonList(
+            new PortBinding().withHostIp(ALL_IP_ADDRESS).withHostPort("32103")));
+
+    labels = new HashMap<>();
+    labels.put("che:server:4301/tcp:ref", "sysServer1-tcp");
+    labels.put("che:server:4305/udp:ref", "devSysServer1-udp");
+
+    env = new String[] {"CHE_WORKSPACE_ID=" + WORKSPACE_ID};
+
+    when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
+    when(networkSettings.getIpAddress()).thenReturn(CONTAINERCONFIG_HOSTNAME);
+    when(networkSettings.getPorts()).thenReturn(ports);
+    when(containerInfo.getConfig()).thenReturn(containerConfig);
+    when(containerConfig.getHostname()).thenReturn(CONTAINERCONFIG_HOSTNAME);
+    when(containerConfig.getEnv()).thenReturn(env);
+    when(containerConfig.getLabels()).thenReturn(labels);
+
+    envContainerConfig =
+        new String[] {WORKSPACE_ID_PROPERTY, MACHINE_NAME_PROPERTY, IS_DEV_MACHINE_PROPERTY};
+    when(containerConfig.getEnv()).thenReturn(envContainerConfig);
+  }
+
+  @Test
+  public void shouldUseExternalAddressForUnsecuredInternalAddress() throws Exception {
+    // given
+    strategy =
+        new AlwaysExternalCustomServerEvaluationStrategy(
+                "10.0.0.1",
+                CHE_DOCKER_IP_EXTERNAL,
+                CHE_DOCKER_SERVER_EVALUATION_STRATEGY_CUSTOM_TEMPLATE,
+                "http",
+                null,
+                null)
+            .withThrowOnUnknownHost(false);
+
+    final Map<String, ServerImpl> expectedServers =
+        getExpectedServers(CHE_DOCKER_IP_EXTERNAL, CONTAINERCONFIG_HOSTNAME, "http");
+
+    // when
+    final Map<String, ServerImpl> servers =
+        strategy.getServers(containerInfo, CHE_DOCKER_IP_EXTERNAL, serverConfs);
+
+    // then
+    assertEquals(servers, expectedServers);
+  }
+
+  @Test
+  public void shouldUseExternalAddressForSecuredInternalAddress() throws Exception {
+    // given
+    strategy =
+        new AlwaysExternalCustomServerEvaluationStrategy(
+                "10.0.0.1",
+                CHE_DOCKER_IP_EXTERNAL,
+                CHE_DOCKER_SERVER_EVALUATION_STRATEGY_CUSTOM_TEMPLATE,
+                "https",
+                null,
+                null)
+            .withThrowOnUnknownHost(false);
+
+    final Map<String, ServerImpl> expectedServers =
+        getExpectedServers(CHE_DOCKER_IP_EXTERNAL, CONTAINERCONFIG_HOSTNAME, "https");
+
+    // when
+    final Map<String, ServerImpl> servers =
+        strategy.getServers(containerInfo, CHE_DOCKER_IP_EXTERNAL, serverConfs);
+
+    // then
+    assertEquals(servers, expectedServers);
+  }
+
+  private Map<String, ServerImpl> getExpectedServers(
+      String externalAddress, String internalAddress, String expectedProtocol) {
+    Map<String, ServerImpl> expectedServers = new HashMap<>();
+    expectedServers.put(
+        "4301/tcp",
+        new ServerImpl(
+            "sysServer1-tcp",
+            expectedProtocol,
+            "sysServer1-tcp-" + WORKSPACE_ID + "-" + externalAddress,
+            expectedProtocol
+                + "://"
+                + "sysServer1-tcp-"
+                + WORKSPACE_ID
+                + "-"
+                + externalAddress
+                + "/some/path1",
+            new ServerPropertiesImpl(
+                "/some/path1",
+                "sysServer1-tcp-" + WORKSPACE_ID + "-" + externalAddress,
+                expectedProtocol
+                    + "://"
+                    + "sysServer1-tcp-"
+                    + WORKSPACE_ID
+                    + "-"
+                    + externalAddress
+                    + "/some/path1")));
+    expectedServers.put(
+        "4305/udp",
+        new ServerImpl(
+            "devSysServer1-udp",
+            null,
+            "devSysServer1-udp-" + WORKSPACE_ID + "-" + externalAddress,
+            null,
+            new ServerPropertiesImpl(
+                "some/path4", "devSysServer1-udp-" + WORKSPACE_ID + "-" + externalAddress, null)));
+    return expectedServers;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

It makes the new `always-external-custom` server evaluation strategy
also support `https`. The previous PR #7004 to fix issue #6953 was not
complete and didn't support the secured use-case correctly.

### What issues does this PR fix or reference?

#7058
