### PR TITLE
added style for css elements for css file types

### DIFF
--- a/ide/che-core-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/orion-codenvy-theme.css
+++ b/ide/che-core-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/orion-codenvy-theme.css
@@ -469,3 +469,7 @@
     color: #B985A8;
     font-weight: bold;
 }
+
+.support type propertyName css{
+       color: #00bcd4;
+    }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This pull request changes the font color of css property while editing a css file.

### What issues does this PR fix or referenced?
https://github.com/eclipse/che/issues/7257
The font color of a css property is blue in color and it's not correctly visible when used with dark theme.  So I just changed the color so that it's clearly visible in the dark theme

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
Dark theme css -- CSS property font color changed

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
