### PR TITLE
Fixes various problems usage of OpenShift client

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -107,8 +107,9 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
       for (Route route : osEnv.getRoutes().values()) {
         createdRoutes.add(project.routes().create(route));
       }
-      project.pods().watch(new AbnormalStopHandler());
-      project.pods().watchContainers(new MachineLogsPublisher());
+      // TODO https://github.com/eclipse/che/issues/7653
+      // project.pods().watch(new AbnormalStopHandler());
+      // project.pods().watchContainers(new MachineLogsPublisher());
 
       createPods(createdServices, createdRoutes);
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
@@ -103,7 +103,10 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
             + Integer.toString(installerTimeoutSeconds)
             + " -file "
             + BOOTSTRAPPER_DIR
-            + CONFIG_FILE);
+            + CONFIG_FILE
+            // redirects command output and makes the bootstrapping process detached,
+            // to avoid the holding of the socket connection for exec watcher.
+            + " &>/dev/null &");
   }
 
   private void injectBootstrapper() throws InfrastructureException {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -97,10 +96,8 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
                 + "application/x-yaml, text/yaml, text/x-yaml");
     }
 
-    KubernetesList list;
-    try (OpenShiftClient client = clientFactory.create()) {
-      list = client.lists().load(new ByteArrayInputStream(content.getBytes())).get();
-    }
+    final KubernetesList list =
+        clientFactory.create().lists().load(new ByteArrayInputStream(content.getBytes())).get();
 
     Map<String, Pod> pods = new HashMap<>();
     Map<String, Service> services = new HashMap<>();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPersistentVolumeClaims.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPersistentVolumeClaims.java
