### PR TITLE
Test commands starting from the Processes area

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
@@ -63,6 +64,16 @@ public class Consoles {
   protected final SeleniumWebDriver seleniumWebDriver;
   private final Loader loader;
   private static final String CONSOLE_PANEL_DRUGGER_CSS = "div.gwt-SplitLayoutPanel-VDragger";
+  public static final String MACHINE_NAME =
+      "//div[@id='gwt-debug-process-tree']//span[text()= '%s']";
+  public static final String CONTEXT_MENU = "gwt-debug-contextMenu/commandsActionGroup";
+  public static final String COMMAND_NAME = "//tr[contains(@id,'command_%s')]";
+
+  public interface CommandsGoal {
+    String COMMON = "gwt-debug-contextMenu/Commands/goal_Common";
+    String BUILD = "gwt-debug-contextMenu/Commands/goal_Build";
+    String RUN = "gwt-debug-contextMenu/Commands/goal_Run";
+  }
 
   @Inject
   public Consoles(SeleniumWebDriver seleniumWebDriver, Loader loader) {
@@ -103,6 +114,9 @@ public class Consoles {
 
   @FindBy(xpath = PROCESSES_MAIN_AREA)
   WebElement processesMainArea;
+
+  @FindBy(id = CONTEXT_MENU)
+  WebElement contextMenu;
 
   /** click on consoles tab in bottom and wait opening console area (terminal on other console ) */
   public void clickOnProcessesTab() {
@@ -145,7 +159,7 @@ public class Consoles {
    */
   public void closeProcessInProcessConsoleTreeByName(String nameProcess) {
     loadPageDriverWait
-        .until(visibilityOfElementLocated(By.xpath(String.format(CLOSE_PROCESS_ICON, nameProcess))))
+        .until(visibilityOfElementLocated(By.xpath(format(CLOSE_PROCESS_ICON, nameProcess))))
         .click();
   }
 
@@ -156,7 +170,7 @@ public class Consoles {
    */
   public void waitProcessInProcessConsoleTree(String nameProcess) {
     loadPageDriverWait.until(
-        visibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))));
+        visibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))));
   }
 
   /**
@@ -167,8 +181,7 @@ public class Consoles {
    */
   public void waitProcessInProcessConsoleTree(String nameProcess, int timeout) {
     new WebDriverWait(seleniumWebDriver, timeout)
-        .until(
-            visibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))));
+        .until(visibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))));
   }
 
   /**
@@ -178,7 +191,7 @@ public class Consoles {
    */
   public void waitProcessIsNotPresentInProcessConsoleTree(String nameProcess) {
     loadPageDriverWait.until(
-        invisibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))));
+        invisibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))));
   }
 
   /**
@@ -188,7 +201,7 @@ public class Consoles {
    */
   public void selectProcessInProcessConsoleTreeByName(String nameProcess) {
     loadPageDriverWait
-        .until(visibilityOfElementLocated(By.xpath(String.format(PROCESS_NAME_XPATH, nameProcess))))
+        .until(visibilityOfElementLocated(By.xpath(format(PROCESS_NAME_XPATH, nameProcess))))
         .click();
   }
 
@@ -200,8 +213,7 @@ public class Consoles {
   public void selectProcessByTabName(String tabNameProcess) {
     loader.waitOnClosed();
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            visibilityOfElementLocated(By.xpath(String.format(TAB_PROCESS_NAME, tabNameProcess))))
+        .until(visibilityOfElementLocated(By.xpath(format(TAB_PROCESS_NAME, tabNameProcess))))
         .click();
     loader.waitOnClosed();
   }
