### PR TITLE
Turn off GDB integration tests

### DIFF
--- a/plugins/plugin-gdb/che-plugin-gdb-server/pom.xml
+++ b/plugins/plugin-gdb/che-plugin-gdb-server/pom.xml
@@ -104,7 +104,7 @@
     </build>
     <profiles>
         <profile>
-            <id>integration</id>
+            <id>gdb-tests</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>


### PR DESCRIPTION
### What does this PR do?
For now we have to disable GDB integration tests because gdb client is still running on host machine and could cause troubles sometimes due to different versions etc.

