### PR TITLE
Display environment and runtime warnings

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+
+/**
+ * This class is handling the controller for the workspace (environment and runtime) warnings container.
+ * @author Ann Shumilova
+ */
+export class WorkspaceWarningsController {
+  /**
+   * Workspace is provided by the scope.
+   */
+  workspace: che.IWorkspace;
+  /**
+   * List of warnings.
+   */
+  warnings: che.IWorkspaceWarning[];
+
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor() {
+    this.warnings = [];
+
+    let environment = (this.workspace && this.workspace.config && this.workspace.config.defaultEnv) ? this.workspace.config.environments[this.workspace.config.defaultEnv] : null;
+    if (environment) {
+      this.warnings = this.warnings.concat(environment.warnings);
+    }
+
+    if (this.workspace && this.workspace.runtime) {
+      this.warnings = this.warnings.concat(this.workspace.runtime.warnings);
+    }
+  }
+}
+
+

--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.directive.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * @ngDoc directive
+ * @name workspace.warnings.directive:WorkspaceWarnings
+ * @description This class is handling the directive for the container with warnings
+ * @author Ann Shumilova
+ */
+export class WorkspaceWarnings {
+  private restrict: string;
+  private bindToController:boolean;
+  private templateUrl: string;
+  private controller: string;
+  private controllerAs: string;
+  private transclude: boolean;
+  private scope: {
+    [propName: string]: string
+  };
+
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor() {
+    this.restrict = 'E';
+    this.bindToController = true;
+    this.templateUrl = 'app/workspaces/workspace-details/warnings/workspace-warnings.html';
+    this.controller = 'WorkspaceWarningsController';
+    this.controllerAs = 'workspaceWarningsController';
+
+    this.transclude = true;
+    this.scope = {
+      workspace: '=workspace'
+    }
+  }
+
+}

--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.html
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.html
@@ -1,0 +1,21 @@
+<md-menu ng-if="workspaceWarningsController.warnings.length > 0" md-offset="0 40">
+  <div ng-click="$mdOpenMenu($event)" class="warnings-container" layout="row" layout-align="start center">
+    <i class="fa fa-exclamation-triangle fa-2x warnings-container-icon"></i>
+    <div class="warnings-count" ng-if="workspaceWarningsController.warnings.length > 1">
+      {{workspaceWarningsController.warnings.length}} warnings
+    </div>
+    <div class="warnings-count" ng-if="workspaceWarningsController.warnings.length === 1">
+      {{workspaceWarningsController.warnings.length}} warning
+    </div>
+  </div>
+  <md-menu-content class="warnings-menu-content">
+    <md-menu-item layout="column" class="warning-item" ng-repeat="warning in workspaceWarningsController.warnings">
+      <div layout="row" layout-align="start start" class="warning-item-content">
+        <i class="fa fa-exclamation-triangle fa-2x warnings-item-icon"></i>
+        <div class="warning-item-message">{{warning.message}}</div>
+      </div>
+    </md-menu-item>
+  </md-menu-content>
+</md-menu>
+
+

--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.styl
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.styl
@@ -1,0 +1,47 @@
+.warnings-container
+  position relative
+  cursor pointer
+  outline none
+
+.warnings-container-icon
+  font-size 19px
+  line-height 19px
+  color $warning-color
+  margin-right 10px
+
+.warnings-menu-content
+  padding 5px 0px
+  margin 0px
+
+.warnings-item-icon
+  font-size 19px
+  color $warning-color
+  margin-right 10px
+  margin-top 2px
+
+.warning-item
+  width 350px
+  margin 0px 20px
+  min-height 18px
+  height 100%
+  padding 10px 0px
+
+.warning-item:not(:last-of-type)
+  border-bottom 1px solid $list-separator-color
+
+.warning-item-content
+  padding 0px
+
+.warning-item-message
+  word-wrap break-word
+  white-space normal
+  overflow hidden
+  text-overflow ellipsis
+
+.warnings-count
+  color $menu-bg-color !important
+  position relative
+  font-size 13px
+  line-height 19px
+  vertical-align middle
+

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -3,6 +3,7 @@
   link-href="#/workspaces" link-title="Workspaces" class="workspace-details-toolbar">
   <div layout="row" layout-align="start center" class="toolbar-info">
     <workspace-status che-status="workspaceDetailsController.getWorkspaceStatus()"></workspace-status>
+    <workspace-warnings workspace="workspaceDetailsController.workspaceDetails"></workspace-warnings>
   </div>
   <div flex layout="row" layout-align="end center">
     <workspace-status-button workspace-status="workspaceDetailsController.getWorkspaceStatus()"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.styl
@@ -13,6 +13,13 @@
   che-button-default a
     background-color #00c183 !important
 
+  workspace-warnings
+    float right
+    margin-left 20px
+
+  .toolbar-info
+    display flex
+
 .workspace-details-content
   md-tab-content
     padding 0

--- a/dashboard/src/app/workspaces/workspaces-config.ts
+++ b/dashboard/src/app/workspaces/workspaces-config.ts
@@ -147,6 +147,8 @@ import {EditMachineServerDialogController} from './workspace-details/workspace-m
 import {MachineAgents} from './workspace-details/workspace-machine-agents/machine-agents.directive';
 import {MachineAgentsController} from './workspace-details/workspace-machine-agents/machine-agents.controller';
 import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory';
+import {WorkspaceWarnings} from './workspace-details/warnings/workspace-warnings.directive';
+import {WorkspaceWarningsController} from './workspace-details/warnings/workspace-warnings.controller';
 
 /**
  * @ngdoc controller
@@ -176,6 +178,9 @@ export class WorkspacesConfig {
 
     register.directive('cheWorkspaceStatus', CheWorkspaceStatus);
     register.controller('WorkspaceStatusController', WorkspaceStatusController);
+
+    register.directive('workspaceWarnings', WorkspaceWarnings);
+    register.controller('WorkspaceWarningsController', WorkspaceWarningsController);
 
     register.directive('workspaceEditModeOverlay', WorkspaceEditModeOverlay);
     register.directive('workspaceEditModeToolbarButton', WorkspaceEditModeToolbarButton);


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Displays warnings from workspace's environment and runtime.
The warnings item is placed in the workspace details toolbar:
![screenshot from 2017-11-07 13-38-53](https://user-images.githubusercontent.com/1611939/32492586-8833d9c2-c3c3-11e7-8e89-c34461206539.png)

![screenshot from 2017-11-07 13-38-42](https://user-images.githubusercontent.com/1611939/32492630-ac20c976-c3c3-11e7-927b-9afe46217491.png)


If no warnings - no icon is displayed.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7050

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
If there are any warnings provided by environment or runtime of the workspace - the user is now able to view them and be aware.

#### Docs PR
N/A
