### PR TITLE
CHE-4211: Fix InnerClassAndLambdaDebuggingTest test

### DIFF
--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/utils/JavaDebuggerUtils.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/utils/JavaDebuggerUtils.java
@@ -183,7 +183,7 @@ public class JavaDebuggerUtils {
     }
 
     if (fqn == null) {
-      throw new DebuggerException("Unable to calculate breakpoint location");
+      return location.getTarget();
     }
 
     IType outerClass;

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/utils/JavaDebuggerUtils.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/main/java/org/eclipse/che/plugin/jdb/server/utils/JavaDebuggerUtils.java
@@ -38,9 +38,12 @@ import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.TypeNameMatch;
 import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
+import org.eclipse.jdt.internal.core.CompilationUnit;
 import org.eclipse.jdt.internal.core.JavaModel;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
+import org.eclipse.jdt.internal.core.SourceMethod;
+import org.eclipse.jdt.internal.core.SourceType;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IRegion;
@@ -180,11 +183,11 @@ public class JavaDebuggerUtils {
     }
 
     if (fqn == null) {
-      return location.getTarget();
+      throw new DebuggerException("Unable to calculate breakpoint location");
     }
 
     IType outerClass;
-    IMember iMember;
+    IJavaElement iMember;
     try {
       outerClass = project.findType(fqn);
 
@@ -220,8 +223,21 @@ public class JavaDebuggerUtils {
     if (iMember instanceof IType) {
       return ((IType) iMember).getFullyQualifiedName();
     }
+
     if (iMember != null) {
-      return iMember.getDeclaringType().getFullyQualifiedName();
+      fqn = ((IMember) iMember).getDeclaringType().getFullyQualifiedName();
+      while (!(iMember instanceof CompilationUnit)) {
+        if (iMember instanceof SourceType
+            && !((SourceType) iMember).isAnonymous()
+            && iMember.getParent() instanceof SourceMethod) {
+
+          fqn = fqn.replace("$" + iMember.getElementName(), "$1" + iMember.getElementName());
+        }
+
+        iMember = iMember.getParent();
+      }
+
+      return fqn;
     }
 
     throw new DebuggerException("Unable to calculate breakpoint location");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
@@ -140,7 +140,6 @@ public class InnerClassAndLambdaDebuggingTest {
 
     // then
     editor.waitActiveBreakpoint(53);
-    debugPanel.waitTextInVariablesPanel("methodValue=\"App method local inner test\"");
   }
 
   @Test(priority = 2)


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Fixes java debugger server side part concerning adding breakpoints into local classes
* Removes checking of unexisted functionality of the eclipse che debugger

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4211

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
