### PR TITLE
add error markers in Project Explorer

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Resource.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/resources/Resource.java
@@ -206,6 +206,20 @@ public interface Resource extends Comparable<Resource> {
   }
 
   /**
+   * Returns whether this resource has an error or not.
+   *
+   * @return true if this resource has an error, false otherwise.
+   */
+  boolean hasError();
+
+  /**
+   * Set the hasError property of this resource.
+   *
+   * @param hasError the new value to set.
+   */
+  void setHasError(boolean hasError);
+
+  /**
    * Copies resource to given {@code destination} path. Copy operation performs asynchronously and
    * result of current operation will be provided in {@code Promise} result. Destination path should
    * have write access.

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceImpl.java
@@ -45,12 +45,23 @@ abstract class ResourceImpl implements Resource {
 
   protected final ResourceManager resourceManager;
   protected final Path path;
+  private boolean hasError;
 
   protected Marker[] markers = new Marker[0];
 
   protected ResourceImpl(Path path, ResourceManager resourceManager) {
     this.path = checkNotNull(path.removeTrailingSeparator(), "Null path occurred");
     this.resourceManager = checkNotNull(resourceManager, "Null project manager occurred");
+  }
+
+  @Override
+  public boolean hasError() {
+    return hasError;
+  }
+
+  @Override
+  public void setHasError(boolean hasError) {
+    this.hasError = hasError;
   }
 
   /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/tree/ResourceNode.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/tree/ResourceNode.java
@@ -199,14 +199,19 @@ public abstract class ResourceNode<R extends Resource> extends AbstractTreeNode
       }
     }
 
-    presentation.setPresentableTextCss(cssBuilder.toString());
-
     if (getData().isFile() && getData().asFile().getVcsStatus() != null) {
       VcsStatus vcsStatus = getData().asFile().getVcsStatus();
       if (vcsStatus != NOT_MODIFIED) {
-        presentation.setPresentableTextCss("color: " + vcsStatus.getColor() + ";");
+        cssBuilder.append("color: ").append(vcsStatus.getColor()).append(';');
       }
     }
+
+    if (getData().hasError()) {
+      // TODO improve CSS
+      cssBuilder.append("border-bottom: 1px dotted red; padding: 1px;");
+    }
+
+    presentation.setPresentableTextCss(cssBuilder.toString());
   }
 
   @Override

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/PublishDiagnosticsProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/PublishDiagnosticsProcessor.java
@@ -46,7 +46,11 @@ public class PublishDiagnosticsProcessor {
         .getAll()
         .stream()
         .filter(node -> node instanceof ResourceNode)
-        .forEach(node -> ((ResourceNode) node).getData().setHasError(false));
+        .forEach(
+            node -> {
+              ((ResourceNode) node).getData().setHasError(false);
+              tree.refresh(node);
+            });
     diagnostics.forEach(this::processDiagnostics);
   }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/PublishDiagnosticsProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/PublishDiagnosticsProcessor.java
@@ -12,7 +12,6 @@ package org.eclipse.che.plugin.languageserver.ide.editor;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.List;
 import java.util.Optional;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedPublishDiagnosticsParams;
 import org.eclipse.che.ide.api.editor.EditorAgent;
@@ -40,21 +39,7 @@ public class PublishDiagnosticsProcessor {
     this.tree = projectExplorer.getTree();
   }
 
-  public void processDiagnostics(List<ExtendedPublishDiagnosticsParams> diagnostics) {
-    tree.getNodeStorage()
-        .getAll()
-        .stream()
-        .filter(node -> node instanceof ResourceNode)
-        .map(node -> ((ResourceNode) node))
-        .forEach(
-            node -> {
-              node.getData().setHasError(false);
-              tree.refresh(node);
-            });
-    diagnostics.forEach(this::processDiagnostics);
-  }
-
-  private void processDiagnostics(ExtendedPublishDiagnosticsParams diagnosticsMessage) {
+  public void processDiagnostics(ExtendedPublishDiagnosticsParams diagnosticsMessage) {
     final Path path = Path.valueOf(diagnosticsMessage.getParams().getUri());
     final Optional<ResourceNode> resource =
         tree.getNodeStorage()

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/PublishDiagnosticsProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/PublishDiagnosticsProcessor.java
@@ -12,6 +12,7 @@ package org.eclipse.che.plugin.languageserver.ide.editor;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Collection;
 import java.util.Optional;
 import org.eclipse.che.api.languageserver.shared.model.ExtendedPublishDiagnosticsParams;
 import org.eclipse.che.ide.api.editor.EditorAgent;
@@ -22,6 +23,7 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.resources.tree.ResourceNode;
+import org.eclipse.che.ide.ui.smartTree.NodeDescriptor;
 import org.eclipse.che.ide.ui.smartTree.Tree;
 import org.eclipse.lsp4j.Diagnostic;
 
@@ -41,16 +43,7 @@ public class PublishDiagnosticsProcessor {
 
   public void processDiagnostics(ExtendedPublishDiagnosticsParams diagnosticsMessage) {
     final Path path = Path.valueOf(diagnosticsMessage.getParams().getUri());
-    final Optional<ResourceNode> resource =
-        tree.getNodeStorage()
-            .getAll()
-            .stream()
-            .filter(node -> node instanceof ResourceNode)
-            .map(node -> ((ResourceNode) node))
-            .filter(node -> node.getData().isFile())
-            .filter(node -> path.equals(node.getData().asFile().getLocation()))
-            .findAny();
-    resource.ifPresent(this::setHasError);
+    findVisibleResource(path).ifPresent(this::setHasError);
 
     EditorPartPresenter openedEditor = editorAgent.getOpenedEditor(path);
     // TODO add markers
@@ -74,6 +67,46 @@ public class PublishDiagnosticsProcessor {
         }
       }
     }
+  }
+
+  /**
+   * Find the given resource in the Project Explorer or its first visible parent.
+   *
+   * @param path the path of the resource to find in the Project Explorer.
+   * @return an optional containing the {@link ResourceNode} with the given path if it is visible.
+   *     If the desired resource is not visible, try to return its first visible parent. If no
+   *     matching {@link ResourceNode} can be find, returns an empty {@link Optional}.
+   */
+  private Optional<ResourceNode> findVisibleResource(Path path) {
+    if (path.isRoot()) {
+      if (tree.getNodeStorage().getStoredNodes().isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(
+          (ResourceNode) tree.getNodeStorage().getStoredNodes().iterator().next().getNode());
+    }
+    return findVisibleResource(path, tree.getNodeStorage().getStoredNodes(), path.uptoSegment(1));
+  }
+
+  private static Optional<ResourceNode> findVisibleResource(
+      Path completePath, Collection<NodeDescriptor> nodes, Path partialPath) {
+    for (final NodeDescriptor child : nodes) {
+      if (!(child.getNode() instanceof ResourceNode)) {
+        continue;
+      }
+      final ResourceNode resourceNode = (ResourceNode) child.getNode();
+      if (!partialPath.equals(resourceNode.getData().getLocation())) {
+        continue;
+      }
+      if (child.getChildren().isEmpty()) {
+        return Optional.of(resourceNode);
+      }
+      return findVisibleResource(
+          completePath,
+          child.getChildren(),
+          completePath.uptoSegment(partialPath.segmentCount() + 1));
+    }
+    return Optional.empty();
   }
 
   private void setHasError(ResourceNode node) {

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/PublishDiagnosticsReceiver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/PublishDiagnosticsReceiver.java
@@ -46,7 +46,7 @@ public class PublishDiagnosticsReceiver {
     configurator
         .newConfiguration()
         .methodName("textDocument/publishDiagnostics")
-        .paramsAsListOfDto(ExtendedPublishDiagnosticsParams.class)
+        .paramsAsDto(ExtendedPublishDiagnosticsParams.class)
         .noResult()
         .withConsumer(params -> provider.get().processDiagnostics(params));
   }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/PublishDiagnosticsReceiver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/PublishDiagnosticsReceiver.java
@@ -46,7 +46,7 @@ public class PublishDiagnosticsReceiver {
     configurator
         .newConfiguration()
         .methodName("textDocument/publishDiagnostics")
-        .paramsAsDto(ExtendedPublishDiagnosticsParams.class)
+        .paramsAsListOfDto(ExtendedPublishDiagnosticsParams.class)
         .noResult()
         .withConsumer(params -> provider.get().processDiagnostics(params));
   }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/TextDocumentServiceClient.java
@@ -22,6 +22,9 @@ import org.eclipse.che.api.languageserver.shared.model.RenameResult;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.promises.client.js.Promises;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
+import org.eclipse.che.ide.ui.smartTree.Tree;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
@@ -48,10 +51,13 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 public class TextDocumentServiceClient {
 
   private final RequestTransmitter requestTransmitter;
+  private final Tree tree;
 
   @Inject
-  public TextDocumentServiceClient(RequestTransmitter requestTransmitter) {
+  public TextDocumentServiceClient(
+      RequestTransmitter requestTransmitter, ProjectExplorerPresenter projectExplorer) {
     this.requestTransmitter = requestTransmitter;
+    this.tree = projectExplorer.getTree();
   }
 
   /**
@@ -166,6 +172,16 @@ public class TextDocumentServiceClient {
    * @return
    */
   public void didChange(DidChangeTextDocumentParams params) {
+    tree.getNodeStorage()
+        .getAll()
+        .stream()
+        .filter(node -> node instanceof ResourceNode)
+        .map(node -> ((ResourceNode) node))
+        .forEach(
+            node -> {
+              node.getData().setHasError(false);
+              tree.refresh(node);
+            });
     transmitDtoAndReceiveNothing(params, "textDocument/didChange");
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add error markers in the Project Explorer for resources in error as the example below :
![error](https://user-images.githubusercontent.com/33962711/33266899-9d02504a-d377-11e7-97f8-afbbb2d786f1.png)


### What issues does this PR fix or reference?
#7557

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Add error markers in the Project Explorer.
<!-- markdown to be included in marketing announcement - N/A for bugs -->


<!-- #### Docs PR -->
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
