### PR TITLE
Add attributes field to ServerConfig and Server model objects

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.api.core.model.workspace.config;
 
+import java.util.Map;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
@@ -52,4 +53,7 @@ public interface ServerConfig {
   /** Path used by server. */
   @Nullable
   String getPath();
+
+  /** Attributes of the server */
+  Map<String, String> getAttributes();
 }

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/runtime/Server.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/runtime/Server.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.api.core.model.workspace.runtime;
 
+import java.util.Map;
+
 /**
  * Server Runtime exposed by URL
  *
@@ -22,4 +24,7 @@ public interface Server {
 
   /** @return the status */
   ServerStatus getStatus();
+
+  /** Returns attributes of the server with some metadata */
+  Map<String, String> getAttributes();
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/MachineImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/MachineImpl.java
@@ -36,12 +36,7 @@ public class MachineImpl implements Machine {
               .collect(
                   HashMap::new,
                   (map, entry) ->
-                      map.put(
-                          entry.getKey(),
-                          new ServerImpl(
-                              entry.getKey(),
-                              entry.getValue().getUrl(),
-                              entry.getValue().getStatus())),
+                      map.put(entry.getKey(), new ServerImpl(entry.getKey(), entry.getValue())),
                   HashMap::putAll);
     }
   }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/ServerConfigImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/ServerConfigImpl.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.ide.api.workspace.model;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 
@@ -18,17 +20,26 @@ public class ServerConfigImpl implements ServerConfig {
   private String port;
   private String protocol;
   private String path;
+  private Map<String, String> attributes;
 
-  public ServerConfigImpl(String port, String protocol, String path) {
+  public ServerConfigImpl(
+      String port, String protocol, String path, Map<String, String> attributes) {
     this.port = port;
     this.protocol = protocol;
     this.path = path;
+    if (attributes != null) {
+      this.attributes = new HashMap<>(attributes);
+    } else {
+      this.attributes = new HashMap<>();
+    }
   }
 
   public ServerConfigImpl(ServerConfig serverConf) {
-    this.port = serverConf.getPort();
-    this.protocol = serverConf.getProtocol();
-    this.path = serverConf.getPath();
+    this(
+        serverConf.getPort(),
+        serverConf.getProtocol(),
+        serverConf.getPath(),
+        serverConf.getAttributes());
   }
 
   @Override
@@ -47,6 +58,11 @@ public class ServerConfigImpl implements ServerConfig {
   }
 
   @Override
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
@@ -57,6 +73,7 @@ public class ServerConfigImpl implements ServerConfig {
     final ServerConfigImpl that = (ServerConfigImpl) obj;
     return Objects.equals(port, that.port)
         && Objects.equals(protocol, that.protocol)
+        && Objects.equals(attributes, that.attributes)
         && getPath().equals(that.getPath());
   }
 
@@ -66,6 +83,7 @@ public class ServerConfigImpl implements ServerConfig {
     hash = 31 * hash + Objects.hashCode(port);
     hash = 31 * hash + Objects.hashCode(protocol);
     hash = 31 * hash + Objects.hashCode(path);
+    hash = 31 * hash + Objects.hashCode(attributes);
     return hash;
   }
 
@@ -78,8 +96,11 @@ public class ServerConfigImpl implements ServerConfig {
         + ", protocol='"
         + protocol
         + '\''
-        + ", path="
+        + ", path='"
         + path
+        + '\''
+        + ", attributes="
+        + attributes
         + '}';
   }
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/ServerImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/ServerImpl.java
@@ -12,6 +12,8 @@ package org.eclipse.che.ide.api.workspace.model;
 
 import static com.google.common.base.Strings.nullToEmpty;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 
@@ -20,15 +22,17 @@ public class ServerImpl implements Server {
   private String name;
   private String url;
   private ServerStatus status;
+  private Map<String, String> attributes;
 
-  public ServerImpl(String name, String url) {
-    this(name, url, ServerStatus.UNKNOWN);
-  }
-
-  public ServerImpl(String name, String url, ServerStatus status) {
+  public ServerImpl(String name, Server server) {
     this.name = name;
-    this.url = nullToEmpty(url); // some servers doesn't have URL
-    this.status = status;
+    this.url = nullToEmpty(server.getUrl()); // some servers doesn't have URL
+    this.status = server.getStatus();
+    if (server.getAttributes() != null) {
+      this.attributes = new HashMap<>(server.getAttributes());
+    } else {
+      this.attributes = new HashMap<>();
+    }
   }
 
   public String getName() {
@@ -43,5 +47,10 @@ public class ServerImpl implements Server {
   @Override
   public ServerStatus getStatus() {
     return this.status;
+  }
+
+  @Override
+  public Map<String, String> getAttributes() {
+    return attributes;
   }
 }

--- a/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/ComposeEnvironmentValidatorTest.java
+++ b/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/ComposeEnvironmentValidatorTest.java
@@ -61,6 +61,7 @@ public class ComposeEnvironmentValidatorTest {
     when(server.getPort()).thenReturn("8080/tcp");
     when(server.getPath()).thenReturn("/some/path");
     when(server.getProtocol()).thenReturn("https");
+    when(server.getAttributes()).thenReturn(singletonMap("key", "value"));
   }
 
   @Test
@@ -74,7 +75,11 @@ public class ComposeEnvironmentValidatorTest {
         .thenReturn(
             newLinkedHashMap(ImmutableMap.of(MACHINE_NAME, service, machine2Name, container2)));
     ServerConfigImpl server =
-        new ServerConfigImpl().withPort("8080").withPath("/some/path").withProtocol("https");
+        new ServerConfigImpl()
+            .withPort("8080")
+            .withPath("/some/path")
+            .withProtocol("https")
+            .withAttributes(singletonMap("key", "value"));
     when(machineConfig.getServers())
         .thenReturn(singletonMap(Constants.SERVER_WS_AGENT_HTTP_REFERENCE, server));
     Map<String, String> attributes =

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInfraModule.java
@@ -68,5 +68,8 @@ public class DockerInfraModule extends AbstractModule {
     install(new FactoryModuleBuilder().build(DockerRuntimeFactory.class));
     install(new FactoryModuleBuilder().build(DockerBootstrapperFactory.class));
     install(new FactoryModuleBuilder().build(DockerRuntimeContextFactory.class));
+    bind(
+        org.eclipse.che.workspace.infrastructure.docker.monit.DockerAbandonedResourcesCleaner
+            .class);
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -10,8 +10,9 @@
  */
 package org.eclipse.che.workspace.infrastructure.docker;
 
-import static java.util.Collections.emptyMap;
-
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -39,10 +40,16 @@ public final class Labels {
   private static final String SERVER_PORT_LABEL_FMT = LABEL_PREFIX + "server.%s.port";
   private static final String SERVER_PROTOCOL_LABEL_FMT = LABEL_PREFIX + "server.%s.protocol";
   private static final String SERVER_PATH_LABEL_FMT = LABEL_PREFIX + "server.%s.path";
+  private static final String SERVER_ATTR_LABEL_FMT = LABEL_PREFIX + "server.%s.attributes";
 
   /** Pattern that matches server labels e.g. "org.eclipse.che.server.exec-agent.port". */
   private static final Pattern SERVER_LABEL_PATTERN =
       Pattern.compile("org\\.eclipse\\.che\\.server\\.(?<ref>[\\w-/.]+)\\..+");
+
+  private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+  // used to avoid frequent creations of the object at runtime
+  private static final java.lang.reflect.Type mapTypeToken =
+      new TypeToken<Map<String, String>>() {}.getType();
 
   /** Creates new label serializer. */
   public static Serializer newSerializer() {
@@ -98,6 +105,9 @@ public final class Labels {
       labels.put(String.format(SERVER_PROTOCOL_LABEL_FMT, ref), server.getProtocol());
       if (server.getPath() != null) {
         labels.put(String.format(SERVER_PATH_LABEL_FMT, ref), server.getPath());
+      }
+      if (server.getAttributes() != null) {
+        labels.put(String.format(SERVER_ATTR_LABEL_FMT, ref), GSON.toJson(server.getAttributes()));
       }
       return this;
     }
@@ -156,7 +166,8 @@ public final class Labels {
                     labels.get(String.format(SERVER_PORT_LABEL_FMT, ref)),
                     labels.get(String.format(SERVER_PROTOCOL_LABEL_FMT, ref)),
                     labels.get(String.format(SERVER_PATH_LABEL_FMT, ref)),
-                    emptyMap()));
+                    GSON.fromJson(
+                        labels.get(String.format(SERVER_ATTR_LABEL_FMT, ref)), mapTypeToken)));
           }
         }
       }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.docker;
 
+import static java.util.Collections.emptyMap;
+
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -153,7 +155,8 @@ public final class Labels {
                 new ServerConfigImpl(
                     labels.get(String.format(SERVER_PORT_LABEL_FMT, ref)),
                     labels.get(String.format(SERVER_PROTOCOL_LABEL_FMT, ref)),
-                    labels.get(String.format(SERVER_PATH_LABEL_FMT, ref))));
+                    labels.get(String.format(SERVER_PATH_LABEL_FMT, ref)),
+                    emptyMap()));
           }
         }
       }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapper.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapper.java
@@ -88,7 +88,10 @@ public class ServersMapper {
         for (String ref : refs) {
           ServerConfig cfg = configs.get(ref);
           mapped.put(
-              ref, new ServerImpl().withUrl(makeUrl(port, cfg.getProtocol(), cfg.getPath())));
+              ref,
+              new ServerImpl()
+                  .withUrl(makeUrl(port, cfg.getProtocol(), cfg.getPath()))
+                  .withAttributes(cfg.getAttributes()));
         }
       }
     }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapper.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapper.java
@@ -83,11 +83,12 @@ public class ServersMapper {
       }
 
       if (refs == null) {
-        mapped.put(rawPort, new ServerImpl(makeUrl(port, null, null)));
+        mapped.put(rawPort, new ServerImpl().withUrl(makeUrl(port, null, null)));
       } else {
         for (String ref : refs) {
           ServerConfig cfg = configs.get(ref);
-          mapped.put(ref, new ServerImpl(makeUrl(port, cfg.getProtocol(), cfg.getPath())));
+          mapped.put(
+              ref, new ServerImpl().withUrl(makeUrl(port, cfg.getProtocol(), cfg.getPath())));
         }
       }
     }

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
@@ -11,9 +11,12 @@
 package org.eclipse.che.workspace.infrastructure.docker;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
