### PR TITLE
Selenium: apply changes for selenium tests from Che6 branch to master

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
@@ -111,6 +111,8 @@ public class EditorTabWidget extends Composite
     this.file = relatedEditorPart.getEditorInput().getFile();
     this.icon = relatedEditorPart.getTitleImage();
     this.title.setText(relatedEditorPart.getTitle());
+    // add "path" attribute describing the full path of opened file, will be used full for testing
+    this.title.getElement().setAttribute("path", file.getLocation().toString());
     this.id = title + UUID.uuid(4);
 
     iconPanel.add(getIcon());

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -1069,6 +1069,14 @@ public class CodenvyEditor {
     loader.waitOnClosed();
   }
 
+  public String getAssociatedPathFromTheTab(String nameOfOpenedFile) {
+    return redrawDriverWait
+        .until(
+            ExpectedConditions.visibilityOfElementLocated(
+                By.xpath(String.format(Locators.TAB_FILE_NAME_XPATH, nameOfOpenedFile))))
+        .getAttribute("path");
+  }
+
   /**
    * wait tab with expected name is present
    *

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NavigateToFile.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NavigateToFile.java
@@ -152,6 +152,7 @@ public class NavigateToFile {
                 By.xpath(format(Locators.FILE_NAME_LIST_SELECT_WITH_PATH, pathName))))
         .click();
     actionsFactory.createAction(seleniumWebDriver).doubleClick().perform();
+    waitFormToClose();
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
@@ -10,7 +10,10 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
@@ -27,17 +30,25 @@ import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.everrest.core.impl.provider.json.JsonValue;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** @author Andrey Chizhikov */
 @Singleton
 public class Swagger {
 
   private final SeleniumWebDriver seleniumWebDriver;
+  private static final Logger LOG = LoggerFactory.getLogger(SeleniumWebDriver.class);
 
   @Inject
   public Swagger(SeleniumWebDriver seleniumWebDriver) {
@@ -67,9 +78,13 @@ public class Swagger {
 
   /** expand 'workspace' item */
   private void expandWorkSpaceItem() {
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-        .until(ExpectedConditions.elementToBeClickable(workSpaceLink))
-        .click();
+    Wait fluentWait =
+        new FluentWait(seleniumWebDriver)
+            .withTimeout(LOAD_PAGE_TIMEOUT_SEC, SECONDS)
+            .pollingEvery(MINIMUM_SEC, SECONDS)
+            .ignoring(StaleElementReferenceException.class, NoSuchElementException.class);
+    fluentWait.until((ExpectedCondition<Boolean>) input -> workSpaceLink.isEnabled());
+    workSpaceLink.click();
   }
 
   /** collapse 'workspace' item */
@@ -112,12 +127,27 @@ public class Swagger {
     expandWorkSpaceItem();
     clickElementByXpath(Locators.GET_WORKSPACES);
     clickTryItOutByXpath(Locators.TRY_IT_OUT);
-    String json =
-        new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
-            .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(Locators.RESPONSE_BODY)))
-            .getText();
-    List<WorkspaceDto> workspaces =
-        DtoFactory.getInstance().createListDtoFromJson(json, WorkspaceDto.class);
+    List<WorkspaceDto> workspaces = new ArrayList<WorkspaceDto>();
+    // Sometimes when we get text from swagger page the JSON may be in rendering state. In this case
+    // we get invalid data.
+    // In this loop we perform 2 attempts with 500 msec. delay for getting correct data after full
+    // rendering page.
+    for (int i = 0; i < 2; i++) {
+      try {
+        workspaces =
+            DtoFactory.getInstance()
+                .createListDtoFromJson(
+                    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
+                        .until(
+                            ExpectedConditions.visibilityOfElementLocated(
+                                By.xpath(Locators.RESPONSE_BODY)))
+                        .getText(),
+                    WorkspaceDto.class);
+        break;
+      } catch (RuntimeException ex) {
+        WaitUtils.sleepQuietly(500, MILLISECONDS);
+      }
+    }
     return workspaces
         .stream()
         .map(workspaceDto -> workspaceDto.getConfig().getName())

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/CheckFindActionFeatureInCheTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/CheckFindActionFeatureInCheTest.java
@@ -28,60 +28,31 @@ import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class CheckFindActionFeatureInCheTest {
-  private static final String FIRST_ACTION_NAME = "con";
-  private static final String SECOND_ACTION_NAME = "comm";
+  private static final String FIRST_ACTION_NAME = "configu";
+  private static final String SECOND_ACTION_NAME = "commands";
   private static final String THIRD_ACTION_NAME = "che";
 
-  private static final String FIRST_ACTION_NAME_EXPECTED_ARRAY_LOCAL_MODE =
-      "Configuration...  Project\n"
-          + "Configure Classpath  Project\n"
-          + "Content Assist  Assistant\n"
-          + "Convert To Project  Project\n"
-          + "Edit Debug Configurations... [Alt+Shift+F9]  Run";
-
-  private static final String SECOND_ACTION_NAME_EXPECTED_ARRAY_LOCAL_MODE =
-      "Commands Palette [Shift+F10]  Run\n"
-          + "Commit ... [Alt+C]  GitCommandGroup\n"
-          + "Commit...  SvnFileCommandGroup\n"
-          + "Community  Help\n"
-          + "Revert commit...  GitCommandGroup\n"
-          + "SvnCredentialsCommandGroup  Subversion";
-
-  private static final String THIRD_ACTION_NAME_EXPECTED_ARRAY_LOCAL_MODE =
-      "Branches... [Ctrl+B]  GitCommandGroup\n" + "Checkout Reference...  GitCommandGroup";
-
-  private static final String FIRST_ACTION_NAME_EXPECTED_ARRAY_WITH_FLAG_LOCAL_MODE =
+  private static final String FIRST_EXPECTED_ITEMS_WITH_DISABLED_NONE_MENU_ACTIONS_CHECKBOX =
       "Update Project Configuration...  Project\n"
           + "Configure Classpath  Project\n"
-          + "Content Assist  Assistant\n"
-          + "Convert To Project  Project\n"
+          + "Edit Debug Configurations... [Alt+Shift+F9]  Run";
+
+  private static final String SECOND_EXPECTED_ITEMS_WITH_DISABLED_NONE_MENU_ACTIONS_CHECKBOX =
+      "Commands Palette [Shift+F10]  Run";
+
+  private static final String THIRD_EXPECTED_ITEMS_WITH_DISABLED_NONE_MENU_ACTIONS_CHECKBOX =
+      "Branches... [Ctrl+B]  GitCommandGroup\n" + "Checkout Reference...  GitCommandGroup";
+
+  private static final String FIRST_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
+      "Configuration \n"
+          + "Update Project Configuration...  Project\n"
+          + "Configure Classpath  Project\n"
           + "Edit Debug Configurations... [Alt+Shift+F9]  Run\n"
-          + "Import From Codenvy Config...  Project\n"
-          + "consolesTreeContextMenu \n"
-          + "debugGroupContextMenu \n"
-          + "editorTabContextMenu \n"
-          + "mainContextMenu \n"
-          + "projectExplorerContextMenu \n"
-          + "runGroupContextMenu ";
+          + "breakpointConfiguration ";
 
-  private static final String SECOND_ACTION_NAME_EXPECTED_ARRAY_WITH_FLAG_LOCAL_MODE =
-      "Commands \n"
-          + "Commands Palette [Shift+F10]  Run\n"
-          + "Commit ... [Alt+C]  GitCommandGroup\n"
-          + "Commit...  SvnFileCommandGroup\n"
-          + "Community  Help\n"
-          + "Execute default command of Debug goal [Alt+D] \n"
-          + "Execute default command of Run goal [Alt+R] \n"
-          + "GitCommandGroup \n"
-          + "Revert commit...  GitCommandGroup\n"
-          + "SvnAddCommandGroup \n"
-          + "SvnCredentialsCommandGroup  Subversion\n"
-          + "SvnFileCommandGroup \n"
-          + "SvnMiscellaneousCommandGroup \n"
-          + "SvnRemoteCommandGroup \n"
-          + "SvnRepositoryCommandGroup ";
-
-  private static final String THIRD_ACTION_NAME_EXPECTED_ARRAY_WITH_FLAG_LOCAL_MODE =
+  private static final String SECOND_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
+      "Commands \n" + "Commands Palette [Shift+F10]  Run";
+  private static final String THIRD_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX =
       "Branches... [Ctrl+B]  GitCommandGroup\n" + "Checkout Reference...  GitCommandGroup";
 
   private static final String PROJECT_NAME =
@@ -96,10 +67,7 @@ public class CheckFindActionFeatureInCheTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    URL resource =
-        CheckFindActionFeatureInCheTest.this
-            .getClass()
-            .getResource("/projects/default-spring-project");
+    URL resource = this.getClass().getResource("/projects/default-spring-project");
     testProjectServiceClient.importProject(
         testWorkspace.getId(),
         Paths.get(resource.toURI()),
@@ -118,6 +86,7 @@ public class CheckFindActionFeatureInCheTest {
 
   @Test(dataProvider = "checkingDataAllActionsData")
   public void checkSearchActionsForAllItemsTest(String actionName, String result) {
+    findAction.setCheckBoxInSelectedPosition();
     checkAction(actionName, result);
   }
 
@@ -130,18 +99,18 @@ public class CheckFindActionFeatureInCheTest {
   @DataProvider
   private Object[][] checkingDataWithMenuActionsOnly() {
     return new Object[][] {
-      {FIRST_ACTION_NAME, FIRST_ACTION_NAME_EXPECTED_ARRAY_LOCAL_MODE},
-      {SECOND_ACTION_NAME, SECOND_ACTION_NAME_EXPECTED_ARRAY_LOCAL_MODE},
-      {THIRD_ACTION_NAME, THIRD_ACTION_NAME_EXPECTED_ARRAY_LOCAL_MODE}
+      {FIRST_ACTION_NAME, FIRST_EXPECTED_ITEMS_WITH_DISABLED_NONE_MENU_ACTIONS_CHECKBOX},
+      {SECOND_ACTION_NAME, SECOND_EXPECTED_ITEMS_WITH_DISABLED_NONE_MENU_ACTIONS_CHECKBOX},
+      {THIRD_ACTION_NAME, THIRD_EXPECTED_ITEMS_WITH_DISABLED_NONE_MENU_ACTIONS_CHECKBOX}
     };
   }
 
   @DataProvider
   private Object[][] checkingDataAllActionsData() {
     return new Object[][] {
-      {FIRST_ACTION_NAME, FIRST_ACTION_NAME_EXPECTED_ARRAY_WITH_FLAG_LOCAL_MODE},
-      {SECOND_ACTION_NAME, SECOND_ACTION_NAME_EXPECTED_ARRAY_WITH_FLAG_LOCAL_MODE},
-      {THIRD_ACTION_NAME, THIRD_ACTION_NAME_EXPECTED_ARRAY_WITH_FLAG_LOCAL_MODE}
+      {FIRST_ACTION_NAME, FIRST_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX},
+      {SECOND_ACTION_NAME, SECOND_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX},
+      {THIRD_ACTION_NAME, THIRD_EXPECTED_ITEMS_WITH_ENABLED_NONE_MENU_ACTIONS_CHECKBOX}
     };
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -23,12 +23,10 @@ import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestStacksConstants;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.Loader;
-import org.eclipse.che.selenium.pageobject.MavenPluginStatusBar;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
-import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceProjects;
@@ -45,7 +43,6 @@ public class CreateAndDeleteProjectsTest {
   @Inject private Dashboard dashboard;
   @Inject private WorkspaceProjects workspaceProjects;
   @Inject private WorkspaceDetails workspaceDetails;
-  @Inject private NavigationBar navigationBar;
   @Inject private CreateWorkspace createWorkspace;
   @Inject private ProjectSourcePage projectSourcePage;
   @Inject private Loader loader;
@@ -54,7 +51,6 @@ public class CreateAndDeleteProjectsTest {
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private TestUser defaultTestUser;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
-  @Inject private MavenPluginStatusBar mavenPluginStatusBar;
   @Inject private Workspaces workspaces;
 
   @BeforeClass
@@ -88,7 +84,6 @@ public class CreateAndDeleteProjectsTest {
     explorer.waitProjectExplorer();
     explorer.waitItem(CONSOLE_JAVA_SIMPLE);
     notificationsPopupPanel.waitPopUpPanelsIsClosed();
-    mavenPluginStatusBar.waitClosingInfoPanel();
     explorer.waitFolderDefinedTypeOfFolderByPath(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);
     explorer.waitFolderDefinedTypeOfFolderByPath(WEB_JAVA_SPRING, PROJECT_FOLDER);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebugExternalClassTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebugExternalClassTest.java
@@ -121,35 +121,6 @@ public class DebugExternalClassTest {
   }
 
   @Test
-  public void shouldDebugJreClass() {
-    // when
-    editor.setInactiveBreakpoint(19);
-    menu.runCommandByXpath(
-        TestMenuCommandsConstants.Run.RUN_MENU,
-        TestMenuCommandsConstants.Run.DEBUG,
-        debugConfig.getXpathToІRunDebugCommand(PROJECT));
-
-    notifications.waitExpectedMessageOnProgressPanelAndClosed("Remote debugger connected");
-    editor.waitActiveBreakpoint(19);
-    debugPanel.clickOnButton(DebugPanel.DebuggerActionButtons.STEP_INTO);
-
-    // then
-    editor.waitActiveTabFileName("Logger"); // there should be class "Logger" opened
-    debugPanel.waitDebugHighlightedText(
-        "    "); // we can't rely on concrete code of external library which can be changed in
-    // future
-    debugPanel.waitTextInVariablesPanel(
-        "=\"Info from java logger\""); // there should be at least parameter with value "Info from
-    // java logger"
-
-    // when
-    debugPanel.clickOnButton(DebugPanel.DebuggerActionButtons.RESUME_BTN_ID);
-
-    // then
-    editor.waitActiveTabFileName("SimpleLogger");
-  }
-
-  @Test(priority = 1)
   public void shouldDebugMavenArtifactClassWithSources() {
     // when
     editor.setInactiveBreakpoint(23);
@@ -189,7 +160,7 @@ public class DebugExternalClassTest {
         "        org.apache.log4j.Logger log4jLogger = org.apache.log4j.Logger.getLogger(SimpleLogger.class);");
   }
 
-  @Test(priority = 2)
+  @Test(priority = 1)
   public void shouldHandleDebugOfMavenArtifactWithoutSources() {
     // when
     editor.setInactiveBreakpoint(27);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
@@ -140,7 +140,6 @@ public class InnerClassAndLambdaDebuggingTest {
 
     // then
     editor.waitActiveBreakpoint(53);
-    debugPanel.waitTextInVariablesPanel("methodValue=\"App method local inner test\"");
   }
 
   @Test(priority = 2)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -122,11 +122,12 @@ public class StepIntoStepOverStepReturnWithChangeVariableTest {
         TestMenuCommandsConstants.Run.DEBUG,
         TestMenuCommandsConstants.Run.DEBUG + "/" + PROJECT);
     editor.waitActiveBreakpoint(34);
-    String appUrl =
-        "http"
-            + "://"
-            + workspaceServiceClient.getServerAddressByPort(ws.getId(), 8080)
-            + "/spring/guess";
+    String appUrl = "";
+    //        workspaceServiceClient
+    //                .getServerFromDevMachineBySymbolicName(ws.getId(), "tomcat8")
+    //                .getUrl()
+    //                .replace("tcp", "http")
+    //            + "/spring/guess";
     String requestMess = "numGuess=6&submit=Ok";
     CompletableFuture<String> instToRequestThread =
         debugUtils.gotoDebugAppAndSendRequest(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -122,12 +122,11 @@ public class StepIntoStepOverStepReturnWithChangeVariableTest {
         TestMenuCommandsConstants.Run.DEBUG,
         TestMenuCommandsConstants.Run.DEBUG + "/" + PROJECT);
     editor.waitActiveBreakpoint(34);
-    String appUrl = "";
-    //        workspaceServiceClient
-    //                .getServerFromDevMachineBySymbolicName(ws.getId(), "tomcat8")
-    //                .getUrl()
-    //                .replace("tcp", "http")
-    //            + "/spring/guess";
+    String appUrl =
+        "http"
+            + "://"
+            + workspaceServiceClient.getServerAddressByPort(ws.getId(), 8080)
+            + "/spring/guess";
     String requestMess = "numGuess=6&submit=Ok";
     CompletableFuture<String> instToRequestThread =
         debugUtils.gotoDebugAppAndSendRequest(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -10,13 +10,10 @@
  */
 package org.eclipse.che.selenium.editor.autocomplete;
 
-import static org.testng.Assert.assertTrue;
-
 import com.google.inject.Inject;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.regex.Pattern;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
@@ -67,6 +64,7 @@ public class AutocompleteProposalJavaDocTest {
     ide.open(workspace);
     loader.waitOnClosed();
     projectExplorer.waitItem(PROJECT);
+    projectExplorer.selectItem(PROJECT);
     notificationsPopupPanel.waitProgressPopupPanelClose();
 
     projectExplorer.quickExpandWithJavaScript();
@@ -92,8 +90,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("concat(String part1, String part2, char divider) : String");
 
     // then
-    verifyJavaDoc(
-        editor.getAutocompleteProposalJavaDocHtml(),
+    editor.waitContextMenuJavaDocText(
         ".*<p><b>Deprecated.</b> <i> As of version 1.0, use "
             + "<code><a href='.*/javadoc/get\\?.*projectpath=/multi-module-java-with-ext-libs/app&handle=%E2%98%82%3Dmulti-module-java-with-ext-libs.*org.apache.commons.lang.StringUtils%E2%98%82join%E2%98%82Object\\+%5B%5D%E2%98%82char'>org.apache.commons.lang.StringUtils.join\\(Object \\[\\], char\\)</a></code>"
             + "</i><p>Returns concatination of two strings into one divided by special symbol."
@@ -115,7 +112,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("App()");
 
     // then
-    verifyJavaDoc(editor.getAutocompleteProposalJavaDocHtml(), ".*No documentation found.*");
+    editor.waitContextMenuJavaDocText(".*No documentation found.*");
   }
 
   @Test
@@ -128,8 +125,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("isEquals(Object o) : boolean");
 
     // then
-    verifyJavaDoc(
-        editor.getAutocompleteProposalJavaDocHtml(),
+    editor.waitContextMenuJavaDocText(
         ".*Returns <code>true</code> if the argument is equal to instance. otherwise <code>false</code>"
             + "<dl><dt>Parameters:</dt>"
             + "<dd><b>o</b> an object.</dd>"
@@ -157,9 +153,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("BookImpl");
 
     // then
-    verifyJavaDoc(
-        editor.getAutocompleteProposalJavaDocHtml(),
-        ".*UPDATE. Implementation of Book interface..*");
+    editor.waitContextMenuJavaDocText(".*UPDATE. Implementation of Book interface..*");
   }
 
   @Test
@@ -172,8 +166,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("hashCode() : int");
 
     // then
-    verifyJavaDoc(
-        editor.getAutocompleteProposalJavaDocHtml(),
+    editor.waitContextMenuJavaDocText(
         ".*Returns a hash code value for the object. "
             + "This method is supported for the benefit of hash tables such as those provided by "
             + "<code><a href='.*/javadoc/get\\?.*projectpath=/multi-module-java-with-ext-libs/app&handle=%E2%98%82%3Dmulti-module-java-with-ext-libs%5C%2Fapp%2F%5C%2Fopt%5C%2Fjdk1.8.0_45%5C%2Fjre%5C%2Flib%5C%2Frt.jar%3Cjava.lang%28Object.class%E2%98%83Object%7EhashCode%E2%98%82java.util.HashMap'>java.util.HashMap</a></code>.*");
@@ -189,7 +182,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("info(String arg0) : void");
 
     // then
-    verifyJavaDoc(editor.getAutocompleteProposalJavaDocHtml(), ".*No documentation found.*");
+    editor.waitContextMenuJavaDocText(".*No documentation found.*");
 
     // when
     editor.closeAutocomplete();
@@ -207,17 +200,10 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("info(String msg) : void");
 
     // then
-    verifyJavaDoc(
-        editor.getAutocompleteProposalJavaDocHtml(),
+    editor.waitContextMenuJavaDocText(
         ".*Log a message at the .* level."
             + "<dl><dt>Parameters:</dt>"
             + "<dd><b>msg</b>"
             + "  the message string to be logged</dd></dl>.*");
-  }
-
-  private void verifyJavaDoc(String javaDocHtml, String regex) {
-    assertTrue(
-        Pattern.compile(regex, Pattern.DOTALL).matcher(javaDocHtml).matches(),
-        String.format("Actual Java Doc HTML was '%s'.", javaDocHtml));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithSincePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithSincePolicyTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import org.eclipse.che.api.factory.shared.dto.PoliciesDto;
@@ -22,9 +24,9 @@ import org.eclipse.che.selenium.core.factory.TestFactoryInitializer;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.PopupDialogsBrowser;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.WarningDialog;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
-import org.testng.Assert;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -32,28 +34,26 @@ import org.testng.annotations.Test;
 /** @author Mihail Kuznyetsov */
 public class CheckFactoryWithSincePolicyTest {
   private static final String FACTORY_NAME = NameGenerator.generate("sincePolicy", 3);
-  private static final String EXPIRE_MESSAGE =
-      "Unable to load Factory: This Factory is not yet valid due to time restrictions applied"
+  private static final String ALERT_EXPIRE_MESSAGE =
+      "Error: This Factory is not yet valid due to time restrictions applied"
           + " by its owner. Please, contact owner for more information.";
-  private static final int FACTORY_INACTIVITY_TIME = 120000;
-  private static final int ADDITIONAL_TIME = 10000;
-  private static long initTime;
+  private static final long INIT_TIME = System.currentTimeMillis();
+  private static final int ADDITIONAL_TIME = 60000;
 
   @Inject private ProjectExplorer projectExplorer;
   @Inject private TestFactoryInitializer testFactoryInitializer;
   @Inject private PopupDialogsBrowser popupDialogsBrowser;
   @Inject private Dashboard dashboard;
   @Inject private SeleniumWebDriver seleniumWebDriver;
-  @Inject private WarningDialog warningDialog;
+
   private TestFactory testFactory;
 
   @BeforeClass
   public void setUp() throws Exception {
     TestFactoryInitializer.TestFactoryBuilder factoryBuilder =
         testFactoryInitializer.fromTemplate(FactoryTemplate.MINIMAL);
-    initTime = System.currentTimeMillis();
-    factoryBuilder.setPolicies(
-        newDto(PoliciesDto.class).withSince(initTime + FACTORY_INACTIVITY_TIME));
+    long initTime = System.currentTimeMillis();
+    factoryBuilder.setPolicies(newDto(PoliciesDto.class).withSince(initTime + ADDITIONAL_TIME));
     factoryBuilder.setName(FACTORY_NAME);
     testFactory = factoryBuilder.build();
   }
@@ -68,17 +68,17 @@ public class CheckFactoryWithSincePolicyTest {
     // check factory now, make sure its restricted
     dashboard.open();
     testFactory.open(seleniumWebDriver);
-    seleniumWebDriver.switchFromDashboardIframeToIde();
 
-    if (System.currentTimeMillis() > initTime + FACTORY_INACTIVITY_TIME) {
-      Assert.fail(
-          "Factory started longer then additional time and next test steps does not make sense");
-    }
-
-    warningDialog.waitWaitWarnDialogWindowWithSpecifiedTextMess(EXPIRE_MESSAGE);
+    // driver.get(factoryUrl);
+    new WebDriverWait(seleniumWebDriver, PREPARING_WS_TIMEOUT_SEC)
+        .until(ExpectedConditions.alertIsPresent());
+    assertTrue(
+        seleniumWebDriver.switchTo().alert().getText().contains(ALERT_EXPIRE_MESSAGE),
+        "actual message: " + seleniumWebDriver.switchTo().alert().getText());
+    popupDialogsBrowser.acceptAlert();
 
     // wait until factory becomes avaialble
-    while (System.currentTimeMillis() <= initTime + FACTORY_INACTIVITY_TIME + ADDITIONAL_TIME) {
+    while (System.currentTimeMillis() <= INIT_TIME + ADDITIONAL_TIME) {
       WaitUtils.sleepQuietly(1);
     }
 
@@ -86,6 +86,5 @@ public class CheckFactoryWithSincePolicyTest {
     testFactory.open(seleniumWebDriver);
     seleniumWebDriver.switchFromDashboardIframeToIde();
     projectExplorer.waitProjectExplorer();
-    warningDialog.waitWaitClosingWarnDialogWindow();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithUntilPolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithUntilPolicyTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
@@ -23,9 +25,9 @@ import org.eclipse.che.selenium.core.factory.TestFactoryInitializer;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.PopupDialogsBrowser;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.WarningDialog;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
-import org.testng.Assert;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -33,27 +35,25 @@ import org.testng.annotations.Test;
 /** @author Mihail Kuznyetsov */
 public class CheckFactoryWithUntilPolicyTest {
   private static final String FACTORY_NAME = NameGenerator.generate("untilPolicy", 3);
-  private static final String EXPIRE_MESSAGE =
-      "Unable to load Factory: This Factory has expired due to time restrictions applied by its owner. Please, contact owner for more information.";
-  private static final int FACTORY_INACTIVITY_TIME = 120000;
-  private static final int ADDITIONAL_TIME = 10000;
-  private static long initTime;
+  private static final String ALERT_EXPIRE_MESSAGE =
+      "Error: This Factory has expired due to time restrictions applied by its owner. Please, contact owner for more information.";
+  private static final long INIT_TIME = System.currentTimeMillis();
+  private static final int ADDITIONAL_TIME = 60000;
 
   @Inject private ProjectExplorer projectExplorer;
   @Inject private TestFactoryInitializer testFactoryInitializer;
   @Inject private PopupDialogsBrowser popupDialogsBrowser;
   @Inject private Dashboard dashboard;
   @Inject private SeleniumWebDriver seleniumWebDriver;
-  @Inject private WarningDialog warningDialog;
+
   private TestFactory testFactory;
 
   @BeforeClass
   public void setUp() throws Exception {
     TestFactoryInitializer.TestFactoryBuilder factoryBuilder =
         testFactoryInitializer.fromTemplate(FactoryTemplate.MINIMAL);
-    initTime = System.currentTimeMillis();
-    factoryBuilder.setPolicies(
-        newDto(PoliciesDto.class).withUntil(initTime + FACTORY_INACTIVITY_TIME));
+    long INIT_TIME = System.currentTimeMillis();
+    factoryBuilder.setPolicies(newDto(PoliciesDto.class).withUntil(INIT_TIME + ADDITIONAL_TIME));
     factoryBuilder.setName(FACTORY_NAME);
     testFactory = factoryBuilder.build();
   }
@@ -65,28 +65,26 @@ public class CheckFactoryWithUntilPolicyTest {
 
   @Test
   public void checkFactoryAcceptingWithUntilPolicy() throws Exception {
+    // first
     dashboard.open();
     testFactory.open(seleniumWebDriver);
     seleniumWebDriver.switchFromDashboardIframeToIde();
-
-    if (System.currentTimeMillis() > initTime + FACTORY_INACTIVITY_TIME) {
-      Assert.fail(
-          "Factory started longer then additional time and next test steps does not make sense");
-    }
-
-    // first
-    while (System.currentTimeMillis() <= initTime + FACTORY_INACTIVITY_TIME + ADDITIONAL_TIME) {
-      if (warningDialog.isPresent()) {
-        warningDialog.clickOkBtn();
+    projectExplorer.waitProjectExplorer();
+    while (System.currentTimeMillis() <= INIT_TIME + ADDITIONAL_TIME) {
+      if (popupDialogsBrowser.isAlertPresent()) {
+        popupDialogsBrowser.acceptAlert();
         fail("Factory expired before the until period");
       }
-      projectExplorer.waitProjectExplorer();
       WaitUtils.sleepQuietly(1);
     }
 
     // second
     testFactory.open(seleniumWebDriver);
-    seleniumWebDriver.switchFromDashboardIframeToIde();
-    warningDialog.waitWaitWarnDialogWindowWithSpecifiedTextMess(EXPIRE_MESSAGE);
+    new WebDriverWait(seleniumWebDriver, PREPARING_WS_TIMEOUT_SEC)
+        .until(ExpectedConditions.alertIsPresent());
+    assertTrue(
+        seleniumWebDriver.switchTo().alert().getText().contains(ALERT_EXPIRE_MESSAGE),
+        "actual message: " + seleniumWebDriver.switchTo().alert().getText());
+    popupDialogsBrowser.acceptAlert();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/RefactoringFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/RefactoringFeatureTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.filewatcher;
 
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -28,6 +29,7 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -96,7 +98,14 @@ public class RefactoringFeatureTest {
     prepareFiles(editor2, projectExplorer2);
     editor1.setCursorToDefinedLineAndChar(21, 14);
     doRenameRefactor();
-    checkWatching(expectedMessAfterRename);
+
+    try {
+      checkWatching(expectedMessAfterRename);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("https://github.com/eclipse/che/issues/5183", ex);
+    }
+
     editor2.waitTabIsNotPresent(renamedClassName);
     doMoveRefactor();
     projectExplorer1.openItemByVisibleNameInExplorer(renamedClassName);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckMavenPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckMavenPluginTest.java
@@ -10,13 +10,17 @@
  */
 package org.eclipse.che.selenium.mavenplugin;
 
+import static java.nio.file.Paths.get;
+import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.ERROR_MARKER;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.SIMPLE_FOLDER;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
+import java.net.URL;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
-import org.eclipse.che.selenium.core.constant.TestCommandsConstants;
+import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
@@ -27,7 +31,6 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.MavenPluginStatusBar;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.git.Git;
 import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
@@ -36,7 +39,6 @@ import org.testng.annotations.Test;
 /** @author Musienko Maxim */
 public class CheckMavenPluginTest {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 6);
-  private static final String CHECKOUT_COMMAND = "checkout";
 
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
@@ -48,96 +50,69 @@ public class CheckMavenPluginTest {
   @Inject private Loader loader;
   @Inject private AskForValueDialog askDialog;
   @Inject private Git git;
-
-  @Inject
-  @Named("github.username")
-  private String gitHubUsername;
+  @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @Inject private TestCommandServiceClient commandServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
-    commandServiceClient.createCommand(
-        "cd /projects/" + PROJECT_NAME + " && git checkout contrib-12042015",
-        CHECKOUT_COMMAND,
-        TestCommandsConstants.CUSTOM,
-        workspace.getId());
-
+    URL resource = getClass().getResource("/projects/check-maven-plugin-test");
+    testProjectServiceClient.importProject(
+        workspace.getId(), get(resource.toURI()), PROJECT_NAME, MAVEN_SPRING);
     ide.open(workspace);
     projectExplorer.waitProjectExplorer();
   }
 
   @Test
-  public void mavenStatusBarShouldDisplayResolvingProjectMessage() {
-    git.importJavaAppAndCheckMavenPluginBar(
-        "https://github.com/" + gitHubUsername + "/pushChangesTest.git",
-        PROJECT_NAME,
-        Wizard.TypeProject.MAVEN,
-        "Resolving project: SpringDemo");
-    mavenPluginStatusBar.waitClosingInfoPanel(100);
-    projectExplorer.waitItem(PROJECT_NAME);
-  }
-
-  @Test(priority = 1)
-  public void shouldExecuteCommandAndWaitTextInConsole() throws Exception {
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.COMMON, PROJECT_NAME, CHECKOUT_COMMAND);
-
-    console.waitExpectedTextIntoConsole("Switched to a new branch 'contrib-12042015'");
-  }
-
-  @Test(priority = 2)
   public void shouldAccessClassCreatedInAnotherModule() {
-    projectExplorer.expandPathInProjectExplorer(PROJECT_NAME + "/my-lib/src/main/java/hello");
+    projectExplorer.quickExpandWithJavaScript();
+    projectExplorer.selectItem(PROJECT_NAME + "/my-lib/src/main/java/hello");
     createNewFileFromMenuFile("TestClass", AskForValueDialog.JavaFiles.CLASS, ".java");
-
-    projectExplorer.clickCollapseAllButton();
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PROJECT_NAME + "/my-webapp/src/main/java/helloworld", "GreetingController.java");
+    projectExplorer.openItemByPath(
+        PROJECT_NAME + "/my-webapp/src/main/java/che/eclipse/sample/Aclass.java");
     editor.waitActiveEditor();
-    editor.setCursorToLine(24);
+    editor.setCursorToLine(14);
     enterClassNameViaAutocomplete();
     editor.typeTextIntoEditor(" testClass = new TestClass();");
     editor.waitAllMarkersDisappear(ERROR_MARKER);
   }
 
-  @Test(priority = 3)
-  public void excludeIncludeModules() {
-    projectExplorer.clickCollapseAllButton();
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(PROJECT_NAME, "pom.xml");
+  @Test(priority = 1)
+  public void shouldExcludeModules() {
+    projectExplorer.openItemByPath(PROJECT_NAME + "/pom.xml");
     editor.waitActiveEditor();
-    editor.setCursorToDefinedLineAndChar(13, 8);
+    editor.setCursorToDefinedLineAndChar(25, 8);
     editor.typeTextIntoEditor("!--");
-    editor.setCursorToDefinedLineAndChar(13, 32);
+    editor.setCursorToDefinedLineAndChar(26, 32);
     editor.typeTextIntoEditor("--");
-
-    projectExplorer.waitFolderDefinedTypeOfFolderByPath(
-        PROJECT_NAME + "/my-lib", ProjectExplorer.FolderTypes.SIMPLE_FOLDER);
-
-    editor.setCursorToDefinedLineAndChar(13, 32);
-    editor.typeTextIntoEditor(Keys.DELETE.toString());
-    editor.typeTextIntoEditor(Keys.DELETE.toString());
-    editor.setCursorToDefinedLineAndChar(13, 8);
-    editor.typeTextIntoEditor(Keys.DELETE.toString());
-    editor.typeTextIntoEditor(Keys.DELETE.toString());
-    editor.typeTextIntoEditor(Keys.DELETE.toString());
-
-    projectExplorer.waitFolderDefinedTypeOfFolderByPath(
-        PROJECT_NAME + "/my-lib", ProjectExplorer.FolderTypes.PROJECT_FOLDER);
-
-    editor.closeAllTabs();
+    projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME + "/my-lib", SIMPLE_FOLDER);
+    projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME + "/my-webapp", SIMPLE_FOLDER);
   }
 
-  @Test(priority = 4)
+  @Test(priority = 2)
   public void shouldAccessClassCreatedInAnotherModuleAfterIncludingModule() {
-    projectExplorer.clickCollapseAllButton();
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PROJECT_NAME + "/my-webapp/src/main/java/helloworld", "GreetingController.java");
+    includeModulesInTheParentPom();
+    projectExplorer.openItemByPath(
+        PROJECT_NAME + "/my-webapp/src/main/java/che/eclipse/sample/Aclass.java");
     editor.waitActiveEditor();
-    editor.setCursorToDefinedLineAndChar(27, 1);
+    editor.setCursorToDefinedLineAndChar(17, 1);
     enterClassNameViaAutocomplete();
     editor.typeTextIntoEditor(" testClass2 = new TestClass();");
     editor.waitAllMarkersDisappear(ERROR_MARKER);
+  }
+
+  private void includeModulesInTheParentPom() {
+    editor.setCursorToDefinedLineAndChar(26, 32);
+    editor.typeTextIntoEditor(Keys.DELETE.toString());
+    editor.typeTextIntoEditor(Keys.DELETE.toString());
+    editor.setCursorToDefinedLineAndChar(25, 8);
+    editor.typeTextIntoEditor(Keys.DELETE.toString());
+    editor.typeTextIntoEditor(Keys.DELETE.toString());
+    editor.typeTextIntoEditor(Keys.DELETE.toString());
+    projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME + "/my-lib", PROJECT_FOLDER);
+    projectExplorer.waitFolderDefinedTypeOfFolderByPath(
+        PROJECT_NAME + "/my-webapp", PROJECT_FOLDER);
+    editor.closeAllTabs();
   }
 
   /** check ability just created class in autocomplete container */

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckMavenPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckMavenPluginTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRIN
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.ERROR_MARKER;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.SIMPLE_FOLDER;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -33,6 +34,7 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.git.Git;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -61,6 +63,8 @@ public class CheckMavenPluginTest {
         workspace.getId(), get(resource.toURI()), PROJECT_NAME, MAVEN_SPRING);
     ide.open(workspace);
     projectExplorer.waitProjectExplorer();
+    projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.selectItem(PROJECT_NAME);
   }
 
   @Test
@@ -85,12 +89,20 @@ public class CheckMavenPluginTest {
     editor.typeTextIntoEditor("!--");
     editor.setCursorToDefinedLineAndChar(26, 32);
     editor.typeTextIntoEditor("--");
-    projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME + "/my-lib", SIMPLE_FOLDER);
+    try {
+      projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME + "/my-lib", SIMPLE_FOLDER);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7109");
+    }
+
     projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME + "/my-webapp", SIMPLE_FOLDER);
   }
 
   @Test(priority = 2)
   public void shouldAccessClassCreatedInAnotherModuleAfterIncludingModule() {
+    projectExplorer.openItemByPath(PROJECT_NAME + "/pom.xml");
+    editor.waitActiveEditor();
     includeModulesInTheParentPom();
     projectExplorer.openItemByPath(
         PROJECT_NAME + "/my-webapp/src/main/java/che/eclipse/sample/Aclass.java");
@@ -119,7 +131,12 @@ public class CheckMavenPluginTest {
   private void enterClassNameViaAutocomplete() {
     editor.typeTextIntoEditor("Test");
     editor.launchAutocomplete();
-    editor.enterAutocompleteProposal("TestClass");
+    try {
+      editor.enterAutocompleteProposal("TestClass");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7109");
+    }
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
@@ -10,18 +10,20 @@
  */
 package org.eclipse.che.selenium.miscellaneous;
 
-import static org.testng.AssertJUnit.assertFalse;
+import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
+import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestGitConstants;
+import org.eclipse.che.selenium.core.constant.TestCommandsConstants;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
-import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -31,46 +33,22 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NavigateToFile;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.git.Git;
+import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
-import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /** Created by aleksandr shmaraev on 10.12.15 */
 public class NavigateToFileTest {
   private static final String PROJECT_NAME = "NavigateFile";
   private static final String PROJECT_NAME_2 = "NavigateFile_2";
-  private static final String PATH_TO_JAVA_FILE =
-      "(/NavigateFile/src/main/java/org/eclipse/qa/examples)";
-  private static final String PATH_TO_JSP_FILE = "(/NavigateFile/src/main/webapp)";
-  private static final String PATH_TO_README_FILE = "(/NavigateFile)";
-  private static final String PATH_2_TO_JAVA_FILE =
-      "(/NavigateFile_2/src/main/java/org/eclipse/qa/examples)";
-  private static final String PATH_2_TO_JSP_FILE = "(/NavigateFile_2/src/main/webapp)";
-  private static final String PATH_2_TO_README_FILE = "(/NavigateFile_2)";
-  private static final String FILE_JAVA = "AppController.java";
-  private static final String FILE_XML = "pom.xml";
-  private static final String FILE_README = "README.md";
-  private static final String FILE_JSP = "index.jsp";
-  private static final String FILE_CREATED_FROM_API = "createdFrom.api";
   private static final String FILE_CREATED_FROM_CONSOLE = "createdFrom.con";
-
-  private static final List<String> FILES_A_SYMBOL =
-      Arrays.asList(
-          "AppController.java (/NavigateFile/src/main/java/org/eclipse/qa/examples)",
-          "AppController.java (/NavigateFile_2/src/main/java/org/eclipse/qa/examples)");
-  private static final List<String> FILES_P_SYMBOL =
-      Arrays.asList("pom.xml (/NavigateFile_2)", "pom.xml (/NavigateFile)");
-  private static final List<String> FILES_I_SYMBOL =
-      Arrays.asList(
-          "index.jsp (/NavigateFile/src/main/webapp)",
-          "index.jsp (/NavigateFile_2/src/main/webapp)");
-  private static final List<String> FILES_R_SYMBOL =
-      Arrays.asList("README.md (/NavigateFile)", "README.md (/NavigateFile_2)");
-  private static final List<String> FILES_C_SYMBOL =
-      Arrays.asList(
-          "classpath (/NavigateFile_2/.che)", "classpath (/NavigateFile/.che)",
-          "createdFrom.con (/NavigateFile_2)", "createdFrom.api (/NavigateFile)");
+  private static final String COMMAND_FOR_FILE_CREATION = "createFile";
+  private static final String HIDDEN_FOLDER_NAME = ".hiddenFolder";
+  private static final String HIDDEN_FILE_NAME = ".hiddenFile";
+  private static final String FILE_IN_HIDDEN_FOLDER = "innerFile.css";
+  private static final int MAX_TIMEOUT_FOR_UPDATING_INDEXES = 10;
 
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
@@ -83,6 +61,8 @@ public class NavigateToFileTest {
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Git git;
   @Inject private AskDialog askDialog;
+  @Inject private TestCommandServiceClient testCommandServiceClient;
+  @Inject private CommandsPalette commandsPalette;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -98,167 +78,139 @@ public class NavigateToFileTest {
         Paths.get(resource.toURI()),
         PROJECT_NAME_2,
         ProjectTemplates.MAVEN_SIMPLE);
+    testCommandServiceClient.createCommand(
+        String.format("touch /projects/%s/%s", PROJECT_NAME_2, FILE_CREATED_FROM_CONSOLE),
+        COMMAND_FOR_FILE_CREATION,
+        TestCommandsConstants.CUSTOM,
+        workspace.getId());
     ide.open(workspace);
-  }
-
-  @Test
-  public void checkNavigateToFileFunction() {
-    // Open the project one and check function 'Navigate To File'
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    projectExplorer.openItemByPath(PROJECT_NAME);
-    selectFileFromNavigate("A", FILE_JAVA + PATH_TO_JAVA_FILE, FILES_A_SYMBOL);
-    editor.waitTabIsPresent("AppController");
-    editor.waitActiveEditor();
-    editor.closeFileByNameWithSaving("AppController");
-    editor.waitWhileFileIsClosed("AppController");
-    selectFileFromNavigate("p", FILE_XML + PATH_TO_README_FILE, FILES_P_SYMBOL);
-    editor.waitTabIsPresent("qa-spring-sample");
-    editor.waitActiveEditor();
-    editor.closeFileByNameWithSaving("qa-spring-sample");
-    editor.waitWhileFileIsClosed("qa-spring-sample");
-    selectFileFromNavigate("i", FILE_JSP + PATH_TO_JSP_FILE);
-    editor.waitTabIsPresent("index.jsp");
-    editor.waitActiveEditor();
-    editor.closeFileByNameWithSaving("index.jsp");
-    editor.waitWhileFileIsClosed("index.jsp");
-    selectFileFromNavigateLaunchByKeyboard("R", FILE_README + PATH_TO_README_FILE);
-    editor.waitTabIsPresent("README.md");
-    editor.waitActiveEditor();
-    editor.closeFileByNameWithSaving("README.md");
-    editor.waitWhileFileIsClosed("README.md");
-    loader.waitOnClosed();
-
-    // Open the project two and check function 'Navigate To File'
     projectExplorer.waitItem(PROJECT_NAME_2);
-    projectExplorer.openItemByPath(PROJECT_NAME_2);
-    selectFileFromNavigate("A", FILE_JAVA + PATH_2_TO_JAVA_FILE, FILES_A_SYMBOL);
-    editor.waitTabIsPresent("AppController");
-    editor.waitActiveEditor();
-    selectFileFromNavigate("p", FILE_XML + PATH_2_TO_README_FILE, FILES_P_SYMBOL);
-    editor.waitTabIsPresent("qa-spring-sample");
-    editor.waitActiveEditor();
-    selectFileFromNavigate("i", FILE_JSP + PATH_2_TO_JSP_FILE);
-    editor.waitTabIsPresent("index.jsp");
-    editor.waitActiveEditor();
-    selectFileFromNavigateLaunchByKeyboard("R", FILE_README + PATH_2_TO_README_FILE);
-    editor.waitTabIsPresent("README.md");
-    editor.waitActiveEditor();
-    editor.closeAllTabsByContextMenu();
-
-    // Check that form is closed by pressing ESC button
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE);
-    navigateToFile.waitFormToOpen();
-    navigateToFile.closeNavigateToFileForm();
-    navigateToFile.waitFormToClose();
   }
 
-  @Test
-  public void checkNavigateToFileFunctionWithJustCreatedFiles() throws Exception {
+  @Test(dataProvider = "dataForCheckingTheSameFileInDifferentProjects")
+  public void shouldNavigateToFileForFirstProject(
+      String inputValueForChecking, Map<Integer, String> expectedValues) {
+    // Open the project one and check function 'Navigate To File'
+    launchNavigateToFileAndCheckResults(inputValueForChecking, expectedValues, 1);
+  }
+
+  @Test(dataProvider = "dataForCheckingTheSameFileInDifferentProjects")
+  public void shouldDoNavigateToFileForSecondProject(
+      String inputValueForChecking, Map<Integer, String> expectedValues) {
+    launchNavigateToFileAndCheckResults(inputValueForChecking, expectedValues, 2);
+  }
+
+  @Test(dataProvider = "dataForCheckingFilesCreatedWithoutIDE")
+  public void shouldNavigateToFileWithJustCreatedFiles(
+      String inputValueForChecking, Map<Integer, String> expectedValues) throws Exception {
+
     String content = "NavigateToFileTest";
-
-    projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(PROJECT_NAME);
-    createFileFromAPI(PROJECT_NAME, FILE_CREATED_FROM_API, content);
-    terminal.waitTerminalTab();
-    terminal.selectTerminalTab();
-    createFileInTerminal(PROJECT_NAME_2, FILE_CREATED_FROM_CONSOLE);
-    WaitUtils.sleepQuietly(10);
-    selectFileFromNavigate("c", FILE_CREATED_FROM_API + PATH_TO_README_FILE, FILES_C_SYMBOL);
-    editor.waitTabIsPresent(FILE_CREATED_FROM_API);
-    editor.waitActiveEditor();
-    editor.closeFileByNameWithSaving(FILE_CREATED_FROM_API);
-    selectFileFromNavigate("c", FILE_CREATED_FROM_CONSOLE + PATH_2_TO_README_FILE, FILES_C_SYMBOL);
-    editor.waitTabIsPresent(FILE_CREATED_FROM_CONSOLE);
-    editor.waitActiveEditor();
-    editor.closeFileByNameWithSaving(FILE_CREATED_FROM_CONSOLE);
+    testProjectServiceClient.createFileInProject(
+        workspace.getId(), PROJECT_NAME, expectedValues.get(1).split(" ")[0], content);
+    commandsPalette.openCommandPalette();
+    commandsPalette.startCommandByDoubleClick(COMMAND_FOR_FILE_CREATION);
+    sleepQuietly(MAX_TIMEOUT_FOR_UPDATING_INDEXES);
+    int randomItemFromList = ThreadLocalRandom.current().nextInt(1, 2);
+    launchNavigateToFileAndCheckResults(inputValueForChecking, expectedValues, randomItemFromList);
   }
 
   @Test
-  public void checkNavigateToFileFunctionWithFilesFromHiddenFolders() {
-    projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(PROJECT_NAME);
-    projectExplorer.selectItem(PROJECT_NAME);
-    menu.runCommand(
-        TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.INITIALIZE_REPOSITORY);
-    askDialog.acceptDialogWithText(
-        "Do you want to initialize the local repository " + PROJECT_NAME + "?");
-    loader.waitOnClosed();
-    git.waitGitStatusBarWithMess(TestGitConstants.GIT_INITIALIZED_SUCCESS);
-
-    // check that HEAD file from .git folder is not appear in list of found files
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE);
-    navigateToFile.waitFormToOpen();
-    navigateToFile.typeSymbolInFileNameField("H");
-    loader.waitOnClosed();
-    navigateToFile.waitFileNamePopUp();
-    assertFalse(navigateToFile.isFilenameSuggested("HEAD (/NavigateFile/.git)"));
+  public void shouldNotDisplayHiddenFilesAndFoldersInDropDown() throws Exception {
+    addHiddenFoldersAndFileThroughProjectService();
+    launchNavigateToFileFromUIAndTypeValue(FILE_IN_HIDDEN_FOLDER);
+    assertTrue(navigateToFile.getText().isEmpty());
     navigateToFile.closeNavigateToFileForm();
-    navigateToFile.waitFormToClose();
+    launchNavigateToFileFromUIAndTypeValue(HIDDEN_FILE_NAME);
+    assertTrue(navigateToFile.getText().isEmpty());
   }
 
-  private void selectFileFromNavigate(String symbol, String pathName, List<String> files) {
+  private void addHiddenFoldersAndFileThroughProjectService() throws Exception {
+    testProjectServiceClient.createFolder(
+        workspace.getId(), PROJECT_NAME + "/" + HIDDEN_FOLDER_NAME);
+    testProjectServiceClient.createFileInProject(
+        workspace.getId(),
+        PROJECT_NAME + "/" + HIDDEN_FOLDER_NAME,
+        FILE_IN_HIDDEN_FOLDER,
+        "contentFile1");
+    testProjectServiceClient.createFileInProject(
+        workspace.getId(), PROJECT_NAME_2 + "/", HIDDEN_FILE_NAME, "content-of-hidden-file");
+    sleepQuietly(MAX_TIMEOUT_FOR_UPDATING_INDEXES);
+  }
+
+  private void launchNavigateToFileAndCheckResults(
+      String navigatingValue,
+      Map<Integer, String> expectedItems,
+      final int numValueFromDropDawnList) {
+
+    // extract the path (without opened class)
+    String dropdownVerificationPath = expectedItems.get(numValueFromDropDawnList).split(" ")[1];
+
+    String openedFileWithExtension = expectedItems.get(numValueFromDropDawnList).split(" ")[0];
+
+    // extract the name of opened files that display in a tab (the ".java" extension are not shown
+    // in tabs)
+    String openedFileNameInTheTab = openedFileWithExtension.replace(".java", "");
+    launchNavigateToFileFromUIAndTypeValue(navigatingValue);
+    waitExpectedItemsInNavigateToFileDropdawn(expectedItems);
+    navigateToFile.selectFileByName(dropdownVerificationPath);
+    editor.waitActiveEditor();
+    editor.getAssociatedPathFromTheTab(openedFileNameInTheTab);
+    editor.closeFileByNameWithSaving(openedFileNameInTheTab);
+  }
+
+  private void launchNavigateToFileFromUIAndTypeValue(String navigatingValue) {
     loader.waitOnClosed();
     menu.runCommand(
         TestMenuCommandsConstants.Assistant.ASSISTANT,
         TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE);
     navigateToFile.waitFormToOpen();
     loader.waitOnClosed();
-    navigateToFile.typeSymbolInFileNameField(symbol);
+    navigateToFile.typeSymbolInFileNameField(navigatingValue);
     loader.waitOnClosed();
-    navigateToFile.waitFileNamePopUp();
-    for (String listFiles : files) {
-      navigateToFile.waitListOfFilesNames(listFiles);
-    }
-    navigateToFile.selectFileByFullName(pathName);
-    navigateToFile.waitFormToClose();
   }
 
-  private void selectFileFromNavigate(String symbol, String pathName) {
-    loader.waitOnClosed();
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE);
-    navigateToFile.waitFormToOpen();
-    loader.waitOnClosed();
-    navigateToFile.typeSymbolInFileNameField(symbol);
-    loader.waitOnClosed();
-    navigateToFile.waitFileNamePopUp();
-    for (String listFiles : FILES_I_SYMBOL) {
-      navigateToFile.waitListOfFilesNames(listFiles);
-    }
-    navigateToFile.selectFileByFullName(pathName);
-    navigateToFile.waitFormToClose();
+  private void waitExpectedItemsInNavigateToFileDropdawn(Map<Integer, String> expectedItems) {
+    expectedItems
+        .values()
+        .stream()
+        .map(it -> it.toString())
+        .forEach(it -> navigateToFile.waitListOfFilesNames(it));
   }
 
-  private void selectFileFromNavigateLaunchByKeyboard(String symbol, String pathName) {
-    loader.waitOnClosed();
-    navigateToFile.launchNavigateToFileByKeyboard();
-    navigateToFile.waitFormToOpen();
-    loader.waitOnClosed();
-    navigateToFile.typeSymbolInFileNameField(symbol);
-    loader.waitOnClosed();
-    navigateToFile.waitFileNamePopUp();
-    for (String listFiles : FILES_R_SYMBOL) {
-      navigateToFile.waitListOfFilesNames(listFiles);
-    }
-    navigateToFile.selectFileByFullName(pathName);
-    navigateToFile.waitFormToClose();
+  @DataProvider
+  private Object[][] dataForCheckingTheSameFileInDifferentProjects() {
+    return new Object[][] {
+      {
+        "A",
+        ImmutableMap.of(
+            1, "AppController.java (/NavigateFile/src/main/java/org/eclipse/qa/examples)",
+            2, "AppController.java (/NavigateFile_2/src/main/java/org/eclipse/qa/examples)")
+      },
+      {
+        "i",
+        ImmutableMap.of(
+            1, "index.jsp (/NavigateFile/src/main/webapp)",
+            2, "index.jsp (/NavigateFile_2/src/main/webapp)")
+      },
+      {
+        "R",
+        ImmutableMap.of(
+            1, "README.md (/NavigateFile)",
+            2, "README.md (/NavigateFile_2)")
+      }
+    };
   }
 
-  private void createFileFromAPI(String path, String fileName, String content) throws Exception {
-    testProjectServiceClient.createFileInProject(workspace.getId(), path, fileName, content);
-  }
-
-  private void createFileInTerminal(String projectName, String fileName) {
-    terminal.typeIntoTerminal("cd " + projectName + Keys.ENTER);
-    terminal.typeIntoTerminal("ls -als > " + fileName + Keys.ENTER);
-    terminal.typeIntoTerminal("cat " + fileName + Keys.ENTER);
-    terminal.typeIntoTerminal("ls" + Keys.ENTER);
-    terminal.waitExpectedTextIntoTerminal(fileName);
+  @DataProvider
+  private Object[][] dataForCheckingFilesCreatedWithoutIDE() {
+    return new Object[][] {
+      {
+        "c",
+        ImmutableMap.of(
+            1, "createdFrom.api (/NavigateFile)", 2, "createdFrom.con (/NavigateFile_2)")
+      }
+    };
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
@@ -41,8 +41,8 @@ import org.testng.annotations.Test;
 
 /** Created by aleksandr shmaraev on 10.12.15 */
 public class NavigateToFileTest {
-  private static final String PROJECT_NAME = "NavigateFile";
-  private static final String PROJECT_NAME_2 = "NavigateFile_2";
+  private static final String PROJECT_NAME = "project";
+  private static final String PROJECT_NAME_2 = "project_2";
   private static final String FILE_CREATED_FROM_CONSOLE = "createdFrom.con";
   private static final String COMMAND_FOR_FILE_CREATION = "createFile";
   private static final String HIDDEN_FOLDER_NAME = ".hiddenFolder";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
@@ -10,6 +10,11 @@
  */
 package org.eclipse.che.selenium.miscellaneous;
 
+import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE;
+import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SIMPLE;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
 import static org.testng.Assert.assertTrue;
 
@@ -21,9 +26,6 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestCommandsConstants;
-import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
-import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -68,20 +70,13 @@ public class NavigateToFileTest {
   public void setUp() throws Exception {
     URL resource = getClass().getResource("/projects/guess-project");
     testProjectServiceClient.importProject(
-        workspace.getId(),
-        Paths.get(resource.toURI()),
-        PROJECT_NAME,
-        ProjectTemplates.MAVEN_SIMPLE);
-
+        workspace.getId(), Paths.get(resource.toURI()), PROJECT_NAME, MAVEN_SIMPLE);
     testProjectServiceClient.importProject(
-        workspace.getId(),
-        Paths.get(resource.toURI()),
-        PROJECT_NAME_2,
-        ProjectTemplates.MAVEN_SIMPLE);
+        workspace.getId(), Paths.get(resource.toURI()), PROJECT_NAME_2, MAVEN_SIMPLE);
     testCommandServiceClient.createCommand(
-        String.format("touch /projects/%s/%s", PROJECT_NAME_2, FILE_CREATED_FROM_CONSOLE),
+        format("touch /projects/%s/%s", PROJECT_NAME_2, FILE_CREATED_FROM_CONSOLE),
         COMMAND_FOR_FILE_CREATION,
-        TestCommandsConstants.CUSTOM,
+        CUSTOM,
         workspace.getId());
     ide.open(workspace);
     projectExplorer.waitProjectExplorer();
@@ -146,7 +141,6 @@ public class NavigateToFileTest {
 
     // extract the path (without opened class)
     String dropdownVerificationPath = expectedItems.get(numValueFromDropDawnList).split(" ")[1];
-
     String openedFileWithExtension = expectedItems.get(numValueFromDropDawnList).split(" ")[0];
 
     // extract the name of opened files that display in a tab (the ".java" extension are not shown
@@ -162,9 +156,7 @@ public class NavigateToFileTest {
 
   private void launchNavigateToFileFromUIAndTypeValue(String navigatingValue) {
     loader.waitOnClosed();
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE);
+    menu.runCommand(ASSISTANT, NAVIGATE_TO_FILE);
     navigateToFile.waitFormToOpen();
     loader.waitOnClosed();
     navigateToFile.typeSymbolInFileNameField(navigatingValue);
@@ -185,20 +177,20 @@ public class NavigateToFileTest {
       {
         "A",
         ImmutableMap.of(
-            1, "AppController.java (/NavigateFile/src/main/java/org/eclipse/qa/examples)",
-            2, "AppController.java (/NavigateFile_2/src/main/java/org/eclipse/qa/examples)")
+            1, "AppController.java (/project/src/main/java/org/eclipse/qa/examples)",
+            2, "AppController.java (/project_2/src/main/java/org/eclipse/qa/examples)")
       },
       {
         "i",
         ImmutableMap.of(
-            1, "index.jsp (/NavigateFile/src/main/webapp)",
-            2, "index.jsp (/NavigateFile_2/src/main/webapp)")
+            1, "index.jsp (/project/src/main/webapp)",
+            2, "index.jsp (/project_2/src/main/webapp)")
       },
       {
         "R",
         ImmutableMap.of(
-            1, "README.md (/NavigateFile)",
-            2, "README.md (/NavigateFile_2)")
+            1, "README.md (/project)",
+            2, "README.md (/project_2)")
       }
     };
   }
@@ -206,11 +198,7 @@ public class NavigateToFileTest {
   @DataProvider
   private Object[][] dataForCheckingFilesCreatedWithoutIDE() {
     return new Object[][] {
-      {
-        "c",
-        ImmutableMap.of(
-            1, "createdFrom.api (/NavigateFile)", 2, "createdFrom.con (/NavigateFile_2)")
-      }
+      {"c", ImmutableMap.of(1, "createdFrom.api (/project)", 2, "createdFrom.con (/project_2)")}
     };
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
@@ -74,7 +74,7 @@ public class NavigateToFileTest {
     testProjectServiceClient.importProject(
         workspace.getId(), Paths.get(resource.toURI()), PROJECT_NAME_2, MAVEN_SIMPLE);
     testCommandServiceClient.createCommand(
-        format("touch /projects/%s/%s", PROJECT_NAME_2, FILE_CREATED_FROM_CONSOLE),
+        format("ls > /projects/%s/%s", PROJECT_NAME_2, FILE_CREATED_FROM_CONSOLE),
         COMMAND_FOR_FILE_CREATION,
         CUSTOM,
         workspace.getId());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeleteProjectsTest.java
@@ -10,6 +10,10 @@
  */
 package org.eclipse.che.selenium.projectexplorer;
 
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.EDIT;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -18,7 +22,6 @@ import java.util.List;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants;
-import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.Consoles;
@@ -39,12 +42,7 @@ import org.testng.annotations.Test;
 public class DeleteProjectsTest {
 
   private static final List<String> PROJECT_NAMES =
-      Arrays.asList(
-          "DeleteProjectTest1",
-          "DeleteProjectTest2",
-          "DeleteProjectTest3",
-          "DeleteProjectTest4",
-          "DeleteProjectTest5");
+      Arrays.asList("Project1", "Project2", "Project3", "Project4", "Project5");
 
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
@@ -61,10 +59,7 @@ public class DeleteProjectsTest {
     for (String projectName : PROJECT_NAMES) {
       URL resource = getClass().getResource("/projects/ProjectWithDifferentTypeOfFiles");
       testProjectServiceClient.importProject(
-          workspace.getId(),
-          Paths.get(resource.toURI()),
-          projectName,
-          ProjectTemplates.MAVEN_SPRING);
+          workspace.getId(), Paths.get(resource.toURI()), projectName, MAVEN_SPRING);
     }
     ide.open(workspace);
     projectExplorer.waitProjectExplorer();
@@ -78,16 +73,18 @@ public class DeleteProjectsTest {
     projectExplorer.openContextMenuByPathSelectedItem(PROJECT_NAMES.get(0));
     projectExplorer.clickOnItemInContextMenu(TestProjectExplorerContextMenuConstants.DELETE);
     acceptDeletion(PROJECT_NAMES.get(0));
-    checkErrorMessageNotPresentInConsole();
+    projectExplorer.waitDisappearItemByPath(PROJECT_NAMES.get(0));
+    checkErrorMessageNotPresentInConsole(PROJECT_NAMES.get(0));
   }
 
   @Test(priority = 1)
   public void shouldDeleteProjectByMenuFile() {
     projectExplorer.waitItem(PROJECT_NAMES.get(1));
     projectExplorer.selectItem(PROJECT_NAMES.get(1));
-    menu.runCommand(TestMenuCommandsConstants.Edit.EDIT, TestMenuCommandsConstants.Edit.DELETE);
+    menu.runCommand(EDIT, TestMenuCommandsConstants.Edit.DELETE);
     acceptDeletion(PROJECT_NAMES.get(1));
-    checkErrorMessageNotPresentInConsole();
+    projectExplorer.waitDisappearItemByPath(PROJECT_NAMES.get(1));
+    checkErrorMessageNotPresentInConsole(PROJECT_NAMES.get(1));
   }
 
   @Test(priority = 2)
@@ -95,7 +92,8 @@ public class DeleteProjectsTest {
     projectExplorer.waitItem(PROJECT_NAMES.get(2));
     deleteFromDeleteIcon(PROJECT_NAMES.get(2));
     acceptDeletion(PROJECT_NAMES.get(2));
-    checkErrorMessageNotPresentInConsole();
+    projectExplorer.waitDisappearItemByPath(PROJECT_NAMES.get(2));
+    checkErrorMessageNotPresentInConsole(PROJECT_NAMES.get(2));
   }
 
   @Test(priority = 3)
@@ -105,10 +103,10 @@ public class DeleteProjectsTest {
     loader.waitOnClosed();
     projectExplorer.waitItem(PROJECT_NAMES.get(3));
     projectExplorer.selectItem(PROJECT_NAMES.get(3));
-    menu.runCommand(TestMenuCommandsConstants.Edit.EDIT, TestMenuCommandsConstants.Edit.DELETE);
+    menu.runCommand(EDIT, TestMenuCommandsConstants.Edit.DELETE);
     acceptDeletion(PROJECT_NAMES.get(3));
     projectExplorer.waitDisappearItemByPath(PROJECT_NAMES.get(3));
-    checkErrorMessageNotPresentInConsole();
+    checkErrorMessageNotPresentInConsole(PROJECT_NAMES.get(3));
   }
 
   @Test(priority = 4)
@@ -122,7 +120,7 @@ public class DeleteProjectsTest {
     projectExplorer.clickOnItemInContextMenu(TestProjectExplorerContextMenuConstants.DELETE);
     acceptDeletion(PROJECT_NAMES.get(4));
     projectExplorer.waitDisappearItemByPath(PROJECT_NAMES.get(4));
-    checkErrorMessageNotPresentInConsole();
+    checkErrorMessageNotPresentInConsole(PROJECT_NAMES.get(4));
   }
 
   private void deleteFromDeleteIcon(String pathToProject) {
@@ -140,9 +138,9 @@ public class DeleteProjectsTest {
     projectExplorer.waitDisappearItemByPath(projectName);
   }
 
-  private void checkErrorMessageNotPresentInConsole() {
+  private void checkErrorMessageNotPresentInConsole(String projectName) {
     try {
-      consoles.waitExpectedTextIntoConsole("[ERROR]", 7);
+      consoles.waitExpectedTextIntoConsole(projectName, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
       Assert.fail("Error message is present in console");
     } catch (TimeoutException ex) {
     }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/subversion/DiffViewTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/subversion/DiffViewTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.S
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Subversion.SVN_VIEW_DIFF;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.IMPORT_PROJECT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.provider.TestSvnPasswordProvider;
@@ -30,6 +31,7 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.subversion.Subversion;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -130,7 +132,13 @@ public class DiffViewTest {
     subversion.clickSvnCommitDiffButton(FILE_NAME_1, FOLDER_NAME);
     loader.waitOnClosed();
     subversion.waitSvnCommitFormOpened();
-    subversion.waitTextDiffView(DIFF_MESS_1);
+
+    try {
+      subversion.waitTextDiffView(DIFF_MESS_1);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("https://github.com/eclipse/che/issues/6452", ex);
+    }
     subversion.clickSvnCommitClosedButtonDiffView();
 
     // Check the diff view 'document.html' in the svn commit form

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/subversion/LockFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/subversion/LockFileTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.S
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Subversion.SVN_RELEASE_LOCK;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.IMPORT_PROJECT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
@@ -32,6 +33,7 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.subversion.Subversion;
 import org.eclipse.che.selenium.pageobject.subversion.SvnCommit;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -93,7 +95,14 @@ public class LockFileTest {
       editor.typeTextIntoEditor("changes for commit");
       projectExplorer.openItemByPath(LOCKED_FILE_PATH);
       menu.runCommand(SUBVERSION, SVN_COMMIT);
-      svnCommit.waitMainFormOpened();
+
+      try {
+        svnCommit.waitMainFormOpened();
+      } catch (TimeoutException ex) {
+        // remove try-catch block after issue has been resolved
+        fail("https://github.com/eclipse/che-plugin-svn/issues/1", ex);
+      }
+
       svnCommit.typeCommitMess("message");
       svnCommit.clickCommitBtn();
       projectExplorer.selectItem(LOCKED_FILE_PATH);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/subversion/UpdateToRevisionTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/subversion/UpdateToRevisionTest.java
@@ -14,7 +14,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.S
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Subversion.SVN_UPDATE_TO_REVISION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.IMPORT_PROJECT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
@@ -29,6 +29,7 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.subversion.Subversion;
+import org.openqa.selenium.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -91,6 +92,12 @@ public class UpdateToRevisionTest {
     subversion.typeSvnUpdateToRevisionName(REVISION);
     subversion.clickSvnUpdateToRevisionButtonUpdate();
     loader.waitOnClosed();
-    assertTrue(subversion.getAllMessageFromSvnStatusBar().contains(MESSAGE));
+
+    try {
+      subversion.waitSvnInfoPanelWithMessage(MESSAGE);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("https://github.com/eclipse/che/issues/6452", ex);
+    }
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/swagger/SwaggerTest.java
@@ -43,6 +43,7 @@ public class SwaggerTest {
   @Test
   public void checkNameProjectTest() throws Exception {
     driver.navigate().to(swaggerUrl);
+
     assertTrue(swagger.getWsNamesFromWorkspacePage().contains(workspace.getName()));
   }
 }

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-lib/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-lib/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+<groupId>org.eclipse.che.examples</groupId>
+<artifactId>qa-multimodule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>my-lib</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>sample-lib</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-lib/src/main/java/hello/SayHello.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-lib/src/main/java/hello/SayHello.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package hello;
+
+ /**
+ * Hello world!
+ *
+ */
+
+public class SayHello
+{
+    public String sayHello(String name)
+    {
+        return "Hello, " + name;
+    }
+}

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-lib/src/test/java/hello/SayHelloTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-lib/src/test/java/hello/SayHelloTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package hello;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class SayHelloTest  extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public SayHelloTest(String testName)
+    {
+        super(testName);
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite(SayHelloTest.class);
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testSayHello()
+    {
+        SayHello sayHello = new SayHello();
+        assertTrue("Hello, codenvy".equals(sayHello.sayHello("codenvy")));
+    }
+}

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/README.md
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/README.md
@@ -1,0 +1,1 @@
+# Developer Workspace

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+    <groupId>org.eclipse.che.examples</groupId>
+    <artifactId>qa-multimodule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>my-webapp</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+       <name>qa-spring-sample</name>
+    <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+    </properties>
+     <dependencies>
+     
+        <dependency>
+            <groupId>org.eclipse.che.examples</groupId>
+            <artifactId>my-lib</artifactId>
+            <version>1.0-SNAPSHOT</version>
+         </dependency>
+     
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>3.0.5.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/java/che/eclipse/sample/Aclass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/java/che/eclipse/sample/Aclass.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package che.eclipse.sample;
+
+public class Aclass {
+
+
+}

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.qa.examples;
+
+import java.util.Random;
+
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.Controller;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AppController implements Controller {
+    private static final String secretNum = Integer.toString(new Random().nextInt(10));
+
+    @Override
+    public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String numGuessByUser = request.getParameter("numGuess");
+        String result = "";
+        
+        if (numGuessByUser != null && numGuessByUser.equals(secretNum)) {
+            result = "Congrats! The number is " + secretNum;
+        } 
+        
+        else if (numGuessByUser != null) {
+            result = "Sorry, you failed. Try again later!";
+        }
+
+        ModelAndView view = new ModelAndView("guess_num");
+        view.addObject("num", result);
+        return view;
+
+    }
+}

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,0 +1,33 @@
+<%--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+--%>
+<html>
+  <body bgcolor="white">
+    <div style="font-size: 120%; color: #1a53ff">
+      <span>Enter number: </span><br />
+      <form method="post" action="guess">
+        <input type=text size="5" name="numGuess" >
+        <input type=submit name="submit" value="Ok">
+      </form>
+    </div>
+    <div>
+      <%
+          {
+            java.lang.String attempt = (java.lang.String)request.getAttribute("num");   
+      %>
+      <span><%=attempt%></span>
+      <%
+          }
+      %>
+    </div>
+  </body>
+</html>

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+   <bean name="/guess" class="projects.debugStepInto.src.main.java.java.org.eclipse.qa.examples.AppController"></bean>
+   <bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+      <property name="prefix" value="/WEB-INF/jsp/" />
+      <property name="suffix" value=".jsp" />
+   </bean>
+</beans>

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+
+<web-app>
+   <display-name>Spring Web Application</display-name>
+   <servlet>
+      <servlet-name>spring</servlet-name>
+      <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+      <load-on-startup>1</load-on-startup>
+   </servlet>
+   <servlet-mapping>
+      <servlet-name>spring</servlet-name>
+      <url-pattern>/spring/*</url-pattern>
+   </servlet-mapping>
+</web-app>

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/my-webapp/src/main/webapp/index.jsp
@@ -1,0 +1,15 @@
+<%--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+--%>
+<%
+   response.sendRedirect("spring/guess");
+%>

--- a/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/check-maven-plugin-test/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+<groupId>org.eclipse.che.examples</groupId>
+<artifactId>qa-multimodule</artifactId>
+   <packaging>pom</packaging>
+   <version>1.0-SNAPSHOT</version>
+   <properties>
+      <maven.compiler.source>1.6</maven.compiler.source>
+      <maven.compiler.target>1.6</maven.compiler.target>
+   </properties>
+   <modules>
+      <module>my-lib</module>
+      <module>my-webapp</module>
+   </modules>
+</project>


### PR DESCRIPTION
### What does this PR do?
In the **che6** branch we made some important improvements and fixes that can be applied for master branch. This will be able to stabilize tests and enhance results. Also it'll reduce time for checking regression by QA.

Next selenium tests will be updated:
- **NavigateToFileTest**
- **SwaggerTest**
- **CheckMavenPluginTest**
- **CheckFindActionFeatureInCheTest**
- **DebugExternalClassTest**

We need add try/catch blocks to selenium tests as is in **CHE-6** branch:
- **DiffViewTest**
- **UpdateToRevisionTest**
- **LockFileTest**
- **CheckMavenPluginTest**
- **RefactoringFeatureTest**

Next selenium tests need change for tests stability:
- **CheckFactoryWithSincePolicyTest**
- **CheckFactoryWithUntilPolicyTest**
- **DeleteProjectsTest**
- **CreateAndDeleteProjectsTest**

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7504