### PR TITLE
Allow to use Eclipse OpenJ9 JVM to run che-server

### DIFF
--- a/dockerfiles/che/Dockerfile.openj9
+++ b/dockerfiles/che/Dockerfile.openj9
@@ -1,0 +1,41 @@
+# Copyright (c) 2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Florent Benoit - Initial Implementation
+#
+# To build it, run in the repository root:
+#  `docker build -t eclipse/che-server:openj9 -f Dockerfile.openj9 .`
+#
+# To run it:
+#  docker run -e IMAGE_CHE=eclipse/che-server:openj9 \
+#             -it \
+#             --rm \
+#             -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/data:/data \
+#             eclipse/che:nightly start --fast
+#
+
+FROM adoptopenjdk/openjdk9-openj9:x86_64-alpine-jdk-9.181
+
+ENV LANG=C.UTF-8 \
+    DOCKER_VERSION=1.6.0 \
+    DOCKER_BUCKET=get.docker.com \
+    CHE_IN_CONTAINER=true
+
+RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk add --update curl openssl sudo bash && \
+    curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
+    chmod +x /usr/bin/docker && \
+    echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    rm -rf /tmp/* /var/cache/apk/*
+
+EXPOSE 8000 8080
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+RUN mkdir /logs /data && \
+    chmod 0777 /logs /data
+ADD eclipse-che /home/user/eclipse-che
+RUN find /home/user -type d -exec chmod 777 {} \;


### PR DESCRIPTION
### What does this PR do?
Eclipse Che can be run on Java9 runtime. So adding Dockerfile for Eclipse JVM OpenJ9


### What issues does this PR fix or reference?
#5326 

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I309e6eb1af4d0166758481bfd462c074de384ad6
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
