### PR TITLE
Update version of openjdk base image to 8u131

### DIFF
--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -19,7 +19,7 @@
 #             -v /home/user/che/storage:/home/user/che/storage \
 #             codenvy/che-server
 #           
-FROM openjdk:8u111-jre-alpine
+FROM openjdk:8u131-jre-alpine
 
 ENV LANG=C.UTF-8 \
     DOCKER_VERSION=1.6.0 \

--- a/dockerfiles/che/open-jdk-source-file-location
+++ b/dockerfiles/che/open-jdk-source-file-location
@@ -1,14 +1,14 @@
 This package distributes OpenJDK binaries that are licensed under the GPL.
 The source code and build scripts used to create this binary are available for download at:
 
-* eclipse che image parent: `FROM openjdk:8u111-jre-alpine`
-   * official openjdk image parent: `FROM alpine:3.4`
-    * summary of alpine `openjdk8u111-b14` package  reference - https://pkgs.alpinelinux.org/package/v3.4/community/x86_64/openjdk8-jre
-        * alpine build scripts for `openjdk8u111-b14` reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8?id=027d8ceca1422c0ffc3fe3a22523f22abedd694c
+* eclipse che image parent: `FROM openjdk:8u131-jre-alpine`
+   * official openjdk image parent: `FROM alpine:3.6`
+    * summary of alpine `openjdk8-jre v8.131.11-r2` package  reference - https://pkgs.alpinelinux.org/package/v3.6/community/x86_64/openjdk8-jre
+        * alpine build scripts for `openjdk8-jre v8.131.11-r2` reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8?h=3.6-stable
             * build performed by running `APKBUILD` script which will:
-                 * define jdk version reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8/APKBUILD?id=027d8ceca1422c0ffc3fe3a22523f22abedd694c#n5
-                 * grab official jdk sources by version from "http://hg.openjdk.java.net" reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8/APKBUILD?id=027d8ceca1422c0ffc3fe3a22523f22abedd694c#n43
-                 * add alpine specific patches reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8?id=027d8ceca1422c0ffc3fe3a22523f22abedd694c
+                 * define jdk version reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8/APKBUILD?h=3.6-stable#n8
+                 * grab official jdk sources by version from "http://icedtea.classpath.org/" reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8/APKBUILD?id=027d8ceca1422c0ffc3fe3a22523f22abedd694c#n43
+                 * add alpine specific patches reference - https://git.alpinelinux.org/cgit/aports/tree/community/openjdk8?h=3.6-stable
                  * perform build
 
 The following license applies to OpenJDK


### PR DESCRIPTION
### What does this PR do?
Update the base Docker image to `openjdk:8u131` (was `8u111` before)

### What issues does this PR fix or reference?
Version `8u111` was a quite old version (1yr old)