### PR TITLE
Update Eclipse Che stack

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -37,7 +37,12 @@
                 "org.eclipse.che.ssh",
                 "org.eclipse.che.ls.js-ts"
               ],
-              "servers": {},
+              "servers": {
+                "GWT-CodeServer": {
+                  "protocol": "http",
+                  "port": "9876"
+                }
+              },
               "attributes": {
                 "memoryLimitBytes": "7516192768"
               }
@@ -57,6 +62,15 @@
           "commandLine": "mvn clean install -DskipIntegrationTests=true -Pnative -f ${current.project.path}",
           "name": "Build project",
           "type": "custom"
+        },
+        {
+          "commandLine": "cd /projects/che && mvn gwt:codeserver -pl :che-ide-gwt-app -am -Pfast",
+          "name": "GWT SDM",
+          "type": "gwt_sdm_che",
+          "attributes": {
+            "previewUrl": "",
+            "goal": "Run"
+          }
         }
       ]
     },


### PR DESCRIPTION
### What does this PR do?
Updates Eclipse Che stack:
- declares server for GWT CodeServer;
- adds command for launching Super DevMode.

![image](https://user-images.githubusercontent.com/1636395/32232357-8938ecb2-be60-11e7-805e-8a854cad3a58.png)
