### PR TITLE
Remove sshd installer from default stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -32,7 +32,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "tomcat8" : {
@@ -120,7 +120,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "tomcat8" : {
@@ -213,7 +213,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "tomcat8" : {
@@ -283,7 +283,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "tomcat8" : {
@@ -354,7 +354,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "VNC" : {
@@ -430,7 +430,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {},
               "attributes" : {
@@ -495,7 +495,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.csharp"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.csharp"
               ],
               "servers": {
                 "dot.net.server" : {
@@ -573,7 +573,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -648,7 +648,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "tomcat8" : {
@@ -738,7 +738,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "3000/tcp" : {
@@ -821,7 +821,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
               ],
               "servers": {
                 "8080/tcp": {
@@ -951,7 +951,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.php"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.php"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1066,7 +1066,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.python"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.python"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1146,7 +1146,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "3000/tcp" : {
@@ -1219,7 +1219,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {},
               "attributes" : {
@@ -1267,7 +1267,6 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ssh",
                 "org.eclipse.che.ls.csharp",
                 "org.eclipse.che.ls.json",
                 "org.eclipse.che.ls.php"
@@ -1331,7 +1330,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1416,7 +1415,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {},
               "attributes" : {
@@ -1495,7 +1494,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1570,7 +1569,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.python"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.python"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1642,7 +1641,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.python"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.python"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1733,7 +1732,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -1806,7 +1805,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "tomcat8" : {
@@ -1870,7 +1869,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {},
               "attributes" : {
@@ -1931,7 +1930,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ls.php", "org.eclipse.che.ls.json"
               ],
               "servers": {
                 "80/tcp" : {
@@ -2055,7 +2054,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -2171,8 +2170,7 @@
               "installers": [
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
-                "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ssh"
+                "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "vertx" : {
@@ -2283,8 +2281,7 @@
               "installers": [
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
-                "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ssh"
+                "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "springboot" : {
@@ -2384,8 +2381,7 @@
               },
               "installers": [
                 "org.eclipse.che.terminal",
-                "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ssh"
+                "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "wildfly" : {
@@ -2476,8 +2472,7 @@
               },
               "installers": [
                 "org.eclipse.che.terminal",
-                "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ssh"
+                "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "angular": {
@@ -2566,7 +2561,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {},
               "attributes" : {
@@ -2615,7 +2610,7 @@
           "machines": {
             "dev-machine": {
               "installers": [
-                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent", "org.eclipse.che.ssh"
+                "org.eclipse.che.exec", "org.eclipse.che.terminal", "org.eclipse.che.ws-agent"
               ],
               "servers": {
                 "8080/tcp" : {
@@ -2678,8 +2673,7 @@
           "dev-machine": {
             "installers": [
               "org.eclipse.che.terminal",
-              "org.eclipse.che.ws-agent",
-              "org.eclipse.che.ssh"
+              "org.eclipse.che.ws-agent"
             ],
             "servers": {},
             "attributes": {
@@ -2779,7 +2773,6 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ssh",
                 "org.eclipse.che.ls.json",
                 "org.eclipse.che.ls.js-ts"
               ]

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
@@ -52,7 +52,6 @@ public class ServerRuntimeInfoTest {
             "wsagent/http",
             "exec-agent/http",
             "wsagent-debug",
-            "ssh",
             "terminal");
 
     for (int i = 0; i < expectedReferenceList.size(); i++) {

--- a/selenium/che-selenium-test/src/test/resources/templates/factory/docker/minimal.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/factory/docker/minimal.json
@@ -43,8 +43,7 @@
           "dev-machine" : {
             "installers" : [
               "org.eclipse.che.terminal",
-              "org.eclipse.che.ws-agent",
-              "org.eclipse.che.ssh"
+              "org.eclipse.che.ws-agent"
             ],
             "servers" : {
               "tomcat8" : {

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/codenvy_ubuntu_jdk8.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/codenvy_ubuntu_jdk8.json
@@ -5,8 +5,7 @@
         "dev-machine": {
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh"
+            "org.eclipse.che.ws-agent"
           ],
           "attributes": {
             "memoryLimitBytes": "desired_memory_value"

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/default.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/default.json
@@ -5,8 +5,7 @@
         "dev-machine": {
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh"
+            "org.eclipse.che.ws-agent"
           ],
           "attributes": {
             "memoryLimitBytes": "desired_memory_value"

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_cpp_gcc.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_cpp_gcc.json
@@ -6,8 +6,7 @@
           "servers": {},
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh"
+            "org.eclipse.che.ws-agent"
           ],
           "attributes": {
             "memoryLimitBytes": "2147483648"

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_nodejs.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_nodejs.json
@@ -9,8 +9,7 @@
           },
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh"
+            "org.eclipse.che.ws-agent"
           ],
           "servers": {
             "3000/tcp" : {

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_php.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_php.json
@@ -22,8 +22,7 @@
           },
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh",
+            "org.eclipse.che.ws-agent"
             "org.eclipse.che.ls.php",
             "org.eclipse.che.ls.json"
           ]

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_php.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/eclipse_php.json
@@ -22,7 +22,7 @@
           },
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent"
+            "org.eclipse.che.ws-agent",
             "org.eclipse.che.ls.php",
             "org.eclipse.che.ls.json"
           ]

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/ubuntu.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/ubuntu.json
@@ -6,8 +6,7 @@
           "servers": {},
           "installers": [
             "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh"
+            "org.eclipse.che.ws-agent"
           ],
           "attributes": {
             "memoryLimitBytes": "desired_memory_value"

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/ubuntu_with_c_sharp_lsp.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/ubuntu_with_c_sharp_lsp.json
@@ -20,7 +20,6 @@
           "installers": [
             "org.eclipse.che.terminal",
             "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ssh",
             "org.eclipse.che.ls.csharp"
           ],
           "attributes": {


### PR DESCRIPTION
### What does this PR do?
Remove sshd installer from default stacks

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7685

#### Release Notes
Remove sshd installer from default stacks


#### Docs PR
n/a
