### PR TITLE
[CHE 6] Test commands starting from the Processes area 

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -67,7 +67,7 @@ public class Consoles {
   public static final String SERVER_INFO_HIDE_INTERNAL_CHECK_BOX =
       "gwt-debug-runtimeInfoHideServersCheckBox";
   public static final String MACHINE_NAME =
-      "//div[@id='gwt-debug-process-tree']//div//span[contains(text(), '%s')]";
+      "//div[@id='gwt-debug-process-tree']//span[text()= '%s']";
   public static final String CONTEXT_MENU = "gwt-debug-contextMenu/commandsActionGroup";
   public static final String COMMAND_NAME = "//tr[contains(@id,'command_%s')]";
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
@@ -29,7 +30,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 /** @author Aleksandr Shmaraev */
@@ -66,6 +66,16 @@ public class Consoles {
   public static final String SERVER_INFO_TABLE_CAPTION = "gwt-debug-runtimeInfoCellTableCaption";
   public static final String SERVER_INFO_HIDE_INTERNAL_CHECK_BOX =
       "gwt-debug-runtimeInfoHideServersCheckBox";
+  public static final String MACHINE_NAME =
+      "//div[@id='gwt-debug-process-tree']//div//span[contains(text(), '%s')]";
+  public static final String CONTEXT_MENU = "gwt-debug-contextMenu/commandsActionGroup";
+  public static final String COMMAND_NAME = "//tr[contains(@id,'command_%s')]";
+
+  public interface CommandsGoal {
+    String COMMON = "gwt-debug-contextMenu/Commands/goal_Common";
+    String BUILD = "gwt-debug-contextMenu/Commands/goal_Build";
+    String RUN = "gwt-debug-contextMenu/Commands/goal_Run";
+  }
 
   protected final SeleniumWebDriver seleniumWebDriver;
   private final Loader loader;
@@ -122,6 +132,9 @@ public class Consoles {
 
   @FindBy(id = SERVER_INFO_HIDE_INTERNAL_CHECK_BOX)
   WebElement serverInfoHideInternalCheckBox;
+
+  @FindBy(id = CONTEXT_MENU)
+  WebElement contextMenu;
 
   /**
    * click on consoles icon in side line and wait opening console area (terminal on other console )
@@ -190,7 +203,7 @@ public class Consoles {
    */
   public void closeProcessInProcessConsoleTreeByName(String nameProcess) {
     loadPageDriverWait
-        .until(visibilityOfElementLocated(By.xpath(String.format(CLOSE_PROCESS_ICON, nameProcess))))
+        .until(visibilityOfElementLocated(By.xpath(format(CLOSE_PROCESS_ICON, nameProcess))))
         .click();
   }
 
@@ -201,7 +214,7 @@ public class Consoles {
    */
   public void waitProcessInProcessConsoleTree(String nameProcess) {
     loadPageDriverWait.until(
-        visibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))));
+        visibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))));
   }
 
   /**
@@ -212,8 +225,7 @@ public class Consoles {
    */
   public void waitProcessInProcessConsoleTree(String nameProcess, int timeout) {
     new WebDriverWait(seleniumWebDriver, timeout)
-        .until(
-            visibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))));
+        .until(visibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))));
   }
 
   /**
@@ -223,7 +235,7 @@ public class Consoles {
    */
   public void waitProcessIsNotPresentInProcessConsoleTree(String nameProcess) {
     loadPageDriverWait.until(
-        invisibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))));
+        invisibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))));
   }
 
   /**
@@ -233,7 +245,7 @@ public class Consoles {
    */
   public void selectProcessInProcessConsoleTreeByName(String nameProcess) {
     loadPageDriverWait
-        .until(visibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))))
+        .until(visibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))))
         .click();
   }
 
@@ -245,8 +257,7 @@ public class Consoles {
   public void selectProcessByTabName(String tabNameProcess) {
     loader.waitOnClosed();
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            visibilityOfElementLocated(By.xpath(String.format(TAB_PROCESS_NAME, tabNameProcess))))
+        .until(visibilityOfElementLocated(By.xpath(format(TAB_PROCESS_NAME, tabNameProcess))))
         .click();
     loader.waitOnClosed();
   }
