### PR TITLE
Introduce a concept of internal machine server which is accessible from the inside of a workspace only

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.core.model.workspace.config;
 
 import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
@@ -19,6 +20,13 @@ import org.eclipse.che.commons.annotation.Nullable;
  * @author Alexander Garagatyi
  */
 public interface ServerConfig {
+
+  /**
+   * {@link ServerConfig} and {@link Server} attribute name which can identify server as internal or
+   * external. Attribute value {@code true} makes a server internal, any other value or lack of the
+   * attribute makes the server external.
+   */
+  String INTERNAL_SERVER_ATTRIBUTE = "internal";
 
   /**
    * Port used by server.

--- a/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/ContainerPort.java
+++ b/infrastructures/docker/docker-client/src/main/java/org/eclipse/che/infrastructure/docker/client/json/ContainerPort.java
@@ -10,10 +10,13 @@
  */
 package org.eclipse.che.infrastructure.docker.client.json;
 
+import org.eclipse.che.commons.annotation.Nullable;
+
 /**
- * Defines information about container port which was published to the host
+ * Defines information about container port which was exposed or published.
  *
  * @author Alexander Andrienko
+ * @author Alexander Garagatyi
  */
 public class ContainerPort {
   private int privatePort;
@@ -28,6 +31,8 @@ public class ContainerPort {
     this.privatePort = privatePort;
   }
 
+  /** When public port is {@code null} the port was not published but just exposed. */
+  @Nullable
   public int getPublicPort() {
     return publicPort;
   }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -14,7 +14,6 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -64,7 +63,7 @@ public final class Labels {
   /** Helps to serialize known entities to docker labels. */
   public static class Serializer {
 
-    private final Map<String, String> labels = new LinkedHashMap<>();
+    private final Map<String, String> labels = new HashMap<>();
 
     /**
      * Serializes machine name as docker container label. Appends serialization result to this

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/Labels.java
@@ -105,9 +105,7 @@ public final class Labels {
       if (server.getPath() != null) {
         labels.put(String.format(SERVER_PATH_LABEL_FMT, ref), server.getPath());
       }
-      if (server.getAttributes() != null) {
-        labels.put(String.format(SERVER_ATTR_LABEL_FMT, ref), GSON.toJson(server.getAttributes()));
-      }
+      labels.put(String.format(SERVER_ATTR_LABEL_FMT, ref), GSON.toJson(server.getAttributes()));
       return this;
     }
 

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/server/ServersConverter.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/server/ServersConverter.java
@@ -47,7 +47,15 @@ public class ServersConverter implements DockerEnvironmentProvisioner {
                   .getServers()
                   .forEach(
                       (key, value) -> {
-                        container.getPorts().add(value.getPort());
+                        // Add ports and exposes if server should be publicly accessible.
+                        // To make server workspace-wide accessible add only exposes.
+                        if (!"true"
+                            .equals(
+                                value
+                                    .getAttributes()
+                                    .get(ServerConfig.INTERNAL_SERVER_ATTRIBUTE))) {
+                          container.getPorts().add(value.getPort());
+                        }
                         container.addExpose(value.getPort());
                       });
             });

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/server/ServersConverterTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/server/ServersConverterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.provisioner.server;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.docker.Labels;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerContainerConfig;
+import org.eclipse.che.workspace.infrastructure.docker.model.DockerEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class ServersConverterTest {
+  @Mock RuntimeIdentity identity;
+  @Mock DockerEnvironment dockerEnvironment;
+  @Mock InternalMachineConfig machine1;
+  @Mock InternalMachineConfig machine2;
+  @Mock DockerContainerConfig container1;
+  @Mock DockerContainerConfig container2;
+  @Mock Map<String, String> container1Labels;
+  @Mock Map<String, String> container2Labels;
+  @Mock List<String> ports1;
+  @Mock List<String> ports2;
+
+  Map<String, ServerConfig> servers1;
+  Map<String, ServerConfig> servers2;
+  ServersConverter serversConverter = new ServersConverter();
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    when(dockerEnvironment.getContainers())
+        .thenReturn(
+            new LinkedHashMap<>(ImmutableMap.of("machine1", container1, "machine2", container2)));
+    when(dockerEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of("machine1", machine1, "machine2", machine2));
+    when(container1.getLabels()).thenReturn(container1Labels);
+    when(container2.getLabels()).thenReturn(container2Labels);
+    servers1 =
+        ImmutableMap.of(
+            "server1",
+            new ServerConfigImpl("7800", "http", "/path", singletonMap("key", "value")),
+            "server2",
+            new ServerConfigImpl(
+                "7979",
+                "tcp",
+                "",
+                singletonMap(ServerConfig.INTERNAL_SERVER_ATTRIBUTE, Boolean.TRUE.toString())));
+    servers2 = ImmutableMap.of("server3", new ServerConfigImpl("20000/udp", "udp", null, null));
+    when(machine1.getServers()).thenReturn(servers1);
+    when(machine2.getServers()).thenReturn(servers2);
+    when(container1.getPorts()).thenReturn(ports1);
+    when(container2.getPorts()).thenReturn(ports2);
+  }
+
+  @Test
+  public void shouldAddLabelsOfServersToAContainer() throws Exception {
+    serversConverter.provision(dockerEnvironment, identity);
+
+    verify(container1Labels).putAll(eq(Labels.newSerializer().servers(servers1).labels()));
+    verify(container2Labels).putAll(eq(Labels.newSerializer().servers(servers2).labels()));
+  }
+
+  @Test
+  public void shouldExposePortsForBothInternalAndExternalServers() throws Exception {
+    serversConverter.provision(dockerEnvironment, identity);
+
+    verify(container1).addExpose("7800");
+    verify(container1).addExpose("7979");
+    verify(container2).addExpose("20000/udp");
+  }
+
+  @Test
+  public void shouldPublishPortsForExternalServersOnly() throws Exception {
+    serversConverter.provision(dockerEnvironment, identity);
+
+    verify(ports1).add("7800");
+    verify(ports1, never()).add("7979");
+    verify(ports2).add("20000/udp");
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Annotations.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Annotations.java
@@ -13,23 +13,21 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import io.fabric8.openshift.api.model.Route;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 
 /**
- * Helps to convert {@link Route} related OpenShift infrastructure entities to annotations and
+ * Helps to convert {@link ServerConfig} objects to OpenShift infrastructure annotations and
  * vise-versa.
  *
  * @author Sergii Leshchenko
  */
-public class RoutesAnnotations {
+public class Annotations {
   public static final String ANNOTATION_PREFIX = "org.eclipse.che.";
 
   public static final String SERVER_PORT_ANNOTATION_FMT = ANNOTATION_PREFIX + "server.%s.port";
@@ -58,13 +56,13 @@ public class RoutesAnnotations {
     return new Deserializer(annotations);
   }
 
-  /** Helps to serialize known route related entities to OpenShift annotations. */
+  /** Helps to serialize ServerConfig entities to OpenShift annotations. */
   public static class Serializer {
-    private final Map<String, String> annotations = new LinkedHashMap<>();
+    private final Map<String, String> annotations = new HashMap<>();
 
     /**
-     * Serializes server configuration as OpenShift Route annotations. Appends serialization result
-     * to this aggregate.
+     * Serializes server configuration as OpenShift annotations. Appends serialization result to
+     * this aggregate.
      *
      * @param ref server reference e.g. "exec-agent"
      * @param server server configuration
@@ -93,17 +91,15 @@ public class RoutesAnnotations {
     }
   }
 
-  /** Helps to deserialize OpenShift annotations to known route related entities. */
+  /** Helps to deserialize OpenShift annotations to known {@link ServerConfig} related entities. */
   public static class Deserializer {
     private final Map<String, String> annotations;
 
     public Deserializer(Map<String, String> annotations) {
-      this.annotations = Objects.requireNonNull(annotations);
+      this.annotations = annotations != null ? annotations : Collections.emptyMap();
     }
 
-    /**
-     * Retrieves server configuration from route annotations and returns (ref -> server config) map.
-     */
+    /** Retrieves server configuration from annotations and returns (ref -> server config) map. */
     public Map<String, ServerConfigImpl> servers() {
       Map<String, ServerConfigImpl> servers = new HashMap<>();
       for (Map.Entry<String, String> entry : annotations.entrySet()) {
@@ -127,5 +123,5 @@ public class RoutesAnnotations {
     }
   }
 
-  private RoutesAnnotations() {}
+  private Annotations() {}
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolver.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 
@@ -33,6 +34,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
  * {@link ServerExposer}.
  *
  * @author Sergii Leshchenko
+ * @author Alexander Garagatyi
  * @see ServerExposer
  */
 public class ServerResolver {
@@ -62,26 +64,50 @@ public class ServerResolver {
             .map(s -> s.getMetadata().getName())
             .collect(Collectors.toSet());
     Map<String, ServerImpl> servers = new HashMap<>();
-    for (Route route : routes) {
-      if (matchedServices.contains(route.getSpec().getTo().getName())) {
-        RoutesAnnotations.newDeserializer(route.getMetadata().getAnnotations())
-            .servers()
-            .forEach(
-                (name, config) ->
-                    servers.put(
-                        name,
-                        newServer(
-                            config.getProtocol(),
-                            route.getSpec().getHost(),
-                            config.getPath(),
-                            config.getAttributes())));
-      }
-    }
+    services
+        .stream()
+        .filter(service -> matchedServices.contains(service.getMetadata().getName()))
+        .forEach(service -> fillServiceServers(service, servers));
+    routes
+        .stream()
+        .filter(route -> matchedServices.contains(route.getSpec().getTo().getName()))
+        .forEach(route -> fillRouteServers(route, servers));
     return servers;
   }
 
+  private void fillServiceServers(Service service, Map<String, ServerImpl> servers) {
+    Annotations.newDeserializer(service.getMetadata().getAnnotations())
+        .servers()
+        .forEach(
+            (name, config) ->
+                servers.put(
+                    name,
+                    newServer(
+                        config.getProtocol(),
+                        service.getMetadata().getName(),
+                        config.getPort(),
+                        config.getPath(),
+                        config.getAttributes())));
+  }
+
+  private void fillRouteServers(Route route, Map<String, ServerImpl> servers) {
+    Annotations.newDeserializer(route.getMetadata().getAnnotations())
+        .servers()
+        .forEach(
+            (name, config) ->
+                servers.put(
+                    name,
+                    newServer(
+                        config.getProtocol(),
+                        route.getSpec().getHost(),
+                        null,
+                        config.getPath(),
+                        config.getAttributes())));
+  }
+
+  /** Constructs {@link ServerImpl} instance from provided parameters. */
   private ServerImpl newServer(
-      String protocol, String host, String path, Map<String, String> attributes) {
+      String protocol, String host, String port, String path, Map<String, String> attributes) {
     StringBuilder ub = new StringBuilder();
     if (protocol != null) {
       ub.append(protocol).append("://");
@@ -89,6 +115,9 @@ public class ServerResolver {
       ub.append("tcp://");
     }
     ub.append(host);
+    if (port != null) {
+      ub.append(':').append(removeSuffix(port));
+    }
     if (path != null) {
       if (!path.isEmpty() && !path.startsWith("/")) {
         ub.append("/");
@@ -99,6 +128,11 @@ public class ServerResolver {
         .withUrl(ub.toString())
         .withStatus(ServerStatus.UNKNOWN)
         .withAttributes(attributes);
+  }
+
+  /** Removes suffix of {@link ServerConfig} such as "/tcp" when port value "8080/tcp". */
+  private String removeSuffix(String port) {
+    return port.split("/")[0];
   }
 
   private List<Service> getMatchedServices(Pod pod, Container container) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/route/TlsRouteProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/route/TlsRouteProvisioner.java
@@ -22,7 +22,7 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.workspace.infrastructure.openshift.RoutesAnnotations;
+import org.eclipse.che.workspace.infrastructure.openshift.Annotations;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.ConfigurationProvisioner;
 
@@ -46,23 +46,23 @@ public class TlsRouteProvisioner implements ConfigurationProvisioner {
   @Override
   public void provision(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
       throws InfrastructureException {
-    if (isTlsEnabled) {
-      final Set<Route> routes = new HashSet<>(osEnv.getRoutes().values());
-      for (Route route : routes) {
-        useSecureProtocolForServers(route);
-        enableTls(route);
-      }
+    if (!isTlsEnabled) {
+      return;
+    }
+    final Set<Route> routes = new HashSet<>(osEnv.getRoutes().values());
+    for (Route route : routes) {
+      useSecureProtocolForServers(route);
+      enableTls(route);
     }
   }
 
   private void useSecureProtocolForServers(final Route route) {
     Map<String, ServerConfigImpl> servers =
-        RoutesAnnotations.newDeserializer(route.getMetadata().getAnnotations()).servers();
+        Annotations.newDeserializer(route.getMetadata().getAnnotations()).servers();
 
     servers.values().forEach(s -> s.setProtocol(getSecureProtocol(s.getProtocol())));
 
-    Map<String, String> annotations =
-        RoutesAnnotations.newSerializer().servers(servers).annotations();
+    Map<String, String> annotations = Annotations.newSerializer().servers(servers).annotations();
 
     route.getMetadata().getAnnotations().putAll(annotations);
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AnnotationsTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AnnotationsTest.java
@@ -23,11 +23,11 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.testng.annotations.Test;
 
 /**
- * Test for {@link RoutesAnnotations}.
+ * Test for {@link Annotations}.
  *
  * @author Sergii Leshchenko
  */
-public class RoutesAnnotationsTest {
+public class AnnotationsTest {
   static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
   static final Map<String, String> ATTRIBUTES = singletonMap("key", "value");
   static final String stringAttributes = GSON.toJson(ATTRIBUTES);
@@ -36,7 +36,7 @@ public class RoutesAnnotationsTest {
   @Test
   public void serialization() {
     Map<String, String> serialized =
-        RoutesAnnotations.newSerializer()
+        Annotations.newSerializer()
             .server(
                 "my-server1/http",
                 new ServerConfigImpl("8000/tcp", "http", "/api/info", ATTRIBUTES))
@@ -76,7 +76,7 @@ public class RoutesAnnotationsTest {
             .put("org.eclipse.che.server.my-server3.attributes", stringEmptyAttributes)
             .build();
 
-    RoutesAnnotations.Deserializer deserializer = RoutesAnnotations.newDeserializer(annotations);
+    Annotations.Deserializer deserializer = Annotations.newDeserializer(annotations);
 
     Map<String, ServerConfigImpl> servers = deserializer.servers();
 

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspacePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspacePermissionsFilterTest.java
@@ -306,7 +306,7 @@ public class WorkspacePermissionsFilterTest {
 
     assertEquals(response.getStatusCode(), 204);
     verify(superPrivilegesChecker).hasSuperPrivileges();
-    verify(workspaceService).getByKey(eq("workspace123"));
+    verify(workspaceService).getByKey(eq("workspace123"), eq("false"));
     verify(subject).hasPermission(eq("workspace"), eq("workspace123"), eq("read"));
   }
 
@@ -327,7 +327,7 @@ public class WorkspacePermissionsFilterTest {
 
     assertEquals(response.getStatusCode(), 204);
     verify(superPrivilegesChecker).hasSuperPrivileges();
-    verify(workspaceService).getByKey(eq("workspace123"));
+    verify(workspaceService).getByKey(eq("workspace123"), eq("false"));
     verify(subject, never()).hasPermission(eq("workspace"), eq("workspace123"), eq("read"));
   }
 
@@ -351,7 +351,7 @@ public class WorkspacePermissionsFilterTest {
             .get(SECURE_PATH + "/workspace/{key}");
 
     assertEquals(response.getStatusCode(), 204);
-    verify(workspaceService).getByKey(eq("userok:myWorkspace"));
+    verify(workspaceService).getByKey(eq("userok:myWorkspace"), eq("false"));
     verify(subject).hasPermission(eq("workspace"), eq("workspace123"), eq("read"));
   }
 


### PR DESCRIPTION
### What does this PR do?
Note: you can review this PR commit-by-commit.
Adds a concept of an "internal server" that use infrastructure-specific workspace-scoped communication mechanism to allow communication from workspace machines only.
This allows defining a server that is accessible from other machines(containers) of the same workspace but not accessible from the internet.
This server doesn't have to be secured by any authentication since alien users cannot access it.
This allows using workspace runtime information about private workspace ports for a service discovery.
Example of flow:
1. A user adds a machine with an LS to a workspace and specifies some port as an internal server. 
1. Workspace API starts workspace and doesn't open that port to the world because it is marked as internal.
1. Another service started as part of the workspace(ws-agent) wants to discover this LS. It fetches workspace runtime information and figures out how to connect to the LS.

Supported infras:
- Docker
- OpenShift

How to use it:
1. Add ServerConfig object to a machine.
1. Add attributes field to the server config.
1. Add attribute `internal` with value `true`.
1. This server will be opened as internal. It won't be available at runtime on GET Workspace API by default
1. To get this server from runtime use GET Workspace API with query parameter `?includeInternalServers=true` or `?includeInternalServers=` or `?includeInternalServers`
1. GET Workspace API will return runtime that includes internal servers.

How ServerConfig and Server objects look:
ServerConfig:
```
"my-internal-server" : {
    "port" : "4488",
    "protocol" : "http",
    "path": null,
    "attributes" : {
        "internal" : "true"
    }
}
```
Server:
```
"my-internal-server" : {
    "status" : "UNKNOWN",
    "url" : "http://ls-ts:4488",
    "attributes" : {
        "internal" : "true"
    }
}
```
Where `ls-ts` is some infra-specific value that identifies machine where server is running. 
For the compose recipe it is a name of service/Che machine, for OpenShift it will be generated OpenShift service.


### What issues does this PR fix or reference?
Fixes #7561 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
