### PR TITLE
Do not index hidden files and files from File Index excludes

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/search/server/SearchApiModule.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/search/server/SearchApiModule.java
@@ -24,6 +24,7 @@ import org.eclipse.che.api.search.server.consumers.IndexedFileDeleteConsumer;
 import org.eclipse.che.api.search.server.consumers.IndexedFileUpdateConsumer;
 import org.eclipse.che.api.search.server.excludes.DotCheExcludeMatcher;
 import org.eclipse.che.api.search.server.excludes.DotNumberSignExcludeMatcher;
+import org.eclipse.che.api.search.server.excludes.HiddenItemPathMatcher;
 import org.eclipse.che.api.search.server.excludes.MediaTypesExcludeMatcher;
 import org.eclipse.che.api.search.server.impl.LuceneSearcher;
 
@@ -38,6 +39,7 @@ public class SearchApiModule extends AbstractModule {
     excludeMatcher.addBinding().to(MediaTypesExcludeMatcher.class);
     excludeMatcher.addBinding().to(DotCheExcludeMatcher.class);
     excludeMatcher.addBinding().to(DotNumberSignExcludeMatcher.class);
+    excludeMatcher.addBinding().to(HiddenItemPathMatcher.class);
 
     newSetBinder(binder(), new TypeLiteral<Consumer<Path>>() {}, Names.named("che.fs.file.create"))
         .addBinding()

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/search/server/excludes/HiddenItemPathMatcher.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/search/server/excludes/HiddenItemPathMatcher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.search.server.excludes;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import javax.inject.Singleton;
+
+/**
+ * Performs match operation on paths to test whether specified item is hidden.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class HiddenItemPathMatcher implements PathMatcher {
+
+  @Override
+  public boolean matches(Path path) {
+    for (Path pathElement : path) {
+      if (pathElement != null && pathElement.toFile().isHidden()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
- Do not index files from File Index excludes:
Current behavior: we do not add to index text field of files from File Index excludes
New behavior: we do not add to index path, name and text fields of files from File Index excludes
- Do not index hidden files and folders


### What issues does this PR fix or reference?
#6948

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>