### PR TITLE
osio-1281: Do not set host for workspace routes on OpenShift

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftRouteCreator.java
@@ -41,8 +41,6 @@ public class OpenShiftRouteCreator {
 
     try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient()) {
       String routeName = generateRouteName(routeId, serverRef);
-      String serviceHost = generateRouteHost(routeName, openShiftNamespaceExternalAddress);
-
       SpecNested<DoneableRoute> routeSpec =
           openShiftClient
               .routes()
@@ -53,7 +51,6 @@ public class OpenShiftRouteCreator {
               .addToLabels(OpenShiftConnector.OPENSHIFT_DEPLOYMENT_LABEL, deploymentName)
               .endMetadata()
               .withNewSpec()
-              .withHost(serviceHost)
               .withNewTo()
               .withKind("Service")
               .withName(serviceName)
@@ -80,10 +77,5 @@ public class OpenShiftRouteCreator {
 
   private String generateRouteName(final String serviceName, final String serverRef) {
     return serverRef + "-" + serviceName;
-  }
-
-  private String generateRouteHost(
-      final String routeName, final String openShiftNamespaceExternalAddress) {
-    return routeName + "-" + openShiftNamespaceExternalAddress;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Do not set host for routes on OpenShift 

### What issues does this PR fix or reference?
Blocker issue on osio - https://github.com/redhat-developer/rh-che/issues/395

<!-- #### Changelog -->
Do not set host for workspace routes on OpenShift

#### Release Notes
Do not set host for workspace routes on OpenShift

#### Docs PR
N / A

