### PR TITLE
CHE-6835: Add binding to GitCheckoutNotifier, fix project synchronization

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/inject/GitGinModule.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/inject/GitGinModule.java
@@ -57,6 +57,7 @@ import org.eclipse.che.ide.ext.git.client.panel.GitPanelViewImpl;
 import org.eclipse.che.ide.ext.git.client.panel.RepositoryNodeFactory;
 import org.eclipse.che.ide.ext.git.client.plugins.EditorTabsColorizer;
 import org.eclipse.che.ide.ext.git.client.plugins.GitChangeMarkerManager;
+import org.eclipse.che.ide.ext.git.client.plugins.GitCheckoutNotifier;
 import org.eclipse.che.ide.ext.git.client.plugins.ProjectExplorerTreeColorizer;
 import org.eclipse.che.ide.ext.git.client.preference.CommitterPreferencePresenter;
 import org.eclipse.che.ide.ext.git.client.pull.PullView;
@@ -131,5 +132,6 @@ public class GitGinModule extends AbstractGinModule {
     bind(ProjectExplorerTreeColorizer.class).asEagerSingleton();
     bind(EditorTabsColorizer.class).asEagerSingleton();
     bind(GitChangeMarkerManager.class).asEagerSingleton();
+    bind(GitCheckoutNotifier.class).asEagerSingleton();
   }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/GitCheckoutNotifier.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/GitCheckoutNotifier.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.ext.git.client.plugins;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
+import static org.eclipse.che.ide.api.resources.ResourceDelta.UPDATED;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -20,8 +21,10 @@ import org.eclipse.che.api.project.shared.dto.event.GitCheckoutEventDto;
 import org.eclipse.che.api.project.shared.dto.event.GitCheckoutEventDto.Type;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.resources.ExternalResourceDelta;
 import org.eclipse.che.ide.ext.git.client.GitEventSubscribable;
 import org.eclipse.che.ide.ext.git.client.GitEventsSubscriber;
+import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.resources.impl.ResourceManager;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -82,6 +85,8 @@ public class GitCheckoutNotifier implements GitEventsSubscriber {
     }
 
     // Update project attributes from server.
-    appContext.getWorkspaceRoot().synchronize();
+
+    Path path = Path.valueOf("/" + gitCheckoutEventDto.getProjectName());
+    appContext.getWorkspaceRoot().synchronize(new ExternalResourceDelta(path, path, UPDATED));
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Restore binding of `GitCheckoutNotifier` class
Change synchronization of the whole project to synchronization of project node to update only the project node.

### What issues does this PR fix or reference?
#6835 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
