### PR TITLE
Cache the query parameters on loading IDE

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/CoreGinModule.java
@@ -19,6 +19,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.SimpleEventBus;
 import elemental.json.Json;
 import elemental.json.JsonFactory;
+import org.eclipse.che.ide.QueryParameters;
 import org.eclipse.che.ide.actions.ActionApiModule;
 import org.eclipse.che.ide.api.ProductInfoDataProvider;
 import org.eclipse.che.ide.api.ProductInfoDataProviderImpl;
@@ -95,6 +96,7 @@ public class CoreGinModule extends AbstractGinModule {
     install(new ClipboardModule());
 
     bind(AppContextImpl.class).asEagerSingleton();
+    bind(QueryParameters.class).asEagerSingleton();
 
     install(new EditorApiModule());
     install(new EditorPreferencesModule());

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/QueryParameters.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/QueryParameters.java
@@ -10,10 +10,11 @@
  */
 package org.eclipse.che.ide;
 
-import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.Window.Location;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
@@ -24,6 +25,15 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class QueryParameters {
+
+  private final Map<String, List<String>> cachedParameters;
+
+  @Inject
+  public QueryParameters() {
+    // cache the query parameters because IDE changes window's location
+    cachedParameters = Location.getParameterMap();
+  }
+
   /**
    * Returns the query parameter by the specified name or empty string if parameter was not found.
    * Note that if multiple parameters have been specified with the same name, the last one will be
@@ -33,8 +43,13 @@ public class QueryParameters {
    * @return query parameter value
    */
   public String getByName(String name) {
-    String value = Window.Location.getParameter(name);
-    return value == null ? "" : value;
+    List<String> paramsForName = cachedParameters.get(name);
+
+    if (paramsForName == null) {
+      return "";
+    } else {
+      return paramsForName.get(paramsForName.size() - 1);
+    }
   }
 
   /**
@@ -48,8 +63,7 @@ public class QueryParameters {
    */
   public Map<String, String> getAll() {
     Map<String, String> parameters = new HashMap<>();
-    for (Map.Entry<String, List<String>> parametersEntry :
-        Window.Location.getParameterMap().entrySet()) {
+    for (Map.Entry<String, List<String>> parametersEntry : cachedParameters.entrySet()) {
       parameters.put(parametersEntry.getKey(), parametersEntry.getValue().get(0));
     }
     return parameters;


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
[org.eclipse.che.ide.QueryParameters](https://github.com/eclipse/che/blob/1e4a702724073d1b834cac2018979f81a7f03df7/ide/commons-gwt/src/main/java/org/eclipse/che/ide/QueryParameters.java) must cache URL query parameters because it's impossible to get them after IDE [changes window's location](https://github.com/eclipse/che/blob/4c268787d5d7e7f28af9deb2bd84451c659e6ccc/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultIdeInitializationStrategy.java#L117).

### What issues does this PR fix or reference?
needed for #6713
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
