### PR TITLE
Displays current project name with vcs head name in status bar if present

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitExtension.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitExtension.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.ide.ext.git.client;
 
+import static org.eclipse.che.ide.api.action.IdeActions.GROUP_LEFT_STATUS_PANEL;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_MAIN_MENU;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_PROFILE;
 import static org.eclipse.che.ide.api.constraints.Anchor.BEFORE;
@@ -44,6 +45,7 @@ import org.eclipse.che.ide.ext.git.client.action.ShowBranchesAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowMergeAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowRemoteAction;
 import org.eclipse.che.ide.ext.git.client.action.ShowStatusAction;
+import org.eclipse.che.ide.ext.git.client.action.StatusBarBranchPointer;
 import org.eclipse.che.ide.ext.git.client.action.ToggleGitPanelAction;
 import org.vectomatic.dom.svg.ui.SVGImage;
 
@@ -100,7 +102,8 @@ public class GitExtension {
       PreviousDiffAction previousDiffAction,
       KeyBindingAgent keyBinding,
       ToggleGitPanelAction gitPanelAction,
-      GitNotificationsSubscriber gitNotificationsSubscriber) {
+      GitNotificationsSubscriber gitNotificationsSubscriber,
+      StatusBarBranchPointer statusBarBranchPointer) {
     gitNotificationsSubscriber.subscribe();
 
     resources.gitCSS().ensureInjected();
@@ -235,5 +238,9 @@ public class GitExtension {
     keyBinding
         .getGlobal()
         .addKey(new KeyBuilder().alt().charCode('g').build(), GIT_PANEL_ACTION_ID);
+
+    DefaultActionGroup rightStatusPanelGroup =
+        (DefaultActionGroup) actionManager.getAction(GROUP_LEFT_STATUS_PANEL);
+    rightStatusPanelGroup.add(statusBarBranchPointer);
   }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/StatusBarBranchPointer.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/StatusBarBranchPointer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.ext.git.client.action;
+
+import com.google.common.annotations.Beta;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Cursor;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.BaseAction;
+import org.eclipse.che.ide.api.action.CustomComponentAction;
+import org.eclipse.che.ide.api.action.Presentation;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.ext.git.client.GitResources;
+import org.eclipse.che.ide.ext.git.client.branch.BranchPresenter;
+import org.vectomatic.dom.svg.ui.SVGImage;
+
+/**
+ * Displays in status bar current project name with vcs branch if present.
+ *
+ * @author Vlad Zhukovskyi
+ * @since 6.0.0
+ */
+@Singleton
+@Beta
+public class StatusBarBranchPointer extends BaseAction implements CustomComponentAction {
+
+  private final AppContext appContext;
+  private final GitResources resources;
+  private final BranchPresenter branchPresenter;
+  private final HorizontalPanel panel;
+
+  @Inject
+  public StatusBarBranchPointer(
+      AppContext appContext, GitResources resources, BranchPresenter branchPresenter) {
+    super();
+    this.appContext = appContext;
+    this.resources = resources;
+    this.branchPresenter = branchPresenter;
+
+    panel = new HorizontalPanel();
+    panel.ensureDebugId("statusBarProjectBranchPointerPanel");
+  }
+
+  @Override
+  public Widget createCustomComponent(Presentation presentation) {
+    return panel;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {}
+
+  @Override
+  public void update(ActionEvent e) {
+    panel.clear();
+
+    Project project = appContext.getRootProject();
+    if (project == null) {
+      return;
+    }
+
+    Label projectNameLabel = new Label(project.getName());
+    projectNameLabel.ensureDebugId("statusBarProjectBranchRepositoryName");
+    projectNameLabel.getElement().getStyle().setMarginLeft(5., Unit.PX);
+    panel.add(projectNameLabel);
+
+    String head = project.getAttribute("git.current.head.name");
+    if (head == null) {
+      return;
+    }
+
+    SVGImage branchIcon = new SVGImage(resources.checkoutReference());
+    branchIcon.getSvgElement().getStyle().setMarginLeft(5., Unit.PX);
+    Label headLabel = new Label(head);
+    headLabel.ensureDebugId("statusBarProjectBranchName");
+    Style headLabelStyle = headLabel.getElement().getStyle();
+    headLabelStyle.setCursor(Cursor.POINTER);
+    headLabelStyle.setMarginLeft(5., Unit.PX);
+    headLabel.addClickHandler(event -> branchPresenter.showBranches(project));
+    panel.add(branchIcon);
+    panel.add(headLabel);
+  }
+}

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/StatusBarBranchPointer.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/StatusBarBranchPointer.java
@@ -25,6 +25,7 @@ import org.eclipse.che.ide.api.action.CustomComponentAction;
 import org.eclipse.che.ide.api.action.Presentation;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.GitResources;
 import org.eclipse.che.ide.ext.git.client.branch.BranchPresenter;
 import org.vectomatic.dom.svg.ui.SVGImage;
@@ -44,15 +45,20 @@ public class StatusBarBranchPointer extends BaseAction implements CustomComponen
   private final AppContext appContext;
   private final GitResources resources;
   private final BranchPresenter branchPresenter;
+  private final GitLocalizationConstant constant;
   private final HorizontalPanel panel;
 
   @Inject
   public StatusBarBranchPointer(
-      AppContext appContext, GitResources resources, BranchPresenter branchPresenter) {
+      AppContext appContext,
+      GitResources resources,
+      BranchPresenter branchPresenter,
+      GitLocalizationConstant constant) {
     super();
     this.appContext = appContext;
     this.resources = resources;
     this.branchPresenter = branchPresenter;
+    this.constant = constant;
 
     panel = new HorizontalPanel();
     panel.ensureDebugId("statusBarProjectBranchPointerPanel");
@@ -83,6 +89,7 @@ public class StatusBarBranchPointer extends BaseAction implements CustomComponen
 
       Label headLabel = new Label(project.getAttribute(GIT_CURRENT_HEAD_NAME));
       headLabel.ensureDebugId("statusBarProjectBranchName");
+      headLabel.setTitle(constant.branchesControlTitle());
       Style headLabelStyle = headLabel.getElement().getStyle();
       headLabelStyle.setCursor(Cursor.POINTER);
       headLabelStyle.setMarginLeft(5., Unit.PX);

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/StatusBarBranchPointer.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/action/StatusBarBranchPointer.java
@@ -39,6 +39,8 @@ import org.vectomatic.dom.svg.ui.SVGImage;
 @Beta
 public class StatusBarBranchPointer extends BaseAction implements CustomComponentAction {
 
+  public static final String GIT_CURRENT_HEAD_NAME = "git.current.head.name";
+
   private final AppContext appContext;
   private final GitResources resources;
   private final BranchPresenter branchPresenter;
@@ -69,29 +71,23 @@ public class StatusBarBranchPointer extends BaseAction implements CustomComponen
     panel.clear();
 
     Project project = appContext.getRootProject();
-    if (project == null) {
-      return;
+    if (project != null && project.getAttributes().containsKey(GIT_CURRENT_HEAD_NAME)) {
+      Label projectNameLabel = new Label(project.getName());
+      projectNameLabel.ensureDebugId("statusBarProjectBranchRepositoryName");
+      projectNameLabel.getElement().getStyle().setMarginLeft(5., Unit.PX);
+      panel.add(projectNameLabel);
+
+      SVGImage branchIcon = new SVGImage(resources.checkoutReference());
+      branchIcon.getSvgElement().getStyle().setMarginLeft(5., Unit.PX);
+      panel.add(branchIcon);
+
+      Label headLabel = new Label(project.getAttribute(GIT_CURRENT_HEAD_NAME));
+      headLabel.ensureDebugId("statusBarProjectBranchName");
+      Style headLabelStyle = headLabel.getElement().getStyle();
+      headLabelStyle.setCursor(Cursor.POINTER);
+      headLabelStyle.setMarginLeft(5., Unit.PX);
+      headLabel.addClickHandler(event -> branchPresenter.showBranches(project));
+      panel.add(headLabel);
     }
-
-    Label projectNameLabel = new Label(project.getName());
-    projectNameLabel.ensureDebugId("statusBarProjectBranchRepositoryName");
-    projectNameLabel.getElement().getStyle().setMarginLeft(5., Unit.PX);
-    panel.add(projectNameLabel);
-
-    String head = project.getAttribute("git.current.head.name");
-    if (head == null) {
-      return;
-    }
-
-    SVGImage branchIcon = new SVGImage(resources.checkoutReference());
-    branchIcon.getSvgElement().getStyle().setMarginLeft(5., Unit.PX);
-    Label headLabel = new Label(head);
-    headLabel.ensureDebugId("statusBarProjectBranchName");
-    Style headLabelStyle = headLabel.getElement().getStyle();
-    headLabelStyle.setCursor(Cursor.POINTER);
-    headLabelStyle.setMarginLeft(5., Unit.PX);
-    headLabel.addClickHandler(event -> branchPresenter.showBranches(project));
-    panel.add(branchIcon);
-    panel.add(headLabel);
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR proposes to display in status bar the current project name from the application context with vcs head name if the last one exists.

![git_branches](https://user-images.githubusercontent.com/1968177/33324469-6314836c-d458-11e7-8293-41755b79cc0c.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
N/A

#### Release Notes
Displays current project name with vcs head name in status bar if present

#### Docs PR
Doesn't need to be documented.
