### PR TITLE
Avoid executing chown command if the user is not a sudoer

### DIFF
--- a/agents/exec/src/main/resources/installers/1.0.0/org.eclipse.che.exec.script.sh
+++ b/agents/exec/src/main/resources/installers/1.0.0/org.eclipse.che.exec.script.sh
@@ -57,7 +57,9 @@ SHELL_INTERPRETER="/bin/sh"
 
 mkdir -p ${CHE_DIR}
 ${SUDO} mkdir -p /projects
-${SUDO} sh -c "chown $(id -u -n) /projects"
+if is_current_user_sudoer; then
+  ${SUDO} sh -c "chown $(id -u -n) /projects"
+fi
 
 ########################
 ### Install packages ###


### PR DESCRIPTION
### What does this PR do?
Avoid changing the ownership of folder `/projects/` in script `org.eclipse.che.exec.script.sh` if the user that is executing the script is not a sudoer. 

### What issues does this PR fix or reference?
That is the last of a list of errors that have been reported [here](https://github.com/openshiftio/openshift.io/issues/531)