### PR TITLE
If workspace base image does not have labels, skip merge of image labels

### DIFF
--- a/plugins/plugin-traefik/plugin-traefik-docker/src/main/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptor.java
+++ b/plugins/plugin-traefik/plugin-traefik-docker/src/main/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptor.java
@@ -86,7 +86,10 @@ public class TraefikCreateContainerInterceptor implements MethodInterceptor {
 
     // Now merge all labels
     final Map<String, String> allLabels = new HashMap<>(containerLabels);
-    allLabels.putAll(imageLabels);
+    if(imageLabels !=  null) {
+        // If image has some labels, merge them
+        allLabels.putAll(imageLabels);
+    }
 
     // Get all ports exposed by the container and by the image
     // it is under the form "22/tcp"

--- a/plugins/plugin-traefik/plugin-traefik-docker/src/main/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptor.java
+++ b/plugins/plugin-traefik/plugin-traefik-docker/src/main/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptor.java
@@ -87,8 +87,8 @@ public class TraefikCreateContainerInterceptor implements MethodInterceptor {
     // Now merge all labels
     final Map<String, String> allLabels = new HashMap<>(containerLabels);
     if (imageLabels != null) {
-        // If image has some labels, merge them
-        allLabels.putAll(imageLabels);
+      // If image has some labels, merge them
+      allLabels.putAll(imageLabels);
     }
 
     // Get all ports exposed by the container and by the image

--- a/plugins/plugin-traefik/plugin-traefik-docker/src/main/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptor.java
+++ b/plugins/plugin-traefik/plugin-traefik-docker/src/main/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptor.java
@@ -86,7 +86,7 @@ public class TraefikCreateContainerInterceptor implements MethodInterceptor {
 
     // Now merge all labels
     final Map<String, String> allLabels = new HashMap<>(containerLabels);
-    if(imageLabels !=  null) {
+    if (imageLabels != null) {
         // If image has some labels, merge them
         allLabels.putAll(imageLabels);
     }

--- a/plugins/plugin-traefik/plugin-traefik-docker/src/test/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptorTest.java
+++ b/plugins/plugin-traefik/plugin-traefik-docker/src/test/java/org/eclipse/che/plugin/traefik/TraefikCreateContainerInterceptorTest.java
@@ -115,6 +115,16 @@ public class TraefikCreateContainerInterceptorTest {
   }
 
   @Test
+  public void testRulesWithNullImageLabels() throws Throwable {
+    when(imageInfoConfig.getLabels()).thenReturn(null);
+    containerLabels.put("foo1", "bar");
+
+    traefikCreateContainerInterceptor.invoke(methodInvocation);
+
+    Assert.assertFalse(containerLabels.containsKey("traefik.service-tomcat8.frontend.rule"));
+  }
+
+  @Test
   public void testRules() throws Throwable {
     containerLabels.put("foo1", "bar");
     containerLabels.put("foo1/dummy", "bar");


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes issue #7249. If image does not have labels in config, the merge fails with nullpointerexception. This patch does the merge only if labels!=null

### What issues does this PR fix or reference?

With SINGLE_MODE, if image does not have any LABEL, an exception is raised when trying to merge the labels. This PR checks that LABEL is not null before merge, else skip the merge.

#### Release Notes
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
None, bug fix only. No impact on documentation.