### PR TITLE
Add handling for avoid unstable after getting data from the Swagger page

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.swagger;
 
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
@@ -20,7 +19,6 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Swagger;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -46,11 +44,6 @@ public class SwaggerTest {
   public void checkNameProjectTest() throws Exception {
     driver.navigate().to(swaggerUrl);
 
-    try {
-      assertTrue(swagger.getWsNamesFromWorkspacePage().contains(workspace.getName()));
-    } catch (IllegalStateException | StaleElementReferenceException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/6015", ex);
-    }
+    assertTrue(swagger.getWsNamesFromWorkspacePage().contains(workspace.getName()));
   }
 }


### PR DESCRIPTION
### What does this PR do?
* Sometimes when we get text from swagger page the JSON may be in rendering state. In this case we get invalid data for further DTO converting. For avoiding this problem in the page object has been added loop, with 2 attempts. Each attempt has 500 msec delay for end of rendering page

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7705
@dmytro-ndp, @tolusha, @vparfonov 