### PR TITLE
Fixed replace_stacks.json after addition of dotnet-centos

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh
@@ -44,7 +44,7 @@ echo ""
 
 echo -n "[CHE] Fetching the list of new Che stacks..."
 #new_stacks_json=$(curl -X GET -s --header 'Accept: application/json' "${NEW_STACKS_URL}" | sed 's/\\\"//g' | sed 's/\"com\.redhat\.bayesian\.lsp\"//g' | sed 's/ws-agent\",/ws-agent\"/g')
-new_stacks_json=$(curl -X GET -s --header 'Accept: application/json' "${NEW_STACKS_URL}" | sed 's/\"com\.redhat\.bayesian\.lsp\"//g' | sed 's/ws-agent\",/ws-agent\"/g')
+new_stacks_json=$(curl -X GET -s --header 'Accept: application/json' "${NEW_STACKS_URL}" | sed 's/,?\"com\.redhat\.bayesian\.lsp\"//g')
 echo "done."
 
 echo "[CHE] These stacks will be added."


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR proposes a fix for https://github.com/redhat-developer/rh-che/issues/408. 

replace_stacks.json was throwing a parse error because it was removing the comma after "org.eclipse.che.ws-agent" on this line: https://github.com/redhat-developer/rh-che/blob/master/assembly/fabric8-stacks/src/main/resources/stacks.json#L295 due to the sed at https://github.com/eclipse/che/blob/master/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh#L47.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/408
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A
