### PR TITLE
Allow to load GWT permutation files from a CodeServer with any address

### DIFF
--- a/ide/che-core-ide-app/src/main/module.gwt.xml
+++ b/ide/che-core-ide-app/src/main/module.gwt.xml
@@ -19,6 +19,8 @@
     </generate-with>
     <stylesheet src="https://fonts.googleapis.com/css?family=Open+Sans"></stylesheet>
 
+    <set-configuration-property name="devModeUrlWhitelistRegexp" value=".*" />
+
     <inherits name="com.google.gwt.user.User"/>
     <inherits name="elemental.Elemental"/>
     <inherits name="org.eclipse.che.ide.Commons"/>


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allows loading GWT permutation files from a CodeServer with any address but not localhost only.
It allows using GWT Super DevMode launched inside a dev-machine during Che in Che development.

### What issues does this PR fix or reference?
#7277 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
