### PR TITLE
Dashboard: added a new way to update factory configuration JSON

### DIFF
--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.directive.spec.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.directive.spec.ts
@@ -22,7 +22,7 @@ interface ITestScope extends ng.IScope {
  * Test of the FactoryInformation directive
  * @author Oleksii Kurinnyi
  */
-fdescribe('FactoryInformation >', () => {
+describe('FactoryInformation >', () => {
 
   let $scope: ITestScope;
 

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
@@ -172,7 +172,7 @@
           <textarea ui-codemirror="factoryInformationController.editorOptions"
                     ng-model="factoryInformationController.factoryContent"
                     aria-label="Factory configuration editor"
-                    ng-focus="factoryInformationController.factoryEditorOnFocus()"></textarea>
+                    ng-change="factoryInformationController.factoryEditorOnChange()"></textarea>
         </div>
       </md-content>
       <div layout="row" flex>


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
It adds a new way to update factory configuration JSON.

If the configuration is changed but not saved and the editor loses focus, a dialog will be displayed.
![screenshot-localhost-3000-2017-10-31-13-40-12-731](https://user-images.githubusercontent.com/16220722/32222577-816280d4-be42-11e7-8188-e52f854d4bad.png)

Corresponding PR for `che6`: https://github.com/eclipse/che/pull/7106

### What issues does this PR fix or reference?
#4734 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>