### PR TITLE
[WIP] set correct limits for CHE pod

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/che-config
+++ b/dockerfiles/init/modules/openshift/files/scripts/che-config
@@ -29,6 +29,6 @@ CHE_OAUTH_GITHUB_CLIENTID: ${CHE_OAUTH_GITHUB_CLIENTID}
 CHE_OAUTH_GITHUB_CLIENTSECRET: ${CHE_OAUTH_GITHUB_CLIENTSECRET}
 CHE_OAUTH_GITHUB_FORCEACTIVATION: "true"
 CHE_PREDEFINED_STACKS_RELOAD__ON__START: ${CHE_PREDEFINED_STACKS_RELOAD}
-CHE_SERVER_JAVA_OPTS: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=700m -Xms256m"
+CHE_SERVER_JAVA_OPTS: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
 CHE_WORKSPACE_AUTO_START: "false"
-CHE_WORKSPACE_JAVA_OPTIONS: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1300m -Xms256m"
+CHE_WORKSPACE_JAVA_OPTIONS: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"

--- a/dockerfiles/init/modules/openshift/files/scripts/che-openshift.yml
+++ b/dockerfiles/init/modules/openshift/files/scripts/che-openshift.yml
@@ -93,7 +93,7 @@ items:
             timeoutSeconds: 60
           resources:
             limits:
-              memory: 600Mi
+              memory: 512Mi
             requests:
               memory: 256Mi
           volumeMounts:

--- a/dockerfiles/init/modules/openshift/files/scripts/che-openshift.yml
+++ b/dockerfiles/init/modules/openshift/files/scripts/che-openshift.yml
@@ -93,7 +93,7 @@ items:
             timeoutSeconds: 60
           resources:
             limits:
-              memory: 512Mi
+              memory: 1024Mi
             requests:
               memory: 256Mi
           volumeMounts:


### PR DESCRIPTION
fixes: https://github.com/eclipse/che/issues/7724

CHE server was exciding limits due to wrong configuration:
```
           resources:
             limits:
              memory: 600Mi
```
while xmx was set to:
```
-XX:MaxRAM=700m
```

So I've increased limits to 1GB for CHE master as it multitenant it it should be OK. Also applied some JVM optimisation args.