### PR TITLE
Do not index files from File Index excludes

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/matchers/DotCheMatcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/matchers/DotCheMatcher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.project.server.matchers;
+
+import static org.eclipse.che.api.project.shared.Constants.CHE_DIR;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import javax.inject.Singleton;
+
+/**
+ * Performs match operation on paths to test whether specified item is .che folder.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class DotCheMatcher implements PathMatcher {
+
+  @Override
+  public boolean matches(Path fsPath) {
+    for (Path pathElement : fsPath) {
+      if (pathElement != null && CHE_DIR.equals(pathElement.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/matchers/DotNumberSignMatcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/matchers/DotNumberSignMatcher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.project.server.matchers;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import javax.inject.Singleton;
+
+/**
+ * Performs match operation on paths to test whether specified item is .# item.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class DotNumberSignMatcher implements PathMatcher {
+
+  @Override
+  public boolean matches(Path fsPath) {
+    return fsPath.startsWith(".#");
+  }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/matchers/HiddenItemPathMatcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/matchers/HiddenItemPathMatcher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.project.server.matchers;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import javax.inject.Singleton;
+
+/**
+ * Performs match operation on paths to test whether specified item is hidden.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class HiddenItemPathMatcher implements PathMatcher {
+
+  @Override
+  public boolean matches(Path path) {
+    for (Path pathElement : path) {
+      if (pathElement != null && pathElement.toFile().isHidden()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/search/impl/LuceneSearcher.java
@@ -407,11 +407,9 @@ public abstract class LuceneSearcher implements Searcher {
   }
 
   protected void addFile(VirtualFile virtualFile) throws ServerException {
-    if (virtualFile.exists()) {
+    if (virtualFile.exists() && shouldIndex(virtualFile)) {
       try (Reader fContentReader =
-          shouldIndexContent(virtualFile)
-              ? new BufferedReader(new InputStreamReader(virtualFile.getContent()))
-              : null) {
+          new BufferedReader(new InputStreamReader(virtualFile.getContent()))) {
         getIndexWriter()
             .updateDocument(
                 new Term(PATH_FIELD, virtualFile.getPath().toString()),
@@ -451,10 +449,12 @@ public abstract class LuceneSearcher implements Searcher {
   }
 
   protected void doUpdate(Term deleteTerm, VirtualFile virtualFile) throws ServerException {
+    if (!shouldIndex(virtualFile)) {
+      return;
+    }
+
     try (Reader fContentReader =
-        shouldIndexContent(virtualFile)
-            ? new BufferedReader(new InputStreamReader(virtualFile.getContent()))
-            : null) {
+        new BufferedReader(new InputStreamReader(virtualFile.getContent()))) {
       getIndexWriter().updateDocument(deleteTerm, createDocument(virtualFile, fContentReader));
     } catch (OutOfMemoryError oome) {
       close();
@@ -480,7 +480,7 @@ public abstract class LuceneSearcher implements Searcher {
     return doc;
   }
 
-  private boolean shouldIndexContent(VirtualFile virtualFile) {
+  private boolean shouldIndex(VirtualFile virtualFile) {
     for (VirtualFileFilter indexFilter : excludeFileIndexFilters) {
       if (indexFilter.accept(virtualFile)) {
         return false;


### PR DESCRIPTION
### What does this PR do?
- Do not index files from File Index excludes: 
   Current behavior: we do not add to index text field of files from File Index excludes
   New behavior: we do not add to index path, name and text fields of files from File Index excludes
- Do not index hidden files and folders

### What issues does this PR fix or reference?
#6948 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
