### PR TITLE
Allow to skip the DTOs generation during maven build

### DIFF
--- a/core/che-core-api-dto-maven-plugin/src/main/java/org/eclipse/che/dto/generator/maven/plugin/DtoGeneratorMojo.java
+++ b/core/che-core-api-dto-maven-plugin/src/main/java/org/eclipse/che/dto/generator/maven/plugin/DtoGeneratorMojo.java
@@ -33,7 +33,17 @@ public class DtoGeneratorMojo extends AbstractMojo {
   @Parameter(property = "impl", required = true)
   private String impl;
 
+  /** A flag to disable generation of the DTOs. */
+  @Parameter(property = "che.dto.skip", defaultValue = "false")
+  private boolean skip;
+
+  @Override
   public void execute() throws MojoExecutionException {
+    if (skip) {
+      getLog().info("Skipping the execution");
+      return;
+    }
+
     DtoGenerator dtoGenerator = new DtoGenerator();
     dtoGenerator.setPackageBase(outputDirectory);
     String genFileName = genClassName.replace('.', File.separatorChar) + ".java";


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Makes it possible to skip the DTOs generation passing `che.dto.skip` system property.
This is mainly required for speeding-up GTW Super DevMode launching.

### What issues does this PR fix or reference?
#7309 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
