### PR TITLE
Setup working dir, switch to nightly tag

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -23,7 +23,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "eclipse/che-dev"
+      "origin": "eclipse/che-dev:nightly"
     },
     "workspaceConfig": {
       "environments": {

--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -57,4 +57,4 @@ RUN sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' && \
     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ed25519_key -N '' && \
     npm install -g typescript@2.5.3 typescript-language-server@0.1.4
 
-WORKDIR /home/user
+WORKDIR /projects


### PR DESCRIPTION
### What does this PR do?
- Setup working dir ```/projects``` as we doing in images for stacks https://github.com/eclipse/che-dockerfiles  
- Setup nightly tag for che-in-che stack to differentiate master and che6. That's is how we can do experiments on che6 and not affect on che5 users.
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6928#issuecomment-341423782

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
- Setup working dir ```/projects``` as we doing in images for stacks 

#### Docs PR
n/a