### PR TITLE
Add an ability to use additional volumes in machines

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -46,6 +46,7 @@ import org.eclipse.che.api.workspace.server.adapter.WorkspaceMessageBodyAdapter;
 import org.eclipse.che.api.workspace.server.hc.ServersCheckerFactory;
 import org.eclipse.che.api.workspace.server.spi.provision.InstallerConfigProvisioner;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
+import org.eclipse.che.api.workspace.server.spi.provision.ProjectsVolumeForWsAgentProvisioner;
 import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarEnvironmentProvisioner;
@@ -136,6 +137,7 @@ public class WsMasterModule extends AbstractModule {
         Multibinder.newSetBinder(binder(), InternalEnvironmentProvisioner.class);
     internalEnvironmentProvisioners.addBinding().to(InstallerConfigProvisioner.class);
     internalEnvironmentProvisioners.addBinding().to(EnvVarEnvironmentProvisioner.class);
+    internalEnvironmentProvisioners.addBinding().to(ProjectsVolumeForWsAgentProvisioner.class);
 
     Multibinder<EnvVarProvider> envVarProviders =
         Multibinder.newSetBinder(binder(), EnvVarProvider.class);

--- a/assembly/assembly-wsmaster-war/src/main/resources/META-INF/persistence.xml
+++ b/assembly/assembly-wsmaster-war/src/main/resources/META-INF/persistence.xml
@@ -30,6 +30,7 @@
         <class>org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.VolumeImpl</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl</class>
 
         <class>org.eclipse.che.api.workspace.server.model.impl.CommandImpl</class>

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -249,7 +249,7 @@ che.docker.network=NULL
 che.docker.cleanup_period_min=60
 
 # Version number of the Docker API used within the Che implementation
-che.docker.api=1.20
+che.docker.api=1.21
 
 # Whether to enable component that detects failures of a machine caused by unexpected container stop
 che.docker.enable_container_stop_detector=true

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/MachineConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/MachineConfig.java
@@ -44,4 +44,7 @@ public interface MachineConfig {
 
   /** Returns attributes of resources of machine. */
   Map<String, String> getAttributes();
+
+  /** Returns volumes of machine */
+  Map<String, ? extends Volume> getVolumes();
 }

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/Volume.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/Volume.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.model.workspace.config;
+
+/**
+ * Machine volume configuration.
+ *
+ * @author Alexander Garagatyi
+ */
+public interface Volume {
+
+  /** Mount path of the volume in the machine */
+  String getPath();
+}

--- a/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
+++ b/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
@@ -198,7 +198,7 @@ export class StackValidationService {
    */
   getMachineValidation(machine: che.IEnvironmentMachine): che.IValidation {
     let mandatoryKeys: Array<string> = ['attributes'];
-    let additionalKeys: Array<string> = ['installers', 'servers', 'source', 'env'];
+    let additionalKeys: Array<string> = ['installers', 'servers', 'volumes', 'source', 'env'];
     let validKeys: Array<string> = mandatoryKeys.concat(additionalKeys);
     let errors: Array<string> = [];
     let isValid: boolean = true;

--- a/dashboard/src/components/api/environment/compose-environment-manager.spec.ts
+++ b/dashboard/src/components/api/environment/compose-environment-manager.spec.ts
@@ -32,11 +32,13 @@ describe('ComposeEnvironmentManager', () => {
           'another-machine': {
             'attributes': {'memoryLimitBytes': '2147483648'},
             'servers': {},
+            'volumes': {},
             'installers': []
           },
           'db': {
             'attributes': {},
             'servers': {},
+            'volumes': {},
             'installers': []
           },
           'dev-machine': {
@@ -44,6 +46,9 @@ describe('ComposeEnvironmentManager', () => {
             'servers': {
               '1024/tcp': {'port': '1024', 'properties': {}, 'protocol': 'http', 'path': ''},
               '1025/tcp': {'port': '1025', 'properties': {}, 'protocol': 'http', 'path': ''}
+            },
+            'volumes': {
+              'volume1': {'path': '/some/path'},
             },
             'installers': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh']
           }
@@ -94,14 +99,19 @@ describe('ComposeEnvironmentManager', () => {
           'another-machine': {
             'attributes': {'memoryLimitBytes': '2147483648'},
             'servers': {},
+            'volumes': {},
             'installers': []
           },
-          'db': {'attributes': {}, 'servers': {}, 'installers': []},
+          'db': {'attributes': {}, 'servers': {}, 'volumes': {}, 'installers': []},
           'dev-machine': {
             'attributes': {'memoryLimitBytes': '5368709120'},
             'servers': {
               '1024/tcp': {'port': '1024', 'properties': {}, 'protocol': 'http', 'path': ''},
               '1025/tcp': {'port': '1025', 'properties': {}, 'protocol': 'http', 'path': ''}
+            },
+            'volumes': {
+              'vol1': {'path': '/some/path'},
+              'm22': {'path': '/home/user/.m2/repository'}
             },
             'installers': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh']
           }
@@ -185,6 +195,7 @@ describe('ComposeEnvironmentManager', () => {
         'machines': {
           'dev-machine': {
             'servers': {},
+            'volumes': {},
             'installers': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh'],
             'attributes': {'memoryLimitBytes': '2147483648'}
           }

--- a/dashboard/src/components/api/environment/docker-file-environment-manager.spec.ts
+++ b/dashboard/src/components/api/environment/docker-file-environment-manager.spec.ts
@@ -29,6 +29,7 @@ describe('If recipe has content', () => {
         'dev-machine': {
           'attributes': {'memoryLimitBytes': '2147483648'},
           'servers': {},
+          'volumes': {},
           'installers': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh']
         }
       },
@@ -106,6 +107,7 @@ describe('If recipe has location', () => {
       'machines': {
         'dev-machine': {
           'servers': {},
+          'volumes': {},
           'installers': ['org.eclipse.che.ws-agent', 'org.eclipse.che.terminal', 'org.eclipse.che.ssh'],
           'attributes': {'memoryLimitBytes': '2147483648'}
         }

--- a/dashboard/src/components/api/environment/docker-image-environment-manager.spec.ts
+++ b/dashboard/src/components/api/environment/docker-image-environment-manager.spec.ts
@@ -34,6 +34,11 @@ describe('DockerImageEnvironmentManager', () => {
               'port': '10240',
               'path': ''
             }
+          },
+          'volumes': {
+            'volume1': {
+              'path': '/123'
+            }
           }, 'installers': ['ws-agent', 'org.eclipse.che.ws-agent'], 'attributes': {'memoryLimitBytes': '16642998272'}
         }
       }, 'recipe': {'location': 'codenvy/ubuntu_jdk8', 'type': 'dockerimage'}

--- a/dashboard/src/components/api/environment/environment-manager.ts
+++ b/dashboard/src/components/api/environment/environment-manager.ts
@@ -137,6 +137,7 @@ export abstract class EnvironmentManager {
       newEnvironment.machines[machineName].attributes.memoryLimitBytes = machine.attributes ? machine.attributes.memoryLimitBytes : '1073741824';
       newEnvironment.machines[machineName].installers = angular.copy(machine.installers);
       newEnvironment.machines[machineName].servers = angular.copy(machine.servers);
+      newEnvironment.machines[machineName].volumes = angular.copy(machine.volumes);
     });
 
     return newEnvironment;

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -324,6 +324,9 @@ declare namespace che {
     servers?: {
       [serverRef: string]: IEnvironmentMachineServer
     };
+    volumes?: {
+      [volumeRef: string]: IEnvironmentMachineVolume
+    }
   }
 
   export interface IEnvironmentMachineServer {
@@ -331,6 +334,10 @@ declare namespace che {
     protocol: string;
     path?: string;
     properties?: any;
+  }
+
+  export interface IEnvironmentMachineVolume {
+    path: string;
   }
 
   export interface IWorkspaceRuntime {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/MachineConfigImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/MachineConfigImpl.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
 
 public class MachineConfigImpl implements MachineConfig {
 
@@ -24,12 +25,14 @@ public class MachineConfigImpl implements MachineConfig {
   private Map<String, String> env;
   private Map<String, String> attributes;
   private Map<String, ServerConfigImpl> servers;
+  private Map<String, VolumeImpl> volumes;
 
   public MachineConfigImpl(
       List<String> installers,
       Map<String, ? extends ServerConfig> servers,
       Map<String, String> env,
-      Map<String, String> attributes) {
+      Map<String, String> attributes,
+      Map<String, ? extends Volume> volumes) {
     if (installers != null) {
       this.installers = new ArrayList<>(installers);
     }
@@ -48,10 +51,23 @@ public class MachineConfigImpl implements MachineConfig {
     if (attributes != null) {
       this.attributes = new HashMap<>(attributes);
     }
+    if (volumes != null) {
+      this.volumes =
+          volumes
+              .entrySet()
+              .stream()
+              .collect(
+                  Collectors.toMap(Map.Entry::getKey, entry -> new VolumeImpl(entry.getValue())));
+    }
   }
 
   public MachineConfigImpl(MachineConfig machine) {
-    this(machine.getInstallers(), machine.getServers(), machine.getEnv(), machine.getAttributes());
+    this(
+        machine.getInstallers(),
+        machine.getServers(),
+        machine.getEnv(),
+        machine.getAttributes(),
+        machine.getVolumes());
   }
 
   @Override
@@ -87,6 +103,14 @@ public class MachineConfigImpl implements MachineConfig {
   }
 
   @Override
+  public Map<String, VolumeImpl> getVolumes() {
+    if (volumes == null) {
+      volumes = new HashMap<>();
+    }
+    return volumes;
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
@@ -98,7 +122,8 @@ public class MachineConfigImpl implements MachineConfig {
     return getInstallers().equals(that.getInstallers())
         && getEnv().equals(that.getEnv())
         && getAttributes().equals(that.getAttributes())
-        && getServers().equals(that.getServers());
+        && getServers().equals(that.getServers())
+        && getVolumes().equals(that.getVolumes());
   }
 
   @Override
@@ -108,6 +133,7 @@ public class MachineConfigImpl implements MachineConfig {
     hash = 31 * hash + getEnv().hashCode();
     hash = 31 * hash + getAttributes().hashCode();
     hash = 31 * hash + getServers().hashCode();
+    hash = 31 * hash + getVolumes().hashCode();
     return hash;
   }
 
@@ -122,6 +148,8 @@ public class MachineConfigImpl implements MachineConfig {
         + attributes
         + ", servers="
         + servers
+        + ", volumes="
+        + volumes
         + '}';
   }
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/VolumeImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/VolumeImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.api.workspace.model;
+
+import java.util.Objects;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+
+/** @author Alexander Garagatyi */
+public class VolumeImpl implements Volume {
+  private final String path;
+
+  public VolumeImpl(String path) {
+    this.path = path;
+  }
+
+  public VolumeImpl(Volume value) {
+    path = value.getPath();
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof VolumeImpl)) {
+      return false;
+    }
+    final VolumeImpl that = (VolumeImpl) obj;
+    return Objects.equals(path, that.path);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + Objects.hashCode(path);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "VolumeImpl{" + "path='" + path + '\'' + '}';
+  }
+}

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/exception/VolumeNotFoundException.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/exception/VolumeNotFoundException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.infrastructure.docker.client.exception;
+
+/**
+ * Is thrown when a docker volume is not found.
+ *
+ * @author Alexander Garagatyi
+ */
+public class VolumeNotFoundException extends DockerException {
+  public VolumeNotFoundException(String message) {
+    super(message, 404);
+  }
+}

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/volume/Volume.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/volume/Volume.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.infrastructure.docker.client.json.volume;
+
+import java.util.Objects;
+
+/** @author Alexander Garagatyi */
+public class Volume {
+  private String name;
+  private String driver;
+  private String mountpoint;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Volume withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getDriver() {
+    return driver;
+  }
+
+  public void setDriver(String driver) {
+    this.driver = driver;
+  }
+
+  public Volume withDriver(String driver) {
+    this.driver = driver;
+    return this;
+  }
+
+  public String getMountpoint() {
+    return mountpoint;
+  }
+
+  public void setMountpoint(String mountpoint) {
+    this.mountpoint = mountpoint;
+  }
+
+  public Volume withMountpoint(String mountpoint) {
+    this.mountpoint = mountpoint;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Volume)) {
+      return false;
+    }
+    Volume volume = (Volume) o;
+    return Objects.equals(getName(), volume.getName())
+        && Objects.equals(getDriver(), volume.getDriver())
+        && Objects.equals(getMountpoint(), volume.getMountpoint());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getDriver(), getMountpoint());
+  }
+
+  @Override
+  public String toString() {
+    return "Volume{"
+        + "name='"
+        + name
+        + '\''
+        + ", driver='"
+        + driver
+        + '\''
+        + ", mountpoint='"
+        + mountpoint
+        + '\''
+        + '}';
+  }
+}

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/volume/Volumes.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/volume/Volumes.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.infrastructure.docker.client.json.volume;
+
+import java.util.List;
+import java.util.Objects;
+
+/** @author Alexander Garagatyi */
+public class Volumes {
+  private List<Volume> volumes;
+
+  public List<Volume> getVolumes() {
+    return volumes;
+  }
+
+  public void setVolumes(List<Volume> volumes) {
+    this.volumes = volumes;
+  }
+
+  public Volumes withVolumes(List<Volume> volumes) {
+    this.volumes = volumes;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Volumes)) {
+      return false;
+    }
+    Volumes volumes1 = (Volumes) o;
+    return Objects.equals(getVolumes(), volumes1.getVolumes());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getVolumes());
+  }
+
+  @Override
+  public String toString() {
+    return "Volumes{" + "volumes=" + volumes + '}';
+  }
+}

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/params/volume/GetVolumesParams.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/params/volume/GetVolumesParams.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.infrastructure.docker.client.params.volume;
+
+import java.util.Objects;
+import org.eclipse.che.infrastructure.docker.client.DockerConnector;
+import org.eclipse.che.infrastructure.docker.client.json.Filters;
+
+/**
+ * Arguments holder for {@link DockerConnector#getVolumes(GetVolumesParams)}.
+ *
+ * @author Alexander Garagatyi
+ */
+public class GetVolumesParams {
+
+  private Filters filters;
+
+  /** Creates arguments holder. */
+  public static GetVolumesParams create() {
+    return new GetVolumesParams();
+  }
+
+  private GetVolumesParams() {}
+
+  /**
+   * Adds filters to this parameters.
+   *
+   * @param filters filter of needed volumes. Available filters: {@code name=<string>}, {@code
+   *     dangling=<boolean>}
+   * @return this params instance
+   */
+  public GetVolumesParams withFilters(Filters filters) {
+    this.filters = filters;
+    return this;
+  }
+
+  public Filters getFilters() {
+    return filters;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof GetVolumesParams)) {
+      return false;
+    }
+    final GetVolumesParams that = (GetVolumesParams) obj;
+    return Objects.equals(filters, that.filters);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + Objects.hashCode(filters);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "GetVolumesParams{" + "filters=" + filters + '}';
+  }
+}

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/params/volume/RemoveVolumeParams.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/params/volume/RemoveVolumeParams.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.infrastructure.docker.client.params.volume;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.infrastructure.docker.client.DockerConnector;
+
+/**
+ * Arguments holder for {@link DockerConnector#removeVolume(RemoveVolumeParams)}.
+ *
+ * @author Alexander Garagatyi
+ */
+public class RemoveVolumeParams {
+  private String volumeName;
+
+  private RemoveVolumeParams() {}
+
+  /**
+   * Creates arguments holder with required parameters.
+   *
+   * @param volumeName name of a volume to remove
+   * @return arguments holder with required parameters
+   * @throws NullPointerException if {@code volumeName} is null
+   */
+  public static RemoveVolumeParams create(@NotNull String volumeName) {
+    return new RemoveVolumeParams().withVolumeName(volumeName);
+  }
+
+  /**
+   * Adds the name of a volume to this parameters.
+   *
+   * @param volumeName name of a volume
+   * @return this params instance
+   * @throws NullPointerException if {@code volumeName} is null
+   */
+  public RemoveVolumeParams withVolumeName(@NotNull String volumeName) {
+    requireNonNull(volumeName);
+    this.volumeName = volumeName;
+    return this;
+  }
+
+  public String getVolumeName() {
+    return volumeName;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof RemoveVolumeParams)) {
+      return false;
+    }
+    final RemoveVolumeParams that = (RemoveVolumeParams) obj;
+    return Objects.equals(volumeName, that.volumeName);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + Objects.hashCode(volumeName);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "RemoveVolumeParams{" + "volumeName='" + volumeName + '\'' + '}';
+  }
+}

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/OnWorkspaceRemoveDataVolumeRemover.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/OnWorkspaceRemoveDataVolumeRemover.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import static java.lang.String.format;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
+import org.eclipse.che.infrastructure.docker.client.DockerConnector;
+import org.eclipse.che.infrastructure.docker.client.json.volume.Volume;
+import org.eclipse.che.workspace.infrastructure.docker.provisioner.volume.VolumeNames;
+import org.slf4j.Logger;
+
+/** @author Alexander Garagatyi */
+@Singleton
+public class OnWorkspaceRemoveDataVolumeRemover implements EventSubscriber<WorkspaceRemovedEvent> {
+
+  private static final Logger LOG = getLogger(OnWorkspaceRemoveDataVolumeRemover.class);
+
+  private final DockerConnector docker;
+
+  @Inject
+  public OnWorkspaceRemoveDataVolumeRemover(DockerConnector docker) {
+    this.docker = docker;
+  }
+
+  @Override
+  public void onEvent(WorkspaceRemovedEvent event) {
+    String wsId = event.getWorkspace().getId();
+    try {
+      List<Volume> volumes = docker.getVolumes().getVolumes();
+      // May happen because Docker API is not very consistent on whether it returns null or empty
+      // collection
+      if (volumes == null) {
+        return;
+      }
+      for (Volume volume : volumes) {
+        String volumeName = volume.getName();
+        if (VolumeNames.matches(volumeName, wsId)) {
+          try {
+            docker.removeVolume(volumeName);
+          } catch (IOException e) {
+            LOG.error(
+                format(
+                    "Error occurs on removing of volume '%s' of workspace '%s'. Error: %s",
+                    volumeName, wsId, e.getLocalizedMessage()),
+                e);
+          }
+        }
+      }
+    } catch (IOException e) {
+      LOG.error(
+          format(
+              "Error occurs on removal of volumes of workspace '%s'. Error: %s",
+              wsId, e.getLocalizedMessage()),
+          e);
+    }
+  }
+
+  @Inject
+  public void subscribe(EventService eventService) {
+    eventService.subscribe(this);
+  }
+}

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/local/LocalDockerModule.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/local/LocalDockerModule.java
@@ -17,6 +17,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import org.eclipse.che.infrastructure.docker.client.DockerRegistryChecker;
 import org.eclipse.che.workspace.infrastructure.docker.DockerEnvironmentProvisioner;
+import org.eclipse.che.workspace.infrastructure.docker.OnWorkspaceRemoveDataVolumeRemover;
 import org.eclipse.che.workspace.infrastructure.docker.local.installer.ExecInstallerInfrastructureProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.local.installer.TerminalInstallerInfrastructureProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.local.installer.WsAgentBinariesInfrastructureProvisioner;
@@ -31,6 +32,7 @@ public class LocalDockerModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(RemoveLocalProjectsFolderOnWorkspaceRemove.class).asEagerSingleton();
+    bind(OnWorkspaceRemoveDataVolumeRemover.class).asEagerSingleton();
 
     bind(DockerRegistryChecker.class).asEagerSingleton();
 

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/RemoveLocalProjectsFolderOnWorkspaceRemove.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/RemoveLocalProjectsFolderOnWorkspaceRemove.java
@@ -31,9 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Listener for removing projects files after {@code WorkspaceRemovedEvent}.
+ * Listener for removing projects files from host after {@code WorkspaceRemovedEvent}.
  *
- * <p>Note that projects folder won't be removed if host projects holder is configured.
+ * <p>Note that projects folder won't be removed if host projects holder is not configured - this
+ * listener is useful when Che master and Che workspaces are on the same host.
  *
  * @author Alexander Andrienko
  * @author Sergii Leshchenko

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/volume/VolumeNames.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/volume/VolumeNames.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.provisioner.volume;
+
+/**
+ * Helps to generate volume names and match existing volumes to workspace.
+ *
+ * @author Alexander Garagatyi
+ */
+public class VolumeNames {
+
+  /** Generates unique volume name for a volume in a workspace. */
+  public static String generate(String workspaceId, String originVolumeName) {
+    return workspaceId + '_' + originVolumeName;
+  }
+
+  /** Check whether a volume with provided name belongs to workspace with provided ID. */
+  public static boolean matches(String volumeName, String workspaceId) {
+    return volumeName.startsWith(workspaceId + '_');
+  }
+
+  /**
+   * Check whether a volume with provided name matches origin Che model volume of workspace with
+   * provided ID.
+   */
+  public static boolean matches(String volumeName, String originVolumeName, String workspaceId) {
+    return volumeName.equals(workspaceId + '_' + originVolumeName);
+  }
+
+  private VolumeNames() {}
+}

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/volume/VolumesConverter.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/volume/VolumesConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.provisioner.volume;
+
+import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.docker.DockerEnvironmentProvisioner;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+
+/**
+ * Converts volumes from {@link MachineConfig} to Docker volumes unique for each workspace.
+ *
+ * @author Alexander Garagatyi
+ */
+public class VolumesConverter implements DockerEnvironmentProvisioner {
+
+  @Override
+  public void provision(DockerEnvironment internalEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+
+    internalEnv
+        .getMachines()
+        .forEach(
+            (machineName, machineConfig) -> {
+              DockerContainerConfig containerConfig = internalEnv.getContainers().get(machineName);
+              machineConfig
+                  .getVolumes()
+                  .forEach(
+                      (volumeName, volume) -> {
+                        String uniqueVolumeName =
+                            VolumeNames.generate(identity.getWorkspaceId(), volumeName);
+                        containerConfig.getVolumes().add(uniqueVolumeName + ':' + volume.getPath());
+                      });
+            });
+  }
+}

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/OnWorkspaceRemoveDataVolumeRemoverTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/OnWorkspaceRemoveDataVolumeRemoverTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
+import org.eclipse.che.infrastructure.docker.client.DockerConnector;
+import org.eclipse.che.infrastructure.docker.client.json.volume.Volume;
+import org.eclipse.che.infrastructure.docker.client.json.volume.Volumes;
+import org.eclipse.che.infrastructure.docker.client.params.volume.RemoveVolumeParams;
+import org.eclipse.che.workspace.infrastructure.docker.provisioner.volume.VolumeNames;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class OnWorkspaceRemoveDataVolumeRemoverTest {
+  static final String WS_ID = "testWSId";
+
+  @Mock WorkspaceRemovedEvent event;
+  @Mock Workspace workspace;
+  @Mock Volumes volumes;
+  @Mock DockerConnector docker;
+  @InjectMocks OnWorkspaceRemoveDataVolumeRemover remover;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    when(event.getWorkspace()).thenReturn(workspace);
+    when(workspace.getId()).thenReturn(WS_ID);
+    when(docker.getVolumes()).thenReturn(volumes);
+  }
+
+  @Test
+  public void shouldRemoveVolumes() throws Exception {
+    // given
+    String volume1Name = VolumeNames.generate(WS_ID, "volume1");
+    String volume2Name = VolumeNames.generate(WS_ID, "volume2");
+    String volume3Name = VolumeNames.generate(WS_ID, "volume3");
+    Volume volume1 = new Volume().withName(volume1Name);
+    Volume volume2 = new Volume().withName(volume2Name);
+    Volume volume3 = new Volume().withName(volume3Name);
+    when(volumes.getVolumes()).thenReturn(asList(volume1, volume2, volume3));
+
+    // when
+    remover.onEvent(event);
+
+    // then
+    verify(docker).removeVolume(eq(volume1Name));
+    verify(docker).removeVolume(eq(volume2Name));
+    verify(docker).removeVolume(eq(volume3Name));
+  }
+
+  @Test
+  public void shouldKeepRemovingWhenOneRemovalFails() throws Exception {
+    // given
+    String volume1Name = VolumeNames.generate(WS_ID, "volume1");
+    String volume2Name = VolumeNames.generate(WS_ID, "volume2");
+    String volume3Name = VolumeNames.generate(WS_ID, "volume3");
+    Volume volume1 = new Volume().withName(volume1Name);
+    Volume volume2 = new Volume().withName(volume2Name);
+    Volume volume3 = new Volume().withName(volume3Name);
+    when(volumes.getVolumes()).thenReturn(asList(volume1, volume2, volume3));
+    doThrow(new IOException("test exc")).when(docker).removeVolume(eq(volume2Name));
+
+    // when
+    remover.onEvent(event);
+
+    // then
+    InOrder inOrder = inOrder(docker);
+    inOrder.verify(docker).removeVolume(eq(volume1Name));
+    inOrder.verify(docker).removeVolume(eq(volume2Name));
+    inOrder.verify(docker).removeVolume(eq(volume3Name));
+  }
+
+  @Test
+  public void shouldNotRemoveVolumesThatDoesNotMatchWorkspace() throws Exception {
+    // given
+    String volume1Name = VolumeNames.generate(WS_ID, "volume1");
+    String volume2Name = VolumeNames.generate(WS_ID + "2", "volume2");
+    String volume3Name = VolumeNames.generate(WS_ID + WS_ID, "volume3");
+    Volume volume1 = new Volume().withName(volume1Name);
+    Volume volume2 = new Volume().withName(volume2Name);
+    Volume volume3 = new Volume().withName(volume3Name);
+    when(volumes.getVolumes()).thenReturn(asList(volume1, volume2, volume3));
+
+    // when
+    remover.onEvent(event);
+
+    // then
+    verify(docker).removeVolume(eq(volume1Name));
+    verify(docker, never()).removeVolume(eq(volume2Name));
+    verify(docker, never()).removeVolume(eq(volume3Name));
+  }
+
+  @Test
+  public void shouldNotThrowExceptionIfVolumesListIsNull() throws Exception {
+    // given
+    when(volumes.getVolumes()).thenReturn(null);
+
+    // when
+    remover.onEvent(event);
+
+    // then
+    verify(docker, never()).removeVolume(anyString());
+    verify(docker, never()).removeVolume(any(RemoveVolumeParams.class));
+  }
+}

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/local/LocalCheDockerEnvironmentProvisionerTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/local/LocalCheDockerEnvironmentProvisionerTest.java
@@ -16,13 +16,14 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.workspace.infrastructure.docker.local.dod.DockerApiHostEnvVariableProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.local.installer.LocalInstallersBinariesVolumeProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.local.installer.WsAgentServerConfigProvisioner;
-import org.eclipse.che.workspace.infrastructure.docker.local.projects.ProjectsVolumeProvisioner;
+import org.eclipse.che.workspace.infrastructure.docker.local.projects.BindMountProjectsVolumeProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.ContainerSystemSettingsProvisionersApplier;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.labels.RuntimeLabelsProvisioner;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.memory.MemoryAttributeConverter;
 import org.eclipse.che.workspace.infrastructure.docker.provisioner.server.ServersConverter;
+import org.eclipse.che.workspace.infrastructure.docker.provisioner.volume.VolumesConverter;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -36,7 +37,7 @@ import org.testng.annotations.Test;
 public class LocalCheDockerEnvironmentProvisionerTest {
 
   @Mock private ContainerSystemSettingsProvisionersApplier settingsProvisioners;
-  @Mock private ProjectsVolumeProvisioner projectsVolumeProvisioner;
+  @Mock private BindMountProjectsVolumeProvisioner projectsVolumeProvisioner;
   @Mock private LocalInstallersBinariesVolumeProvisioner installerConfigProvisioner;
   @Mock private RuntimeLabelsProvisioner labelsProvisioner;
   @Mock private DockerApiHostEnvVariableProvisioner dockerApiEnvProvisioner;
@@ -46,6 +47,7 @@ public class LocalCheDockerEnvironmentProvisionerTest {
   @Mock private ServersConverter serversConverter;
   @Mock private EnvVarsConverter envVarsConverter;
   @Mock private MemoryAttributeConverter memoryAttributeConverter;
+  @Mock private VolumesConverter volumesConverter;
 
   private LocalCheDockerEnvironmentProvisioner provisioner;
 
@@ -63,7 +65,8 @@ public class LocalCheDockerEnvironmentProvisionerTest {
             wsAgentServerConfigProvisioner,
             serversConverter,
             envVarsConverter,
-            memoryAttributeConverter);
+            memoryAttributeConverter,
+            volumesConverter);
 
     allInnerProvisioners =
         new Object[] {
@@ -75,7 +78,8 @@ public class LocalCheDockerEnvironmentProvisionerTest {
           wsAgentServerConfigProvisioner,
           serversConverter,
           envVarsConverter,
-          memoryAttributeConverter
+          memoryAttributeConverter,
+          volumesConverter
         };
   }
 
@@ -88,6 +92,7 @@ public class LocalCheDockerEnvironmentProvisionerTest {
     InOrder inOrder = Mockito.inOrder((Object[]) allInnerProvisioners);
     inOrder.verify(serversConverter).provision(eq(dockerEnvironment), eq(runtimeIdentity));
     inOrder.verify(envVarsConverter).provision(eq(dockerEnvironment), eq(runtimeIdentity));
+    inOrder.verify(volumesConverter).provision(eq(dockerEnvironment), eq(runtimeIdentity));
     inOrder.verify(memoryAttributeConverter).provision(eq(dockerEnvironment), eq(runtimeIdentity));
     inOrder.verify(labelsProvisioner).provision(eq(dockerEnvironment), eq(runtimeIdentity));
     inOrder

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/volume/VolumesConverterTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/volume/VolumesConverterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.provisioner.volume;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class VolumesConverterTest {
+
+  static final String WS_ID = "testWSId";
+  static final String MACHINE_1_NAME = "machine1";
+  static final String MACHINE_2_NAME = "machine2";
+
+  @Mock InternalMachineConfig machineConfig1;
+  @Mock InternalMachineConfig machineConfig2;
+  @Mock DockerContainerConfig container1;
+  @Mock DockerContainerConfig container2;
+  @Mock DockerEnvironment internalEnvironment;
+  @Mock RuntimeIdentity runtimeIdentity;
+  @InjectMocks VolumesConverter converter;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WS_ID);
+    when(internalEnvironment.getMachines())
+        .thenReturn(
+            ImmutableMap.of(MACHINE_1_NAME, machineConfig1, MACHINE_2_NAME, machineConfig2));
+    when(internalEnvironment.getContainers())
+        .thenReturn(
+            new LinkedHashMap<>(
+                ImmutableMap.of(MACHINE_1_NAME, container1, MACHINE_2_NAME, container2)));
+  }
+
+  @Test
+  public void shouldAddContainerVolumesFromEachMachine() throws Exception {
+    // given
+    String volume1Name = "vol1";
+    String volume1Path = "/some/path";
+    String volume2Name = "vol2";
+    String volume2Path = "/another/path";
+
+    List<String> machine1ActualVolumes = new ArrayList<>();
+    List<String> machine2ActualVolumes = new ArrayList<>();
+
+    when(machineConfig1.getVolumes())
+        .thenReturn(singletonMap(volume1Name, new VolumeImpl().withPath(volume1Path)));
+    when(machineConfig2.getVolumes())
+        .thenReturn(
+            ImmutableMap.of(
+                volume1Name,
+                new VolumeImpl().withPath(volume1Path),
+                volume2Name,
+                new VolumeImpl().withPath(volume2Path)));
+    when(container1.getVolumes()).thenReturn(machine1ActualVolumes);
+    when(container2.getVolumes()).thenReturn(machine2ActualVolumes);
+
+    // when
+    converter.provision(internalEnvironment, runtimeIdentity);
+
+    // then
+    verify(container1).getVolumes();
+    verify(container2, times(2)).getVolumes();
+    assertEquals(
+        machine1ActualVolumes,
+        singletonList(VolumeNames.generate(WS_ID, volume1Name) + ":" + volume1Path));
+    assertEquals(
+        machine2ActualVolumes,
+        asList(
+            VolumeNames.generate(WS_ID, volume1Name) + ":" + volume1Path,
+            VolumeNames.generate(WS_ID, volume2Name) + ":" + volume2Path));
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -20,7 +20,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.provision.env.EnvVarsC
 import org.eclipse.che.workspace.infrastructure.openshift.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.route.TlsRouteProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.server.ServersConverter;
-import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.PersistentVolumeClaimProvisioner;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.VolumesProvisioner;
 
 /**
  * Applies the set of configurations to the OpenShift environment and environment configuration with
@@ -32,7 +32,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.Persi
 @Singleton
 public class OpenShiftEnvironmentProvisioner {
 
-  private final PersistentVolumeClaimProvisioner persistentVolumeClaimProvisioner;
+  private final VolumesProvisioner volumesProvisioner;
   private final UniqueNamesProvisioner uniqueNamesProvisioner;
   private final TlsRouteProvisioner tlsRouteProvisioner;
   private final ServersConverter serversConverter;
@@ -41,13 +41,13 @@ public class OpenShiftEnvironmentProvisioner {
 
   @Inject
   public OpenShiftEnvironmentProvisioner(
-      PersistentVolumeClaimProvisioner projectVolumeProvisioner,
+      VolumesProvisioner volumesProvisioner,
       UniqueNamesProvisioner uniqueNamesProvisioner,
       TlsRouteProvisioner tlsRouteProvisioner,
       ServersConverter serversConverter,
       EnvVarsConverter envVarsConverter,
       RestartPolicyRewriter restartPolicyRewriter) {
-    this.persistentVolumeClaimProvisioner = projectVolumeProvisioner;
+    this.volumesProvisioner = volumesProvisioner;
     this.uniqueNamesProvisioner = uniqueNamesProvisioner;
     this.tlsRouteProvisioner = tlsRouteProvisioner;
     this.serversConverter = serversConverter;
@@ -60,10 +60,10 @@ public class OpenShiftEnvironmentProvisioner {
     // 1 stage - converting Che model env to OpenShift env
     serversConverter.provision(osEnv, identity);
     envVarsConverter.provision(osEnv, identity);
+    volumesProvisioner.provision(osEnv, identity);
 
     // 2 stage - add OpenShift env items
     restartPolicyRewriter.provision(osEnv, identity);
-    persistentVolumeClaimProvisioner.provision(osEnv, identity);
     uniqueNamesProvisioner.provision(osEnv, identity);
     tlsRouteProvisioner.provision(osEnv, identity);
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -27,8 +27,8 @@ import org.eclipse.che.workspace.infrastructure.openshift.project.RemoveProjectO
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.CommonPVCStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.UniqueWorkspacePVCStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCCleaner;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategyProvider;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumeStrategyProvider;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftCheApiEnvVarProvider;
 
 /** @author Sergii Leshchenko */
@@ -52,10 +52,10 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     bind(CheApiEnvVarProvider.class).to(OpenShiftCheApiEnvVarProvider.class);
 
-    MapBinder<String, WorkspacePVCStrategy> pvcStrategies =
-        MapBinder.newMapBinder(binder(), String.class, WorkspacePVCStrategy.class);
-    pvcStrategies.addBinding(COMMON_STRATEGY).to(CommonPVCStrategy.class);
-    pvcStrategies.addBinding(UNIQUE_STRATEGY).to(UniqueWorkspacePVCStrategy.class);
-    bind(WorkspacePVCStrategy.class).toProvider(WorkspacePVCStrategyProvider.class);
+    MapBinder<String, WorkspaceVolumesStrategy> volumesStrategies =
+        MapBinder.newMapBinder(binder(), String.class, WorkspaceVolumesStrategy.class);
+    volumesStrategies.addBinding(COMMON_STRATEGY).to(CommonPVCStrategy.class);
+    volumesStrategies.addBinding(UNIQUE_STRATEGY).to(UniqueWorkspacePVCStrategy.class);
+    bind(WorkspaceVolumesStrategy.class).toProvider(WorkspaceVolumeStrategyProvider.class);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
-import static org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil.getWsAgentServerMachine;
 import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newPVC;
 import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newVolume;
 import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.newVolumeMount;
@@ -21,9 +20,12 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.openshift.Names;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -40,8 +42,9 @@ import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProje
  * related to the workspace.
  *
  * @author Anton Korneta
+ * @author Alexander Garagatyi
  */
-public class UniqueWorkspacePVCStrategy implements WorkspacePVCStrategy {
+public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
 
   public static final String UNIQUE_STRATEGY = "unique";
 
@@ -49,7 +52,6 @@ public class UniqueWorkspacePVCStrategy implements WorkspacePVCStrategy {
   private final String projectName;
   private final String pvcQuantity;
   private final String pvcAccessMode;
-  private final String projectsPath;
   private final OpenShiftClientFactory clientFactory;
   private final OpenShiftProjectFactory factory;
 
@@ -59,14 +61,12 @@ public class UniqueWorkspacePVCStrategy implements WorkspacePVCStrategy {
       @Named("che.infra.openshift.pvc.name") String pvcName,
       @Named("che.infra.openshift.pvc.quantity") String pvcQuantity,
       @Named("che.infra.openshift.pvc.access_mode") String pvcAccessMode,
-      @Named("che.workspace.projects.storage") String projectFolderPath,
       OpenShiftClientFactory clientFactory,
       OpenShiftProjectFactory factory) {
     this.pvcName = pvcName;
     this.pvcQuantity = pvcQuantity;
     this.projectName = projectName;
     this.pvcAccessMode = pvcAccessMode;
-    this.projectsPath = projectFolderPath;
     this.clientFactory = clientFactory;
     this.factory = factory;
   }
@@ -74,25 +74,36 @@ public class UniqueWorkspacePVCStrategy implements WorkspacePVCStrategy {
   @Override
   public void prepare(OpenShiftEnvironment osEnv, String workspaceId)
       throws InfrastructureException {
-    final String machineWithSources =
-        getWsAgentServerMachine(osEnv)
-            .orElseThrow(() -> new InfrastructureException("Machine with ws-agent not found"));
-    final String pvcUniqueName = pvcName + '-' + workspaceId;
-    final Map<String, PersistentVolumeClaim> claims = osEnv.getPersistentVolumeClaims();
-    claims.put(pvcUniqueName, newPVC(pvcUniqueName, pvcAccessMode, pvcQuantity));
-    factory.create(workspaceId).persistentVolumeClaims().createIfNotExist(claims.values());
+    Map<String, PersistentVolumeClaim> claims = osEnv.getPersistentVolumeClaims();
     for (Pod pod : osEnv.getPods().values()) {
       final PodSpec podSpec = pod.getSpec();
       for (Container container : podSpec.getContainers()) {
         final String machineName = Names.machineName(pod, container);
-        if (machineName.equals(machineWithSources)) {
-          final String subPath =
-              projectsPath.startsWith("/") ? projectsPath.substring(1) : projectsPath;
-          container.getVolumeMounts().add(newVolumeMount(pvcUniqueName, projectsPath, subPath));
-          podSpec.getVolumes().add(newVolume(pvcUniqueName, pvcUniqueName));
-          return;
-        }
+        InternalMachineConfig machineConfig = osEnv.getMachines().get(machineName);
+        addMachineVolumes(workspaceId, claims, podSpec, container, machineConfig);
       }
+    }
+    factory.create(workspaceId).persistentVolumeClaims().createIfNotExist(claims.values());
+  }
+
+  private void addMachineVolumes(
+      String workspaceId,
+      Map<String, PersistentVolumeClaim> claims,
+      PodSpec podSpec,
+      Container container,
+      InternalMachineConfig machineConfig) {
+    if (machineConfig == null || machineConfig.getVolumes().isEmpty()) {
+      return;
+    }
+    for (Entry<String, Volume> volumeEntry : machineConfig.getVolumes().entrySet()) {
+      String volumeName = volumeEntry.getKey();
+      String volumePath = volumeEntry.getValue().getPath();
+      String subPath = workspaceId + '/' + volumeName;
+      String pvcUniqueName = pvcName + '-' + workspaceId + '-' + volumeName;
+
+      container.getVolumeMounts().add(newVolumeMount(pvcUniqueName, volumePath, subPath));
+      claims.put(pvcUniqueName, newPVC(pvcUniqueName, pvcAccessMode, pvcQuantity));
+      addVolumeIfNeeded(podSpec, pvcUniqueName);
     }
   }
 
@@ -101,6 +112,13 @@ public class UniqueWorkspacePVCStrategy implements WorkspacePVCStrategy {
     try (OpenShiftClient client = clientFactory.create()) {
       final String pvcUniqueName = pvcName + '-' + workspaceId;
       client.persistentVolumeClaims().inNamespace(projectName).withName(pvcUniqueName).delete();
+    }
+  }
+
+  private void addVolumeIfNeeded(PodSpec podSpec, String pvcUniqueName) {
+    if (podSpec.getVolumes().stream().noneMatch(volume -> volume.getName().equals(pvcName))) {
+
+      podSpec.getVolumes().add(newVolume(pvcUniqueName, pvcUniqueName));
     }
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleaner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleaner.java
@@ -39,13 +39,13 @@ public class WorkspacePVCCleaner {
 
   private final boolean pvcEnabled;
   private final String projectName;
-  private final WorkspacePVCStrategy strategy;
+  private final WorkspaceVolumesStrategy strategy;
 
   @Inject
   public WorkspacePVCCleaner(
       @Named("che.infra.openshift.pvc.enabled") boolean pvcEnabled,
       @Nullable @Named("che.infra.openshift.project") String projectName,
-      WorkspacePVCStrategy pvcStrategy) {
+      WorkspaceVolumesStrategy pvcStrategy) {
     this.pvcEnabled = pvcEnabled;
     this.projectName = projectName;
     this.strategy = pvcStrategy;
@@ -63,7 +63,7 @@ public class WorkspacePVCCleaner {
                 strategy.cleanup(workspaceId);
               } catch (InfrastructureException ex) {
                 LOG.error(
-                    "Failed to cleanup workspace '{}' data cause: {}",
+                    "Failed to cleanup workspace '{}' data. Cause: {}",
                     workspaceId,
                     ex.getMessage());
               }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspaceVolumeStrategyProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspaceVolumeStrategyProvider.java
@@ -19,22 +19,22 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 /**
- * Provides implementation of {@link WorkspacePVCStrategy} for configured value.
+ * Provides implementation of {@link WorkspaceVolumesStrategy} for configured value.
  *
  * @author Anton Korneta
  */
 @Singleton
-public class WorkspacePVCStrategyProvider implements Provider<WorkspacePVCStrategy> {
+public class WorkspaceVolumeStrategyProvider implements Provider<WorkspaceVolumesStrategy> {
 
-  private final WorkspacePVCStrategy pvcStrategy;
+  private final WorkspaceVolumesStrategy volumeStrategy;
 
   @Inject
-  public WorkspacePVCStrategyProvider(
+  public WorkspaceVolumeStrategyProvider(
       @Named("che.infra.openshift.pvc.strategy") String strategy,
-      Map<String, WorkspacePVCStrategy> strategies) {
-    final WorkspacePVCStrategy pvcStrategy = strategies.get(strategy);
-    if (pvcStrategy != null) {
-      this.pvcStrategy = pvcStrategy;
+      Map<String, WorkspaceVolumesStrategy> strategies) {
+    final WorkspaceVolumesStrategy volumeStrategy = strategies.get(strategy);
+    if (volumeStrategy != null) {
+      this.volumeStrategy = volumeStrategy;
     } else {
       throw new IllegalArgumentException(
           format("Unsupported PVC strategy '%s' configured", strategy));
@@ -42,7 +42,7 @@ public class WorkspacePVCStrategyProvider implements Provider<WorkspacePVCStrate
   }
 
   @Override
-  public WorkspacePVCStrategy get() {
-    return pvcStrategy;
+  public WorkspaceVolumesStrategy get() {
+    return volumeStrategy;
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspaceVolumesStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspaceVolumesStrategy.java
@@ -14,17 +14,17 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 
 /**
- * Defines a basic set of operations for workspace PVC strategies.
+ * Defines a basic set of operations for workspace volume provisioning strategies.
  *
  * @author Anton Korneta
  */
-public interface WorkspacePVCStrategy {
+public interface WorkspaceVolumesStrategy {
 
   /**
-   * Prepares PVC for backup of workspace data on a specific machine and in strategy specific way.
+   * Prepares volumes for backup of workspace data on a specific machine in a strategy specific way.
    *
    * @param osEnv OpenShift environment that changes as a result of preparation
-   * @param workspaceId the workspace identifier for which PVC will be prepared
+   * @param workspaceId the workspace identifier for which volumes will be prepared
    * @throws InfrastructureException when any error while preparation occurs
    */
   void prepare(OpenShiftEnvironment osEnv, String workspaceId) throws InfrastructureException;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/VolumesProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/VolumesProvisioner.java
@@ -16,33 +16,33 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.ConfigurationProvisioner;
 
 /**
- * Provides persistent volume claim into OpenShift environment.
+ * Provisions volumes to OpenShift environment.
  *
  * @author Anton Korneta
  */
 @Singleton
-public class PersistentVolumeClaimProvisioner implements ConfigurationProvisioner {
+public class VolumesProvisioner implements ConfigurationProvisioner {
 
   private final boolean pvcEnable;
-  private final WorkspacePVCStrategy pvcStrategy;
+  private final WorkspaceVolumesStrategy volumesStrategy;
 
   @Inject
-  public PersistentVolumeClaimProvisioner(
+  public VolumesProvisioner(
       @Named("che.infra.openshift.pvc.enabled") boolean pvcEnable,
-      WorkspacePVCStrategy pvcStrategy) {
+      WorkspaceVolumesStrategy volumesStrategy) {
     this.pvcEnable = pvcEnable;
-    this.pvcStrategy = pvcStrategy;
+    this.volumesStrategy = volumesStrategy;
   }
 
   @Override
   public void provision(OpenShiftEnvironment osEnv, RuntimeIdentity runtimeIdentity)
       throws InfrastructureException {
     if (pvcEnable) {
-      pvcStrategy.prepare(osEnv, runtimeIdentity.getWorkspaceId());
+      volumesStrategy.prepare(osEnv, runtimeIdentity.getWorkspaceId());
     }
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -20,7 +20,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.provision.env.EnvVarsC
 import org.eclipse.che.workspace.infrastructure.openshift.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.route.TlsRouteProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.server.ServersConverter;
-import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.PersistentVolumeClaimProvisioner;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.volume.VolumesProvisioner;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class OpenShiftEnvironmentProvisionerTest {
 
-  @Mock private PersistentVolumeClaimProvisioner pvcProvisioner;
+  @Mock private VolumesProvisioner volumesProvisioner;
   @Mock private UniqueNamesProvisioner uniqueNamesProvisioner;
   @Mock private OpenShiftEnvironment osEnv;
   @Mock private RuntimeIdentity runtimeIdentity;
@@ -53,7 +53,7 @@ public class OpenShiftEnvironmentProvisionerTest {
   public void setUp() {
     osInfraProvisioner =
         new OpenShiftEnvironmentProvisioner(
-            pvcProvisioner,
+            volumesProvisioner,
             uniqueNamesProvisioner,
             tlsRouteProvisioner,
             serversProvisioner,
@@ -61,7 +61,7 @@ public class OpenShiftEnvironmentProvisionerTest {
             restartPolicyRewriter);
     provisionOrder =
         inOrder(
-            pvcProvisioner,
+            volumesProvisioner,
             uniqueNamesProvisioner,
             tlsRouteProvisioner,
             serversProvisioner,
@@ -75,8 +75,8 @@ public class OpenShiftEnvironmentProvisionerTest {
 
     provisionOrder.verify(serversProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(envVarsProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(volumesProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(restartPolicyRewriter).provision(eq(osEnv), eq(runtimeIdentity));
-    provisionOrder.verify(pvcProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(uniqueNamesProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(tlsRouteProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verifyNoMoreInteractions();

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/CommonPVCStrategyTest.java
@@ -10,16 +10,16 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.project.pvc;
 
-import static java.util.Collections.emptyMap;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.workspace.shared.Constants.SERVER_WS_AGENT_HTTP_REFERENCE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
@@ -36,7 +36,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
@@ -60,15 +61,25 @@ public class CommonPVCStrategyTest {
   private static final String WORKSPACE_ID = "workspace123";
   private static final String PVC_NAME = "che-claim";
   private static final String POD_NAME = "main";
+  private static final String POD_NAME_2 = "second";
   private static final String CONTAINER_NAME = "app";
-  private static final String MACHINE_NAME = POD_NAME + '/' + CONTAINER_NAME;
+  private static final String CONTAINER_NAME_2 = "db";
+  private static final String CONTAINER_NAME_3 = "app2";
+  private static final String MACHINE_1_NAME = POD_NAME + '/' + CONTAINER_NAME;
+  private static final String MACHINE_2_NAME = POD_NAME + '/' + CONTAINER_NAME_2;
+  private static final String MACHINE_3_NAME = POD_NAME_2 + '/' + CONTAINER_NAME_3;
   private static final String PVC_QUANTITY = "10Gi";
   private static final String PVC_ACCESS_MODE = "RWO";
-  private static final String PROJECT_FOLDER_PATH = "/projects";
+  private static final String VOLUME_1_NAME = "vol1";
+  private static final String VOLUME_2_NAME = "vol2";
 
   @Mock private Pod pod;
+  @Mock private Pod pod2;
   @Mock private PodSpec podSpec;
+  @Mock private PodSpec podSpec2;
   @Mock private Container container;
+  @Mock private Container container2;
+  @Mock private Container container3;
   @Mock private OpenShiftEnvironment osEnv;
   @Mock private PVCSubPathHelper pvcSubPathHelper;
   @Mock private OpenShiftProjectFactory factory;
@@ -80,50 +91,78 @@ public class CommonPVCStrategyTest {
   @BeforeMethod
   public void setup() throws Exception {
     commonPVCStrategy =
-        new CommonPVCStrategy(
-            PVC_NAME,
-            PVC_QUANTITY,
-            PVC_ACCESS_MODE,
-            PROJECT_FOLDER_PATH,
-            pvcSubPathHelper,
-            factory);
-    final InternalMachineConfig machine = mock(InternalMachineConfig.class);
-    when(machine.getServers())
-        .thenReturn(singletonMap(SERVER_WS_AGENT_HTTP_REFERENCE, mock(ServerConfig.class)));
-    when(osEnv.getMachines()).thenReturn(singletonMap(MACHINE_NAME, machine));
+        new CommonPVCStrategy(PVC_NAME, PVC_QUANTITY, PVC_ACCESS_MODE, pvcSubPathHelper, factory);
+
+    Map<String, InternalMachineConfig> machines = new HashMap<>();
+    InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
+    Map<String, Volume> volumes1 = new HashMap<>();
+    volumes1.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
+    volumes1.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
+    when(machine1.getVolumes()).thenReturn(volumes1);
+    machines.put(MACHINE_1_NAME, machine1);
+    InternalMachineConfig machine2 = mock(InternalMachineConfig.class);
+    Map<String, Volume> volumes2 = new HashMap<>();
+    volumes2.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
+    when(machine2.getVolumes()).thenReturn(volumes2);
+    machines.put(MACHINE_2_NAME, machine2);
+    InternalMachineConfig machine3 = mock(InternalMachineConfig.class);
+    Map<String, Volume> volumes3 = new HashMap<>();
+    volumes3.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
+    when(machine3.getVolumes()).thenReturn(volumes3);
+    machines.put(MACHINE_3_NAME, machine3);
+    when(osEnv.getMachines()).thenReturn(machines);
+
+    Map<String, Pod> pods = new HashMap<>();
+    pods.put(POD_NAME, pod);
+    pods.put(POD_NAME_2, pod2);
+    when(osEnv.getPods()).thenReturn(pods);
+
+    when(pod.getSpec()).thenReturn(podSpec);
+    when(pod2.getSpec()).thenReturn(podSpec2);
+    when(podSpec.getContainers()).thenReturn(asList(container, container2));
+    when(podSpec2.getContainers()).thenReturn(singletonList(container3));
+    when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
+    when(podSpec2.getVolumes()).thenReturn(new ArrayList<>());
+    when(container.getName()).thenReturn(CONTAINER_NAME);
+    when(container2.getName()).thenReturn(CONTAINER_NAME_2);
+    when(container3.getName()).thenReturn(CONTAINER_NAME_3);
+    when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
+    when(container2.getVolumeMounts()).thenReturn(new ArrayList<>());
+    when(container3.getVolumeMounts()).thenReturn(new ArrayList<>());
+
     doNothing().when(pvcSubPathHelper).execute(any(), any(), any());
     when(osEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
     when(pvcSubPathHelper.removeDirsAsync(anyString(), any(String.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(factory.create(WORKSPACE_ID)).thenReturn(osProject);
     when(osProject.persistentVolumeClaims()).thenReturn(osPVCs);
-  }
 
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsInfrastructureExceptionWhenMachineWithWsAgentNotFound() throws Exception {
-    when(osEnv.getMachines()).thenReturn(emptyMap());
-
-    commonPVCStrategy.prepare(osEnv, WORKSPACE_ID);
+    mockName(pod, POD_NAME);
+    mockName(pod2, POD_NAME_2);
   }
 
   @Test
   public void addPVCWithConfiguredNameToOsEnv() throws Exception {
-    when(pod.getSpec()).thenReturn(podSpec);
-    mockName(pod, POD_NAME);
     when(osEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
-    when(osEnv.getPods()).thenReturn(singletonMap(POD_NAME, pod));
-    when(podSpec.getContainers()).thenReturn(singletonList(container));
-    when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
-    when(container.getName()).thenReturn(CONTAINER_NAME);
-    when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
 
     commonPVCStrategy.prepare(osEnv, WORKSPACE_ID);
 
-    verify(container).getVolumeMounts();
-    verify(podSpec).getVolumes();
-    verify(pvcSubPathHelper).createDirs(WORKSPACE_ID, WORKSPACE_ID + PROJECT_FOLDER_PATH);
+    // 2 volumes in machine1
+    verify(container, times(2)).getVolumeMounts();
+    verify(container2).getVolumeMounts();
+    verify(container3).getVolumeMounts();
+    // 1 addition + 3 checks because there are 3 volumes in pod
+    verify(podSpec, times(4)).getVolumes();
+    // 1 addition + 1 check
+    verify(podSpec2, times(2)).getVolumes();
+    verify(pvcSubPathHelper)
+        .createDirs(
+            WORKSPACE_ID, expectedVolumeDir(VOLUME_1_NAME), expectedVolumeDir(VOLUME_2_NAME));
     assertFalse(podSpec.getVolumes().isEmpty());
+    assertFalse(podSpec2.getVolumes().isEmpty());
     assertFalse(container.getVolumeMounts().isEmpty());
+    assertFalse(container2.getVolumeMounts().isEmpty());
+    assertFalse(container3.getVolumeMounts().isEmpty());
     assertFalse(osEnv.getPersistentVolumeClaims().isEmpty());
     assertTrue(osEnv.getPersistentVolumeClaims().containsKey(PVC_NAME));
   }
@@ -183,5 +222,9 @@ public class CommonPVCStrategyTest {
     final ObjectMeta objectMeta = mock(ObjectMeta.class);
     when(obj.getMetadata()).thenReturn(objectMeta);
     when(objectMeta.getName()).thenReturn(name);
+  }
+
+  private String expectedVolumeDir(String volumeName) {
+    return WORKSPACE_ID + '/' + volumeName;
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleanerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/WorkspacePVCCleanerTest.java
@@ -41,7 +41,7 @@ public class WorkspacePVCCleanerTest {
   private static final String WORKSPACE_ID = "workspace132";
   private static final String PROJECT_NAME = "che";
 
-  @Mock private WorkspacePVCStrategy pvcStrategy;
+  @Mock private WorkspaceVolumesStrategy pvcStrategy;
   @Mock private EventService eventService;
 
   private WorkspacePVCCleaner workspacePVCCleaner;

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/VolumesProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/volume/VolumesProvisionerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
-import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspacePVCStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -24,25 +24,25 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
- * Tests {@link PersistentVolumeClaimProvisioner}.
+ * Tests {@link VolumesProvisioner}.
  *
  * @author Anton Korneta
  */
 @Listeners(MockitoTestNGListener.class)
-public class PersistentVolumeClaimProvisionerTest {
+public class VolumesProvisionerTest {
 
   private static final String WORKSPACE_ID = "workspace132";
 
   @Mock private OpenShiftEnvironment osEnv;
   @Mock private RuntimeIdentity runtimeIdentity;
-  @Mock private WorkspacePVCStrategy pvcStrategy;
+  @Mock private WorkspaceVolumesStrategy volumeStrategy;
 
-  private PersistentVolumeClaimProvisioner provisioner;
+  private VolumesProvisioner provisioner;
 
   @BeforeMethod
   public void setup() {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
-    provisioner = new PersistentVolumeClaimProvisioner(false, pvcStrategy);
+    provisioner = new VolumesProvisioner(false, volumeStrategy);
   }
 
   @Test
@@ -55,9 +55,9 @@ public class PersistentVolumeClaimProvisionerTest {
 
   @Test
   public void testPrepareWorkspacePVCUsingConfiguredStrategy() throws Exception {
-    provisioner = new PersistentVolumeClaimProvisioner(true, pvcStrategy);
+    provisioner = new VolumesProvisioner(true, volumeStrategy);
     provisioner.provision(osEnv, runtimeIdentity);
 
-    verify(pvcStrategy).prepare(osEnv, WORKSPACE_ID);
+    verify(volumeStrategy).prepare(osEnv, WORKSPACE_ID);
   }
 }

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/resources/META-INF/persistence.xml
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/resources/META-INF/persistence.xml
@@ -29,6 +29,7 @@
         <class>org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.VolumeImpl</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl</class>
 
         <class>org.eclipse.che.api.workspace.server.model.impl.CommandImpl</class>

--- a/multiuser/integration-tests/che-multiuser-postgresql-tck/src/test/resources/META-INF/persistence.xml
+++ b/multiuser/integration-tests/che-multiuser-postgresql-tck/src/test/resources/META-INF/persistence.xml
@@ -30,6 +30,7 @@
         <class>org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl</class>
         <class>org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl</class>
+        <class>org.eclipse.che.api.workspace.server.model.impl.VolumeImpl</class>
 
         <class>org.eclipse.che.api.workspace.server.model.impl.CommandImpl</class>
         <class>org.eclipse.che.workspace.infrastructure.docker.snapshot.MachineSourceImpl</class>

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/WorkspaceTckModule.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/WorkspaceTckModule.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
@@ -75,7 +76,8 @@ public class WorkspaceTckModule extends TckModule {
                 ServerConfigImpl.class,
                 StackImpl.class,
                 CommandImpl.class,
-                RecipeImpl.class)
+                RecipeImpl.class,
+                VolumeImpl.class)
             .addEntityClass(
                 "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
             .setExceptionHandler(H2ExceptionHandler.class)

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaTckModule.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaTckModule.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
@@ -67,7 +68,8 @@ public class JpaTckModule extends TckModule {
                 ServerConfigImpl.class,
                 StackImpl.class,
                 CommandImpl.class,
-                RecipeImpl.class)
+                RecipeImpl.class,
+                VolumeImpl.class)
             .addEntityClass(
                 "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
             .setExceptionHandler(H2ExceptionHandler.class)

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/jpa/FactoryTckModule.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/jpa/FactoryTckModule.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.commons.test.db.H2DBTestServer;
 import org.eclipse.che.commons.test.db.H2JpaCleaner;
@@ -75,7 +76,8 @@ public class FactoryTckModule extends TckModule {
                 MachineConfigImpl.class,
                 SourceStorageImpl.class,
                 ServerConfigImpl.class,
-                CommandImpl.class)
+                CommandImpl.class,
+                VolumeImpl.class)
             .addEntityClass(
                 "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
             .setExceptionHandler(H2ExceptionHandler.class)

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/MachineConfigDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/MachineConfigDto.java
@@ -52,4 +52,12 @@ public interface MachineConfigDto extends MachineConfig {
   void setAttributes(Map<String, String> attributes);
 
   MachineConfigDto withAttributes(Map<String, String> attributes);
+
+  @Override
+  @FactoryParameter(obligation = OPTIONAL)
+  Map<String, VolumeDto> getVolumes();
+
+  void setVolumes(Map<String, VolumeDto> volumes);
+
+  MachineConfigDto withVolumes(Map<String, VolumeDto> volumes);
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/VolumeDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/VolumeDto.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.shared.dto;
+
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.dto.shared.DTO;
+
+/** @author Alexander Garagatyi */
+@DTO
+public interface VolumeDto extends Volume {
+  @Override
+  String getPath();
+
+  void setPath(String path);
+
+  VolumeDto withPath(String path);
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -26,6 +26,7 @@ import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.ProjectConfig;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.config.SourceStorage;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
@@ -41,6 +42,7 @@ import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
 import org.eclipse.che.api.workspace.shared.dto.ServerConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.ServerDto;
 import org.eclipse.che.api.workspace.shared.dto.SourceStorageDto;
+import org.eclipse.che.api.workspace.shared.dto.VolumeDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.stack.StackComponentDto;
@@ -204,6 +206,14 @@ public final class DtoConverter {
     if (machine.getAttributes() != null) {
       machineDto.setAttributes(machine.getAttributes());
     }
+    if (machine.getVolumes() != null) {
+      machineDto.setVolumes(
+          machine
+              .getVolumes()
+              .entrySet()
+              .stream()
+              .collect(toMap(Map.Entry::getKey, entry -> asDto(entry.getValue()))));
+    }
     return machineDto;
   }
 
@@ -252,6 +262,11 @@ public final class DtoConverter {
         .withWorkspaceId(identity.getWorkspaceId())
         .withEnvName(identity.getEnvName())
         .withOwner(identity.getOwner());
+  }
+
+  /** Converts {@link Volume} to {@link VolumeDto}. */
+  public static VolumeDto asDto(Volume volume) {
+    return newDto(VolumeDto.class).withPath(volume.getPath());
   }
 
   private DtoConverter() {}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -17,7 +17,9 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.eclipse.che.api.core.model.workspace.Runtime;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Command;
@@ -43,6 +45,7 @@ import org.eclipse.che.api.workspace.shared.dto.ServerConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.ServerDto;
 import org.eclipse.che.api.workspace.shared.dto.SourceStorageDto;
 import org.eclipse.che.api.workspace.shared.dto.VolumeDto;
+import org.eclipse.che.api.workspace.shared.dto.WarningDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.stack.StackComponentDto;
@@ -50,7 +53,6 @@ import org.eclipse.che.api.workspace.shared.dto.stack.StackDto;
 import org.eclipse.che.api.workspace.shared.dto.stack.StackSourceDto;
 import org.eclipse.che.api.workspace.shared.stack.Stack;
 import org.eclipse.che.api.workspace.shared.stack.StackSource;
-import org.eclipse.che.dto.server.DtoFactory;
 
 /**
  * Helps to convert to/from DTOs related to workspace.
@@ -253,12 +255,14 @@ public final class DtoConverter {
     }
 
     runtimeDto.setMachines(machineDtos);
+    runtimeDto.setWarnings(
+        runtime.getWarnings().stream().map(DtoConverter::asDto).collect(Collectors.toList()));
     return runtimeDto;
   }
 
   /** Converts {@link RuntimeIdentity} to {@link RuntimeIdentityDto}. */
   public static RuntimeIdentityDto asDto(RuntimeIdentity identity) {
-    return DtoFactory.newDto(RuntimeIdentityDto.class)
+    return newDto(RuntimeIdentityDto.class)
         .withWorkspaceId(identity.getWorkspaceId())
         .withEnvName(identity.getEnvName())
         .withOwner(identity.getOwner());
@@ -267,6 +271,11 @@ public final class DtoConverter {
   /** Converts {@link Volume} to {@link VolumeDto}. */
   public static VolumeDto asDto(Volume volume) {
     return newDto(VolumeDto.class).withPath(volume.getPath());
+  }
+
+  /** Converts {@link Warning} to {@link WarningDto}. */
+  public static WarningDto asDto(Warning warning) {
+    return newDto(WarningDto.class).withCode(warning.getCode()).withMessage(warning.getMessage());
   }
 
   private DtoConverter() {}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -232,6 +232,7 @@ public class WorkspaceManager {
       throws ConflictException, ServerException, NotFoundException, ValidationException {
     requireNonNull(id, "Required non-null workspace id");
     requireNonNull(update, "Required non-null workspace update");
+    requireNonNull(update.getConfig(), "Required non-null workspace configuration update");
     validator.validateConfig(update.getConfig());
     validator.validateAttributes(update.getAttributes());
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.core.model.workspace.config.Command;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.Recipe;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
 /**
@@ -44,6 +45,9 @@ public class WorkspaceValidator {
    */
   private static final Pattern WS_NAME =
       Pattern.compile("[a-zA-Z0-9][-_.a-zA-Z0-9]{1,98}[a-zA-Z0-9]");
+
+  private static final Pattern VOLUME_NAME = Pattern.compile("[a-z][a-z0-9]{1,18}");
+  private static final Pattern VOLUME_PATH = Pattern.compile("/.+");
 
   private final WorkspaceRuntimes runtimes;
 
@@ -145,6 +149,27 @@ public class WorkspaceValidator {
                 "Value '%s' of attribute '%s' in machine '%s' is illegal",
                 memoryAttribute, MEMORY_LIMIT_ATTRIBUTE, name));
       }
+    }
+
+    for (Entry<String, ? extends Volume> volumeEntry : machine.getVolumes().entrySet()) {
+      String volumeName = volumeEntry.getKey();
+      check(
+          VOLUME_NAME.matcher(volumeName).matches(),
+          "Volume name '%s' in machine '%s' is invalid",
+          volumeName,
+          name);
+      Volume volume = volumeEntry.getValue();
+      check(
+          volume != null && !isNullOrEmpty(volume.getPath()),
+          "Path of volume '%s' in machine '%s' is invalid. It should not be empty",
+          volumeName,
+          name);
+      check(
+          VOLUME_PATH.matcher(volume.getPath()).matches(),
+          "Path '%s' of volume '%s' in machine '%s' is invalid. It should be absolute",
+          volume.getPath(),
+          volumeName,
+          name);
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/VolumeImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/VolumeImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.model.impl;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+
+/** @author Alexander Garagatyi */
+@Entity(name = "MachineVolume")
+@Table(name = "machine_volume")
+public class VolumeImpl implements Volume {
+
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "path")
+  private String path;
+
+  public VolumeImpl() {}
+
+  public VolumeImpl(Volume value) {
+    path = value.getPath();
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public VolumeImpl withPath(String path) {
+    this.path = path;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof VolumeImpl)) {
+      return false;
+    }
+    VolumeImpl volume = (VolumeImpl) o;
+    return Objects.equals(id, volume.id) && Objects.equals(getPath(), volume.getPath());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, getPath());
+  }
+
+  @Override
+  public String toString() {
+    return "VolumeImpl{" + "id=" + id + ", path='" + path + '\'' + '}';
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -103,7 +103,8 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
               installers,
               normalizeServers(machineConfig.getServers()),
               machineConfig.getEnv(),
-              machineConfig.getAttributes()));
+              machineConfig.getAttributes(),
+              machineConfig.getVolumes()));
     }
 
     machinesValidator.validate(machines);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
@@ -36,12 +37,14 @@ public class InternalMachineConfig {
   private final Map<String, ServerConfig> servers;
   private final Map<String, String> env;
   private final Map<String, String> attributes;
+  private final Map<String, Volume> volumes;
 
   InternalMachineConfig(
       List<Installer> installers,
       Map<String, ? extends ServerConfig> servers,
       Map<String, String> env,
-      Map<String, String> attributes)
+      Map<String, String> attributes,
+      Map<String, ? extends Volume> volumes)
       throws InfrastructureException {
     this.servers = new HashMap<>();
     if (servers != null) {
@@ -61,6 +64,11 @@ public class InternalMachineConfig {
     this.attributes = new HashMap<>();
     if (attributes != null) {
       this.attributes.putAll(attributes);
+    }
+
+    this.volumes = new HashMap<>();
+    if (volumes != null) {
+      this.volumes.putAll(volumes);
     }
   }
 
@@ -82,5 +90,10 @@ public class InternalMachineConfig {
   /** Returns modifiable map of machine attributes. */
   public Map<String, String> getAttributes() {
     return attributes;
+  }
+
+  /** Returns modifiable map of machine volumes. */
+  public Map<String, Volume> getVolumes() {
+    return volumes;
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisioner.java
@@ -27,16 +27,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Applies OpenShift specific properties of the installers to {@link InternalMachineConfig}.
+ * Applies properties of the installers to {@link InternalMachineConfig}.
  *
  * <p>This class must be called before environment is started, otherwise changing configuration has
  * no effect.
  *
  * <p>This class performs following changes to environment: <br>
- * - adds environment variables which are specified in properties of installer configuration. The
- * environment property contains environment variables in the following format:
- * "env1=value1,env2=value2,..."; <br>
- * - add servers that is declared by configure installers.
+ * - adds environment variables defined in properties of installers configuration. The environment
+ * property contains environment variables in the following format: "env1=value1,env2=value2,...";
+ * <br>
+ * - add servers defined in installers configuration.
  *
  * @author Sergii Leshchenko
  */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/ProjectsVolumeForWsAgentProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/ProjectsVolumeForWsAgentProvisioner.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.spi.provision;
+
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+
+/**
+ * Adds projects volumes to a machine with 'ws-agent' server.
+ *
+ * @author Alexander Garagatyi
+ */
+public class ProjectsVolumeForWsAgentProvisioner implements InternalEnvironmentProvisioner {
+  public static final String PROJECTS_VOLUME_NAME = "projects";
+
+  private final String projectFolderPath;
+
+  @Inject
+  public ProjectsVolumeForWsAgentProvisioner(
+      @Named("che.workspace.projects.storage") String projectFolderPath) {
+    this.projectFolderPath =
+        projectFolderPath.startsWith("/") ? projectFolderPath : "/" + projectFolderPath;
+  }
+
+  @Override
+  public void provision(RuntimeIdentity id, InternalEnvironment internalEnvironment)
+      throws InfrastructureException {
+
+    Optional<String> wsAgentServerMachine =
+        WsAgentMachineFinderUtil.getWsAgentServerMachine(internalEnvironment);
+
+    if (wsAgentServerMachine.isPresent()) {
+      InternalMachineConfig machineConfig =
+          internalEnvironment.getMachines().get(wsAgentServerMachine.get());
+      machineConfig
+          .getVolumes()
+          .put(PROJECTS_VOLUME_NAME, new VolumeImpl().withPath(projectFolderPath));
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -558,7 +558,8 @@ public class WorkspaceManagerTest {
             singletonList("org.eclipse.che.ws-agent"),
             null,
             singletonMap("CHE_ENV", "value"),
-            singletonMap(MEMORY_LIMIT_ATTRIBUTE, "10000"));
+            singletonMap(MEMORY_LIMIT_ATTRIBUTE, "10000"),
+            emptyMap());
     EnvironmentImpl environment =
         new EnvironmentImpl(
             new RecipeImpl("type", "contentType", "content", null),

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -915,7 +915,8 @@ public class WorkspaceServiceTest {
             singletonList("org.eclipse.che.ws-agent"),
             null,
             singletonMap("CHE_ENV", "value"),
-            singletonMap(MEMORY_LIMIT_ATTRIBUTE, "10000"));
+            singletonMap(MEMORY_LIMIT_ATTRIBUTE, "10000"),
+            emptyMap());
 
     return DtoConverter.asDto(
         new EnvironmentImpl(

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
@@ -61,7 +62,8 @@ public class WorkspaceTckModule extends TckModule {
                 ServerConfigImpl.class,
                 StackImpl.class,
                 CommandImpl.class,
-                RecipeImpl.class)
+                RecipeImpl.class,
+                VolumeImpl.class)
             .addEntityClass(
                 "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
             .setExceptionHandler(H2ExceptionHandler.class)

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
@@ -115,7 +115,7 @@ public class InternalEnvironmentFactoryTest {
     doReturn(normalizedServers).when(environmentFactory).normalizeServers(any());
 
     ImmutableMap<String, ServerConfigImpl> sourceServers = ImmutableMap.of("server", server);
-    MachineConfigImpl machineConfig = new MachineConfigImpl(null, sourceServers, null, null);
+    MachineConfigImpl machineConfig = new MachineConfigImpl(null, sourceServers, null, null, null);
 
     EnvironmentImpl env =
         new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig), null);
@@ -138,7 +138,7 @@ public class InternalEnvironmentFactoryTest {
     ImmutableMap<String, String> sourceEnv = ImmutableMap.of("CHE_API", "localhost");
     ImmutableMap<String, String> sourceAttributes = ImmutableMap.of("attribute", "value");
     MachineConfigImpl machineConfig =
-        new MachineConfigImpl(null, null, sourceEnv, sourceAttributes);
+        new MachineConfigImpl(null, null, sourceEnv, sourceAttributes, null);
 
     EnvironmentImpl env =
         new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig), sourceWarnings);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -46,6 +46,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
@@ -554,6 +555,12 @@ public class WorkspaceDaoTest {
     exMachine1.setInstallers(ImmutableList.of("agent5", "agent4"));
     exMachine1.setAttributes(singletonMap("att1", "val"));
     exMachine1.setEnv(ImmutableMap.of("CHE_ENV1", "value", "CHE_ENV2", "value"));
+    exMachine1.setVolumes(
+        ImmutableMap.of(
+            "vol1",
+            new VolumeImpl().withPath("/path/1"),
+            "vol2",
+            new VolumeImpl().withPath("/path/2")));
 
     final MachineConfigImpl exMachine2 = new MachineConfigImpl();
     final ServerConfigImpl serverConf3 = new ServerConfigImpl("2333", "https", "path3");
@@ -562,6 +569,7 @@ public class WorkspaceDaoTest {
     exMachine2.setInstallers(ImmutableList.of("agent2", "agent1"));
     exMachine2.setAttributes(singletonMap("att1", "val"));
     exMachine2.setEnv(singletonMap("CHE_ENV2", "value"));
+    exMachine2.setVolumes(ImmutableMap.of("vol2", new VolumeImpl().withPath("/path/2")));
 
     final MachineConfigImpl exMachine3 = new MachineConfigImpl();
     final ServerConfigImpl serverConf5 = new ServerConfigImpl("2333", "https", "path5");
@@ -569,6 +577,7 @@ public class WorkspaceDaoTest {
     exMachine3.setInstallers(ImmutableList.of("agent6", "agent2"));
     exMachine3.setAttributes(singletonMap("att1", "val"));
     exMachine3.setEnv(singletonMap("CHE_ENV3", "value"));
+    exMachine3.setVolumes(ImmutableMap.of("vol3", new VolumeImpl().withPath("/path/3")));
 
     // Environments
     final RecipeImpl recipe1 = new RecipeImpl();

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.0.0/7__add_machine_volumes.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.0.0/7__add_machine_volumes.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright (c) 2012-2017 Red Hat, Inc.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+-- Machine volumes configuration -----------------------------------------------
+CREATE TABLE machine_volume (
+    id              BIGINT          NOT NULL,
+    name            VARCHAR(255),
+    path            VARCHAR(255)    NOT NULL,
+    machine_id      BIGINT,
+
+    PRIMARY KEY (id)
+);
+--constraints
+ALTER TABLE machine_volume ADD CONSTRAINT fk_machine_volume_id FOREIGN KEY (machine_id) REFERENCES externalmachine (id);
+--------------------------------------------------------------------------------
+--indexes
+CREATE INDEX index_machine_volume_machine_id ON machine_volume (machine_id);

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
@@ -71,6 +71,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
@@ -160,7 +161,8 @@ public class CascadeRemovalTest {
                             StackImpl.class,
                             CommandImpl.class,
                             RecipeImpl.class,
-                            SshPairImpl.class)
+                            SshPairImpl.class,
+                            VolumeImpl.class)
                         .addEntityClass(
                             "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
                         .setExceptionHandler(H2ExceptionHandler.class)

--- a/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
+++ b/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
@@ -50,6 +50,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
@@ -116,7 +117,8 @@ public class PostgreSqlTckModule extends TckModule {
                 CommandImpl.class,
                 SshPairImpl.class,
                 InstallerImpl.class,
-                InstallerServerConfigImpl.class)
+                InstallerServerConfigImpl.class,
+                VolumeImpl.class)
             .addEntityClass(
                 "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
             .build());


### PR DESCRIPTION
### What does this PR do?
I recommend reviewing this PR commit by commit. 
Adds an ability to specify additional volumes in Machine configuration (inside of Workspace configuration).
Che6 model of MachineConfig: 
```
{
    "servers" : ...
    "attributes" : ...
    "env" : ...
    "installers" : ...
}
```
Model of MachineConfig in this PR: 
```
{
    "servers" : ...
    "attributes" : ...
    "env" : ...
    "installers" : ...
    "volumes" : {
        "myvolume" : {
            "path" : "/some/path/in/container"
        }
    }
}
```
where field `volumes` contains volumes names as keys and volume object as value. 
Volume object contains the path of volume in the machine.
Here are some additional details that may be useful to write docs and implement UI for volumes:
- field 'path' in volume object contains the absolute path in the machine, so should start from '/'
- folders that don’t exist in the container before machine start get root access level which may lead to some errors, issues for a user. A user might want to create appropriate folders in the image before adding mounts for them.
- this PR doesn't provide UI for adding volumes, but they can be added using API or editing workspace config on UD.
- when volume with the same name is used in different machines it is treated as a volume shared between those machines. This provides sharing data between machines.
- volumes in the environment recipe are still not allowed.
- there is no sharing of volumes between workspaces since they are workspace-scoped. 

Further improvements:
- this PR doesn't add volumes to installers but it might be useful because in this case, we won't need code that adds projects volume to a machine with the ws-agent server - an installer will request volumes it needs. Should we create an issue for this change?
- maybe we should declare volumes on the environment level to declare these volumes and use it in machines. This would more explicitly show sharing of volumes between machines. Should we do that?
- there is no ability to mount a particular folder on Docker host to a machine volume for now. It is not clear whether it is needed and how this fits cloud-native tooling approach. 
- do we want to add support for usage of volumes from the recipe? What pros and cons?
- add UI for volumes management.
- add warnings if volumes conf may prevent runtime start. This is interesting for the OpenShift environment in particular. For example, volumes declared shared between machines from different pods may lead to runtime strat failure in most cases. Whether start will fail or not depends on read-write access settings of OpenShift volumes infrastructure, pods scheduling. 


### What issues does this PR fix or reference?
Fixes #7010 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
