### PR TITLE
CHE-6699: Clear debugger panel on workspace stopped

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenter.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenter.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -42,6 +43,7 @@ import org.eclipse.che.ide.api.parts.PartStackType;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.parts.base.BasePresenter;
 import org.eclipse.che.ide.api.resources.VirtualFile;
+import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
 import org.eclipse.che.ide.debug.Debugger;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
@@ -67,7 +69,10 @@ import org.vectomatic.dom.svg.ui.SVGResource;
  */
 @Singleton
 public class DebuggerPresenter extends BasePresenter
-    implements DebuggerView.ActionDelegate, DebuggerManagerObserver, BreakpointManagerObserver {
+    implements DebuggerView.ActionDelegate,
+        DebuggerManagerObserver,
+        BreakpointManagerObserver,
+        WorkspaceStoppedEvent.Handler {
   private static final String TITLE = "Debug";
 
   private final DebuggerResources debuggerResources;
@@ -100,7 +105,8 @@ public class DebuggerPresenter extends BasePresenter
       final DebuggerManager debuggerManager,
       final WorkspaceAgent workspaceAgent,
       final DebuggerLocationHandlerManager resourceHandlerManager,
-      final BreakpointContextMenuFactory breakpointContextMenuFactory) {
+      final BreakpointContextMenuFactory breakpointContextMenuFactory,
+      final EventBus eventBus) {
     this.view = view;
     this.debuggerResources = debuggerResources;
     this.debuggerToolbar = debuggerToolbar;
@@ -121,6 +127,8 @@ public class DebuggerPresenter extends BasePresenter
     this.breakpointManager.addObserver(this);
 
     this.watchExpressions = new ArrayList<>();
+
+    eventBus.addHandler(WorkspaceStoppedEvent.TYPE, this);
 
     resetView();
     addDebuggerPanel();
@@ -536,5 +544,10 @@ public class DebuggerPresenter extends BasePresenter
               @Override
               public void onSuccess(VirtualFile result) {}
             });
+  }
+
+  @Override
+  public void onWorkspaceStopped(WorkspaceStoppedEvent event) {
+    resetView();
   }
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenterTest.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/test/java/org/eclipse/che/plugin/debugger/ide/debug/DebuggerPresenterTest.java
@@ -10,10 +10,13 @@
  */
 package org.eclipse.che.plugin.debugger.ide.debug;
 
+import static java.util.Collections.emptyList;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
@@ -23,6 +26,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.web.bindery.event.shared.EventBus;
 import java.util.List;
 import org.eclipse.che.api.debug.shared.dto.SimpleValueDto;
 import org.eclipse.che.api.debug.shared.model.Location;
@@ -30,6 +34,7 @@ import org.eclipse.che.api.debug.shared.model.MutableVariable;
 import org.eclipse.che.api.debug.shared.model.StackFrameDump;
 import org.eclipse.che.api.debug.shared.model.ThreadState;
 import org.eclipse.che.api.debug.shared.model.Variable;
+import org.eclipse.che.api.debug.shared.model.WatchExpression;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
@@ -37,6 +42,7 @@ import org.eclipse.che.ide.api.debug.BreakpointManager;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
 import org.eclipse.che.ide.debug.Debugger;
 import org.eclipse.che.ide.debug.DebuggerDescriptor;
 import org.eclipse.che.ide.debug.DebuggerManager;
@@ -89,6 +95,7 @@ public class DebuggerPresenterTest extends BaseTest {
   @Mock private Promise<List<ThreadState>> promiseThreadDump;
   @Mock private Promise<StackFrameDump> promiseStackFrame;
   @Mock private Promise<Void> promiseVoid;
+  @Mock private EventBus eventBus;
 
   @Captor private ArgumentCaptor<Operation<Void>> operationVoidCaptor;
   @Captor private ArgumentCaptor<Operation<List<ThreadState>>> operationThreadDumpCaptor;
@@ -115,7 +122,8 @@ public class DebuggerPresenterTest extends BaseTest {
                 debuggerManager,
                 workspaceAgent,
                 debuggerLocationHandlerManager,
-                breakpointContextMenuFactory));
+                breakpointContextMenuFactory,
+                eventBus));
 
     Mockito.reset(view);
     when(view.getSelectedThreadId()).thenReturn(THREAD_ID);
@@ -236,5 +244,25 @@ public class DebuggerPresenterTest extends BaseTest {
     operationValueCaptor.getValue().apply(valueDto);
     verify(debugger).getValue(eq(selectedVariable), eq(THREAD_ID), eq(FRAME_INDEX));
     verify(view).updateVariable(any(Variable.class));
+  }
+
+  @Test
+  public void shouldClearPanelOnWorkspaceStopped() throws Exception {
+    Promise promise = mock(Promise.class);
+    when(promise.then(any(Operation.class))).thenReturn(promise);
+    when(debugger.evaluate(anyString(), anyLong(), anyInt())).thenReturn(promise);
+    WatchExpression watchExpression = mock(WatchExpression.class);
+    when(watchExpression.getExpression()).thenReturn("expresion");
+
+    presenter.onAddExpressionBtnClicked(watchExpression);
+    presenter.onWorkspaceStopped(mock(WorkspaceStoppedEvent.class));
+
+    verify(view).setVMName(eq(""));
+    verify(view).setExecutionPoint(eq(null));
+    verify(view).setThreadDump(eq(emptyList()), eq(-1L));
+    verify(view).setFrames(eq(emptyList()));
+    verify(view).removeAllVariables();
+    verify(watchExpression).setResult(eq(""));
+    verify(view).updateExpression(eq(watchExpression));
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Clear debugger panel on workspace stopped:
![debbuger_workspace_stop](https://user-images.githubusercontent.com/7668752/32652847-6801510a-c60e-11e7-9c20-bd048664100a.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6699

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
