### PR TITLE
Update unstable selenium tests from the Workspaces package

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
@@ -76,8 +76,21 @@ public class MachineTerminal {
     new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC).until(visibilityOf(defaultTermTab));
   }
 
-  /** wait default terminal tab */
-  public void waitTerminalTab(int termNumber) {
+  /**
+   * wait default terminal tab
+   *
+   * @param timeWait time of waiting terminal container in seconds
+   */
+  public void waitTerminalTab(int timeWait) {
+    new WebDriverWait(seleniumWebDriver, timeWait).until(visibilityOf(defaultTermTab));
+  }
+
+  /**
+   * wait terminal tab with number
+   *
+   * @param termNumber number of terminal
+   */
+  public void waitNumberTerminalTab(int termNumber) {
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(visibilityOfElementLocated(By.xpath(getTerminalTabXPath(termNumber))));
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
@@ -71,13 +71,13 @@ public class MachineTerminal {
   @FindBy(xpath = Locators.TERMINAL_CONSOLE_CONTAINER_XPATH)
   WebElement defaultTermContainer;
 
-  /** wait default terminal tab */
+  /** waits default terminal tab */
   public void waitTerminalTab() {
     new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC).until(visibilityOf(defaultTermTab));
   }
 
   /**
-   * wait default terminal tab
+   * waits default terminal tab
    *
    * @param timeWait time of waiting terminal container in seconds
    */
@@ -86,7 +86,7 @@ public class MachineTerminal {
   }
 
   /**
-   * wait terminal tab with number
+   * waits terminal tab with number
    *
    * @param termNumber number of terminal
    */
@@ -95,7 +95,7 @@ public class MachineTerminal {
         .until(visibilityOfElementLocated(By.xpath(getTerminalTabXPath(termNumber))));
   }
 
-  /** wait appearance the main terminal container */
+  /** waits appearance the main terminal container */
   public void waitTerminalConsole() {
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(visibilityOf(defaultTermContainer));
@@ -111,7 +111,7 @@ public class MachineTerminal {
   }
 
   /**
-   * wait appearance the main terminal container
+   * waits appearance the main terminal container
    *
    * @param timeWait time of waiting terminal container in seconds
    */
@@ -119,7 +119,7 @@ public class MachineTerminal {
     new WebDriverWait(seleniumWebDriver, timeWait).until(visibilityOf(defaultTermContainer));
   }
 
-  /** wait appearance the main terminal container */
+  /** gets visible text from terminal container */
   public String getVisibleTextFromTerminal() {
     return new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(visibilityOf(defaultTermContainer))
@@ -127,7 +127,7 @@ public class MachineTerminal {
   }
 
   /**
-   * wait text into the terminal
+   * waits text into the terminal
    *
    * @param expectedText expected text into terminal
    */
@@ -137,7 +137,7 @@ public class MachineTerminal {
   }
 
   /**
-   * wait expected text is not present in the terminal
+   * waits expected text is not present in the terminal
    *
    * @param expectedText expected text
    */
@@ -149,7 +149,7 @@ public class MachineTerminal {
   }
 
   /**
-   * wait text into the terminal
+   * waits text into the terminal
    *
    * @param expectedText expected text into terminal
    * @param definedTimeout timeout in seconds defined with user

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -62,7 +62,6 @@ public class CreateWorkspaceOnDashboardTest {
     createWorkspace.clickCreate();
     seleniumWebDriver.switchFromDashboardIframeToIde();
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalConsole(LOADER_TIMEOUT_SEC);
-    terminal.waitTerminalTab();
+    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
@@ -101,6 +101,7 @@ public class WorkingWithJavaMySqlStackTest {
     loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME, 600);
+    loader.waitOnClosed();
     projectExplorer.selectItem(PROJECT_NAME);
     projectExplorer.expandPathInProjectExplorer(
         PROJECT_NAME + "/src/main/java/org.springframework.samples.petclinic");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
@@ -86,6 +86,8 @@ public class WorkingWithNodeWsTest {
     loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(NODE_JS_PROJECT_NAME);
+    loader.waitOnClosed();
+    projectExplorer.selectItem(NODE_JS_PROJECT_NAME);
     projectExplorer.openItemByPath(NODE_JS_PROJECT_NAME);
     projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app");
     projectExplorer.openItemByPath(NODE_JS_PROJECT_NAME + "/app");


### PR DESCRIPTION
### What does this PR do?
We need update unstable tests from the workspaces package:
- Wait for the **Update project** loader is closed before select a project from the Project Explorer(**WorkingWithJavaMySqlStackTest** and **WorkingWithNodeWsTest)**
![mysql-stack](https://user-images.githubusercontent.com/5408906/32728383-c987f970-c888-11e7-8195-e0d96a689a53.png)
- Add a new method for waiting that the default terminal is visible with timeout (**CreateWorkspaceOnDashboardTest**)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7335