### PR TITLE
Fix the OpenshiftClient connection leaks

### DIFF
--- a/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
+++ b/plugins/plugin-docker/che-plugin-openshift-client/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>openshift-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/CheKubernetesClient.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/CheKubernetesClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.openshift.client;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import okhttp3.OkHttpClient;
+
+class CheKubernetesClient extends DefaultKubernetesClient {
+
+  public CheKubernetesClient(OkHttpClient httpClient, Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/CheOpenshiftClient.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/CheOpenshiftClient.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.plugin.openshift.client;
 
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
@@ -20,14 +21,17 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-public class OpenShiftClientExtension extends DefaultOpenShiftClient {
-
+class CheOpenshiftClient extends DefaultOpenShiftClient {
   private static final String VERSION = "version";
 
-  public OpenShiftClientExtension(OkHttpClient httpClient, OpenShiftConfig config)
-      throws KubernetesClientException {
-    super(httpClient, config);
+  public CheOpenshiftClient(OkHttpClient httpClient, Config config) {
+    super(
+        httpClient,
+        config instanceof OpenShiftConfig ? (OpenShiftConfig) config : new OpenShiftConfig(config));
   }
+
+  @Override
+  public void close() {}
 
   public String getVersion() {
     try {

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import okhttp3.Authenticator;
 import okhttp3.Interceptor;
-import okhttp3.Interceptor.Chain;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.openshift.client;
+
+import static io.fabric8.kubernetes.client.utils.Utils.isNotNullOrEmpty;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import io.fabric8.openshift.client.OpenShiftConfigBuilder;
+import io.fabric8.openshift.client.internal.OpenShiftOAuthInterceptor;
+import java.io.IOException;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import okhttp3.Authenticator;
+import okhttp3.Interceptor;
+import okhttp3.Interceptor.Chain;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@Singleton
+public class OpenShiftClientFactory {
+
+  private OkHttpClient httpClient;
+
+  @Inject
+  public OpenShiftClientFactory(
+      OpenshiftWorkspaceEnvironmentProvider workspaceEnvironmentProvider) {
+    this.httpClient =
+        HttpClientUtils.createHttpClient(workspaceEnvironmentProvider.getDefaultOpenshiftConfig());
+  }
+
+  @PreDestroy
+  public void cleanup() {
+    if (httpClient.connectionPool() != null) {
+      httpClient.connectionPool().evictAll();
+    }
+    if (httpClient.dispatcher() != null
+        && httpClient.dispatcher().executorService() != null
+        && !httpClient.dispatcher().executorService().isShutdown()) {
+      httpClient.dispatcher().executorService().shutdown();
+    }
+  }
+
+  public CheOpenshiftClient newOcClient(Config config) {
+    OkHttpClient clientHttpClient =
+        httpClient.newBuilder().authenticator(Authenticator.NONE).build();
+    OkHttpClient.Builder builder = clientHttpClient.newBuilder();
+    builder.interceptors().clear();
+    clientHttpClient =
+        builder
+            .addInterceptor(
+                new OpenShiftOAuthInterceptor(clientHttpClient, OpenShiftConfig.wrap(config)))
+            .build();
+
+    return new CheOpenshiftClient(clientHttpClient, config);
+  }
+
+  public CheKubernetesClient newKubeClient(Config config) {
+    OkHttpClient clientHttpClient =
+        httpClient.newBuilder().authenticator(Authenticator.NONE).build();
+    OkHttpClient.Builder builder = clientHttpClient.newBuilder();
+    builder.interceptors().clear();
+    clientHttpClient =
+        builder
+            .addInterceptor(
+                new Interceptor() {
+                  @Override
+                  public Response intercept(Chain chain) throws IOException {
+                    Request request = chain.request();
+                    if (isNotNullOrEmpty(config.getOauthToken())) {
+                      Request authReq =
+                          chain
+                              .request()
+                              .newBuilder()
+                              .addHeader("Authorization", "Bearer " + config.getOauthToken())
+                              .build();
+                      return chain.proceed(authReq);
+                    }
+                    return chain.proceed(request);
+                  }
+                })
+            .build();
+
+    return new CheKubernetesClient(clientHttpClient, config);
+  }
+
+  public CheOpenshiftClient newOcClient() {
+    return newOcClient(new OpenShiftConfigBuilder().build());
+  }
+
+  public CheKubernetesClient newKubeClient() {
+    return newKubeClient(new OpenShiftConfigBuilder().build());
+  }
+}

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenshiftWorkspaceEnvironmentProvider.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenshiftWorkspaceEnvironmentProvider.java
@@ -30,6 +30,10 @@ public class OpenshiftWorkspaceEnvironmentProvider {
     this.openShiftCheProjectName = openShiftCheProjectName;
   }
 
+  public Config getDefaultOpenshiftConfig() {
+    return new OpenShiftConfigBuilder().build();
+  }
+
   public Config getWorkspacesOpenshiftConfig(Subject subject) throws OpenShiftException {
     return new OpenShiftConfigBuilder().build();
   }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesResourceUtil.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/kubernetes/KubernetesResourceUtil.java
@@ -15,12 +15,13 @@ import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
 import java.util.List;
+import org.eclipse.che.plugin.openshift.client.OpenShiftClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,76 +31,80 @@ public final class KubernetesResourceUtil {
   private KubernetesResourceUtil() {}
 
   public static Deployment getDeploymentByName(
-      String deploymentName, String namespace, final Config config) throws IOException {
-    try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient(config)) {
-      Deployment deployment =
-          openShiftClient
-              .extensions()
-              .deployments()
-              .inNamespace(namespace)
-              .withName(deploymentName)
-              .get();
-      if (deployment == null) {
-        LOG.warn("No Deployment with name {} could be found", deploymentName);
-      }
-      return deployment;
+      String deploymentName,
+      String namespace,
+      final Config config,
+      final OpenShiftClientFactory ocFactory)
+      throws IOException {
+    DefaultKubernetesClient kubeClient = ocFactory.newKubeClient(config);
+    Deployment deployment =
+        kubeClient.extensions().deployments().inNamespace(namespace).withName(deploymentName).get();
+    if (deployment == null) {
+      LOG.warn("No Deployment with name {} could be found", deploymentName);
     }
+    return deployment;
   }
 
   public static Service getServiceBySelector(
       final String selectorKey,
       final String selectorValue,
       final String namespace,
-      final Config config) {
-    try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient(config)) {
-      ServiceList svcs = openShiftClient.services().inNamespace(namespace).list();
+      final Config config,
+      final OpenShiftClientFactory ocFactory) {
+    DefaultKubernetesClient kubeClient = ocFactory.newKubeClient(config);
+    ServiceList svcs = kubeClient.services().inNamespace(namespace).list();
 
-      Service svc =
-          svcs.getItems()
-              .stream()
-              .filter(s -> s.getSpec().getSelector().containsKey(selectorKey))
-              .filter(s -> s.getSpec().getSelector().get(selectorKey).equals(selectorValue))
-              .findAny()
-              .orElse(null);
+    Service svc =
+        svcs.getItems()
+            .stream()
+            .filter(s -> s.getSpec().getSelector().containsKey(selectorKey))
+            .filter(s -> s.getSpec().getSelector().get(selectorKey).equals(selectorValue))
+            .findAny()
+            .orElse(null);
 
-      if (svc == null) {
-        LOG.warn("No Service with selector {}={} could be found", selectorKey, selectorValue);
-      }
-      return svc;
+    if (svc == null) {
+      LOG.warn("No Service with selector {}={} could be found", selectorKey, selectorValue);
     }
+    return svc;
   }
 
   public static List<Route> getRoutesByLabel(
-      final String labelKey, final String labelValue, final String namespace, final Config config)
+      final String labelKey,
+      final String labelValue,
+      final String namespace,
+      final Config config,
+      final OpenShiftClientFactory ocFactory)
       throws IOException {
-    try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient(config)) {
-      RouteList routeList =
-          openShiftClient.routes().inNamespace(namespace).withLabel(labelKey, labelValue).list();
+    OpenShiftClient openShiftClient = ocFactory.newOcClient(config);
+    RouteList routeList =
+        openShiftClient.routes().inNamespace(namespace).withLabel(labelKey, labelValue).list();
 
-      List<Route> items = routeList.getItems();
+    List<Route> items = routeList.getItems();
 
-      if (items.isEmpty()) {
-        LOG.warn("No Route with label {}={} could be found", labelKey, labelValue);
-        throw new IOException(
-            "No Route with label " + labelKey + "=" + labelValue + " could be found");
-      }
-
-      return items;
+    if (items.isEmpty()) {
+      LOG.warn("No Route with label {}={} could be found", labelKey, labelValue);
+      throw new IOException(
+          "No Route with label " + labelKey + "=" + labelValue + " could be found");
     }
+
+    return items;
   }
 
   public static List<ReplicaSet> getReplicaSetByLabel(
-      final String key, final String value, final String namespace, final Config config) {
-    try (OpenShiftClient openShiftClient = new DefaultOpenShiftClient(config)) {
-      List<ReplicaSet> replicaSets =
-          openShiftClient
-              .extensions()
-              .replicaSets()
-              .inNamespace(namespace)
-              .withLabel(key, value)
-              .list()
-              .getItems();
-      return replicaSets;
-    }
+      final String key,
+      final String value,
+      final String namespace,
+      final Config config,
+      final OpenShiftClientFactory ocFactory) {
+    DefaultKubernetesClient kubeClient = ocFactory.newKubeClient(config);
+    List<ReplicaSet> replicaSets =
+        kubeClient
+            .extensions()
+            .replicaSets()
+            .inNamespace(namespace)
+            .withLabel(key, value)
+            .list()
+            .getItems();
+    return replicaSets;
   }
 }


### PR DESCRIPTION
### What does this PR do?

Fix the OpenshiftClient connection leaks ... while reusing a common `OkHttpClient` instance as much as possible (not possible in some cases, like `startExec()`, that involve
`InputStreamPumper` and broken pipes).

### What issues does this PR fix or reference?

This PR is related to the issue discussed [here](https://github.com/eclipse/che/issues/5902#issuecomment-346858757) and [here](https://github.com/eclipse/che/issues/5902#issuecomment-348516145), as well as this initial issue of the `OpenshiftConnector` : https://issues.jboss.org/browse/CHE-180

It fixes these issues in a way that is compatible with the CHE-5-based OSIO multi-tenant server.