### PR TITLE
[CLI] fix overriding of docker images through environment variables

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -166,6 +166,8 @@ generate_configuration_with_puppet() {
     var2=$(echo $element | cut -f2 -d=)
 
     if [[ $var1 == CHE_* ]] ||
+       [[ $var1 == IMAGE_* ]]  ||
+       [[ $var1 == *_IMAGE_* ]]  ||
        [[ $var1 == ${CHE_PRODUCT_NAME}_* ]]; then
       WRITE_PARAMETERS+=" -e \"$var1=$var2\""
     fi


### PR DESCRIPTION
### What does this PR do?
https://github.com/eclipse/che/pull/6379 introduced a way to override the images used by the CLI by using environment variables.
But it was not propagated to puppet data so for example trying to override IMAGE_CHE was not working.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/6379

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: Ibc2386c7508de5ae76ecd677402050c259a77c32
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

