### PR TITLE
findResource method refactoring related to hierarchical load resourcetree

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.ide.resources.impl;
 
 import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Optional.of;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -103,6 +102,7 @@ import org.eclipse.che.ide.util.Arrays;
  */
 @Beta
 public final class ResourceManager {
+
   /** Describes zero depth level for the descendants. */
   private static final int DEPTH_ZERO = 0;
 
@@ -333,30 +333,28 @@ public final class ResourceManager {
   Promise<Folder> createFolder(final Container parent, final String name) {
     final Path path = Path.valueOf(name);
 
-    return findResource(parent.getLocation().append(path), true)
+    Optional<Resource> existed = store.getResource(parent.getLocation().append(name));
+
+    if (existed.isPresent()) {
+      return promises.reject(new IllegalStateException("Resource already exists"));
+    }
+
+    if (parent.getLocation().isRoot()) {
+      return promises.reject(
+          new IllegalArgumentException("Failed to create folder in workspace root"));
+    }
+
+    if (path.segmentCount() == 1 && !checkFolderName(name)) {
+      return promises.reject(new IllegalArgumentException("Invalid folder name"));
+    }
+
+    return ps.createFolder(parent.getLocation().append(name))
         .thenPromise(
-            resource -> {
-              if (resource.isPresent()) {
-                return promises.reject(new IllegalStateException("Resource already exists"));
-              }
+            reference -> {
+              final Resource createdFolder = newResourceFrom(reference);
+              store.register(createdFolder);
 
-              if (parent.getLocation().isRoot()) {
-                return promises.reject(
-                    new IllegalArgumentException("Failed to create folder in workspace root"));
-              }
-
-              if (path.segmentCount() == 1 && !checkFolderName(name)) {
-                return promises.reject(new IllegalArgumentException("Invalid folder name"));
-              }
-
-              return ps.createFolder(parent.getLocation().append(name))
-                  .thenPromise(
-                      reference -> {
-                        final Resource createdFolder = newResourceFrom(reference);
-                        store.register(createdFolder);
-
-                        return promises.resolve(createdFolder.asFolder());
-                      });
+              return promises.resolve(createdFolder.asFolder());
             });
   }
 
@@ -365,26 +363,24 @@ public final class ResourceManager {
       return promises.reject(new IllegalArgumentException("Invalid file name"));
     }
 
-    return findResource(parent.getLocation().append(name), true)
+    Optional<Resource> existed = store.getResource(parent.getLocation().append(name));
+
+    if (existed.isPresent()) {
+      return promises.reject(new IllegalStateException("Resource already exists"));
+    }
+
+    if (parent.getLocation().isRoot()) {
+      return promises.reject(
+          new IllegalArgumentException("Failed to create file in workspace root"));
+    }
+
+    return ps.createFile(parent.getLocation().append(name), content)
         .thenPromise(
-            resource -> {
-              if (resource.isPresent()) {
-                return promises.reject(new IllegalStateException("Resource already exists"));
-              }
+            reference -> {
+              final Resource createdFile = newResourceFrom(reference);
+              store.register(createdFile);
 
-              if (parent.getLocation().isRoot()) {
-                return promises.reject(
-                    new IllegalArgumentException("Failed to create file in workspace root"));
-              }
-
-              return ps.createFile(parent.getLocation().append(name), content)
-                  .thenPromise(
-                      reference -> {
-                        final Resource createdFile = newResourceFrom(reference);
-                        store.register(createdFile);
-
-                        return promises.resolve(createdFile.asFile());
-                      });
+              return promises.resolve(createdFile.asFile());
             });
   }
 
@@ -767,6 +763,7 @@ public final class ResourceManager {
               public Resource[] apply(TreeElement tree) throws FunctionException {
 
                 class Visitor implements ResourceVisitor {
+
                   Resource[] resources;
 
                   private int size = 0; // size of total items
@@ -944,28 +941,42 @@ public final class ResourceManager {
     }
   }
 
-  private Promise<Optional<Resource>> findResource(final Path absolutePath, boolean quiet) {
-    return ps.getItem(absolutePath)
+  private Promise<Optional<Resource>> doFindResource(Path path) {
+    return ps.getTree(path.parent(), 1, true)
         .thenPromise(
-            itemReference -> {
-              final Resource resource = newResourceFrom(itemReference);
+            treeElement -> {
+              Resource resource = null;
 
-              store.register(resource);
+              for (TreeElement nodeElement : treeElement.getChildren()) {
+                ItemReference reference = nodeElement.getNode();
+                Resource tempResource = newResourceFrom(reference);
+                store.register(tempResource);
 
-              if (resource.isProject()) {
-                inspectProject(resource.asProject());
+                if (tempResource.isProject()) {
+                  inspectProject(tempResource.asProject());
+                }
+
+                if (tempResource.getLocation().equals(path)) {
+                  resource = tempResource;
+                }
               }
 
-              return promises.resolve(fromNullable(resource));
+              return promises.resolve(Optional.fromNullable(resource));
             })
-        .catchErrorPromise(
-            arg -> {
-              if (!quiet) {
-                throw new IllegalStateException(arg.getCause());
-              }
+        .catchErrorPromise(error -> promises.resolve(absent()));
+  }
 
-              return promises.resolve(absent());
-            });
+  private Promise<Optional<Resource>> findResource(final Path absolutePath, boolean quiet) {
+    String[] segments = absolutePath.segments();
+
+    Promise<Optional<Resource>> chain = promises.resolve(null);
+
+    for (int i = 0; i <= segments.length; i++) {
+      Path pathToRetrieve = absolutePath.removeLastSegments(segments.length - i);
+      chain = chain.thenPromise(__ -> doFindResource(pathToRetrieve));
+    }
+
+    return chain;
   }
 
   private Promise<Optional<Resource>> findResourceForExternalOperation(
@@ -1328,10 +1339,12 @@ public final class ResourceManager {
   }
 
   interface ResourceVisitor {
+
     void visit(Resource resource);
   }
 
   public interface ResourceFactory {
+
     ProjectImpl newProjectImpl(ProjectConfig reference, ResourceManager resourceManager);
 
     FolderImpl newFolderImpl(Path path, ResourceManager resourceManager);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -973,7 +973,7 @@ public final class ResourceManager {
 
     for (int i = 0; i <= segments.length; i++) {
       Path pathToRetrieve = absolutePath.removeLastSegments(segments.length - i);
-      chain = chain.thenPromise(__ -> doFindResource(pathToRetrieve));
+      chain = chain.thenPromise(ignored -> doFindResource(pathToRetrieve));
     }
 
     return chain;

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
@@ -11,8 +11,8 @@
 package org.eclipse.che.ide.ui.smartTree;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Comparator.comparingInt;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.gwt.event.shared.EventHandler;
@@ -28,14 +28,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
-import org.eclipse.che.api.promises.client.Function;
-import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.ide.ui.smartTree.Tree.Joint;
 import org.eclipse.che.ide.ui.smartTree.data.Node;
 import org.eclipse.che.ide.ui.smartTree.data.NodeInterceptor;
 import org.eclipse.che.ide.ui.smartTree.event.BeforeLoadEvent;
@@ -73,12 +71,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
   private Set<NodeInterceptor> nodeInterceptors;
 
   private final Comparator<NodeInterceptor> priorityComparator =
-      new Comparator<NodeInterceptor>() {
-        @Override
-        public int compare(NodeInterceptor o1, NodeInterceptor o2) {
-          return o1.getPriority() - o2.getPriority();
-        }
-      };
+      comparingInt(NodeInterceptor::getPriority);
 
   /**
    * When caching is on nodes will be loaded from cache if they exist otherwise nodes will be loaded
@@ -104,7 +97,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
 
       // remove joint element if non-leaf node doesn't have any children
       if (!parent.isLeaf() && event.getReceivedNodes().isEmpty()) {
-        tree.getView().onJointChange(tree.getNodeDescriptor(parent), Tree.Joint.NONE);
+        tree.getView().onJointChange(tree.getNodeDescriptor(parent), Joint.EXPANDED);
       }
 
       NodeDescriptor requested = tree.getNodeDescriptor(parent);
@@ -140,7 +133,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
       // Iterate on nested descendants to make additional load request
       if (childRequested.remove(parent)) {
         for (Node node : tree.getNodeStorage().getChildren(parent)) {
-          if (tree.isExpanded(node)) {
+          if (tree.isExpanded(node) && !tree.getNodeDescriptor(node).getChildren().isEmpty()) {
             loadChildren(node, true);
           }
         }
@@ -187,16 +180,13 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
     Iterable<Node> newItems =
         Iterables.filter(
             loadedChildren,
-            new Predicate<Node>() {
-              @Override
-              public boolean apply(Node loadedChild) {
-                for (NodeDescriptor nodeDescriptor : existed) {
-                  if (nodeDescriptor.getNode().equals(loadedChild)) {
-                    return false;
-                  }
+            loadedChild -> {
+              for (NodeDescriptor nodeDescriptor : existed) {
+                if (nodeDescriptor.getNode().equals(loadedChild)) {
+                  return false;
                 }
-                return true;
               }
+              return true;
             });
 
     return Lists.newArrayList(newItems);
@@ -213,17 +203,14 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
     Iterable<NodeDescriptor> removedItems =
         Iterables.filter(
             existed,
-            new Predicate<NodeDescriptor>() {
-              @Override
-              public boolean apply(NodeDescriptor existedChild) {
-                boolean found = false;
-                for (Node loadedChild : loadedChildren) {
-                  if (existedChild.getNode().equals(loadedChild)) {
-                    found = true;
-                  }
+            existedChild -> {
+              boolean found = false;
+              for (Node loadedChild : loadedChildren) {
+                if (existedChild.getNode().equals(loadedChild)) {
+                  found = true;
                 }
-                return !found;
               }
+              return !found;
             });
 
     return Lists.newArrayList(removedItems);
@@ -266,14 +253,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
    * @return true if node has children, otherwise false
    */
   public Promise<Boolean> hasChildren(@NotNull Node node) {
-    return node.getChildren(false)
-        .thenPromise(
-            new Function<List<Node>, Promise<Boolean>>() {
-              @Override
-              public Promise<Boolean> apply(List<Node> children) throws FunctionException {
-                return Promises.resolve(!children.isEmpty());
-              }
-            });
+    return node.getChildren(false).thenPromise(children -> Promises.resolve(!children.isEmpty()));
   }
 
   /**
@@ -310,12 +290,9 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
    */
   @NotNull
   private Operation<PromiseError> onLoadFailure(@NotNull final Node parent) {
-    return new Operation<PromiseError>() {
-      @Override
-      public void apply(PromiseError t) throws OperationException {
-        childRequested.remove(parent);
-        fireEvent(new LoadExceptionEvent(parent, t.getCause()));
-      }
+    return error -> {
+      childRequested.remove(parent);
+      fireEvent(new LoadExceptionEvent(parent, error.getCause()));
     };
   }
 
@@ -386,18 +363,15 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
    */
   @NotNull
   private Operation<List<Node>> interceptChildren(@NotNull final Node parent) {
-    return new Operation<List<Node>>() {
-      @Override
-      public void apply(List<Node> children) throws OperationException {
-        if (nodeInterceptors.isEmpty()) {
-          onLoadSuccess(parent, children);
-        }
-
-        LinkedList<NodeInterceptor> sortedByPriorityQueue = new LinkedList<>(nodeInterceptors);
-        Collections.sort(sortedByPriorityQueue, priorityComparator);
-
-        iterate(sortedByPriorityQueue, parent, children);
+    return children -> {
+      if (nodeInterceptors.isEmpty()) {
+        onLoadSuccess(parent, children);
       }
+
+      LinkedList<NodeInterceptor> sortedByPriorityQueue = new LinkedList<>(nodeInterceptors);
+      sortedByPriorityQueue.sort(priorityComparator);
+
+      iterate(sortedByPriorityQueue, parent, children);
     };
   }
 
@@ -416,11 +390,8 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
     interceptor
         .intercept(parent, children)
         .then(
-            new Operation<List<Node>>() {
-              @Override
-              public void apply(List<Node> arg) throws OperationException {
-                iterate(deque, parent, arg);
-              }
+            childrenList -> {
+              iterate(deque, parent, childrenList);
             });
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/Tree.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/Tree.java
@@ -622,12 +622,6 @@ public class Tree extends FocusWidget
       return Joint.NONE;
     }
 
-    if (getNodeDescriptor(node) != null
-        && getNodeDescriptor(node).isLoaded()
-        && nodeStorage.getChildCount(node) == 0) {
-      return Joint.NONE;
-    }
-
     return getNodeDescriptor(node).isExpanded() ? Joint.EXPANDED : Joint.COLLAPSED;
   }
 


### PR DESCRIPTION
### What does this PR do?
This changes proposal modifies the load resources from the server. As Resource Manager uses internal storage for caching loaded file resources we need to take in account that situation, when user request from the server file for example with path `/project/a/b/file.ext` then resource manager should get single tree to the file path. It means that resource manager should call and cache (if need) tree `/project`, then tree `/project/a`, then tree `/project/a/b` and find `file.ext` inside `b` directory.

Back port of https://github.com/eclipse/che/pull/7250

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#7128 

#### Changelog
findResource method refactoring related to hierarchical load resource tree

#### Release Notes
N/A

#### Docs PR
N/A
