### PR TITLE
Use extension of jdt.ls

### DIFF
--- a/agents/ls-java/src/main/resources/installers/1.0.1/org.eclipse.che.ls.java.script.sh
+++ b/agents/ls-java/src/main/resources/installers/1.0.1/org.eclipse.che.ls.java.script.sh
@@ -26,7 +26,8 @@ unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
 
-AGENT_BINARIES_URI=http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+DOWNLOAD_AGENT_BINARIES_URI='${WORKSPACE_MASTER_URI}/agent-binaries/jdt.ls.tar.gz'
+
 CHE_DIR=$HOME/che
 LS_DIR=${CHE_DIR}/ls-java
 LS_LAUNCHER=${LS_DIR}/launch.sh
@@ -121,10 +122,16 @@ fi
 
 
 #######################
-### Install Json LS ###
+### Install JDT LS ###
 #######################
 
-curl -sL ${AGENT_BINARIES_URI} | tar xzf - -C ${LS_DIR}
+# Compute URI of workspace master
+WORKSPACE_MASTER_URI=$(echo $CHE_API | cut -d / -f 1-3)
+
+## Evaluate variables now that prefix is defined
+eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
+
+curl -sL ${DOWNLOAD_AGENT_BINARIES_URI} | tar xzf - -C ${LS_DIR}
 
 touch ${LS_LAUNCHER}
 chmod +x ${LS_LAUNCHER}

--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -86,6 +86,11 @@
             <type>zip</type>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.ls.jdt</groupId>
+            <artifactId>jdt.ls.extension.product</artifactId>
+            <type>tar.gz</type>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-sdk-tools</artifactId>
             <type>jar</type>

--- a/assembly/assembly-main/src/assembly/assembly.xml
+++ b/assembly/assembly-main/src/assembly/assembly.xml
@@ -68,6 +68,15 @@
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>
             <outputDirectory>lib</outputDirectory>
+            <outputFileNameMapping>jdt.ls.tar.gz</outputFileNameMapping>
+            <includes>
+                <include>org.eclipse.che.ls.jdt:jdt.ls.extension.product</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>false</unpack>
+            <outputDirectory>lib</outputDirectory>
             <outputFileNameMapping>ws-agent.tar.gz</outputFileNameMapping>
             <includes>
                 <include>org.eclipse.che:assembly-wsagent-server</include>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <che.docs.version>6.0.0-M2-SNAPSHOT</che.docs.version>
         <che.lib.version>6.0.0-M2-SNAPSHOT</che.lib.version>
         <che.version>6.0.0-M2-SNAPSHOT</che.version>
+        <che.ls.jdt.version>0.0.1-SNAPSHOT</che.ls.jdt.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>
@@ -800,6 +801,12 @@
                 <groupId>org.eclipse.che.lib</groupId>
                 <artifactId>org-eclipse-jdt-core-repack</artifactId>
                 <version>${che.lib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.ls.jdt</groupId>
+                <artifactId>jdt.ls.extension.product</artifactId>
+                <version>${che.ls.jdt.version}</version>
+                <type>tar.gz</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.multiuser</groupId>

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/ExtendedExecuteCommandParams.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/model/ExtendedExecuteCommandParams.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.shared.model;
+
+import org.eclipse.lsp4j.ExecuteCommandParams;
+
+/** Version of execute command params that holds the uri of the file the ide has open. */
+public class ExtendedExecuteCommandParams extends ExecuteCommandParams {
+  private String fileUri;
+
+  public String getFileUri() {
+    return fileUri;
+  }
+
+  public void setFileUri(String fileUri) {
+    this.fileUri = fileUri;
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/ExecuteCommandService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/ExecuteCommandService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.service;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.languageserver.exception.LanguageServerException;
+import org.eclipse.che.api.languageserver.registry.InitializedLanguageServer;
+import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
+import org.eclipse.che.api.languageserver.shared.model.ExtendedExecuteCommandParams;
+import org.eclipse.che.api.languageserver.util.LSOperation;
+import org.eclipse.che.api.languageserver.util.OperationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Json RPC API for the textDoc to send workspace/executeCommand requests. */
+@Singleton
+public class ExecuteCommandService {
+  private static final Logger LOG = LoggerFactory.getLogger(ExecuteCommandService.class);
+
+  private LanguageServerRegistry registry;
+
+  @Inject
+  public ExecuteCommandService(LanguageServerRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Sends a workspace/executeCommand request to the applicable language servers with custom
+   * command.
+   *
+   * @param extendedExecuteCommandParams command parameters describe custom command {@link
+   *     ExtendedExecuteCommandParams}
+   * @return result of executing workspace/executeCommand
+   */
+  public Object executeCommand(ExtendedExecuteCommandParams extendedExecuteCommandParams) {
+
+    final Object[] result = new Object[1];
+    try {
+      List<InitializedLanguageServer> servers =
+          registry
+              .getApplicableLanguageServers(extendedExecuteCommandParams.getFileUri())
+              .stream()
+              .flatMap(Collection::stream)
+              .collect(Collectors.toList());
+      OperationUtil.doInSequence(
+          servers,
+          new LSOperation<InitializedLanguageServer, Object>() {
+            @Override
+            public boolean canDo(InitializedLanguageServer element) {
+              return element.getServer().getWorkspaceService() != null;
+            }
+
+            @Override
+            public CompletableFuture<Object> start(InitializedLanguageServer element) {
+              return element
+                  .getServer()
+                  .getWorkspaceService()
+                  .executeCommand(extendedExecuteCommandParams);
+            }
+
+            @Override
+            public boolean handleResult(InitializedLanguageServer element, Object response) {
+              result[0] = response;
+              return true;
+            }
+          },
+          10_000);
+      return result[0];
+    } catch (LanguageServerException e) {
+      LOG.error("error executing command", e);
+      throw new JsonRpcException(-27000, e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
The PR proposes to use jdt.ls extension (https://github.com/eclipse/che-ls-jdt) instead of jdt.ls.
Also provides a service ( `ExecuteCommandService` ) which helps to execute custom commands on jdt.ls side.

