### PR TITLE
Fix showing machine env vars in API

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -216,6 +216,9 @@ public final class DtoConverter {
               .stream()
               .collect(toMap(Map.Entry::getKey, entry -> asDto(entry.getValue()))));
     }
+    if (machine.getEnv() != null) {
+      machineDto.setEnv(machine.getEnv());
+    }
     return machineDto;
   }
 


### PR DESCRIPTION
### What does this PR do?
Because of a bug in DtoConverter we don't show env vars configuration of the machine in API.
This PR fixes this.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
