### PR TITLE
Prevent NPE after applying the refactoring session

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/RefactoringUpdater.java
@@ -97,6 +97,11 @@ public class RefactoringUpdater {
     final List<String> pathChanged = new ArrayList<>();
     for (ChangeInfo change : changes) {
 
+      // in some cases incoming change might be a null
+      if (change.getName() == null) {
+        continue;
+      }
+
       final ExternalResourceDelta delta;
 
       final Path newPath = Path.valueOf(change.getPath());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuCons
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -224,6 +225,7 @@ public class RenamePackageTest {
   @Inject private Refactor refactor;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
+  @Inject private Consoles console;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -234,6 +236,7 @@ public class RenamePackageTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(workspace);
+    console.clickOnProcessesTab();
     expandTestProject(PROJECT_NAME);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
@@ -236,7 +236,7 @@ public class RenamePackageTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(workspace);
-    console.clickOnProcessesTab();
+    console.closeProcessesArea();
     expandTestProject(PROJECT_NAME);
   }
 


### PR DESCRIPTION
### What does this PR do?
Fix an issue with apply refactoring session. After applying the session server responses with bunch of changes (type, old path, new path), but in changes there a may be en nullable change, so this PR adds additional check for `null` in refactoring updater component.

Back port of https://github.com/eclipse/che/pull/7458

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#4979 

#### Changelog
Prevent NPE after applying the refactoring session

#### Release Notes
N/A

#### Docs PR
N/A
