### PR TITLE
webdriver.sh respects system properties

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -147,6 +147,7 @@ checkParameters() {
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
         elif [[ "$var" =~ ^-D.* ]]; then :
         elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
+        elif [[ "$var" == "--fast" ]]; then :
         else
             printHelp
             echo "[TEST] Unrecognized or misused parameter "${var}
@@ -207,6 +208,8 @@ extractMavenOptions() {
             MAVEN_OPTIONS="${MAVEN_OPTIONS} $var"
         elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
             MAVEN_OPTIONS="${MAVEN_OPTIONS} $var"
+        elif [[ "$var" == "--fast" ]]; then :
+            MAVEN_OPTIONS="${MAVEN_OPTIONS} -Dskip-enforce -Dskip-validate-sources"
         fi
     done
 }
@@ -431,6 +434,7 @@ Handle failing tests:
 
 Other options:
     --debug                             Run tests in debug mode
+    --fast                              Fast build. Skips source validation and enforce plugins
 
 HOW TO of usage:
     Test Eclipse Che assembly:

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -147,7 +147,7 @@ checkParameters() {
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
         elif [[ "$var" =~ ^-D.* ]]; then :
         elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
-        elif [[ "$var" == "--fast" ]]; then :
+        elif [[ "$var" == "--skip-sources-validation" ]]; then :
         else
             printHelp
             echo "[TEST] Unrecognized or misused parameter "${var}
@@ -208,7 +208,7 @@ extractMavenOptions() {
             MAVEN_OPTIONS="${MAVEN_OPTIONS} $var"
         elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
             MAVEN_OPTIONS="${MAVEN_OPTIONS} $var"
-        elif [[ "$var" == "--fast" ]]; then :
+        elif [[ "$var" == "--skip-sources-validation" ]]; then :
             MAVEN_OPTIONS="${MAVEN_OPTIONS} -Dskip-enforce -Dskip-validate-sources"
         fi
     done
@@ -434,7 +434,7 @@ Handle failing tests:
 
 Other options:
     --debug                             Run tests in debug mode
-    --fast                              Fast build. Skips source validation and enforce plugins
+    --skip-sources-validation           Fast build. Skips source validation and enforce plugins
 
 HOW TO of usage:
     Test Eclipse Che assembly:

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -145,7 +145,8 @@ checkParameters() {
         elif [[ "$var" == "--compare-with-ci" ]]; then :
         elif [[ "$var" =~ ^--workspace-pool-size=(auto|[0-9]+)$ ]]; then :
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
-        elif [[ "$var" =~ -D.* ]]; then :
+        elif [[ "$var" =~ ^-D.* ]]; then :
+        elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
         else
             printHelp
             echo "[TEST] Unrecognized or misused parameter "${var}
@@ -200,10 +201,12 @@ applyCustomOptions() {
     done
 }
 
-extractSystemProperties() {
+extractMavenOptions() {
     for var in "$@"; do
-        if [[ "$var" =~ -D.* ]]; then
-            MAVEN_OPTIONS=${MAVEN_OPTIONS}" "$var
+        if [[ "$var" =~ ^-D.* ]]; then
+            MAVEN_OPTIONS="${MAVEN_OPTIONS} $var"
+        elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
+            MAVEN_OPTIONS="${MAVEN_OPTIONS} $var"
         fi
     done
 }
@@ -896,7 +899,7 @@ run() {
 
     initVariables
     init
-    extractSystemProperties $@
+    extractMavenOptions $@
     checkBuild
 
     checkParameters $@

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -145,6 +145,7 @@ checkParameters() {
         elif [[ "$var" == "--compare-with-ci" ]]; then :
         elif [[ "$var" =~ ^--workspace-pool-size=(auto|[0-9]+)$ ]]; then :
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
+        elif [[ "$var" =~ -D.* ]]; then :
         else
             printHelp
             echo "[TEST] Unrecognized or misused parameter "${var}
@@ -198,6 +199,15 @@ applyCustomOptions() {
         fi
     done
 }
+
+extractSystemProperties() {
+    for var in "$@"; do
+        if [[ "$var" =~ -D.* ]]; then
+            MAVEN_OPTIONS=${MAVEN_OPTIONS}" "$var
+        fi
+    done
+}
+
 
 defineTestsScope() {
     for var in "$@"; do
@@ -783,8 +793,8 @@ generateTestNgFailedReport() {
 
 # generates and updates failsafe report
 generateFailSafeReport () {
-    mvn -q surefire-report:failsafe-report-only
-    mvn -q site -DgenerateReports=false
+    mvn -q surefire-report:failsafe-report-only ${MAVEN_OPTIONS}
+    mvn -q site -DgenerateReports=false ${MAVEN_OPTIONS}
 
     echo "[TEST]"
 
@@ -855,7 +865,7 @@ storeTestReport() {
 }
 
 checkBuild() {
-    mvn package
+    mvn package ${MAVEN_OPTIONS}
     [[ $? != 0 ]] && { exit 1; }
 }
 
@@ -886,6 +896,7 @@ run() {
 
     initVariables
     init
+    extractSystemProperties $@
     checkBuild
 
     checkParameters $@

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -99,6 +99,7 @@ Handle failing tests:
 
 Other options:
     --debug                             Run tests in debug mode
+    --fast                              Fast build. Skips source validation and enforce plugins
 
 HOW TO of usage:
     Test Eclipse Che single user assembly:

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -99,7 +99,7 @@ Handle failing tests:
 
 Other options:
     --debug                             Run tests in debug mode
-    --fast                              Fast build. Skips source validation and enforce plugins
+    --skip-sources-validation           Fast build. Skips source validation and enforce plugins
 
 HOW TO of usage:
     Test Eclipse Che single user assembly:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Allows `webdriver.sh` to respect system properties and maven options:
```
./selenium-tests.sh --test=DialogAboutTest -Dskip-enforce
./selenium-tests.sh --test=DialogAboutTest -U
```

* Introduces a new option `--skip-sources-validation` which reduce time needed to run a test (for development purpose)
