### PR TITLE
Rework selenium tests according to changes in workspace loading sequence

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
@@ -331,7 +332,8 @@ public class Consoles {
 
   /** wait a preview url into 'Consoles' */
   public void waitPreviewUrlIsPresent() {
-    redrawDriverWait.until(visibilityOf(previewUrl));
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOf(previewUrl));
   }
 
   /** wait a preview url is not present into 'Consoles' */

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.pageobject.machineperspective;
 
 import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
 import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLocated;
@@ -72,8 +73,7 @@ public class MachineTerminal {
 
   /** wait default terminal tab */
   public void waitTerminalTab() {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(visibilityOf(defaultTermTab));
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC).until(visibilityOf(defaultTermTab));
   }
 
   /** wait default terminal tab */

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
@@ -29,7 +29,6 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -51,7 +50,6 @@ public class CheckRestoringWorkspaceAfterStoppingWsAgentProcess {
   @Inject private TestUser defaultTestUser;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private ToastLoader toastLoader;
   @Inject private MachineTerminal terminal;
   @Inject private Consoles consoles;
   @Inject private TestCommandServiceClient testCommandServiceClient;
@@ -79,7 +77,7 @@ public class CheckRestoringWorkspaceAfterStoppingWsAgentProcess {
   public void checkRestoreWsAgentByApi() throws Exception {
     String expectedMessageOInDialog =
         "Workspace agent is no longer responding. To fix the problem, restart the workspace.";
-    toastLoader.waitAppeareanceAndClosing();
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     terminal.waitTerminalTab();
     projectExplorer.invokeCommandWithContextMenu(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
@@ -18,7 +20,6 @@ import org.eclipse.che.selenium.core.constant.TestStacksConstants;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace;
@@ -41,7 +42,6 @@ public class CreateWorkspaceOnDashboardTest {
   @Inject private DashboardWorkspace dashboardWorkspace;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
-  @Inject private ToastLoader toastLoader;
 
   @AfterClass
   public void tearDown() throws Exception {
@@ -61,9 +61,8 @@ public class CreateWorkspaceOnDashboardTest {
     createWorkspace.setMachineRAM("2");
     createWorkspace.clickCreate();
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    toastLoader.waitExpectedTextInToastLoader("Starting workspace runtime.", 60);
     projectExplorer.waitProjectExplorer();
-    loader.waitOnClosed();
+    terminal.waitTerminalConsole(LOADER_TIMEOUT_SEC);
     terminal.waitTerminalTab();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
@@ -101,7 +101,7 @@ public class WorkingWithJavaMySqlStackTest {
     loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME, 600);
-    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.selectItem(PROJECT_NAME);
     projectExplorer.expandPathInProjectExplorer(
         PROJECT_NAME + "/src/main/java/org.springframework.samples.petclinic");
     projectExplorer.expandPathInProjectExplorer(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
@@ -101,6 +101,7 @@ public class WorkingWithJavaMySqlStackTest {
     loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME, 600);
+    projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.expandPathInProjectExplorer(
         PROJECT_NAME + "/src/main/java/org.springframework.samples.petclinic");
     projectExplorer.expandPathInProjectExplorer(


### PR DESCRIPTION
According to the changes in the PR https://github.com/eclipse/che/pull/7225 we need to rework next  selenium tests:
1. Because the '**Toast Loader**' widget was removed by https://github.com/eclipse/che/pull/7225 we need to remove it using from next test:
- **CreateWorkspaceOnDashboardTest** 
- **CheckRestoringWorkspaceAfterStoppingWsAgentProcess**
2. In  **WorkingWithJavaMySqlStackTest** selenium test need to check that the project don't loose focus after starting workspace.
3. In **WorkingWithNodeWsTest** need increased timeout for waiting if preview URL in the terminal is present.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7258