### PR TITLE
Create che dir when this one doesn't exist at adding to File Watcher excludes

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/vfs/watcher/FileWatcherIgnoreFileTracker.java
@@ -14,6 +14,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.exists;
 import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.lines;
@@ -171,14 +172,7 @@ public class FileWatcherIgnoreFileTracker {
     fileWatcherManager.addIncludeMatcher(getIgnoreFileMatcher());
     fileWatchingOperationID =
         fileWatcherManager.registerByMatcher(
-            getCheDirectoryMatcher(),
-            getCreateConsumer(),
-            getModifyConsumer(),
-            getDeleteConsumer());
-  }
-
-  private PathMatcher getCheDirectoryMatcher() {
-    return path -> isDirectory(path) && CHE_DIR.equals(path.getFileName().toString());
+            getIgnoreFileMatcher(), getCreateConsumer(), getModifyConsumer(), getDeleteConsumer());
   }
 
   private PathMatcher getIgnoreFileMatcher() {
@@ -281,6 +275,11 @@ public class FileWatcherIgnoreFileTracker {
 
   private void writeExcludesToIgnoreFile(Path ignoreFilePath, Set<String> locationsToExclude) {
     try {
+      Path cheDir = ignoreFilePath.getParent();
+      if (!exists(cheDir)) {
+        createDirectories(cheDir);
+      }
+
       write(ignoreFilePath, locationsToExclude, UTF_8, CREATE, APPEND);
     } catch (IOException e) {
       String errorMessage = "Can not add paths to File Watcher excludes ";


### PR DESCRIPTION
### What does this PR do?
Create '.che' directory when this one doesn't exist at adding to File Watcher excludes

### What issues does this PR fix or reference?
#5760 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>