### PR TITLE
Port from che6 Added missing lib to be able to configure LogstashEncoder on wsagent

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -32,15 +32,7 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-access</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/wsagent/che-wsagent-core/pom.xml
+++ b/wsagent/che-wsagent-core/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash.logback.encoder.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
@@ -149,6 +154,7 @@
                             <ignoredDependencies>
                                 <ignoredDependency>org.everrest:everrest-core</ignoredDependency>
                                 <ignoredDependency>ch.qos.logback:logback-classic</ignoredDependency>
+                                <ignoredDependency>net.logstash.logback:logstash-logback-encoder</ignoredDependency>
                                 <ignoredDependency>org.slf4j:jul-to-slf4j</ignoredDependency>
                                 <ignoredDependency>org.slf4j:jcl-over-slf4j</ignoredDependency>
                                 <ignoredDependency>org.slf4j:log4j-over-slf4j</ignoredDependency>


### PR DESCRIPTION
### What does this PR do?
Added missing lib to be able to configure net.logstash.logback.encoder.LogstashEncoder on wsagent. Removed unused libs from ws-master war (#7444)
