### PR TITLE
Add Nullable annotation. This is necessary if we have a project on a file system but not in WS config

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/RegisteredProject.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/RegisteredProject.java
@@ -38,6 +38,7 @@ import org.eclipse.che.api.project.server.type.ValueProvider;
 import org.eclipse.che.api.project.server.type.ValueStorageException;
 import org.eclipse.che.api.project.server.type.Variable;
 import org.eclipse.che.api.workspace.shared.ProjectProblemImpl;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Internal Project implementation. It is supposed that it is object always consistent.
@@ -68,7 +69,7 @@ public class RegisteredProject implements ProjectConfig {
   @AssistedInject
   public RegisteredProject(
       @Assisted("folder") String folder,
-      @Assisted("config") ProjectConfig config,
+      @Assisted("config") @Nullable ProjectConfig config,
       @Assisted("updated") boolean updated,
       @Assisted("detected") boolean detected,
       ProjectTypesFactory projectTypesFactory,


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?

Add `@Nullable` annotation. This need if we have project on file system but not in WS config.
Meet this problem if mount project source from host machine.

[log.txt](https://github.com/eclipse/che/files/1509391/log.txt)
