### PR TITLE
Added publishing of OpenShift container events to machines logs channel

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Names.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Names.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.eclipse.che.commons.lang.NameGenerator;
+
+/**
+ * Helps to work with OpenShift objects names.
+ *
+ * @author Sergii Leshchenko
+ */
+public class Names {
+  static final char WORKSPACE_ID_PREFIX_SEPARATOR = '.';
+
+  static final String ROUTE_PREFIX = "route";
+  static final int ROUTE_PREFIX_SIZE = 8;
+
+  /** Returns machine name that has the following format `{POD_NAME}/{CONTAINER_NAME}`. */
+  public static String machineName(String podName, String containerName) {
+    return podName + '/' + containerName;
+  }
+
+  /** Returns machine name that has the following format `{POD_NAME}/{CONTAINER_NAME}`. */
+  public static String machineName(Pod pod, Container container) {
+    return machineName(pod.getMetadata().getName(), container.getName());
+  }
+
+  /**
+   * Returns pod name that is extracted from machine name.
+   *
+   * @see #machineName(String, String)
+   */
+  public static String podName(String machineName) {
+    return machineName.split("/")[0];
+  }
+
+  /** Return pod name that will be unique for a whole namespace. */
+  public static String uniquePodName(String originalPodName, String workspaceId) {
+    return workspaceId + WORKSPACE_ID_PREFIX_SEPARATOR + originalPodName;
+  }
+
+  /** Return original pod name that is extracted from unique value. */
+  public static String originalPodName(String podName, String workspaceId) {
+    return podName.replace(workspaceId + WORKSPACE_ID_PREFIX_SEPARATOR, "");
+  }
+
+  /** Returns route name that will be unique whole a namespace. */
+  public static String uniqueRouteName() {
+    return NameGenerator.generate(ROUTE_PREFIX, ROUTE_PREFIX_SIZE);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import static org.eclipse.che.workspace.infrastructure.openshift.project.CommonPVCStrategy.COMMON_STRATEGY;
-import static org.eclipse.che.workspace.infrastructure.openshift.project.UniqueWorkspacePVCStrategy.UNIQUE_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.CommonPVCStrategy.COMMON_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.UniqueWorkspacePVCStrategy.UNIQUE_STRATEGY;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
@@ -20,12 +20,12 @@ import com.google.inject.multibindings.Multibinder;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiEnvVarProvider;
 import org.eclipse.che.workspace.infrastructure.openshift.bootstrapper.OpenShiftBootstrapperFactory;
-import org.eclipse.che.workspace.infrastructure.openshift.project.CommonPVCStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.project.RemoveProjectOnWorkspaceRemove;
-import org.eclipse.che.workspace.infrastructure.openshift.project.UniqueWorkspacePVCStrategy;
-import org.eclipse.che.workspace.infrastructure.openshift.project.WorkspacePVCCleaner;
-import org.eclipse.che.workspace.infrastructure.openshift.project.WorkspacePVCStrategy;
-import org.eclipse.che.workspace.infrastructure.openshift.project.WorkspacePVCStrategyProvider;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.CommonPVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.UniqueWorkspacePVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCCleaner;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftCheApiEnvVarProvider;
 
 /** @author Sergii Leshchenko */

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -236,9 +236,10 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
       final Pod createdPod = project.pods().create(toCreate);
       final ObjectMeta podMetadata = createdPod.getMetadata();
       for (Container container : createdPod.getSpec().getContainers()) {
+        String podOriginalName = podMetadata.getLabels().get(CHE_ORIGINAL_NAME_LABEL);
         OpenShiftMachine machine =
             new OpenShiftMachine(
-                podMetadata.getLabels().get(CHE_ORIGINAL_NAME_LABEL) + '/' + container.getName(),
+                Names.machineName(podOriginalName, container.getName()),
                 podMetadata.getName(),
                 container.getName(),
                 serverResolver.resolve(createdPod, container),

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposer.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposer.java
@@ -127,7 +127,7 @@ public class ServerExposer {
     Service service =
         new ServiceBuilder()
             .withName(generate(SERVER_PREFIX, SERVER_UNIQUE_PART_SIZE) + '-' + machineName)
-            .withSelectorEntry(CHE_ORIGINAL_NAME_LABEL, machineName.split("/")[0])
+            .withSelectorEntry(CHE_ORIGINAL_NAME_LABEL, Names.podName(machineName))
             .withPorts(new ArrayList<>(portToServicePort.values()))
             .build();
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPods.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPods.java
@@ -197,7 +197,7 @@ public class OpenShiftPods {
   /**
    * Starts watching the pods inside OpenShift namespace and registers a specified handler for such
    * events. Note that watcher can be started only once so two times invocation of this method will
-   * not produce new watcher and just register the event podActionHandlers.
+   * not produce new watcher and just register the event handlers.
    *
    * @param handler pod action events handler
    * @throws InfrastructureException if any error occurs while watcher starting

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/event/ContainerEvent.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/event/ContainerEvent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project.event;
+
+import java.util.Objects;
+
+/**
+ * The event that should be published when container change occurs, e.g. image pulled, container
+ * started.
+ *
+ * @author Sergii Leshchenko
+ */
+public class ContainerEvent {
+  private final String machineName;
+  private final String message;
+  private final String time;
+
+  public ContainerEvent(String machineName, String message, String time) {
+    this.machineName = machineName;
+    this.message = message;
+    this.time = time;
+  }
+
+  /** Returns the name of the machine that produces the logs. */
+  public String getMachineName() {
+    return machineName;
+  }
+
+  /** Returns the contents of the event. */
+  public String getMessage() {
+    return message;
+  }
+
+  /** Returns time in format '2017-06-27T17:11:09.306+03:00' */
+  public String getTime() {
+    return time;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ContainerEvent that = (ContainerEvent) o;
+    return Objects.equals(machineName, that.machineName)
+        && Objects.equals(message, that.message)
+        && Objects.equals(time, that.time);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(machineName, message, time);
+  }
+
+  @Override
+  public String toString() {
+    return "ContainerEvent{"
+        + "machineName='"
+        + machineName
+        + '\''
+        + ", message='"
+        + message
+        + '\''
+        + ", time='"
+        + time
+        + '\''
+        + '}';
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/event/ContainerEventHandler.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/event/ContainerEventHandler.java
@@ -8,18 +8,15 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
-
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.Watcher.Action;
+package org.eclipse.che.workspace.infrastructure.openshift.project.event;
 
 /**
- * Defines the handling mechanism for OpenShift pod action events.
+ * Defines the handling mechanism for OpenShift container events.
  *
- * @author Anton Korneta
+ * @author Sergii Leshchenko
  */
-public interface PodActionHandler {
+public interface ContainerEventHandler {
 
-  /** Handles the pod action events. */
-  void handle(Action action, Pod pod);
+  /** Handles the container event. */
+  void handle(ContainerEvent event);
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/event/PodActionHandler.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/event/PodActionHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project.event;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.Watcher.Action;
+
+/**
+ * Defines the handling mechanism for OpenShift pod action events.
+ *
+ * @author Anton Korneta
+ */
+public interface PodActionHandler {
+
+  /** Handles the pod action events. */
+  void handle(Action action, Pod pod);
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategy.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.Names;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 
 /**
@@ -72,7 +73,7 @@ public class CommonPVCStrategy implements WorkspacePVCStrategy {
     for (Pod pod : osEnv.getPods().values()) {
       final PodSpec podSpec = pod.getSpec();
       for (Container container : podSpec.getContainers()) {
-        final String machine = pod.getMetadata().getName() + '/' + container.getName();
+        final String machine = Names.machineName(pod, container);
         if (machine.equals(machineWithSources)) {
           final String subPath =
               workspaceId + (projectsPath.startsWith("/") ? projectsPath : "/" + projectsPath);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategy.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import static org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil.getWsAgentServerMachine;
 import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newPVC;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import static org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil.getWsAgentServerMachine;
 import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newPVC;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleaner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleaner.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCStrategy.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCStrategyProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCStrategyProvider.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import static java.lang.String.format;
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/UniqueNamesProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/UniqueNamesProvisioner.java
@@ -21,25 +21,22 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.workspace.infrastructure.openshift.Constants;
+import org.eclipse.che.workspace.infrastructure.openshift.Names;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 
 /**
- * Changes names of OpenShift pods by adding the workspace identifier to the prefix also generates
- * OpenShift routes names with prefix 'route' see {@link NameGenerator#generate(String, int)}.
+ * Makes names of OpenShift pods and routes unique whole namespace by {@link Names}.
  *
  * <p>Original names will be stored in {@link Constants#CHE_ORIGINAL_NAME_LABEL} label of renamed
  * object.
  *
  * @author Anton Korneta
+ * @see Names#uniquePodName(String, String)
+ * @see Names#uniqueRouteName()
  */
 @Singleton
 public class UniqueNamesProvisioner implements ConfigurationProvisioner {
-
-  public static final String ROUTE_PREFIX = "route";
-  public static final int ROUTE_PREFIX_SIZE = 8;
-  public static final char SEPARATOR = '.';
 
   @Override
   public void provision(
@@ -51,7 +48,7 @@ public class UniqueNamesProvisioner implements ConfigurationProvisioner {
     for (Pod pod : pods) {
       final ObjectMeta podMeta = pod.getMetadata();
       putLabel(pod, Constants.CHE_ORIGINAL_NAME_LABEL, podMeta.getName());
-      final String podName = workspaceId + SEPARATOR + podMeta.getName();
+      final String podName = Names.uniquePodName(podMeta.getName(), workspaceId);
       podMeta.setName(podName);
       osEnv.getPods().put(podName, pod);
     }
@@ -60,7 +57,7 @@ public class UniqueNamesProvisioner implements ConfigurationProvisioner {
     for (Route route : routes) {
       final ObjectMeta routeMeta = route.getMetadata();
       putLabel(route, Constants.CHE_ORIGINAL_NAME_LABEL, routeMeta.getName());
-      final String routeName = NameGenerator.generate(ROUTE_PREFIX, ROUTE_PREFIX_SIZE);
+      final String routeName = Names.uniqueRouteName();
       routeMeta.setName(routeName);
       osEnv.getRoutes().put(routeName, route);
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/env/EnvVarsConverter.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/env/EnvVarsConverter.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.openshift.Names;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.ConfigurationProvisioner;
 
@@ -38,7 +39,7 @@ public class EnvVarsConverter implements ConfigurationProvisioner {
       String podName = pod.getMetadata().getName();
       for (Container container : pod.getSpec().getContainers()) {
         String containerName = container.getName();
-        String machineName = podName + "/" + containerName;
+        String machineName = Names.machineName(podName, containerName);
         InternalMachineConfig machineConf = environment.getMachines().get(machineName);
 
         if (machineConf != null) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisioner.java
@@ -17,7 +17,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
-import org.eclipse.che.workspace.infrastructure.openshift.project.WorkspacePVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.ConfigurationProvisioner;
 
 /**

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/CommonPVCStrategyTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/CommonPVCStrategyTest.java
@@ -38,6 +38,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.CommonPVCStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/UniqueWorkspacePVCStrategyTest.java
@@ -41,6 +41,7 @@ import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.UniqueWorkspacePVCStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/WorkspacePVCCleanerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/WorkspacePVCCleanerTest.java
@@ -24,6 +24,8 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCCleaner;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/UniqueNamesProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/UniqueNamesProvisionerTest.java
@@ -10,15 +10,11 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.provision;
 
-import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.CHE_ORIGINAL_NAME_LABEL;
-import static org.eclipse.che.workspace.infrastructure.openshift.provision.UniqueNamesProvisioner.ROUTE_PREFIX;
-import static org.eclipse.che.workspace.infrastructure.openshift.provision.UniqueNamesProvisioner.ROUTE_PREFIX_SIZE;
-import static org.eclipse.che.workspace.infrastructure.openshift.provision.UniqueNamesProvisioner.SEPARATOR;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotEquals;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
@@ -27,7 +23,6 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import java.util.HashMap;
-import java.util.regex.Pattern;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
@@ -48,8 +43,6 @@ public class UniqueNamesProvisionerTest {
   private static final String WORKSPACE_ID = "workspace37";
   private static final String POD_NAME = "testPod";
   private static final String ROUTE_NAME = "testRoute";
-  private static final Pattern UNIQUE_ROUTE_NAME_REGEX =
-      Pattern.compile('^' + ROUTE_PREFIX + "[A-z0-9]{" + ROUTE_PREFIX_SIZE + "}$");
 
   @Mock private InternalEnvironment environment;
   @Mock private OpenShiftEnvironment osEnv;
@@ -66,29 +59,28 @@ public class UniqueNamesProvisionerTest {
   public void provideUniquePodsNames() throws Exception {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     final HashMap<String, Pod> pods = new HashMap<>();
-    pods.put(POD_NAME, newPod());
+    Pod pod = newPod();
+    pods.put(POD_NAME, pod);
     doReturn(pods).when(osEnv).getPods();
 
     uniqueNamesProvisioner.provision(environment, osEnv, runtimeIdentity);
 
-    final String expected = WORKSPACE_ID + SEPARATOR + POD_NAME;
-    final ObjectMeta podMeta = osEnv.getPods().get(expected).getMetadata();
-    assertEquals(podMeta.getName(), expected);
-    assertEquals(podMeta.getLabels().get(CHE_ORIGINAL_NAME_LABEL), POD_NAME);
+    ObjectMeta podMetadata = pod.getMetadata();
+    assertNotEquals(podMetadata.getName(), POD_NAME);
+    assertEquals(podMetadata.getLabels().get(CHE_ORIGINAL_NAME_LABEL), POD_NAME);
   }
 
   @Test
   public void provideUniqueRoutesNames() throws Exception {
     final HashMap<String, Route> routes = new HashMap<>();
-    routes.put(POD_NAME, newRoute());
+    Route route = newRoute();
+    routes.put(POD_NAME, route);
     doReturn(routes).when(osEnv).getRoutes();
 
     uniqueNamesProvisioner.provision(environment, osEnv, runtimeIdentity);
 
-    final ObjectMeta routeData =
-        osEnv.getRoutes().values().stream().map(Route::getMetadata).collect(toList()).get(0);
-    assertTrue(routeData.getName().startsWith(ROUTE_PREFIX));
-    assertTrue(UNIQUE_ROUTE_NAME_REGEX.matcher(routeData.getName()).matches());
+    final ObjectMeta routeData = route.getMetadata();
+    assertNotEquals(routeData.getName(), ROUTE_NAME);
     assertEquals(routeData.getLabels().get(CHE_ORIGINAL_NAME_LABEL), ROUTE_NAME);
   }
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/PersistentVolumeClaimProvisionerTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
-import org.eclipse.che.workspace.infrastructure.openshift.project.WorkspacePVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;


### PR DESCRIPTION
### What does this PR do?
Moves PVC related objects to separate package.
Moves converting of OpenShift objects name to separate class.

Adds publishing of OpenShift container events to machines logs channel.
![screenshot_20171106_120528](https://user-images.githubusercontent.com/5887312/32435901-05b8198c-c2eb-11e7-8c36-19eca19de081.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6356

#### Release Notes
Added publishing of OpenShift container events to machines logs channel