### PR TITLE
Add the ability to configure logback (MDC) to show `identity_id` and `X-Request-ID` in logs files when available.

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -168,6 +168,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-logback</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-db</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Singleton;
 import org.apache.catalina.filters.CorsFilter;
+import org.eclipse.che.commons.logback.filter.RequestIdLoggerFilter;
 import org.eclipse.che.inject.DynaModule;
 import org.everrest.guice.servlet.GuiceEverrestServlet;
 
@@ -43,6 +44,7 @@ public class WsMasterServletModule extends ServletModule {
     bind(CorsFilter.class).in(Singleton.class);
 
     filter("/*").through(CorsFilter.class, corsFilterParams);
+    filter("/*").through(RequestIdLoggerFilter.class);
 
     serveRegex("^/api((?!(/(ws|eventbus)($|/.*)))/.*)").with(GuiceEverrestServlet.class);
     install(new org.eclipse.che.swagger.deploy.BasicSwaggerConfigurationModule());

--- a/core/commons/che-core-commons-logback/pom.xml
+++ b/core/commons/che-core-commons-logback/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/core/commons/che-core-commons-logback/pom.xml
+++ b/core/commons/che-core-commons-logback/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-core-commons-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>5.22.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-core-commons-logback</artifactId>
+    <packaging>jar</packaging>
+    <name>Che Core :: Commons :: Commons Logback</name>
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/IdentityIdLoggerFilter.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/IdentityIdLoggerFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.commons.logback.filter;
+
+import java.io.IOException;
+import javax.inject.Singleton;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.eclipse.che.commons.subject.Subject;
+import org.slf4j.MDC;
+
+/**
+ * A servlet filter that retrieves the identity_id from the servlet context and put it in the MDC
+ * context. Logback can be configured to display this value in each log message when available. MDC
+ * property name is `identity_id`.
+ */
+@Singleton
+public class IdentityIdLoggerFilter implements Filter {
+
+  private static final String IDENTITY_ID_MDC_KEY = "identity_id";
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  @Override
+  public final void doFilter(
+      ServletRequest request, ServletResponse response, FilterChain filterChain)
+      throws IOException, ServletException {
+    final HttpServletRequest httpRequest = (HttpServletRequest) request;
+    final HttpSession session = httpRequest.getSession();
+    Subject subject = (Subject) session.getAttribute("che_subject");
+
+    if (subject != null && subject.getUserId() != null) {
+      MDC.put(IDENTITY_ID_MDC_KEY, subject.getUserId());
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/RequestIdLoggerFilter.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/RequestIdLoggerFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.commons.logback.filter;
+
+import java.io.IOException;
+import javax.inject.Singleton;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
+
+/**
+ * A servlet filter that retrieves the X-Request-Id header from the http request and put it in the
+ * MDC context. Logback can be configured to display this value in each log message when available.
+ * MDC property name is `req_id`.
+ */
+@Singleton
+public class RequestIdLoggerFilter implements Filter {
+
+  private static final String REQUEST_ID_HEADER = "X-Request-Id";
+  private static final String REQUEST_ID_MDC_KEY = "req_id";
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  @Override
+  public final void doFilter(
+      ServletRequest request, ServletResponse response, FilterChain filterChain)
+      throws IOException, ServletException {
+    final HttpServletRequest httpRequest = (HttpServletRequest) request;
+    String requestId = httpRequest.getHeader(REQUEST_ID_HEADER);
+    if (requestId != null) {
+      MDC.put(REQUEST_ID_MDC_KEY, requestId);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/core/commons/pom.xml
+++ b/core/commons/pom.xml
@@ -26,6 +26,7 @@
         <module>che-core-commons-annotations</module>
         <module>che-core-commons-auth</module>
         <module>che-core-commons-lang</module>
+        <module>che-core-commons-logback</module>
         <module>che-core-commons-inject</module>
         <module>che-core-commons-json</module>
         <module>che-core-commons-xml</module>

--- a/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-logback</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-api-authorization</artifactId>
         </dependency>

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -12,6 +12,7 @@ package org.eclipse.che.multiuser.keycloak.server.deploy;
 
 import com.google.inject.servlet.ServletModule;
 import javax.inject.Singleton;
+import org.eclipse.che.commons.logback.filter.IdentityIdLoggerFilter;
 import org.eclipse.che.multiuser.keycloak.server.KeycloakAuthenticationFilter;
 import org.eclipse.che.multiuser.keycloak.server.KeycloakEnvironmentInitalizationFilter;
 
@@ -26,5 +27,7 @@ public class KeycloakServletModule extends ServletModule {
         .through(KeycloakAuthenticationFilter.class);
     filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
         .through(KeycloakEnvironmentInitalizationFilter.class);
+    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
+        .through(IdentityIdLoggerFilter.class);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-commons-logback</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-commons-mail</artifactId>
                 <version>${che.version}</version>
             </dependency>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add the ability to configure logback to show `identity_id` and `X-Request-ID` in logs files when available.

- Add `X-Request-ID` http header in the logs through MDC
- Add identity_id from keycloack when available in the logs through MDC

### What issues does this PR fix or reference?

https://github.com/redhat-developer/rh-che/issues/312

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add the ability to configure logback to show `identity_id` and `X-Request-ID` in logs files when available.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
TODO