### PR TITLE
Fix menu position: if not enough space under button will be shown above 

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/menu/MenuWidget.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/menu/MenuWidget.java
@@ -46,7 +46,6 @@ public class MenuWidget extends Composite implements Menu {
 
   private ActionDelegate delegate;
   private long closeTime;
-  private int itemsInMenu;
 
   private MenuItem.ActionDelegate itemDelegate =
       new MenuItem.ActionDelegate() {
@@ -112,32 +111,28 @@ public class MenuWidget extends Composite implements Menu {
     popupPanel.getElement().getStyle().setProperty("position", "absolute");
     popupPanel.getElement().getStyle().clearProperty("left");
     popupPanel.getElement().getStyle().setProperty("right", "calc(100% - " + x + "px");
-    fixPositionIfNeed();
+    adjustTopPosition();
   }
 
   @Override
   public void addListItem(MenuItem menuItem) {
-    itemsInMenu++;
     menuItem.setDelegate(itemDelegate);
     listPanel.add(menuItem);
-    fixPositionIfNeed();
+    adjustTopPosition();
   }
 
   @Override
   public void removeListItem(MenuItem menuItem) {
-    itemsInMenu--;
     listPanel.remove(menuItem);
-    fixPositionIfNeed();
+    adjustTopPosition();
   }
 
-  /**
-   * Fix top value if need. Need in case if bottom part of menu not display
-   */
-  private void fixPositionIfNeed() {
-    int totalHeight = itemsInMenu * 19; //19 height of menu item
+  /** Fix top value if need. Need in case if bottom part of menu not display */
+  private void adjustTopPosition() {
+    int totalHeight = listPanel.getWidgetCount() * 19; // 19 height of menu item
     int y = getAbsoluteTop() + 19 + totalHeight;
     if (y > Window.getClientHeight()) {
-      y = getAbsoluteTop() - 8 - totalHeight; //8 need some correction for looking good in UI
+      y = getAbsoluteTop() - 8 - totalHeight; // 8 need some correction for looking good in UI
       popupPanel.getElement().getStyle().clearProperty("top");
     } else {
       y = getAbsoluteTop() + 19;

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/menu/MenuWidget.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/menu/MenuWidget.java
@@ -19,6 +19,7 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.PopupPanel;
@@ -45,6 +46,7 @@ public class MenuWidget extends Composite implements Menu {
 
   private ActionDelegate delegate;
   private long closeTime;
+  private int itemsInMenu;
 
   private MenuItem.ActionDelegate itemDelegate =
       new MenuItem.ActionDelegate() {
@@ -106,24 +108,41 @@ public class MenuWidget extends Composite implements Menu {
 
   public void showList() {
     int x = getAbsoluteLeft() + getOffsetWidth() - 6;
-    int y = getAbsoluteTop() + 19;
-
     popupPanel.show();
     popupPanel.getElement().getStyle().setProperty("position", "absolute");
     popupPanel.getElement().getStyle().clearProperty("left");
     popupPanel.getElement().getStyle().setProperty("right", "calc(100% - " + x + "px");
-    popupPanel.getElement().getStyle().setProperty("top", "" + y + "px");
+    fixPositionIfNeed();
   }
 
   @Override
   public void addListItem(MenuItem menuItem) {
+    itemsInMenu++;
     menuItem.setDelegate(itemDelegate);
     listPanel.add(menuItem);
+    fixPositionIfNeed();
   }
 
   @Override
   public void removeListItem(MenuItem menuItem) {
+    itemsInMenu--;
     listPanel.remove(menuItem);
+    fixPositionIfNeed();
+  }
+
+  /**
+   * Fix top value if need. Need in case if bottom part of menu not display
+   */
+  private void fixPositionIfNeed() {
+    int totalHeight = itemsInMenu * 19; //19 height of menu item
+    int y = getAbsoluteTop() + 19 + totalHeight;
+    if (y > Window.getClientHeight()) {
+      y = getAbsoluteTop() - 8 - totalHeight; //8 need some correction for looking good in UI
+      popupPanel.getElement().getStyle().clearProperty("top");
+    } else {
+      y = getAbsoluteTop() + 19;
+    }
+    popupPanel.getElement().getStyle().setProperty("top", "" + y + "px");
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?
Fix menu position: if not enough space under button will be shown above.
Should fix _WorkingWithSplitPanelTest_
Before:
![not-dispay](https://user-images.githubusercontent.com/1636592/32623150-d608c4f2-c58d-11e7-8b66-e434c512ac7e.png)
After:
![dispay](https://user-images.githubusercontent.com/1636592/32623164-def40f72-c58d-11e7-9be5-8d8002a32ad0.png)



### What issues does this PR fix or reference?
#7095 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
