### PR TITLE
Remove separation of selenium tests on stable/unstable/failed

### DIFF
--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -17,6 +17,13 @@ newly created [OAuth application](https://github.com/settings/developers).
 Set `CHE_LOCAL_CONF_DIR` environment variable and point to the folder where selenium tests configuration will be stored.
 Create file `selenium.properties` in that folder with the following content:
 ```
+# Credentials of Eclipse Che multiuser assemblies
+che.admin_user.email=<CHE_ADMIN_EMAIL>
+che.admin_user.password=<CHE_ADMIN_PASSWORD>
+
+che.test_user.email=<CHE_USER_EMAIL>
+che.test_user.password=<CHE_USER_PASSWORD>
+
 # GitHub account credentials
 github.username=<MAIN_GITHUB_USERNAME>
 github.password=<MAIN_GITHUB_PASSWORD>
@@ -67,7 +74,7 @@ Options:
     --multiuser                         Run tests of Multi User Che
 
 Modes (defines environment to run tests):
-    local                               All tests will be run in a Web browser on the developer machine.
+    -Mlocal                             All tests will be run in a Web browser on the developer machine.
                                         Recommended if test visualization is needed and for debugging purpose.
 
         Options that go with 'local' mode:
@@ -77,8 +84,7 @@ Modes (defines environment to run tests):
                                         Web browsers will be opened on the developer machine.
                                         Default value is in range [2,5] and depends on available RAM.
 
-
-    grid (default)                      All tests will be run in parallel among several docker containers.
+    -Mgrid (default)                    All tests will be run in parallel among several docker containers.
                                         One container per thread. Recommended to run test suite.
 
         Options that go with 'grid' mode:
@@ -86,7 +92,6 @@ Modes (defines environment to run tests):
                                         Default value is in range [2,5] and depends on available RAM.
 
 Define tests scope:
-    --all-tests                         Run all tests within the suite despite of <exclude>/<include> sections in the test suite.
     --test=<TEST_CLASS>                 Single test to run
     --suite=<SUITE>                     Test suite to run, found:
                                             * CheSuite.xml
@@ -100,17 +105,18 @@ Handle failing tests:
 Other options:
     --debug                             Run tests in debug mode
     --skip-sources-validation           Fast build. Skips source validation and enforce plugins
+    --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
+                                        Default value is 0, that means that test workspaces are created on demand.
 
 HOW TO of usage:
     Test Eclipse Che single user assembly:
-        ./selenium-tests.sh -Mgrid
         ./selenium-tests.sh
 
     Test Eclipse Che multi user assembly:
         ./selenium-tests.sh --multiuser
 
     Test Eclipse Che assembly and automatically rerun failing tests:
-        ./selenium-tests.sh -Mgrid --rerun
+        ./selenium-tests.sh --rerun
 
     Run single test or package of tests:
         ./selenium-tests.sh <...> --test=<TEST>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -18,71 +18,26 @@
 
     <test name="all">
         <classes>
-          <class name="org.eclipse.che.selenium.assistant.CheckFindActionFeatureInCheTest">
-            <methods>
-              <exclude name="checkSearchActionsForAllItemsTest"/>
-              <exclude name="checkSearchActionsForMenuItemsTest"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.assistant.KeyBindingsTest">
-            <methods>
-              <exclude name="enterKeyCombinationTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.assistant.CheckFindActionFeatureInCheTest"/>
+          <class name="org.eclipse.che.selenium.assistant.KeyBindingsTest"/>
           <class name="org.eclipse.che.selenium.assistant.OrganizeImportsTest"/>
-          <class name="org.eclipse.che.selenium.languageserver.CheckMainFeatureForCSharpLanguageTest">
-            <methods>
-              <exclude name="checkLaunchingCodeserver"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.dashboard.CreateAndDeleteProjectsTest">
-            <methods>
-              <exclude name="shouldDeleteOpenedProjectByMenuFile"/>
-              <exclude name="shouldDeleteOpenedProjectFromContextMenu"/>
-              <exclude name="shouldDeleteProjectByContextMenu"/>
-              <exclude name="shouldDeleteProjectByDeleteIcon"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.languageserver.CheckMainFeatureForCSharpLanguageTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.CreateAndDeleteProjectsTest"/>
           <class name="org.eclipse.che.selenium.dashboard.DeleteRunningWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.dashboard.DeleteStoppingWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.dashboard.ImportMavenProjectFromGitHubTest"/>
           <class name="org.eclipse.che.selenium.dashboard.ImportProjectFromZipTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.RenameWorkspaceTest">
-            <methods>
-              <exclude name="renameNameWorkspaceTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.dashboard.RenameWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.dashboard.WorkspaceDetailsTest"/>
           <class name="org.eclipse.che.selenium.debugger.ChangeVariableWithEvaluatingTest"/>
           <class name="org.eclipse.che.selenium.debugger.CheckBreakPointStateTest"/>
-          <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest">
-            <methods>
-              <exclude name="shouldDebugCppProject"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.debugger.DebugExternalClassTest">
-            <methods>
-              <exclude name="shouldDebugJreClass"/>
-              <exclude name="shouldDebugMavenArtifactClassWithSources"/>
-              <exclude name="shouldHandleDebugOfMavenArtifactWithoutSources"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.debugger.InnerClassAndLambdaDebuggingTest">
-            <methods>
-              <exclude name="shouldDebugInnerClass"/>
-              <exclude name="shouldDebugLambdaExpressions"/>
-              <exclude name="shouldDebugMethodLocalInnerClass"/>
-              <exclude name="shouldDebugStaticInnerClass"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest"/>
+          <class name="org.eclipse.che.selenium.debugger.DebugExternalClassTest"/>
+          <class name="org.eclipse.che.selenium.debugger.InnerClassAndLambdaDebuggingTest"/>
           <class name="org.eclipse.che.selenium.debugger.RunToCursorTest"/>
           <class name="org.eclipse.che.selenium.debugger.MultimoduleProjectDebuggingTest"/>
           <class name="org.eclipse.che.selenium.debugger.DebuggerWatchExpressionTest"/>
-          <class name="org.eclipse.che.selenium.debugger.NodeJsDebugTest">
-            <methods>
-              <exclude name="debugNodeJsTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.debugger.NodeJsDebugTest"/>
           <class name="org.eclipse.che.selenium.debugger.PhpProjectDebuggingTest"/>
           <class name="org.eclipse.che.selenium.debugger.StepIntoStepOverStepReturnWithChangeVariableTest"/>
           <class name="org.eclipse.che.selenium.debugger.ThreadDumpTest"/>
@@ -90,105 +45,44 @@
           <class name="org.eclipse.che.selenium.debugger.ConditionalBreakpointsTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteFeaturesInEditorTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteJSFilesTest"/>
-          <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocTest">
-            <methods>
-              <exclude name="shouldDisplayJavaDocOfJreClass"/>
-              <exclude name="shouldReflectChangesInJavaDoc"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteWithInheritTest">
-            <methods>
-              <exclude name="updateDependencyWithInheritTest"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.editor.autocomplete.CheckAutocompleteFeaturesInTheTestFolderTest">
-            <methods>
-              <exclude name="checkAutocompleteFeaturesInTheTestFolderTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocTest"/>
+          <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteWithInheritTest"/>
+          <class name="org.eclipse.che.selenium.editor.autocomplete.CheckAutocompleteFeaturesInTheTestFolderTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.EditorMemberActiveLineForOpenedTabTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.EditorValidationTest"/>
-          <class name="org.eclipse.che.selenium.editor.autocomplete.FormatterTest">
-            <methods>
-              <exclude name="formatterTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.editor.autocomplete.FormatterTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.InheritClassTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.JavaDocPopupTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.OpenDeclarationTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.QuickFixAndCodeAssistantFeaturesTest"/>
           <class name="org.eclipse.che.selenium.editor.autocomplete.ShowHintsCommandTest"/>
           <class name="org.eclipse.che.selenium.editor.CheckReplaceFeatureInEditorTest"/>
-          <class name="org.eclipse.che.selenium.editor.CheckRestoringSplitEditorTest">
-            <methods>
-              <exclude name="checkRestoringStateSplittedEditor"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.editor.CheckRestoringSplitEditorTest"/>
           <class name="org.eclipse.che.selenium.editor.CheckSearchFeatureInEditorTest"/>
           <class name="org.eclipse.che.selenium.editor.CheckWorkingWithTabByUsingTabListTest"/>
           <class name="org.eclipse.che.selenium.editor.CheckWorkingWithTabsByUsingContextMenuTest"/>
-          <class name="org.eclipse.che.selenium.editor.ContextMenuEditorTest">
-            <methods>
-              <exclude name="checkClose"/>
-              <exclude name="checkFind"/>
-              <exclude name="checkFormatContextMenu"/>
-              <exclude name="checkNaviFileStructure"/>
-              <exclude name="checkOpenDeclaration"/>
-              <exclude name="checkQuickDocumentation"/>
-              <exclude name="checkQuickFix"/>
-              <exclude name="checkRefactoring"/>
-              <exclude name="checkUndoRedo"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.editor.ContextMenuEditorTest"/>
           <class name="org.eclipse.che.selenium.editor.SplitEditorFeatureTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckFactoryWithPerUserCreatePolicyTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckFactoryWithPerClickCreatePolicyTest"/>
           <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithKeepDirectory"/>
-          <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithRootFolder">
-            <methods>
-              <exclude name="factoryWithDirectUrlWithRootFolder"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithSpecificBranch">
-            <methods>
-              <exclude name="factoryWithDirectUrlWithSpecificBranch"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithRootFolder"/>
+          <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithSpecificBranch"/>
           <class name="org.eclipse.che.selenium.factory.CheckFactoryWithMultiModuleTest"/>
-          <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSincePolicyTest">
-            <methods>
-              <exclude name="checkFactoryAcceptingWithSincePolicy"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSincePolicyTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckFactoryWithUntilPolicyTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckOpenFileFeatureTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckRunCommandFeatureTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckWelcomePanelOnCodenvyTest"/>
-          <class name="org.eclipse.che.selenium.factory.CreateNamedFactoryFromDashBoard">
-            <methods>
-              <exclude name="createFactoryFromDashBoard"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.factory.CreateNamedFactoryFromDashBoard"/>
           <class name="org.eclipse.che.selenium.factory.CreateFactoryFromUiWithKeepDirTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSparseCheckoutTest"/>
-          <class name="org.eclipse.che.selenium.filewatcher.EditFilesWithTabsTest">
-            <methods>
-              <exclude name="checkEditingFilesFromIde"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.filewatcher.RefactoringFeatureTest">
-            <methods>
-              <exclude name="checkRefactorFilesFromIde"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.filewatcher.EditFilesWithTabsTest"/>
+          <class name="org.eclipse.che.selenium.filewatcher.RefactoringFeatureTest"/>
           <class name="org.eclipse.che.selenium.filewatcher.RemoveFilesWithActiveTabs"/>
           <class name="org.eclipse.che.selenium.filewatcher.UpdateFilesWithoutIDE"/>
           <class name="org.eclipse.che.selenium.filewatcher.CheckDeletingProjectByApiTest"/>
-          <class name="org.eclipse.che.selenium.filewatcher.CheckFileWatcherExcludeFeatureTest">
-            <methods>
-              <exclude name="checkIsNotExcludeOperationEventAboutIgnoreFile"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.filewatcher.CheckFileWatcherExcludeFeatureTest"/>
           <class name="org.eclipse.che.selenium.git.AddFilesToIndexTest"/>
           <class name="org.eclipse.che.selenium.git.AmendCommitTest"/>
           <class name="org.eclipse.che.selenium.git.BranchTest"/>
@@ -203,43 +97,17 @@
           <class name="org.eclipse.che.selenium.gwt.CheckSimpleGwtAppTest"/>
           <class name="org.eclipse.che.selenium.intelligencecommand.MacrosCommandsEditorTest"/>
           <class name="org.eclipse.che.selenium.intelligencecommand.AutocompleteCommandsEditorTest"/>
-          <class name="org.eclipse.che.selenium.intelligencecommand.CheckBasicFunctionalityInCommandsExplorerTest">
-            <methods>
-              <exclude name="shouldCreateAndRunBuildCommand"/>
-              <exclude name="shouldCreateDifferentTypesCommandsInDifferentGoals"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.intelligencecommand.CheckIntelligenceCommandFromToolbarTest">
-            <methods>
-              <exclude name="checkButtonsOnToolbar"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.intelligencecommand.CheckBasicFunctionalityInCommandsExplorerTest"/>
+          <class name="org.eclipse.che.selenium.intelligencecommand.CheckIntelligenceCommandFromToolbarTest"/>
           <class name="org.eclipse.che.selenium.intelligencecommand.CommandsEditorTest"/>
-          <class name="org.eclipse.che.selenium.intelligencecommand.CommandsPaletteTest">
-            <methods>
-              <exclude name="newCommandTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.intelligencecommand.CommandsPaletteTest"/>
           <class name="org.eclipse.che.selenium.intelligencecommand.PreviewUrlIntoCommandsEditorTest"/>
           <class name="org.eclipse.che.selenium.mavenplugin.CheckGeneratingMavenArchetypeTest"/>
-          <class name="org.eclipse.che.selenium.mavenplugin.CheckMavenPluginTest">
-            <methods>
-              <exclude name="excludeIncludeModules"/>
-              <exclude name="shouldAccessClassCreatedInAnotherModule"/>
-              <exclude name="shouldAccessClassCreatedInAnotherModuleAfterIncludingModule"/>
-              <exclude name="mavenStatusBarShouldDisplayResolvingProjectMessage"/>
-              <exclude name="shouldExecuteCommandAndWaitTextInConsole"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.mavenplugin.CheckMavenPluginTest"/>
           <class name="org.eclipse.che.selenium.mavenplugin.GenerateEffectivePomTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.CheckCreatingProjectInEmptyWsTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.CheckMacrosFeatureTest"/>
-          <class name="org.eclipse.che.selenium.miscellaneous.CheckRestoringWorkspaceAfterStoppingWsAgentProcess">
-            <methods>
-              <exclude name="checkRestoreIdeItems"/>
-              <exclude name="checkRestoreWsAgentByApi"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.miscellaneous.CheckRestoringWorkspaceAfterStoppingWsAgentProcess"/>
           <class name="org.eclipse.che.selenium.miscellaneous.ConvertToProjectFromConfigurationTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.ConvertToProjectWithPomFileTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.DialogAboutTest"/>
@@ -247,13 +115,7 @@
           <class name="org.eclipse.che.selenium.miscellaneous.FileStructureByKeyboardTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.FileStructureCodeEditorTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.FileStructureNodesTest"/>
-          <class name="org.eclipse.che.selenium.miscellaneous.FindTextFeatureTest">
-            <methods>
-              <exclude name="checkFindTextBasic"/>
-              <exclude name="checkFindByFileMask"/>
-              <exclude name="checkFindIntoSelectedPath"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.miscellaneous.FindTextFeatureTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.FindUsagesBaseOperationTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.ImplementationBaseOperationsTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.NavigateToFileTest"/>
@@ -263,64 +125,26 @@
           <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithTerminalTest"/>
           <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0087Test"/>
           <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0091Test"/>
-          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0093Test">
-            <methods>
-              <exclude name="test0093"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0093Test"/>
           <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0097Test"/>
           <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0114Test"/>
-          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0115Test">
-            <methods>
-              <exclude name="test0115"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0115Test"/>
           <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0119Test"/>
-          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0120Test">
-            <methods>
-              <exclude name="test0120"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0121Test">
-            <methods>
-              <exclude name="test0121"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0120Test"/>
+          <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0121Test"/>
           <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0122Test"/>
           <class name="org.eclipse.che.selenium.plainjava.ConfigureClasspathBaseTest"/>
-          <class name="org.eclipse.che.selenium.plainjava.ConfigureSomeSourceFoldersTest">
-            <methods>
-              <exclude name="checkConfigureClasspathPlainJavaProject"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.plainjava.PlainJavaProjectConfigureClasspathTest">
-            <methods>
-              <exclude name="checkConfigureClasspathPlainJavaProject"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.plainjava.ConfigureSomeSourceFoldersTest"/>
+          <class name="org.eclipse.che.selenium.plainjava.PlainJavaProjectConfigureClasspathTest"/>
           <class name="org.eclipse.che.selenium.plainjava.RunPlainJavaProjectTest"/>
-          <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginJunit4Test">
-            <methods>
-              <exclude name="shouldExecuteJUnit4MethodWithDifferentStatuses"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginJunit4Test"/>
           <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginJunit4CheckRunSuitesAndScopesTest"/>
-          <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginTestNgTest">
-            <methods>
-              <exclude name="shouldExecuteTestClassSuccessfully"/>
-              <exclude name="shouldExecuteTestMethodsSuccessfully"/>
-              <exclude name="shouldExecuteAlltets"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginTestNgTest"/>
           <class name="org.eclipse.che.selenium.preferences.CheckErrorsWarningsTabTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.CheckAutoSaveForFileWhichAlreadyExistTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.CheckCollapseAllNodesProjectTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.CheckCopyCutFeaturesForFilesTest"/>
-          <class name="org.eclipse.che.selenium.projectexplorer.CheckErrorMessageWhenCreationDuplicateFolderOrFileTest">
-            <methods>
-              <exclude name="checkDuplicatedFile"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.projectexplorer.CheckErrorMessageWhenCreationDuplicateFolderOrFileTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.CheckHiddenFolderAndFileCreatedFromCommandTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.CheckOnValidAndInvalidClassNameTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.CheckOnValidAndInvalidPackageNameTest"/>
@@ -345,32 +169,12 @@
           <class name="org.eclipse.che.selenium.projectexplorer.DeletePackageFromContextMenuTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.DeletePackageTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.DeletePackageWithOpenedFilesTabTest"/>
-          <class name="org.eclipse.che.selenium.projectexplorer.DeleteProjectsTest">
-            <methods>
-              <exclude name="shouldDeleteOpenedProjectByMenuFile"/>
-              <exclude name="shouldDeleteOpenedProjectFromContextMenu"/>
-              <exclude name="shouldDeleteProjectByContextMenu"/>
-              <exclude name="shouldDeleteProjectByDeleteIcon"/>
-              <exclude name="shouldDeleteProjectByMenuFile"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.projectexplorer.dependencies.TransitiveDependencyTest">
-            <methods>
-              <exclude name="transitiveDependencyTest"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.projectexplorer.dependencies.UpdateListOfLibraryTest">
-            <methods>
-              <exclude name="checkUpdateLibraryAfterChangingDependencyTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.projectexplorer.DeleteProjectsTest"/>
+          <class name="org.eclipse.che.selenium.projectexplorer.dependencies.TransitiveDependencyTest"/>
+          <class name="org.eclipse.che.selenium.projectexplorer.dependencies.UpdateListOfLibraryTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.FileNotExistIntoEditorAfterDeleteTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.FileOpenedAfterCreationTest"/>
-          <class name="org.eclipse.che.selenium.projectexplorer.JustCreatedFileNotExistIntoEditorAfterDeleteTest">
-            <methods>
-              <exclude name="deleteFileTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.projectexplorer.JustCreatedFileNotExistIntoEditorAfterDeleteTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.NavigationByKeyboardTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.OpenFileWithHelpContextMenuTest"/>
           <class name="org.eclipse.che.selenium.projectexplorer.PreviewHtmlFileTest"/>
@@ -390,78 +194,29 @@
           <class name="org.eclipse.che.selenium.refactor.methods.RenameVirtualMethodsTest"/>
           <class name="org.eclipse.che.selenium.refactor.move.CodeAssistAfterMoveItemTest"/>
           <class name="org.eclipse.che.selenium.refactor.move.FailMoveItemTest"/>
-          <class name="org.eclipse.che.selenium.refactor.move.MoveItemsTest">
-            <methods>
-              <exclude name="checkMoveItem5"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.refactor.move.MoveJavaClassToSubpackageTest">
-            <methods>
-              <exclude name="checkProjectTreeAfterMoveJavaFile"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.refactor.move.MoveJavaFileInNewSourceFolderTest">
-            <methods>
-              <exclude name="checkMoveJavaClassInNewSourceFolder"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageSpringTest">
-            <methods>
-              <exclude name="checkRenamePackageSpringApp"/>
-              <exclude name="checkRenamePackageWithMainMethod"/>
-              <exclude name="checkTest3"/>
-              <exclude name="checkTest4"/>
-              <exclude name="checkTestDisableImport11"/>
-              <exclude name="checkTestHierarchical9_1"/>
-            </methods>
-          </class>
-          <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageTest">
-            <methods>
-              <exclude name="checkTest3"/>
-              <exclude name="checkTest4"/>
-              <exclude name="checkTestDisableImport11"/>
-              <exclude name="checkTestHierarchical9_1"/>
-              <exclude name="checkTestPackageRenameWithResource12"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.refactor.move.MoveItemsTest"/>
+          <class name="org.eclipse.che.selenium.refactor.move.MoveJavaClassToSubpackageTest"/>
+          <class name="org.eclipse.che.selenium.refactor.move.MoveJavaFileInNewSourceFolderTest"/>
+          <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageSpringTest"/>
+          <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageTest"/>
           <class name="org.eclipse.che.selenium.refactor.parameters.FailParametersTest"/>
           <class name="org.eclipse.che.selenium.refactor.parameters.RenameParametersTest"/>
           <class name="org.eclipse.che.selenium.refactor.preview.CheckTreeInRefactorPanelTest"/>
           <class name="org.eclipse.che.selenium.refactor.preview.PreviewRefactoringTest"/>
-          <class name="org.eclipse.che.selenium.refactor.types.GenericsTest">
-            <methods>
-              <exclude name="testGenerics2"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.refactor.types.GenericsTest"/>
           <class name="org.eclipse.che.selenium.refactor.types.IllegalTypeNameTest"/>
           <class name="org.eclipse.che.selenium.refactor.types.RenameTypeTest"/>
           <class name="org.eclipse.che.selenium.refactor.types.TestAnnotationsTest"/>
-          <class name="org.eclipse.che.selenium.refactor.types.TestEnumerationsTest">
-            <methods>
-              <exclude name="testEnum1"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.refactor.types.TestEnumerationsTest"/>
           <class name="org.eclipse.che.selenium.refactor.types.TestFailTest"/>
-          <class name="org.eclipse.che.selenium.swagger.SwaggerTest">
-            <methods>
-              <exclude name="checkNameProjectTest"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.swagger.SwaggerTest"/>
           <class name="org.eclipse.che.selenium.workspaces.CheckStopStartWsTest"/>
           <class name="org.eclipse.che.selenium.workspaces.CreateWorkspaceOnDashboardTest"/>
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRefreshTest"/>
-          <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRenameWorkspaceTest">
-            <methods>
-              <exclude name="checkProjectAfterRenameWs"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRenameWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterWorkspaceRestartTest"/>
           <class name="org.eclipse.che.selenium.workspaces.WorkingWithJavaMySqlStackTest"/>
-          <class name="org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest">
-            <methods>
-              <exclude name="checkNodeJsWsAndRunApp"/>
-            </methods>
-          </class>
+          <class name="org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest"/>
           <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest"/>
           <class name="org.eclipse.che.selenium.consoles.ServerRuntimeInfoTest"/>
         </classes>


### PR DESCRIPTION
### What does this PR do?
It removes code which aimed to separate selenium tests on three groups: stable/unstable/failed.

### What issues does this PR fix or reference?
- issue #7508
- PR into the master branch: https://github.com/eclipse/che/pull/7749

#### Docs PR
https://github.com/eclipse/che-docs/pull/322