### PR TITLE
Fix samples.json loading

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -311,11 +311,11 @@ init() {
     rm -rf "${CHE_DATA}"/stacks
   fi
 
-  if [[ ! -f "${CHE_DATA}"/templates/samples.json ]];then
-    rm -rf "${CHE_DATA}"/templates/*
-    mkdir -p "${CHE_DATA}"/templates
-    cp -rf "${CHE_HOME}"/templates/* "${CHE_DATA}"/templates
-  fi
+  # replace samples.json each run to make sure that we are using corrent samples from the assembly.
+  # also it allows users to store their own samples which should not be touched by us.
+  mkdir -p "${CHE_DATA}"/templates
+  rm -rf "${CHE_DATA}"/templates/samples.json
+  cp -rf "${CHE_HOME}"/templates/* "${CHE_DATA}"/templates
 
   # A che property, which names the Docker network used for che + ws to communicate
   if [ -z "$CHE_DOCKER_NETWORK" ]; then


### PR DESCRIPTION
fixes: https://github.com/eclipse/che/issues/7057

We have an issue that new samples added to default samples.json in newversion won't be loaded after update. That PR makes sure that on each run of che-server it will use accurate samples right from the assembly.
Also it allows users to add their own samples in `templates` dir as separate files as we are now not deleting everything `rm -rf "${CHE_DATA}"/templates/*` 