### PR TITLE
Disable changing page URL by IDE

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultIdeInitializationStrategy.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultIdeInitializationStrategy.java
@@ -113,9 +113,6 @@ class DefaultIdeInitializationStrategy implements IdeInitializationStrategy {
         .then(showUI())
         .then(
             arg -> {
-              WorkspaceImpl workspace = appContext.getWorkspace();
-              browserAddress.setAddress(workspace.getNamespace(), workspace.getConfig().getName());
-
               eventBus.fireEvent(new BasicIDEInitializedEvent());
             });
   }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/QueryParameters.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/QueryParameters.java
@@ -10,11 +10,11 @@
  */
 package org.eclipse.che.ide;
 
-import com.google.gwt.user.client.Window.Location;
+import static com.google.gwt.user.client.Window.Location.getParameter;
+import static com.google.gwt.user.client.Window.Location.getParameterMap;
+
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
@@ -26,14 +26,6 @@ import javax.inject.Singleton;
 @Singleton
 public class QueryParameters {
 
-  private final Map<String, List<String>> cachedParameters;
-
-  @Inject
-  public QueryParameters() {
-    // cache the query parameters because IDE changes window's location
-    cachedParameters = Location.getParameterMap();
-  }
-
   /**
    * Returns the query parameter by the specified name or empty string if parameter was not found.
    * Note that if multiple parameters have been specified with the same name, the last one will be
@@ -43,13 +35,9 @@ public class QueryParameters {
    * @return query parameter value
    */
   public String getByName(String name) {
-    List<String> paramsForName = cachedParameters.get(name);
+    String value = getParameter(name);
 
-    if (paramsForName == null) {
-      return "";
-    } else {
-      return paramsForName.get(paramsForName.size() - 1);
-    }
+    return value == null ? "" : value;
   }
 
   /**
@@ -63,9 +51,8 @@ public class QueryParameters {
    */
   public Map<String, String> getAll() {
     Map<String, String> parameters = new HashMap<>();
-    for (Map.Entry<String, List<String>> parametersEntry : cachedParameters.entrySet()) {
-      parameters.put(parametersEntry.getKey(), parametersEntry.getValue().get(0));
-    }
+    getParameterMap().forEach((key, value) -> parameters.put(key, value.get(0)));
+
     return parameters;
   }
 }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
IDE resets URL of the browser page after loading to remove all the query parameters. It causes several problems.
URL resetting has been added a long time ago but today it's not needed anymore. So this PR removes it.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
