### PR TITLE
Fix for replace stacks not working when agents was on multiline

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh
@@ -44,7 +44,15 @@ echo ""
 
 echo -n "[CHE] Fetching the list of new Che stacks..."
 #new_stacks_json=$(curl -X GET -s --header 'Accept: application/json' "${NEW_STACKS_URL}" | sed 's/\\\"//g' | sed 's/\"com\.redhat\.bayesian\.lsp\"//g' | sed 's/ws-agent\",/ws-agent\"/g')
-new_stacks_json=$(curl -X GET -s --header 'Accept: application/json' "${NEW_STACKS_URL}" | sed 's/,?\"com\.redhat\.bayesian\.lsp\"//g')
+new_stacks_json=$(curl -X GET -s --header 'Accept: application/json' "${NEW_STACKS_URL}" | jq "def walk(f):
+  . as \$in
+  | if type == \"object\" then
+      reduce keys_unsorted[] as \$key
+        ( {}; . + { (\$key):  (\$in[\$key] | walk(f)) } ) | f
+  elif type == \"array\" then map( walk(f) ) | f
+  else f
+  end;
+  walk( if type == \"array\" then map(select(. != \"com.redhat.bayesian.lsp\")) else . end )")
 echo "done."
 
 echo "[CHE] These stacks will be added."


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes replace_stacks to work with agents that are in a flat list in the stacks json as well as multi line. The regression was introduced in 2e90ad67225e31b23e320fa7f2f536509af2abe2 due to a misunderstanding of sed as well as a misunderstanding of the use case.

### What issues does this PR fix or reference?
Fixes replace_stacks to work with agents that are a flat list in the stacks json as well as multi line.

Previously it would not remove com.redhat.bayesian.lsp from something like https://github.com/redhat-developer/rh-che/blob/master/assembly/fabric8-stacks/src/main/resources/stacks.json#L542 but would work for something like https://github.com/redhat-developer/rh-che/blob/master/assembly/fabric8-stacks/src/main/resources/stacks.json#L184. This PR makes it work for both cases.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A