@@ -258,7 +269,7 @@ public class Consoles {
    */
   public void waitTabNameProcessIsPresent(String tabNameProcess) {
     redrawDriverWait.until(
-        visibilityOfElementLocated(By.xpath(String.format(TAB_PROCESS_NAME, tabNameProcess))));
+        visibilityOfElementLocated(By.xpath(format(TAB_PROCESS_NAME, tabNameProcess))));
   }
 
   /**
@@ -268,7 +279,7 @@ public class Consoles {
    */
   public void waitTabNameProcessIsNotPresent(String tabNameProcess) {
     redrawDriverWait.until(
-        invisibilityOfElementLocated(By.xpath(String.format(TAB_PROCESS_NAME, tabNameProcess))));
+        invisibilityOfElementLocated(By.xpath(format(TAB_PROCESS_NAME, tabNameProcess))));
   }
 
   /**
@@ -278,8 +289,7 @@ public class Consoles {
    */
   public void closeProcessByTabName(String tabNameProcess) {
     redrawDriverWait
-        .until(
-            elementToBeClickable(By.xpath(String.format(TAB_PROCESS_CLOSE_ICON, tabNameProcess))))
+        .until(elementToBeClickable(By.xpath(format(TAB_PROCESS_CLOSE_ICON, tabNameProcess))))
         .click();
   }
 
@@ -305,8 +315,7 @@ public class Consoles {
    * @param definedTimeout timeout in seconds defined with user
    */
   public void waitIsCommandConsoleOpened(int definedTimeout) {
-    new WebDriverWait(seleniumWebDriver, definedTimeout)
-        .until(ExpectedConditions.visibilityOf(consoleContainer));
+    new WebDriverWait(seleniumWebDriver, definedTimeout).until(visibilityOf(consoleContainer));
   }
 
   /** wait expected text into 'Command console' */
@@ -332,8 +341,7 @@ public class Consoles {
 
   /** wait a preview url into 'Consoles' */
   public void waitPreviewUrlIsPresent() {
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(previewUrl));
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC).until(visibilityOf(previewUrl));
   }
 
   /** wait a preview url is not present into 'Consoles' */