@@ -28,6 +31,10 @@ import org.testng.annotations.Test;
  * @author Yevhenii Voevodin
  */
 public class LabelsTest {
+  static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+  static final Map<String, String> ATTRIBUTES = singletonMap("key", "value");
+  static final String STRING_ATTRIBUTES = GSON.toJson(ATTRIBUTES);
+  static final String STRING_EMPTY_ATTRIBUTES = GSON.toJson(emptyMap());
 
   @Test
   public void serialization() {
@@ -38,11 +45,11 @@ public class LabelsTest {
             .server(
                 "my-server1/http",
                 new ServerConfigImpl("8000/tcp", "http", "/api/info", emptyMap()))
-            .server("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap()))
-            .server("my-server3", new ServerConfigImpl("7070/tcp", "http", null, emptyMap()))
+            .server("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", null))
+            .server("my-server3", new ServerConfigImpl("7070/tcp", "http", null, ATTRIBUTES))
             .server(
                 "my.dot.separated.server",
-                new ServerConfigImpl("9090/tcp", "http", null, emptyMap()))
+                new ServerConfigImpl("9090/tcp", "http", null, ATTRIBUTES))
             .labels();
     Map<String, String> expected =
         ImmutableMap.<String, String>builder()
@@ -53,13 +60,17 @@ public class LabelsTest {
             .put("org.eclipse.che.server.my-server1/http.port", "8000/tcp")
             .put("org.eclipse.che.server.my-server1/http.protocol", "http")
             .put("org.eclipse.che.server.my-server1/http.path", "/api/info")
+            .put("org.eclipse.che.server.my-server1/http.attributes", STRING_EMPTY_ATTRIBUTES)
             .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
             .put("org.eclipse.che.server.my-server2.protocol", "ws")
             .put("org.eclipse.che.server.my-server2.path", "/connect")
+            .put("org.eclipse.che.server.my-server2.attributes", STRING_EMPTY_ATTRIBUTES)
             .put("org.eclipse.che.server.my-server3.port", "7070/tcp")
             .put("org.eclipse.che.server.my-server3.protocol", "http")
+            .put("org.eclipse.che.server.my-server3.attributes", STRING_ATTRIBUTES)
             .put("org.eclipse.che.server.my.dot.separated.server.port", "9090/tcp")
             .put("org.eclipse.che.server.my.dot.separated.server.protocol", "http")
+            .put("org.eclipse.che.server.my.dot.separated.server.attributes", STRING_ATTRIBUTES)
             .build();
 
     assertEquals(serialized, expected);
@@ -78,11 +89,14 @@ public class LabelsTest {
             .put("org.eclipse.che.server.my-server1/http.port", "8000/tcp")
             .put("org.eclipse.che.server.my-server1/http.protocol", "http")
             .put("org.eclipse.che.server.my-server1/http.path", "/api/info")
+            .put("org.eclipse.che.server.my-server1/http.attributes", STRING_ATTRIBUTES)
             .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
             .put("org.eclipse.che.server.my-server2.protocol", "ws")
             .put("org.eclipse.che.server.my-server2.path", "/connect")
+            .put("org.eclipse.che.server.my-server2.attributes", STRING_EMPTY_ATTRIBUTES)
             .put("org.eclipse.che.server.my-server3.port", "7070/tcp")
             .put("org.eclipse.che.server.my-server3.protocol", "http")
+            .put("org.eclipse.che.server.my-server3.attributes", STRING_ATTRIBUTES)
             .put("org.eclipse.che.server.my.dot.separated.server.port", "9090/tcp")
             .put("org.eclipse.che.server.my.dot.separated.server.protocol", "http")
             .build();
@@ -90,12 +104,12 @@ public class LabelsTest {
     Labels.Deserializer deserializer = Labels.newDeserializer(labels);
     Map<String, ServerConfig> expectedServers = new HashMap<>();
     expectedServers.put(
-        "my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info", emptyMap()));
+        "my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info", ATTRIBUTES));
     expectedServers.put(
         "my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap()));
-    expectedServers.put("my-server3", new ServerConfigImpl("7070/tcp", "http", null, emptyMap()));
+    expectedServers.put("my-server3", new ServerConfigImpl("7070/tcp", "http", null, ATTRIBUTES));
     expectedServers.put(
-        "my.dot.separated.server", new ServerConfigImpl("9090/tcp", "http", null, emptyMap()));
+        "my.dot.separated.server", new ServerConfigImpl("9090/tcp", "http", null, null));
 
     assertEquals(deserializer.machineName(), "dev-machine");
 

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/LabelsTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.docker;
 
+import static java.util.Collections.emptyMap;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
@@ -34,10 +35,14 @@ public class LabelsTest {
         Labels.newSerializer()
             .machineName("dev-machine")
             .runtimeId(new RuntimeIdentityImpl("workspace123", "my-env", "owner"))
-            .server("my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info"))
-            .server("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect"))
-            .server("my-server3", new ServerConfigImpl("7070/tcp", "http", null))
-            .server("my.dot.separated.server", new ServerConfigImpl("9090/tcp", "http", null))
+            .server(
+                "my-server1/http",
+                new ServerConfigImpl("8000/tcp", "http", "/api/info", emptyMap()))
+            .server("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap()))
+            .server("my-server3", new ServerConfigImpl("7070/tcp", "http", null, emptyMap()))
+            .server(
+                "my.dot.separated.server",
+                new ServerConfigImpl("9090/tcp", "http", null, emptyMap()))
             .labels();
     Map<String, String> expected =
         ImmutableMap.<String, String>builder()
@@ -84,10 +89,13 @@ public class LabelsTest {
 
     Labels.Deserializer deserializer = Labels.newDeserializer(labels);
     Map<String, ServerConfig> expectedServers = new HashMap<>();
-    expectedServers.put("my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info"));
-    expectedServers.put("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect"));
-    expectedServers.put("my-server3", new ServerConfigImpl("7070/tcp", "http", null));
-    expectedServers.put("my.dot.separated.server", new ServerConfigImpl("9090/tcp", "http", null));
+    expectedServers.put(
+        "my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info", emptyMap()));
+    expectedServers.put(
+        "my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap()));
+    expectedServers.put("my-server3", new ServerConfigImpl("7070/tcp", "http", null, emptyMap()));
+    expectedServers.put(
+        "my.dot.separated.server", new ServerConfigImpl("9090/tcp", "http", null, emptyMap()));
 
     assertEquals(deserializer.machineName(), "dev-machine");
 

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/BindMountProjectsVolumeProvisionerTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/BindMountProjectsVolumeProvisionerTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.docker.local.projects;
 
+import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -72,7 +73,7 @@ public class BindMountProjectsVolumeProvisionerTest {
         .thenReturn(
             Collections.singletonMap(
                 Constants.SERVER_WS_AGENT_HTTP_REFERENCE,
-                new ServerConfigImpl("8080", "http", "/api")));
+                new ServerConfigImpl("8080", "http", "/api", singletonMap("key", "value"))));
   }
 
   @Test

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapperTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapperTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.docker.server.mapping;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
 import static org.testng.Assert.assertEquals;
@@ -50,8 +51,8 @@ public class ServersMapperTest {
             "8080/tcp", "0.0.0.0:32080",
             "8081/tcp", "0.0.0.0:32081"),
         ImmutableMap.of(
-            "server1", new ServerConfigImpl("8080", "http", "no-slash-path"),
-            "server2", new ServerConfigImpl("8081", "http", "/slash-path")),
+            "server1", new ServerConfigImpl("8080", "http", "no-slash-path", emptyMap()),
+            "server2", new ServerConfigImpl("8081", "http", "/slash-path", emptyMap())),
         ImmutableMap.of(
             "server1", new ServerImpl("http://" + hostname + ":32080/no-slash-path"),
             "server2", new ServerImpl("http://" + hostname + ":32081/slash-path"))
@@ -59,8 +60,8 @@ public class ServersMapperTest {
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
         ImmutableMap.of(
-            "server1", new ServerConfigImpl("8080", "http", "http-endpoint"),
-            "server2", new ServerConfigImpl("8080", "ws", "ws-endpoint")),
+            "server1", new ServerConfigImpl("8080", "http", "http-endpoint", emptyMap()),
+            "server2", new ServerConfigImpl("8080", "ws", "ws-endpoint", emptyMap())),
         ImmutableMap.of(
             "server1", new ServerImpl("http://" + hostname + ":32080/http-endpoint"),
             "server2", new ServerImpl("ws://" + hostname + ":32080/ws-endpoint"))
@@ -68,8 +69,8 @@ public class ServersMapperTest {
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
         ImmutableMap.of(
-            "server1", new ServerConfigImpl("8080", "http", "http-endpoint"),
-            "server2", new ServerConfigImpl("8080/tcp", "ws", "ws-endpoint")),
+            "server1", new ServerConfigImpl("8080", "http", "http-endpoint", emptyMap()),
+            "server2", new ServerConfigImpl("8080/tcp", "ws", "ws-endpoint", emptyMap())),
         ImmutableMap.of(
             "server1", new ServerImpl("http://" + hostname + ":32080/http-endpoint"),
             "server2", new ServerImpl("ws://" + hostname + ":32080/ws-endpoint"))
