### PR TITLE
Update the command for launching GWT Super DevMode

### DIFF
--- a/ide/README.md
+++ b/ide/README.md
@@ -55,4 +55,4 @@ Just add a Maven dependency on the appropriate artifact (gwt-lib) to the `che-id
 In case the added artifact represents Che's sub-project, dependency should be declared with `<type>gwt-lib</type>` or `<classifier>sources</classifier>` to be able to use it with Super DevMode.
 
 ## GWT Super DevMode
-To launch GWT Super DevMode run the command `mvn gwt:codeserver -pl :che-ide-gwt-app -am -Pfast` from the root folder of the Che project.
+To launch GWT Super DevMode run the command `mvn gwt:codeserver -pl :che-ide-gwt-app -am -Dmaven.main.skip -Dmaven.resources.skip -Dche.dto.skip -Dskip-enforce -Dskip-validate-sources` from the root folder of the Che project.

--- a/ide/README.md
+++ b/ide/README.md
@@ -55,4 +55,6 @@ Just add a Maven dependency on the appropriate artifact (gwt-lib) to the `che-id
 In case the added artifact represents Che's sub-project, dependency should be declared with `<type>gwt-lib</type>` or `<classifier>sources</classifier>` to be able to use it with Super DevMode.
 
 ## GWT Super DevMode
-To launch GWT Super DevMode run the command `mvn gwt:codeserver -pl :che-ide-gwt-app -am -Dmaven.main.skip -Dmaven.resources.skip -Dche.dto.skip -Dskip-enforce -Dskip-validate-sources` from the root folder of the Che project.
+To launch GWT Super DevMode run the following command from the root folder of the Che project:
+
+```mvn gwt:codeserver -pl :che-ide-gwt-app -am -Dmaven.main.skip -Dmaven.resources.skip -Dche.dto.skip -Dskip-enforce -Dskip-validate-sources```.


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Updates the command for launching GWT Super DevMode.
With a new command, GWT SDM starts in ~30 sec. instead of >  3 min.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
