### PR TITLE
[CHE6] Rework selenium tests according to changes with the Popup Loader 

### DIFF
--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.ui.xml
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/loaders/PopupLoaderImpl.ui.xml
@@ -81,7 +81,7 @@
 
     </ui:style>
 
-    <g:FlowPanel styleName="{style.main}">
+    <g:FlowPanel styleName="{style.main}" debugId="popupLoader">
         <g:Label ui:field="titleLabel" addStyleNames="{style.title}" />
         <g:Label ui:field="descriptionLabel" addStyleNames="{style.description}" />
         <g:FlowPanel ui:field="customWidget" styleName="{style.customWidget}" visible="false">

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ToastLoader.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ToastLoader.java
@@ -46,15 +46,15 @@ public class ToastLoader {
   }
 
   private interface Locators {
-    String MAIN_FORM_CSS = "div.inDown";
-    String START_BUTTON = "div.inDown button";
+    String MAIN_FORM = "gwt-debug-popupLoader";
+    String START_BUTTON = "//button[text()='Start']";
     String MAINFORM_WITH_TEXT_CONTAINER = "//div[text()='%s']";
   }
 
-  @FindBy(css = Locators.MAIN_FORM_CSS)
+  @FindBy(id = Locators.MAIN_FORM)
   WebElement mainForm;
 
-  @FindBy(css = Locators.START_BUTTON)
+  @FindBy(xpath = Locators.START_BUTTON)
   WebElement startBtn;
 
   /** wait appearance toast loader widget */
@@ -91,9 +91,7 @@ public class ToastLoader {
   /** wait for closing of widget */
   public void waitToastLoaderIsClosed() {
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.invisibilityOfElementLocated(
-                By.cssSelector(Locators.MAIN_FORM_CSS)));
+        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.MAIN_FORM)));
   }
 
   /**
@@ -103,9 +101,7 @@ public class ToastLoader {
    */
   public void waitToastLoaderIsClosed(int userTimeout) {
     new WebDriverWait(seleniumWebDriver, userTimeout)
-        .until(
-            ExpectedConditions.invisibilityOfElementLocated(
-                By.cssSelector(Locators.MAIN_FORM_CSS)));
+        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.MAIN_FORM)));
   }
 
   /** wait appearance the 'Toast widget' with some text, and wait disappearance this one */

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
@@ -48,8 +48,6 @@ public class CheckStopStartWsTest {
     toastLoader.waitExpectedTextInToastLoader("Workspace is not running", 60);
     toastLoader.clickOnStartButton();
     loader.waitOnClosed();
-    toastLoader.waitExpectedTextInToastLoader("Starting workspace runtime.", 20);
-    loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
     terminal.waitTerminalTab();
   }


### PR DESCRIPTION
### What does this PR do?
According to the changes with the **Popup Loader** (https://github.com/eclipse/che/pull/7469) we need:
- rework **CheckStopStartWsTest** selenium test(remove waiting "Starting workspace runtime." message);
- change locators for the **Popup Loader**.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7490