### PR TITLE
Backport of che-dev image from che6 branch

### DIFF
--- a/dockerfiles/dev/.cccp.yml
+++ b/dockerfiles/dev/.cccp.yml
@@ -1,0 +1,13 @@
+# Copyright (c) 2012-2017 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# This is file is needed to include the project in the CentOS Container
+# Pipeline main index. It can be used to set the image name (using job-id), set
+# the test script and/or build script and whether to perform or skip the
+# user-defined tests. More information on cccp.yml file can be found on:
+# https://github.com/CentOS/container-index#the-cccpyml-file
+
+job-id: che-dev

--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -27,48 +27,54 @@
 # For Windows, replace $PWD with Che source code directory.
 #
 
-FROM codenvy/debian_jdk8
-ENV NODE_VERSION=4.8.0 \
-    NODE_PATH=/usr/local/lib/node_modules
 
-RUN sudo apt-get update && \
-    sudo apt-get -y install build-essential libssl-dev libkrb5-dev gcc make ruby-full rubygems && \
-    sudo gem install sass compass && \
-    sudo apt-get clean && \
-    sudo apt-get -y autoremove && \
-    sudo apt-get -y clean && \
-    sudo rm -rf /var/lib/apt/lists/* && \
-    set -ex \
-    && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
-    ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-    done && \
-    cd /home/user && curl --insecure -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-    && curl --insecure -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-    && gpg --verify SHASUMS256.txt.asc \
-    && grep "node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-    && sudo tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-    && sudo rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
+FROM registry.centos.org/che-stacks/centos-stack-base
 
-EXPOSE 3000 5000 9000
-RUN sudo npm install -g npm@latest
-RUN sudo npm install --unsafe-perm -g gulp bower typings
-RUN mkdir ~/gopath && \
-    cd /home/user && wget -q https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz && \
-    sudo tar -xvf go1.6.2.linux-amd64.tar.gz -C /opt/ && \
-    rm go1.6.2.linux-amd64.tar.gz
-ENV GOROOT=/opt/go
-ENV GOPATH=/home/user/gopath
-RUN echo "export PATH=$GOROOT/bin:$PATH" >> ~/.bashrc && \
-    sudo chown -R user:user /opt
+EXPOSE 4403 8080 8000 9876 22
+
+RUN sudo yum -y update && \
+    sudo yum -y install  \
+           rh-maven35 \
+           plexus-classworlds \
+           rh-nodejs6 \
+           gcc-c++ \
+           gcc \
+           glibc-devel \
+           bzip2 \
+           make \
+           golang \
+    sudo yum clean all && \
+    cat /opt/rh/rh-maven35/enable >> /home/user/.bashrc  && \
+    cat /opt/rh/rh-nodejs6/enable >> /home/user/.bashrc && \
+    sudo ln -s /opt/rh/rh-nodejs6/root/usr/bin/node /usr/local/bin/nodejs
+
+ENV TOMCAT_VERSION=8.5.23
+
+RUN mkdir $HOME/.m2 && \
+    mkdir /home/user/tomcat8 && \
+    wget -qO- "https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
+    rm -rf /home/user/tomcat8/webapps/* && \
+    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc
+
+USER user
+
+
+ENV LD_LIBRARY_PATH=/opt/rh/rh-nodejs6/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+ PYTHONPATH=/opt/rh/rh-nodejs6/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}} \
+ MANPATH=/opt/rh/rh-nodejs6/root/usr/share/man:$MANPATH \
+ TOMCAT_HOME=/home/user/tomcat8 \
+ TERM=xterm  \
+ M2_HOME=/opt/rh/rh-maven35/root/usr/share/maven \
+ GOPATH=$HOME/go \
+ NODEJS_VERSION=6 \
+ NPM_RUN=start \
+ NPM_CONFIG_PREFIX=$HOME/.npm-global
+ENV PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$GOPATH/bin:$M2_HOME/bin:/opt/rh/rh-nodejs6/root/usr/bin:/usr/local/go/bin:$PATH
+
+RUN sudo mkdir /var/run/sshd
+RUN sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' && \
+    sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ecdsa_key -N '' && \
+    sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ed25519_key -N '' && \
+    npm install -g typescript@2.5.3 typescript-language-server@0.1.4
+
 WORKDIR /home/user
-ENV PATH $GOROOT/bin:$PATH


### PR DESCRIPTION
### What does this PR do?
Switch to Centos based image
Upgrade of 
- Maven 3.5.0
- tomcat 8.5
- go 1.8.3
- java 1.8.0_151-b12
- node 6.9.1

### What issues does this PR fix or reference?

<!-- #### Changelog -->

#### Release Notes
che-dev image are now Centos based



#### Docs PR
N/A