### PR TITLE
Update deployment-config.yaml

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/postgres/deployment-config.yaml
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/postgres/deployment-config.yaml
@@ -42,7 +42,6 @@ spec:
           tcpSocket:
             port: 5432
           timeoutSeconds: 1
-        name: postgres
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
- [x] Before merging, someone will need to apply fix in che6 branch as well: https://github.com/eclipse/che/blob/che6/dockerfiles/init/modules/openshift/files/scripts/multi-user/postgres/deployment-config.yaml

### What does this PR do?
Fixes deployment-config.yaml that has duplicate name definition that throws error when used in openshift web console.

### What issues does this PR fix or reference?
N/A

<!-- #### Changelog -->
Fixes deployment-config.yaml that has duplicate name definition that throws error when used in openshift web console.


#### Release Notes
N/A

Signed-off-by: James Drummond <james@devcomb.com>
