### PR TITLE
Selenium: Add changes to selenium tests according to new client

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/AutocompleteCommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/AutocompleteCommandsEditorTest.java
@@ -125,12 +125,14 @@ public class AutocompleteCommandsEditorTest {
     commandsEditor.waitTextIntoEditor("${server.tomcat8-debug}");
     commandsEditor.typeTextIntoEditor(Keys.ENTER.toString());
     commandsEditor.waitActiveEditor();
-    commandsEditor.typeTextIntoEditor("ssh");
+    commandsEditor.typeTextIntoEditor("wsagent");
     commandsEditor.launchAutocomplete();
-    commandsEditor.waitTextIntoEditor("${server.ssh}");
+    commandsEditor.waitTextIntoAutocompleteContainer("${server.wsagent/ws}");
+    commandsEditor.selectItemIntoAutocompleteAndPasteByDoubleClick("/ws}");
+    commandsEditor.waitTextIntoEditor("${server.wsagent/ws}");
     commandsEditor.clickOnRunButton();
     consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS);
-    consoles.waitExpectedTextIntoPreviewUrl("ssh");
+    consoles.waitExpectedTextIntoPreviewUrl("ws:");
   }
 
   @Test(priority = 3)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
@@ -64,6 +64,7 @@ public class CheckIntelligenceCommandFromToolbarTest {
     commandsToolbar.clickWithHoldAndLaunchCommandFromList(PROJECT_NAME + ": build and run");
     consoles.waitExpectedTextIntoConsole(" Server startup in");
 
+    // it needs when the test is running on the che6-ocp platform
     String previewUrl = consoles.getPreviewUrl();
     if (previewUrl.contains("route")) {
       WaitUtils.sleepQuietly(10);
@@ -86,6 +87,7 @@ public class CheckIntelligenceCommandFromToolbarTest {
     String currentWindow = seleniumWebDriver.getWindowHandle();
     commandsToolbar.clickExecStopBtn();
 
+    // it needs when the test is running on the che6-ocp platform
     String previewUrl = consoles.getPreviewUrl();
     String expectedText =
         previewUrl.contains("route")
@@ -101,6 +103,7 @@ public class CheckIntelligenceCommandFromToolbarTest {
     Assert.assertTrue(commandsToolbar.getTimerValue().matches("\\d\\d:\\d\\d"));
     Assert.assertTrue(commandsToolbar.getNumOfProcessCounter().equals("#2"));
 
+    // it needs when the test is running on the che6-ocp platform
     if (previewUrl.contains("route")) {
       WaitUtils.sleepQuietly(10);
     }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MULTI
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
@@ -62,6 +63,12 @@ public class CheckIntelligenceCommandFromToolbarTest {
     projectExplorer.waitItem(PROJECT_NAME);
     commandsToolbar.clickWithHoldAndLaunchCommandFromList(PROJECT_NAME + ": build and run");
     consoles.waitExpectedTextIntoConsole(" Server startup in");
+
+    String previewUrl = consoles.getPreviewUrl();
+    if (previewUrl.contains("route")) {
+      WaitUtils.sleepQuietly(10);
+    }
+
     consoles.clickOnPreviewUrl();
     checkTestAppAndReturnToIde(currentWindow, "Enter your name:");
     consoles.waitExpectedTextIntoConsole(" Server startup in");
@@ -78,14 +85,26 @@ public class CheckIntelligenceCommandFromToolbarTest {
     projectExplorer.waitProjectExplorer();
     String currentWindow = seleniumWebDriver.getWindowHandle();
     commandsToolbar.clickExecStopBtn();
+
+    String previewUrl = consoles.getPreviewUrl();
+    String expectedText =
+        previewUrl.contains("route")
+            ? "Application is not available"
+            : "This site can’t be reached";
+
     consoles.clickOnPreviewUrl();
-    checkTestAppAndReturnToIde(currentWindow, "This site can’t be reached");
+    checkTestAppAndReturnToIde(currentWindow, expectedText);
     commandsToolbar.clickExecRerunBtn();
     consoles.waitExpectedTextIntoConsole(" Server startup in");
     consoles.clickOnPreviewUrl();
     checkTestAppAndReturnToIde(currentWindow, "Enter your name:");
     Assert.assertTrue(commandsToolbar.getTimerValue().matches("\\d\\d:\\d\\d"));
     Assert.assertTrue(commandsToolbar.getNumOfProcessCounter().equals("#2"));
+
+    if (previewUrl.contains("route")) {
+      WaitUtils.sleepQuietly(10);
+    }
+
     commandsToolbar.clickOnPreviewCommandBtnAndSelectUrl("dev-machine:tomcat8");
     checkTestAppAndReturnToIde(currentWindow, "Enter your name:");
     commandsToolbar.clickExecStopBtn();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
@@ -119,7 +119,6 @@ public class MacrosCommandsEditorTest {
       "${server.codeserver}",
       "${server.exec-agent/http}",
       "${server.exec-agent/ws}",
-      "${server.ssh}",
       "${server.terminal}",
       "${server.tomcat8-debug}",
       "${server.tomcat8}",
@@ -130,23 +129,23 @@ public class MacrosCommandsEditorTest {
     for (String macrosItem : macrosItems) {
       commandsEditor.waitTextIntoMacrosContainer(macrosItem);
     }
-    commandsEditor.enterMacroCommandByEnter("${server.ssh}");
-    commandsEditor.waitTextIntoEditor("${server.ssh");
+    commandsEditor.enterMacroCommandByEnter("${server.wsagent/http}");
+    commandsEditor.waitTextIntoEditor("${server.wsagent/http");
     commandsEditor.clickOnRunButton();
-    consoles.waitExpectedTextIntoPreviewUrl("ssh");
+    consoles.waitExpectedTextIntoPreviewUrl("http");
     commandsEditor.setFocusIntoTypeCommandsEditor(PREVIEW_URL_EDITOR);
     commandsEditor.setCursorToLine(1);
     commandsEditor.selectLineAndDelete();
     commandsEditor.waitActiveEditor();
     commandsEditor.selectMacrosLinkInCommandsEditor(PREVIEW_MACROS_LINK);
-    commandsEditor.selectMacroCommand("${server.ssh}");
+    commandsEditor.selectMacroCommand("${server.wsagent/http}");
     commandsEditor.typeTextIntoEditor(Keys.ARROW_UP.toString());
     commandsEditor.typeTextIntoEditor(Keys.SPACE.toString());
-    commandsEditor.waitMacroCommandIsSelected("${server.ssh}");
-    commandsEditor.enterMacroCommandByDoubleClick("${server.ssh}");
-    commandsEditor.waitTextIntoEditor("${server.ssh}");
+    commandsEditor.waitMacroCommandIsSelected("${server.wsagent/http}");
+    commandsEditor.enterMacroCommandByDoubleClick("${server.wsagent/http}");
+    commandsEditor.waitTextIntoEditor("${server.wsagent/http}");
     commandsEditor.clickOnRunButton();
-    consoles.waitExpectedTextIntoPreviewUrl("ssh");
+    consoles.waitExpectedTextIntoPreviewUrl("http");
   }
 
   private void createNewJavaCommand() {


### PR DESCRIPTION
### What does this PR do?
* Add some changes to selenium tests from 'intelligencecommand' according  removing sshd installer from default stacks
__Related selenium tests: MacrosCommandsEditorTest_, AutocompleteCommandsEditorTest_

* Add some change to the selenium test _'CheckIntelligenceCommandFromToolbarTest'_  to successful passing both platform che6 (docker and ocp)

### What issues does this PR fix or reference?
#7713
