### PR TITLE
Rework CheckFileWatcherExcludeFeatureTest selenium test 

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
@@ -10,14 +10,19 @@
  */
 package org.eclipse.che.selenium.filewatcher;
 
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES;
+
 import com.google.inject.Inject;
 import java.nio.file.Paths;
 import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
@@ -30,20 +35,20 @@ import org.testng.annotations.Test;
 
 public class CheckFileWatcherExcludeFeatureTest {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 4);
-  private static final String FILE_NAME_FOR_EXCLUDE = "README.md";
   private static final String FOLDER_NAME_FOR_EXCLUDE = "src";
   private static final String FILE_WATCHER_IGNORE_FILE_NAME = "fileWatcherIgnore";
-  private static final String PATH_FOR_EXCLUDED_FILE = PROJECT_NAME + "/" + FILE_NAME_FOR_EXCLUDE;
 
-  @Inject private TestWorkspace testWorkspace;
   @Inject private TestProjectServiceClient projectServiceClient;
-  @Inject private Ide ide;
+  @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private ProjectExplorer projectExplorer;
+  @Inject private TestWorkspace testWorkspace;
+  @Inject private MachineTerminal terminal;
+  @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
+  @Inject private Loader loader;
   @Inject private Events events;
   @Inject private Menu menu;
-  @Inject private CodenvyEditor editor;
-  @Inject private MachineTerminal terminal;
-  @Inject private Loader loader;
+  @Inject private Ide ide;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -53,140 +58,146 @@ public class CheckFileWatcherExcludeFeatureTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
-  }
 
-  @Test
-  public void checkAddRemoveFileFromFileWatcher() throws Exception {
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
+  }
 
+  @Test
+  public void testAddRemoveFileFromFileWatcherExcludeFeature() throws Exception {
+    String fileNameForExcluding = "pom.xml";
+    String pathToExcludedFile = PROJECT_NAME + "/" + fileNameForExcluding;
+
+    projectExplorer.waitItem(PROJECT_NAME);
+    doFileWatcherExcludeOperation(pathToExcludedFile, ADD_TO_FILE_WATCHER_EXCLUDES);
+    doFileWatcherExcludeOperation(pathToExcludedFile, REMOVE_FROM_FILE_WATCHER_EXCLUDES);
+
+    // Refresh web page(for checking that the File Watcher Exclude feature works after refresh)
+    seleniumWebDriver.navigate().refresh();
+    projectExplorer.waitItem(PROJECT_NAME);
+
+    // Exclude file and check that its name is in the 'fileWatcherIgnore' file
+    doFileWatcherExcludeOperation(pathToExcludedFile, ADD_TO_FILE_WATCHER_EXCLUDES);
     menu.runCommand(
         TestMenuCommandsConstants.Project.PROJECT,
         TestMenuCommandsConstants.Project.SHOW_HIDE_HIDDEN_FILES);
     projectExplorer.waitItemInVisibleArea(".che");
     projectExplorer.openItemByVisibleNameInExplorer(".che");
-    projectExplorer.waitItemIsNotPresentVisibleArea(FILE_WATCHER_IGNORE_FILE_NAME);
-
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES);
     projectExplorer.waitItemInVisibleArea(FILE_WATCHER_IGNORE_FILE_NAME);
     projectExplorer.openItemByVisibleNameInExplorer(FILE_WATCHER_IGNORE_FILE_NAME);
     editor.waitActiveEditor();
-    editor.waitTextIntoEditor(FILE_NAME_FOR_EXCLUDE);
+    editor.waitTextIntoEditor(fileNameForExcluding);
 
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES);
+    // Remove the file from the File Watcher Excludes feature and check that the file name is not
+    // exists in the 'fileWatcherIgnore' file
+    doFileWatcherExcludeOperation(pathToExcludedFile, REMOVE_FROM_FILE_WATCHER_EXCLUDES);
+    editor.clickOnCloseFileIcon(FILE_WATCHER_IGNORE_FILE_NAME);
+    projectExplorer.openItemByVisibleNameInExplorer(FILE_WATCHER_IGNORE_FILE_NAME);
     editor.selectTabByName(FILE_WATCHER_IGNORE_FILE_NAME);
