### PR TITLE
Add JVM options for Java9 runtime

### DIFF
--- a/assembly/assembly-wsagent-server/src/assembly/setenv.sh
+++ b/assembly/assembly-wsagent-server/src/assembly/setenv.sh
@@ -34,6 +34,10 @@
 [ -z "${CLASSPATH}" ]  && CLASSPATH="${CATALINA_HOME}/conf/:${JAVA_HOME}/lib/tools.jar"
 
 
+# On java9 runtime, enable activation and JAXB API
+JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1 | sed 's/[^0-9]*//g')
+[ "$JAVA_VERSION" -ge 9 ] && JAVA_OPTS="$JAVA_OPTS --add-modules java.activation --add-modules java.xml.bind"
+
 export JAVA_OPTS="$JAVA_OPTS  -Dche.logs.dir=${CHE_LOGS_DIR} -Dche.logs.level=${CHE_LOGS_LEVEL} -Djuli-logback.configurationFile=file:$CATALINA_HOME/conf/tomcat-logger.xml"
 
 [ -z "${SERVER_PORT}" ]  && SERVER_PORT=8080

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -159,10 +159,6 @@ call_catalina () {
   export JAVA_OPTS="${JAVA_OPTS} -Dport.http=${CHE_PORT} -Dche.home=${CHE_HOME}"
   export SERVER_PORT=${CHE_PORT}
 
-  # On java9 runtime, enable activation and JAXB API
-  JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1 | sed 's/[^0-9]*//g')
-  [ "$JAVA_VERSION" -ge 9 ] && JAVA_OPTS="$JAVA_OPTS --add-modules java.activation --add-modules java.xml.bind"
-
   # Launch the Che application server, passing in command line parameters
   if [[ "${CHE_DEBUG_SERVER}" == true ]]; then
     "${ASSEMBLY_BIN_DIR}"/catalina.sh jpda ${CHE_SERVER_ACTION}

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -159,6 +159,10 @@ call_catalina () {
   export JAVA_OPTS="${JAVA_OPTS} -Dport.http=${CHE_PORT} -Dche.home=${CHE_HOME}"
   export SERVER_PORT=${CHE_PORT}
 
+  # On java9 runtime, enable activation and JAXB API
+  JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1 | sed 's/[^0-9]*//g')
+  [ "$JAVA_VERSION" -ge 9 ] && JAVA_OPTS="$JAVA_OPTS --add-modules java.activation --add-modules java.xml.bind"
+
   # Launch the Che application server, passing in command line parameters
   if [[ "${CHE_DEBUG_SERVER}" == true ]]; then
     "${ASSEMBLY_BIN_DIR}"/catalina.sh jpda ${CHE_SERVER_ACTION}


### PR DESCRIPTION
### What does this PR do?

It brings some required modules that are not exposed by default (javax.* classes are turned off by default) when using Java9+ runtime

### What issues does this PR fix or reference?
#7177 

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: Ie3e63200bc5cbe7a371c00bd56333a144d68fd32
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
