### PR TITLE
Removed scl enable rh-nodejs dependency (centos-nodejs)

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2241,7 +2241,7 @@
   },
   {
     "name": "CentOS nodejs",
-    "id": "nodejs4",
+    "id": "nodejs6",
     "creator": "Dharmit Shah",
     "scope": "advanced",
     "source": {
@@ -2293,7 +2293,7 @@
             "goal": "Run",
             "previewUrl": "http://${server.port.8080}"
           },
-          "commandLine": "cd ${current.project.path} && scl enable rh-nodejs4 'node app.js'"
+          "commandLine": "cd ${current.project.path} && node app.js"
         }
       ],
       "projects": [],

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2241,7 +2241,7 @@
   },
   {
     "name": "CentOS nodejs",
-    "id": "nodejs6",
+    "id": "nodejs-centos",
     "creator": "Dharmit Shah",
     "scope": "advanced",
     "source": {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Removes the scl enable rh-nodejs dependency in centos-nodejs stack

### What issues does this PR fix or reference?
As of eclipse/che-dockerfiles@8e70296cb5a9bd79add294b3ce1bd55daf414798 we no longer have to preface commands with scl enable rh-nodejs

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
scl enable rh-nodejs removed from run command in centos-nodejs stack

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
