### PR TITLE
Adapt webdriver.sh to Multiuser Che; add ability to set rerun attempts

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -53,13 +53,14 @@ initVariables() {
 
     readonly MAX_RERUN=2
 
+    export CHE_MULTIUSER=${CHE_MULTIUSER:-false}
+
     # CALLER variable contains parent caller script name
     # CUR_DIR variable contains the current directory where CALLER is executed
     [[ -z ${CALLER+x} ]] && { CALLER=$(basename $0); }
     [[ -z ${CUR_DIR+x} ]] && { CUR_DIR=$(cd "$(dirname "$0")"; pwd); }
 
     [[ -z ${API_SUFFIX+x} ]] && { API_SUFFIX="/api/"; }
-    [[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/che-integration-tests-che6/"; }
 
     MODE="grid"
     GRID_OPTIONS="-Dgrid.mode=true"
@@ -78,7 +79,6 @@ initVariables() {
     PRODUCT_PROTOCOL="http"
     PRODUCT_HOST=$(detectDockerInterfaceIp)
     PRODUCT_PORT=8080
-    export CHE_MULTIUSER=${CHE_MULTIUSER:-false}
 
     unset DEBUG_OPTIONS
     unset MAVEN_OPTIONS
@@ -506,6 +506,15 @@ detectLatestResultsUrl() {
 fetchActualResults() {
     unset ACTUAL_RESULTS
     unset ACTUAL_RESULTS_URL
+
+    # define the URL of CI job to compare result with it
+    if [[ ${CHE_MULTIUSER} == true ]]; then
+      local nameOfCIJob=che-multiuser-integration-tests-che6
+    else
+      local nameOfCIJob=che-integration-tests-che6
+    fi
+
+    [[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/$nameOfCIJob/"; }
 
     local job=$(echo $@ | sed 's/.*--compare-with-ci\W\+\([0-9]\+\).*/\1/')
     if [[ ! ${job} =~ ^[0-9]+$ ]]; then

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -78,6 +78,7 @@ initVariables() {
     PRODUCT_PROTOCOL="http"
     PRODUCT_HOST=$(detectDockerInterfaceIp)
     PRODUCT_PORT=8080
+    export CHE_MULTIUSER=${CHE_MULTIUSER:-false}
 
     unset DEBUG_OPTIONS
     unset MAVEN_OPTIONS
@@ -97,15 +98,15 @@ checkParameters() {
     for var in "$@"; do
         if [[ "$var" =~ --web-driver-version=.* ]]; then :
         elif [[ "$var" =~ --web-driver-port=[0-9]+$ ]]; then :
-        elif [[ "$var" == "--http" ]]; then :
-        elif [[ "$var" == "--https" ]]; then :
-        elif [[ "$var" == "--che" ]]; then :
+        elif [[ "$var" == --http ]]; then :
+        elif [[ "$var" == --https ]]; then :
+        elif [[ "$var" == --che ]]; then :
         elif [[ "$var" =~ --host=.* ]]; then :
         elif [[ "$var" =~ --port=.* ]]; then :
         elif [[ "$var" =~ --threads=[0-9]+$ ]]; then :
-        elif [[ "$var" == "--rerun" ]]; then :
-        elif [[ "$var" == "--debug" ]]; then :
-        elif [[ "$var" == "--all-tests" ]]; then
+        elif [[ "$var" == --rerun ]]; then :
+        elif [[ "$var" == --debug ]]; then :
+        elif [[ "$var" == --all-tests ]]; then
             echo "[WARN] '--all-tests' parameter is outdated and is being ignored"
 
         elif [[ "$var" =~ --test=.* ]]; then
@@ -130,17 +131,18 @@ checkParameters() {
                 exit 1;
             }
 
-        elif [[ "$var" == "--failed-tests" ]]; then :
-        elif [[ "$var" == "--regression-tests" ]]; then :
+        elif [[ "$var" == --failed-tests ]]; then :
+        elif [[ "$var" == --regression-tests ]]; then :
         elif [[ "$var" =~ -M.* ]]; then :
         elif [[ "$var" =~ -P.* ]]; then :
-        elif [[ "$var" == "--help" ]]; then :
-        elif [[ "$var" == "--compare-with-ci" ]]; then :
+        elif [[ "$var" == --help ]]; then :
+        elif [[ "$var" == --compare-with-ci ]]; then :
         elif [[ "$var" =~ ^--workspace-pool-size=(auto|[0-9]+)$ ]]; then :
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
         elif [[ "$var" =~ ^-D.* ]]; then :
         elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
-        elif [[ "$var" == "--skip-sources-validation" ]]; then :
+        elif [[ "$var" == --skip-sources-validation ]]; then :
+        elif [[ "$var" == --multiuser ]]; then :
         else
             printHelp
             echo "[TEST] Unrecognized or misused parameter "${var}
@@ -161,10 +163,10 @@ applyCustomOptions() {
                 WEBDRIVER_PORT=$(echo "$var" | sed -e "s/--web-driver-port=//g")
             fi
 
-        elif [[ "$var" == "--http" ]]; then
+        elif [[ "$var" == --http ]]; then
             PRODUCT_PROTOCOL="http"
 
-        elif [[ "$var" == "--https" ]]; then
+        elif [[ "$var" == --https ]]; then
             PRODUCT_PROTOCOL="https"
 
         elif [[ "$var" =~ --host=.* ]]; then
@@ -179,15 +181,18 @@ applyCustomOptions() {
         elif [[ "$var" =~ --workspace-pool-size=.* ]]; then
             WORKSPACE_POOL_SIZE=$(echo "$var" | sed -e "s/--workspace-pool-size=//g")
 
-        elif [[ "$var" == "--rerun" ]]; then
+        elif [[ "$var" == --rerun ]]; then
             RERUN=true
 
-        elif [[ "$var" == "--debug" ]]; then
+        elif [[ "$var" == --debug ]]; then
             DEBUG_OPTIONS="-Dmaven.failsafe.debug"
             NODE_CHROME_DEBUG_SUFFIX="-debug"
 
-        elif [[ "$var" == "--compare-with-ci" ]]; then
+        elif [[ "$var" == --compare-with-ci ]]; then
             COMPARE_WITH_CI=true
+
+        elif [[ "$var" == --multiuser ]]; then
+            CHE_MULTIUSER=true
 
         fi
     done
@@ -215,11 +220,11 @@ defineTestsScope() {
         elif [[ "$var" =~ --suite=.* ]]; then
             TESTS_SCOPE="-DrunSuite=src/test/resources/suites/"$(echo "$var" | sed -e "s/--suite=//g")
 
-        elif [[ "$var" == "--failed-tests" ]]; then
+        elif [[ "$var" == --failed-tests ]]; then
             generateTestNgFailedReport $(fetchFailedTests)
             TESTS_SCOPE="-DrunSuite=${TESTNG_FAILED_SUITE}"
 
-        elif [[ "$var" == "--regression-tests" ]]; then
+        elif [[ "$var" == --regression-tests ]]; then
             generateTestNgFailedReport $(findRegressions)
             TESTS_SCOPE="-DrunSuite=${TESTNG_FAILED_SUITE}"
         fi

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -423,7 +423,7 @@ HOW TO of usage:
         ${CALLER} -Mlocal --test=<TEST> --debug
 
     Analyse tests results:
-        ${CALLER} --compare-with-ci [CI job number]
+        ${CALLER} --compare-with-ci [BUILD NUMBER]
 "
 
     printf "%s" "${usage}"
@@ -497,8 +497,8 @@ fetchFailedTestsNumber() {
 }
 
 detectLatestResultsUrl() {
-    local job=$(curl -s ${BASE_ACTUAL_RESULTS_URL} | tr '\n' ' ' | sed 's/.*Last build (#\([0-9]\+\)).*/\1/')
-    echo ${BASE_ACTUAL_RESULTS_URL}${job}"/testReport/"
+    local build=$(curl -s ${BASE_ACTUAL_RESULTS_URL} | tr '\n' ' ' | sed 's/.*Last build (#\([0-9]\+\)).*/\1/')
+    echo ${BASE_ACTUAL_RESULTS_URL}${build}"/testReport/"
 }
 
 # Fetches list of failed tests and failed configurations.
@@ -507,7 +507,7 @@ fetchActualResults() {
     unset ACTUAL_RESULTS
     unset ACTUAL_RESULTS_URL
 
-    # define the URL of CI job to compare result with it
+    # define the URL of CI job to compare result with result on it
     if [[ ${CHE_MULTIUSER} == true ]]; then
       local nameOfCIJob=che-multiuser-integration-tests-che6
     else
@@ -516,11 +516,11 @@ fetchActualResults() {
 
     [[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/$nameOfCIJob/"; }
 
-    local job=$(echo $@ | sed 's/.*--compare-with-ci\W\+\([0-9]\+\).*/\1/')
-    if [[ ! ${job} =~ ^[0-9]+$ ]]; then
+    local build=$(echo $@ | sed 's/.*--compare-with-ci\W\+\([0-9]\+\).*/\1/')
+    if [[ ! ${build} =~ ^[0-9]+$ ]]; then
         ACTUAL_RESULTS_URL=$(detectLatestResultsUrl)
     else
-        ACTUAL_RESULTS_URL=${BASE_ACTUAL_RESULTS_URL}${job}"/testReport/"
+        ACTUAL_RESULTS_URL=${BASE_ACTUAL_RESULTS_URL}${build}"/testReport/"
     fi
 
     # get list of failed tests from CI server, remove duplicates from it and sort
@@ -650,11 +650,11 @@ printProposals() {
     fi
 
     echo "[TEST]"
-    echo "[TEST] To compare tests results with the latest CI job"
+    echo "[TEST] To compare tests results with the latest results on CI job"
     echo -e "[TEST] \t${BLUE}${CUR_DIR}/${CALLER} ${cmd} --compare-with-ci${NO_COLOUR}"
     echo "[TEST]"
-    echo "[TEST] To compare tests results with results of the specific CI job"
-    echo -e "[TEST] \t${BLUE}${CUR_DIR}/${CALLER} ${cmd} --compare-with-ci CI_JOB_NUMBER${NO_COLOUR}"
+    echo "[TEST] To compare local tests results with certain build on CI job"
+    echo -e "[TEST] \t${BLUE}${CUR_DIR}/${CALLER} ${cmd} --compare-with-ci [BUILD NUMBER]${NO_COLOUR}"
     echo "[TEST]"
     echo "[TEST]"
 }

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -187,7 +187,7 @@ applyCustomOptions() {
             if [[ "$rerunAttempts" =~ ^[0-9]+$ ]]; then
               RERUN_ATTEMPTS=$rerunAttempts
             else
-              RERUN_ATTEMPTS=2
+              RERUN_ATTEMPTS=1
             fi
 
         elif [[ "$var" == --debug ]]; then
@@ -397,9 +397,9 @@ Handle failing tests:
     --failed-tests                      Rerun failed tests that left after the previous try
     --regression-tests                  Rerun regression tests that left after the previous try
     --rerun [ATTEMPTS]                  Automatically rerun failing tests.
-                                        Default attempts number is 2.
+                                        Default attempts number is 1.
     --compare-with-ci [BUILD NUMBER]    Compare failed tests with results on CI server.
-                                        Default build is latest.
+                                        Default build is the latest.
 
 Other options:
     --debug                             Run tests in debug mode
@@ -702,7 +702,7 @@ rerunTests() {
     local total=$(echo ${regressions[@]} | wc -w)
 
     if [[ ! ${total} -eq 0 ]]; then
-        local rerun=$1 && shift
+        local rerunCounter=$1 && shift
 
         analyseTestsResults $@
         generateFailSafeReport
@@ -712,14 +712,14 @@ rerunTests() {
 
         echo -e "[TEST]"
         echo -e "[TEST] ${YELLOW}---------------------------------------------------${NO_COLOUR}"
-        echo -e "[TEST] ${YELLOW}RERUNNING FAILED TESTS IN ONE THREAD: ATTEMPT #${rerun}${NO_COLOUR}"
+        echo -e "[TEST] ${YELLOW}RERUNNING FAILED TESTS IN ONE THREAD: ATTEMPT #${rerunCounter}${NO_COLOUR}"
         echo -e "[TEST] ${YELLOW}---------------------------------------------------${NO_COLOUR}"
 
         defineTestsScope "--failed-tests"
         runTests
 
-        if [[ ${rerun} < ${RERUN_ATTEMPTS} ]]; then
-            rerunTests $(($rerun+1)) $@
+        if [[ ${rerunCounter} < ${RERUN_ATTEMPTS} ]]; then
+            rerunTests $(($rerunCounter+1)) $@
         fi
     fi
 }

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -100,9 +100,9 @@ Handle failing tests:
     --failed-tests                      Rerun failed tests that left after the previous try
     --regression-tests                  Rerun regression tests that left after the previous try
     --rerun [ATTEMPTS]                  Automatically rerun failing tests.
-                                        Default attempts number is 2.
+                                        Default attempts number is 1.
     --compare-with-ci [BUILD NUMBER]    Compare failed tests with results on CI server.
-                                        Default build is latest.
+                                        Default build is the latest.
 
 Other options:
     --debug                             Run tests in debug mode

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -132,7 +132,7 @@ HOW TO of usage:
         ./selenium-tests.sh -Mlocal --test=<TEST> --debug
 
     Analyse tests results:
-        ./selenium-tests.sh --compare-with-ci [CI job number]
+        ./selenium-tests.sh --compare-with-ci [BUILD NUMBER]
 ```
 
 

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -99,8 +99,10 @@ Define tests scope:
 Handle failing tests:
     --failed-tests                      Rerun failed tests that left after the previous try
     --regression-tests                  Rerun regression tests that left after the previous try
-    --rerun                             Automatically rerun failing tests
-    --compare-with-ci                   Compare failed tests with results on CI server
+    --rerun [ATTEMPTS]                  Automatically rerun failing tests.
+                                        Default attempts number is 2.
+    --compare-with-ci [BUILD NUMBER]    Compare failed tests with results on CI server.
+                                        Default build is latest.
 
 Other options:
     --debug                             Run tests in debug mode
@@ -116,7 +118,7 @@ HOW TO of usage:
         ./selenium-tests.sh --multiuser
 
     Test Eclipse Che assembly and automatically rerun failing tests:
-        ./selenium-tests.sh --rerun
+        ./selenium-tests.sh --rerun [ATTEMPTS]
 
     Run single test or package of tests:
         ./selenium-tests.sh <...> --test=<TEST>
@@ -126,7 +128,7 @@ HOW TO of usage:
 
     Rerun failed tests:
         ./selenium-tests.sh <...> --failed-tests
-        ./selenium-tests.sh <...> --failed-tests --rerun
+        ./selenium-tests.sh <...> --failed-tests --rerun [ATTEMPTS]
 
     Debug selenium test:
         ./selenium-tests.sh -Mlocal --test=<TEST> --debug

--- a/selenium/che-selenium-test/selenium-tests.sh
+++ b/selenium/che-selenium-test/selenium-tests.sh
@@ -31,22 +31,6 @@ for var in "$@"; do
     fi
 done
 
-index=0
-params=($*)
-cheMultiuserValue=${CHE_MULTIUSER:-false}
-for var in "$@"; do
-    if [[ "$var" =~ --multiuser ]]; then
-        cheMultiuserValue=true
-        unset params[$index]                     # remove "--multiuser" from parameters
-        break
-    fi
-    let "index+=1"
-done
-
-export CHE_MULTIUSER=$cheMultiuserValue
-
-set -- "${params[@]}"
-
 mvn $CLEAN_GOAL dependency:unpack-dependencies \
     -DincludeArtifactIds=che-selenium-core \
     -DincludeGroupIds=org.eclipse.che.selenium \


### PR DESCRIPTION
### What does this PR do?
- moves `--multiuser` parameter from **selenium-test.sh** to **webdriver.sh**;
- fixed **webdriver.sh** script to compare selenium testing results with multiuser CI job;
- makes it clear the difference between 'CI job' from 'build' in terms of comparison of test results;
- adds an ability to set exact number of rerun of selenium tests.

### What issues does this PR fix or reference?
- #7511
- #7512

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

#### Docs PR
https://github.com/eclipse/che-docs/pull/323