### PR TITLE
Adapt methods and steps to latest changes in the IDE

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -56,6 +56,8 @@ public class ProjectExplorer {
   private final NavigateToFile navigateToFile;
   private final Menu menu;
   private final CodenvyEditor editor;
+  private WebDriverWait loadPageTimeout;
+  private WebDriverWait redrawUiElementsWait;
 
   @Inject
   public ProjectExplorer(
@@ -71,6 +73,8 @@ public class ProjectExplorer {
     this.navigateToFile = navigateToFile;
     this.menu = menu;
     this.editor = editor;
+    loadPageTimeout = new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC);
+    redrawUiElementsWait = new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -96,7 +100,8 @@ public class ProjectExplorer {
     String GO_BACK_BUTTON = "gwt-debug-goBackButton";
     String COLLAPSE_ALL_BUTTON = "gwt-debug-collapseAllButton";
     String ALL_PROJECTS_XPATH = "//div[@path=@project]";
-    String REFRESH_BUTTON_ID = "gwt-debug-refreshSelectedPath";
+    String MENU_BUTTON_PART_STACK_ID = "gwt-debug-menuButton";
+    String REFRESH_CONTEXT_MENU_ID = "gwt-debug-contextMenu/refreshPathAction";
     String PROJECT_EXPLORER_TAB_IN_THE_LEFT_PANEL =
         "//div[@id='gwt-debug-navPanel']//div[@id='gwt-debug-partButton-Projects']";
   }
@@ -130,14 +135,17 @@ public class ProjectExplorer {
   @FindBy(xpath = Locators.ALL_PROJECTS_XPATH)
   WebElement allProjects;
 
-  @FindBy(id = Locators.REFRESH_BUTTON_ID)
-  WebElement refreshProjectButton;
+  @FindBy(id = Locators.MENU_BUTTON_PART_STACK_ID)
+  WebElement refreshButtonPartStack;
+
+  @FindBy(id = Locators.REFRESH_CONTEXT_MENU_ID)
+  WebElement refreshContextMenuItem;
 
   @FindBy(xpath = Locators.PROJECT_EXPLORER_TAB_IN_THE_LEFT_PANEL)
   WebElement projectExplorerTabInTheLeftPanel;
 
   public void clickOnProjectExplorerOptionsButton() {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+    redrawUiElementsWait
         .until(
             ExpectedConditions.visibilityOfElementLocated(
                 By.xpath(
@@ -146,7 +154,7 @@ public class ProjectExplorer {
   }
 
   public void clickOnOptionsMenuItem(String menuID) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+    redrawUiElementsWait
         .until(
             ExpectedConditions.elementToBeClickable(
                 By.xpath(String.format("//nobr[@id='%s']", menuID))))
@@ -167,9 +175,7 @@ public class ProjectExplorer {
 
   /** press on the project explorer tab */
   public void clickOnProjectExplorerTab() {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(projectExplorerTab))
-        .click();
+    redrawUiElementsWait.until(ExpectedConditions.visibilityOf(projectExplorerTab)).click();
   }
 
   /**
@@ -273,43 +279,39 @@ public class ProjectExplorer {
   }
 
   public void waitYellowNode(String path) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath(
-                    String.format(
-                        "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
-                        path, "color: #e0b91d;"))));
+    redrawUiElementsWait.until(
+        ExpectedConditions.visibilityOfElementLocated(
+            By.xpath(
+                String.format(
+                    "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
+                    path, "color: #e0b91d;"))));
   }
 
   public void waitGreenNode(String path) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath(
-                    String.format(
-                        "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
-                        path, "color: #72ad42;"))));
+    redrawUiElementsWait.until(
+        ExpectedConditions.visibilityOfElementLocated(
+            By.xpath(
+                String.format(
+                    "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
+                    path, "color: #72ad42;"))));
   }
 
   public void waitBlueNode(String path) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath(
-                    String.format(
-                        "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
-                        path, "color: #3193d4;"))));
+    redrawUiElementsWait.until(
+        ExpectedConditions.visibilityOfElementLocated(
+            By.xpath(
+                String.format(
+                    "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
+                    path, "color: #3193d4;"))));
   }
 
   public void waitDefaultColorNode(String path) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath(
-                    String.format(
-                        "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
-                        path, "opacity:1;"))));
+    redrawUiElementsWait.until(
+        ExpectedConditions.visibilityOfElementLocated(
+            By.xpath(
+                String.format(
+                    "//div[@id='gwt-debug-projectTree']//div[@path='/%s']/descendant::div[@style='%s']",
+                    path, "opacity:1;"))));
   }
 
   /**
@@ -321,8 +323,7 @@ public class ProjectExplorer {
    */
   public void waitItemInVisibleArea(String item) {
     String locator = String.format("//div[@id='gwt-debug-projectTree']//div[text()='%s']", item);
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
+    loadPageTimeout.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
   }
 
   /**
@@ -345,8 +346,7 @@ public class ProjectExplorer {
    * @param item
    */
   public void waitItemIsNotPresentVisibleArea(String item) {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.name(item)));
+    loadPageTimeout.until(ExpectedConditions.invisibilityOfElementLocated(By.name(item)));
   }
 
   /**
@@ -386,7 +386,7 @@ public class ProjectExplorer {
    */
   public void selectVisibleItem(String item) {
     String locator = "//div[@name='" + item + "']/div";
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+    redrawUiElementsWait
         .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)))
         .click();
   }
@@ -435,10 +435,8 @@ public class ProjectExplorer {
     waitItem(path);
     String locator = "//div[@path='/%s']/div";
     WebElement item =
-        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-            .until(
-                ExpectedConditions.visibilityOfElementLocated(
-                    By.xpath(String.format(locator, path))));
+        redrawUiElementsWait.until(
+            ExpectedConditions.visibilityOfElementLocated(By.xpath(String.format(locator, path))));
     try {
 
       item.click();
@@ -483,8 +481,7 @@ public class ProjectExplorer {
    */
   public void openVisiblePackage(String packageName) {
     String locator = "//div[text()='" + packageName + "']";
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
+    loadPageTimeout.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
     WebElement visiblePacksge = seleniumWebDriver.findElement(By.xpath(locator));
     actionsFactory.createAction(seleniumWebDriver).doubleClick(visiblePacksge).perform();
   }
@@ -514,8 +511,7 @@ public class ProjectExplorer {
             + "']/div/*[local-name() = 'svg' and @id='"
             + typeFolder
             + "']";
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
+    loadPageTimeout.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
   }
 
   /**
@@ -538,8 +534,7 @@ public class ProjectExplorer {
    */
   public void openContextMenuByPathSelectedItem(String path) {
     String locator = "//div[@path='/" + path + "']/div";
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
+    loadPageTimeout.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(locator)));
     WebElement node = seleniumWebDriver.findElement(By.xpath(locator));
     node.click();
     Actions act = actionsFactory.createAction(seleniumWebDriver);
@@ -560,9 +555,7 @@ public class ProjectExplorer {
    * @param item
    */
   public void clickOnItemInContextMenu(String item) {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.id(item)))
-        .click();
+    loadPageTimeout.until(ExpectedConditions.visibilityOfElementLocated(By.id(item))).click();
   }
 
   /**
@@ -579,8 +572,8 @@ public class ProjectExplorer {
   }
 
   public void waitContextMenuPopUpClosed() {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.CONTEXT_MENU_ID)));
+    loadPageTimeout.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.CONTEXT_MENU_ID)));
   }
 
   /**
@@ -603,8 +596,7 @@ public class ProjectExplorer {
 
   /** click on the 'go back' in the project explorer */
   public void clickGoBackButton() {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.elementToBeClickable(goBackBtn));
+    loadPageTimeout.until(ExpectedConditions.elementToBeClickable(goBackBtn));
     goBackBtn.click();
   }
 
@@ -628,10 +620,9 @@ public class ProjectExplorer {
    */
   public List<String> getNamesAllProjects() {
     List<WebElement> projects =
-        new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-            .until(
-                ExpectedConditions.visibilityOfAllElementsLocatedBy(
-                    By.xpath(Locators.ALL_PROJECTS_XPATH)));
+        loadPageTimeout.until(
+            ExpectedConditions.visibilityOfAllElementsLocatedBy(
+                By.xpath(Locators.ALL_PROJECTS_XPATH)));
     return projects
         .stream()
         .map((webElement) -> webElement.getAttribute("name"))
@@ -675,9 +666,8 @@ public class ProjectExplorer {
 
   /** wait refresh button and click this one */
   public void clickOnRefreshTreeButton() {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(refreshProjectButton))
-        .click();
+    redrawUiElementsWait.until(ExpectedConditions.visibilityOf(refreshButtonPartStack)).click();
+    redrawUiElementsWait.until(ExpectedConditions.visibilityOf(refreshContextMenuItem)).click();
   }
 
   public void clickOnImportProjectLink(int userTimeout) {
@@ -691,7 +681,7 @@ public class ProjectExplorer {
   }
 
   public void clickOnProjectExplorerTabInTheLeftPanel() {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+    redrawUiElementsWait
         .until(ExpectedConditions.visibilityOf(projectExplorerTabInTheLeftPanel))
         .click();
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/CheckFindActionFeatureInCheTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/CheckFindActionFeatureInCheTest.java
@@ -45,12 +45,12 @@ public class CheckFindActionFeatureInCheTest {
       "Branches... [Ctrl+B]  GitCommandGroup\n" + "Checkout Reference...  GitCommandGroup";
 
   private static final String FIRST_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
-      "Configuration \n"
-          + "Update Project Configuration...  Project\n"
+      "Update Project Configuration...  Project\n"
+          + "Configure \n"
           + "Configure Classpath  Project\n"
           + "Edit Debug Configurations... [Alt+Shift+F9]  Run\n"
           + "Import From Codenvy Config...  Project\n"
-          + "breakpointConfiguration";
+          + "breakpointConfiguration ";
 
   private static final String SECOND_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
       "Commands \n" + "Commands \n" + "Commands Palette [Shift+F10]  Run";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -100,7 +100,7 @@ public class StepIntoStepOverStepReturnWithChangeVariableTest {
 
   @AfterMethod
   public void shutDownTomCatAndCleanWebApp() {
-    editor.closeAllTabs();
+    editor.closeAllTabsByContextMenu();
     debugPanel.stopDebuggerWithUiAndCleanUpTomcat(CLEAN_TOMCAT);
     projectExplorer.clickOnProjectExplorerTabInTheLeftPanel();
   }


### PR DESCRIPTION
### What does this PR do?
* Rework clickOnRefreshTreeButton() method, because the widget with button that refreshes tree was removed into other place.
* Change closing of the opened tabs method in the StepIntoStepOverStepReturnWithChangeVariableTest. In the test action with closing all tabs last time unstable. I try to apply close all feature from context menu
* update the list of checked actions in the CheckFindActionFeatureInCheTest.
* Use waiter in fields instead of new objects in the ProjectExplorer pageobject.
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7311
@vparfonov, @tolusha, @dmytro-ndp 