-    editor.waitTextNotPresentIntoEditor(FILE_NAME_FOR_EXCLUDE);
+    editor.waitTextNotPresentIntoEditor(fileNameForExcluding);
+
+    editor.closeAllTabsByContextMenu();
   }
 
-  @Test(priority = 1)
-  public void checkFileWatcherFeatureBeforeExcluding() {
-    projectExplorer.openItemByVisibleNameInExplorer(FILE_NAME_FOR_EXCLUDE);
+  @Test
+  public void testFeatureAfterExcludingFile() {
+    String fileNameForExluding = "README.md";
+    String pathToExcludedFile = PROJECT_NAME + "/" + fileNameForExluding;
+
+    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.openItemByVisibleNameInExplorer(fileNameForExluding);
     editor.waitActiveEditor();
 
+    // Check that changes with file in the Terminal appeared in the Editor
     terminal.selectTerminalTab();
     terminal.waitTerminalConsole();
     terminal.waitTerminalIsNotEmpty();
     terminal.typeIntoTerminal("cd /projects/" + PROJECT_NAME + Keys.ENTER);
     terminal.waitExpectedTextIntoTerminal("/projects/" + PROJECT_NAME);
-    terminal.typeIntoTerminal("df > " + FILE_NAME_FOR_EXCLUDE + Keys.ENTER);
-
-    editor.selectTabByName(FILE_NAME_FOR_EXCLUDE);
+    terminal.typeIntoTerminal("df > " + fileNameForExluding + Keys.ENTER);
+    editor.selectTabByName(fileNameForExluding);
     editor.waitTextIntoEditor("Filesystem");
-  }
 
-  @Test(priority = 2)
-  public void checkFileInEditorAfterExluding() {
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES);
-    editor.selectTabByName(FILE_WATCHER_IGNORE_FILE_NAME);
-    editor.waitTextIntoEditor(FILE_NAME_FOR_EXCLUDE);
+    // Add the file to exclude and check that the file content in the Editor is not changed
+    doFileWatcherExcludeOperation(pathToExcludedFile, ADD_TO_FILE_WATCHER_EXCLUDES);
 
     terminal.selectTerminalTab();
     terminal.waitTerminalConsole();
     terminal.waitTerminalIsNotEmpty();
     terminal.typeIntoTerminal("cd /projects/" + PROJECT_NAME + Keys.ENTER);
     terminal.waitExpectedTextIntoTerminal("/projects/" + PROJECT_NAME);
-    terminal.typeIntoTerminal("pwd > " + FILE_NAME_FOR_EXCLUDE + Keys.ENTER);
-
-    editor.selectTabByName(FILE_NAME_FOR_EXCLUDE);
+    terminal.typeIntoTerminal("pwd > " + fileNameForExluding + Keys.ENTER);
+    editor.selectTabByName(fileNameForExluding);
     editor.waitTextNotPresentIntoEditor("/projects/" + PROJECT_NAME);
-    editor.clickOnCloseFileIcon(FILE_NAME_FOR_EXCLUDE);
-    projectExplorer.openItemByVisibleNameInExplorer(FILE_NAME_FOR_EXCLUDE);
+
+    // Close file and open again and check that the file content is changed
+    editor.clickOnCloseFileIcon(fileNameForExluding);
+    projectExplorer.openItemByVisibleNameInExplorer(fileNameForExluding);
     editor.waitActiveEditor();
     editor.waitTextIntoEditor("/projects/" + PROJECT_NAME);
+    doFileWatcherExcludeOperation(pathToExcludedFile, REMOVE_FROM_FILE_WATCHER_EXCLUDES);
 
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES);
-    editor.selectTabByName(FILE_WATCHER_IGNORE_FILE_NAME);
-    editor.waitTextNotPresentIntoEditor(FILE_NAME_FOR_EXCLUDE);
+    editor.closeAllTabsByContextMenu();
   }
 
