### PR TITLE
Add some new macro for commands 

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -938,6 +938,9 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("macro.workspace.name.description")
   String macroWorkspaceNameDescription();
 
+  @Key("macro.workspace.namespace.description")
+  String macroWorkspaceNamespaceDescription();
+
   @Key("macro.explorer.current.file.name.description")
   String macroExplorerCurrentFileNameDescription();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -1090,6 +1090,9 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("macro.current.project.path.description")
   String macroCurrentProjectPathDescription();
 
+  @Key("macro.current.project.eldest.parent.path.description")
+  String macroCurrentProjectEldestParentPathDescription();
+
   @Key("macro.current.project.relpath.description")
   String macroCurrentProjectRelpathDescription();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/CurrentProjectEldestParentPathMacro.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/CurrentProjectEldestParentPathMacro.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.macro;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.macro.Macro;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.resource.Path;
+
+/**
+ * Provides current project's parent path. Path means full absolute path to project's parent on the
+ * FS, e.g. /projects/project_name
+ */
+@Singleton
+public class CurrentProjectEldestParentPathMacro implements Macro {
+
+  private static final String KEY = "${current.project.eldest.parent.path}";
+
+  private final AppContext appContext;
+  private final PromiseProvider promises;
+  private final CoreLocalizationConstant localizationConstants;
+
+  @Inject
+  public CurrentProjectEldestParentPathMacro(
+      AppContext appContext,
+      PromiseProvider promises,
+      CoreLocalizationConstant localizationConstants) {
+    this.appContext = appContext;
+    this.promises = promises;
+    this.localizationConstants = localizationConstants;
+  }
+
+  @NotNull
+  @Override
+  public String getName() {
+    return KEY;
+  }
+
+  @Override
+  public String getDescription() {
+    return localizationConstants.macroCurrentProjectEldestParentPathDescription();
+  }
+
+  @NotNull
+  @Override
+  public Promise<String> expand() {
+    String value = "";
+
+    Resource[] resources = appContext.getResources();
+
+    if (resources != null && resources.length == 1) {
+      Project project = appContext.getResource().getProject();
+
+      if (project != null) {
+        Path location = project.getLocation();
+        String eldestParent = location.segment(0);
+        if (eldestParent != null) {
+          value = appContext.getProjectsRoot().append(eldestParent).toString();
+        }
+      }
+    }
+
+    return promises.resolve(value);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/MacroApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/MacroApiModule.java
@@ -63,6 +63,7 @@ public class MacroApiModule extends AbstractGinModule {
     macrosBinder.addBinding().to(WorkspaceNamespaceMacro.class);
     macrosBinder.addBinding().to(DevMachineHostNameMacro.class);
     macrosBinder.addBinding().to(CurrentProjectPathMacro.class);
+    macrosBinder.addBinding().to(CurrentProjectEldestParentPathMacro.class);
     macrosBinder.addBinding().to(CurrentProjectRelativePathMacro.class);
 
     bind(ServerAddressMacroRegistrar.class).asEagerSingleton();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/MacroApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/MacroApiModule.java
@@ -60,6 +60,7 @@ public class MacroApiModule extends AbstractGinModule {
     macrosBinder.addBinding().to(ExplorerCurrentProjectNameMacro.class);
     macrosBinder.addBinding().to(ExplorerCurrentProjectTypeMacro.class);
     macrosBinder.addBinding().to(WorkspaceNameMacro.class);
+    macrosBinder.addBinding().to(WorkspaceNamespaceMacro.class);
     macrosBinder.addBinding().to(DevMachineHostNameMacro.class);
     macrosBinder.addBinding().to(CurrentProjectPathMacro.class);
     macrosBinder.addBinding().to(CurrentProjectRelativePathMacro.class);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/WorkspaceNamespaceMacro.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/macro/WorkspaceNamespaceMacro.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.macro;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.macro.Macro;
+
+/**
+ * Provider which is responsible for retrieving the workspace namespace.
+ *
+ * <p>Macro provided: <code>${workspace.namespace}</code>
+ */
+@Beta
+@Singleton
+public class WorkspaceNamespaceMacro implements Macro {
+
+  public static final String KEY = "${workspace.namespace}";
+
+  private final AppContext appContext;
+  private final PromiseProvider promises;
+  private final CoreLocalizationConstant localizationConstants;
+
+  @Inject
+  public WorkspaceNamespaceMacro(
+      AppContext appContext,
+      PromiseProvider promises,
+      CoreLocalizationConstant localizationConstants) {
+    this.appContext = appContext;
+    this.promises = promises;
+    this.localizationConstants = localizationConstants;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return KEY;
+  }
+
+  @Override
+  public String getDescription() {
+    return localizationConstants.macroWorkspaceNamespaceDescription();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Promise<String> expand() {
+    return promises.resolve(appContext.getWorkspace().getNamespace());
+  }
+}

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -427,6 +427,7 @@ macro.editor.current.file.name.description=Currently selected file in editor
 macro.editor.current.file.base.name.description=Currently selected file in editor without extension
 macro.editor.current.file.path.description=Absolute path to the selected file in editor
 macro.workspace.name.description=Returns the name of the workspace
+macro.workspace.namespace.description=Returns the namespace of the workspace
 macro.explorer.current.file.name.description=Currently selected file in project tree
 macro.explorer.current.file.base.name.description=Currently selected file in project tree without extension
 macro.explorer.current.project.name.description=Project name of the file currently selected in explorer

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -437,6 +437,7 @@ macro.explorer.current.file.parent.path.description=Absolute path to the selecte
 macro.explorer.current.file.path.description=Absolute path to the selected file in project tree
 macro.current.project.relpath.description=The path to the currently selected project relative to /projects. Effectively removes the /projects path from any project reference
 macro.current.project.path.description=Absolute path to the project or module currently selected in the project explorer tree
+macro.current.project.eldest.parent.path.description=Absolute path of the eldest parent of the project
 macro.machine.dev.hostname.description=Dev-machine''s host name
 
 ################ Empty state #######################


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/7485

Added a couple of macro for commands:
- `${workspace.namespace}` - is used to refer to current workspace namespace
- `${current.project.eldest.parent.path}` - is used to refer to current project's eldest parent project (e.g. for sub project `/projects/che/core/che-core-api` this will refer to `/projects/che`)