@@ -213,7 +225,7 @@ public class Consoles {
    */
   public void waitTabNameProcessIsPresent(String tabNameProcess) {
     redrawDriverWait.until(
-        visibilityOfElementLocated(By.xpath(String.format(TAB_PROCESS_NAME, tabNameProcess))));
+        visibilityOfElementLocated(By.xpath(format(TAB_PROCESS_NAME, tabNameProcess))));
   }
 
   /**
@@ -223,7 +235,7 @@ public class Consoles {
    */
   public void waitTabNameProcessIsNotPresent(String tabNameProcess) {
     redrawDriverWait.until(
-        invisibilityOfElementLocated(By.xpath(String.format(TAB_PROCESS_NAME, tabNameProcess))));
+        invisibilityOfElementLocated(By.xpath(format(TAB_PROCESS_NAME, tabNameProcess))));
   }
 
   /**
@@ -233,8 +245,7 @@ public class Consoles {
    */
   public void closeProcessByTabName(String tabNameProcess) {
     redrawDriverWait
-        .until(
-            elementToBeClickable(By.xpath(String.format(TAB_PROCESS_CLOSE_ICON, tabNameProcess))))
+        .until(elementToBeClickable(By.xpath(format(TAB_PROCESS_CLOSE_ICON, tabNameProcess))))
         .click();
   }
 
