### PR TITLE
Move clean up to the end of selenium test execution

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -58,6 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.IAnnotationTransformer;
 import org.testng.IConfigurationListener;
+import org.testng.IExecutionListener;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
@@ -77,7 +78,11 @@ import org.testng.TestException;
  * @author Dmytro Nochevnov
  */
 public abstract class SeleniumTestHandler
-    implements ITestListener, ISuiteListener, IInvokedMethodListener, IAnnotationTransformer {
+    implements ITestListener,
+        ISuiteListener,
+        IInvokedMethodListener,
+        IAnnotationTransformer,
+        IExecutionListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(SeleniumTestHandler.class);
   private static final AtomicBoolean isCleanUpCompleted = new AtomicBoolean();
@@ -150,9 +155,7 @@ public abstract class SeleniumTestHandler
 
   @Override
   public void onStart(ISuite suite) {
-    isCleanUpCompleted.set(false);
     runningTests.clear();
-
     suite.setParentInjector(injector);
   }
 
@@ -168,9 +171,7 @@ public abstract class SeleniumTestHandler
   }
 
   @Override
-  public void onFinish(ISuite suite) {
-    shutdown();
-  }
+  public void onFinish(ISuite suite) {}
 
   @Override
   public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
@@ -207,6 +208,14 @@ public abstract class SeleniumTestHandler
 
   @Override
   public void afterInvocation(IInvokedMethod method, ITestResult result) {}
+
+  @Override
+  public void onExecutionStart() {}
+
+  @Override
+  public void onExecutionFinish() {
+    shutdown();
+  }
 
   /** Injects dependencies into the given test class using {@link Guice} and custom injectors. */
   private void injectDependencies(ITestContext testContext, Object testInstance) throws Exception {


### PR DESCRIPTION
### What does this PR do?
It moves clean up step from the end of selenium suite execution (**onFinish(suite)** method) to the end of all selenium tests execution (**onExecutionFinish()** method). 

### What issues does this PR fix or reference?
- issue #7018
- PR into che6: https://github.com/eclipse/che/pull/7731