### PR TITLE
Rework tests to actual state after latest changes in CHE

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -156,7 +156,7 @@ public class Consoles {
   }
 
   public void checkReferenceList(String id, String expectedText) {
-    updateProjDriverWait.until(textToBePresentInElementLocated(By.id(id), expectedText));
+    redrawDriverWait.until(textToBePresentInElementLocated(By.id(id), expectedText));
   }
 
   public void waitReferenceIsNotPresent(String referenceId) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
@@ -44,24 +44,24 @@ public class ServerRuntimeInfoTest {
 
     List<String> expectedReferenceList =
         Lists.newArrayList(
+            "codeserver",
+            "tomcat8",
+            "tomcat8-debug",
             "wsagent/ws",
             "exec-agent/ws",
             "wsagent/http",
-            "8080/tcp",
             "exec-agent/http",
+            "wsagent-debug",
             "ssh",
-            "9876/tcp",
-            "4403/tcp",
-            "8000/tcp",
             "terminal");
 
     for (int i = 0; i < expectedReferenceList.size(); i++) {
       String referenceId = "gwt-debug-runtime-info-reference-" + i;
-
       consoles.checkReferenceList(referenceId, expectedReferenceList.get(i));
     }
 
     consoles.clickOnHideInternalServers();
-    consoles.waitReferenceIsNotPresent("gwt-debug-runtime-info-reference-0");
+    consoles.waitReferenceIsNotPresent("gwt-debug-runtime-info-reference-3");
+    consoles.waitReferenceIsNotPresent("gwt-debug-runtime-info-reference-6");
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/ChangeVariableWithEvaluatingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/ChangeVariableWithEvaluatingTest.java
@@ -122,7 +122,7 @@ public class ChangeVariableWithEvaluatingTest {
         TestMenuCommandsConstants.Run.DEBUG + "/" + PROJECT_NAME_CHANGE_VARIABLE);
     String appUrl =
         workspaceServiceClient
-                .getServerFromDevMachineBySymbolicName(ws.getId(), "8080/tcp")
+                .getServerFromDevMachineBySymbolicName(ws.getId(), "tomcat8")
                 .getUrl()
                 .replace("tcp", "http")
             + "/spring/guess";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -124,7 +124,7 @@ public class StepIntoStepOverStepReturnWithChangeVariableTest {
     editor.waitActiveBreakpoint(34);
     String appUrl =
         workspaceServiceClient
-                .getServerFromDevMachineBySymbolicName(ws.getId(), "8080/tcp")
+                .getServerFromDevMachineBySymbolicName(ws.getId(), "tomcat8")
                 .getUrl()
                 .replace("tcp", "http")
             + "/spring/guess";
@@ -163,6 +163,7 @@ public class StepIntoStepOverStepReturnWithChangeVariableTest {
         .activeElement()
         .sendKeys(Keys.SHIFT.toString() + Keys.F9.toString());
     editor.waitActiveBreakpoint(26);
+    seleniumWebDriver.navigate().refresh();
   }
 
   private void buildProjectAndOpenMainClass() {

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_php.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_php.json
@@ -14,6 +14,10 @@
             "8000/tcp" : {
               "port" : "8000",
               "protocol" : "http"
+            },
+            "80/tcp" : {
+              "port" : "80",
+              "protocol" : "http"
             }
           },
           "installers": [
@@ -54,7 +58,7 @@
       "commandLine": "sudo service apache2 start && sudo tail -f /var/log/apache2/access.log -f /var/log/apache2/error.log",
       "name": "start apache",
       "attributes": {
-        "previewUrl": "http://${server.port.80}/${current.project.relpath}"
+        "previewUrl": "${server.80/tcp}/${current.project.relpath}"
       },
       "type": "custom"
     },
@@ -70,7 +74,7 @@
       "commandLine": "sudo service apache2 restart",
       "name": "restart apache",
       "attributes": {
-        "previewUrl": "http://${server.port.80}/${current.project.relpath}"
+        "previewUrl": "${server.80/tcp}/${current.project.relpath}"
       },
       "type": "custom"
     }


### PR DESCRIPTION
### What does this PR do?
* Replace the argument in the getServerFromDevMachineBySymbolicName() method for correct getting of URL to tests app. in  related debugger tests
* Update list of servers in the ServerRuntimeInfoTest.java
* Update configuration of macroses in the workspace configuration for PHP tests
 ### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7110

