### PR TITLE
Fix error of getting machine token in multiuser che

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -225,7 +225,7 @@ public class TestWorkspaceServiceClient {
   }
 
   /** Gets workspace by its id. */
-  public Workspace getById(String workspaceId) throws Exception {
+  public WorkspaceDto getById(String workspaceId) throws Exception {
     return requestFactory.fromUrl(getIdBasedUrl(workspaceId)).request().asDto(WorkspaceDto.class);
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestMachineServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestMachineServiceClient.java
@@ -12,23 +12,19 @@ package org.eclipse.che.selenium.core.client;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
-import org.eclipse.che.api.core.rest.HttpJsonResponse;
-import org.eclipse.che.commons.json.JsonHelper;
-import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
 
-/** @author Musienko Maxim */
+/**
+ * @author Musienko Maxim
+ * @author Dmytro Nochevnov
+ */
 @Singleton
 public class CheTestMachineServiceClient implements TestMachineServiceClient {
 
-  private final String apiEndpoint;
-  private final HttpJsonRequestFactory requestFactory;
+  private final TestWorkspaceServiceClient testWorkspaceServiceClient;
 
   @Inject
-  public CheTestMachineServiceClient(
-      TestApiEndpointUrlProvider apiEndpointProvider, HttpJsonRequestFactory requestFactory) {
-    this.apiEndpoint = apiEndpointProvider.get().toString();
-    this.requestFactory = requestFactory;
+  public CheTestMachineServiceClient(TestWorkspaceServiceClient testWorkspaceServiceClient) {
+    this.testWorkspaceServiceClient = testWorkspaceServiceClient;
   }
 
   /**
@@ -39,11 +35,6 @@ public class CheTestMachineServiceClient implements TestMachineServiceClient {
    */
   @Override
   public String getMachineApiToken(String workspaceId) throws Exception {
-    HttpJsonResponse response =
-        requestFactory
-            .fromUrl(apiEndpoint + "machine/token/" + workspaceId)
-            .useGetMethod()
-            .request();
-    return JsonHelper.parseJson(response.asString()).getElement("machineToken").getStringValue();
+    return testWorkspaceServiceClient.getById(workspaceId).getRuntime().getMachineToken();
   }
 }


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
It fixes the method to get machine token in Multiuser Che 6, which acceptance tests use to communicate with che-server. 

### What issues does this PR fix or reference?
#7269

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