-  @Test(priority = 3)
-  public void checkFeatureAfterExcludingFolder() {
+  @Test
+  public void testFeatureAfterExcludingFolder() {
+    String fileNameForExcluding = "AppController.java";
+    String pathToJavaFile = "/projects/" + PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples";
+
+    // Exclude 'src' folder
     doFileWatcherExcludeOperation(
-        PROJECT_NAME + "/" + FOLDER_NAME_FOR_EXCLUDE,
-        ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES);
-    projectExplorer.openItemByVisibleNameInExplorer("AppController.java");
+        PROJECT_NAME + "/" + FOLDER_NAME_FOR_EXCLUDE, ADD_TO_FILE_WATCHER_EXCLUDES);
+
+    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.openItemByVisibleNameInExplorer(fileNameForExcluding);
     editor.waitActiveEditor();
 
+    // Change content of file from the excluded folder
     terminal.selectTerminalTab();
     terminal.waitTerminalConsole();
     terminal.waitTerminalIsNotEmpty();
+    terminal.typeIntoTerminal("cd " + pathToJavaFile + Keys.ENTER);
+    terminal.waitExpectedTextIntoTerminal(pathToJavaFile);
     terminal.typeIntoTerminal(
-        "cd /projects/" + PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples" + Keys.ENTER);
-    terminal.waitExpectedTextIntoTerminal(
-        "/projects/" + PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples");
-    terminal.typeIntoTerminal("pwd > " + "AppController.java" + Keys.ENTER);
+        "pwd | cat - "
+            + fileNameForExcluding
+            + "> temp && mv temp "
+            + "AppController.java"
+            + Keys.ENTER);
 
+    // Check that content in the excluded file is not changed in the Editor
     editor.selectTabByName("AppController");
-    editor.waitTextNotPresentIntoEditor(
-        "/projects/" + PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples");
+    editor.waitTextNotPresentIntoEditor(pathToJavaFile);
+
+    // Reopen the file and check that its content changed
     editor.clickOnCloseFileIcon("AppController");
-    projectExplorer.openItemByVisibleNameInExplorer("AppController.java");
+    projectExplorer.openItemByVisibleNameInExplorer(fileNameForExcluding);
     editor.waitActiveEditor();
-    editor.waitTextIntoEditor(
-        "/projects/" + PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples");
+    editor.waitTextIntoEditor(pathToJavaFile);
     doFileWatcherExcludeOperation(
-        PROJECT_NAME + "/" + FOLDER_NAME_FOR_EXCLUDE,
-        ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES);
+        PROJECT_NAME + "/" + FOLDER_NAME_FOR_EXCLUDE, REMOVE_FROM_FILE_WATCHER_EXCLUDES);
+
+    editor.closeAllTabsByContextMenu();
   }
 
-  @Test(priority = 4)
-  public void checkFileWatcherExcludeFeatureAfterChangingIgnoreFile() {
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES);
-    editor.selectTabByName(FILE_WATCHER_IGNORE_FILE_NAME);
-    editor.deleteAllContent();
-    editor.typeTextIntoEditor(FILE_NAME_FOR_EXCLUDE);
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES);
-  }
+  @Test
+  public void testIsNotExcludeOperationEventAboutIgnoreFile() {
+    projectExplorer.waitItem(PROJECT_NAME);
 
-  @Test(priority = 5)
-  public void checkIsNotExcludeOperationEventAboutIgnoreFile() {
+    // Clear event log
     events.clickEventLogBtn();
     events.clearAllMessages();
+    consoles.clickOnProcessesButton();
 
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES);
-    editor.selectTabByName(FILE_WATCHER_IGNORE_FILE_NAME);
-    editor.waitTextIntoEditor(FILE_NAME_FOR_EXCLUDE);
-    doFileWatcherExcludeOperation(
-        PATH_FOR_EXCLUDED_FILE,
-        ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES);
-    editor.waitTextNotPresentIntoEditor(FILE_NAME_FOR_EXCLUDE);
-    // This test fails because of issue: https://github.com/eclipse/che/issues/5883.
+    doFileWatcherExcludeOperation(PROJECT_NAME, ADD_TO_FILE_WATCHER_EXCLUDES);
+    doFileWatcherExcludeOperation(PROJECT_NAME, REMOVE_FROM_FILE_WATCHER_EXCLUDES);
+
+    // Check in the Events that there are not "File 'fileWatcherIgnore' is updated" messages
+    events.clickEventLogBtn();
     events.waitMessageIsNotPresent("File 'fileWatcherIgnore' is updated");
+    consoles.clickOnProcessesButton();
   }
 
   private void doFileWatcherExcludeOperation(String itemName, String typeOfOperation) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
