### PR TITLE
Add support for Docker HostConfig SecurityOpt through che.env

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -161,6 +161,17 @@ che.docker.always_pull_image=true
 # to be able to launch their own runtimes which are embedded Docker containers.
 che.docker.privileged=false
 
+# This parameter allows to specify custom security options for the created docker container.
+# seccomp:unconfined is the default for kubernetes, but not for docker. This is needed
+# for debugging with gdbserver. See https://github.com/eclipse/che/issues/4284 for details.
+# Parameters are passed as an array, so you can add multiple 
+# values comma seperated. Please also see https://docs.docker.com/engine/api/v1.21/#2-endpoints,
+# in particular the "HostConfig":{"SecurityOpt": []} entry. If this parameter is empty,
+# docker blocks certain Syscalls by default https://docs.docker.com/engine/security/seccomp/
+# WARNING: if you give incorrect values, docker gives an error and doesn't start the container
+# Example: che.docker.securityopt=seccomp:unconfined,apparmor:unconfined
+che.docker.securityopt=
+
 # Limits the number of processes that can be forked inside a cgroup. Set -1 for unlimited.
 # Since 4.3 kernel.
 che.docker.pids_limit=-1

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -111,6 +111,18 @@
 #     containers from within their Docker-powered workspace.
 #CHE_DOCKER_PRIVILEGED=false
 
+# HostConfig SecurityOpt Parameters
+#     This parameter allows to specify custom security options for the created docker container.
+#     seccomp:unconfined is the default for kubernetes, but not for docker. This is needed
+#     for debugging with gdbserver. See https://github.com/eclipse/che/issues/4284 for details.
+#     Parameters are passed as an array, so you can add multiple 
+#     values comma seperated. Please also see https://docs.docker.com/engine/api/v1.21/#2-endpoints,
+#     in particular the "HostConfig":{"SecurityOpt": []} entry. If this parameter is empty,
+#     docker blocks certain Syscalls by default https://docs.docker.com/engine/security/seccomp/
+#     WARNING: if you give incorrect values, docker gives an error and doesn't start the container
+#     Example: che.docker.securityopt=seccomp:unconfined,apparmor:unconfined
+#CHE_DOCKER_SECURITYOPT=seccomp:unconfined
+
 # Agent Start Timeout
 #     The length of time that a workspace will be allowed to boot before the system terminates the
 #     boot process. If the Che container cannot establish two way communications with the

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/ContainerConfig.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/ContainerConfig.java
@@ -333,14 +333,20 @@ public class ContainerConfig {
     return this;
   }
 
+  /*
+   * There is no "SecurityOpts" in the docker specification, only "HostConfig":{"SecurityOpt":[]}.
+   */
+  @Deprecated
   public String[] getSecurityOpts() {
     return securityOpts;
   }
 
+  @Deprecated
   public void setSecurityOpts(String[] securityOpts) {
     this.securityOpts = securityOpts;
   }
 
