### PR TITLE
Bind GWT CodeServer to different addresses at a host machine and inside a container (dev-machine)

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -64,7 +64,7 @@
           "type": "custom"
         },
         {
-          "commandLine": "cd /projects/che && mvn gwt:codeserver -pl :che-ide-gwt-app -am -Pfast",
+          "commandLine": "cd /projects/che && mvn gwt:codeserver -pl :che-ide-gwt-app -am -Pfast,sdm-in-che",
           "name": "GWT SDM",
           "type": "gwt_sdm_che",
           "attributes": {

--- a/plugins/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/java/org/eclipse/che/ide/ext/plugins/client/GwtCheCommandType.java
+++ b/plugins/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/java/org/eclipse/che/ide/ext/plugins/client/GwtCheCommandType.java
@@ -29,7 +29,7 @@ import org.eclipse.che.ide.api.icon.IconRegistry;
 public class GwtCheCommandType implements CommandType {
 
   private static final String COMMAND_TEMPLATE =
-      "mvn -f /projects/che gwt:codeserver -pl :che-ide-gwt-app -am -Pfast";
+      "mvn -f /projects/che gwt:codeserver -pl :che-ide-gwt-app -am -Pfast,sdm-in-che";
   private static final String ID = "gwt_sdm_che";
 
   @Inject

--- a/pom.xml
+++ b/pom.xml
@@ -1867,7 +1867,7 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <!-- Configuration for launching GWT Super DevMode with gwt:codeserver -->
+                <!-- Configuration for launching GWT Super DevMode -->
                 <groupId>net.ltgt.gwt.maven</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
                 <inherited>false</inherited>
@@ -1875,10 +1875,6 @@
                     <codeserverArgs>
                         <arg>-noprecompile</arg>
                         <arg>-noincremental</arg>
-                        <!-- For che-in-che development, the CodeServer launched
-                             inside a container must be reachable at local machine. -->
-                        <arg>-bindAddress</arg>
-                        <arg>0.0.0.0</arg>
                     </codeserverArgs>
                     <jvmArgs>
                         <arg>${gwt.compiler.jvmArgs.Xss}</arg>
@@ -1899,6 +1895,25 @@
                 <mdep.analyze.skip>true</mdep.analyze.skip>
                 <skipTests>true</skipTests>
             </properties>
+        </profile>
+        <!-- Profile for launching GWT Super DevMode in Che IDE (inside a container) -->
+        <profile>
+            <id>sdm-in-che</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.ltgt.gwt.maven</groupId>
+                        <artifactId>gwt-maven-plugin</artifactId>
+                        <configuration>
+                            <codeserverArgs combine.children="append">
+                                <!-- CodeServer launched inside a container must be reachable at host machine -->
+                                <arg>-bindAddress</arg>
+                                <arg>0.0.0.0</arg>
+                            </codeserverArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
By default, GWT CodeServer will be launched on a default bind address (127.0.0.1) but 0.0.0.0 bind address will be used when launching it in Che IDE (in a container).

### What issues does this PR fix or reference?
#7198 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

