### PR TITLE
Make bootstrapper output redirection compliant with POSIX syntax

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
@@ -107,10 +107,10 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
             + CONFIG_FILE
             // redirects command output and makes the bootstrapping process detached,
             // to avoid the holding of the socket connection for exec watcher.
-            + " &>"
+            + " > "
             + BOOTSTRAPPER_DIR
             + BOOTSTRAPPER_LOG_FILE
-            + " &");
+            + " 2>&1 &");
   }
 
   private void injectBootstrapper() throws InfrastructureException {


### PR DESCRIPTION
### What does this PR do?
Changes redirection of bootstrapper output in compliance with POSIX syntax.

### What issues does this PR fix or reference?
Fixes start of workspaces from eclipse/ubuntu_jdk8 image on OpenShift infrastructure.