### PR TITLE
Fix of che-dev image build

### DIFF
--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -62,8 +62,7 @@ COPY traefik.toml /home/user/traefik/
 
 
 RUN sudo mkdir /var/run/sshd
-RUN sudo /usr/bin/ssh-keygen -A && \
-    sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' && \
+RUN sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' && \
     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ecdsa_key -N '' && \
     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ed25519_key -N '' && \
     npm install -g typescript@2.5.3 typescript-language-server@0.1.4


### PR DESCRIPTION
### What does this PR do?
We have an error
```
Step 11/13 : RUN sudo mkdir /var/run/sshd
 ---> Using cache
 ---> 0bd9698f120c
Step 12/13 : RUN sudo /usr/bin/ssh-keygen -A &&     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' &&     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ecdsa_key -N '' &&     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ed25519_key -N '' &&     npm install -g typescript@2.5.3 typescript-language-server@0.1.4
 ---> Running in d12fd99cb356
ssh-keygen: generating new host keys: RSA1 RSA DSA ECDSA ED25519
Generating public/private rsa key pair.
/etc/ssh/ssh_host_rsa_key already exists.
Overwrite (y/n)? The command '/bin/sh -c sudo /usr/bin/ssh-keygen -A &&     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' &&     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ecdsa_key -N '' &&     sudo  ssh-keygen -t rsa -f /etc/ssh/ssh_host_ed25519_key -N '' &&     npm install -g typescript@2.5.3 typescript-language-server@0.1.4' returned a non-zero code: 1

[15:53:04]sj:dev[che6]#: ./build.sh
```
This is a revert of commit that add this change