@@ -14,7 +14,6 @@ import static java.util.stream.Collectors.toSet;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.openshift.client.OpenShiftClient;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -44,8 +43,8 @@ public class OpenShiftPersistentVolumeClaims {
    * @throws InfrastructureException when any exception occurs
    */
   public PersistentVolumeClaim create(PersistentVolumeClaim pvc) throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      return client.persistentVolumeClaims().inNamespace(namespace).create(pvc);
+    try {
+      return clientFactory.create().persistentVolumeClaims().inNamespace(namespace).create(pvc);
     } catch (KubernetesClientException e) {
       throw new InfrastructureException(e.getMessage(), e);
     }
@@ -57,8 +56,13 @@ public class OpenShiftPersistentVolumeClaims {
    * @throws InfrastructureException when any exception occurs
    */
   public List<PersistentVolumeClaim> get() throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      return client.persistentVolumeClaims().inNamespace(namespace).list().getItems();
+    try {
+      return clientFactory
+          .create()
+          .persistentVolumeClaims()
+          .inNamespace(namespace)
+          .list()
+          .getItems();
     } catch (KubernetesClientException e) {
       throw new InfrastructureException(e.getMessage(), e);
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -38,10 +38,9 @@ public class OpenShiftProject {
     this.services = new OpenShiftServices(name, workspaceId, clientFactory);
     this.routes = new OpenShiftRoutes(name, workspaceId, clientFactory);
     this.pvcs = new OpenShiftPersistentVolumeClaims(name, clientFactory);
-    try (OpenShiftClient client = clientFactory.create()) {
-      if (get(name, client) == null) {
-        create(name, client);
-      }
+    final OpenShiftClient client = clientFactory.create();
+    if (get(name, client) == null) {
+      create(name, client);
     }
   }
 
@@ -67,7 +66,6 @@ public class OpenShiftProject {
 
   /** Removes all object except persistent volume claim inside project. */
   public void cleanUp() throws InfrastructureException {
-    pods.stopWatch();
     pods.delete();
     services.delete();
     routes.delete();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftRoutes.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftRoutes.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShi
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.client.OpenShiftClient;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -46,8 +45,8 @@ public class OpenShiftRoutes {
    */
   public Route create(Route route) throws InfrastructureException {
     putLabel(route, CHE_WORKSPACE_ID_LABEL, workspaceId);
-    try (OpenShiftClient client = clientFactory.create()) {
-      return client.routes().inNamespace(namespace).create(route);
+    try {
+      return clientFactory.create().routes().inNamespace(namespace).create(route);
     } catch (KubernetesClientException e) {
       throw new InfrastructureException(e.getMessage(), e);
     }
@@ -59,8 +58,9 @@ public class OpenShiftRoutes {
    * @throws InfrastructureException when any exception occurs
    */
   public List<Route> get() throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      return client
+    try {
+      return clientFactory
+          .create()
           .routes()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
@@ -77,8 +77,9 @@ public class OpenShiftRoutes {
    * @throws InfrastructureException when any exception occurs
    */
   public void delete() throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      client
+    try {
+      clientFactory
+          .create()
           .routes()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftServices.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftServices.java
@@ -16,7 +16,6 @@ import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShi
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.openshift.client.OpenShiftClient;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -48,8 +47,8 @@ public class OpenShiftServices {
   public Service create(Service service) throws InfrastructureException {
     putLabel(service, CHE_WORKSPACE_ID_LABEL, workspaceId);
     putSelector(service, CHE_WORKSPACE_ID_LABEL, workspaceId);
-    try (OpenShiftClient client = clientFactory.create()) {
-      return client.services().inNamespace(namespace).create(service);
+    try {
+      return clientFactory.create().services().inNamespace(namespace).create(service);
     } catch (KubernetesClientException e) {
       throw new InfrastructureException(e.getMessage(), e);
     }
@@ -61,8 +60,9 @@ public class OpenShiftServices {
    * @throws InfrastructureException when any exception occurs
    */
   public List<Service> get() throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      return client
+    try {
+      return clientFactory
+          .create()
           .services()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
@@ -79,8 +79,9 @@ public class OpenShiftServices {
    * @throws InfrastructureException when any exception occurs
    */
   public void delete() throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      client
+    try {
+      clientFactory
+          .create()
           .services()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemove.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemove.java
@@ -15,7 +15,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.fabric8.openshift.client.OpenShiftClient;
 import javax.inject.Named;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
@@ -67,8 +66,6 @@ public class RemoveProjectOnWorkspaceRemove implements EventSubscriber<Workspace
 
   @VisibleForTesting
   void doRemoveProject(String projectName) throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      client.projects().withName(projectName).delete();
-    }
+    clientFactory.create().projects().withName(projectName).delete();
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/pvc/UniqueWorkspacePVCStrategy.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.openshift.client.OpenShiftClient;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.inject.Inject;
@@ -109,10 +108,13 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
 
   @Override
   public void cleanup(String workspaceId) throws InfrastructureException {
-    try (OpenShiftClient client = clientFactory.create()) {
-      final String pvcUniqueName = pvcName + '-' + workspaceId;
-      client.persistentVolumeClaims().inNamespace(projectName).withName(pvcUniqueName).delete();
-    }
+    final String pvcUniqueName = pvcName + '-' + workspaceId;
+    clientFactory
+        .create()
+        .persistentVolumeClaims()
+        .inNamespace(projectName)
+        .withName(pvcUniqueName)
+        .delete();
   }
 
   private void addVolumeIfNeeded(PodSpec podSpec, String pvcUniqueName) {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -288,16 +288,6 @@ public class OpenShiftInternalRuntimeTest {
     internalRuntime.internalStop(emptyMap());
   }
 
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsInfrastructureExceptionWhenMachineAbnormallyStopped() throws Exception {
-    doThrow(InfrastructureException.class).when(pods).watch(any());
-
-    internalRuntime.internalStart(emptyMap());
-
-    verify(project, times(2)).cleanUp();
-    verify(project, never()).pods();
-  }
-
   @Test
   public void testRepublishContainerOutputAsMachineLogEvents() throws Exception {
     final MachineLogsPublisher logsPublisher = internalRuntime.new MachineLogsPublisher();


### PR DESCRIPTION
### What does this PR do?
Replaces the usage of one `OpenShiftClient` per action to one client per che-server. The reason why we do that is the `OpenShiftClient` holds an instance of `OkHttpClient` inside and each time when we create new `OpenShiftClient` we create new `OkHttpClient` with all the components inside,  on close, the `OpenShiftClient` prevent cancel all calls currently that are executed by `OkHttpClient`, close all the connections and stop the dispatcher executor service (that undoubtedly is overhead).
Adds closing of watcher on pod removing.
Disables abnormal stop and container events watching.
Launches bootstrapper as a detached process.

### What issues does this PR fix or reference?
#7418
This problem is not reproduced in case of using one OpenShift client per che server: #5902 