@@ -97,9 +98,9 @@ public class ServersMapperTest {
             "2288/udp", "0.0.0.0:32288",
             "4401/tcp", "0.0.0.0:32401"),
         ImmutableMap.of(
-            "ws-master", new ServerConfigImpl("8080", "http", "/api"),
-            "exec-agent-api", new ServerConfigImpl("4401", "http", "/process"),
-            "exec-agent-ws", new ServerConfigImpl("4401", "ws", "/connect")),
+            "ws-master", new ServerConfigImpl("8080", "http", "/api", emptyMap()),
+            "exec-agent-api", new ServerConfigImpl("4401", "http", "/process", emptyMap()),
+            "exec-agent-ws", new ServerConfigImpl("4401", "ws", "/connect", emptyMap())),
         ImmutableMap.of(
             "ws-master", new ServerImpl("http://" + hostname + ":32080/api"),
             "exec-agent-api", new ServerImpl("http://" + hostname + ":32401/process"),

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapperTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapperTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.workspace.infrastructure.docker.server.mapping;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 import static org.testng.Assert.assertEquals;
 
@@ -27,6 +28,9 @@ import org.testng.annotations.Test;
 
 /** Tests {@link ServersMapper}. */
 public class ServersMapperTest {
+  static final Map<String, String> ONE_ATTRIBUTE_MAP = singletonMap("testAttr", "testValue");
+  static final Map<String, String> ATTRIBUTES_MAP =
+      ImmutableMap.of("testAttr", "testValue", "anotherTestAttr", "secondValue");
 
   private final String hostname = "localhost";
   private final ServersMapper mapper = new ServersMapper(hostname);
@@ -51,29 +55,47 @@ public class ServersMapperTest {
             "8080/tcp", "0.0.0.0:32080",
             "8081/tcp", "0.0.0.0:32081"),
         ImmutableMap.of(
-            "server1", new ServerConfigImpl("8080", "http", "no-slash-path", emptyMap()),
-            "server2", new ServerConfigImpl("8081", "http", "/slash-path", emptyMap())),
+            "server1", new ServerConfigImpl("8080", "http", "no-slash-path", ONE_ATTRIBUTE_MAP),
+            "server2", new ServerConfigImpl("8081", "http", "/slash-path", null)),
         ImmutableMap.of(
-            "server1", new ServerImpl().withUrl("http://" + hostname + ":32080/no-slash-path"),
-            "server2", new ServerImpl().withUrl("http://" + hostname + ":32081/slash-path"))
+            "server1",
+                new ServerImpl()
+                    .withUrl("http://" + hostname + ":32080/no-slash-path")
+                    .withAttributes(ONE_ATTRIBUTE_MAP),
+            "server2",
+                new ServerImpl()
+                    .withUrl("http://" + hostname + ":32081/slash-path")
+                    .withAttributes(emptyMap()))
       },
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
         ImmutableMap.of(
             "server1", new ServerConfigImpl("8080", "http", "http-endpoint", emptyMap()),
-            "server2", new ServerConfigImpl("8080", "ws", "ws-endpoint", emptyMap())),
+            "server2", new ServerConfigImpl("8080", "ws", "ws-endpoint", ATTRIBUTES_MAP)),
         ImmutableMap.of(
-            "server1", new ServerImpl().withUrl("http://" + hostname + ":32080/http-endpoint"),
-            "server2", new ServerImpl().withUrl("ws://" + hostname + ":32080/ws-endpoint"))
+            "server1",
+                new ServerImpl()
+                    .withUrl("http://" + hostname + ":32080/http-endpoint")
+                    .withAttributes(emptyMap()),
+            "server2",
+                new ServerImpl()
+                    .withUrl("ws://" + hostname + ":32080/ws-endpoint")
+                    .withAttributes(ATTRIBUTES_MAP))
       },
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
         ImmutableMap.of(
             "server1", new ServerConfigImpl("8080", "http", "http-endpoint", emptyMap()),
-            "server2", new ServerConfigImpl("8080/tcp", "ws", "ws-endpoint", emptyMap())),
+            "server2", new ServerConfigImpl("8080/tcp", "ws", "ws-endpoint", null)),
         ImmutableMap.of(
-            "server1", new ServerImpl().withUrl("http://" + hostname + ":32080/http-endpoint"),
-            "server2", new ServerImpl().withUrl("ws://" + hostname + ":32080/ws-endpoint"))
+            "server1",
+                new ServerImpl()
+                    .withUrl("http://" + hostname + ":32080/http-endpoint")
+                    .withAttributes(emptyMap()),
+            "server2",
+                new ServerImpl()
+                    .withUrl("ws://" + hostname + ":32080/ws-endpoint")
+                    .withAttributes(emptyMap()))
       },
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
@@ -99,12 +121,21 @@ public class ServersMapperTest {
             "4401/tcp", "0.0.0.0:32401"),
         ImmutableMap.of(
             "ws-master", new ServerConfigImpl("8080", "http", "/api", emptyMap()),
-            "exec-agent-api", new ServerConfigImpl("4401", "http", "/process", emptyMap()),
-            "exec-agent-ws", new ServerConfigImpl("4401", "ws", "/connect", emptyMap())),
+            "exec-agent-api", new ServerConfigImpl("4401", "http", "/process", ONE_ATTRIBUTE_MAP),
+            "exec-agent-ws", new ServerConfigImpl("4401", "ws", "/connect", ATTRIBUTES_MAP)),
         ImmutableMap.of(
-            "ws-master", new ServerImpl().withUrl("http://" + hostname + ":32080/api"),
-            "exec-agent-api", new ServerImpl().withUrl("http://" + hostname + ":32401/process"),
-            "exec-agent-ws", new ServerImpl().withUrl("ws://" + hostname + ":32401/connect"),
+            "ws-master",
+                new ServerImpl()
+                    .withUrl("http://" + hostname + ":32080/api")
+                    .withAttributes(emptyMap()),
+            "exec-agent-api",
+                new ServerImpl()
+                    .withUrl("http://" + hostname + ":32401/process")
+                    .withAttributes(ONE_ATTRIBUTE_MAP),
+            "exec-agent-ws",
+                new ServerImpl()
+                    .withUrl("ws://" + hostname + ":32401/connect")
+                    .withAttributes(ATTRIBUTES_MAP),
             "8000/tcp", new ServerImpl().withUrl("tcp://" + hostname + ":32000"),
             "2288/udp", new ServerImpl().withUrl("udp://" + hostname + ":32288"))
       }

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapperTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/ServersMapperTest.java
@@ -54,8 +54,8 @@ public class ServersMapperTest {
             "server1", new ServerConfigImpl("8080", "http", "no-slash-path", emptyMap()),
             "server2", new ServerConfigImpl("8081", "http", "/slash-path", emptyMap())),
         ImmutableMap.of(
-            "server1", new ServerImpl("http://" + hostname + ":32080/no-slash-path"),
-            "server2", new ServerImpl("http://" + hostname + ":32081/slash-path"))
+            "server1", new ServerImpl().withUrl("http://" + hostname + ":32080/no-slash-path"),
+            "server2", new ServerImpl().withUrl("http://" + hostname + ":32081/slash-path"))
       },
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
@@ -63,8 +63,8 @@ public class ServersMapperTest {
             "server1", new ServerConfigImpl("8080", "http", "http-endpoint", emptyMap()),
             "server2", new ServerConfigImpl("8080", "ws", "ws-endpoint", emptyMap())),
         ImmutableMap.of(
-            "server1", new ServerImpl("http://" + hostname + ":32080/http-endpoint"),
-            "server2", new ServerImpl("ws://" + hostname + ":32080/ws-endpoint"))
+            "server1", new ServerImpl().withUrl("http://" + hostname + ":32080/http-endpoint"),
+            "server2", new ServerImpl().withUrl("ws://" + hostname + ":32080/ws-endpoint"))
       },
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
@@ -72,13 +72,13 @@ public class ServersMapperTest {
             "server1", new ServerConfigImpl("8080", "http", "http-endpoint", emptyMap()),
             "server2", new ServerConfigImpl("8080/tcp", "ws", "ws-endpoint", emptyMap())),
         ImmutableMap.of(
-            "server1", new ServerImpl("http://" + hostname + ":32080/http-endpoint"),
-            "server2", new ServerImpl("ws://" + hostname + ":32080/ws-endpoint"))
+            "server1", new ServerImpl().withUrl("http://" + hostname + ":32080/http-endpoint"),
+            "server2", new ServerImpl().withUrl("ws://" + hostname + ":32080/ws-endpoint"))
       },
       {
         ImmutableMap.of("8080/tcp", "0.0.0.0:32080"),
         ImmutableMap.of(),
-        ImmutableMap.of("8080/tcp", new ServerImpl("tcp://" + hostname + ":32080"))
+        ImmutableMap.of("8080/tcp", new ServerImpl().withUrl("tcp://" + hostname + ":32080"))
       },
       {
         ImmutableMap.of(
@@ -87,9 +87,9 @@ public class ServersMapperTest {
             "8082", "0.0.0.0:32082"),
         ImmutableMap.of(),
         ImmutableMap.of(
-            "8080/tcp", new ServerImpl("tcp://" + hostname + ":32080"),
-            "8081/udp", new ServerImpl("udp://" + hostname + ":32081"),
-            "8082/tcp", new ServerImpl("tcp://" + hostname + ":32082"))
+            "8080/tcp", new ServerImpl().withUrl("tcp://" + hostname + ":32080"),
+            "8081/udp", new ServerImpl().withUrl("udp://" + hostname + ":32081"),
+            "8082/tcp", new ServerImpl().withUrl("tcp://" + hostname + ":32082"))
       },
       {
         ImmutableMap.of(
@@ -102,11 +102,11 @@ public class ServersMapperTest {
             "exec-agent-api", new ServerConfigImpl("4401", "http", "/process", emptyMap()),
             "exec-agent-ws", new ServerConfigImpl("4401", "ws", "/connect", emptyMap())),
         ImmutableMap.of(
-            "ws-master", new ServerImpl("http://" + hostname + ":32080/api"),
-            "exec-agent-api", new ServerImpl("http://" + hostname + ":32401/process"),
-            "exec-agent-ws", new ServerImpl("ws://" + hostname + ":32401/connect"),
-            "8000/tcp", new ServerImpl("tcp://" + hostname + ":32000"),
-            "2288/udp", new ServerImpl("udp://" + hostname + ":32288"))
+            "ws-master", new ServerImpl().withUrl("http://" + hostname + ":32080/api"),
+            "exec-agent-api", new ServerImpl().withUrl("http://" + hostname + ":32401/process"),
+            "exec-agent-ws", new ServerImpl().withUrl("ws://" + hostname + ":32401/connect"),
+            "8000/tcp", new ServerImpl().withUrl("tcp://" + hostname + ":32000"),
+            "2288/udp", new ServerImpl().withUrl("udp://" + hostname + ":32288"))
       }
     };
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/RoutesAnnotations.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/RoutesAnnotations.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import static java.util.Collections.emptyMap;
+
 import io.fabric8.openshift.api.model.Route;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -102,7 +104,8 @@ public class RoutesAnnotations {
                 new ServerConfigImpl(
                     annotations.get(String.format(SERVER_PORT_ANNOTATION_FMT, ref)),
                     annotations.get(String.format(SERVER_PROTOCOL_ANNOTATION_FMT, ref)),
-                    annotations.get(String.format(SERVER_PATH_ANNOTATION_FMT, ref))));
+                    annotations.get(String.format(SERVER_PATH_ANNOTATION_FMT, ref)),
+                    emptyMap()));
           }
         }
       }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
@@ -71,13 +71,17 @@ public class ServerResolver {
                     servers.put(
                         name,
                         newServer(
-                            config.getProtocol(), route.getSpec().getHost(), config.getPath())));
+                            config.getProtocol(),
+                            route.getSpec().getHost(),
+                            config.getPath(),
+                            config.getAttributes())));
       }
     }
     return servers;
   }
 
-  private ServerImpl newServer(String protocol, String host, String path) {
+  private ServerImpl newServer(
+      String protocol, String host, String path, Map<String, String> attributes) {
     StringBuilder ub = new StringBuilder();
     if (protocol != null) {
       ub.append(protocol).append("://");
@@ -91,7 +95,10 @@ public class ServerResolver {
       }
       ub.append(path);
     }
-    return new ServerImpl().withUrl(ub.toString()).withStatus(ServerStatus.UNKNOWN);
+    return new ServerImpl()
+        .withUrl(ub.toString())
+        .withStatus(ServerStatus.UNKNOWN)
+        .withAttributes(attributes);
   }
 
   private List<Service> getMatchedServices(Pod pod, Container container) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
@@ -91,7 +91,7 @@ public class ServerResolver {
       }
       ub.append(path);
     }
