### PR TITLE
Change default OpenShift workspace template in qa samples

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/centos_jdk8_openshift_recipe.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/centos_jdk8_openshift_recipe.json
@@ -1,0 +1,27 @@
+{
+  "environments": {
+    "replaced_name": {
+      "machines": {
+        "app/main": {
+          "installers": [
+            "org.eclipse.che.terminal",
+            "org.eclipse.che.ws-agent"
+          ],
+          "attributes": {
+            "memoryLimitBytes": "desired_memory_value"
+          }
+        }
+      },
+      "recipe": {
+        "content": "kind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: app\n  spec:\n    containers:\n      -\n        image: rhche/centos_jdk8:latest\n        name: main\n        ports:\n          -\n            containerPort: 8080\n            protocol: TCP",
+        "contentType": "application/x-yaml",
+        "type": "openshift"
+      }
+    }
+  },
+  "defaultEnv": "replaced_name",
+  "projects": [],
+  "name": "replaced_name",
+  "attributes": {},
+  "temporary": false
+}

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
@@ -1,21 +1,34 @@
 {
-  "environments": {
-    "replaced_name": {
-      "machines": {
-        "app/main": {
-          "installers": [
+  "environments":{
+    "replaced_name":{
+      "machines":{
+        "dev-machine":{
+          "installers":[
             "org.eclipse.che.terminal",
             "org.eclipse.che.ws-agent"
           ],
           "attributes": {
             "memoryLimitBytes": "desired_memory_value"
+          },
+          "servers":{
+            "tomcat8-debug":{
+              "protocol":"http",
+              "port":"8000"
+            },
+            "codeserver":{
+              "protocol":"http",
+              "port":"9876"
+            },
+            "tomcat8":{
+              "protocol":"http",
+              "port":"8080"
+            }
           }
         }
       },
-      "recipe": {
-        "content": "kind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: app\n  spec:\n    containers:\n      -\n        image: rhche/centos_jdk8:latest\n        name: main\n        ports:\n          -\n            containerPort: 8080\n            protocol: TCP",
-        "contentType": "application/x-yaml",
-        "type": "openshift"
+      "recipe":{
+        "location":"rhche/centos_jdk8",
+        "type":"dockerimage"
       }
     }
   },


### PR DESCRIPTION
### What does this PR do?
Since we have added support for _dockerimage_ recipe type in OpenShift infrastructure, we decided to check base Che functionality from workspace template based on _dockerimage_ recipe. Other specific cases related to the use of OpenShift recipe for the OpenShift infrastructure will be checked separately by using the templates of the workspaces from the OpenShift recipe.