### PR TITLE
Add ability of fast switching between IDE parts

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/IdeActions.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/IdeActions.java
@@ -21,6 +21,7 @@ public interface IdeActions {
   String GROUP_PROJECT = "projectGroup";
   String GROUP_EDIT = "editGroup";
   String GROUP_ASSISTANT = "assistantGroup";
+  String TOOL_WINDOWS_GROUP = "toolWindows";
   String GROUP_RUN = "runGroup";
   String GROUP_PROFILE = "profileGroup";
   String GROUP_FILE_NEW = "newGroup";

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/Perspective.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/Perspective.java
@@ -119,5 +119,6 @@ public interface Perspective extends StateComponent {
    *
    * @return the active part
    */
+  @Nullable
   PartPresenter getActivePart();
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/WorkspaceAgent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/WorkspaceAgent.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.ide.api.parts;
 
 import javax.validation.constraints.NotNull;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.constraints.Constraints;
 import org.eclipse.che.ide.api.extension.SDK;
 
@@ -68,6 +69,7 @@ public interface WorkspaceAgent {
    *
    * @return the active part
    */
+  @Nullable
   PartPresenter getActivePart();
 
   /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -128,6 +128,42 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("mixedProjectDeleteMessage")
   String mixedProjectDeleteMessage();
 
+  @Key("action.switch.editor.displaying.title")
+  String switchEditorDisplayingTitle();
+
+  @Key("action.switch.editor.displaying.description")
+  String switchEditorDisplayingDescription();
+
+  @Key("action.switch.project.explorer.displaying.title")
+  String switchProjectExplorerDisplayingTitle();
+
+  @Key("action.switch.project.explorer.displaying.description")
+  String switchProjectExplorerDisplayingDescription();
+
+  @Key("action.switch.command.explorer.displaying.title")
+  String switchCommandExplorerDisplayingTitle();
+
+  @Key("action.switch.command.explorer.displaying.description")
+  String switchCommandExplorerDisplayingDescription();
+
+  @Key("action.switch.find.part.displaying.title")
+  String switchFindPartDisplayingTitle();
+
+  @Key("action.switch.find.part.displaying.description")
+  String switchFindPartDisplayingDescription();
+
+  @Key("action.switch.event.logs.displaying.title")
+  String switchEventLogsDisplayingTitle();
+
+  @Key("action.switch.event.logs.displaying.description")
+  String switchEventLogsDisplayingDescription();
+
+  @Key("action.switch.terminal.displaying.title")
+  String switchTerminalDisplayingTitle();
+
+  @Key("action.switch.terminal.displaying.description")
+  String switchTerminalDisplayingDescription();
+
   /* RenameItem */
   @Key("action.rename.text")
   String renameItemActionText();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/CommandsExplorerDisplayingModeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/CommandsExplorerDisplayingModeAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.actions.switching;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.parts.PartStackType.NAVIGATION;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.command.explorer.CommandsExplorerPresenter;
+
+/**
+ * Switches Commands Explorer display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Commands Explorer is invisible -> make it visible and active
+ *   <li>Commands Explorer is active -> make it invisible
+ *   <li>Commands Explorer is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class CommandsExplorerDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+  private Provider<CommandsExplorerPresenter> commandsExplorerPresenterProvider;
+
+  @Inject
+  public CommandsExplorerDisplayingModeAction(
+      Resources resources,
+      EditorAgent editorAgent,
+      CoreLocalizationConstant localizedConstant,
+      WorkspaceAgent workspaceAgent,
+      Provider<CommandsExplorerPresenter> commandsExplorerPresenterProvider) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchCommandExplorerDisplayingTitle(),
+        localizedConstant.switchCommandExplorerDisplayingDescription(),
+        resources.editCommands());
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+    this.commandsExplorerPresenterProvider = commandsExplorerPresenterProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    CommandsExplorerPresenter commandsExplorerPresenter = commandsExplorerPresenterProvider.get();
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart != null && activePart instanceof CommandsExplorerPresenter) {
+      workspaceAgent.hidePart(commandsExplorerPresenter);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    workspaceAgent.openPart(commandsExplorerPresenter, NAVIGATION);
+    workspaceAgent.setActivePart(commandsExplorerPresenter);
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/EditorDisplayingModeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/EditorDisplayingModeAction.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.actions.switching;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.che.ide.FontAwesome.FILE_TEXT;
+import static org.eclipse.che.ide.api.parts.PartStack.State.HIDDEN;
+import static org.eclipse.che.ide.api.parts.PartStack.State.MINIMIZED;
+import static org.eclipse.che.ide.api.parts.PartStackType.INFORMATION;
+import static org.eclipse.che.ide.api.parts.PartStackType.NAVIGATION;
+import static org.eclipse.che.ide.api.parts.PartStackType.TOOLING;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashSet;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.PartStack;
+import org.eclipse.che.ide.api.parts.PartStack.State;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+
+/**
+ * Switches Editor display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Editor is inactive -> make it active
+ *   <li>Editor is active -> maximize it
+ *   <li>Editor is maximized -> set normal mode
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class EditorDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+
+  @Inject
+  public EditorDisplayingModeAction(
+      EditorAgent editorAgent,
+      WorkspaceAgent workspaceAgent,
+      CoreLocalizationConstant localizedConstant) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchEditorDisplayingTitle(),
+        localizedConstant.switchEditorDisplayingDescription(),
+        FILE_TEXT);
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    Set<PartStack> partStacks = new HashSet<>(3);
+    partStacks.add(workspaceAgent.getPartStack(NAVIGATION));
+    partStacks.add(workspaceAgent.getPartStack(TOOLING));
+    partStacks.add(workspaceAgent.getPartStack(INFORMATION));
+
+    Set<State> states = partStacks.stream().map(PartStack::getPartStackState).collect(toSet());
+    if (states.stream().anyMatch(state -> MINIMIZED == state)) {
+      partStacks.forEach(PartStack::restore);
+      activateEditor();
+      return;
+    }
+
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart == null || !(activePart instanceof EditorPartPresenter)) {
+      activateEditor();
+      return;
+    }
+
+    if (states.stream().allMatch(state -> HIDDEN == state)) {
+      partStacks.forEach(PartStack::show);
+      activateEditor();
+      return;
+    }
+
+    partStacks.forEach(PartStack::minimize);
+    activateEditor();
+  }
+
+  private void activateEditor() {
+    EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+    if (activeEditor != null) {
+      workspaceAgent.setActivePart(activeEditor);
+    }
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/EventLogsDisplayingModeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/EventLogsDisplayingModeAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.actions.switching;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.parts.PartStackType.INFORMATION;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+
+/**
+ * Switches Event Logs display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Event Logs part is invisible -> make it visible and active
+ *   <li>Event Logs part is active -> make it invisible
+ *   <li>Event Logs part is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class EventLogsDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+  private Provider<NotificationManager> notificationManagerProvider;
+
+  @Inject
+  public EventLogsDisplayingModeAction(
+      Resources resources,
+      EditorAgent editorAgent,
+      CoreLocalizationConstant localizedConstant,
+      WorkspaceAgent workspaceAgent,
+      Provider<NotificationManager> notificationManagerProvider) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchEventLogsDisplayingTitle(),
+        localizedConstant.switchEventLogsDisplayingDescription(),
+        resources.eventsPartIcon());
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+    this.notificationManagerProvider = notificationManagerProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    NotificationManager notificationManager = notificationManagerProvider.get();
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart != null && activePart instanceof NotificationManager) {
+      workspaceAgent.hidePart(notificationManager);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    workspaceAgent.openPart(notificationManager, INFORMATION);
+    workspaceAgent.setActivePart(notificationManager);
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/FindResultDisplayingModeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/FindResultDisplayingModeAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.actions.switching;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.parts.PartStackType.INFORMATION;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.search.presentation.FindResultPresenter;
+
+/**
+ * Switches Find part display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Find part is invisible -> make it visible and active
+ *   <li>Find part is active -> make it invisible
+ *   <li>Find part is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class FindResultDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+  private Provider<FindResultPresenter> findResultPresenterProvider;
+
+  @Inject
+  public FindResultDisplayingModeAction(
+      Resources resources,
+      EditorAgent editorAgent,
+      CoreLocalizationConstant localizedConstant,
+      WorkspaceAgent workspaceAgent,
+      Provider<FindResultPresenter> findResultPresenterProvider) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchFindPartDisplayingTitle(),
+        localizedConstant.switchFindPartDisplayingDescription(),
+        resources.find());
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+    this.findResultPresenterProvider = findResultPresenterProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    FindResultPresenter findResultPresenter = findResultPresenterProvider.get();
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart != null && activePart instanceof FindResultPresenter) {
+      workspaceAgent.hidePart(findResultPresenter);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    workspaceAgent.openPart(findResultPresenter, INFORMATION);
+    workspaceAgent.setActivePart(findResultPresenter);
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/ProjectExplorerDisplayingModeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/ProjectExplorerDisplayingModeAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.actions.switching;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.parts.PartStackType.NAVIGATION;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+
+/**
+ * Switches Project Explorer display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Project Explorer is invisible -> make it visible and active
+ *   <li>Project Explorer is active -> make it invisible
+ *   <li>Project Explorer is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class ProjectExplorerDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+  private Provider<ProjectExplorerPresenter> projectExplorerPresenterProvider;
+
+  @Inject
+  public ProjectExplorerDisplayingModeAction(
+      Resources resources,
+      EditorAgent editorAgent,
+      CoreLocalizationConstant localizedConstant,
+      WorkspaceAgent workspaceAgent,
+      Provider<ProjectExplorerPresenter> projectExplorerPresenterProvider) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchProjectExplorerDisplayingTitle(),
+        localizedConstant.switchProjectExplorerDisplayingDescription(),
+        resources.projectExplorerPartIcon());
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+    this.projectExplorerPresenterProvider = projectExplorerPresenterProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    ProjectExplorerPresenter projectExplorerPresenter = projectExplorerPresenterProvider.get();
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart != null && activePart instanceof ProjectExplorerPresenter) {
+      workspaceAgent.hidePart(projectExplorerPresenter);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    workspaceAgent.openPart(projectExplorerPresenter, NAVIGATION);
+    workspaceAgent.setActivePart(projectExplorerPresenter);
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/TerminalDisplayingModeAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/switching/TerminalDisplayingModeAction.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.actions.switching;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+import static org.eclipse.che.ide.processes.ProcessTreeNode.ProcessNodeType.TERMINAL_NODE;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.Resources;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.processes.ProcessTreeNode;
+import org.eclipse.che.ide.processes.ProcessTreeNodeSelectedEvent;
+import org.eclipse.che.ide.processes.panel.ProcessesPanelPresenter;
+
+/**
+ * Switches Terminal display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Terminal part is invisible -> make it visible and active
+ *   <li>Terminal part is active -> make it invisible
+ *   <li>Terminal part is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class TerminalDisplayingModeAction extends AbstractPerspectiveAction
+    implements ProcessTreeNodeSelectedEvent.Handler {
+  private EditorAgent editorAgent;
+  private Provider<WorkspaceAgent> workspaceAgentProvider;
+  private Provider<ProcessesPanelPresenter> processesPanelPresenterProvider;
+  private ProcessTreeNode selectedNode;
+
+  @Inject
+  public TerminalDisplayingModeAction(
+      Resources resources,
+      EventBus eventBus,
+      EditorAgent editorAgent,
+      CoreLocalizationConstant localizedConstant,
+      Provider<WorkspaceAgent> workspaceAgentProvider,
+      Provider<ProcessesPanelPresenter> processesPanelPresenterProvider) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchTerminalDisplayingTitle(),
+        localizedConstant.switchTerminalDisplayingDescription(),
+        resources.terminal());
+    this.editorAgent = editorAgent;
+    this.workspaceAgentProvider = workspaceAgentProvider;
+    this.processesPanelPresenterProvider = processesPanelPresenterProvider;
+
+    eventBus.addHandler(ProcessTreeNodeSelectedEvent.TYPE, this);
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    WorkspaceAgent workspaceAgent = workspaceAgentProvider.get();
+    ProcessesPanelPresenter processesPanelPresenter = processesPanelPresenterProvider.get();
+    if (isProcessesPanelActive() && isTerminalActive()) {
+      workspaceAgent.hidePart(processesPanelPresenter);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    processesPanelPresenter.provideTerminal();
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+
+  @Override
+  public void onProcessTreeNodeSelected(ProcessTreeNodeSelectedEvent event) {
+    selectedNode = event.getProcessTreeNode();
+  }
+
+  private boolean isProcessesPanelActive() {
+    PartPresenter activePart = workspaceAgentProvider.get().getActivePart();
+    return activePart != null && activePart instanceof ProcessesPanelPresenter;
+  }
+
+  private boolean isTerminalActive() {
+    return selectedNode != null && selectedNode.getType() == TERMINAL_NODE;
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/selector/PanelSelectorPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/selector/PanelSelectorPresenter.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.ide.api.parts.PartStack.State.HIDDEN;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
+import javax.inject.Singleton;
 import org.eclipse.che.ide.api.mvp.Presenter;
 import org.eclipse.che.ide.api.parts.PartStack;
 import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
@@ -23,6 +24,7 @@ import org.eclipse.che.ide.api.parts.Perspective;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
 
 /** Presenter to manage Panel selector widget and perspective layout. */
+@Singleton
 public class PanelSelectorPresenter implements Presenter, PanelSelectorView.ActionDelegate {
 
   private PanelSelectorView view;

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -37,6 +37,8 @@ import static org.eclipse.che.ide.api.action.IdeActions.GROUP_RIGHT_MAIN_MENU;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_RIGHT_TOOLBAR;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_TOOLBAR_CONTROLLER;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_WORKSPACE;
+import static org.eclipse.che.ide.api.action.IdeActions.TOOL_WINDOWS_GROUP;
+import static org.eclipse.che.ide.api.constraints.Anchor.AFTER;
 import static org.eclipse.che.ide.api.constraints.Constraints.FIRST;
 import static org.eclipse.che.ide.api.constraints.Constraints.LAST;
 import static org.eclipse.che.ide.part.editor.recent.RecentFileStore.RECENT_GROUP_ID;
@@ -90,6 +92,12 @@ import org.eclipse.che.ide.actions.common.HidePartAction;
 import org.eclipse.che.ide.actions.common.MaximizePartAction;
 import org.eclipse.che.ide.actions.common.RestorePartAction;
 import org.eclipse.che.ide.actions.find.FindActionAction;
+import org.eclipse.che.ide.actions.switching.CommandsExplorerDisplayingModeAction;
+import org.eclipse.che.ide.actions.switching.EditorDisplayingModeAction;
+import org.eclipse.che.ide.actions.switching.EventLogsDisplayingModeAction;
+import org.eclipse.che.ide.actions.switching.FindResultDisplayingModeAction;
+import org.eclipse.che.ide.actions.switching.ProjectExplorerDisplayingModeAction;
+import org.eclipse.che.ide.actions.switching.TerminalDisplayingModeAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.ActionManager;
 import org.eclipse.che.ide.api.action.BaseAction;
@@ -181,6 +189,12 @@ public class StandardComponentInitializer {
   public static final String SHOW_REFERENCE = "showReference";
   public static final String SHOW_COMMANDS_PALETTE = "showCommandsPalette";
   public static final String NEW_TERMINAL = "newTerminal";
+  public static final String PROJECT_EXPLORER_DISPLAYING_MODE = "projectExplorerDisplayingMode";
+  public static final String COMMAND_EXPLORER_DISPLAYING_MODE = "commandExplorerDisplayingMode";
+  public static final String FIND_RESULT_DISPLAYING_MODE = "findResultDisplayingMode";
+  public static final String EVENT_LOGS_DISPLAYING_MODE = "eventLogsDisplayingMode";
+  public static final String EDITOR_DISPLAYING_MODE = "editorDisplayingMode";
+  public static final String TERMINAL_DISPLAYING_MODE = "terminalDisplayingMode";
 
   public interface ParserResource extends ClientBundle {
     @Source("org/eclipse/che/ide/blank.svg")
@@ -344,6 +358,18 @@ public class StandardComponentInitializer {
   @Inject private CollapseAllAction collapseAllAction;
 
   @Inject private PerspectiveManager perspectiveManager;
+
+  @Inject private CommandsExplorerDisplayingModeAction commandsExplorerDisplayingModeAction;
+
+  @Inject private ProjectExplorerDisplayingModeAction projectExplorerDisplayingModeAction;
+
+  @Inject private EventLogsDisplayingModeAction eventLogsDisplayingModeAction;
+
+  @Inject private FindResultDisplayingModeAction findResultDisplayingModeAction;
+
+  @Inject private EditorDisplayingModeAction editorDisplayingModeAction;
+
+  @Inject private TerminalDisplayingModeAction terminalDisplayingModeAction;
 
   @Inject
   @Named("XMLFileType")
@@ -594,6 +620,32 @@ public class StandardComponentInitializer {
 
     assistantGroup.addSeparator();
 
+    // Switching of parts
+    DefaultActionGroup toolWindowsGroup =
+        new DefaultActionGroup("Tool Windows", true, actionManager);
+    actionManager.registerAction(TOOL_WINDOWS_GROUP, toolWindowsGroup);
+
+    actionManager.registerAction(
+        PROJECT_EXPLORER_DISPLAYING_MODE, projectExplorerDisplayingModeAction);
+    actionManager.registerAction(FIND_RESULT_DISPLAYING_MODE, findResultDisplayingModeAction);
+    actionManager.registerAction(EVENT_LOGS_DISPLAYING_MODE, eventLogsDisplayingModeAction);
+    actionManager.registerAction(
+        COMMAND_EXPLORER_DISPLAYING_MODE, commandsExplorerDisplayingModeAction);
+    actionManager.registerAction(EDITOR_DISPLAYING_MODE, editorDisplayingModeAction);
+    actionManager.registerAction(TERMINAL_DISPLAYING_MODE, terminalDisplayingModeAction);
+    toolWindowsGroup.add(projectExplorerDisplayingModeAction, FIRST);
+    toolWindowsGroup.add(
+        eventLogsDisplayingModeAction, new Constraints(AFTER, PROJECT_EXPLORER_DISPLAYING_MODE));
+    toolWindowsGroup.add(
+        findResultDisplayingModeAction, new Constraints(AFTER, EVENT_LOGS_DISPLAYING_MODE));
+    toolWindowsGroup.add(
+        commandsExplorerDisplayingModeAction, new Constraints(AFTER, FIND_RESULT_DISPLAYING_MODE));
+    toolWindowsGroup.add(editorDisplayingModeAction);
+    toolWindowsGroup.add(terminalDisplayingModeAction);
+
+    assistantGroup.add(toolWindowsGroup);
+    assistantGroup.addSeparator();
+
     actionManager.registerAction("callCompletion", completeAction);
     assistantGroup.add(completeAction);
 
@@ -649,7 +701,7 @@ public class StandardComponentInitializer {
 
     DefaultActionGroup mainContextMenuGroup =
         (DefaultActionGroup) actionManager.getAction(GROUP_MAIN_CONTEXT_MENU);
-    mainContextMenuGroup.add(newGroup, Constraints.FIRST);
+    mainContextMenuGroup.add(newGroup, FIRST);
     mainContextMenuGroup.addSeparator();
     mainContextMenuGroup.add(resourceOperation);
 
@@ -802,6 +854,34 @@ public class StandardComponentInitializer {
 
     keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('z').build(), UNDO);
     keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('y').build(), REDO);
+
+    keyBinding
+        .getGlobal()
+        .addKey(
+            new KeyBuilder().action().alt().charCode('1').build(),
+            PROJECT_EXPLORER_DISPLAYING_MODE);
+
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().action().alt().charCode('2').build(), EVENT_LOGS_DISPLAYING_MODE);
+
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().action().alt().charCode('3').build(), FIND_RESULT_DISPLAYING_MODE);
+
+    keyBinding
+        .getGlobal()
+        .addKey(
+            new KeyBuilder().action().alt().charCode('4').build(),
+            COMMAND_EXPLORER_DISPLAYING_MODE);
+
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().alt().charCode('E').build(), EDITOR_DISPLAYING_MODE);
+
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().alt().charCode('T').build(), TERMINAL_DISPLAYING_MODE);
 
     if (UserAgent.isMac()) {
       keyBinding

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/FocusManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/FocusManager.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.ide.part;
 
+import static org.eclipse.che.ide.api.parts.PartStack.State.HIDDEN;
+
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
@@ -19,6 +21,7 @@ import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.Focusable;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStack;
+import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
 import org.eclipse.che.ide.part.PartStackPresenter.PartStackEventHandler;
 
 /**
@@ -29,7 +32,7 @@ import org.eclipse.che.ide.part.PartStackPresenter.PartStackEventHandler;
  * @author Vlad Zhukovskyi
  */
 @Singleton
-public class FocusManager {
+public class FocusManager implements PartStackStateChangedEvent.Handler {
 
   private final PartStackEventHandler partStackHandler;
 
@@ -48,6 +51,7 @@ public class FocusManager {
 
   @Inject
   public FocusManager(final EventBus eventBus) {
+    eventBus.addHandler(PartStackStateChangedEvent.TYPE, this);
 
     this.partStackHandler =
         new PartStackEventHandler() {
@@ -103,5 +107,14 @@ public class FocusManager {
                     });
           }
         };
+  }
+
+  @Override
+  public void onPartStackStateChanged(PartStackStateChangedEvent event) {
+    PartStack changedPartStack = event.getPartStack();
+    if (HIDDEN == changedPartStack.getPartStackState() && activePartStack == changedPartStack) {
+      activePartStack = null;
+      activePart = null;
+    }
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelView.java
@@ -52,6 +52,7 @@ public interface ProcessesPanelView extends View<ProcessesPanelView.ActionDelega
   ProcessTreeNode getNodeByIndex(@NotNull int index);
 
   /** Returns node by given ID */
+  @Nullable
   ProcessTreeNode getNodeById(@NotNull String nodeId);
 
   /** Add process node */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspacePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspacePresenter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.constraints.Constraints;
 import org.eclipse.che.ide.api.mvp.Presenter;
 import org.eclipse.che.ide.api.parts.PartPresenter;
@@ -158,6 +159,7 @@ public class WorkspacePresenter
   }
 
   @Override
+  @Nullable
   public PartPresenter getActivePart() {
     return activePerspective.getActivePart();
   }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -23,6 +23,24 @@ projectWizard.titleText = Project Configuration
 projectWizard.defaultSaveButtonText = Create
 projectWizard.saveButtonText = Save
 
+############### Switching parts ######################
+action.switch.editor.displaying.title=Editor
+action.switch.editor.displaying.description=Switch Editor displaying mode
+
+action.switch.project.explorer.displaying.title=Project Explorer
+action.switch.project.explorer.displaying.description=Switch Project Explorer displaying mode
+
+action.switch.command.explorer.displaying.title=Commands
+action.switch.command.explorer.displaying.description=Switch Command Explorer displaying mode
+
+action.switch.event.logs.displaying.title=Event Logs
+action.switch.event.logs.displaying.description=Switch Event Logs displaying mode
+
+action.switch.find.part.displaying.title=Find
+action.switch.find.part.displaying.description=Switch Find part displaying mode
+
+action.switch.terminal.displaying.title=Terminal
+action.switch.terminal.displaying.description=Switch Terminal displaying mode
 ############### RenameItem ######################
 action.rename.text = Rename...
 action.rename.description = Rename selected item

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/panel/SubPanelViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/multisplitpanel/panel/SubPanelViewImpl.java
@@ -22,6 +22,7 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DeckLayoutPanel;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.SplitLayoutPanel;
@@ -212,19 +213,23 @@ public class SubPanelViewImpl extends Composite
   }
 
   @Override
-  public void activateWidget(WidgetToShow widget) {
-    final Tab tab = widgets2Tabs.get(widget);
+  public void activateWidget(WidgetToShow widgetToActivate) {
+    final Tab tab = widgets2Tabs.get(widgetToActivate);
     if (tab != null) {
       selectTab(tab);
     }
 
-    widgetsPanel.showWidget(widget.getWidget().asWidget());
+    IsWidget widget = widgetToActivate.getWidget();
+    widgetsPanel.showWidget(widget.asWidget());
+    if (widget instanceof Focusable) {
+      ((Focusable) widget).setFocus(true);
+    }
 
     // add 'active' attribute for active widget for testing purpose
     for (WidgetToShow widgetToShow : widgets2Tabs.keySet()) {
       widgetToShow.getWidget().asWidget().getElement().removeAttribute("active");
     }
-    widget.getWidget().asWidget().getElement().setAttribute("active", "");
+    widget.asWidget().getElement().setAttribute("active", "");
   }
 
   @Override

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/FontAwesome.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/FontAwesome.java
@@ -134,4 +134,7 @@ public class FontAwesome {
 
   /** http://fontawesome.io/icon/arrow-down/ */
   public static final String ARROW_DOWN = "<i class=\"fa fa-arrow-down\"></i>";
+
+  /** http://fontawesome.io/icon/file-text/ */
+  public static final String FILE_TEXT = "<i class=\"fa fa-file-text\"></i>";
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerExtension.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerExtension.java
@@ -12,7 +12,10 @@ package org.eclipse.che.plugin.debugger.ide;
 
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_DEBUG_CONTEXT_MENU;
 import static org.eclipse.che.ide.api.action.IdeActions.GROUP_RUN;
+import static org.eclipse.che.ide.api.action.IdeActions.TOOL_WINDOWS_GROUP;
+import static org.eclipse.che.ide.api.constraints.Anchor.AFTER;
 import static org.eclipse.che.ide.api.constraints.Constraints.LAST;
+import static org.eclipse.che.ide.core.StandardComponentInitializer.COMMAND_EXPLORER_DISPLAYING_MODE;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -28,6 +31,7 @@ import org.eclipse.che.ide.util.browser.UserAgent;
 import org.eclipse.che.ide.util.input.KeyCodeMap;
 import org.eclipse.che.plugin.debugger.ide.actions.AddWatchExpressionAction;
 import org.eclipse.che.plugin.debugger.ide.actions.DebugAction;
+import org.eclipse.che.plugin.debugger.ide.actions.DebuggerDisplayingModeAction;
 import org.eclipse.che.plugin.debugger.ide.actions.DeleteAllBreakpointsAction;
 import org.eclipse.che.plugin.debugger.ide.actions.DeleteBreakpointAction;
 import org.eclipse.che.plugin.debugger.ide.actions.DisableBreakpointAction;
@@ -82,6 +86,7 @@ public class DebuggerExtension {
   public static final String DISABLE_BREAKPOINT_ID = "disableBreakpoint";
   public static final String ENABLE_BREAKPOINT_ID = "enableBreakpoint";
   public static final String DELETE_BREAKPOINT_ID = "deleteBreakpoint";
+  public static final String DEBUGGER_DISPLAYING_MODE_ID = "debuggerDisplayingMode";
 
   public static final String BREAKPOINT = "breakpoint";
 
@@ -113,7 +118,8 @@ public class DebuggerExtension {
       BreakpointActionGroup breakpointActionGroup,
       EnableBreakpointAction enableBreakpointAction,
       DisableBreakpointAction disableBreakpointAction,
-      DeleteBreakpointAction deleteBreakpointAction) {
+      DeleteBreakpointAction deleteBreakpointAction,
+      DebuggerDisplayingModeAction debuggerDisplayingModeAction) {
     debuggerResources.getCss().ensureInjected();
     breakpointResources.getCss().ensureInjected();
 
@@ -138,6 +144,7 @@ public class DebuggerExtension {
     actionManager.registerAction(ENABLE_BREAKPOINT_ID, enableBreakpointAction);
     actionManager.registerAction(DISABLE_BREAKPOINT_ID, disableBreakpointAction);
     actionManager.registerAction(DELETE_BREAKPOINT_ID, deleteBreakpointAction);
+    actionManager.registerAction(DEBUGGER_DISPLAYING_MODE_ID, debuggerDisplayingModeAction);
 
     // create group for selecting (changing) debug configurations
     final DefaultActionGroup debugActionGroup =
@@ -196,6 +203,11 @@ public class DebuggerExtension {
     debugContextMenuGroup.add(debugAction);
     debugContextMenuGroup.addSeparator();
 
+    DefaultActionGroup toolWindowGroup =
+        (DefaultActionGroup) actionManager.getAction(TOOL_WINDOWS_GROUP);
+    toolWindowGroup.add(
+        debuggerDisplayingModeAction, new Constraints(AFTER, COMMAND_EXPLORER_DISPLAYING_MODE));
+
     // keys binding
     keyBinding
         .getGlobal()
@@ -223,6 +235,10 @@ public class DebuggerExtension {
     keyBinding
         .getGlobal()
         .addKey(new KeyBuilder().charCode(KeyCodeMap.F2).build(), EDIT_DEBUG_VARIABLE_ID);
+
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().action().alt().charCode('5').build(), DEBUGGER_DISPLAYING_MODE_ID);
 
     if (UserAgent.isMac()) {
       keyBinding

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.java
@@ -291,4 +291,10 @@ public interface DebuggerLocalizationConstant extends com.google.gwt.i18n.client
 
   @Key("edit.expression.view.expression.field.title")
   String editExpressionViewExpressionFieldTitle();
+
+  @Key("action.switch.debugger.displaying.title")
+  String switchDebuggerDisplayingTitle();
+
+  @Key("action.switch.debugger.displaying.description")
+  String switchDebuggerDisplayingDescription();
 }

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebuggerDisplayingModeAction.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/actions/DebuggerDisplayingModeAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.debugger.ide.actions;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.parts.PartStackType.INFORMATION;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.plugin.debugger.ide.DebuggerLocalizationConstant;
+import org.eclipse.che.plugin.debugger.ide.DebuggerResources;
+import org.eclipse.che.plugin.debugger.ide.debug.DebuggerPresenter;
+
+/**
+ * Switches Debugger display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Debugger part is invisible -> make it visible and active
+ *   <li>Debugger part is active -> make it invisible
+ *   <li>Debugger part is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class DebuggerDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+  private Provider<DebuggerPresenter> debuggerPresenterProvider;
+
+  @Inject
+  public DebuggerDisplayingModeAction(
+      DebuggerResources resources,
+      EditorAgent editorAgent,
+      WorkspaceAgent workspaceAgent,
+      Provider<DebuggerPresenter> debuggerPresenterProvider,
+      DebuggerLocalizationConstant localizedConstant) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchDebuggerDisplayingTitle(),
+        localizedConstant.switchDebuggerDisplayingDescription(),
+        resources.debug());
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+    this.debuggerPresenterProvider = debuggerPresenterProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    DebuggerPresenter debuggerPresenter = debuggerPresenterProvider.get();
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart != null && activePart instanceof DebuggerPresenter) {
+      workspaceAgent.hidePart(debuggerPresenter);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    workspaceAgent.openPart(debuggerPresenter, INFORMATION);
+    workspaceAgent.setActivePart(debuggerPresenter);
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/resources/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.properties
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/resources/org/eclipse/che/plugin/debugger/ide/DebuggerLocalizationConstant.properties
@@ -121,3 +121,7 @@ view.editConfigurations.saveChanges.discard=Discard changes
 ############### ThreadDumps ################
 debugger.frames.title=Frames:
 debugger.threadNotSuspend=Thread is not suspended
+
+############### Switching Debugger  ######################
+action.switch.debugger.displaying.title=Debug
+action.switch.debugger.displaying.description=Switch Debug displaying mode

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/pom.xml
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/pom.xml
@@ -117,6 +117,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-ide-app</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-ide-ui</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.java
@@ -271,4 +271,11 @@ public interface ContributeMessages extends Messages {
 
   @Key("stub.text.should.be.selected.only.one.project")
   String stubTextShouldBeSelectedOnlyOneProject();
+
+  // Switch contribute part action
+  @Key("action.switch.contribute.part.displaying.title")
+  String switchContributePartDisplayingTitle();
+
+  @Key("action.switch.contribute.part.displaying.description")
+  String switchContributePartDisplayingDescription();
 }

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributionExtension.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributionExtension.java
@@ -10,9 +10,19 @@
  */
 package org.eclipse.che.plugin.pullrequest.client;
 
+import static org.eclipse.che.ide.api.action.IdeActions.TOOL_WINDOWS_GROUP;
+import static org.eclipse.che.ide.api.constraints.Anchor.BEFORE;
+import static org.eclipse.che.ide.core.StandardComponentInitializer.EDITOR_DISPLAYING_MODE;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.DefaultActionGroup;
+import org.eclipse.che.ide.api.constraints.Constraints;
 import org.eclipse.che.ide.api.extension.Extension;
+import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
+import org.eclipse.che.ide.api.keybinding.KeyBuilder;
+import org.eclipse.che.plugin.pullrequest.client.actions.ContributePartDisplayingModeAction;
 
 /**
  * Registers event handlers for adding/removing contribution part.
@@ -28,11 +38,29 @@ import org.eclipse.che.ide.api.extension.Extension;
 @Singleton
 @Extension(title = "Contributor", version = "1.0.0")
 public class ContributionExtension {
+  public static final String CONTRIBUTE_PART_DISPLAYING_MODE = "contributePartDisplayingMode";
 
   @Inject
   @SuppressWarnings("unused")
   public ContributionExtension(
-      ContributeResources resources, ContributionMixinProvider contributionMixinProvider) {
+      ContributeResources resources,
+      ContributionMixinProvider contributionMixinProvider,
+      KeyBindingAgent keyBinding,
+      ActionManager actionManager,
+      ContributePartDisplayingModeAction contributePartDisplayingModeAction) {
     resources.contributeCss().ensureInjected();
+
+    actionManager.registerAction(
+        CONTRIBUTE_PART_DISPLAYING_MODE, contributePartDisplayingModeAction);
+
+    DefaultActionGroup toolWindowGroup =
+        (DefaultActionGroup) actionManager.getAction(TOOL_WINDOWS_GROUP);
+    toolWindowGroup.add(
+        contributePartDisplayingModeAction, new Constraints(BEFORE, EDITOR_DISPLAYING_MODE));
+
+    keyBinding
+        .getGlobal()
+        .addKey(
+            new KeyBuilder().action().alt().charCode('6').build(), CONTRIBUTE_PART_DISPLAYING_MODE);
   }
 }

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/actions/ContributePartDisplayingModeAction.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/actions/ContributePartDisplayingModeAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.pullrequest.client.actions;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.parts.PartStackType.TOOLING;
+import static org.eclipse.che.ide.part.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.plugin.pullrequest.client.ContributeMessages;
+import org.eclipse.che.plugin.pullrequest.client.ContributeResources;
+import org.eclipse.che.plugin.pullrequest.client.parts.contribute.ContributePartPresenter;
+
+/**
+ * Switches Contribute part display mode depends on the current state of IDE:
+ *
+ * <ul>
+ *   <li>Contribute part is invisible -> make it visible and active
+ *   <li>Contribute part is active -> make it invisible
+ *   <li>Contribute part is inactive -> make it active
+ * </ul>
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class ContributePartDisplayingModeAction extends AbstractPerspectiveAction {
+  private EditorAgent editorAgent;
+  private WorkspaceAgent workspaceAgent;
+  private Provider<ContributePartPresenter> contributePartPresenterProvider;
+
+  @Inject
+  public ContributePartDisplayingModeAction(
+      ContributeResources resources,
+      EditorAgent editorAgent,
+      WorkspaceAgent workspaceAgent,
+      Provider<ContributePartPresenter> contributePartPresenterProvider,
+      ContributeMessages localizedConstant) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.switchContributePartDisplayingTitle(),
+        localizedConstant.switchContributePartDisplayingDescription(),
+        resources.titleIcon());
+    this.editorAgent = editorAgent;
+    this.workspaceAgent = workspaceAgent;
+    this.contributePartPresenterProvider = contributePartPresenterProvider;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    ContributePartPresenter contributePartPresenter = contributePartPresenterProvider.get();
+    PartPresenter activePart = workspaceAgent.getActivePart();
+    if (activePart != null && activePart instanceof ContributePartPresenter) {
+      workspaceAgent.hidePart(contributePartPresenter);
+
+      EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
+      if (activeEditor != null) {
+        workspaceAgent.setActivePart(activeEditor);
+      }
+      return;
+    }
+
+    workspaceAgent.openPart(contributePartPresenter, TOOLING);
+    workspaceAgent.setActivePart(contributePartPresenter);
+  }
+
+  @Override
+  public void updateInPerspective(@NotNull ActionEvent event) {
+    event.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/resources/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.properties
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/resources/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.properties
@@ -154,3 +154,10 @@ stub.text.nothing.to.show=Nothing to show
 stub.text.should.be.selected.only.one.project=Contribution panel supports handling only one selected project.
 failed.to.get.vcs.service=Failed to get VCS hosting service {0}. Cause: {1}
 failed.to.apply.vcs.mixin=Failed to apply mixin to project: {0}. Cause: {1}
+
+
+#
+# Switching Contribute Part displaying mode
+#
+action.switch.contribute.part.displaying.title=Contribute
+action.switch.contribute.part.displaying.description=Switch Contribute part displaying mode

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/CheckFindActionFeatureInCheTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/CheckFindActionFeatureInCheTest.java
@@ -53,7 +53,10 @@ public class CheckFindActionFeatureInCheTest {
           + "breakpointConfiguration ";
 
   private static final String SECOND_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
-      "Commands \n" + "Commands \n" + "Commands Palette [Shift+F10]  Run";
+      "Commands \n"
+          + "Commands [Ctrl+Alt+4]  Tool Windows\n"
+          + "Commands \n"
+          + "Commands Palette [Shift+F10]  Run";
   private static final String THIRD_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
       "Branches... [Ctrl+B]  GitCommandGroup\n" + "Checkout Reference...  GitCommandGroup";
 


### PR DESCRIPTION
### What does this PR do?
Add ability of fast switching between IDE parts(Editor, Project Explorer, Command Explorer, Terminal, Find part, Debugger, Event Logs, Contribute part) depends on the current state of IDE:

For example, for Terminal:
- Processes panel is invisible -> make it visible and active last active terminal, opens new terminal when terminal is absent
- Terminal is active -> make it invisible
- Terminal is inactive -> make it active

For Editor:
- Editor is inactive -> make it active
- Editor is active -> maximize it
- Editor is maximized -> set normal mode

For Project Explorer part:
- Project explorer is invisible -> make it visible and active
- Project explorer is active -> make it invisible
- Project explorer is inactive -> make it active

Hotkeys:
![hotkeys](https://user-images.githubusercontent.com/5676062/33669437-23c59724-daab-11e7-964d-8540dd91195d.png)


### What issues does this PR fix or reference?
#7024 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
