### PR TITLE
Change default test workspace template image to eclipse/ubuntu_jdk8

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
@@ -27,7 +27,7 @@
         }
       },
       "recipe":{
-        "location":"rhche/centos_jdk8",
+        "location":"eclipse/ubuntu_jdk8",
         "type":"dockerimage"
       }
     }


### PR DESCRIPTION
### What does this PR do?
Changes default workspace template for integration tests from `rhche/centos_jdk8` to `eclipse/ubuntu_jdk8`.

### What issues does this PR fix or reference?
Fixes the passage of integration tests that rely on docs from java classes.