### PR TITLE
Don't unregister the cached resource to have consistent tree representation of files

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -952,7 +952,6 @@ public final class ResourceManager {
             itemReference -> {
               final Resource resource = newResourceFrom(itemReference);
 
-              store.dispose(absolutePath, false);
               store.register(resource);
 
               if (resource.isProject()) {


### PR DESCRIPTION
### What does this PR do?
Do not remove resource if it has been already registered in resource store to have a consistent representation of resources.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#5752

#### Release Notes
N/A

#### Docs PR
N/A
