### PR TITLE
Suppressing logs produced during selenium test

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.core.inject;
 import static com.google.inject.Guice.createInjector;
 import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -223,7 +222,19 @@ public abstract class SeleniumTestHandler
   /** Is invoked when test or configuration is finished. */
   private void onTestFinish(ITestResult result) {
     if (result.getStatus() == ITestResult.FAILURE || result.getStatus() == ITestResult.SKIP) {
-      ofNullable(result.getThrowable()).ifPresent(e -> LOG.error("" + e.getMessage(), e));
+      if (result.getThrowable() != null) {
+        LOG.error(
+            "Test {} method {} failed because {}",
+            result.getTestClass().getName(),
+            result.getMethod().getMethodName(),
+            result.getThrowable().getLocalizedMessage());
+        LOG.debug(result.getThrowable().getLocalizedMessage(), result.getThrowable());
+      } else {
+        LOG.error(
+            "Test {} method {} failed ",
+            result.getTestClass().getName(),
+            result.getMethod().getMethodName());
+      }
       captureScreenshot(result);
       captureHtmlSource(result);
     }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
@@ -52,10 +52,16 @@ public class TestWorkspaceImpl implements TestWorkspace {
         CompletableFuture.runAsync(
             () -> {
               try {
+
                 final Workspace ws =
                     workspaceServiceClient.createWorkspace(name, memoryInGB, GB, template);
+                long start = System.currentTimeMillis();
                 workspaceServiceClient.start(id.updateAndGet((s) -> ws.getId()), name, owner);
-                LOG.info("Workspace name='{}' id='{}' started.", name, ws.getId());
+                LOG.info(
+                    "Workspace name='{}' id='{}' started in {} sec.",
+                    name,
+                    ws.getId(),
+                    (System.currentTimeMillis() - start) / 1000);
               } catch (Exception e) {
                 String errorMessage = format("Workspace name='%s' start failed.", name);
                 LOG.error(errorMessage, e);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebuggerUtils.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebuggerUtils.java
@@ -63,7 +63,7 @@ public class DebuggerUtils {
             while ((response = br.readLine()) != null) {
               responseData.append(response);
             }
-            System.out.println(responseData.toString());
+            LOG.debug(responseData.toString());
             br.close();
           } catch (Exception e) {
             LOG.error(e.getMessage(), e);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/BranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/BranchTest.java
@@ -298,7 +298,6 @@ public class BranchTest {
     git.waitBranchInTheList(TEST_BRANCH);
     git.selectBranchAndClickCheckoutBtn(TEST_BRANCH);
     git.closeBranchesForm();
-    System.out.println(git.gitStatusBar.getTextStatus());
     git.waitGitStatusBarWithMess(CONFLICT_MESSAGE);
   }
 

--- a/selenium/che-selenium-test/src/test/resources/logback-test.xml
+++ b/selenium/che-selenium-test/src/test/resources/logback-test.xml
@@ -31,7 +31,7 @@
     
     <logger name="org.openqa.selenium.remote.ProtocolHandshake" level="OFF"/>
 
-    <root level="INFO">
+    <root level="${che.logs.level:-INFO}">
         <appender-ref ref="stdout"/>
         <appender-ref ref="file"/>
     </root>


### PR DESCRIPTION
### What does this PR do?
1. Removed or redirected ```System.out.println```
2. ```onTestFinish``` produced shorter message by default.  same message in debug mode.
3. Added ability to configure default logger level with ```-Dche.logs.level``` (Same like we have for out tomcats) 

### What issues does this PR fix or reference?
n/a


#### Release Notes
n/a

#### Docs PR
n/a