### PR TITLE
Check if C# language server client is already there before downloading it

### DIFF
--- a/agents/ls-csharp/src/main/resources/org.eclipse.che.ls.csharp.script.sh
+++ b/agents/ls-csharp/src/main/resources/org.eclipse.che.ls.csharp.script.sh
@@ -237,8 +237,10 @@ fi
 ### Install C# LS ###
 #####################
 
-curl -s ${AGENT_BINARIES_URI} | tar xzf - -C ${CHE_DIR}
+if [ ! -f "${LS_LAUNCHER}" ]; then
+    curl -s ${AGENT_BINARIES_URI} | tar xzf - -C ${CHE_DIR}
 
-touch ${LS_LAUNCHER}
-chmod +x ${LS_LAUNCHER}
-echo "nodejs ${LS_DIR}/node_modules/omnisharp-client/languageserver/server.js" > ${LS_LAUNCHER}
+    touch ${LS_LAUNCHER}
+    chmod +x ${LS_LAUNCHER}
+    echo "nodejs ${LS_DIR}/node_modules/omnisharp-client/languageserver/server.js" > ${LS_LAUNCHER}
+fi


### PR DESCRIPTION
### What does this PR do?
Modify C# language server script to only download omnisharp client if it's not downloaded yet

### What issues does this PR fix or reference?
https://github.com/eclipse/che-dockerfiles/issues/125

#### Release Notes
The time to start C# language server on .NET CentOS stack has been reduced 
