### PR TITLE
CHE6-7404 Return back popup loader when workspace is stopped

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceStatusNotification.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspaceStatusNotification.java
@@ -77,7 +77,7 @@ class WorkspaceStatusNotification implements PopupLoader.ActionDelegate {
           WorkspaceStatus status = appContext.getWorkspace().getStatus();
 
           if (status == STARTING) {
-            show(STARTING_WORKSPACE_RUNTIME);
+            setSuccess(WORKSPACE_STOPPED);
           } else if (status == STOPPING) {
             show(STOPPING_WORKSPACE);
           }
@@ -87,7 +87,6 @@ class WorkspaceStatusNotification implements PopupLoader.ActionDelegate {
         WorkspaceStartingEvent.TYPE,
         e -> {
           setSuccess(WORKSPACE_STOPPED);
-          show(STARTING_WORKSPACE_RUNTIME);
         });
 
     eventBus.addHandler(WorkspaceRunningEvent.TYPE, e -> setSuccess(STARTING_WORKSPACE_RUNTIME));

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.ui.xml
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.ui.xml
@@ -36,7 +36,6 @@
             box-sizing: border-box;
             -moz-box-shadow: popupLoaderShadow;
             box-shadow: popupLoaderShadow;
-            display: none;
         }
 
         .title {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Return back popup loader containing button to start workspace.

![popup loader when workspace is stopped](https://user-images.githubusercontent.com/1655894/33027892-06215af4-ce1d-11e7-9aeb-1752bba2788b.png)

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/7273

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
