### PR TITLE
Add ability to fast reveal and collapse resources

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -26,6 +26,12 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("extension.category")
   String extensionCategory();
 
+  @Key("action.revealResource.text")
+  String actionRevealResourceText();
+
+  @Key("action.revealResource.description")
+  String actionRevealResourceDescription();
+
   @Key("action.navigateToFile.text")
   String actionNavigateToFileText();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CollapseAllAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CollapseAllAction.java
@@ -12,13 +12,9 @@ package org.eclipse.che.ide.actions;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.action.BaseAction;
-import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
-import org.eclipse.che.ide.api.parts.ActivePartChangedHandler;
-import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 
 /**
@@ -27,37 +23,25 @@ import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
  * @author Vlad Zhukovskiy
  */
 @Singleton
-public class CollapseAllAction extends BaseAction implements ActivePartChangedHandler {
-
+public class CollapseAllAction extends BaseAction {
   private ProjectExplorerPresenter projectExplorer;
-
-  private PartPresenter activePart;
 
   @Inject
   public CollapseAllAction(
-      ProjectExplorerPresenter projectExplorer,
-      EventBus eventBus,
-      CoreLocalizationConstant localizationConstant) {
+      ProjectExplorerPresenter projectExplorer, CoreLocalizationConstant localizationConstant) {
     super(
         localizationConstant.collapseAllActionTitle(),
         localizationConstant.collapseAllActionDescription());
     this.projectExplorer = projectExplorer;
-
-    eventBus.addHandler(ActivePartChangedEvent.TYPE, this);
   }
 
   @Override
   public void update(ActionEvent e) {
-    e.getPresentation().setEnabledAndVisible(activePart instanceof ProjectExplorerPresenter);
+    e.getPresentation().setEnabledAndVisible(true);
   }
 
   @Override
   public void actionPerformed(ActionEvent e) {
     projectExplorer.collapseAll();
-  }
-
-  @Override
-  public void onActivePartChanged(ActivePartChangedEvent event) {
-    activePart = event.getActivePart();
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -43,6 +43,8 @@ import static org.eclipse.che.ide.api.constraints.Constraints.FIRST;
 import static org.eclipse.che.ide.api.constraints.Constraints.LAST;
 import static org.eclipse.che.ide.part.editor.recent.RecentFileStore.RECENT_GROUP_ID;
 import static org.eclipse.che.ide.projecttype.BlankProjectWizardRegistrar.BLANK_CATEGORY;
+import static org.eclipse.che.ide.util.input.KeyCodeMap.ARROW_DOWN;
+import static org.eclipse.che.ide.util.input.KeyCodeMap.ARROW_UP;
 
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.inject.Inject;
@@ -195,6 +197,8 @@ public class StandardComponentInitializer {
   public static final String EVENT_LOGS_DISPLAYING_MODE = "eventLogsDisplayingMode";
   public static final String EDITOR_DISPLAYING_MODE = "editorDisplayingMode";
   public static final String TERMINAL_DISPLAYING_MODE = "terminalDisplayingMode";
+  public static final String REVEAL_RESOURCE = "revealResourceInProjectTree";
+  public static final String COLLAPSE_ALL = "collapseAll";
 
   public interface ParserResource extends ClientBundle {
     @Source("org/eclipse/che/ide/blank.svg")
@@ -602,9 +606,6 @@ public class StandardComponentInitializer {
     editGroup.add(switchPreviousEditorAction);
     editGroup.add(switchNextEditorAction);
 
-    editGroup.addSeparator();
-    editGroup.add(revealResourceAction);
-
     // Assistant (New Menu)
     DefaultActionGroup assistantGroup =
         (DefaultActionGroup) actionManager.getAction(GROUP_ASSISTANT);
@@ -691,6 +692,7 @@ public class StandardComponentInitializer {
     resourceOperation.add(downloadResourceAction);
     resourceOperation.add(refreshPathAction);
     resourceOperation.add(linkWithEditorAction);
+    resourceOperation.add(collapseAllAction);
     resourceOperation.addSeparator();
     resourceOperation.add(convertFolderToProjectAction);
     resourceOperation.addSeparator();
@@ -711,6 +713,7 @@ public class StandardComponentInitializer {
     partMenuGroup.add(hidePartAction);
     partMenuGroup.add(restorePartAction);
     partMenuGroup.add(showConsoleTreeAction);
+    partMenuGroup.add(revealResourceAction);
     partMenuGroup.add(collapseAllAction);
     partMenuGroup.add(refreshPathAction);
     partMenuGroup.add(linkWithEditorAction);
@@ -731,12 +734,12 @@ public class StandardComponentInitializer {
     actionManager.registerAction("goInto", goIntoAction);
     actionManager.registerAction(SHOW_REFERENCE, showReferenceAction);
 
-    actionManager.registerAction("collapseAll", collapseAllAction);
+    actionManager.registerAction(REVEAL_RESOURCE, revealResourceAction);
+    actionManager.registerAction(COLLAPSE_ALL, collapseAllAction);
 
     actionManager.registerAction("openFile", openFileAction);
     actionManager.registerAction(SWITCH_LEFT_TAB, switchPreviousEditorAction);
     actionManager.registerAction(SWITCH_RIGHT_TAB, switchNextEditorAction);
-    actionManager.registerAction("scrollFromSource", revealResourceAction);
 
     changeResourceGroup.add(cutResourceAction);
     changeResourceGroup.add(copyResourceAction);
@@ -808,6 +811,9 @@ public class StandardComponentInitializer {
     editorContextMenuGroup.addSeparator();
     editorContextMenuGroup.add(fullTextSearchAction);
     editorContextMenuGroup.add(closeActiveEditorAction);
+
+    editorContextMenuGroup.addSeparator();
+    editorContextMenuGroup.add(revealResourceAction);
 
     // Define hot-keys
     keyBinding
@@ -882,6 +888,13 @@ public class StandardComponentInitializer {
     keyBinding
         .getGlobal()
         .addKey(new KeyBuilder().alt().charCode('T').build(), TERMINAL_DISPLAYING_MODE);
+
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().action().charCode(ARROW_DOWN).build(), REVEAL_RESOURCE);
+    keyBinding
+        .getGlobal()
+        .addKey(new KeyBuilder().action().charCode(ARROW_UP).build(), COLLAPSE_ALL);
 
     if (UserAgent.isMac()) {
       keyBinding

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -471,9 +471,8 @@ public class ProjectExplorerPresenter extends BasePresenter
   }
 
   /** Collapse all non-leaf nodes. */
-  @Deprecated
   public void collapseAll() {
-    view.collapseAll();
+    doCollapse();
   }
 
   /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/RevealResourceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/action/RevealResourceAction.java
@@ -21,6 +21,7 @@ import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
+import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
@@ -44,8 +45,12 @@ public class RevealResourceAction extends AbstractPerspectiveAction {
   private final EventBus eventBus;
 
   @Inject
-  public RevealResourceAction(AppContext appContext, EventBus eventBus) {
-    super(singletonList(PROJECT_PERSPECTIVE_ID), "Reveal Resource");
+  public RevealResourceAction(
+      AppContext appContext, EventBus eventBus, CoreLocalizationConstant localizedConstant) {
+    super(
+        singletonList(PROJECT_PERSPECTIVE_ID),
+        localizedConstant.actionRevealResourceText(),
+        localizedConstant.actionRevealResourceDescription());
     this.appContext = appContext;
     this.eventBus = eventBus;
   }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -64,6 +64,10 @@ projectExplorer.titleBar.text=Projects Explorer
 
 projectExplorer.linkWithEditor.tooltip=Link with editor
 
+############### Reveal Resource ###############
+action.revealResource.text=Reveal in project explorer
+action.revealResource.description=Reveal resource in project explorer
+
 ############### Navigate To File ###############
 action.navigateToFile.text = Navigate to File
 action.navigateToFile.description = Navigate to file

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/constant/TestMenuCommandsConstants.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/constant/TestMenuCommandsConstants.java
@@ -61,7 +61,6 @@ public interface TestMenuCommandsConstants {
     String RENAME = EDIT_MENU_PREFIX + "renameResource";
     String DELETE = EDIT_MENU_PREFIX + "deleteItem";
     String FIND = EDIT_MENU_PREFIX + "fullTextSearch";
-    String REVEAL_RESOURCE = EDIT_MENU_PREFIX + "scrollFromSource";
     String OPEN_RECENT_FILE = EDIT_MENU_PREFIX + "openRecentFiles";
 
     interface Recent {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.action.ActionsFactory;
-import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants;
 import org.eclipse.che.selenium.core.constant.TestTimeoutsConstants;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
@@ -119,6 +118,7 @@ public class ProjectExplorer {
     String MAXIMIZE = "gwt-debug-contextMenu/Maximize";
     String HIDE = "gwt-debug-contextMenu/Hide";
     String COLLAPSE_ALL = "gwt-debug-contextMenu/collapseAll";
+    String REVEAL_RESOURCE = "gwt-debug-contextMenu/revealResourceInProjectTree";
     String REFRESH_MAIN = "gwt-debug-contextMenu/refreshPathAction";
     String LINK_WITH_EDITOR = "gwt-debug-contextMenu/linkWithEditor";
   }
@@ -639,6 +639,12 @@ public class ProjectExplorer {
     actions.keyUp(Keys.CONTROL).perform();
   }
 
+  /** Click on the 'Reveal in project explorer' in 'Options'menu */
+  public void revealResourceByOptionsButton() {
+    clickOnProjectExplorerOptionsButton();
+    clickOnOptionsMenuItem(ProjectExplorerOptionsMenuItem.REVEAL_RESOURCE);
+  }
+
   /** click on the 'collapse all' in the project explorer */
   public void collapseProjectTreeByOptionsButton() {
     clickOnProjectExplorerOptionsButton();
@@ -887,8 +893,7 @@ public class ProjectExplorer {
     navigateToFile.waitListOfFilesNames(file);
     navigateToFile.selectFileByName(file);
     navigateToFile.waitFormToClose();
-    menu.runCommand(
-        TestMenuCommandsConstants.Edit.EDIT, TestMenuCommandsConstants.Edit.REVEAL_RESOURCE);
+    revealResourceByOptionsButton();
     waitItem(pathToFile);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/KeyBindingsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/KeyBindingsTest.java
@@ -89,7 +89,7 @@ public class KeyBindingsTest {
     menu.runCommand(
         TestMenuCommandsConstants.Assistant.ASSISTANT,
         TestMenuCommandsConstants.Assistant.KEY_BINDINGS);
-    keyBindings.checkSearchResultKeyBinding("open", 5);
+    keyBindings.checkSearchResultKeyBinding("open", 6);
     keyBindings.clickOkButton();
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckRecentFilesAndRevealResourceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckRecentFilesAndRevealResourceTest.java
@@ -75,8 +75,7 @@ public class CheckRecentFilesAndRevealResourceTest {
     editor.goToCursorPositionVisible(5, 1);
     projectExplorer.collapseProjectTreeByOptionsButton();
     projectExplorer.waitDisappearItemByPath(PATH_TO_FILE_FIRST_PROJECT);
-    menu.runCommand(
-        TestMenuCommandsConstants.Edit.EDIT, TestMenuCommandsConstants.Edit.REVEAL_RESOURCE);
+    projectExplorer.revealResourceByOptionsButton();
     projectExplorer.waitItem(PATH_TO_FILE_FIRST_PROJECT);
   }
 


### PR DESCRIPTION
### What does this PR do?
- Rename 'Reveal resource' to 'Reveal in project explorer' action title
- Add hotkeys:
Ctrl+↓ for Reveal in project explorer action
Ctrl+↑ for Collapse All action
- Move 'Reveal resource' action from 'Edit' menu in 'Options'

![options](https://user-images.githubusercontent.com/5676062/33839049-e5a59d52-de99-11e7-8398-3a5d1843272b.png)
- Add 'Reveal resource' action to editor context menu

![editorcontext](https://user-images.githubusercontent.com/5676062/33839147-295ab014-de9a-11e7-981c-8c664ca4005b.png)
- Add 'Collapse All' action to resource context menu

![projecttreecontext](https://user-images.githubusercontent.com/5676062/33839306-7e1ec5fe-de9a-11e7-9442-e55a231eba96.png)


### What issues does this PR fix or reference?
#7163 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>