### PR TITLE
Selenium: Add change to 'CommitFilesTest' to increase stability

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesTest.java
@@ -148,7 +148,9 @@ public class CommitFilesTest {
     loader.waitOnClosed();
     refactor.typeAndWaitNewName("org.eclipse.de");
     refactor.sendKeysIntoField("v.exam");
-    refactor.sendKeysIntoField("ples");
+    refactor.sendKeysIntoField("pl");
+    refactor.sendKeysIntoField("es");
+    refactor.sendKeysIntoField("");
     refactor.waitTextIntoNewNameField(NEW_NAME_PACKAGE);
     refactor.clickOkButtonRefactorForm();
     projectExplorer.selectItem(PROJECT_NAME);


### PR DESCRIPTION
### What does this PR do?
* Sometimes the selenium test 'CommitFilesTest' fails when performing rename package
* It is happened from fast typing text by web-driver, so need to split typing of new name on several steps

### What issues does this PR fix or reference?
#7256
