### PR TITLE
Selenium: Add workspace templates into resources

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/WorkspaceTemplate.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/WorkspaceTemplate.java
@@ -20,7 +20,7 @@ public class WorkspaceTemplate {
   public static final String UBUNTU_LSP = "ubuntu_with_c_sharp_lsp.json";
   public static final String ECLIPSE_NODEJS = "eclipse_nodejs.json";
   public static final String ECLIPSE_PHP = "eclipse_php.json";
-  public static final String CODENVY_UBUNTU_JDK8 = "codenvy_ubuntu_jdk8.json";
+  public static final String UBUNTU_JDK8 = "ubuntu_jdk8.json";
   public static final String UBUNTU = "ubuntu.json";
   public static final String DEFAULT = "default.json";
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SU
 import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.workspace.WorkspaceTemplate.CODENVY_UBUNTU_JDK8;
+import static org.eclipse.che.selenium.core.workspace.WorkspaceTemplate.UBUNTU_JDK8;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.COMMON;
 
 import com.google.inject.Inject;
@@ -30,6 +30,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.user.TestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.utils.WorkspaceDtoDeserializer;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceImpl;
@@ -69,7 +70,7 @@ public class CheckSimpleGwtAppTest {
     projectName = NameGenerator.generate("project", 4);
 
     WorkspaceConfigDto workspace =
-        workspaceDtoDeserializer.deserializeWorkspaceTemplate(CODENVY_UBUNTU_JDK8);
+        workspaceDtoDeserializer.deserializeWorkspaceTemplate(UBUNTU_JDK8);
 
     workspace
         .getEnvironments()
@@ -133,6 +134,9 @@ public class CheckSimpleGwtAppTest {
             .getServerFromDevMachineBySymbolicName(testWorkspace.getId(), GWT_CODESERVER_NAME)
             .getUrl()
             .replace("tcp", "http");
+
+    // the timeout needs for che6-ocp platform
+    WaitUtils.sleepQuietly(10);
     seleniumWebDriver.get(url);
 
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -71,7 +71,7 @@ public class JavaTestPluginTestNgTest {
   public static final String END_OF_FAILED_TEST =
       "===============================================Default SuiteTotal tests run: 1, Failures: 1, Skips: 0===============================================";
 
-  @InjectTestWorkspace(template = WorkspaceTemplate.CODENVY_UBUNTU_JDK8)
+  @InjectTestWorkspace(template = WorkspaceTemplate.UBUNTU_JDK8)
   private TestWorkspace ws;
 
   @Inject private Ide ide;

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/ubuntu_jdk8.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/docker/ubuntu_jdk8.json
@@ -3,7 +3,14 @@
     "replaced_name": {
       "machines": {
         "dev-machine": {
-          "servers": {
+          "installers": [
+            "org.eclipse.che.terminal",
+            "org.eclipse.che.ws-agent"
+          ],
+          "attributes": {
+            "memoryLimitBytes": "desired_memory_value"
+          },
+          "servers" : {
             "tomcat8" : {
               "port" : "8080",
               "protocol" : "http"
@@ -16,19 +23,11 @@
               "port" : "9876",
               "protocol" : "http"
             }
-          },
-          "installers": [
-            "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ls.csharp"
-          ],
-          "attributes": {
-            "memoryLimitBytes": "desired_memory_value"
           }
         }
       },
       "recipe": {
-        "content": "eclipse/dotnet_core",
+        "content": "eclipse/ubuntu_jdk8",
         "type": "dockerimage"
       }
     }

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu.json
@@ -1,0 +1,24 @@
+{
+  "environments": {
+    "replaced_name": {
+      "machines": {
+        "dev-machine": {
+          "servers": {},
+          "installers": [
+            "org.eclipse.che.terminal",
+            "org.eclipse.che.ws-agent"
+          ],
+          "attributes": {
+            "memoryLimitBytes": "desired_memory_value"
+          }
+        }
+      },
+      "recipe": {
+        "content": "ubuntu",
+        "type": "dockerimage"
+      }
+    }
+  },
+  "defaultEnv": "replaced_name",
+  "name": "replaced_name"
+}

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu_jdk8.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu_jdk8.json
@@ -3,7 +3,14 @@
     "replaced_name": {
       "machines": {
         "dev-machine": {
-          "servers": {
+          "installers": [
+            "org.eclipse.che.terminal",
+            "org.eclipse.che.ws-agent"
+          ],
+          "attributes": {
+            "memoryLimitBytes": "desired_memory_value"
+          },
+          "servers" : {
             "tomcat8" : {
               "port" : "8080",
               "protocol" : "http"
@@ -16,19 +23,11 @@
               "port" : "9876",
               "protocol" : "http"
             }
-          },
-          "installers": [
-            "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent",
-            "org.eclipse.che.ls.csharp"
-          ],
-          "attributes": {
-            "memoryLimitBytes": "desired_memory_value"
           }
         }
       },
       "recipe": {
-        "content": "eclipse/dotnet_core",
+        "content": "eclipse/ubuntu_jdk8",
         "type": "dockerimage"
       }
     }

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu_with_c_sharp_lsp.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu_with_c_sharp_lsp.json
@@ -3,14 +3,7 @@
     "replaced_name": {
       "machines": {
         "dev-machine": {
-          "installers": [
-            "org.eclipse.che.terminal",
-            "org.eclipse.che.ws-agent"
-          ],
-          "attributes": {
-            "memoryLimitBytes": "desired_memory_value"
-          },
-          "servers" : {
+          "servers": {
             "tomcat8" : {
               "port" : "8080",
               "protocol" : "http"
@@ -23,13 +16,20 @@
               "port" : "9876",
               "protocol" : "http"
             }
+          },
+          "installers": [
+            "org.eclipse.che.terminal",
+            "org.eclipse.che.ws-agent",
+            "org.eclipse.che.ls.csharp"
+          ],
+          "attributes": {
+            "memoryLimitBytes": "desired_memory_value"
           }
         }
       },
       "recipe": {
-        "content": "FROM codenvy/ubuntu_jdk8",
-        "contentType": "text/x-dockerfile",
-        "type": "dockerfile"
+        "content": "eclipse/dotnet_core",
+        "type": "dockerimage"
       }
     }
   },


### PR DESCRIPTION

### What does this PR do?
* Add some templates of workspaces to resources related to running selenium tests on CHE6-ocp platform
* Add timeout to the `CheckSimpleGwtAppTest` related to running on CHE6-ocp platform

### What issues does this PR fix or reference?
#7644
