### PR TITLE
Do not pull all CHE images on CLI init if --skip:pull specified

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_init.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_init.sh
@@ -73,7 +73,9 @@ cmd_init() {
     warning "($CHE_MINI_PRODUCT_NAME init): 'nightly' installations cannot be upgraded to non-nightly versions"
   fi
 
-  cmd_lifecycle download $FORCE_UPDATE
+  if ! skip_pull && ! is_fast; then
+      cmd_lifecycle download $FORCE_UPDATE
+  fi
 
   if require_license; then
     if [[ "${AUTO_ACCEPT_LICENSE}" = "false" ]]; then

--- a/dockerfiles/base/scripts/base/commands/cmd_init.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_init.sh
@@ -73,7 +73,7 @@ cmd_init() {
     warning "($CHE_MINI_PRODUCT_NAME init): 'nightly' installations cannot be upgraded to non-nightly versions"
   fi
 
-  if ! skip_pull && ! is_fast; then
+  if ! skip_pull; then
       cmd_lifecycle download $FORCE_UPDATE
   fi
 


### PR DESCRIPTION
Do not pull all CHE images on CLI `init` if `--skip:pull` specified
this is very annoying when user wants perform ONLY cli `config` action or `init` it always pull all the images if they are missing. but in fact it does not need it.