@@ -352,9 +360,26 @@ public class Consoles {
   }
 
   public void dragConsolesInDefinePosition(int verticalShiftInPixels) {
-    WebElement drag = redrawDriverWait.until(ExpectedConditions.visibilityOf(consolesPanelDrag));
+    WebElement drag = redrawDriverWait.until(visibilityOf(consolesPanelDrag));
     new Actions(seleniumWebDriver)
         .dragAndDropBy(drag, verticalShiftInPixels, verticalShiftInPixels)
         .perform();
+  }
+
+  public void startCommandFromProcessesArea(
+      String machineName, String commandGoal, String commandName) {
+    WebElement machine =
+        redrawDriverWait.until(
+            visibilityOfElementLocated(By.xpath(format(MACHINE_NAME, machineName))));
+    machine.click();
+
+    Actions action = new Actions(seleniumWebDriver);
+    action.moveToElement(machine).contextClick().perform();
+    redrawDriverWait.until(visibilityOf(contextMenu)).click();
+
+    redrawDriverWait.until(visibilityOfElementLocated(By.id(commandGoal))).click();
+    redrawDriverWait
+        .until(visibilityOfElementLocated(By.xpath(format(COMMAND_NAME, commandName))))
+        .click();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
@@ -10,8 +10,19 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SUCCESS;
+import static org.eclipse.che.selenium.core.constant.TestStacksConstants.JAVA_MYSQL;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.pageobject.Consoles.CommandsGoal.COMMON;
+import static org.eclipse.che.selenium.pageobject.Consoles.CommandsGoal.RUN;
+import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.WORKSPACES;
+import static org.openqa.selenium.Keys.ENTER;
+import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 
 import com.google.inject.Inject;
 import java.util.Arrays;
@@ -19,13 +30,9 @@ import java.util.List;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
-import org.eclipse.che.selenium.core.constant.TestBuildConstants;
-import org.eclipse.che.selenium.core.constant.TestStacksConstants;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.AskDialog;
-import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
-import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
@@ -35,8 +42,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -45,19 +50,16 @@ import org.testng.annotations.Test;
 public class WorkingWithJavaMySqlStackTest {
   private static final String WORKSPACE = NameGenerator.generate("java-mysql", 4);
   private static final String PROJECT_NAME = "web-java-petclinic";
-  private static final String PROCESS_NAME = PROJECT_NAME + ":build and deploy";
+  private static final String BUIL_AND_DEPLOY_PROCESS = PROJECT_NAME + ":build and deploy";
 
   private static final List<String> infoDataBases =
       Arrays.asList("Database", "information_schema", "petclinic", "mysql");
   private static final String MSG_CLOSE_PROCESS =
-      "The process "
-          + PROJECT_NAME
-          + ":build and deploy will be terminated after closing console. Do you want to continue?";
-
-  private String currentWindow;
+      String.format(
+          "The process %s:build and deploy will be terminated after closing console. Do you want to continue?",
+          PROJECT_NAME);
 
   @Inject private TestUser defaultTestUser;
-  @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private Consoles consoles;
@@ -67,7 +69,6 @@ public class WorkingWithJavaMySqlStackTest {
   @Inject private Dashboard dashboard;
   @Inject private DashboardWorkspace dashboardWorkspace;
   @Inject private AskDialog askDialog;
-  @Inject private CodenvyEditor editor;
   @Inject private MachineTerminal terminal;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
@@ -79,95 +80,74 @@ public class WorkingWithJavaMySqlStackTest {
 
   @Test
   public void checkJavaMySqlAndRunApp() {
-    // create workspace and project
+    String currentWindow;
+
+    // create a workspace from the Java-MySql stack with the web-java-petclinic project
     dashboard.open();
     navigationBar.waitNavigationBar();
-    navigationBar.clickOnMenu(NavigationBar.MenuItem.WORKSPACES);
+    navigationBar.clickOnMenu(WORKSPACES);
     dashboardWorkspace.waitToolbarTitleName("Workspaces");
     dashboardWorkspace.clickOnNewWorkspaceBtn();
     createWorkspace.waitToolbar();
-    loader.waitOnClosed();
-    createWorkspace.selectStack(TestStacksConstants.JAVA_MYSQL.getId());
+    createWorkspace.selectStack(JAVA_MYSQL.getId());
     createWorkspace.typeWorkspaceName(WORKSPACE);
     projectSourcePage.clickAddOrImportProjectButton();
     projectSourcePage.selectSample(PROJECT_NAME);
     projectSourcePage.clickAdd();
     createWorkspace.clickCreate();
-    loader.waitOnClosed();
-    seleniumWebDriver.switchFromDashboardIframeToIde(60);
 
-    // expand the project
+    seleniumWebDriver.switchFromDashboardIframeToIde(LOADER_TIMEOUT_SEC);
     currentWindow = seleniumWebDriver.getWindowHandle();
-    loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(PROJECT_NAME, 600);
-    loader.waitOnClosed();
+    projectExplorer.waitItem(PROJECT_NAME, APPLICATION_START_TIMEOUT_SEC);
     projectExplorer.selectItem(PROJECT_NAME);
-    projectExplorer.expandPathInProjectExplorer(
-        PROJECT_NAME + "/src/main/java/org.springframework.samples.petclinic");
-    projectExplorer.expandPathInProjectExplorer(
-        PROJECT_NAME + "/src/test/java/org.springframework.samples.petclinic", 2);
-    projectExplorer.openItemByPath(
-        PROJECT_NAME + "/src/test/java/org/springframework/samples/petclinic/model");
-    projectExplorer.openItemByPath(
-        PROJECT_NAME
-            + "/src/test/java/org/springframework/samples/petclinic/model/OwnerTests.java");
-    editor.waitActiveEditor();
-    projectExplorer.openItemByPath(
-        PROJECT_NAME + "/src/main/java/org/springframework/samples/petclinic/service");
-    projectExplorer.openItemByPath(
-        PROJECT_NAME
-            + "/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java");
-    editor.waitActiveEditor();
 
-    // select the db machine and perform 'show databases'
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.COMMON, PROJECT_NAME, "show databases", "db");
-    loader.waitOnClosed();
+    // Select the db machine and perform 'show databases'
+    consoles.startCommandFromProcessesArea("db", COMMON, "show databases");
+    consoles.waitTabNameProcessIsPresent("db");
     for (String text : infoDataBases) {
       consoles.waitExpectedTextIntoConsole(text);
     }
 
-    // build and deploy the web application
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.RUN, PROJECT_NAME, "build and deploy", "dev-machine");
-    loader.waitOnClosed();
-    consoles.waitTabNameProcessIsPresent(PROCESS_NAME);
-    consoles.waitProcessInProcessConsoleTree(PROCESS_NAME);
-    consoles.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS, 150);
-    consoles.waitExpectedTextIntoConsole("Server startup in", 200);
+    // Build and deploy the web application
+    consoles.startCommandFromProcessesArea("dev-machine", RUN, BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsPresent(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitProcessInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS, UPDATING_PROJECT_TIMEOUT_SEC);
+    consoles.waitExpectedTextIntoConsole("Server startup in", PREPARING_WS_TIMEOUT_SEC);
     consoles.waitPreviewUrlIsPresent();
 
-    // run the application
-    loader.waitOnClosed();
+    // Run the application
     consoles.clickOnPreviewUrl();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWindow);
     checkWebJavaPetclinicAppl();
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(currentWindow);
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    consoles.waitProcessInProcessConsoleTree(PROCESS_NAME);
-    consoles.waitTabNameProcessIsPresent(PROCESS_NAME);
-    consoles.closeProcessByTabName(PROCESS_NAME);
+
+    // Close terminal tab for 'build and deploy' process
+    consoles.waitProcessInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsPresent(BUIL_AND_DEPLOY_PROCESS);
+    consoles.closeProcessByTabName(BUIL_AND_DEPLOY_PROCESS);
     askDialog.acceptDialogWithText(MSG_CLOSE_PROCESS);
-    consoles.waitProcessIsNotPresentInProcessConsoleTree(PROCESS_NAME);
-    consoles.waitTabNameProcessIsNotPresent(PROCESS_NAME);
+    consoles.waitProcessIsNotPresentInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsNotPresent(BUIL_AND_DEPLOY_PROCESS);
+
+    // Check that tomcat is not running
     consoles.selectProcessByTabName("Terminal");
     loader.waitOnClosed();
     terminal.typeIntoTerminal("ps ax | grep tomcat8");
-    terminal.typeIntoTerminal(Keys.ENTER.toString());
+    terminal.typeIntoTerminal(ENTER.toString());
     terminal.waitExpectedTextNotPresentTerminal("catalina.startup.Bootstrap start");
   }
 
   /** check main elements of the web-java-petclinic */
   private void checkWebJavaPetclinicAppl() {
     new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//h2[text()='Welcome']")));
+        .until(visibilityOfElementLocated(By.xpath("//h2[text()='Welcome']")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath("//div[@class='navbar-inner']")));
+        .until(visibilityOfElementLocated(By.xpath("//div[@class='navbar-inner']")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.presenceOfElementLocated(By.xpath("//table[@class='footer']")));
+        .until(presenceOfElementLocated(By.xpath("//table[@class='footer']")));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
@@ -10,7 +10,12 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.BUILD;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.RUN;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
@@ -22,7 +27,6 @@ import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
@@ -31,25 +35,22 @@ import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
 public class WorkingWithNodeWsTest {
-  private static final String NODE_JS_PROJECT_NAME = "web-nodejs-simple";
+  private static final String WORKSPACE = NameGenerator.generate("WorkingWithNode", 4);
+  private static final String PROJECT_NAME = "web-nodejs-simple";
+  private static final String RUN_PROCESS = PROJECT_NAME + ":run";
+  private static final String INSTALL_DEPENDENCIES = PROJECT_NAME + ":install dependencies";
   private static final String ASK_DIALOG_MSG_ANGULAR_APP =
       "The process web-nodejs-simple:run will be terminated after closing console. Do you want to continue?";
-
-  private static final String WORKSPACE = NameGenerator.generate("WorkingWithNode", 4);
-
-  private String currentWindow;
 
   @Inject private TestUser defaultTestUser;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private Consoles consoles;
   @Inject private NavigationBar navigationBar;
   @Inject private CreateWorkspace createWorkspace;
@@ -67,7 +68,9 @@ public class WorkingWithNodeWsTest {
 
   @Test
   public void checkNodeJsWsAndRunApp() {
-    // create workspace and project
+    String currentWindow;
+
+    // create a workspace from the Node stack with the web-nodejs-simple project
     dashboard.open();
     navigationBar.waitNavigationBar();
     navigationBar.clickOnMenu(NavigationBar.MenuItem.WORKSPACES);
@@ -77,79 +80,60 @@ public class WorkingWithNodeWsTest {
     createWorkspace.selectStack(TestStacksConstants.NODE.getId());
     createWorkspace.typeWorkspaceName(WORKSPACE);
     projectSourcePage.clickAddOrImportProjectButton();
-    projectSourcePage.selectSample(NODE_JS_PROJECT_NAME);
+    projectSourcePage.selectSample(PROJECT_NAME);
     projectSourcePage.clickAdd();
     createWorkspace.clickCreate();
-    loader.waitOnClosed();
+
     seleniumWebDriver.switchFromDashboardIframeToIde();
-
-    // expand web nodeJs simple project
     currentWindow = seleniumWebDriver.getWindowHandle();
-    loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME);
-    loader.waitOnClosed();
-    projectExplorer.selectItem(NODE_JS_PROJECT_NAME);
-    projectExplorer.openItemByPath(NODE_JS_PROJECT_NAME);
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app");
-    projectExplorer.openItemByPath(NODE_JS_PROJECT_NAME + "/app");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/images");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/scripts");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/styles");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/views");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/test");
+    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.selectItem(PROJECT_NAME);
 
-    // perform run web nodeJs application
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.BUILD,
-        NODE_JS_PROJECT_NAME,
-        "web-nodejs-simple:install dependencies");
-    consoles.waitExpectedTextIntoConsole("bower_components/angular", 400);
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.RUN, NODE_JS_PROJECT_NAME, "web-nodejs-simple:run");
-    loader.waitOnClosed();
-    consoles.waitExpectedTextIntoConsole("Started connect web server", 200);
-    loader.waitOnClosed();
+    // Perform run web nodeJs application
+    consoles.startCommandFromProcessesArea("dev-machine", BUILD, INSTALL_DEPENDENCIES);
+    consoles.waitTabNameProcessIsPresent(INSTALL_DEPENDENCIES);
+    consoles.waitExpectedTextIntoConsole("bower_components/angular", APPLICATION_START_TIMEOUT_SEC);
 
-    // check the preview url is present after refreshing
+    consoles.startCommandFromProcessesArea("dev-machine", RUN, RUN_PROCESS);
+    consoles.waitTabNameProcessIsPresent(RUN_PROCESS);
+    consoles.waitExpectedTextIntoConsole("Started connect web server", PREPARING_WS_TIMEOUT_SEC);
+
+    // Check the preview url is present after refreshing
     consoles.waitPreviewUrlIsPresent();
     seleniumWebDriver.navigate().refresh();
     seleniumWebDriver.switchFromDashboardIframeToIde();
     try {
       consoles.waitPreviewUrlIsPresent();
     } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
+      // Remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/7072");
     }
 
-    projectExplorer.selectItem(NODE_JS_PROJECT_NAME);
-    consoles.selectProcessInProcessConsoleTreeByName("web-nodejs-simple:run");
-
-    // run the application
-    loader.waitOnClosed();
+    // Run the application
+    projectExplorer.selectItem(PROJECT_NAME);
+    consoles.selectProcessInProcessConsoleTreeByName(RUN_PROCESS);
     consoles.clickOnPreviewUrl();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWindow);
     checkAngularYeomanAppl();
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(currentWindow);
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    consoles.closeProcessInProcessConsoleTreeByName("web-nodejs-simple:run");
+
+    // Close terminal tab for 'run' process
+    consoles.closeProcessInProcessConsoleTreeByName(RUN_PROCESS);
     askDialog.acceptDialogWithText(ASK_DIALOG_MSG_ANGULAR_APP);
