### PR TITLE
Apply try/catch blocks in expected failure places of WorkingWithTerminalTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.util.HashMap;
@@ -33,7 +32,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.DashboardProject.Template;
 import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace.TabNames;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
-import org.openqa.selenium.TimeoutException;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -264,13 +262,7 @@ public class WorkspaceDetailsTest {
 
   private void clickOnSaveButton() {
     dashboardWorkspace.clickOnSaveBtn();
-    try {
-      dashboard.waitNotificationMessage("Workspace updated");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7178");
-    }
-
+    dashboard.waitNotificationMessage("Workspace updated");
     dashboard.waitNotificationIsClosed();
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -161,45 +161,48 @@ public class WorkingWithTerminalTest {
     try {
       // check scrolling of the terminal
       terminal.movePageDownListTerminal("opt");
-      terminal.moveDownListTerminal(".dockerenv");
-      terminal.waitExpectedTextIntoTerminal(".dockerenv");
-      terminal.movePageUpListTerminal("projects");
-      terminal.moveUpListTerminal("bin");
-      terminal.waitExpectedTextIntoTerminal("bin");
+
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7592");
+      fail("Known issue https://github.com/eclipse/che/issues/7592", ex);
     }
+
+    terminal.moveDownListTerminal(".dockerenv");
+    terminal.waitExpectedTextIntoTerminal(".dockerenv");
+    terminal.movePageUpListTerminal("projects");
+    terminal.moveUpListTerminal("bin");
+    terminal.waitExpectedTextIntoTerminal("bin");
   }
 
   @Test(priority = 3)
   public void shouldResizeTerminal() {
     openMC("/");
 
-    // check the root content of the midnight commander
+    try {
+      // check the root content of the midnight commander
+      for (String partOfContent : CHECK_MC_OPENING) {
+        terminal.waitExpectedTextIntoTerminal(partOfContent);
+      }
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7592", ex);
+    }
+
+    terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
+    consoles.clickOnMaximizePanelIcon();
+    loader.waitOnClosed();
+
+    // check resize of the terminal
     for (String partOfContent : CHECK_MC_OPENING) {
       terminal.waitExpectedTextIntoTerminal(partOfContent);
     }
-
-    try {
-      // check resize of the terminal
-      terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
-      consoles.clickOnMaximizePanelIcon();
-      loader.waitOnClosed();
-      for (String partOfContent : CHECK_MC_OPENING) {
-        terminal.waitExpectedTextIntoTerminal(partOfContent);
-      }
-      terminal.waitExpectedTextIntoTerminal(".dockerenv");
-      consoles.clickOnMaximizePanelIcon();
-      loader.waitOnClosed();
-      for (String partOfContent : CHECK_MC_OPENING) {
-        terminal.waitExpectedTextIntoTerminal(partOfContent);
-      }
-      terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7592");
+    terminal.waitExpectedTextIntoTerminal(".dockerenv");
+    consoles.clickOnMaximizePanelIcon();
+    loader.waitOnClosed();
+    for (String partOfContent : CHECK_MC_OPENING) {
+      terminal.waitExpectedTextIntoTerminal(partOfContent);
     }
+    terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
   }
 
   @Test(priority = 4)
@@ -223,7 +226,7 @@ public class WorkingWithTerminalTest {
       }
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7592");
+      fail("Known issue https://github.com/eclipse/che/issues/7592", ex);
     }
 
     terminal.typeIntoTerminal(Keys.F10.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.miscellaneous;
 
 import static java.lang.String.valueOf;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -27,6 +28,7 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -156,13 +158,18 @@ public class WorkingWithTerminalTest {
   public void shouldScrollIntoTerminal() throws InterruptedException {
     openMC("/");
 
-    // check scrolling of the terminal
-    terminal.movePageDownListTerminal("opt");
-    terminal.moveDownListTerminal(".dockerenv");
-    terminal.waitExpectedTextIntoTerminal(".dockerenv");
-    terminal.movePageUpListTerminal("projects");
-    terminal.moveUpListTerminal("bin");
-    terminal.waitExpectedTextIntoTerminal("bin");
+    try {
+      // check scrolling of the terminal
+      terminal.movePageDownListTerminal("opt");
+      terminal.moveDownListTerminal(".dockerenv");
+      terminal.waitExpectedTextIntoTerminal(".dockerenv");
+      terminal.movePageUpListTerminal("projects");
+      terminal.moveUpListTerminal("bin");
+      terminal.waitExpectedTextIntoTerminal("bin");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7592");
+    }
   }
 
   @Test(priority = 3)
@@ -173,20 +180,26 @@ public class WorkingWithTerminalTest {
     for (String partOfContent : CHECK_MC_OPENING) {
       terminal.waitExpectedTextIntoTerminal(partOfContent);
     }
-    // check resize of the terminal
-    terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
-    consoles.clickOnMaximizePanelIcon();
-    loader.waitOnClosed();
-    for (String partOfContent : CHECK_MC_OPENING) {
-      terminal.waitExpectedTextIntoTerminal(partOfContent);
+
+    try {
+      // check resize of the terminal
+      terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
+      consoles.clickOnMaximizePanelIcon();
+      loader.waitOnClosed();
+      for (String partOfContent : CHECK_MC_OPENING) {
+        terminal.waitExpectedTextIntoTerminal(partOfContent);
+      }
+      terminal.waitExpectedTextIntoTerminal(".dockerenv");
+      consoles.clickOnMaximizePanelIcon();
+      loader.waitOnClosed();
+      for (String partOfContent : CHECK_MC_OPENING) {
+        terminal.waitExpectedTextIntoTerminal(partOfContent);
+      }
+      terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7592");
     }
-    terminal.waitExpectedTextIntoTerminal(".dockerenv");
-    consoles.clickOnMaximizePanelIcon();
-    loader.waitOnClosed();
-    for (String partOfContent : CHECK_MC_OPENING) {
-      terminal.waitExpectedTextIntoTerminal(partOfContent);
-    }
-    terminal.waitExpectedTextNotPresentTerminal(".dockerenv");
   }
 
   @Test(priority = 4)
@@ -203,10 +216,16 @@ public class WorkingWithTerminalTest {
     terminal.typeIntoTerminal(Keys.ARROW_DOWN.toString());
     terminal.typeIntoTerminal(Keys.ENTER.toString());
 
-    // check the home content of the midnight commander
-    for (String partOfContent : CHECK_MC_OPENING) {
-      terminal.waitExpectedTextIntoTerminal(partOfContent);
+    try {
+      // check the home content of the midnight commander
+      for (String partOfContent : CHECK_MC_OPENING) {
+        terminal.waitExpectedTextIntoTerminal(partOfContent);
+      }
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7592");
     }
+
     terminal.typeIntoTerminal(Keys.F10.toString());
   }
 


### PR DESCRIPTION
### What does this PR do?
- apply try/catch blocks in expected failure places of **WorkingWithTerminalTest** selenium test(https://github.com/eclipse/che/issues/7592);
- delete try/catch blocks from **WorkspaceDetailsTest** selenium test because https://github.com/eclipse/che/issues/7178 fixed.