### PR TITLE
Removed warnings from environment config

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/Environment.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/Environment.java
@@ -10,9 +10,7 @@
  */
 package org.eclipse.che.api.core.model.workspace.config;
 
-import java.util.List;
 import java.util.Map;
-import org.eclipse.che.api.core.model.workspace.Warning;
 
 /**
  * Defines environment for machines network.
@@ -29,10 +27,4 @@ public interface Environment {
 
   /** Returns mapping of machine name to additional configuration of machine. */
   Map<String, ? extends MachineConfig> getMachines();
-
-  /**
-   * Returns the list of the warnings indicating that the environment violates some non-critical
-   * constraints or some preferable configuration is missing so defaults are used.
-   */
-  List<? extends Warning> getWarnings();
 }

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
@@ -182,8 +182,7 @@ export class DiagnosticsWorkspaceStartCheck {
               'content': 'FROM openjdk:8-jre-alpine\nRUN apk add --update bash\nCMD tail -f /dev/null\n',
               'contentType': 'text/x-dockerfile',
               'type': 'dockerfile'
-            },
-            warnings: []
+            }
           }
         },
         'name': 'diagnostics',

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.directive.spec.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.directive.spec.ts
@@ -101,8 +101,7 @@ describe('FactoryInformation >', () => {
           recipe: {
             content: 'FROM test/image',
             type: 'dockerfile'
-          },
-          warnings: []
+          }
         }
       };
     const workspace = cheAPIBuilder.getWorkspaceBuilder()

