### PR TITLE
Multi tenant workspace cleaning

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -266,6 +266,8 @@ echo "done!"
 # If command == clean up then delete all openshift objects
 # -------------------------------------------------------------
 if [ "${COMMAND}" == "cleanup" ]; then
+  echo "[CHE] Stopping the Che server..."
+  oc scale --replicas=0 --timeout=3h dc che
   echo "[CHE] Deleting all OpenShift objects..."
   oc delete all --all 
   echo "[CHE] Cleanup successfully started. Use \"oc get all\" to verify that all resources have been deleted."

--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -267,7 +267,7 @@ echo "done!"
 # -------------------------------------------------------------
 if [ "${COMMAND}" == "cleanup" ]; then
   echo "[CHE] Stopping the Che server..."
-  oc scale --replicas=0 --timeout=3h dc che
+  oc scale --replicas=0 --timeout=3m dc che
   echo "[CHE] Deleting all OpenShift objects..."
   oc delete all --all 
   echo "[CHE] Cleanup successfully started. Use \"oc get all\" to verify that all resources have been deleted."

--- a/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
@@ -68,6 +68,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilter.java
@@ -33,6 +33,7 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.workspace.server.WorkspaceSubjectRegistry;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
@@ -51,15 +52,18 @@ public class KeycloakEnvironmentInitalizationFilter extends AbstractKeycloakFilt
   private final UserManager userManager;
   private final RequestTokenExtractor tokenExtractor;
   private final PermissionChecker permissionChecker;
+  private final WorkspaceSubjectRegistry workspaceSubjectRegistry;
 
   @Inject
   public KeycloakEnvironmentInitalizationFilter(
       UserManager userManager,
       RequestTokenExtractor tokenExtractor,
-      PermissionChecker permissionChecker) {
+      PermissionChecker permissionChecker,
+      WorkspaceSubjectRegistry workspaceSubjectRegistry) {
     this.userManager = userManager;
     this.tokenExtractor = tokenExtractor;
     this.permissionChecker = permissionChecker;
+    this.workspaceSubjectRegistry = workspaceSubjectRegistry;
   }
 
   @Override
@@ -91,6 +95,7 @@ public class KeycloakEnvironmentInitalizationFilter extends AbstractKeycloakFilt
         subject =
             new AuthorizedSubject(
                 new SubjectImpl(user.getName(), user.getId(), token, false), permissionChecker);
