### PR TITLE
[wip] do not merge - Update to GWT 2.8.2 (Java9 compliant)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <che.docs.version>6.0.0-M2-SNAPSHOT</che.docs.version>
         <che.lib.version>6.0.0-M2-SNAPSHOT</che.lib.version>
         <che.version>6.0.0-M2-SNAPSHOT</che.version>
+        <com.google.gwt.version>2.8.2</com.google.gwt.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
note: this PR will be closed, it's only to verify with Che jenkins after it is working on my side.
Real PR will be at https://github.com/eclipse/che-dependencies/pull/69

### What does this PR do?
Update GWT to a java9 compliant version

### What issues does this PR fix or reference?
#5326 


#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: If919cb89b6d14018403afaf78687c4829ac8fc52
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
