### PR TITLE
Remove unnecessary step from the test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -163,7 +163,6 @@ public class StepIntoStepOverStepReturnWithChangeVariableTest {
         .activeElement()
         .sendKeys(Keys.SHIFT.toString() + Keys.F9.toString());
     editor.waitActiveBreakpoint(26);
-    seleniumWebDriver.navigate().refresh();
   }
 
   private void buildProjectAndOpenMainClass() {


### PR DESCRIPTION
### What does this PR do?
Remove from the test refreshing the browser. After refreshing the opened tabs begun to restore and this created unexpected results in the StepIntoStepOverStepReturnWithChangeVariableTest test.
@tolusha @vparfonov 
