### PR TITLE
Add cleanup of workspace data for common PVC strategy

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -452,6 +452,12 @@ che.infra.openshift.pvc.name=claim-che-workspace
 # https://docs.openshift.com/container-platform/latest/dev_guide/compute_resources.html#dev-compute-resources
 che.infra.openshift.pvc.quantity=10Gi
 
+# Pod that is launched when performing persistent volume claim maintenance jobs on OpenShift
+che.infra.openshift.pvc.jobs.image=centos:centos7
+
+# Defines pod memory limit for persistent volume claim maintenance jobs
+che.infra.openshift.pvc.jobs.memorylimit=250Mi
+
 # Defines Persistent Volume Claim access mode.
 # Note that for common PVC strategy changing of access mode affects the number of simultaneously running workspaces.
 # If OpenShift flavor where che running is using PVs with RWX access mode then a limit of running workspaces at the same time

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>openshift-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -12,21 +12,18 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.CHE_ORIGINAL_NAME_LABEL;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.assistedinject.Assisted;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import javax.inject.Inject;
@@ -94,7 +91,6 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
   protected void internalStart(Map<String, String> startOptions) throws InfrastructureException {
     try {
       final OpenShiftEnvironment osEnv = getContext().getOpenShiftEnvironment();
-      prepareOpenShiftPVCs(osEnv.getPersistentVolumeClaims());
 
       List<Service> createdServices = new ArrayList<>();
       for (Service service : osEnv.getServices().values()) {
@@ -246,23 +242,6 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
                 project);
         machines.put(machine.getName(), machine);
         sendStartingEvent(machine.getName());
-      }
-    }
-  }
-
-  private void prepareOpenShiftPVCs(Map<String, PersistentVolumeClaim> pvcs)
-      throws InfrastructureException {
-    Set<String> existing =
-        project
-            .persistentVolumeClaims()
-            .get()
-            .stream()
-            .map(p -> p.getMetadata().getName())
-            .collect(toSet());
-
-    for (Map.Entry<String, PersistentVolumeClaim> pvcEntry : pvcs.entrySet()) {
-      if (!existing.contains(pvcEntry.getKey())) {
-        project.persistentVolumeClaims().create(pvcEntry.getValue());
       }
     }
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -67,6 +67,6 @@ public class OpenShiftRuntimeContext extends RuntimeContext {
 
   @Override
   public InternalRuntime getRuntime() throws InfrastructureException {
-    return runtimeFactory.create(this, projectFactory.create(getIdentity()));
+    return runtimeFactory.create(this, projectFactory.create(getIdentity().getWorkspaceId()));
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -15,7 +15,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import javax.inject.Named;
-import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -39,8 +38,7 @@ public class OpenShiftProjectFactory {
     this.clientFactory = clientFactory;
   }
 
-  public OpenShiftProject create(RuntimeIdentity identity) throws InfrastructureException {
-    final String workspaceId = identity.getWorkspaceId();
+  public OpenShiftProject create(String workspaceId) throws InfrastructureException {
     final String projectName = isNullOrEmpty(this.projectName) ? workspaceId : this.projectName;
     return new OpenShiftProject(clientFactory, projectName, workspaceId);
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/PVCSubPathHelper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/PVCSubPathHelper.java
@@ -140,12 +140,10 @@ public class PVCSubPathHelper {
       }
     } catch (InfrastructureException ex) {
       LOG.error(
-          "Unable to perform '"
-              + Arrays.toString(command)
-              + "' command for the workspace '"
-              + workspaceId
-              + "'.",
-          ex);
+          "Unable to perform '{}' command for the workspace '{}' cause: '{}'",
+          Arrays.toString(command),
+          workspaceId,
+          ex.getMessage());
     } finally {
       if (pods != null) {
         try {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/PVCSubPathHelper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/PVCSubPathHelper.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
+
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newVolume;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newVolumeMount;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Stream;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftPods;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helps to execute commands needed for workspace PVC preparation and cleanup.
+ *
+ * <p>Creates a short-lived Pod based on CentOS image which mounts a specified PVC and executes a
+ * command (either {@code mkdir -p <path>} or {@code rm -rf <path>}). Reports back whether the pod
+ * succeeded or failed. Supports multiple paths for one command.
+ *
+ * <p>Note that the commands execution is needed only for {@link CommonPVCStrategy}.
+ *
+ * @author amisevsk
+ * @author Anton Korneta
+ */
+@Singleton
+public class PVCSubPathHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PVCSubPathHelper.class);
+  private static final JobFinishedPredicate POD_PREDICATE = new JobFinishedPredicate();
+
+  static final int COUNT_THREADS = 4;
+  static final int WAIT_POD_TIMEOUT_MIN = 5;
+
+  static final String[] RM_COMMAND_BASE = new String[] {"rm", "-rf"};
+  static final String[] MKDIR_COMMAND_BASE = new String[] {"mkdir", "-p"};
+
+  static final String IMAGE_PULL_POLICY = "IfNotPresent";
+  static final String POD_RESTART_POLICY = "Never";
+  static final String POD_PHASE_SUCCEEDED = "Succeeded";
+  static final String POD_PHASE_FAILED = "Failed";
+  static final String JOB_MOUNT_PATH = "/tmp/job_mount";
+
+  private final String pvcName;
+  private final String jobImage;
+  private final String jobMemoryLimit;
+  private final OpenShiftProjectFactory factory;
+  private final ExecutorService executor;
+
+  @Inject
+  PVCSubPathHelper(
+      @Named("che.infra.openshift.pvc.name") String pvcName,
+      @Named("che.infra.openshift.pvc.jobs.memorylimit") String jobMemoryLimit,
+      @Named("che.infra.openshift.pvc.jobs.image") String jobImage,
+      OpenShiftProjectFactory factory) {
+    this.pvcName = pvcName;
+    this.jobMemoryLimit = jobMemoryLimit;
+    this.jobImage = jobImage;
+    this.factory = factory;
+    this.executor =
+        Executors.newFixedThreadPool(
+            COUNT_THREADS,
+            new ThreadFactoryBuilder()
+                .setNameFormat("PVCSubPathHelper-ThreadPool-%d")
+                .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+                .setDaemon(false)
+                .build());
+  }
+
+  /**
+   * Performs create workspace directories job by given paths and waits until it finished.
+   *
+   * @param workspaceId workspace identifier
+   * @param dirs workspace directories to create
+   */
+  void createDirs(String workspaceId, String... dirs) {
+    execute(workspaceId, MKDIR_COMMAND_BASE, dirs);
+  }
+
+  /**
+   * Asynchronously starts a job for removing workspace directories by given paths.
+   *
+   * @param workspaceId workspace identifier
+   * @param dirs workspace directories to remove
+   */
+  CompletableFuture<Void> removeDirsAsync(String workspaceId, String... dirs) {
+    return CompletableFuture.runAsync(
+        ThreadLocalPropagateContext.wrap(() -> execute(workspaceId, RM_COMMAND_BASE, dirs)),
+        executor);
+  }
+
+  /**
+   * Executes the job with the specified arguments.
+   *
+   * @param commandBase the command base to execute
+   * @param arguments the list of arguments for the specified job
+   */
+  @VisibleForTesting
+  void execute(String workspaceId, String[] commandBase, String... arguments) {
+    final String jobName = commandBase[0];
+    final String podName = jobName + '-' + workspaceId;
+    final String[] command = buildCommand(commandBase, arguments);
+    final Pod pod = newPod(podName, command);
+    OpenShiftPods pods = null;
+    try {
+      pods = factory.create(workspaceId).pods();
+      pods.create(pod);
+      final Pod finished = pods.wait(podName, WAIT_POD_TIMEOUT_MIN, POD_PREDICATE::apply);
+      if (POD_PHASE_FAILED.equals(finished.getStatus().getPhase())) {
+        LOG.error("Job command '%s' execution is failed.", Arrays.toString(command));
+      }
+    } catch (InfrastructureException ex) {
+      LOG.error(
+          "Unable to perform '"
+              + Arrays.toString(command)
+              + "' command for the workspace '"
+              + workspaceId
+              + "'.",
+          ex);
+    } finally {
+      if (pods != null) {
+        try {
+          pods.delete(podName);
+        } catch (InfrastructureException ignored) {
+        }
+      }
+    }
+  }
+
+  /**
+   * Builds the command by given base and paths.
+   *
+   * <p>Command is consists of base(e.g. rm -rf) and list of directories which are modified with
+   * mount path.
+   *
+   * @param base command base
+   * @param dirs the paths which are used as arguments for the command base
+   * @return complete command with given arguments
+   */
+  @VisibleForTesting
+  String[] buildCommand(String[] base, String... dirs) {
+    return Stream.concat(
+            Arrays.stream(base),
+            Arrays.stream(dirs)
+                .map(dir -> JOB_MOUNT_PATH + (dir.startsWith("/") ? dir : '/' + dir)))
+        .toArray(String[]::new);
+  }
+
+  @PreDestroy
+  void shutdown() {
+    if (!executor.isShutdown()) {
+      executor.shutdown();
+      try {
+        if (!executor.awaitTermination(30, SECONDS)) {
+          executor.shutdownNow();
+          if (!executor.awaitTermination(60, SECONDS))
+            LOG.error("Couldn't shutdown PVCSubPathHelper thread pool");
+        }
+      } catch (InterruptedException ignored) {
+        executor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+      LOG.info("PVCSubPathHelper thread pool is terminated");
+    }
+  }
+
+  /** Returns new instance of {@link Pod} with given name and command. */
+  private Pod newPod(String podName, String[] command) {
+    final Container container =
+        new ContainerBuilder()
+            .withName(podName)
+            .withImage(jobImage)
+            .withImagePullPolicy(IMAGE_PULL_POLICY)
+            .withCommand(command)
+            .withVolumeMounts(newVolumeMount(pvcName, JOB_MOUNT_PATH, null))
+            .withNewResources()
+            .withLimits(singletonMap("memory", new Quantity(jobMemoryLimit)))
+            .endResources()
+            .build();
+    return new PodBuilder()
+        .withNewMetadata()
+        .withName(podName)
+        .endMetadata()
+        .withNewSpec()
+        .withContainers(container)
+        .withVolumes(newVolume(pvcName, pvcName))
+        .withRestartPolicy(POD_RESTART_POLICY)
+        .endSpec()
+        .build();
+  }
+
+  /** Checks whether pod is Failed or Successfully finished command execution */
+  static class JobFinishedPredicate implements Predicate<Pod> {
+    @Override
+    public boolean apply(Pod pod) {
+      if (pod.getStatus() == null) {
+        return false;
+      }
+      switch (pod.getStatus().getPhase()) {
+        case POD_PHASE_FAILED:
+          // fall through
+        case POD_PHASE_SUCCEEDED:
+          // job is finished.
+          return true;
+        default:
+          // job is not finished.
+          return false;
+      }
+    }
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategyTest.java
@@ -14,14 +14,17 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_WS_AGENT_HTTP_REFERENCE;
+import static org.eclipse.che.workspace.infrastructure.openshift.Names.machineName;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -32,12 +35,16 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftPersistentVolumeClaims;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -56,7 +63,7 @@ public class CommonPVCStrategyTest {
   private static final String PVC_NAME = "che-claim";
   private static final String POD_NAME = "main";
   private static final String CONTAINER_NAME = "app";
-  private static final String MACHINE_NAME = POD_NAME + '/' + CONTAINER_NAME;
+  private static final String MACHINE_NAME = machineName(POD_NAME, CONTAINER_NAME);
   private static final String PVC_QUANTITY = "10Gi";
   private static final String PVC_ACCESS_MODE = "RWO";
   private static final String PROJECT_FOLDER_PATH = "/projects";
@@ -67,6 +74,9 @@ public class CommonPVCStrategyTest {
   @Mock private InternalEnvironment env;
   @Mock private OpenShiftEnvironment osEnv;
   @Mock private PVCSubPathHelper pvcSubPathHelper;
+  @Mock private OpenShiftProjectFactory factory;
+  @Mock private OpenShiftProject osProject;
+  @Mock private OpenShiftPersistentVolumeClaims osPVCs;
 
   private CommonPVCStrategy commonPVCStrategy;
 
@@ -74,7 +84,12 @@ public class CommonPVCStrategyTest {
   public void setup() throws Exception {
     commonPVCStrategy =
         new CommonPVCStrategy(
-            PVC_NAME, PVC_QUANTITY, PVC_ACCESS_MODE, PROJECT_FOLDER_PATH, pvcSubPathHelper);
+            PVC_NAME,
+            PVC_QUANTITY,
+            PVC_ACCESS_MODE,
+            PROJECT_FOLDER_PATH,
+            pvcSubPathHelper,
+            factory);
     final InternalMachineConfig machine = mock(InternalMachineConfig.class);
     when(machine.getServers())
         .thenReturn(singletonMap(SERVER_WS_AGENT_HTTP_REFERENCE, mock(ServerConfig.class)));
@@ -83,6 +98,8 @@ public class CommonPVCStrategyTest {
     when(osEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
     when(pvcSubPathHelper.removeDirsAsync(anyString(), any(String.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(factory.create(WORKSPACE_ID)).thenReturn(osProject);
+    when(osProject.persistentVolumeClaims()).thenReturn(osPVCs);
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
@@ -115,14 +132,30 @@ public class CommonPVCStrategyTest {
   }
 
   @Test
-  public void testDoNothingWhenPVCAlreadyAddedToOsEnv() throws Exception {
-    when(osEnv.getPersistentVolumeClaims())
-        .thenReturn(singletonMap(PVC_NAME, mock(PersistentVolumeClaim.class)));
+  public void testReplacePVCWhenItsAlreadyInOsEnvironment() throws Exception {
+    final Map<String, PersistentVolumeClaim> claims = new HashMap<>();
+    final PersistentVolumeClaim provisioned = mock(PersistentVolumeClaim.class);
+    claims.put(PVC_NAME, provisioned);
+    when(osEnv.getPersistentVolumeClaims()).thenReturn(claims);
 
     commonPVCStrategy.prepare(env, osEnv, WORKSPACE_ID);
 
-    verify(osEnv).getPersistentVolumeClaims();
-    verify(osEnv, never()).getPods();
+    verify(factory).create(WORKSPACE_ID);
+    assertNotEquals(osEnv.getPersistentVolumeClaims().get(PVC_NAME), provisioned);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwInfrastructureExceptionWhenOsProjectCreationFailed() throws Exception {
+    when(factory.create(any())).thenThrow(new InfrastructureException("Project creation failed"));
+
+    commonPVCStrategy.prepare(env, osEnv, WORKSPACE_ID);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwInfrastructureExceptionWhenPVCCreationFailed() throws Exception {
+    doThrow(InfrastructureException.class).when(osPVCs).createIfNotExist(any());
+
+    commonPVCStrategy.prepare(env, osEnv, WORKSPACE_ID);
   }
 
   @Test

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/PVCSubPathHelperTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/PVCSubPathHelperTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
+
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.PVCSubPathHelper.JOB_MOUNT_PATH;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.PVCSubPathHelper.MKDIR_COMMAND_BASE;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.PVCSubPathHelper.POD_PHASE_FAILED;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.PVCSubPathHelper.POD_PHASE_SUCCEEDED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftPods;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
+import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link PVCSubPathHelper}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class PVCSubPathHelperTest {
+
+  private static final String WORKSPACE_ID = "workspace132";
+  private static final String PVC_NAME = "che-workspace-claim";
+  private static final String jobMemoryLimit = "250Mi";
+  private static final String jobImage = "centos:centos7";
+  private static final String PROJECTS_PATH = "/projects";
+  private static final String M2_PATH = "/.m2";
+
+  @Mock private OpenShiftProjectFactory osProjectFactory;
+  @Mock private OpenShiftProject osProject;
+  @Mock private OpenShiftPods osPods;
+  @Mock private Pod pod;
+  @Mock private PodStatus podStatus;
+
+  @Captor private ArgumentCaptor<Pod> podCaptor;
+
+  private PVCSubPathHelper pvcSubPathHelper;
+
+  @BeforeMethod
+  public void setup() throws Exception {
+    pvcSubPathHelper = new PVCSubPathHelper(PVC_NAME, jobMemoryLimit, jobImage, osProjectFactory);
+    when(osProjectFactory.create(anyString())).thenReturn(osProject);
+    when(osProject.pods()).thenReturn(osPods);
+    when(pod.getStatus()).thenReturn(podStatus);
+    when(osPods.create(any(Pod.class))).thenReturn(pod);
+    when(osPods.wait(anyString(), anyInt(), any())).thenReturn(pod);
+    doNothing().when(osPods).delete(anyString());
+  }
+
+  @Test
+  public void testBuildsCommandByGivenBaseAndPaths() throws Exception {
+    final String[] paths = {WORKSPACE_ID + PROJECTS_PATH, WORKSPACE_ID + M2_PATH};
+
+    final String[] actual = pvcSubPathHelper.buildCommand(MKDIR_COMMAND_BASE, paths);
+
+    final String[] expected = new String[MKDIR_COMMAND_BASE.length + 2];
+    System.arraycopy(MKDIR_COMMAND_BASE, 0, expected, 0, MKDIR_COMMAND_BASE.length);
+    expected[expected.length - 1] = JOB_MOUNT_PATH + '/' + WORKSPACE_ID + M2_PATH;
+    expected[expected.length - 2] = JOB_MOUNT_PATH + '/' + WORKSPACE_ID + PROJECTS_PATH;
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testSuccessfullyCreatesWorkspaceDirs() throws Exception {
+    when(podStatus.getPhase()).thenReturn(POD_PHASE_SUCCEEDED);
+
+    pvcSubPathHelper.createDirs(WORKSPACE_ID, WORKSPACE_ID + PROJECTS_PATH);
+
+    verify(osPods).create(podCaptor.capture());
+    final List<String> actual = podCaptor.getValue().getSpec().getContainers().get(0).getCommand();
+    final List<String> expected =
+        Stream.concat(
+                Arrays.stream(MKDIR_COMMAND_BASE),
+                Stream.of(JOB_MOUNT_PATH + '/' + WORKSPACE_ID + PROJECTS_PATH))
+            .collect(toList());
+    assertEquals(actual, expected);
+    verify(osPods).wait(anyString(), anyInt(), any());
+    verify(podStatus).getPhase();
+    verify(osPods).delete(anyString());
+  }
+
+  @Test
+  public void testLogErrorWhenJobExecutionFailed() throws Exception {
+    when(podStatus.getPhase()).thenReturn(POD_PHASE_FAILED);
+
+    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+
+    verify(osPods).create(any());
+    verify(osPods).wait(anyString(), anyInt(), any());
+    verify(podStatus).getPhase();
+    verify(osPods).delete(anyString());
+  }
+
+  @Test
+  public void testLogErrorWhenOpenShiftProjectCreationFailed() throws Exception {
+    when(osProjectFactory.create(WORKSPACE_ID))
+        .thenThrow(new InfrastructureException("OpenShift project creation failed"));
+
+    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+
+    verify(osProjectFactory).create(WORKSPACE_ID);
+    verify(osProject, never()).pods();
+  }
+
+  @Test
+  public void testLogErrorWhenOpenShiftPodCreationFailed() throws Exception {
+    when(osPods.create(any()))
+        .thenThrow(new InfrastructureException("OpenShift pod creation failed"));
+
+    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+
+    verify(osProjectFactory).create(WORKSPACE_ID);
+    verify(osProject).pods();
+    verify(osPods).create(any());
+    verify(osPods, never()).wait(anyString(), anyInt(), any());
+  }
+
+  @Test
+  public void testIgnoreExceptionWhenPodJobRemovalFailed() throws Exception {
+    when(podStatus.getPhase()).thenReturn(POD_PHASE_SUCCEEDED);
+    doThrow(InfrastructureException.class).when(osPods).delete(anyString());
+
+    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+
+    verify(osPods).create(any());
+    verify(osPods).wait(anyString(), anyInt(), any());
+    verify(podStatus).getPhase();
+    verify(osPods).delete(anyString());
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -8,12 +8,12 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_WS_AGENT_HTTP_REFERENCE;
-import static org.eclipse.che.workspace.infrastructure.openshift.project.CommonPVCStrategyTest.mockName;
+import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.CommonPVCStrategyTest.mockName;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -41,7 +41,6 @@ import org.eclipse.che.api.workspace.server.spi.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.UniqueWorkspacePVCStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleanerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleanerTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
+package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -24,15 +24,17 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCCleaner;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-/** Tests {@link WorkspacePVCCleaner}. */
+/**
+ * Tests {@link WorkspacePVCCleaner}.
+ *
+ * @author Anton Korneta
+ */
 @Listeners(MockitoTestNGListener.class)
 public class WorkspacePVCCleanerTest {
 


### PR DESCRIPTION
### What does this PR do?
Partially move the logic of cleanup and preparation of PVC from the master branch.
The main idea of changes borrowed from the master branch is to be able to clean up the PV from workspace backed up data. These changes relate only to common PVC strategy and do the preparation of the workspace data folders during the workspace startup and async clean up of the workspace data on the workspace removal. Preparation step is needed because folders that mount into a container by kubernetes would be with root rights and they cannot be removed.
Added `OpenshiftPods.delete(name)` method.

### What issues does this PR fix or reference?
#6767 
