### PR TITLE
Update RenameProjectTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AskForValueDialog.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AskForValueDialog.java
@@ -15,7 +15,9 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRA
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.action.ActionsFactory;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -45,6 +47,8 @@ public class AskForValueDialog {
       "//*[@id='gwt-debug-newJavaSourceFileView-typeField' ]//option[@value='Interface']";
   private static final String ENUM_ITEM =
       "//*[@id='gwt-debug-newJavaSourceFileView-typeField' ]//option[@value='Enum']";
+
+  private final ActionsFactory actionsFactory;
 
   public enum JavaFiles {
     CLASS,
@@ -95,9 +99,11 @@ public class AskForValueDialog {
   private final Loader loader;
 
   @Inject
-  public AskForValueDialog(SeleniumWebDriver seleniumWebDriver, Loader loader) {
+  public AskForValueDialog(
+      SeleniumWebDriver seleniumWebDriver, Loader loader, ActionsFactory actionsFactory) {
     this.seleniumWebDriver = seleniumWebDriver;
     this.loader = loader;
+    this.actionsFactory = actionsFactory;
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -230,5 +236,11 @@ public class AskForValueDialog {
     } catch (NoSuchElementException ex) {
       return false;
     }
+  }
+
+  /** launch the 'Rename project' form by keyboard */
+  public void launchFindFormByKeyboard() {
+    actionsFactory.createAction(seleniumWebDriver).sendKeys(Keys.SHIFT, Keys.F6).perform();
+    actionsFactory.createAction(seleniumWebDriver).sendKeys(Keys.SHIFT).perform();
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AskForValueDialog.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AskForValueDialog.java
@@ -241,6 +241,5 @@ public class AskForValueDialog {
   /** launch the 'Rename project' form by keyboard */
   public void launchFindFormByKeyboard() {
     actionsFactory.createAction(seleniumWebDriver).sendKeys(Keys.SHIFT, Keys.F6).perform();
-    actionsFactory.createAction(seleniumWebDriver).sendKeys(Keys.SHIFT).perform();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
@@ -23,7 +23,6 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.testng.annotations.BeforeClass;
@@ -38,7 +37,6 @@ public class RenameProjectTest {
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private TestWorkspace testWorkspace;
-  @Inject private Loader loader;
   @Inject private Menu menu;
   @Inject private Ide ide;
 
@@ -59,19 +57,6 @@ public class RenameProjectTest {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.selectItem(PROJECT_NAME);
 
-    // Test that the Rename project dialog is started from menu
-    menu.runCommand(Edit.EDIT, Edit.RENAME);
-    askForValueDialog.waitFormToOpen();
-    askForValueDialog.clickCancelBtn();
-    askForValueDialog.waitFormToClose();
-
-    // Test that the Rename project dialog is started by SHIFT + F6 keys
-    projectExplorer.selectItem(PROJECT_NAME);
-    askForValueDialog.launchFindFormByKeyboard();
-    askForValueDialog.waitFormToOpen();
-    askForValueDialog.clickCancelBtn();
-    askForValueDialog.waitFormToClose();
-
     // Rename project from context menu
     projectExplorer.selectItem(PROJECT_NAME);
     projectExplorer.openContextMenuByPathSelectedItem(PROJECT_NAME);
@@ -86,5 +71,19 @@ public class RenameProjectTest {
     projectExplorer.waitItem(NEW_PROJECT_NAME);
     projectExplorer.waitItemIsDisappeared(PROJECT_NAME);
     projectExplorer.waitFolderDefinedTypeOfFolderByPath(NEW_PROJECT_NAME, PROJECT_FOLDER);
+
+    // Test that the Rename project dialog is started from menu
+    projectExplorer.selectItem(NEW_PROJECT_NAME);
+    menu.runCommand(Edit.EDIT, Edit.RENAME);
+    askForValueDialog.waitFormToOpen();
+    askForValueDialog.clickCancelBtn();
+    askForValueDialog.waitFormToClose();
+
+    // Test that the Rename project dialog is started by SHIFT + F6 keys
+    projectExplorer.selectItem(NEW_PROJECT_NAME);
+    askForValueDialog.launchFindFormByKeyboard();
+    askForValueDialog.waitFormToOpen();
+    askForValueDialog.clickCancelBtn();
+    askForValueDialog.waitFormToClose();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
@@ -10,31 +10,37 @@
  */
 package org.eclipse.che.selenium.projectexplorer;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.RENAME;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants;
+import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
+import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
 public class RenameProjectTest {
-  private static final String PROJECT_NAME = RenameProjectTest.class.getSimpleName();
-  private static final String NEW_PROJECT_NAME = "new-name-project";
+  private static final String PROJECT_NAME = generate("project", 5);
+  private static final String NEW_PROJECT_NAME = generate("project", 5);
 
-  @Inject private TestWorkspace testWorkspace;
-  @Inject private Ide ide;
-  @Inject private ProjectExplorer projectExplorer;
-  @Inject private AskForValueDialog askForValueDialog;
-  @Inject private Loader loader;
   @Inject private TestProjectServiceClient testProjectServiceClient;
+  @Inject private AskForValueDialog askForValueDialog;
+  @Inject private ProjectExplorer projectExplorer;
+  @Inject private TestWorkspace testWorkspace;
+  @Inject private Loader loader;
+  @Inject private Menu menu;
+  @Inject private Ide ide;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -50,18 +56,35 @@ public class RenameProjectTest {
   @Test
   public void renameProjectTest() {
     projectExplorer.waitProjectExplorer();
-    loader.waitOnClosed();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.selectItem(PROJECT_NAME);
+
+    // Test that the Rename project dialog is started from menu
+    menu.runCommand(Edit.EDIT, Edit.RENAME);
+    askForValueDialog.waitFormToOpen();
+    askForValueDialog.clickCancelBtn();
+    askForValueDialog.waitFormToClose();
+
+    // Test that the Rename project dialog is started by SHIFT + F6 keys
+    projectExplorer.selectItem(PROJECT_NAME);
+    askForValueDialog.launchFindFormByKeyboard();
+    askForValueDialog.waitFormToOpen();
+    askForValueDialog.clickCancelBtn();
+    askForValueDialog.waitFormToClose();
+
+    // Rename project from context menu
+    projectExplorer.selectItem(PROJECT_NAME);
     projectExplorer.openContextMenuByPathSelectedItem(PROJECT_NAME);
-    projectExplorer.clickOnItemInContextMenu(TestProjectExplorerContextMenuConstants.RENAME);
+    projectExplorer.clickOnItemInContextMenu(RENAME);
     askForValueDialog.waitFormToOpen();
     askForValueDialog.clearInput();
     askForValueDialog.typeAndWaitText(NEW_PROJECT_NAME);
     askForValueDialog.clickOkBtn();
     askForValueDialog.waitFormToClose();
 
+    // Wait that project renamed and folder has project type
     projectExplorer.waitItem(NEW_PROJECT_NAME);
     projectExplorer.waitItemIsDisappeared(PROJECT_NAME);
+    projectExplorer.waitFolderDefinedTypeOfFolderByPath(NEW_PROJECT_NAME, PROJECT_FOLDER);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
@@ -55,7 +55,6 @@ public class RenameProjectTest {
   public void renameProjectTest() {
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    projectExplorer.selectItem(PROJECT_NAME);
 
     // Rename project from context menu
     projectExplorer.selectItem(PROJECT_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 /** @author Andrey Chizhikov */
 public class RenameProjectTest {
   private static final String PROJECT_NAME = generate("project", 5);
-  private static final String NEW_PROJECT_NAME = generate("project", 5);
+  private static final String NEW_PROJECT_NAME = generate("new-project", 5);
 
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private AskForValueDialog askForValueDialog;


### PR DESCRIPTION
We need update **RenameProjectTest** selenium test:
1. Cover use case described in issue https://github.com/eclipse/che/issues/6352 (project has a simple folder type after renaming) to ensure that functionality works properly.
2. Check that the **Rename Project** form is opened by Shift+F6 keys, the project context menu and from the main menu.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7290