-    return new ServerImpl(ub.toString(), ServerStatus.UNKNOWN);
+    return new ServerImpl().withUrl(ub.toString()).withStatus(ServerStatus.UNKNOWN);
   }
 
   private List<Service> getMatchedServices(Pod pod, Container container) {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/RoutesAnnotationsTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/RoutesAnnotationsTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import static java.util.Collections.emptyMap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -29,9 +30,12 @@ public class RoutesAnnotationsTest {
   public void serialization() {
     Map<String, String> serialized =
         RoutesAnnotations.newSerializer()
-            .server("my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info"))
+            .server(
+                "my-server1/http",
+                new ServerConfigImpl("8000/tcp", "http", "/api/info", emptyMap()))
             .servers(
-                ImmutableMap.of("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect")))
+                ImmutableMap.of(
+                    "my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap())))
             .annotations();
     Map<String, String> expected =
         ImmutableMap.<String, String>builder()

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/RoutesAnnotationsTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/RoutesAnnotationsTest.java
@@ -11,12 +11,14 @@
 package org.eclipse.che.workspace.infrastructure.openshift;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.HashMap;
 import java.util.Map;
-import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.testng.annotations.Test;
 
@@ -26,13 +28,18 @@ import org.testng.annotations.Test;
  * @author Sergii Leshchenko
  */
 public class RoutesAnnotationsTest {
+  static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+  static final Map<String, String> ATTRIBUTES = singletonMap("key", "value");
+  static final String stringAttributes = GSON.toJson(ATTRIBUTES);
+  static final String stringEmptyAttributes = GSON.toJson(emptyMap());
+
   @Test
   public void serialization() {
     Map<String, String> serialized =
         RoutesAnnotations.newSerializer()
             .server(
                 "my-server1/http",
-                new ServerConfigImpl("8000/tcp", "http", "/api/info", emptyMap()))
+                new ServerConfigImpl("8000/tcp", "http", "/api/info", ATTRIBUTES))
             .servers(
                 ImmutableMap.of(
                     "my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap())))
@@ -42,9 +49,11 @@ public class RoutesAnnotationsTest {
             .put("org.eclipse.che.server.my-server1/http.port", "8000/tcp")
             .put("org.eclipse.che.server.my-server1/http.protocol", "http")
             .put("org.eclipse.che.server.my-server1/http.path", "/api/info")
+            .put("org.eclipse.che.server.my-server1/http.attributes", stringAttributes)
             .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
             .put("org.eclipse.che.server.my-server2.protocol", "ws")
             .put("org.eclipse.che.server.my-server2.path", "/connect")
+            .put("org.eclipse.che.server.my-server2.attributes", stringEmptyAttributes)
             .build();
 
     assertEquals(serialized, expected);
@@ -61,21 +70,20 @@ public class RoutesAnnotationsTest {
             .put("org.eclipse.che.server.my-server2.port", "8080/tcp")
             .put("org.eclipse.che.server.my-server2.protocol", "ws")
             .put("org.eclipse.che.server.my-server2.path", "/connect")
+            .put("org.eclipse.che.server.my-server2.attributes", stringAttributes)
+            .put("org.eclipse.che.server.my-server3.port", "7070/tcp")
+            .put("org.eclipse.che.server.my-server3.protocol", "http")
+            .put("org.eclipse.che.server.my-server3.attributes", stringEmptyAttributes)
             .build();
 
     RoutesAnnotations.Deserializer deserializer = RoutesAnnotations.newDeserializer(annotations);
 
     Map<String, ServerConfigImpl> servers = deserializer.servers();
-    ServerConfig server1 = servers.get("my-server1/http");
-    assertNotNull(server1, "first server");
-    assertEquals(server1.getPort(), "8000/tcp");
-    assertEquals(server1.getProtocol(), "http");
-    assertEquals(server1.getPath(), "/api/info");
 
-    ServerConfig server2 = servers.get("my-server2");
-    assertNotNull(server2, "second server");
-    assertEquals(server2.getPort(), "8080/tcp");
-    assertEquals(server2.getProtocol(), "ws");
-    assertEquals(server2.getPath(), "/connect");
+    Map<String, ServerConfigImpl> expected = new HashMap<>();
+    expected.put("my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info", null));
+    expected.put("my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", ATTRIBUTES));
+    expected.put("my-server3", new ServerConfigImpl("7070/tcp", "http", null, emptyMap()));
+    assertEquals(servers, expected);
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposerTest.java
@@ -10,7 +10,9 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.eclipse.che.workspace.infrastructure.openshift.ServerExposer.SERVER_PREFIX;
 import static org.eclipse.che.workspace.infrastructure.openshift.ServerExposer.SERVER_UNIQUE_PART_SIZE;
 import static org.testng.Assert.assertEquals;
@@ -72,7 +74,8 @@ public class ServerExposerTest {
   @Test
   public void shouldExposeContainerPortAndCreateServiceAndRouteForServer() {
     // given
-    ServerConfigImpl httpServerConfig = new ServerConfigImpl("8080/tcp", "http", "/api");
+    ServerConfigImpl httpServerConfig =
+        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of("http-server", httpServerConfig);
 
@@ -80,15 +83,21 @@ public class ServerExposerTest {
     serverExposer.expose(serversToExpose);
 
     // then
-    assertThatServerIsExposed("http-server", "tcp", 8080, httpServerConfig);
+    assertThatServerIsExposed(
+        "http-server",
+        "tcp",
+        8080,
+        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
   }
 
   @Test
   public void
       shouldExposeContainerPortAndCreateServiceAndRouteForServerWhenTwoServersHasTheSamePort() {
     // given
-    ServerConfigImpl httpServerConfig = new ServerConfigImpl("8080/tcp", "http", "/api");
-    ServerConfigImpl wsServerConfig = new ServerConfigImpl("8080/tcp", "ws", "/connect");
+    ServerConfigImpl httpServerConfig =
+        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
+    ServerConfigImpl wsServerConfig =
+        new ServerConfigImpl("8080/tcp", "ws", "/connect", singletonMap("key", "value"));
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of(
             "http-server", httpServerConfig,
@@ -100,16 +109,23 @@ public class ServerExposerTest {
     // then
     assertEquals(openShiftEnvironment.getServices().size(), 1);
     assertEquals(openShiftEnvironment.getRoutes().size(), 1);
-    assertThatServerIsExposed("http-server", "tcp", 8080, httpServerConfig);
-    assertThatServerIsExposed("ws-server", "tcp", 8080, wsServerConfig);
+    assertThatServerIsExposed(
+        "http-server",
+        "tcp",
+        8080,
+        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+    assertThatServerIsExposed(
+        "ws-server", "tcp", 8080, new ServerConfigImpl(wsServerConfig).withAttributes(emptyMap()));
   }
 
   @Test
   public void
       shouldExposeContainerPortsAndCreateServiceAndRoutesForServerWhenTwoServersHasDifferentPorts() {
     // given
-    ServerConfigImpl httpServerConfig = new ServerConfigImpl("8080/tcp", "http", "/api");
-    ServerConfigImpl wsServerConfig = new ServerConfigImpl("8081/tcp", "ws", "/connect");
+    ServerConfigImpl httpServerConfig =
+        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
+    ServerConfigImpl wsServerConfig =
+        new ServerConfigImpl("8081/tcp", "ws", "/connect", singletonMap("key", "value"));
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of(
             "http-server", httpServerConfig,
@@ -121,15 +137,21 @@ public class ServerExposerTest {
     // then
     assertEquals(openShiftEnvironment.getServices().size(), 1);
     assertEquals(openShiftEnvironment.getRoutes().size(), 2);
-    assertThatServerIsExposed("http-server", "tcp", 8080, httpServerConfig);
-    assertThatServerIsExposed("ws-server", "tcp", 8081, wsServerConfig);
+    assertThatServerIsExposed(
+        "http-server",
+        "tcp",
+        8080,
+        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+    assertThatServerIsExposed(
+        "ws-server", "tcp", 8081, new ServerConfigImpl(wsServerConfig).withAttributes(emptyMap()));
   }
 
   @Test
   public void
       shouldExposeTcpContainerPortsAndCreateServiceAndRouteForServerWhenProtocolIsMissedInPort() {
     // given
-    ServerConfigImpl httpServerConfig = new ServerConfigImpl("8080", "http", "/api");
+    ServerConfigImpl httpServerConfig =
+        new ServerConfigImpl("8080", "http", "/api", singletonMap("key", "value"));
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of("http-server", httpServerConfig);
 
@@ -139,13 +161,18 @@ public class ServerExposerTest {
     // then
     assertEquals(openShiftEnvironment.getServices().size(), 1);
     assertEquals(openShiftEnvironment.getRoutes().size(), 1);
-    assertThatServerIsExposed("http-server", "TCP", 8080, httpServerConfig);
+    assertThatServerIsExposed(
+        "http-server",
+        "TCP",
+        8080,
+        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
   }
 
   @Test
   public void shouldNotAddAdditionalContainerPortWhenItIsAlreadyExposed() {
     // given
-    ServerConfigImpl httpServerConfig = new ServerConfigImpl("8080/tcp", "http", "/api");
+    ServerConfigImpl httpServerConfig =
+        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of("http-server", httpServerConfig);
     container.setPorts(
@@ -160,13 +187,18 @@ public class ServerExposerTest {
     serverExposer.expose(serversToExpose);
 
     // then
-    assertThatServerIsExposed("http-server", "tcp", 8080, httpServerConfig);
+    assertThatServerIsExposed(
+        "http-server",
+        "tcp",
+        8080,
+        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
   }
 
   @Test
   public void shouldAddAdditionalContainerPortWhenThereIsTheSameButWithDifferentProtocol() {
     // given
-    ServerConfigImpl udpServerConfig = new ServerConfigImpl("8080/udp", "udp", "/api");
+    ServerConfigImpl udpServerConfig =
+        new ServerConfigImpl("8080/udp", "udp", "/api", singletonMap("key", "value"));
     Map<String, ServerConfigImpl> serversToExpose = ImmutableMap.of("server", udpServerConfig);
     container.setPorts(
         new ArrayList<>(
@@ -184,7 +216,8 @@ public class ServerExposerTest {
     assertEquals(container.getPorts().size(), 2);
     assertEquals(container.getPorts().get(1).getContainerPort(), new Integer(8080));
     assertEquals(container.getPorts().get(1).getProtocol(), "UDP");
-    assertThatServerIsExposed("server", "udp", 8080, udpServerConfig);
+    assertThatServerIsExposed(
+        "server", "udp", 8080, new ServerConfigImpl(udpServerConfig).withAttributes(emptyMap()));
   }
 
   private void assertThatServerIsExposed(

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerExposerTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.workspace.infrastructure.openshift.ServerExposer.SERVER_PREFIX;
@@ -45,6 +44,7 @@ import org.testng.annotations.Test;
  * @author Sergii Leshchenko
  */
 public class ServerExposerTest {
+  private static final Map<String, String> ATTRIBUTES_MAP = singletonMap("key", "value");
 
   private static final Pattern SERVER_PREFIX_REGEX =
       Pattern.compile('^' + SERVER_PREFIX + "[A-z0-9]{" + SERVER_UNIQUE_PART_SIZE + "}-pod-main$");
@@ -75,7 +75,7 @@ public class ServerExposerTest {
   public void shouldExposeContainerPortAndCreateServiceAndRouteForServer() {
     // given
     ServerConfigImpl httpServerConfig =
-        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
+        new ServerConfigImpl("8080/tcp", "http", "/api", ATTRIBUTES_MAP);
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of("http-server", httpServerConfig);
 
@@ -87,7 +87,7 @@ public class ServerExposerTest {
         "http-server",
         "tcp",
         8080,
-        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+        new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
@@ -95,9 +95,9 @@ public class ServerExposerTest {
       shouldExposeContainerPortAndCreateServiceAndRouteForServerWhenTwoServersHasTheSamePort() {
     // given
     ServerConfigImpl httpServerConfig =
-        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
+        new ServerConfigImpl("8080/tcp", "http", "/api", ATTRIBUTES_MAP);
     ServerConfigImpl wsServerConfig =
-        new ServerConfigImpl("8080/tcp", "ws", "/connect", singletonMap("key", "value"));
+        new ServerConfigImpl("8080/tcp", "ws", "/connect", ATTRIBUTES_MAP);
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of(
             "http-server", httpServerConfig,
@@ -113,9 +113,12 @@ public class ServerExposerTest {
         "http-server",
         "tcp",
         8080,
-        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+        new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
     assertThatServerIsExposed(
-        "ws-server", "tcp", 8080, new ServerConfigImpl(wsServerConfig).withAttributes(emptyMap()));
+        "ws-server",
+        "tcp",
+        8080,
+        new ServerConfigImpl(wsServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
@@ -123,9 +126,9 @@ public class ServerExposerTest {
       shouldExposeContainerPortsAndCreateServiceAndRoutesForServerWhenTwoServersHasDifferentPorts() {
     // given
     ServerConfigImpl httpServerConfig =
-        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
+        new ServerConfigImpl("8080/tcp", "http", "/api", ATTRIBUTES_MAP);
     ServerConfigImpl wsServerConfig =
-        new ServerConfigImpl("8081/tcp", "ws", "/connect", singletonMap("key", "value"));
+        new ServerConfigImpl("8081/tcp", "ws", "/connect", ATTRIBUTES_MAP);
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of(
             "http-server", httpServerConfig,
@@ -141,9 +144,12 @@ public class ServerExposerTest {
         "http-server",
         "tcp",
         8080,
-        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+        new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
     assertThatServerIsExposed(
-        "ws-server", "tcp", 8081, new ServerConfigImpl(wsServerConfig).withAttributes(emptyMap()));
+        "ws-server",
+        "tcp",
+        8081,
+        new ServerConfigImpl(wsServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
@@ -151,7 +157,7 @@ public class ServerExposerTest {
       shouldExposeTcpContainerPortsAndCreateServiceAndRouteForServerWhenProtocolIsMissedInPort() {
     // given
     ServerConfigImpl httpServerConfig =
-        new ServerConfigImpl("8080", "http", "/api", singletonMap("key", "value"));
+        new ServerConfigImpl("8080", "http", "/api", ATTRIBUTES_MAP);
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of("http-server", httpServerConfig);
 
@@ -165,14 +171,14 @@ public class ServerExposerTest {
         "http-server",
         "TCP",
         8080,
-        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+        new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
   public void shouldNotAddAdditionalContainerPortWhenItIsAlreadyExposed() {
     // given
     ServerConfigImpl httpServerConfig =
-        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
+        new ServerConfigImpl("8080/tcp", "http", "/api", ATTRIBUTES_MAP);
     Map<String, ServerConfigImpl> serversToExpose =
         ImmutableMap.of("http-server", httpServerConfig);
     container.setPorts(
@@ -191,14 +197,14 @@ public class ServerExposerTest {
         "http-server",
         "tcp",
         8080,
-        new ServerConfigImpl(httpServerConfig).withAttributes(emptyMap()));
+        new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
   public void shouldAddAdditionalContainerPortWhenThereIsTheSameButWithDifferentProtocol() {
     // given
     ServerConfigImpl udpServerConfig =
-        new ServerConfigImpl("8080/udp", "udp", "/api", singletonMap("key", "value"));
+        new ServerConfigImpl("8080/udp", "udp", "/api", ATTRIBUTES_MAP);
     Map<String, ServerConfigImpl> serversToExpose = ImmutableMap.of("server", udpServerConfig);
     container.setPorts(
         new ArrayList<>(
@@ -217,7 +223,10 @@ public class ServerExposerTest {
     assertEquals(container.getPorts().get(1).getContainerPort(), new Integer(8080));
     assertEquals(container.getPorts().get(1).getProtocol(), "UDP");
     assertThatServerIsExposed(
-        "server", "udp", 8080, new ServerConfigImpl(udpServerConfig).withAttributes(emptyMap()));
+        "server",
+        "udp",
+        8080,
+        new ServerConfigImpl(udpServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
 
   private void assertThatServerIsExposed(

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.core.model.workspace.runtime.ServerStatus.UNKNOWN;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -106,8 +107,12 @@ public class ServerResolverTest {
     Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
 
     assertEquals(resolved.size(), 2);
-    assertEquals(resolved.get("http-server"), new ServerImpl("http://localhost/api"));
-    assertEquals(resolved.get("ws-server"), new ServerImpl("ws://localhost/connect"));
+    assertEquals(
+        resolved.get("http-server"),
+        new ServerImpl().withUrl("http://localhost/api").withStatus(UNKNOWN));
+    assertEquals(
+        resolved.get("ws-server"),
+        new ServerImpl().withUrl("ws://localhost/connect").withStatus(UNKNOWN));
   }
 
   @Test
@@ -129,7 +134,9 @@ public class ServerResolverTest {
     Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
 
     assertEquals(resolved.size(), 1);
-    assertEquals(resolved.get("http-server"), new ServerImpl("http://localhost"));
+    assertEquals(
+        resolved.get("http-server"),
+        new ServerImpl().withUrl("http://localhost").withStatus(UNKNOWN));
   }
 
   @Test
@@ -151,7 +158,9 @@ public class ServerResolverTest {
     Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
 
     assertEquals(resolved.size(), 1);
-    assertEquals(resolved.get("http-server"), new ServerImpl("http://localhost"));
+    assertEquals(
+        resolved.get("http-server"),
+        new ServerImpl().withUrl("http://localhost").withStatus(UNKNOWN));
   }
 
   @Test
@@ -173,7 +182,9 @@ public class ServerResolverTest {
     Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
 
     assertEquals(resolved.size(), 1);
-    assertEquals(resolved.get("http-server"), new ServerImpl("http://localhost/api"));
+    assertEquals(
+        resolved.get("http-server"),
+        new ServerImpl().withUrl("http://localhost/api").withStatus(UNKNOWN));
   }
 
   private Pod createPod(Map<String, String> labels) {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
  * @author Sergii Leshchenko
  */
 public class ServerResolverTest {
+  private static final Map<String, String> ATTRIBUTES_MAP = singletonMap("key", "value");
   private static final int CONTAINER_PORT = 3054;
   private static final String ROUTE_HOST = "localhost";
 
@@ -52,8 +53,7 @@ public class ServerResolverTest {
         createRoute(
             "nonMatched",
             ImmutableMap.of(
-                "http-server",
-                new ServerConfigImpl("3054", "http", "/api", singletonMap("key", "value"))));
+                "http-server", new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP)));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -75,8 +75,7 @@ public class ServerResolverTest {
         createRoute(
             "nonMatched",
             ImmutableMap.of(
-                "http-server",
-                new ServerConfigImpl("3054", "http", "/api", singletonMap("key", "value"))));
+                "http-server", new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP)));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -97,9 +96,9 @@ public class ServerResolverTest {
             "matched",
             ImmutableMap.of(
                 "http-server",
-                new ServerConfigImpl("3054", "http", "/api", singletonMap("key", "value")),
+                new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP),
                 "ws-server",
-                new ServerConfigImpl("3054", "ws", "/connect", singletonMap("key", "value"))));
+                new ServerConfigImpl("3054", "ws", "/connect", ATTRIBUTES_MAP)));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -109,10 +108,16 @@ public class ServerResolverTest {
     assertEquals(resolved.size(), 2);
     assertEquals(
         resolved.get("http-server"),
-        new ServerImpl().withUrl("http://localhost/api").withStatus(UNKNOWN));
+        new ServerImpl()
+            .withUrl("http://localhost/api")
+            .withStatus(UNKNOWN)
+            .withAttributes(ATTRIBUTES_MAP));
     assertEquals(
         resolved.get("ws-server"),
-        new ServerImpl().withUrl("ws://localhost/connect").withStatus(UNKNOWN));
+        new ServerImpl()
+            .withUrl("ws://localhost/connect")
+            .withStatus(UNKNOWN)
+            .withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
@@ -125,8 +130,7 @@ public class ServerResolverTest {
         createRoute(
             "matched",
             singletonMap(
-                "http-server",
-                new ServerConfigImpl("3054", "http", null, singletonMap("key", "value"))));
+                "http-server", new ServerConfigImpl("3054", "http", null, ATTRIBUTES_MAP)));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -136,7 +140,10 @@ public class ServerResolverTest {
     assertEquals(resolved.size(), 1);
     assertEquals(
         resolved.get("http-server"),
-        new ServerImpl().withUrl("http://localhost").withStatus(UNKNOWN));
+        new ServerImpl()
+            .withUrl("http://localhost")
+            .withStatus(UNKNOWN)
+            .withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
@@ -148,9 +155,7 @@ public class ServerResolverTest {
     Route route =
         createRoute(
             "matched",
-            singletonMap(
-                "http-server",
-                new ServerConfigImpl("3054", "http", "", singletonMap("key", "value"))));
+            singletonMap("http-server", new ServerConfigImpl("3054", "http", "", ATTRIBUTES_MAP)));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -160,7 +165,10 @@ public class ServerResolverTest {
     assertEquals(resolved.size(), 1);
     assertEquals(
         resolved.get("http-server"),
-        new ServerImpl().withUrl("http://localhost").withStatus(UNKNOWN));
+        new ServerImpl()
+            .withUrl("http://localhost")
+            .withStatus(UNKNOWN)
+            .withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
@@ -173,8 +181,7 @@ public class ServerResolverTest {
         createRoute(
             "matched",
             singletonMap(
-                "http-server",
-                new ServerConfigImpl("3054", "http", "api", singletonMap("key", "value"))));
+                "http-server", new ServerConfigImpl("3054", "http", "api", ATTRIBUTES_MAP)));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -184,7 +191,10 @@ public class ServerResolverTest {
     assertEquals(resolved.size(), 1);
     assertEquals(
         resolved.get("http-server"),
-        new ServerImpl().withUrl("http://localhost/api").withStatus(UNKNOWN));
+        new ServerImpl()
+            .withUrl("http://localhost/api")
+            .withStatus(UNKNOWN)
+            .withAttributes(ATTRIBUTES_MAP));
   }
 
   private Pod createPod(Map<String, String> labels) {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
@@ -50,7 +50,9 @@ public class ServerResolverTest {
     Route route =
         createRoute(
             "nonMatched",
-            ImmutableMap.of("http-server", new ServerConfigImpl("3054", "http", "/api")));
+            ImmutableMap.of(
+                "http-server",
+                new ServerConfigImpl("3054", "http", "/api", singletonMap("key", "value"))));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -71,7 +73,9 @@ public class ServerResolverTest {
     Route route =
         createRoute(
             "nonMatched",
-            ImmutableMap.of("http-server", new ServerConfigImpl("3054", "http", "/api")));
+            ImmutableMap.of(
+                "http-server",
+                new ServerConfigImpl("3054", "http", "/api", singletonMap("key", "value"))));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -92,9 +96,9 @@ public class ServerResolverTest {
             "matched",
             ImmutableMap.of(
                 "http-server",
-                new ServerConfigImpl("3054", "http", "/api"),
+                new ServerConfigImpl("3054", "http", "/api", singletonMap("key", "value")),
                 "ws-server",
-                new ServerConfigImpl("3054", "ws", "/connect")));
+                new ServerConfigImpl("3054", "ws", "/connect", singletonMap("key", "value"))));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -114,7 +118,10 @@ public class ServerResolverTest {
         createService("matched", CONTAINER_PORT, singletonMap("kind", "web-app"));
     Route route =
         createRoute(
-            "matched", singletonMap("http-server", new ServerConfigImpl("3054", "http", null)));
+            "matched",
+            singletonMap(
+                "http-server",
+                new ServerConfigImpl("3054", "http", null, singletonMap("key", "value"))));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -133,7 +140,10 @@ public class ServerResolverTest {
         createService("matched", CONTAINER_PORT, singletonMap("kind", "web-app"));
     Route route =
         createRoute(
-            "matched", singletonMap("http-server", new ServerConfigImpl("3054", "http", "")));
+            "matched",
+            singletonMap(
+                "http-server",
+                new ServerConfigImpl("3054", "http", "", singletonMap("key", "value"))));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
@@ -152,7 +162,10 @@ public class ServerResolverTest {
         createService("matched", CONTAINER_PORT, singletonMap("kind", "web-app"));
     Route route =
         createRoute(
-            "matched", singletonMap("http-server", new ServerConfigImpl("3054", "http", "api")));
+            "matched",
+            singletonMap(
+                "http-server",
+                new ServerConfigImpl("3054", "http", "api", singletonMap("key", "value"))));
 
     ServerResolver serverResolver =
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/FactoryServiceTest.java
@@ -708,7 +708,8 @@ public class FactoryServiceTest {
     extendedMachine.setInstallers(singletonList("agent"));
     extendedMachine.setAttributes(singletonMap("att1", "value"));
     extendedMachine.setServers(
-        singletonMap("agent", new ServerConfigImpl("5555", "https", "path")));
+        singletonMap(
+            "agent", new ServerConfigImpl("5555", "https", "path", singletonMap("key", "value"))));
     env.setRecipe(environmentRecipe);
     env.setMachines(singletonMap("machine1", extendedMachine));
     return org.eclipse.che.api.workspace.server.DtoConverter.asDto(env);

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -326,23 +326,28 @@ public class FactoryDaoTest {
 
     // Machine configs
     final MachineConfigImpl exMachine1 = new MachineConfigImpl();
-    final ServerConfigImpl serverConf1 = new ServerConfigImpl("2265", "http", "/path1");
-    final ServerConfigImpl serverConf2 = new ServerConfigImpl("2266", "ftp", "/path2");
+    final ServerConfigImpl serverConf1 =
+        new ServerConfigImpl("2265", "http", "/path1", singletonMap("key", "value"));
+    final ServerConfigImpl serverConf2 =
+        new ServerConfigImpl("2266", "ftp", "/path2", singletonMap("key", "value"));
     exMachine1.setServers(ImmutableMap.of("ref1", serverConf1, "ref2", serverConf2));
     exMachine1.setInstallers(ImmutableList.of("agent5", "agent4"));
     exMachine1.setAttributes(singletonMap("att1", "val"));
     exMachine1.setEnv(singletonMap("CHE_ENV", "value"));
 
     final MachineConfigImpl exMachine2 = new MachineConfigImpl();
-    final ServerConfigImpl serverConf3 = new ServerConfigImpl("2333", "https", "/path1");
-    final ServerConfigImpl serverConf4 = new ServerConfigImpl("2334", "wss", "/path2");
+    final ServerConfigImpl serverConf3 =
+        new ServerConfigImpl("2333", "https", "/path1", singletonMap("key", "value"));
+    final ServerConfigImpl serverConf4 =
+        new ServerConfigImpl("2334", "wss", "/path2", singletonMap("key", "value"));
     exMachine2.setServers(ImmutableMap.of("ref1", serverConf3, "ref2", serverConf4));
     exMachine2.setInstallers(ImmutableList.of("agent2", "agent1"));
     exMachine2.setAttributes(singletonMap("att1", "val"));
     exMachine2.setEnv(singletonMap("CHE_ENV2", "value"));
 
     final MachineConfigImpl exMachine3 = new MachineConfigImpl();
-    final ServerConfigImpl serverConf5 = new ServerConfigImpl("2333", "https", "/path3");
+    final ServerConfigImpl serverConf5 =
+        new ServerConfigImpl("2333", "https", "/path3", singletonMap("key", "value"));
     exMachine3.setServers(singletonMap("ref1", serverConf5));
     exMachine3.setInstallers(ImmutableList.of("agent6", "agent2"));
     exMachine3.setAttributes(singletonMap("att1", "val"));

--- a/wsmaster/che-core-api-installer/src/main/java/org/eclipse/che/api/installer/server/DtoConverter.java
+++ b/wsmaster/che-core-api-installer/src/main/java/org/eclipse/che/api/installer/server/DtoConverter.java
@@ -44,7 +44,8 @@ public class DtoConverter {
     return newDto(ServerConfigDto.class)
         .withPort(serverConf.getPort())
         .withProtocol(serverConf.getProtocol())
-        .withPath(serverConf.getPath());
+        .withPath(serverConf.getPath())
+        .withAttributes(serverConf.getAttributes());
   }
 
   private DtoConverter() {}

--- a/wsmaster/che-core-api-installer/src/test/java/org/eclipse/che/api/installer/server/impl/TestInstallerFactory.java
+++ b/wsmaster/che-core-api-installer/src/test/java/org/eclipse/che/api/installer/server/impl/TestInstallerFactory.java
@@ -31,7 +31,10 @@ public class TestInstallerFactory {
         singletonMap(
             generate("server"),
             new InstallerServerConfigImpl(
-                generate("port"), generate("protocol"), generate("path"))));
+                generate("port"),
+                generate("protocol"),
+                generate("path"),
+                singletonMap(generate("attr"), generate("value")))));
   }
 
   private static String generate(String prefix) {

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/ServerConfigDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/ServerConfigDto.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.shared.dto;
 import static org.eclipse.che.api.core.factory.FactoryParameter.Obligation.MANDATORY;
 import static org.eclipse.che.api.core.factory.FactoryParameter.Obligation.OPTIONAL;
 
+import java.util.Map;
 import org.eclipse.che.api.core.factory.FactoryParameter;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.dto.shared.DTO;
@@ -43,4 +44,12 @@ public interface ServerConfigDto extends ServerConfig {
   void setPath(String path);
 
   ServerConfigDto withPath(String path);
+
+  @Override
+  @FactoryParameter(obligation = OPTIONAL)
+  Map<String, String> getAttributes();
+
+  void setAttributes(Map<String, String> attributes);
+
+  ServerConfigDto withAttributes(Map<String, String> attributes);
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/ServerDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/ServerDto.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.api.workspace.shared.dto;
 
+import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.dto.shared.DTO;
@@ -33,4 +34,9 @@ public interface ServerDto extends Server {
   ServerStatus getStatus();
 
   ServerDto withStatus(ServerStatus status);
+
+  @Override
+  Map<String, String> getAttributes();
+
+  ServerDto withAttributes(Map<String, String> attributes);
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -227,7 +227,8 @@ public final class DtoConverter {
     return newDto(ServerConfigDto.class)
         .withPort(serverConf.getPort())
         .withProtocol(serverConf.getProtocol())
-        .withPath(serverConf.getPath());
+        .withPath(serverConf.getPath())
+        .withAttributes(serverConf.getAttributes());
   }
 
   /** Converts {@link Runtime} to {@link RuntimeDto}. */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/MachineImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/MachineImpl.java
@@ -10,8 +10,6 @@
  */
 package org.eclipse.che.api.workspace.server.model.impl;
 
-import static java.util.stream.Collectors.toMap;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -43,7 +41,10 @@ public class MachineImpl implements Machine {
           servers
               .entrySet()
               .stream()
-              .collect(toMap(Map.Entry::getKey, entry -> new ServerImpl(entry.getValue())));
+              .collect(
+                  HashMap::new,
+                  (map, entry) -> map.put(entry.getKey(), new ServerImpl(entry.getValue())),
+                  HashMap::putAll);
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -10,11 +10,18 @@
  */
 package org.eclipse.che.api.workspace.server.model.impl;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 
@@ -37,18 +44,33 @@ public class ServerConfigImpl implements ServerConfig {
   @Column(name = "path")
   private String path;
 
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(
+    name = "serverconf_attributes",
+    joinColumns = @JoinColumn(name = "serverconf_id")
+  )
+  @MapKeyColumn(name = "attributes_key")
+  @Column(name = "attributes")
+  private Map<String, String> attributes;
+
   public ServerConfigImpl() {}
 
-  public ServerConfigImpl(String port, String protocol, String path) {
+  public ServerConfigImpl(
+      String port, String protocol, String path, Map<String, String> attributes) {
     this.port = port;
     this.protocol = protocol;
     this.path = path;
+    if (attributes != null) {
+      this.attributes = new HashMap<>(attributes);
+    }
   }
 
   public ServerConfigImpl(ServerConfig serverConf) {
-    this.port = serverConf.getPort();
-    this.protocol = serverConf.getProtocol();
-    this.path = serverConf.getPath();
+    this(
+        serverConf.getPort(),
+        serverConf.getProtocol(),
+        serverConf.getPath(),
+        serverConf.getAttributes());
   }
 
   @Override
@@ -94,28 +116,45 @@ public class ServerConfigImpl implements ServerConfig {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public Map<String, String> getAttributes() {
+    if (attributes == null) {
+      attributes = new HashMap<>();
+    }
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    if (attributes != null) {
+      this.attributes = new HashMap<>(attributes);
+    } else {
+      this.attributes = new HashMap<>();
+    }
+  }
+
+  public ServerConfigImpl withAttributes(Map<String, String> attributes) {
+    setAttributes(attributes);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (!(obj instanceof ServerConfigImpl)) {
+    if (!(o instanceof ServerConfigImpl)) {
       return false;
     }
-    final ServerConfigImpl that = (ServerConfigImpl) obj;
+    ServerConfigImpl that = (ServerConfigImpl) o;
     return Objects.equals(id, that.id)
-        && Objects.equals(port, that.port)
-        && Objects.equals(protocol, that.protocol)
-        && Objects.equals(path, that.path);
+        && Objects.equals(getPort(), that.getPort())
+        && Objects.equals(getProtocol(), that.getProtocol())
+        && Objects.equals(getPath(), that.getPath())
+        && Objects.equals(getAttributes(), that.getAttributes());
   }
 
   @Override
   public int hashCode() {
-    int hash = 7;
-    hash = 31 * hash + Objects.hashCode(id);
-    hash = 31 * hash + Objects.hashCode(port);
-    hash = 31 * hash + Objects.hashCode(protocol);
-    hash = 31 * hash + Objects.hashCode(path);
-    return hash;
+    return Objects.hash(id, getPort(), getProtocol(), getPath(), getAttributes());
   }
 
   @Override
@@ -129,8 +168,11 @@ public class ServerConfigImpl implements ServerConfig {
         + ", protocol='"
         + protocol
         + '\''
-        + ", path="
+        + ", path='"
         + path
+        + '\''
+        + ", attributes="
+        + attributes
         + '}';
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerImpl.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.api.workspace.server.model.impl;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
@@ -19,18 +21,18 @@ public class ServerImpl implements Server {
 
   private String url;
   private ServerStatus status;
+  private Map<String, String> attributes;
 
-  public ServerImpl(String url) {
-    this(url, ServerStatus.UNKNOWN);
-  }
-
-  public ServerImpl(String url, ServerStatus status) {
-    this.url = url;
-    this.status = status;
-  }
+  public ServerImpl() {}
 
   public ServerImpl(Server server) {
-    this(server.getUrl(), server.getStatus());
+    this.url = server.getUrl();
+    this.status = server.getStatus();
+    if (server.getAttributes() != null) {
+      this.attributes = new HashMap<>(server.getAttributes());
+    } else {
+      this.attributes = new HashMap<>();
+    }
   }
 
   @Override
@@ -42,6 +44,11 @@ public class ServerImpl implements Server {
     this.url = url;
   }
 
+  public ServerImpl withUrl(String url) {
+    this.url = url;
+    return this;
+  }
+
   @Override
   public ServerStatus getStatus() {
     return this.status;
@@ -51,28 +58,61 @@ public class ServerImpl implements Server {
     this.status = status;
   }
 
-  @Override
-  public String toString() {
-    return url;
+  public ServerImpl withStatus(ServerStatus status) {
+    this.status = status;
+    return this;
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public Map<String, String> getAttributes() {
+    if (attributes == null) {
+      attributes = new HashMap<>();
+    }
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    if (attributes != null) {
+      this.attributes = attributes;
+    } else {
+      this.attributes = new HashMap<>();
+    }
+  }
+
+  public ServerImpl withAttributes(Map<String, String> attributes) {
+    setAttributes(attributes);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (!(obj instanceof Server)) {
+    if (!(o instanceof ServerImpl)) {
       return false;
     }
-    final Server that = (Server) obj;
-    return Objects.equals(url, that.getUrl()) && Objects.equals(status, that.getStatus());
+    ServerImpl server = (ServerImpl) o;
+    return Objects.equals(getUrl(), server.getUrl())
+        && getStatus() == server.getStatus()
+        && Objects.equals(getAttributes(), server.getAttributes());
   }
 
   @Override
   public int hashCode() {
-    int hash = 7;
-    hash = 31 * hash + Objects.hashCode(url);
-    hash = 31 * hash + Objects.hashCode(status);
-    return hash;
+    return Objects.hash(getUrl(), getStatus(), getAttributes());
+  }
+
+  @Override
+  public String toString() {
+    return "ServerImpl{"
+        + "url='"
+        + url
+        + '\''
+        + ", status="
+        + status
+        + ", attributes="
+        + attributes
+        + '}';
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -180,9 +180,8 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
       Server incomingServer = entry.getValue();
       try {
         ServerImpl server =
-            new ServerImpl(
-                urlRewriter.rewriteURL(identity, name, incomingServer.getUrl()),
-                incomingServer.getStatus());
+            new ServerImpl(incomingServer)
+                .withUrl(urlRewriter.rewriteURL(identity, name, incomingServer.getUrl()));
         outgoing.put(name, server);
       } catch (InfrastructureException e) {
         warnings.add(new WarningImpl(101, "Malformed URL for " + name + " : " + e.getMessage()));

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -139,6 +139,7 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
     if (port != null && !port.contains("/")) {
       port = port + "/tcp";
     }
-    return new ServerConfigImpl(port, serverConfig.getProtocol(), serverConfig.getPath());
+    return new ServerConfigImpl(
+        port, serverConfig.getProtocol(), serverConfig.getPath(), serverConfig.getAttributes());
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
@@ -336,7 +336,10 @@ public class WorkspaceValidatorTest {
             .withServers(
                 singletonMap(
                     "ref1",
-                    newDto(ServerConfigDto.class).withPort("8080/tcp").withProtocol("https")))
+                    newDto(ServerConfigDto.class)
+                        .withPort("8080/tcp")
+                        .withProtocol("https")
+                        .withAttributes(singletonMap("key", "value"))))
             .withAttributes(new HashMap<>(singletonMap(MEMORY_LIMIT_ATTRIBUTE, "1000000")));
     EnvironmentDto env =
         newDto(EnvironmentDto.class)

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
@@ -64,9 +64,9 @@ public class ServersCheckerTest {
     servers = new HashMap<>();
     servers.putAll(
         ImmutableMap.of(
-            "wsagent/http", new ServerImpl("http://localhost"),
-            "exec-agent/http", new ServerImpl("http://localhost"),
-            "terminal", new ServerImpl("http://localhost")));
+            "wsagent/http", new ServerImpl().withUrl("http://localhost"),
+            "exec-agent/http", new ServerImpl().withUrl("http://localhost"),
+            "terminal", new ServerImpl().withUrl("http://localhost")));
 
     compFuture = new CompletableFuture<>();
 
@@ -90,7 +90,7 @@ public class ServersCheckerTest {
   @Test(timeOut = 1000)
   public void shouldUseMachineTokenWhenConstructionUrlToCheck() throws Exception {
     servers.clear();
-    servers.put("wsagent/http", new ServerImpl("http://localhost"));
+    servers.put("wsagent/http", new ServerImpl().withUrl("http://localhost"));
 
     checker.startAsync(readinessHandler);
     connectionChecker.getReportCompFuture().complete("wsagent/http");
@@ -133,8 +133,8 @@ public class ServersCheckerTest {
     servers.clear();
     servers.putAll(
         ImmutableMap.of(
-            "wsagent/http", new ServerImpl("http://localhost"),
-            "not-hardcoded", new ServerImpl("http://localhost")));
+            "wsagent/http", new ServerImpl().withUrl("http://localhost"),
+            "not-hardcoded", new ServerImpl().withUrl("http://localhost")));
 
     checker.startAsync(readinessHandler);
     connectionChecker.getReportCompFuture().complete("test_ref");

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -377,7 +377,8 @@ public class InternalRuntimeTest {
         new MachineImpl(
             expectedProps,
             singletonMap(
-                expectedServerName, new ServerImpl(expectedServerUrl, expectedServerStatus)));
+                expectedServerName,
+                new ServerImpl().withUrl(expectedServerUrl).withStatus(expectedServerStatus)));
     HashMap<String, MachineImpl> result = new HashMap<>();
     result.put("m1", createMachine());
     result.put("m2", createMachine());
@@ -402,7 +403,10 @@ public class InternalRuntimeTest {
     assertTrue(actualMachine.getServers().containsKey(expectedServerName));
     assertEquals(
         actualMachine.getServers().get(expectedServerName),
-        new ServerImpl(expectedServerUrl, expectedServerStatus));
+        new ServerImpl()
+            .withUrl(expectedServerUrl)
+            .withStatus(expectedServerStatus)
+            .withAttributes(emptyMap()));
   }
 
   private void modifyMachines(
@@ -479,11 +483,11 @@ public class InternalRuntimeTest {
   }
 
   private static ServerImpl createServer(ServerStatus status) throws Exception {
-    return new ServerImpl("http://localhost:8080/", status);
+    return new ServerImpl().withUrl("http://localhost:8080/").withStatus(status);
   }
 
   private static ServerImpl createServer(String url) throws Exception {
-    return new ServerImpl(url, RUNNING);
+    return new ServerImpl().withUrl(url).withStatus(RUNNING);
   }
 
   private static MachineImpl rewriteURLs(MachineImpl machine) throws InfrastructureException {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.workspace.server.spi.environment;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -108,7 +109,8 @@ public class InternalEnvironmentFactoryTest {
   @Test
   public void shouldUseNormalizedServersWhileInternalEnvironmentCreation() throws Exception {
     // given
-    ServerConfigImpl server = new ServerConfigImpl("8080", "http", "/api");
+    ServerConfigImpl server =
+        new ServerConfigImpl("8080", "http", "/api", singletonMap("key", "value"));
 
     Map<String, ServerConfig> normalizedServers =
         ImmutableMap.of("server", mock(ServerConfig.class));
@@ -169,9 +171,12 @@ public class InternalEnvironmentFactoryTest {
 
   @Test
   public void normalizeServersProtocols() throws InfrastructureException {
-    ServerConfigImpl serverWithoutProtocol = new ServerConfigImpl("8080", "http", "/api");
-    ServerConfigImpl udpServer = new ServerConfigImpl("8080/udp", "http", "/api");
-    ServerConfigImpl normalizedServer = new ServerConfigImpl("8080/tcp", "http", "/api");
+    ServerConfigImpl serverWithoutProtocol =
+        new ServerConfigImpl("8080", "http", "/api", singletonMap("key", "value"));
+    ServerConfigImpl udpServer =
+        new ServerConfigImpl("8080/udp", "http", "/api", singletonMap("key", "value"));
+    ServerConfigImpl normalizedServer =
+        new ServerConfigImpl("8080/tcp", "http", "/api", singletonMap("key", "value"));
 
     Map<String, ServerConfig> servers = new HashMap<>();
     servers.put("serverWithoutProtocol", serverWithoutProtocol);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/MachineConfigsValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/MachineConfigsValidatorTest.java
@@ -113,7 +113,8 @@ public class MachineConfigsValidatorTest {
   )
   public void shouldFailIfServerPortIsInvalid(String servicePort) throws Exception {
     // given
-    ServerConfigImpl server = new ServerConfigImpl(servicePort, "https", "/some/path");
+    ServerConfigImpl server =
+        new ServerConfigImpl(servicePort, "https", "/some/path", singletonMap("key", "value"));
     when(machineConfig.getServers())
         .thenReturn(singletonMap(Constants.SERVER_WS_AGENT_HTTP_REFERENCE, server));
 
@@ -131,7 +132,8 @@ public class MachineConfigsValidatorTest {
   @Test(dataProvider = "validServerPorts")
   public void shouldNotFailIfServerPortIsValid(String servicePort) throws Exception {
     // given
-    ServerConfigImpl server = new ServerConfigImpl(servicePort, "https", "/some/path");
+    ServerConfigImpl server =
+        new ServerConfigImpl(servicePort, "https", "/some/path", singletonMap("key", "value"));
     when(machineConfig.getServers())
         .thenReturn(singletonMap(Constants.SERVER_WS_AGENT_HTTP_REFERENCE, server));
 
@@ -154,7 +156,8 @@ public class MachineConfigsValidatorTest {
   )
   public void shouldFailIfServerProtocolIsInvalid(String serviceProtocol) throws Exception {
     // given
-    ServerConfigImpl server = new ServerConfigImpl("8080", serviceProtocol, "/some/path");
+    ServerConfigImpl server =
+        new ServerConfigImpl("8080", serviceProtocol, "/some/path", singletonMap("key", "value"));
     when(machineConfig.getServers())
         .thenReturn(singletonMap(Constants.SERVER_WS_AGENT_HTTP_REFERENCE, server));
 
@@ -170,7 +173,8 @@ public class MachineConfigsValidatorTest {
   @Test(dataProvider = "validServerProtocols")
   public void shouldNotFailIfServerProtocolIsValid(String serviceProtocol) throws Exception {
     // given
-    ServerConfigImpl server = new ServerConfigImpl("8080", serviceProtocol, "/some/path");
+    ServerConfigImpl server =
+        new ServerConfigImpl("8080", serviceProtocol, "/some/path", singletonMap("key", "value"));
     when(machineConfig.getServers())
         .thenReturn(singletonMap(Constants.SERVER_WS_AGENT_HTTP_REFERENCE, server));
 
@@ -256,6 +260,8 @@ public class MachineConfigsValidatorTest {
   private static Map<String, ServerConfig> createServers(String... servers) {
     return Arrays.stream(servers)
         .collect(
-            Collectors.toMap(Function.identity(), s -> new ServerConfigImpl("8080", "http", "/")));
+            Collectors.toMap(
+                Function.identity(),
+                s -> new ServerConfigImpl("8080", "http", "/", singletonMap("key", "value"))));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -381,8 +381,10 @@ public class WorkspaceDaoTest {
     newRecipe.setContentType("new-content-type");
     newRecipe.setContent("new-content");
     final MachineConfigImpl newMachine = new MachineConfigImpl();
-    final ServerConfigImpl serverConf1 = new ServerConfigImpl("2265", "http", "path1");
-    final ServerConfigImpl serverConf2 = new ServerConfigImpl("2266", "ftp", "path2");
+    final ServerConfigImpl serverConf1 =
+        new ServerConfigImpl("2265", "http", "path1", singletonMap("key", "value"));
+    final ServerConfigImpl serverConf2 =
+        new ServerConfigImpl("2266", "ftp", "path2", singletonMap("key", "value"));
     newMachine.setServers(ImmutableMap.of("ref1", serverConf1, "ref2", serverConf2));
     newMachine.setInstallers(ImmutableList.of("agent5", "agent4"));
     newMachine.setAttributes(singletonMap("att1", "val"));
@@ -408,7 +410,10 @@ public class WorkspaceDaoTest {
     existingMachine.getServers().clear();
     existingMachine
         .getServers()
-        .put("new-ref", new ServerConfigImpl("new-port", "new-protocol", "new-path"));
+        .put(
+            "new-ref",
+            new ServerConfigImpl(
+                "new-port", "new-protocol", "new-path", singletonMap("key", "value")));
     defaultEnv.getMachines().remove(machineNames.get(0));
     defaultEnv.getRecipe().setContent("updated-content");
     defaultEnv.getRecipe().setContentType("updated-content-type");
@@ -549,8 +554,10 @@ public class WorkspaceDaoTest {
 
     // OldMachine configs
     final MachineConfigImpl exMachine1 = new MachineConfigImpl();
-    final ServerConfigImpl serverConf1 = new ServerConfigImpl("2265", "http", "path1");
-    final ServerConfigImpl serverConf2 = new ServerConfigImpl("2266", "ftp", "path2");
+    final ServerConfigImpl serverConf1 =
+        new ServerConfigImpl("2265", "http", "path1", singletonMap("key", "value"));
+    final ServerConfigImpl serverConf2 =
+        new ServerConfigImpl("2266", "ftp", "path2", singletonMap("key", "value"));
     exMachine1.setServers(ImmutableMap.of("ref1", serverConf1, "ref2", serverConf2));
     exMachine1.setInstallers(ImmutableList.of("agent5", "agent4"));
     exMachine1.setAttributes(singletonMap("att1", "val"));
@@ -563,8 +570,10 @@ public class WorkspaceDaoTest {
             new VolumeImpl().withPath("/path/2")));
 
     final MachineConfigImpl exMachine2 = new MachineConfigImpl();
-    final ServerConfigImpl serverConf3 = new ServerConfigImpl("2333", "https", "path3");
-    final ServerConfigImpl serverConf4 = new ServerConfigImpl("2334", "wss", "path4");
+    final ServerConfigImpl serverConf3 =
+        new ServerConfigImpl("2333", "https", "path3", singletonMap("key", "value"));
+    final ServerConfigImpl serverConf4 =
+        new ServerConfigImpl("2334", "wss", "path4", singletonMap("key", "value"));
     exMachine2.setServers(ImmutableMap.of("ref1", serverConf3, "ref2", serverConf4));
     exMachine2.setInstallers(ImmutableList.of("agent2", "agent1"));
     exMachine2.setAttributes(singletonMap("att1", "val"));
@@ -572,7 +581,8 @@ public class WorkspaceDaoTest {
     exMachine2.setVolumes(ImmutableMap.of("vol2", new VolumeImpl().withPath("/path/2")));
 
     final MachineConfigImpl exMachine3 = new MachineConfigImpl();
-    final ServerConfigImpl serverConf5 = new ServerConfigImpl("2333", "https", "path5");
+    final ServerConfigImpl serverConf5 =
+        new ServerConfigImpl("2333", "https", "path5", singletonMap("key", "value"));
     exMachine3.setServers(singletonMap("ref1", serverConf5));
     exMachine3.setInstallers(ImmutableList.of("agent6", "agent2"));
     exMachine3.setAttributes(singletonMap("att1", "val"));

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
@@ -188,7 +188,11 @@ public class StackLoaderTest {
 
     Map<String, ServerConfigDto> servers = new HashMap<>();
     servers.put(
-        "server1Ref", newDto(ServerConfigDto.class).withPort("8080/tcp").withProtocol("http"));
+        "server1Ref",
+        newDto(ServerConfigDto.class)
+            .withPort("8080/tcp")
+            .withProtocol("http")
+            .withAttributes(singletonMap("key", "value")));
     Map<String, MachineConfigDto> machines = new HashMap<>();
     machines.put(
         "someMachineName",

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.0.0/8__add_serverconf_attributes.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.0.0/8__add_serverconf_attributes.sql
@@ -1,0 +1,34 @@
+--
+-- Copyright (c) 2012-2017 Red Hat, Inc.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+-- ServerConfig attributes ----------------------------------------------
+CREATE TABLE serverconf_attributes (
+    serverconf_id           BIGINT,
+    attributes              VARCHAR(255),
+    attributes_key          VARCHAR(255)
+);
+--constraints
+ALTER TABLE serverconf_attributes ADD CONSTRAINT fk_serverconf_attributes_serverconf_id FOREIGN KEY (serverconf_id) REFERENCES serverconf (id);
+--indexes
+CREATE INDEX index_serverconf_attributes_serverconf_id ON serverconf_attributes (serverconf_id);
+-------------------------------------------------------------------------
+
+-- InstallerServerConfig attributes ----------------------------------------------
+CREATE TABLE installer_serverconf_attributes (
+    serverconf_id           BIGINT,
+    attributes              VARCHAR(255),
+    attributes_key          VARCHAR(255)
+);
+--constraints
+ALTER TABLE installer_serverconf_attributes ADD CONSTRAINT fk_installer_serverconf_attributes_serverconf_id FOREIGN KEY (serverconf_id) REFERENCES installer_servers (id);
+--indexes
+CREATE INDEX index_installer_serverconf_attributes_serverconf_id ON installer_serverconf_attributes (serverconf_id);
+-------------------------------------------------------------------------

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
@@ -113,8 +113,10 @@ public final class TestObjectsFactory {
     newRecipe.setContent("new-content");
 
     final MachineConfigImpl newMachine = new MachineConfigImpl();
-    final ServerConfigImpl serverConf1 = new ServerConfigImpl("2265", "http", "/path1");
-    final ServerConfigImpl serverConf2 = new ServerConfigImpl("2266", "ftp", "/path2");
+    final ServerConfigImpl serverConf1 =
+        new ServerConfigImpl("2265", "http", "/path1", singletonMap("key", "value"));
+    final ServerConfigImpl serverConf2 =
+        new ServerConfigImpl("2266", "ftp", "/path2", singletonMap("key", "value"));
     newMachine.setServers(ImmutableMap.of("ref1", serverConf1, "ref2", serverConf2));
     newMachine.setInstallers(ImmutableList.of("agent5", "agent4"));
     newMachine.setAttributes(singletonMap("att1", "val"));


### PR DESCRIPTION
### What does this PR do?
Note: this PR is designed for commit-by-commit review. 
This PR adds field `attributes` represented by map<string, string> to the model of objects ServerConfig and Server. This allows us to store some metadata in a server and use it at runtime for different purposes, e.g. recognizing LS servers started in separate containers.

Also, this PR enables DockerAbandonedResourceCleaner which was disabled some time ago, probably, by mistake.

### What issues does this PR fix or reference?
Fixes #7560 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
