### PR TITLE
Minor changes for extending che by rh-che

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/replace_stacks.sh
@@ -22,7 +22,7 @@ if [ -z "${CHE_API_ENDPOINT+x}" ]; then
     echo "done (${CHE_API_ENDPOINT})"
 fi
 
-DEFAULT_NEW_STACKS_URL="https://raw.githubusercontent.com/redhat-developer/rh-che/master/assembly/fabric8-stacks/src/main/resources/stacks.json"
+DEFAULT_NEW_STACKS_URL="https://raw.githubusercontent.com/redhat-developer/rh-che/multi-tenant-che6/assembly/fabric8-stacks/src/main/resources/stacks.json"
 NEW_STACKS_URL=${NEW_STACKS_URL:-${DEFAULT_NEW_STACKS_URL}}
 
 echo -n "[CHE] Fetching the list of current Che stacks..."

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -18,6 +18,7 @@ import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /** @author Sergii Leshchenko */
@@ -54,7 +55,12 @@ public class OpenShiftClientFactory {
     config = configBuilder.build();
   }
 
-  public OpenShiftClient create() {
+  /**
+   * Creates instance of {@link OpenShiftClient}.
+   *
+   * @throws InfrastructureException if any error occurs on client instance creation.
+   */
+  public OpenShiftClient create() throws InfrastructureException {
     return new DefaultOpenShiftClient(config);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
@@ -108,7 +108,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   }
 
   @Override
-  public void cleanup(String workspaceId) {
+  public void cleanup(String workspaceId) throws InfrastructureException {
     try (OpenShiftClient client = clientFactory.create()) {
       final String pvcUniqueName = pvcName + '-' + workspaceId;
       client.persistentVolumeClaims().inNamespace(projectName).withName(pvcUniqueName).delete();

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -18,7 +18,7 @@ import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.RUN
 import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.STARTING;
 import static org.eclipse.che.workspace.infrastructure.openshift.Constants.CHE_ORIGINAL_NAME_LABEL;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
@@ -60,7 +60,6 @@ import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
-import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.DtoConverter;
 import org.eclipse.che.api.workspace.server.URLRewriter;
 import org.eclipse.che.api.workspace.server.hc.ServersChecker;
@@ -151,8 +150,7 @@ public class OpenShiftInternalRuntimeTest {
     when(project.services()).thenReturn(services);
     when(project.routes()).thenReturn(routes);
     when(project.pods()).thenReturn(pods);
-    when(bootstrapperFactory.create(any(), anyListOf(Installer.class), any()))
-        .thenReturn(bootstrapper);
+    when(bootstrapperFactory.create(any(), anyList(), any())).thenReturn(bootstrapper);
     when(context.getEnvironment()).thenReturn(osEnv);
     doReturn(
             ImmutableMap.of(

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
@@ -68,7 +68,7 @@ public class OpenShiftEnvironmentFactoryTest {
       serverGettable;
 
   @BeforeMethod
-  public void setup() {
+  public void setup() throws Exception {
     osEnvironmentFactory =
         new OpenShiftEnvironmentFactory(null, null, null, factory, osEnvValidator);
     when(factory.create()).thenReturn(client);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemoveTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemoveTest.java
@@ -41,7 +41,7 @@ public class RemoveProjectOnWorkspaceRemoveTest {
   private RemoveProjectOnWorkspaceRemove removeProjectOnWorkspaceRemove;
 
   @BeforeMethod
-  public void setUp() {
+  public void setUp() throws Exception {
     removeProjectOnWorkspaceRemove = spy(new RemoveProjectOnWorkspaceRemove(null, null));
 
     doNothing().when(removeProjectOnWorkspaceRemove).doRemoveProject(anyString());
@@ -59,7 +59,7 @@ public class RemoveProjectOnWorkspaceRemoveTest {
   }
 
   @Test
-  public void shouldRemoveProjectOnWorkspaceRemovedEvent() {
+  public void shouldRemoveProjectOnWorkspaceRemovedEvent() throws Exception {
     removeProjectOnWorkspaceRemove.onEvent(new WorkspaceRemovedEvent(workspace));
 
     verify(removeProjectOnWorkspaceRemove).doRemoveProject(WORKSPACE_ID);

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/WorkspaceProjectSynchronizer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/WorkspaceProjectSynchronizer.java
@@ -42,7 +42,6 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer {
   private final HttpJsonRequestFactory httpJsonRequestFactory;
   private final WorkspaceSyncCommunication workspaceSyncCommunication;
 
-  private final String userToken;
   private final String apiEndpoint;
   private final String workspaceId;
 
@@ -59,11 +58,9 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer {
     this.projectConfigRegistry = projectConfigRegistry;
 
     this.workspaceId = System.getenv("CHE_WORKSPACE_ID");
-    this.userToken = System.getenv("USER_TOKEN");
 
     LOG.info("Workspace ID: " + workspaceId);
     LOG.info("API Endpoint: " + apiEndpoint);
-    LOG.info("User Token  : " + (userToken != null));
 
     // check connection
     try {
@@ -168,9 +165,6 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer {
         UriBuilder.fromUri(apiEndpoint)
             .path(WorkspaceService.class)
             .path(WorkspaceService.class, "addProject");
-    if (userToken != null) {
-      builder.queryParam("token", userToken);
-    }
     final String href = builder.build(workspaceId).toString();
     try {
       httpJsonRequestFactory.fromUrl(href).usePostMethod().setBody(asDto(project)).request();
@@ -186,9 +180,6 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer {
         UriBuilder.fromUri(apiEndpoint)
             .path(WorkspaceService.class)
             .path(WorkspaceService.class, "updateProject");
-    if (userToken != null) {
-      builder.queryParam("token", userToken);
-    }
     final String href =
         builder.build(new String[] {workspaceId, project.getPath()}, false).toString();
     try {
@@ -205,9 +196,7 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer {
         UriBuilder.fromUri(apiEndpoint)
             .path(WorkspaceService.class)
             .path(WorkspaceService.class, "deleteProject");
-    if (userToken != null) {
-      builder.queryParam("token", userToken);
-    }
+
     final String href =
         builder.build(new String[] {workspaceId, project.getPath()}, false).toString();
     try {
@@ -224,9 +213,6 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer {
         UriBuilder.fromUri(apiEndpoint)
             .path(WorkspaceService.class)
             .path(WorkspaceService.class, "getByKey");
-    if (userToken != null) {
-      builder.queryParam("token", userToken);
-    }
     final String href = builder.build(workspaceId).toString();
     try {
       return httpJsonRequestFactory


### PR DESCRIPTION
### What does this PR do?
Adds an ability to throw an exception while OpenShift client creation. It is needed while other OpenShift client factory implementations should be able to do some operations before construction of OpenShift client instance and throw an exception if an error occurs and it is impossible to create OpenShift client. 

Replace stacks has an outdated link. So this PR fixes it.

The following change is not related to rh-che: Workspace agent components use AgentHttpJsonRequestFactory that is responsible for the setting of machine token to requests to workspace master API. So such logic is removed in WorkspaceProjectSynchronizer because:
- it uses the outdated environment variable `USER_TOKEN`, it should be `CHE_MACHINE_TOKEN`.
- AgentHttpJsonRequestFactory does the same thing.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7155
