### PR TITLE
Added Traefik's docker.network label to fix multiuser single_port

### DIFF
--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -64,6 +64,9 @@ services:
       traefik.che.frontend.entryPoints: "http"
       traefik.che.port: "<%= scope.lookupvar('che::che_port') -%>"
       traefik.che.frontend.rule: "PathPrefix:/"
+      <% if scope.lookupvar('che::che_multiuser') == 'true' -%>
+      traefik.che.docker.network: "che_default"
+      <% end -%>
 <% end -%>
     restart: always
     container_name: <%= ENV["CHE_CONTAINER_NAME"] %>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Attempts to fix the gateway timeout issue when running multiuser single_port mode.

### What issues does this PR fix or reference?

#7059 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
