### PR TITLE
Uses specific to che6 branch image tag for che in che stack

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -23,7 +23,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "eclipse/che-dev:nightly"
+      "origin": "eclipse/che-dev:che6"
     },
     "workspaceConfig": {
       "environments": {


### PR DESCRIPTION
### What does this PR do?
Uses specific to che6 branch image tag for che in che stack
Somewhere in DevOps underwear, we are using eclipse/che-dev:nightly stack. @riuvshin  asked to change image tag  to eclipse/che-dev:che6  for che in che stack
