### PR TITLE
Introduce wsagent ping success threshold

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -110,6 +110,7 @@ che.workspace.che_server_endpoint=http://che-host:${SERVER_PORT}/wsmaster/api
 che.workspace.agent.dev.max_start_time_ms=180000
 che.workspace.agent.dev.ping_delay_ms=2000
 che.workspace.agent.dev.ping_conn_timeout_ms=2000
+che.workspace.agent.dev.ping_success_threshold=1
 che.workspace.agent.dev.ping_timeout_error_msg=Timeout. The Che server is unable to ping your workspace. This implies a network configuration issue, workspace boot failure, or an unusually slow workspace boot.
 
 che.agent.dev.max_start_time_ms=120000


### PR DESCRIPTION
### What does this PR do?
It introduces a ping success threshold in the wsagent launcher. That's the minimum consecutive successes for the ping to be considered successful after having failed. Defaults to 1.

### What issues does this PR fix or reference?
This is needed for situations where one successful ping is not enough to consider that the wsagent is started: https://github.com/openshiftio/openshift.io/issues/1304#issuecomment-349666094