### PR TITLE
Set correct recipe.location for che in che docker image

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -68,7 +68,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/che-dev:nightly",
+            "location": "eclipse/che-dev:che6",
             "type": "dockerimage"
           }
         }


### PR DESCRIPTION
### What does this PR do?
Set correct recipe.location for che in che docker image
