### PR TITLE
Fixed location of centos blank stack which was previously invalid

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2451,7 +2451,7 @@
   "components": [],
   "source": {
     "type": "image",
-    "origin": "registry.centos.org/che-stacks/centos-git"
+    "origin": "registry.centos.org/che-stacks/centos-stack-base"
   },
   "workspaceConfig": {
     "environments": {
@@ -2470,7 +2470,7 @@
           }
         },
         "recipe": {
-          "location": "registry.centos.org/che-stacks/centos-git",
+          "location": "registry.centos.org/che-stacks/centos-stack-base",
           "type": "dockerimage"
         }
       }


### PR DESCRIPTION
Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes an issue with the centos blank stack where the location was invalid

### What issues does this PR fix or reference?
Part of redhat-developer/rh-che/issues/431

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A