-    consoles.waitProcessIsNotPresentInProcessConsoleTree("web-nodejs-simple:run");
+    consoles.waitProcessIsNotPresentInProcessConsoleTree(RUN_PROCESS);
   }
 
-  /** check main elements of the AngularJS-Yeoman */
+  /** Check main elements of the AngularJS-Yeoman */
   public void checkAngularYeomanAppl() {
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath("//h1[text()=\"'Allo, 'Allo!\"]")));
+        .until(visibilityOfElementLocated(By.xpath("//h1[text()=\"'Allo, 'Allo!\"]")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath("//img[@src='images/yeoman.png']")));
+        .until(visibilityOfElementLocated(By.xpath("//img[@src='images/yeoman.png']")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.linkText("Splendid!")))
+        .until(visibilityOfElementLocated(By.linkText("Splendid!")))
         .click();
   }
 }


### PR DESCRIPTION
### What does this PR do?
We need test commands starting from the **Processes area**:
- add to the **Console** selenium page object method for commands starting;
- change **WorkingWithNodeWsTest** and **WorkingWithJavaMySqlStackTest** selenium tests for starting commands from the **Processes** area;
- remove unnecessary steps in these tests(checking created project in the **Project Explorer**).
![selection_078](https://user-images.githubusercontent.com/7760565/33431146-e9f83368-d5db-11e7-9939-7bf883ea77e9.png)

### What issues does this PR fix or reference?
Create test for checking project commands starting from the Processes area https://github.com/eclipse/che/issues/6241.
