### PR TITLE
Fix warning: Remove duplicate declaration of antrun plugin

### DIFF
--- a/ide/che-ide-gwt-app/pom.xml
+++ b/ide/che-ide-gwt-app/pom.xml
@@ -319,26 +319,6 @@
                     <shortRevisionLength>16</shortRevisionLength>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>buildnumber</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <echo append="false" file="${project.build.directory}/classes/org/eclipse/che/ide/ext/help/client/BuildInfo.properties">revision = ${revision}
-                                    buildTime = ${timestamp}
-                                    version = ${project.version}</echo>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- pass the generated sources to compiler:compile -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -388,6 +368,20 @@
                                 </length>
                                 <echo append="false" file="${project.build.directory}/${project.artifactId}-${project.version}/_app/compilation-mappings.properties">${compilation-mappings-properties}</echo>
                                 <replace file="${project.build.directory}/${project.artifactId}-${project.version}/_app/compilation-mappings.properties" token="${project.build.directory}/${project.artifactId}-${project.version}/_app/" value="" />
+                            </tasks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>buildnumber</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <echo append="false" file="${project.build.directory}/classes/org/eclipse/che/ide/ext/help/client/BuildInfo.properties">revision = ${revision}
+                                    buildTime = ${timestamp}
+                                    version = ${project.version}</echo>
                             </tasks>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### What does this PR do?
Fixes maven warning 
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.eclipse.che:che-ide-gwt-app:gwt-app:6.0.0-M2-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-antrun-plugin @ org.eclipse.che:che-ide-gwt-app:[unknown-version], /home/codenvy/workspace/che-ci-che6/ide/che-ide-gwt-app/pom.xml, line 372, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```