--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
@@ -12,7 +12,7 @@
 
 
 /**
- * This class is handling the controller for the workspace (environment and runtime) warnings container.
+ * This class is handling the controller for the workspace runtime warnings container.
  * @author Ann Shumilova
  */
 export class WorkspaceWarningsController {
@@ -31,11 +31,6 @@ export class WorkspaceWarningsController {
    */
   constructor() {
     this.warnings = [];
-
-    let environment = (this.workspace && this.workspace.config && this.workspace.config.defaultEnv) ? this.workspace.config.environments[this.workspace.config.defaultEnv] : null;
-    if (environment) {
-      this.warnings = this.warnings.concat(environment.warnings);
-    }
 
     if (this.workspace && this.workspace.runtime) {
       this.warnings = this.warnings.concat(this.workspace.runtime.warnings);

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -305,7 +305,6 @@ declare namespace che {
       [machineName: string]: IEnvironmentMachine
     };
     recipe: IRecipe;
-    warnings?: IWorkspaceWarning[];
   }
 
   export interface IRecipe {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/EnvironmentImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/EnvironmentImpl.java
@@ -10,15 +10,10 @@
  */
 package org.eclipse.che.ide.api.workspace.model;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.Recipe;
@@ -28,12 +23,8 @@ public class EnvironmentImpl implements Environment {
 
   private RecipeImpl recipe;
   private Map<String, MachineConfigImpl> machines;
-  private List<WarningImpl> warnings;
 
-  public EnvironmentImpl(
-      Recipe recipe,
-      Map<String, ? extends MachineConfig> machines,
-      List<? extends Warning> warnings) {
+  public EnvironmentImpl(Recipe recipe, Map<String, ? extends MachineConfig> machines) {
     if (recipe != null) {
       this.recipe = new RecipeImpl(recipe);
     }
@@ -46,13 +37,10 @@ public class EnvironmentImpl implements Environment {
                   Collectors.toMap(
                       Map.Entry::getKey, entry -> new MachineConfigImpl(entry.getValue())));
     }
-    if (warnings != null) {
-      this.warnings = warnings.stream().map(WarningImpl::new).collect(toList());
-    }
   }
 
   public EnvironmentImpl(Environment environment) {
-    this(environment.getRecipe(), environment.getMachines(), environment.getWarnings());
+    this(environment.getRecipe(), environment.getMachines());
   }
 
   public RecipeImpl getRecipe() {
@@ -68,14 +56,6 @@ public class EnvironmentImpl implements Environment {
   }
 
   @Override
-  public List<? extends WarningImpl> getWarnings() {
-    if (warnings == null) {
-      warnings = new ArrayList<>();
-    }
-    return warnings;
-  }
-
-  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
@@ -84,9 +64,7 @@ public class EnvironmentImpl implements Environment {
       return false;
     }
     final EnvironmentImpl that = (EnvironmentImpl) obj;
-    return Objects.equals(recipe, that.recipe)
-        && getMachines().equals(that.getMachines())
-        && getWarnings().equals(that.getWarnings());
+    return Objects.equals(recipe, that.recipe) && getMachines().equals(that.getMachines());
   }
 
   @Override
@@ -94,19 +72,11 @@ public class EnvironmentImpl implements Environment {
     int hash = 7;
     hash = 31 * hash + Objects.hashCode(recipe);
     hash = 31 * hash + getMachines().hashCode();
-    hash = 31 * hash + getWarnings().hashCode();
     return hash;
   }
 
   @Override
   public String toString() {
-    return "EnvironmentImpl{"
-        + "recipe="
-        + recipe
-        + ", machines="
-        + machines
-        + ", warnings="
-        + warnings
-        + '}';
+    return "EnvironmentImpl{" + "recipe=" + recipe + ", machines=" + machines + '}';
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
@@ -67,11 +68,12 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
   /**
    * Creates non running runtime. Normally created by {@link
-   * DockerRuntimeFactory#create(DockerRuntimeContext)}.
+   * DockerRuntimeFactory#create(DockerRuntimeContext, List)}.
    */
   @AssistedInject
   public DockerInternalRuntime(
       @Assisted DockerRuntimeContext context,
+      @Assisted List<Warning> warnings,
       ExternalIpURLRewriter urlRewriter,
       NetworkLifecycle networks,
       DockerMachineStarter machineStarter,
@@ -82,6 +84,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     this(
         context,
         urlRewriter,
+        warnings,
         false, // <- non running
         networks,
         machineStarter,
@@ -93,12 +96,13 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
   /**
    * Creates a running runtime from the list of given containers. Normally created by {@link
-   * DockerRuntimeFactory#create(DockerRuntimeContext, List)}.
+   * DockerRuntimeFactory#create(DockerRuntimeContext, List, List)}.
    */
   @AssistedInject
   public DockerInternalRuntime(
       @Assisted DockerRuntimeContext context,
       @Assisted List<ContainerListEntry> containers,
+      @Assisted List<Warning> warnings,
       ExternalIpURLRewriter urlRewriter,
       NetworkLifecycle networks,
       DockerMachineStarter machineStarter,
@@ -112,6 +116,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     this(
         context,
         urlRewriter,
+        warnings,
         true, // <- running
         networks,
         machineStarter,
@@ -133,6 +138,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
   private DockerInternalRuntime(
       DockerRuntimeContext context,
       URLRewriter urlRewriter,
+      List<Warning> warnings,
       boolean running,
       NetworkLifecycle networks,
       DockerMachineStarter machineStarter,
@@ -140,7 +146,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
       DockerBootstrapperFactory bootstrapperFactory,
       ServersCheckerFactory serverCheckerFactory,
       MachineLoggersFactory loggers) {
-    super(context, urlRewriter, running);
+    super(context, urlRewriter, warnings, running);
     this.networks = networks;
     this.containerStarter = machineStarter;
     this.eventService = eventService;

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContext.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeContext.java
@@ -81,13 +81,15 @@ public class DockerRuntimeContext extends RuntimeContext<DockerEnvironment> {
   public DockerInternalRuntime getRuntime() throws InfrastructureException {
     RuntimeIdentity identity = getIdentity();
     List<ContainerListEntry> runningContainers = containers.find(identity);
+    DockerEnvironment environment = getEnvironment();
     if (runningContainers.isEmpty()) {
-      return runtimeFactory.create(this);
+      return runtimeFactory.create(this, environment.getWarnings());
     }
 
-    DockerInternalRuntime runtime = runtimeFactory.create(this, runningContainers);
+    DockerInternalRuntime runtime =
+        runtimeFactory.create(this, runningContainers, environment.getWarnings());
     try {
-      consistencyChecker.check(getEnvironment(), runtime);
+      consistencyChecker.check(environment, runtime);
       runtime.checkServers();
     } catch (InfrastructureException | ValidationException x) {
       LOG.warn(

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeFactory.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeFactory.java
@@ -11,11 +11,13 @@
 package org.eclipse.che.workspace.infrastructure.docker;
 
 import java.util.List;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.infrastructure.docker.client.json.ContainerListEntry;
 
 /** @author Alexander Garagatyi */
 public interface DockerRuntimeFactory {
-  DockerInternalRuntime create(DockerRuntimeContext context);
+  DockerInternalRuntime create(DockerRuntimeContext context, List<Warning> warnings);
 
-  DockerInternalRuntime create(DockerRuntimeContext context, List<ContainerListEntry> containers);
+  DockerInternalRuntime create(
+      DockerRuntimeContext context, List<ContainerListEntry> containers, List<Warning> warnings);
 }

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
@@ -115,6 +115,7 @@ public class DockerInternalRuntimeTest {
     dockerRuntime =
         new DockerInternalRuntime(
             runtimeContext,
+            emptyList(),
             mock(ExternalIpURLRewriter.class),
             networks,
             starter,

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
@@ -83,8 +84,9 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
       OpenShiftBootstrapperFactory bootstrapperFactory,
       ServersCheckerFactory serverCheckerFactory,
       @Assisted OpenShiftRuntimeContext context,
-      @Assisted OpenShiftProject project) {
-    super(context, urlRewriter, false);
+      @Assisted OpenShiftProject project,
+      @Assisted List<Warning> warnings) {
+    super(context, urlRewriter, warnings, false);
     this.eventService = eventService;
     this.bootstrapperFactory = bootstrapperFactory;
     this.serverCheckerFactory = serverCheckerFactory;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -57,6 +57,9 @@ public class OpenShiftRuntimeContext extends RuntimeContext<OpenShiftEnvironment
 
   @Override
   public OpenShiftInternalRuntime getRuntime() throws InfrastructureException {
-    return runtimeFactory.create(this, projectFactory.create(getIdentity().getWorkspaceId()));
+    return runtimeFactory.create(
+        this,
+        projectFactory.create(getIdentity().getWorkspaceId()),
+        getEnvironment().getWarnings());
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeFactory.java
@@ -10,9 +10,12 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import java.util.List;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
 
 /** @author Sergii Leshchenko */
 public interface OpenShiftRuntimeFactory {
-  OpenShiftInternalRuntime create(OpenShiftRuntimeContext context, OpenShiftProject namespace);
+  OpenShiftInternalRuntime create(
+      OpenShiftRuntimeContext context, OpenShiftProject namespace, List<Warning> warnings);
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.workspace.infrastructure.openshift;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.FAILED;
@@ -142,7 +143,8 @@ public class OpenShiftInternalRuntimeTest {
             bootstrapperFactory,
             serverCheckerFactory,
             context,
-            project);
+            project,
+            emptyList());
     when(context.getEnvironment()).thenReturn(osEnv);
     when(serverCheckerFactory.create(any(), anyString(), any())).thenReturn(serversChecker);
     when(context.getIdentity()).thenReturn(IDENTITY);

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/EnvironmentDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/EnvironmentDto.java
@@ -12,7 +12,6 @@ package org.eclipse.che.api.workspace.shared.dto;
 
 import static org.eclipse.che.api.core.factory.FactoryParameter.Obligation.MANDATORY;
 
-import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.factory.FactoryParameter;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
@@ -37,11 +36,4 @@ public interface EnvironmentDto extends Environment {
   void setMachines(Map<String, MachineConfigDto> machines);
 
   EnvironmentDto withMachines(Map<String, MachineConfigDto> machines);
-
-  @Override
-  List<WarningDto> getWarnings();
-
-  void setWarnings(List<WarningDto> warnings);
-
-  EnvironmentDto withWarnings(List<WarningDto> warnings);
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
@@ -10,9 +10,7 @@
  */
 package org.eclipse.che.api.workspace.server.model.impl;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -27,8 +25,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Transient;
-import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.Recipe;
@@ -54,14 +50,9 @@ public class EnvironmentImpl implements Environment {
   @MapKeyColumn(name = "machines_key")
   private Map<String, MachineConfigImpl> machines;
 
-  @Transient private List<WarningImpl> warnings;
-
   public EnvironmentImpl() {}
 
-  public EnvironmentImpl(
-      Recipe recipe,
-      Map<String, ? extends MachineConfig> machines,
-      List<? extends Warning> warnings) {
+  public EnvironmentImpl(Recipe recipe, Map<String, ? extends MachineConfig> machines) {
     if (recipe != null) {
       this.recipe = new RecipeImpl(recipe);
     }
@@ -74,13 +65,10 @@ public class EnvironmentImpl implements Environment {
                   Collectors.toMap(
                       Map.Entry::getKey, entry -> new MachineConfigImpl(entry.getValue())));
     }
-    if (warnings != null) {
-      this.warnings = warnings.stream().map(WarningImpl::new).collect(Collectors.toList());
-    }
   }
 
   public EnvironmentImpl(Environment environment) {
-    this(environment.getRecipe(), environment.getMachines(), environment.getWarnings());
+    this(environment.getRecipe(), environment.getMachines());
   }
 
   @Override
@@ -100,14 +88,6 @@ public class EnvironmentImpl implements Environment {
     return machines;
   }
 
-  @Override
-  public List<? extends Warning> getWarnings() {
-    if (warnings == null) {
-      warnings = new ArrayList<>();
-    }
-    return warnings;
-  }
-
   public void setMachines(Map<String, MachineConfigImpl> machines) {
     this.machines = machines;
   }
@@ -119,26 +99,16 @@ public class EnvironmentImpl implements Environment {
     EnvironmentImpl that = (EnvironmentImpl) o;
     return Objects.equals(id, that.id)
         && Objects.equals(getRecipe(), that.getRecipe())
-        && Objects.equals(getMachines(), that.getMachines())
-        && Objects.equals(getWarnings(), that.getWarnings());
+        && Objects.equals(getMachines(), that.getMachines());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, getRecipe(), getMachines(), getWarnings());
+    return Objects.hash(id, getRecipe(), getMachines());
   }
 
   @Override
   public String toString() {
-    return "EnvironmentImpl{"
-        + "id="
-        + id
-        + ", recipe="
-        + recipe
-        + ", machines="
-        + machines
-        + ", warnings="
-        + warnings
-        + '}';
+    return "EnvironmentImpl{" + "id=" + id + ", recipe=" + recipe + ", machines=" + machines + '}';
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -39,10 +39,14 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
   private final List<Warning> warnings;
   private WorkspaceStatus status;
 
-  public InternalRuntime(T context, URLRewriter urlRewriter, boolean running) {
+  public InternalRuntime(
+      T context, URLRewriter urlRewriter, List<Warning> warnings, boolean running) {
     this.context = context;
     this.urlRewriter = urlRewriter;
     this.warnings = new CopyOnWriteArrayList<>();
+    if (warnings != null) {
+      this.warnings.addAll(warnings);
+    }
     if (running) {
       status = WorkspaceStatus.RUNNING;
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -80,9 +80,6 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
 
     Map<String, InternalMachineConfig> machines = new HashMap<>();
     List<Warning> warnings = new ArrayList<>();
-    if (sourceEnv.getWarnings() != null) {
-      warnings.addAll(sourceEnv.getWarnings());
-    }
 
     InternalRecipe recipe = recipeRetriever.getRecipe(sourceEnv.getRecipe());
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -586,7 +586,7 @@ public class WorkspaceManagerTest {
     final Map<String, Machine> machines;
 
     TestInternalRuntime(RuntimeContext context, Map<String, Machine> machines) {
-      super(context, null, false);
+      super(context, null, null, false);
       this.machines = machines;
     }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.workspace.server;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -385,7 +384,7 @@ public class WorkspaceManagerTest {
   @Test
   public void startsWorkspaceWithProvidedEnvironment() throws Exception {
     final WorkspaceConfigImpl config = createConfig();
-    final EnvironmentImpl environment = new EnvironmentImpl(null, emptyMap(), emptyList());
+    final EnvironmentImpl environment = new EnvironmentImpl(null, emptyMap());
     config.getEnvironments().put("non-default-env", environment);
     final WorkspaceImpl workspace = createAndMockWorkspace(config, NAMESPACE_1);
 
@@ -563,8 +562,7 @@ public class WorkspaceManagerTest {
     EnvironmentImpl environment =
         new EnvironmentImpl(
             new RecipeImpl("type", "contentType", "content", null),
-            singletonMap("dev-machine", machineConfig),
-            emptyList());
+            singletonMap("dev-machine", machineConfig));
     return WorkspaceConfigImpl.builder()
         .setName("dev-workspace")
         .setDefaultEnv("dev-env")

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -221,7 +221,7 @@ public class WorkspaceRuntimesTest {
     final Map<String, Machine> machines;
 
     TestInternalRuntime(RuntimeContext context, Map<String, Machine> machines) {
-      super(context, null, false);
+      super(context, null, null, false);
       this.machines = machines;
     }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -12,7 +12,6 @@ package org.eclipse.che.api.workspace.server;
 
 import static com.jayway.restassured.RestAssured.given;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -921,8 +920,7 @@ public class WorkspaceServiceTest {
     return DtoConverter.asDto(
         new EnvironmentImpl(
             new RecipeImpl("type", "content-type", "content", null),
-            singletonMap("dev-machine", devMachine),
-            emptyList()));
+            singletonMap("dev-machine", devMachine)));
   }
 
   private static WorkspaceConfigDto createConfigDto() {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.api.workspace.server.spi;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.runtime.ServerStatus.RUNNING;
@@ -578,17 +579,10 @@ public class InternalRuntimeTest {
   private static class TestInternalRuntime extends InternalRuntime<RuntimeContext> {
     public TestInternalRuntime(URLRewriter urlRewriter, boolean running)
         throws ValidationException, InfrastructureException {
-      /*super(new TestRuntimeContext(new EnvironmentImpl(new RecipeImpl("type", "contentType", "content", null),
-                                                 emptyMap(),
-                                                 null),
-                             new RuntimeIdentityImpl("ws", "env", "owner"),
-                             null,
-                             null),
-      urlRewriter,
-      running);*/
       super(
           new TestRuntimeContext(null, new RuntimeIdentityImpl("ws", "env", "owner"), null),
           urlRewriter,
+          emptyList(),
           running);
     }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.installer.server.InstallerRegistry;
@@ -36,7 +35,6 @@ import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
-import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -75,7 +73,7 @@ public class InternalEnvironmentFactoryTest {
     InternalRecipe retrievedRecipe = mock(InternalRecipe.class);
     doReturn(retrievedRecipe).when(recipeRetriever).getRecipe(any());
 
-    EnvironmentImpl env = new EnvironmentImpl(recipe, null, null);
+    EnvironmentImpl env = new EnvironmentImpl(recipe, null);
 
     // when
     environmentFactory.create(env);
@@ -93,8 +91,7 @@ public class InternalEnvironmentFactoryTest {
 
     List<String> sourceInstallers = singletonList("ws-agent");
     MachineConfigImpl machineConfig = new MachineConfigImpl().withInstallers(sourceInstallers);
-    EnvironmentImpl env =
-        new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig), null);
+    EnvironmentImpl env = new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig));
 
     // when
     environmentFactory.create(env);
@@ -119,8 +116,7 @@ public class InternalEnvironmentFactoryTest {
     ImmutableMap<String, ServerConfigImpl> sourceServers = ImmutableMap.of("server", server);
     MachineConfigImpl machineConfig = new MachineConfigImpl(null, sourceServers, null, null, null);
 
-    EnvironmentImpl env =
-        new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig), null);
+    EnvironmentImpl env = new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig));
 
     // when
     environmentFactory.create(env);
@@ -130,29 +126,6 @@ public class InternalEnvironmentFactoryTest {
     verify(environmentFactory).doCreate(any(), machinesCaptor.capture(), any());
     Map<String, InternalMachineConfig> internalMachines = machinesCaptor.getValue();
     assertEquals(internalMachines.get("machine").getServers(), normalizedServers);
-  }
-
-  @Test
-  public void shouldUseSourceWarningsEnvVarsAndAttributesWhileInternalEnvironmentCreation()
-      throws Exception {
-    // given
-    List<Warning> sourceWarnings = singletonList(new WarningImpl(123, "message"));
-    ImmutableMap<String, String> sourceEnv = ImmutableMap.of("CHE_API", "localhost");
-    ImmutableMap<String, String> sourceAttributes = ImmutableMap.of("attribute", "value");
-    MachineConfigImpl machineConfig =
-        new MachineConfigImpl(null, null, sourceEnv, sourceAttributes, null);
-
-    EnvironmentImpl env =
-        new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig), sourceWarnings);
-
-    // when
-    environmentFactory.create(env);
-
-    // then
-    verify(environmentFactory).doCreate(any(), machinesCaptor.capture(), eq(sourceWarnings));
-    Map<String, InternalMachineConfig> internalMachines = machinesCaptor.getValue();
-    assertEquals(internalMachines.get("machine").getEnv(), sourceEnv);
-    assertEquals(internalMachines.get("machine").getAttributes(), sourceAttributes);
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackServiceTest.java
@@ -143,7 +143,7 @@ public class StackServiceTest {
     componentsImpl = singletonList(new StackComponentImpl(COMPONENT_NAME, COMPONENT_VERSION));
     stackSourceImpl = new StackSourceImpl(SOURCE_TYPE, SOURCE_ORIGIN);
     CommandImpl command = new CommandImpl(COMMAND_NAME, COMMAND_LINE, COMMAND_TYPE);
-    EnvironmentImpl environment = new EnvironmentImpl(null, null, null);
+    EnvironmentImpl environment = new EnvironmentImpl(null, null);
 
     WorkspaceConfigImpl workspaceConfig =
         WorkspaceConfigImpl.builder()


### PR DESCRIPTION
### What does this PR do?
Removes warnings from environment config.
Adds copying of warnings from `InternalEnvironment` to `Runtime`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7495