### PR TITLE
CHE-5904: Add support of dockerimage recipes

### DIFF
--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -103,6 +103,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.infrastructure.docker</groupId>
+            <artifactId>docker-environment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -20,6 +20,8 @@ import com.google.inject.multibindings.Multibinder;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiEnvVarProvider;
+import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
+import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.bootstrapper.OpenShiftBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory;
@@ -39,6 +41,7 @@ public class OpenShiftInfraModule extends AbstractModule {
         MapBinder.newMapBinder(binder(), String.class, InternalEnvironmentFactory.class);
 
     factories.addBinding(OpenShiftEnvironment.TYPE).to(OpenShiftEnvironmentFactory.class);
+    factories.addBinding(DockerImageEnvironment.TYPE).to(DockerImageEnvironmentFactory.class);
 
     Multibinder<RuntimeInfrastructure> infrastructures =
         Multibinder.newSetBinder(binder(), RuntimeInfrastructure.class);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructure.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructure.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import static java.lang.String.format;
+
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.inject.Inject;
@@ -18,10 +20,13 @@ import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
+import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.convert.DockerImageEnvironmentConverter;
 
 /** @author Sergii Leshchenko */
 @Singleton
@@ -29,6 +34,7 @@ public class OpenShiftInfrastructure extends RuntimeInfrastructure {
 
   public static final String NAME = "openshift";
 
+  private final DockerImageEnvironmentConverter dockerImageEnvConverter;
   private final OpenShiftRuntimeContextFactory runtimeContextFactory;
   private final OpenShiftEnvironmentProvisioner osEnvProvisioner;
 
@@ -37,25 +43,40 @@ public class OpenShiftInfrastructure extends RuntimeInfrastructure {
       EventService eventService,
       OpenShiftRuntimeContextFactory runtimeContextFactory,
       OpenShiftEnvironmentProvisioner osEnvProvisioner,
-      Set<InternalEnvironmentProvisioner> internalEnvProvisioners) {
-    super(NAME, ImmutableSet.of(OpenShiftEnvironment.TYPE), eventService, internalEnvProvisioners);
+      Set<InternalEnvironmentProvisioner> internalEnvProvisioners,
+      DockerImageEnvironmentConverter dockerImageEnvConverter) {
+    super(
+        NAME,
+        ImmutableSet.of(OpenShiftEnvironment.TYPE, DockerImageEnvironment.TYPE),
+        eventService,
+        internalEnvProvisioners);
     this.runtimeContextFactory = runtimeContextFactory;
     this.osEnvProvisioner = osEnvProvisioner;
+    this.dockerImageEnvConverter = dockerImageEnvConverter;
   }
 
   @Override
   protected OpenShiftRuntimeContext internalPrepare(
       RuntimeIdentity id, InternalEnvironment environment)
       throws ValidationException, InfrastructureException {
-    if (!(environment instanceof OpenShiftEnvironment)) {
-      throw new ValidationException(
-          "Environment type '%s' is not supported. Supported environment " + "types: %s",
-          environment.getRecipe().getType(), OpenShiftEnvironment.TYPE);
-    }
-    OpenShiftEnvironment openShiftEnvironment = (OpenShiftEnvironment) environment;
+    final OpenShiftEnvironment openShiftEnvironment = asOpenShiftEnv(environment);
 
     osEnvProvisioner.provision(openShiftEnvironment, id);
 
     return runtimeContextFactory.create(openShiftEnvironment, id, this);
+  }
+
+  private OpenShiftEnvironment asOpenShiftEnv(InternalEnvironment source)
+      throws ValidationException, InfrastructureException {
+    if (source instanceof OpenShiftEnvironment) {
+      return (OpenShiftEnvironment) source;
+    }
+    if (source instanceof DockerImageEnvironment) {
+      return dockerImageEnvConverter.convert((DockerImageEnvironment) source);
+    }
+    throw new InternalInfrastructureException(
+        format(
+            "Environment type '%s' is not supported. Supported environment types: %s",
+            source.getRecipe().getType(), OpenShiftEnvironment.TYPE));
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.Warning;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
@@ -49,8 +48,7 @@ public class OpenShiftEnvironment extends InternalEnvironment {
       Map<String, Pod> pods,
       Map<String, Service> services,
       Map<String, Route> routes,
-      Map<String, PersistentVolumeClaim> persistentVolumeClaims)
-      throws InfrastructureException {
+      Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
     super(internalRecipe, machines, warnings);
     this.pods = pods;
     this.services = services;
@@ -124,7 +122,7 @@ public class OpenShiftEnvironment extends InternalEnvironment {
       return this;
     }
 
-    public OpenShiftEnvironment build() throws InfrastructureException {
+    public OpenShiftEnvironment build() {
       return new OpenShiftEnvironment(
           internalRecipe, machines, warnings, pods, services, routes, persistentVolumeClaims);
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/convert/DockerImageEnvironmentConverter.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/convert/DockerImageEnvironmentConverter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.environment.convert;
+
+import static java.lang.String.format;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.MACHINE_NAME_ANNOTATION_FMT;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import javax.inject.Singleton;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+
+/**
+ * Converts {@link DockerImageEnvironment} to {@link OpenShiftEnvironment}.
+ *
+ * @author Sergii Leshchenko
+ * @author Anton Korneta
+ */
+@Singleton
+public class DockerImageEnvironmentConverter {
+
+  static final String POD_NAME = "dockerimage";
+  static final String CONTAINER_NAME = "container";
+
+  public OpenShiftEnvironment convert(DockerImageEnvironment environment)
+      throws InfrastructureException {
+    final Iterator<String> iterator = environment.getMachines().keySet().iterator();
+    if (!iterator.hasNext()) {
+      throw new InternalInfrastructureException(
+          "DockerImage environment must contain at least one machine configuration");
+    }
+    final String machineName = iterator.next();
+    final String dockerImage = environment.getRecipe().getContent();
+    final Map<String, String> annotations = new HashMap<>();
+    annotations.put(format(MACHINE_NAME_ANNOTATION_FMT, CONTAINER_NAME), machineName);
+
+    final Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName(POD_NAME)
+            .withAnnotations(annotations)
+            .endMetadata()
+            .withNewSpec()
+            .withContainers(
+                new ContainerBuilder().withImage(dockerImage).withName(CONTAINER_NAME).build())
+            .endSpec()
+            .build();
+    return OpenShiftEnvironment.builder()
+        .setMachines(environment.getMachines())
+        .setInternalRecipe(environment.getRecipe())
+        .setWarnings(environment.getWarnings())
+        .setPods(ImmutableMap.of(POD_NAME, pod))
+        .build();
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/convert/DockerImageEnvironmentConverterTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/convert/DockerImageEnvironmentConverterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.environment.convert;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.MACHINE_NAME_ANNOTATION_FMT;
+import static org.eclipse.che.workspace.infrastructure.openshift.environment.convert.DockerImageEnvironmentConverter.CONTAINER_NAME;
+import static org.eclipse.che.workspace.infrastructure.openshift.environment.convert.DockerImageEnvironmentConverter.POD_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
+import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Anton Korneta */
+@Listeners(MockitoTestNGListener.class)
+public class DockerImageEnvironmentConverterTest {
+
+  private static final String MACHINE_NAME = "testMachine";
+  private static final String RECIPE_CONTENT = "suse_jdk8";
+  private static final String RECIPE_TYPE = "dockerimage";
+
+  @Mock DockerImageEnvironment dockerEnv;
+  @Mock InternalRecipe recipe;
+
+  private Pod pod;
+  private Map<String, InternalMachineConfig> machines;
+  private DockerImageEnvironmentConverter converter;
+
+  @BeforeMethod
+  public void setup() throws Exception {
+    converter = new DockerImageEnvironmentConverter();
+    when(recipe.getContent()).thenReturn(RECIPE_CONTENT);
+    when(recipe.getType()).thenReturn(RECIPE_TYPE);
+    machines = ImmutableMap.of(MACHINE_NAME, mock(InternalMachineConfig.class));
+    final Map<String, String> annotations = new HashMap<>();
+    annotations.put(format(MACHINE_NAME_ANNOTATION_FMT, CONTAINER_NAME), MACHINE_NAME);
+    pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName(POD_NAME)
+            .withAnnotations(annotations)
+            .endMetadata()
+            .withNewSpec()
+            .withContainers(
+                new ContainerBuilder().withImage(RECIPE_CONTENT).withName(CONTAINER_NAME).build())
+            .endSpec()
+            .build();
+  }
+
+  @Test
+  public void testConvertsDockerImageEnvironment2OpenShiftEnvironment() throws Exception {
+    when(dockerEnv.getMachines()).thenReturn(machines);
+    when(dockerEnv.getRecipe()).thenReturn(recipe);
+
+    final OpenShiftEnvironment actual = converter.convert(dockerEnv);
+
+    assertEquals(pod, actual.getPods().values().iterator().next());
+    assertEquals(recipe, actual.getRecipe());
+    assertEquals(machines, actual.getMachines());
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "DockerImage environment must contain at least one machine configuration"
+  )
+  public void throwsValidationExceptionWhenNoMachineConfigProvided() throws Exception {
+    when(dockerEnv.getMachines()).thenReturn(emptyMap());
+
+    converter.convert(dockerEnv);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds docker environment converter that allows to start workspaces on OpenShift flavours with docker image recipe type.
Names for pod and container are hard coded because they do not bring any information to the user, basically they can be generated or moved into configuration but for now it would be enough. The name of the machine is placed in the pod annotations.

### What issues does this PR fix or reference?
#5904 