@@ -10,8 +10,10 @@
  */
 package org.eclipse.che.selenium.filewatcher;
 
+import static java.lang.String.format;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FileWatcherExcludeOperations.ADD_TO_FILE_WATCHER_EXCLUDES;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FileWatcherExcludeOperations.REMOVE_FROM_FILE_WATCHER_EXCLUDES;
+import static org.openqa.selenium.Keys.ENTER;
 
 import com.google.inject.Inject;
 import java.nio.file.Paths;
@@ -29,7 +31,6 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
-import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -113,9 +114,9 @@ public class CheckFileWatcherExcludeFeatureTest {
     terminal.selectTerminalTab();
     terminal.waitTerminalConsole();
     terminal.waitTerminalIsNotEmpty();
-    terminal.typeIntoTerminal("cd /projects/" + PROJECT_NAME + Keys.ENTER);
+    terminal.typeIntoTerminal(format("cd /projects/%s%s", PROJECT_NAME, ENTER));
     terminal.waitExpectedTextIntoTerminal("/projects/" + PROJECT_NAME);
-    terminal.typeIntoTerminal("df > " + fileNameForExluding + Keys.ENTER);
+    terminal.typeIntoTerminal(format("df > %s%s", fileNameForExluding, ENTER));
     editor.selectTabByName(fileNameForExluding);
     editor.waitTextIntoEditor("Filesystem");
 
@@ -125,9 +126,9 @@ public class CheckFileWatcherExcludeFeatureTest {
     terminal.selectTerminalTab();
     terminal.waitTerminalConsole();
     terminal.waitTerminalIsNotEmpty();
-    terminal.typeIntoTerminal("cd /projects/" + PROJECT_NAME + Keys.ENTER);
+    terminal.typeIntoTerminal(format("cd /projects/%s%s", PROJECT_NAME, ENTER));
     terminal.waitExpectedTextIntoTerminal("/projects/" + PROJECT_NAME);
-    terminal.typeIntoTerminal("pwd > " + fileNameForExluding + Keys.ENTER);
+    terminal.typeIntoTerminal(format("pwd > %s%s", fileNameForExluding, ENTER));
     editor.selectTabByName(fileNameForExluding);
     editor.waitTextNotPresentIntoEditor("/projects/" + PROJECT_NAME);
 
@@ -144,7 +145,8 @@ public class CheckFileWatcherExcludeFeatureTest {
   @Test
   public void testFeatureAfterExcludingFolder() {
     String fileNameForExcluding = "AppController.java";
-    String pathToJavaFile = "/projects/" + PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples";
+    String pathToJavaFile =
+        format("/projects/%s/src/main/java/org/eclipse/qa/examples", PROJECT_NAME);
 
     // Exclude 'src' folder
     doFileWatcherExcludeOperation(
@@ -158,14 +160,12 @@ public class CheckFileWatcherExcludeFeatureTest {
     terminal.selectTerminalTab();
     terminal.waitTerminalConsole();
     terminal.waitTerminalIsNotEmpty();
-    terminal.typeIntoTerminal("cd " + pathToJavaFile + Keys.ENTER);
+    terminal.typeIntoTerminal(format("cd %s%s", pathToJavaFile, ENTER));
     terminal.waitExpectedTextIntoTerminal(pathToJavaFile);
     terminal.typeIntoTerminal(
-        "pwd | cat - "
-            + fileNameForExcluding
-            + "> temp && mv temp "
-            + "AppController.java"
-            + Keys.ENTER);
+        format(
+            "pwd | cat - %s > temp && mv temp %s%s",
+            fileNameForExcluding, fileNameForExcluding, ENTER));
 
     // Check that content in the excluded file is not changed in the Editor
     editor.selectTabByName("AppController");


### PR DESCRIPTION
### What does this PR do?
We need rework the **CheckFileWatcherExcludeFeatureTest** selenium test:
- according to changes from https://github.com/eclipse/che/pull/7342 pull request("**Do not track 'fileWatcherIgnore' file by **File Watcher****") remove checking content from the **fileWatcherIgnore** file(file that contains list of excluded files and folders);
- add comments.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7414
