### PR TITLE
[CHE 6] Fix unexpected fail of selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FileStructure.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FileStructure.java
@@ -105,6 +105,7 @@ public class FileStructure {
    * @param expText expected value
    */
   public void waitExpectedTextInFileStructure(String expText) {
+    loader.waitOnClosed();
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(
             new ExpectedCondition<Boolean>() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -49,6 +51,6 @@ public class CheckStopStartWsTest {
     toastLoader.clickOnStartButton();
     loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab();
+    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
   }
 }


### PR DESCRIPTION
### What does this PR do?
We have unexpected fail of next selenium tests:
- **FileStructureNodesTest** selenium test. The test failed on CI while waited to closing  loader. 
- **CheckStopStartWsTest** selenium test. This test failed on CI while waited to restarting the test workspace.

Reports with reproduced problems: 
- https://ci.codenvycorp.com/view/qa-release/job/release-che-integration-tests-che6/2/Selenium_tests_report/ for **FileStructureNodesTest**
![org eclipse che selenium miscellaneous filestructurenodestest checkfilestructurenodes_nnxhcyil](https://user-images.githubusercontent.com/7760565/33213016-4172ac2a-d12e-11e7-9a1d-cb0fcb73dacf.png)

- https://ci.codenvycorp.com/view/qa-release/job/release-che-multiuser-integration-tests-che6/1/Selenium_tests_report/ for **CheckStopStartWsTest** 