### PR TITLE
Remove redundant console hide method call

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/packages/RenamePackageTest.java
@@ -20,7 +20,6 @@ import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuCons
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
-import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -225,7 +224,6 @@ public class RenamePackageTest {
   @Inject private Refactor refactor;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
-  @Inject private Consoles console;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -236,7 +234,6 @@ public class RenamePackageTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(workspace);
-    console.closeProcessesArea();
     expandTestProject(PROJECT_NAME);
   }
 


### PR DESCRIPTION
### What does this PR do?
Remove redundant console hide method call. In Che 5 there was a need to hide consoles panel to avoid Stale Element Exception in selenium tests, but in Che 6 consoles panel doesn't back off project explorer panel.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
-

#### Release Notes
N/A

#### Docs PR
N/A
