### PR TITLE
Set screen size in the selenium chrome node to 1920x1080

### DIFF
--- a/selenium/che-selenium-test/docker-compose.yml
+++ b/selenium/che-selenium-test/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
       - NODE_MAX_INSTANCES=5
       - NODE_MAX_SESSION=5
+      - SCREEN_HEIGHT=1080
+      - SCREEN_WIDTH=1920
+      - SCREEN_DEPTH=24
     ports:
       - 5900
       - 5555


### PR DESCRIPTION
### What does this PR do?
Sets screen size in the selenium chrome node to 1920x1080

### What issues does this PR fix or reference?
- issue https://github.com/eclipse/che/issues/7602
- pull request into the Eclipse Che 6: https://github.com/eclipse/che/pull/7693