@@ -310,5 +321,22 @@ public class Consoles {
     new Actions(seleniumWebDriver)
         .dragAndDropBy(drag, verticalShiftInPixels, verticalShiftInPixels)
         .perform();
+  }
+
+  public void startCommandFromProcessesArea(
+      String machineName, String commandGoal, String commandName) {
+    WebElement machine =
+        redrawDriverWait.until(
+            visibilityOfElementLocated(By.xpath(format(MACHINE_NAME, machineName))));
+    machine.click();
+
+    Actions action = new Actions(seleniumWebDriver);
+    action.moveToElement(machine).contextClick().perform();
+    redrawDriverWait.until(visibilityOf(contextMenu)).click();
+
+    redrawDriverWait.until(visibilityOfElementLocated(By.id(commandGoal))).click();
+    redrawDriverWait
+        .until(visibilityOfElementLocated(By.xpath(format(COMMAND_NAME, commandName))))
+        .click();
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -61,8 +61,6 @@ public class Consoles {
   public static final String PREVIEW_URL = "//div[@active]//a[@href]";
   public static final String COMMAND_CONSOLE_ID =
       "//div[@active]//div[@id='gwt-debug-commandConsoleLines']";
-  protected final SeleniumWebDriver seleniumWebDriver;
-  private final Loader loader;
   private static final String CONSOLE_PANEL_DRUGGER_CSS = "div.gwt-SplitLayoutPanel-VDragger";
   public static final String MACHINE_NAME =
       "//div[@id='gwt-debug-process-tree']//span[text()= '%s']";
@@ -74,6 +72,9 @@ public class Consoles {
     String BUILD = "gwt-debug-contextMenu/Commands/goal_Build";
     String RUN = "gwt-debug-contextMenu/Commands/goal_Run";
   }
+
+  protected final SeleniumWebDriver seleniumWebDriver;
+  private final Loader loader;
 
   @Inject
   public Consoles(SeleniumWebDriver seleniumWebDriver, Loader loader) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
@@ -10,8 +10,21 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SUCCESS;
+import static org.eclipse.che.selenium.core.constant.TestStacksConstants.JAVA_MYSQL;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.pageobject.Consoles.CommandsGoal.COMMON;
+import static org.eclipse.che.selenium.pageobject.Consoles.CommandsGoal.RUN;
+import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.WORKSPACES;
+import static org.openqa.selenium.Keys.ENTER;
+import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.util.Arrays;
@@ -19,13 +32,9 @@ import java.util.List;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
-import org.eclipse.che.selenium.core.constant.TestBuildConstants;
-import org.eclipse.che.selenium.core.constant.TestStacksConstants;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.AskDialog;
-import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
-import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
@@ -35,8 +44,7 @@ import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -45,19 +53,16 @@ import org.testng.annotations.Test;
 public class WorkingWithJavaMySqlStackTest {
   private static final String WORKSPACE = NameGenerator.generate("java-mysql", 4);
   private static final String PROJECT_NAME = "web-java-petclinic";
-  private static final String PROCESS_NAME = PROJECT_NAME + ":build and deploy";
+  private static final String BUIL_AND_DEPLOY_PROCESS = PROJECT_NAME + ":build and deploy";
 
   private static final List<String> infoDataBases =
       Arrays.asList("Database", "information_schema", "petclinic", "mysql");
   private static final String MSG_CLOSE_PROCESS =
-      "The process "
-          + PROJECT_NAME
-          + ":build and deploy will be terminated after closing console. Do you want to continue?";
-
-  private String currentWindow;
+      String.format(
+          "The process %s:build and deploy will be terminated after closing console. Do you want to continue?",
+          PROJECT_NAME);
 
   @Inject private TestUser defaultTestUser;
-  @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private Consoles consoles;
@@ -67,7 +72,6 @@ public class WorkingWithJavaMySqlStackTest {
   @Inject private Dashboard dashboard;
   @Inject private DashboardWorkspace dashboardWorkspace;
   @Inject private AskDialog askDialog;
-  @Inject private CodenvyEditor editor;
   @Inject private MachineTerminal terminal;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
@@ -79,95 +83,82 @@ public class WorkingWithJavaMySqlStackTest {
 
   @Test
   public void checkJavaMySqlAndRunApp() {
-    // create workspace and project
+    String currentWindow;
+
+    // create a workspace from the Java-MySql stack with the web-java-petclinic project
     dashboard.open();
     navigationBar.waitNavigationBar();
-    navigationBar.clickOnMenu(NavigationBar.MenuItem.WORKSPACES);
+    navigationBar.clickOnMenu(WORKSPACES);
     dashboardWorkspace.waitToolbarTitleName("Workspaces");
     dashboardWorkspace.clickOnNewWorkspaceBtn();
-
     createWorkspace.waitToolbar();
-    loader.waitOnClosed();
-    createWorkspace.selectStack(TestStacksConstants.JAVA_MYSQL.getId());
+    createWorkspace.selectStack(JAVA_MYSQL.getId());
     createWorkspace.typeWorkspaceName(WORKSPACE);
     projectSourcePage.clickAddOrImportProjectButton();
     projectSourcePage.selectSample(PROJECT_NAME);
     projectSourcePage.clickAdd();
-
     createWorkspace.clickCreate();
-    loader.waitOnClosed();
-    seleniumWebDriver.switchFromDashboardIframeToIde(60);
 
-    // expand the project
+    seleniumWebDriver.switchFromDashboardIframeToIde(LOADER_TIMEOUT_SEC);
     currentWindow = seleniumWebDriver.getWindowHandle();
-    loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(PROJECT_NAME, 600);
-    projectExplorer.expandPathInProjectExplorer(
-        PROJECT_NAME + "/src/main/java/org.springframework.samples.petclinic");
-    projectExplorer.expandPathInProjectExplorer(
-        PROJECT_NAME + "/src/test/java/org.springframework.samples.petclinic", 2);
-    projectExplorer.openItemByPath(
-        PROJECT_NAME + "/src/test/java/org/springframework/samples/petclinic/model");
-    projectExplorer.openItemByPath(
-        PROJECT_NAME
-            + "/src/test/java/org/springframework/samples/petclinic/model/OwnerTests.java");
-    editor.waitActiveEditor();
-    projectExplorer.openItemByPath(
-        PROJECT_NAME + "/src/main/java/org/springframework/samples/petclinic/service");
-    projectExplorer.openItemByPath(
-        PROJECT_NAME
-            + "/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java");
-    editor.waitActiveEditor();
-
-    // select the db machine and perform 'show databases'
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.COMMON, PROJECT_NAME, "show databases", "db");
+    projectExplorer.waitItem(PROJECT_NAME, APPLICATION_START_TIMEOUT_SEC);
     loader.waitOnClosed();
+    projectExplorer.selectItem(PROJECT_NAME);
+
+    // Select the db machine and perform 'show databases'
+    projectExplorer.invokeCommandWithContextMenu(COMMON, PROJECT_NAME, "show databases", "db");
+    consoles.waitTabNameProcessIsPresent("db");
     for (String text : infoDataBases) {
       consoles.waitExpectedTextIntoConsole(text);
     }
 
-    // build and deploy the web application
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.RUN, PROJECT_NAME, "build and deploy", "dev-machine");
-    loader.waitOnClosed();
-    consoles.waitTabNameProcessIsPresent(PROCESS_NAME);
-    consoles.waitProcessInProcessConsoleTree(PROCESS_NAME);
-    consoles.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS, 150);
-    consoles.waitExpectedTextIntoConsole("Server startup in", 200);
+    // Build and deploy the web application
+    projectExplorer.selectItem(PROJECT_NAME);
+    consoles.startCommandFromProcessesArea("dev-machine", RUN, BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsPresent(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitProcessInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    try {
+      consoles.waitExpectedTextIntoConsole("[INFO] Building petclinic ", ELEMENT_TIMEOUT_SEC);
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/6483", ex);
+    }
+    consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS, UPDATING_PROJECT_TIMEOUT_SEC);
+    consoles.waitExpectedTextIntoConsole("Server startup in", PREPARING_WS_TIMEOUT_SEC);
     consoles.waitPreviewUrlIsPresent();
 
-    // run the application
-    loader.waitOnClosed();
+    // Run the application
     consoles.clickOnPreviewUrl();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWindow);
     checkWebJavaPetclinicAppl();
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(currentWindow);
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    consoles.waitProcessInProcessConsoleTree(PROCESS_NAME);
-    consoles.waitTabNameProcessIsPresent(PROCESS_NAME);
-    consoles.closeProcessByTabName(PROCESS_NAME);
+
+    // Close terminal tab for 'build and deploy' process
+    consoles.waitProcessInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsPresent(BUIL_AND_DEPLOY_PROCESS);
+    consoles.closeProcessByTabName(BUIL_AND_DEPLOY_PROCESS);
     askDialog.acceptDialogWithText(MSG_CLOSE_PROCESS);
-    consoles.waitProcessIsNotPresentInProcessConsoleTree(PROCESS_NAME);
-    consoles.waitTabNameProcessIsNotPresent(PROCESS_NAME);
+    consoles.waitProcessIsNotPresentInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsNotPresent(BUIL_AND_DEPLOY_PROCESS);
+
+    // Check that tomcat is not running
     consoles.selectProcessByTabName("Terminal");
     loader.waitOnClosed();
     terminal.typeIntoTerminal("ps ax | grep tomcat8");
-    terminal.typeIntoTerminal(Keys.ENTER.toString());
+    terminal.typeIntoTerminal(ENTER.toString());
     terminal.waitExpectedTextNotPresentTerminal("catalina.startup.Bootstrap start");
   }
 
   /** check main elements of the web-java-petclinic */
   private void checkWebJavaPetclinicAppl() {
     new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//h2[text()='Welcome']")));
+        .until(visibilityOfElementLocated(By.xpath("//h2[text()='Welcome']")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath("//div[@class='navbar-inner']")));
+        .until(visibilityOfElementLocated(By.xpath("//div[@class='navbar-inner']")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.presenceOfElementLocated(By.xpath("//table[@class='footer']")));
+        .until(presenceOfElementLocated(By.xpath("//table[@class='footer']")));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithJavaMySqlStackTest.java
@@ -53,7 +53,7 @@ import org.testng.annotations.Test;
 public class WorkingWithJavaMySqlStackTest {
   private static final String WORKSPACE = NameGenerator.generate("java-mysql", 4);
   private static final String PROJECT_NAME = "web-java-petclinic";
-  private static final String BUIL_AND_DEPLOY_PROCESS = PROJECT_NAME + ":build and deploy";
+  private static final String BUILD_AND_DEPLOY_PROCESS = PROJECT_NAME + ":build and deploy";
 
   private static final List<String> infoDataBases =
       Arrays.asList("Database", "information_schema", "petclinic", "mysql");
@@ -115,9 +115,9 @@ public class WorkingWithJavaMySqlStackTest {
 
     // Build and deploy the web application
     projectExplorer.selectItem(PROJECT_NAME);
-    consoles.startCommandFromProcessesArea("dev-machine", RUN, BUIL_AND_DEPLOY_PROCESS);
-    consoles.waitTabNameProcessIsPresent(BUIL_AND_DEPLOY_PROCESS);
-    consoles.waitProcessInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
+    consoles.startCommandFromProcessesArea("dev-machine", RUN, BUILD_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsPresent(BUILD_AND_DEPLOY_PROCESS);
+    consoles.waitProcessInProcessConsoleTree(BUILD_AND_DEPLOY_PROCESS);
     try {
       consoles.waitExpectedTextIntoConsole("[INFO] Building petclinic ", ELEMENT_TIMEOUT_SEC);
     } catch (TimeoutException ex) {
@@ -137,12 +137,12 @@ public class WorkingWithJavaMySqlStackTest {
     seleniumWebDriver.switchFromDashboardIframeToIde();
 
     // Close terminal tab for 'build and deploy' process
-    consoles.waitProcessInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
-    consoles.waitTabNameProcessIsPresent(BUIL_AND_DEPLOY_PROCESS);
-    consoles.closeProcessByTabName(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitProcessInProcessConsoleTree(BUILD_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsPresent(BUILD_AND_DEPLOY_PROCESS);
+    consoles.closeProcessByTabName(BUILD_AND_DEPLOY_PROCESS);
     askDialog.acceptDialogWithText(MSG_CLOSE_PROCESS);
-    consoles.waitProcessIsNotPresentInProcessConsoleTree(BUIL_AND_DEPLOY_PROCESS);
-    consoles.waitTabNameProcessIsNotPresent(BUIL_AND_DEPLOY_PROCESS);
+    consoles.waitProcessIsNotPresentInProcessConsoleTree(BUILD_AND_DEPLOY_PROCESS);
+    consoles.waitTabNameProcessIsNotPresent(BUILD_AND_DEPLOY_PROCESS);
 
     // Check that tomcat is not running
     consoles.selectProcessByTabName("Terminal");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
@@ -10,20 +10,24 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.BUILD;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.RUN;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestStacksConstants;
-import org.eclipse.che.selenium.core.constant.TestWorkspaceConstants;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
-import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
@@ -31,32 +35,29 @@ import org.eclipse.che.selenium.pageobject.dashboard.DashboardWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
 public class WorkingWithNodeWsTest {
-  private static final String NODE_JS_PROJECT_NAME = "web-nodejs-simple";
+  private static final String WORKSPACE = NameGenerator.generate("WorkingWithNode", 4);
+  private static final String PROJECT_NAME = "web-nodejs-simple";
+  private static final String RUN_PROCESS = PROJECT_NAME + ":run";
+  private static final String INSTALL_DEPENDENCIES = PROJECT_NAME + ":install dependencies";
   private static final String ASK_DIALOG_MSG_ANGULAR_APP =
       "The process web-nodejs-simple:run will be terminated after closing console. Do you want to continue?";
-
-  private static final String WORKSPACE = NameGenerator.generate("WorkingWithNode", 4);
-
-  private String currentWindow;
 
   @Inject private TestUser defaultTestUser;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private Consoles consoles;
   @Inject private NavigationBar navigationBar;
   @Inject private CreateWorkspace createWorkspace;
   @Inject private ProjectSourcePage projectSourcePage;
   @Inject private Dashboard dashboard;
   @Inject private DashboardWorkspace dashboardWorkspace;
-  @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private AskDialog askDialog;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
@@ -68,86 +69,73 @@ public class WorkingWithNodeWsTest {
 
   @Test
   public void checkNodeJsWsAndRunApp() {
-    // create workspace and project
+    String currentWindow;
+
+    // create a workspace from the Node stack with the web-nodejs-simple project
     dashboard.open();
     navigationBar.waitNavigationBar();
     navigationBar.clickOnMenu(NavigationBar.MenuItem.WORKSPACES);
     dashboardWorkspace.waitToolbarTitleName("Workspaces");
     dashboardWorkspace.clickOnNewWorkspaceBtn();
-
     createWorkspace.waitToolbar();
     createWorkspace.selectStack(TestStacksConstants.NODE.getId());
     createWorkspace.typeWorkspaceName(WORKSPACE);
     projectSourcePage.clickAddOrImportProjectButton();
-    projectSourcePage.selectSample(NODE_JS_PROJECT_NAME);
+    projectSourcePage.selectSample(PROJECT_NAME);
     projectSourcePage.clickAdd();
-
     createWorkspace.clickCreate();
 
-    loader.waitOnClosed();
     seleniumWebDriver.switchFromDashboardIframeToIde();
-
-    // expand web nodeJs simple project
     currentWindow = seleniumWebDriver.getWindowHandle();
-    loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME);
-    projectExplorer.openItemByPath(NODE_JS_PROJECT_NAME);
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app");
-    projectExplorer.openItemByPath(NODE_JS_PROJECT_NAME + "/app");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/images");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/scripts");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/styles");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/app/views");
-    projectExplorer.waitItem(NODE_JS_PROJECT_NAME + "/test");
+    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.selectItem(PROJECT_NAME);
 
-    // perform run web nodeJs application
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.BUILD,
-        NODE_JS_PROJECT_NAME,
-        "web-nodejs-simple:install dependencies");
-    consoles.waitExpectedTextIntoConsole("bower_components/angular", 400);
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.RUN, NODE_JS_PROJECT_NAME, "web-nodejs-simple:run");
-    loader.waitOnClosed();
-    consoles.waitExpectedTextIntoConsole("Started connect web server", 200);
-    loader.waitOnClosed();
+    // Perform run web nodeJs application
+    consoles.startCommandFromProcessesArea("dev-machine", BUILD, INSTALL_DEPENDENCIES);
+    consoles.waitTabNameProcessIsPresent(INSTALL_DEPENDENCIES);
+    try {
+      consoles.waitExpectedTextIntoConsole("> node install.js", WIDGET_TIMEOUT_SEC);
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/6483", ex);
+    }
+    consoles.waitExpectedTextIntoConsole("bower_components/angular", APPLICATION_START_TIMEOUT_SEC);
 
-    // check the preview url is present after refreshing
+    consoles.startCommandFromProcessesArea("dev-machine", RUN, RUN_PROCESS);
+    consoles.waitTabNameProcessIsPresent(RUN_PROCESS);
+    consoles.waitExpectedTextIntoConsole("Started connect web server", PREPARING_WS_TIMEOUT_SEC);
+
+    // Check the preview url is present after refreshing
     consoles.waitPreviewUrlIsPresent();
     seleniumWebDriver.navigate().refresh();
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    notificationsPopupPanel.waitExpectedMessageOnProgressPanelAndClosed(
-        TestWorkspaceConstants.RUNNING_WORKSPACE_MESS);
     consoles.waitPreviewUrlIsPresent();
-    projectExplorer.selectItem(NODE_JS_PROJECT_NAME);
-    consoles.selectProcessInProcessConsoleTreeByName("web-nodejs-simple:run");
 
-    // run the application
-    loader.waitOnClosed();
+    // Run the application
+    projectExplorer.selectItem(PROJECT_NAME);
+    consoles.selectProcessInProcessConsoleTreeByName(RUN_PROCESS);
     consoles.clickOnPreviewUrl();
     seleniumWebDriver.switchToNoneCurrentWindow(currentWindow);
     checkAngularYeomanAppl();
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(currentWindow);
     seleniumWebDriver.switchFromDashboardIframeToIde();
-    consoles.closeProcessInProcessConsoleTreeByName("web-nodejs-simple:run");
+
+    // Close terminal tab for 'run' process
+    consoles.closeProcessInProcessConsoleTreeByName(RUN_PROCESS);
     askDialog.acceptDialogWithText(ASK_DIALOG_MSG_ANGULAR_APP);
-    consoles.waitProcessIsNotPresentInProcessConsoleTree("web-nodejs-simple:run");
+    consoles.waitProcessIsNotPresentInProcessConsoleTree(RUN_PROCESS);
   }
 
-  /** check main elements of the AngularJS-Yeoman */
+  /** Check main elements of the AngularJS-Yeoman */
   public void checkAngularYeomanAppl() {
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath("//h1[text()=\"'Allo, 'Allo!\"]")));
+        .until(visibilityOfElementLocated(By.xpath("//h1[text()=\"'Allo, 'Allo!\"]")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.visibilityOfElementLocated(
-                By.xpath("//img[@src='images/yeoman.png']")));
+        .until(visibilityOfElementLocated(By.xpath("//img[@src='images/yeoman.png']")));
     new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.linkText("Splendid!")))
+        .until(visibilityOfElementLocated(By.linkText("Splendid!")))
         .click();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/WorkingWithNodeWsTest.java
@@ -45,7 +45,7 @@ public class WorkingWithNodeWsTest {
   private static final String WORKSPACE = NameGenerator.generate("WorkingWithNode", 4);
   private static final String PROJECT_NAME = "web-nodejs-simple";
   private static final String RUN_PROCESS = PROJECT_NAME + ":run";
-  private static final String INSTALL_DEPENDENCIES = PROJECT_NAME + ":install dependencies";
+  private static final String INSTALL_DEPENDENCIES_PROCESS = PROJECT_NAME + ":install dependencies";
   private static final String ASK_DIALOG_MSG_ANGULAR_APP =
       "The process web-nodejs-simple:run will be terminated after closing console. Do you want to continue?";
 
@@ -92,8 +92,8 @@ public class WorkingWithNodeWsTest {
     projectExplorer.selectItem(PROJECT_NAME);
 
     // Perform run web nodeJs application
-    consoles.startCommandFromProcessesArea("dev-machine", BUILD, INSTALL_DEPENDENCIES);
-    consoles.waitTabNameProcessIsPresent(INSTALL_DEPENDENCIES);
+    consoles.startCommandFromProcessesArea("dev-machine", BUILD, INSTALL_DEPENDENCIES_PROCESS);
+    consoles.waitTabNameProcessIsPresent(INSTALL_DEPENDENCIES_PROCESS);
     try {
       consoles.waitExpectedTextIntoConsole("> node install.js", WIDGET_TIMEOUT_SEC);
     } catch (TimeoutException ex) {


### PR DESCRIPTION
### What does this PR do?
We need test commands starting from the **Processes area**:
- add to the **Console** selenium page object method for commands starting;
- change **WorkingWithNodeWsTest** and **WorkingWithJavaMySqlStackTest** selenium tests for starting commands from the **Processes** area;
- remove unnecessary steps in these tests(checking created project in the **Project Explorer**).
![selection_078](https://user-images.githubusercontent.com/7760565/33431146-e9f83368-d5db-11e7-9939-7bf883ea77e9.png)

### What issues does this PR fix or reference?
Create test for checking project commands starting from the Processes area https://github.com/eclipse/che/issues/6241.

PR for **che6** branch - https://github.com/eclipse/che/pull/7652.