### PR TITLE
CHE-7407: Remove redundant file watcher initialization

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitEventsHandler.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitEventsHandler.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.ide.ext.git.client;
 
+import static org.eclipse.che.api.git.shared.Constants.EVENT_GIT_FILE_CHANGED;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.HashSet;
@@ -32,7 +34,6 @@ import org.eclipse.che.api.project.shared.dto.event.GitCheckoutEventDto;
 @Singleton
 public class GitEventsHandler implements GitEventSubscribable {
 
-  private static final String EVENT_GIT_FILE_CHANGED = "event/git-change";
   private static final String EVENT_GIT_STATUS_CHANGED = "event/git/status-changed";
   private static final String EVENT_GIT_CHECKOUT = "event/git-checkout";
   private static final String EVENT_GIT_REPOSITORY_INITIALIZED = "event/git/initialized";

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitNotificationsSubscriber.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitNotificationsSubscriber.java
@@ -46,7 +46,6 @@ public class GitNotificationsSubscriber {
 
   private void initialize() {
     initializeGitCheckoutWatcher();
-    initializeGitChangeWatcher();
     initializeGitIndexWatcher();
     initializeGitEventsWatcher();
   }
@@ -56,15 +55,6 @@ public class GitNotificationsSubscriber {
         .newRequest()
         .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
         .methodName("track/git-checkout")
-        .noParams()
-        .sendAndSkipResult();
-  }
-
-  private void initializeGitChangeWatcher() {
-    requestTransmitter
-        .newRequest()
-        .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
-        .methodName("track/git-change")
         .noParams()
         .sendAndSkipResult();
   }

--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Constants.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Constants.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.git.shared;
 public class Constants {
   public static final int DEFAULT_PAGE_SIZE = 20;
   public static final String DEFAULT_PAGE_SIZE_QUERY_PARAM = "20";
+  public static final String EVENT_GIT_FILE_CHANGED = "event/git-change";
 
   private Constants() {}
 }

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitChangesDetector.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitChangesDetector.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.git;
 
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.fs.server.WsPathUtils.absolutize;
+import static org.eclipse.che.api.git.shared.Constants.EVENT_GIT_FILE_CHANGED;
 import static org.eclipse.che.api.git.shared.FileChangedEventDto.Status.ADDED;
 import static org.eclipse.che.api.git.shared.FileChangedEventDto.Status.MODIFIED;
 import static org.eclipse.che.api.git.shared.FileChangedEventDto.Status.NOT_MODIFIED;
@@ -48,8 +49,6 @@ import org.slf4j.Logger;
 public class GitChangesDetector {
 
   private static final Logger LOG = getLogger(GitChangesDetector.class);
-
-  private static final String OUTGOING_METHOD = "event/git-change";
 
   private final RequestTransmitter transmitter;
   private final FileWatcherManager manager;
@@ -185,7 +184,7 @@ public class GitChangesDetector {
         transmitter
             .newRequest()
             .endpointId(endpointId)
-            .methodName(OUTGOING_METHOD)
+            .methodName(EVENT_GIT_FILE_CHANGED)
             .paramsAsDto(
                 newDto(FileChangedEventDto.class)
                     .withPath(wsPath)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove redundant file watcher initialization
Move Git change event method to constants

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