+        workspaceSubjectRegistry.updateSubject(subject);
         session.setAttribute("che_subject", subject);
       } catch (ServerException | ConflictException e) {
         throw new ServletException(

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenRegistry.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenRegistry.java
@@ -96,6 +96,26 @@ public class MachineTokenRegistry {
   }
 
   /**
+   * Gets workspaceId by machine token
+   *
+   * @return workspace identifier
+   * @throws NotFoundException when no such machine token exists
+   */
+  public String getWorkspaceId(String token) throws NotFoundException {
+    lock.readLock().lock();
+    try {
+      for (Table.Cell<String, String, String> tokenCell : tokens.cellSet()) {
+        if (tokenCell.getValue().equals(token)) {
+          return tokenCell.getRowKey();
+        }
+      }
+      throw new NotFoundException("Workspace not found for token " + token);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
    * Invalidates machine security tokens for all users of given workspace.
    *
    * @param workspaceId workspace to invalidate tokens

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenRegistryTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenRegistryTest.java
@@ -53,4 +53,19 @@ public class MachineTokenRegistryTest {
       return false;
     }
   }
+
+  @Test
+  public void shouldreturnWorkspaceId() throws Exception {
+    final MachineTokenRegistry registry = new MachineTokenRegistry();
+
+    String token11 = registry.generateToken("user1", "workspace1");
+    String token12 = registry.generateToken("user1", "workspace2");
+    String token21 = registry.generateToken("user2", "workspace1");
+    String token22 = registry.generateToken("user2", "workspace2");
+
+    assertEquals(registry.getWorkspaceId(token11), "workspace1");
+    assertEquals(registry.getWorkspaceId(token12), "workspace2");
+    assertEquals(registry.getWorkspaceId(token21), "workspace1");
+    assertEquals(registry.getWorkspaceId(token22), "workspace2");
+  }
 }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftPvcHelper.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.plugin.openshift.client.exception.OpenShiftException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +101,7 @@ public class OpenShiftPvcHelper {
    * @see Command
    */
   protected boolean createJobPod(
+      Subject subject,
       String workspacesPvcName,
       String projectNamespace,
       String jobNamePrefix,

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenshiftWorkspaceEnvironmentProvider.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenshiftWorkspaceEnvironmentProvider.java
@@ -15,6 +15,8 @@ import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.plugin.openshift.client.exception.OpenShiftException;
 
 @Singleton
@@ -28,12 +30,20 @@ public class OpenshiftWorkspaceEnvironmentProvider {
     this.openShiftCheProjectName = openShiftCheProjectName;
   }
 
-  public Config getWorkspacesOpenshiftConfig() throws OpenShiftException {
+  public Config getWorkspacesOpenshiftConfig(Subject subject) throws OpenShiftException {
     return new OpenShiftConfigBuilder().build();
   }
 
-  public String getWorkspacesOpenshiftNamespace() throws OpenShiftException {
+  public final Config getWorkspacesOpenshiftConfig() throws OpenShiftException {
+    return getWorkspacesOpenshiftConfig(EnvironmentContext.getCurrent().getSubject());
+  }
+
+  public String getWorkspacesOpenshiftNamespace(Subject subject) throws OpenShiftException {
     return openShiftCheProjectName;
+  }
+
+  public final String getWorkspacesOpenshiftNamespace() throws OpenShiftException {
+    return getWorkspacesOpenshiftNamespace(EnvironmentContext.getCurrent().getSubject());
   }
 
   public Boolean areWorkspacesExternal() {

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesExecHolder.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesExecHolder.java
@@ -27,6 +27,7 @@ public class KubernetesExecHolder {
 
   private String[] command;
   private String podName;
+  private String containerId;
 
   public KubernetesExecHolder withCommand(String[] command) {
     this.command = command;
@@ -38,12 +39,21 @@ public class KubernetesExecHolder {
     return this;
   }
 
+  public KubernetesExecHolder withContainerId(String containerId) {
+    this.containerId = containerId;
+    return this;
+  }
+
   public String[] getCommand() {
     return command;
   }
 
   public String getPod() {
     return podName;
+  }
+
+  public String getContainerId() {
+    return containerId;
   }
 
   public String toString() {

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.WorkspaceSubjectRegistry;
 import org.eclipse.che.plugin.docker.client.DockerApiVersionPathPrefixProvider;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
 import org.eclipse.che.plugin.docker.client.DockerRegistryAuthResolver;
@@ -59,6 +60,7 @@ public class OpenShiftConnectorTest {
   @Mock private OpenShiftPvcHelper openShiftPvcHelper;
   @Mock private OpenShiftRouteCreator openShiftRouteCreator;
   @Mock private OpenShiftDeploymentCleaner openShiftDeploymentCleaner;
+  @Mock private WorkspaceSubjectRegistry workspaceSubjectRegistry;
 
   private OpenShiftConnector openShiftConnector;
 
@@ -77,6 +79,7 @@ public class OpenShiftConnectorTest {
             openShiftRouteCreator,
             openShiftDeploymentCleaner,
             eventService,
+            workspaceSubjectRegistry,
             CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS,
             null,
             CHE_DEFAULT_OPENSHIFT_PROJECT_NAME,

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleanerTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftWorkspaceFilesCleanerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.plugin.openshift.client;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -25,9 +26,11 @@ import java.util.List;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.WorkspaceSubjectRegistry;
 import org.eclipse.che.api.workspace.server.event.ServerIdleEvent;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.plugin.openshift.client.exception.OpenShiftException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -43,6 +46,8 @@ public class OpenShiftWorkspaceFilesCleanerTest {
 
   @Mock private OpenShiftPvcHelper pvcHelper;
   @Mock private ServerIdleEvent serverIdleEvent;
+  @Mock private OpenshiftWorkspaceEnvironmentProvider workspaceEnvironmentProvider;
+  @Mock private WorkspaceSubjectRegistry workspaceSubjectRegistry;
   private EventService eventService;
   private OpenShiftWorkspaceFilesCleaner cleaner;
 
@@ -50,10 +55,21 @@ public class OpenShiftWorkspaceFilesCleanerTest {
   public void setup() {
     OpenShiftWorkspaceFilesCleaner.clearDeleteQueue();
     MockitoAnnotations.initMocks(this);
+    when(workspaceEnvironmentProvider.areWorkspacesExternal()).thenReturn(false);
+    try {
+      when(workspaceEnvironmentProvider.getWorkspacesOpenshiftNamespace(null))
+          .thenReturn(CHE_OPENSHIFT_PROJECT);
+    } catch (OpenShiftException e) {
+      e.printStackTrace();
+    }
     eventService = new EventService();
     cleaner =
         new OpenShiftWorkspaceFilesCleaner(
-            eventService, pvcHelper, CHE_OPENSHIFT_PROJECT, WORKSPACES_PVC_NAME);
+            eventService,
+            pvcHelper,
+            workspaceEnvironmentProvider,
+            workspaceSubjectRegistry,
+            WORKSPACES_PVC_NAME);
   }
 
   @Test
@@ -67,6 +83,7 @@ public class OpenShiftWorkspaceFilesCleanerTest {
     // Then
     verify(pvcHelper, never())
         .createJobPod(
+            isNull(),
             anyString(),
             anyString(),
             anyString(),
@@ -86,6 +103,7 @@ public class OpenShiftWorkspaceFilesCleanerTest {
     // Then
     verify(pvcHelper, times(1))
         .createJobPod(
+            isNull(),
             anyString(),
             anyString(),
             anyString(),
@@ -109,6 +127,7 @@ public class OpenShiftWorkspaceFilesCleanerTest {
     // Then
     verify(pvcHelper, times(1))
         .createJobPod(
+            isNull(),
             anyString(),
             anyString(),
             anyString(),
@@ -137,6 +156,7 @@ public class OpenShiftWorkspaceFilesCleanerTest {
     // Then
     verify(pvcHelper, times(1))
         .createJobPod(
+            isNull(),
             anyString(),
             anyString(),
             anyString(),
@@ -149,6 +169,7 @@ public class OpenShiftWorkspaceFilesCleanerTest {
     // Then
     verify(pvcHelper, times(2))
         .createJobPod(
+            isNull(),
             anyString(),
             anyString(),
             anyString(),
@@ -169,6 +190,7 @@ public class OpenShiftWorkspaceFilesCleanerTest {
     // Then
     verify(pvcHelper, times(1))
         .createJobPod(
+            isNull(),
             eq(WORKSPACES_PVC_NAME),
             eq(CHE_OPENSHIFT_PROJECT),
             anyString(),

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/SystemManager.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/SystemManager.java
@@ -106,6 +106,7 @@ public class SystemManager {
   @PreDestroy
   @VisibleForTesting
   void shutdown() throws InterruptedException {
+    LOG.info("Synchronous shutdown requested");
     if (!statusRef.compareAndSet(RUNNING, PREPARING_TO_SHUTDOWN)) {
       shutdownLatch.await();
     } else {

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/SystemManager.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/SystemManager.java
@@ -106,7 +106,7 @@ public class SystemManager {
   @PreDestroy
   @VisibleForTesting
   void shutdown() throws InterruptedException {
-    LOG.info("Synchronous shutdown requested");
+    LOG.debug("Synchronous shutdown requested");
     if (!statusRef.compareAndSet(RUNNING, PREPARING_TO_SHUTDOWN)) {
       shutdownLatch.await();
     } else {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.slf4j.Logger;
+
+@Singleton
+public class WorkspaceSubjectRegistry implements EventSubscriber<WorkspaceStatusEvent> {
+
+  private static final Logger LOG = getLogger(WorkspaceSubjectRegistry.class);
+
+  private final EventService eventService;
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+  private final Map<String, Subject> workspaceOwners = new HashMap<>();
+  private final Multimap<String, String> userIdToWorkspaces =
+      ArrayListMultimap.<String, String>create();
+
+  @Inject
+  public WorkspaceSubjectRegistry(EventService eventService) {
+    this.eventService = eventService;
+  }
+
+  @Override
+  public void onEvent(WorkspaceStatusEvent event) {
+
+    String workspaceId = event.getWorkspaceId();
+    if (WorkspaceStatusEvent.EventType.STOPPED.equals(event.getEventType())) {
+      workspaceOwners.remove(workspaceId);
+      while (userIdToWorkspaces.values().remove(workspaceId)) {}
+    }
+
+    if (WorkspaceStatusEvent.EventType.STARTING.equals(event.getEventType())) {
+      Subject subject = EnvironmentContext.getCurrent().getSubject();
+      if (subject == Subject.ANONYMOUS) {
+        LOG.warn("Workspace {} is being started by the 'anonymous' user.", workspaceId);
+        return;
+      }
+      userIdToWorkspaces.put(subject.getUserId(), workspaceId);
+      updateSubject(subject);
+    }
+  }
+
+  @PostConstruct
+  @VisibleForTesting
+  void subscribe() {
+    eventService.subscribe(this);
+  }
+
+  public Subject getWorkspaceStarter(String workspaceId) {
+    lock.writeLock().lock();
+    try {
+      return workspaceOwners.get(workspaceId);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public void updateSubject(Subject subject) {
+    String token = subject != null ? subject.getToken() : null;
+    if (token != null && token.startsWith("machine")) {
+      // We are not interested in machine tokens here, but in
+      // having the up-to-date token used by the user to connect
+      // to the front-end application and create the workspace
+      return;
+    }
+    lock.readLock().lock();
+    try {
+      String userId = subject.getUserId();
+      for (String workspaceId : userIdToWorkspaces.get(userId)) {
+        workspaceOwners.put(workspaceId, subject);
+      }
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
@@ -78,8 +78,11 @@ public class WorkspaceSubjectRegistry implements EventSubscriber<WorkspaceStatus
     if (WorkspaceStatusEvent.EventType.STARTING.equals(event.getEventType())) {
       Subject subject = EnvironmentContext.getCurrent().getSubject();
       if (subject == Subject.ANONYMOUS) {
-        LOG.warn("Workspace {} is being started by the 'anonymous' user.", workspaceId);
-        return;
+        throw new IllegalStateException(
+            "Workspace "
+                + workspaceId
+                + " is being started by the 'Anonymous' user.\n"
+                + "This shouldn't happen, and workspaces should always be created by a real user.");
       }
       userIdToWorkspaces.put(subject.getUserId(), workspaceId);
       updateSubject(subject);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
@@ -71,8 +71,8 @@ public class WorkspaceSubjectRegistry implements EventSubscriber<WorkspaceStatus
 
     String workspaceId = event.getWorkspaceId();
     if (WorkspaceStatusEvent.EventType.STOPPED.equals(event.getEventType())) {
-      workspaceOwners.remove(workspaceId);
       while (userIdToWorkspaces.values().remove(workspaceId)) {}
+      workspaceOwners.remove(workspaceId);
     }
 
     if (WorkspaceStatusEvent.EventType.STARTING.equals(event.getEventType())) {
@@ -127,5 +127,13 @@ public class WorkspaceSubjectRegistry implements EventSubscriber<WorkspaceStatus
     } finally {
       lock.readLock().unlock();
     }
+  }
+
+  /*
+   * Only for tests
+   */
+  @VisibleForTesting
+  boolean isUserKnown(String userId) {
+    return userIdToWorkspaces.containsKey(userId);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistry.java
@@ -29,6 +29,27 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.slf4j.Logger;
 
+/**
+ * This class allows maintaining a link between a started workspace and the user who started it.
+ * This also allows updating, at any time, the user informations (<code>Subject</code>) of users
+ * that started workspaces.
+ *
+ * <p></br>
+ *
+ * <p>In particular, this allows having access to the up-to-date connection information (userName
+ * and Keycloak token) of the user that was used when creating a workspace.
+ *
+ * <p>This is required for all the use-cases where these user informations would be necessary to
+ * perform batch-like operations on the user workspaces (such as idling, stop at shutdown, etc ...).
+ *
+ * <p></br>
+ *
+ * <p>An example of such use-case is the multi-tenant scenario when deployment is done to Openshift:
+ * the user connection informations are required to have access to the Openshift cluster / namespace
+ * where the workspace has been created.
+ *
+ * @author David Festal
+ */
 @Singleton
 public class WorkspaceSubjectRegistry implements EventSubscriber<WorkspaceStatusEvent> {
 
@@ -80,6 +101,12 @@ public class WorkspaceSubjectRegistry implements EventSubscriber<WorkspaceStatus
     }
   }
 
+  /*
+   * If some workspaces have been started by the userId contained
+   * in this <code>Subject</code>, then the subject (with
+   * the userName and token) is updated in the workspace-to-subject
+   * cache for all these workspaces.
+   */
   public void updateSubject(Subject subject) {
     String token = subject != null ? subject.getToken() : null;
     if (token != null && token.startsWith("machine")) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistryTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import org.eclipse.che.api.agent.server.AgentRegistry;
+import org.eclipse.che.api.agent.server.impl.AgentSorter;
+import org.eclipse.che.api.agent.server.launcher.AgentLauncherFactory;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.environment.server.CheEnvironmentEngine;
+import org.eclipse.che.api.machine.server.model.impl.SnapshotImpl;
+import org.eclipse.che.api.machine.server.spi.SnapshotDao;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceRuntimeImpl;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author David Festal */
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceSubjectRegistryTest {
+
+  @Spy private EventService eventService;
+  @Mock private CheEnvironmentEngine envEngine;
+  @Mock private AgentSorter agentSorter;
+  @Mock private AgentLauncherFactory launcherFactory;
+  @Mock private AgentRegistry agentRegistry;
+  @Mock private WorkspaceSharedPool sharedPool;
+  @Mock private SnapshotDao snapshotDao;
+  @Mock private Future<WorkspaceRuntimeImpl> runtimeFuture;
+  @Mock private WorkspaceRuntimes.StartTask startTask;
+  @Mock private WorkspaceStatusEvent event;
+
+  @Captor private ArgumentCaptor<WorkspaceStatusEvent> eventCaptor;
+  @Captor private ArgumentCaptor<Callable<?>> taskCaptor;
+  @Captor private ArgumentCaptor<Collection<SnapshotImpl>> snapshotsCaptor;
+
+  private WorkspaceSubjectRegistry workspaceSubjectRegistry;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    workspaceSubjectRegistry = Mockito.spy(new WorkspaceSubjectRegistry(eventService));
+  }
+
+  @Test
+  public void shouldSubscribeToEventService() throws Exception {
+    workspaceSubjectRegistry.subscribe();
+    verify(eventService).subscribe(workspaceSubjectRegistry);
+    eventService.publish(event);
+    verify(workspaceSubjectRegistry).onEvent(event);
+  }
+
+  public void shouldAddSubjectOnStartingEvent() throws Exception {
+    final String workspaceId = "myWorkspaceId";
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STARTING);
+    when(event.getWorkspaceId()).thenReturn(workspaceId);
+    Subject workspaceStarter = new SubjectImpl("userName", "userId", "userToken", false);
+    EnvironmentContext.getCurrent().setSubject(workspaceStarter);
+    workspaceSubjectRegistry.onEvent(event);
+    assertTrue(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId) == workspaceStarter);
+  }
+
+  @Test(expectedExceptions = {IllegalStateException.class})
+  public void shouldThrowWhenStartingWorkspaceAsAnonymous() throws Exception {
+    final String workspaceId = "myWorkspaceId";
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STARTING);
+    when(event.getWorkspaceId()).thenReturn(workspaceId);
+    EnvironmentContext.getCurrent().setSubject(Subject.ANONYMOUS);
+    workspaceSubjectRegistry.onEvent(event);
+  }
+
+  public void shouldUpdateSubjectWithSameId() throws Exception {
+    final String workspaceId = "myWorkspaceId";
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STARTING);
+    when(event.getWorkspaceId()).thenReturn(workspaceId);
+    Subject workspaceStarter = new SubjectImpl("user", "userId", "userToken", false);
+    EnvironmentContext.getCurrent().setSubject(workspaceStarter);
+    workspaceSubjectRegistry.onEvent(event);
+
+    Subject updatedSubject = new SubjectImpl("newUserName", "userId", "newUserToken", false);
+    workspaceSubjectRegistry.updateSubject(updatedSubject);
+    assertTrue(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId) == updatedSubject);
+  }
+
+  public void shouldNotUpdateSubjectWithDifferentId() throws Exception {
+    final String workspaceId = "myWorkspaceId";
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STARTING);
+    when(event.getWorkspaceId()).thenReturn(workspaceId);
+    Subject workspaceStarter = new SubjectImpl("user", "userId", "userToken", false);
+    EnvironmentContext.getCurrent().setSubject(workspaceStarter);
+    workspaceSubjectRegistry.onEvent(event);
+
+    Subject updatedSubject = new SubjectImpl("newUserName", "newUserId", "newUserToken", false);
+    workspaceSubjectRegistry.updateSubject(updatedSubject);
+    assertTrue(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId) == workspaceStarter);
+  }
+
+  public void shouldRemoveUsersOnWorkspaceStop() throws Exception {
+    final String workspaceId1 = "myWorkspaceId";
+    final String workspaceId2 = "myWorkspaceId2";
+    Subject workspaceStarter = new SubjectImpl("user", "userId", "userToken", false);
+    EnvironmentContext.getCurrent().setSubject(workspaceStarter);
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STARTING);
+    when(event.getWorkspaceId()).thenReturn(workspaceId1);
+    workspaceSubjectRegistry.onEvent(event);
+
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STARTING);
+    when(event.getWorkspaceId()).thenReturn(workspaceId2);
+    workspaceSubjectRegistry.onEvent(event);
+
+    assertTrue(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId1) == workspaceStarter);
+    assertTrue(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId2) == workspaceStarter);
+
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STOPPED);
+    when(event.getWorkspaceId()).thenReturn(workspaceId2);
+    workspaceSubjectRegistry.onEvent(event);
+
+    when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STOPPED);
+    when(event.getWorkspaceId()).thenReturn(workspaceId1);
+    workspaceSubjectRegistry.onEvent(event);
+
+    assertNull(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId1) == null);
+    assertNull(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId2) == null);
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceSubjectRegistryTest.java
@@ -140,9 +140,13 @@ public class WorkspaceSubjectRegistryTest {
     when(event.getWorkspaceId()).thenReturn(workspaceId2);
     workspaceSubjectRegistry.onEvent(event);
 
+    assertTrue(workspaceSubjectRegistry.isUserKnown(workspaceStarter.getUserId()));
+
     when(event.getEventType()).thenReturn(WorkspaceStatusEvent.EventType.STOPPED);
     when(event.getWorkspaceId()).thenReturn(workspaceId1);
     workspaceSubjectRegistry.onEvent(event);
+
+    assertFalse(workspaceSubjectRegistry.isUserKnown(workspaceStarter.getUserId()));
 
     assertNull(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId1) == null);
     assertNull(workspaceSubjectRegistry.getWorkspaceStarter(workspaceId2) == null);

--- a/wsmaster/wsmaster-local/pom.xml
+++ b/wsmaster/wsmaster-local/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/filters/EnvironmentInitializationFilter.java
+++ b/wsmaster/wsmaster-local/src/main/java/org/eclipse/che/api/local/filters/EnvironmentInitializationFilter.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.local.filters;
 
 import java.io.IOException;
 import java.security.Principal;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -22,6 +23,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpSession;
+import org.eclipse.che.api.workspace.server.WorkspaceSubjectRegistry;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.commons.subject.SubjectImpl;
@@ -34,6 +36,8 @@ import org.eclipse.che.commons.subject.SubjectImpl;
 @Singleton
 public class EnvironmentInitializationFilter implements Filter {
 
+  @Inject private WorkspaceSubjectRegistry workspaceSubjectRegistry;
+
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {}
 
@@ -45,6 +49,7 @@ public class EnvironmentInitializationFilter implements Filter {
     Subject subject = new SubjectImpl("che", "che", "dummy_token", false);
     HttpSession session = httpRequest.getSession();
     session.setAttribute("codenvy_user", subject);
+    workspaceSubjectRegistry.updateSubject(subject);
 
     final EnvironmentContext environmentContext = EnvironmentContext.getCurrent();
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces changes required to support some multi-tenancy use-cases that were not supported until now:
- clean openshift resources associated to a workspace when the workspace is idled
- clean openshift resources associated to all started workspaces on che-server shutdown.

These 2 use-cases are critical to allow OSIO multi-tenancy to go to production.

### What issues does this PR fix or reference?

https://github.com/redhat-developer/rh-che/issues/370

