### PR TITLE
Prevent NPE after applying the refactoring session

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -39,7 +39,6 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.web.bindery.event.shared.EventBus;
-import elemental.util.ArrayOf;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -1171,45 +1170,38 @@ public final class ResourceManager {
   }
 
   protected Promise<ResourceDelta[]> synchronize(final ResourceDelta[] deltas) {
-    List<Promise<Void>> promisesToResolve = new ArrayList<>(deltas.length);
+    Promise<Void> chain = promises.resolve(null);
+
     for (final ResourceDelta delta : deltas) {
       if (delta.getKind() == ADDED) {
         if (delta.getFlags() == (MOVED_FROM | MOVED_TO)) {
-          promisesToResolve.add(onExternalDeltaMoved(delta));
+          chain = chain.thenPromise(ignored -> onExternalDeltaMoved(delta));
         } else {
-          promisesToResolve.add(onExternalDeltaAdded(delta));
+          chain = chain.thenPromise(ignored -> onExternalDeltaAdded(delta));
         }
       } else if (delta.getKind() == REMOVED) {
-        promisesToResolve.add(onExternalDeltaRemoved(delta));
-
+        chain = chain.thenPromise(ignored -> onExternalDeltaRemoved(delta));
       } else if (delta.getKind() == UPDATED) {
-        promisesToResolve.add(onExternalDeltaUpdated(delta));
+        chain = chain.thenPromise(ignored -> onExternalDeltaUpdated(delta));
       }
     }
-
-    Promise<ArrayOf<?>> promise =
-        promises.all2(promisesToResolve.toArray(new Promise[promisesToResolve.size()]));
-    return promise.then((Function<ArrayOf<?>, ResourceDelta[]>) arg -> deltas);
+    return chain.thenPromise(ignored -> promises.resolve(deltas));
   }
 
   private Promise<Void> onExternalDeltaMoved(final ResourceDelta delta) {
     final Optional<Resource> toRemove = store.getResource(delta.getFromPath());
     store.dispose(delta.getFromPath(), true);
 
-    return findResourceForExternalOperation(delta.getToPath(), true)
+    return findResource(delta.getToPath(), true)
         .thenPromise(
             resource -> {
               if (resource.isPresent() && toRemove.isPresent()) {
-                Resource intercepted = resource.get();
-
-                if (!store.getResource(intercepted.getLocation()).isPresent()) {
-                  store.register(intercepted);
-                }
-
                 eventBus.fireEvent(
                     new ResourceChangedEvent(
                         new ResourceDeltaImpl(
-                            intercepted, toRemove.get(), ADDED | MOVED_FROM | MOVED_TO | DERIVED)));
+                            resource.get(),
+                            toRemove.get(),
+                            ADDED | MOVED_FROM | MOVED_TO | DERIVED)));
               }
 
               return promises.resolve(null);
@@ -1240,18 +1232,13 @@ public final class ResourceManager {
               });
     }
 
-    return findResourceForExternalOperation(delta.getToPath(), true)
+    return findResource(delta.getToPath(), true)
         .thenPromise(
             resource -> {
               if (resource.isPresent()) {
-                Resource intercepted = resource.get();
-
-                if (!store.getResource(intercepted.getLocation()).isPresent()) {
-                  store.register(intercepted);
-                }
-
                 eventBus.fireEvent(
-                    new ResourceChangedEvent(new ResourceDeltaImpl(intercepted, ADDED | DERIVED)));
+                    new ResourceChangedEvent(
+                        new ResourceDeltaImpl(resource.get(), ADDED | DERIVED)));
               }
 
               return promises.resolve(null);
@@ -1265,7 +1252,7 @@ public final class ResourceManager {
       return promises.resolve(null);
     }
 
-    return findResourceForExternalOperation(delta.getToPath(), true)
+    return findResource(delta.getToPath(), true)
         .thenPromise(
             resource -> {
               if (resource.isPresent()) {

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
@@ -97,7 +97,7 @@ public class RefactoringUpdater {
     final List<String> pathChanged = new ArrayList<>();
     for (ChangeInfo change : changes) {
 
-      //in some cases incoming change might be a null
+      // in some cases incoming change might be a null
       if (change.getName() == null) {
         continue;
       }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
@@ -97,6 +97,11 @@ public class RefactoringUpdater {
     final List<String> pathChanged = new ArrayList<>();
     for (ChangeInfo change : changes) {
 
+      //in some cases incoming change might be a null
+      if (change.getName() == null) {
+        continue;
+      }
+
       final ExternalResourceDelta delta;
 
       final Path newPath = Path.valueOf(change.getPath());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuCons
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -224,6 +225,7 @@ public class RenamePackageTest {
   @Inject private Refactor refactor;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
+  @Inject private Consoles console;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -234,6 +236,7 @@ public class RenamePackageTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(workspace);
+    console.clickOnProcessesTab();
     expandTestProject(PROJECT_NAME);
   }
 


### PR DESCRIPTION
### What does this PR do?
Fix an issue with apply refactoring session. After applying the session server responses with bunch of changes (type, old path, new path), but in changes there a may be en nullable change, so this PR adds additional check for `null` in refactoring updater component.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#4979 

#### Changelog
Prevent NPE after applying the refactoring session

#### Release Notes
N/A

#### Docs PR
N/A