+  @Deprecated
   public ContainerConfig withSecurityOpts(String[] securityOpts) {
     this.securityOpts = securityOpts;
     return this;

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/HostConfig.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/HostConfig.java
@@ -22,6 +22,7 @@ public class HostConfig {
   private boolean publishAllPorts;
   private boolean privileged;
   private String[] dns;
+  private String[] securityOpt;
   private String[] dnsSearch;
   private String[] extraHosts;
   private String[] volumesFrom;
@@ -236,6 +237,19 @@ public class HostConfig {
 
   public HostConfig withDns(String[] dns) {
     this.dns = dns;
+    return this;
+  }
+
+  public String[] getSecurityOpt() {
+    return securityOpt;
+  }
+
+  public void setSecurityOpt(String[] securityOpt) {
+    this.securityOpt = securityOpt;
+  }
+
+  public HostConfig withSecurityOpt(String[] securityOpt) {
+    this.securityOpt = securityOpt;
     return this;
   }
 
@@ -501,6 +515,8 @@ public class HostConfig {
         + readonlyRootfs
         + ", ulimits="
         + Arrays.toString(ulimits)
+        + ", SecurityOpt="
+        + Arrays.toString(securityOpt)
         + ", portBindings="
         + portBindings
         + ", memorySwappiness="

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
@@ -30,6 +30,7 @@ import org.eclipse.che.workspace.infrastructure.docker.provisioner.limits.ram.De
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.limits.swap.SwapLimitProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.priviliged.PrivilegedModeProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.proxy.ProxySettingsProvisioner;
+import org.eclipse.che.workspace.infrastructure.docker.provisioner.securityopt.SecurityOptProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.volume.ExtraVolumesProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.snapshot.JpaSnapshotDao;
 import org.eclipse.che.workspace.infrastructure.docker.snapshot.SnapshotDao;
@@ -41,6 +42,7 @@ public class DockerInfraModule extends AbstractModule {
     Multibinder<ContainerSystemSettingsProvisioner> settingsProvisioners =
         Multibinder.newSetBinder(binder(), ContainerSystemSettingsProvisioner.class);
     settingsProvisioners.addBinding().to(DnsSettingsProvisioner.class);
+    settingsProvisioners.addBinding().to(SecurityOptProvisioner.class);
     settingsProvisioners.addBinding().to(ExtraHostsProvisioner.class);
     settingsProvisioners.addBinding().to(ProxySettingsProvisioner.class);
     settingsProvisioners.addBinding().to(ExtraVolumesProvisioner.class);

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineStarter.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineStarter.java
@@ -419,6 +419,10 @@ public class DockerMachineStarter {
                 .toArray(new String[containerConfig.getExtraHosts().size()]))
         .withPrivileged(containerConfig.getPrivileged())
         .withDns(containerConfig.getDns().toArray(new String[containerConfig.getDns().size()]))
+        .withSecurityOpt(
+            containerConfig
+                .getSecurityOpt()
+                .toArray(new String[containerConfig.getSecurityOpt().size()]))
         .withCpusetCpus(containerConfig.getCpuSet())
         .withCpuQuota(containerConfig.getCpuQuota())
         .withCpuPeriod(containerConfig.getCpuPeriod())

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/model/DockerContainerConfig.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/model/DockerContainerConfig.java
@@ -32,6 +32,7 @@ public class DockerContainerConfig {
   private String cpuSet;
   private List<String> dependsOn;
   private List<String> dns;
+  private List<String> securityOpt;
   private List<String> entrypoint;
   private Map<String, String> environment;
   private List<String> expose;
@@ -69,6 +70,9 @@ public class DockerContainerConfig {
     }
     if (container.getDns() != null) {
       dns = new ArrayList<>(container.getDns());
+    }
+    if (container.getSecurityOpt() != null) {
+      securityOpt = new ArrayList<>(container.getSecurityOpt());
     }
     if (container.getEntrypoint() != null) {
       entrypoint = new ArrayList<>(container.getEntrypoint());
@@ -423,6 +427,21 @@ public class DockerContainerConfig {
     return this;
   }
 
+  public List<String> getSecurityOpt() {
+    if (securityOpt == null) {
+      securityOpt = new ArrayList<>();
+    }
+    return securityOpt;
+  }
+
+  public DockerContainerConfig setSecurityOpt(List<String> securityOpt) {
+    if (securityOpt != null) {
+      securityOpt = new ArrayList<>(securityOpt);
+    }
+    this.securityOpt = securityOpt;
+    return this;
+  }
+
   public List<String> getExtraHosts() {
     if (extraHosts == null) {
       extraHosts = new ArrayList<>();
@@ -515,6 +534,7 @@ public class DockerContainerConfig {
         && Objects.equals(getCpuSet(), that.getCpuSet())
         && Objects.equals(getDependsOn(), that.getDependsOn())
         && Objects.equals(getDns(), that.getDns())
+        && Objects.equals(getSecurityOpt(), that.getSecurityOpt())
         && Objects.equals(getEntrypoint(), that.getEntrypoint())
         && Objects.equals(getEnvironment(), that.getEnvironment())
         && Objects.equals(getExpose(), that.getExpose())
@@ -546,6 +566,7 @@ public class DockerContainerConfig {
         getCpuSet(),
         getDependsOn(),
         getDns(),
+        getSecurityOpt(),
         getEntrypoint(),
         getEnvironment(),
         getExpose(),

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/model/DockerContainerConfig.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/model/DockerContainerConfig.java
@@ -636,6 +636,8 @@ public class DockerContainerConfig {
         + networks
         + ", ports="
         + ports
+        + ", SecurityOpt="
+        + securityOpt
         + ", volumes="
         + volumes
         + ", volumesFrom="

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/securityopt/SecurityOptProvider.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/securityopt/SecurityOptProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.provisioner.securityopt;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Collections.emptyList;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import org.eclipse.che.commons.annotation.Nullable;
+
+/**
+ * Injects SecurityOpt configuration values and ensures that it is neither empty array nor single
+ * value array with null or empty string.
+ *
+ * @author Hanno Kolvenbach
+ */
+@Singleton
+public class SecurityOptProvider implements Provider<List<String>> {
+  private final List<String> securityopt;
+
+  @Inject
+  public SecurityOptProvider(@Nullable @Named("che.docker.securityopt") String[] securityopt) {
+    if (securityopt == null
+        || securityopt.length == 0
+        || (securityopt.length == 1 && isNullOrEmpty(securityopt[0]))) {
+      this.securityopt = emptyList();
+    } else {
+      this.securityopt = Arrays.asList(securityopt);
+    }
+  }
+
+  @Nullable
+  @Override
+  public List<String> get() {
+    return securityopt;
+  }
+}

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/securityopt/SecurityOptProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/securityopt/SecurityOptProvisioner.java
@@ -32,7 +32,6 @@ public class SecurityOptProvisioner implements ContainerSystemSettingsProvisione
   @Override
   public void provision(DockerEnvironment internalEnv) throws InfrastructureException {
     for (DockerContainerConfig containerConfig : internalEnv.getContainers().values()) {
-      // TODO
       containerConfig.getSecurityOpt().addAll(securityOptProvider.get());
     }
   }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/securityopt/SecurityOptProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/securityopt/SecurityOptProvisioner.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.provisioner.securityopt;
+
+import javax.inject.Inject;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+import org.eclipse.che.workspace.infrastructure.docker.provisioner.ContainerSystemSettingsProvisioner;
+
+/**
+ * Adds securityOpt configuration to {@link DockerContainerConfig}.
+ *
+ * @author Hanno Kolvenbach
+ */
+public class SecurityOptProvisioner implements ContainerSystemSettingsProvisioner {
+  private SecurityOptProvider securityOptProvider;
+
+  @Inject
+  public SecurityOptProvisioner(SecurityOptProvider securityOptProvider) {
+    this.securityOptProvider = securityOptProvider;
+  }
+
+  @Override
+  public void provision(DockerEnvironment internalEnv) throws InfrastructureException {
+    for (DockerContainerConfig containerConfig : internalEnv.getContainers().values()) {
+      // TODO
+      containerConfig.getSecurityOpt().addAll(securityOptProvider.get());
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Hanno Kolvenbach <kolvenbach@silexica.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Port SecurityOpt Pull Request to Che6 (https://github.com/eclipse/che/pull/6856)

### What issues does this PR fix or reference?
See https://github.com/eclipse/che/pull/6856

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
- Add new config variable che.docker.securityopt / CHE_DOCKER_SECURITYOPT
- Support for GDB in unprivileged docker containers

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/305