### PR TITLE
DynaModule plugin test: Avoid timestamp usage when copying dependency + sorting files issue

### DIFF
--- a/core/che-core-dynamodule-maven-plugin/pom.xml
+++ b/core/che-core-dynamodule-maven-plugin/pom.xml
@@ -145,6 +145,7 @@
                                     <artifactId>che-wsagent-core</artifactId>
                                     <version>${project.version}</version>
                                     <type>war</type>
+                                    <destFileName>che-wsagent-core-${project.version}.war</destFileName>
                                     <outputDirectory>${project.build.directory}/local-repo/org/eclipse/che/core/che-wsagent-core/${project.version}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/core/che-core-dynamodule-maven-plugin/src/it/java/org/eclipse/che/plugin/dynamodule/DynaModuleListGeneratorMojoITest.java
+++ b/core/che-core-dynamodule-maven-plugin/src/it/java/org/eclipse/che/plugin/dynamodule/DynaModuleListGeneratorMojoITest.java
@@ -84,7 +84,7 @@ public class DynaModuleListGeneratorMojoITest {
         // search generated guice module list file
         Path p = this.buildDirectory;
         final int maxDepth = 10;
-        Stream<Path> matches = java.nio.file.Files.find(p, maxDepth, (path, basicFileAttributes) -> path.getFileName().toString().equals(GENERATED_GUICE_FILE));
+        Stream<Path> matches = java.nio.file.Files.find(p, maxDepth, (path, basicFileAttributes) -> (path.getFileName().toString().equals(GENERATED_GUICE_FILE) && path.toString().contains("testModuleListGenerated")));
 
         // take first
         Optional<Path> optionalPath = matches.findFirst();


### PR DESCRIPTION
backport of che6 PR https://github.com/eclipse/che/pull/7206 to master

### What does this PR do?
-Use a fixed name for the dependency instead of using timestamped dependency artifact name if the dependency is downloaded from nexus
- Apply another filter for getting test module class as filesystem may not following lexicographical order

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7140

#### Release Notes
N/A

#### Docs PR
N/A