### PR TITLE
Adapt webdriver.sh to Multiuser Che; add ability to set rerun attempts

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -57,18 +57,18 @@ readonly FAILSAFE_DIR="target/failsafe-reports"
 readonly TESTNG_FAILED_SUITE=${FAILSAFE_DIR}"/testng-failed.xml"
 readonly FAILSAFE_REPORT="target/site/failsafe-report.html"
 
+export CHE_MULTIUSER=${CHE_MULTIUSER:-false}
+
 # CALLER variable contains parent caller script name
 # CUR_DIR variable contains the current directory where CALLER is executed
 [[ -z ${CALLER+x} ]] && { CALLER=$(basename $0); }
 [[ -z ${CUR_DIR+x} ]] && { CUR_DIR=$(cd "$(dirname "$0")"; pwd); }
 
 [[ -z ${API_SUFFIX+x} ]] && { API_SUFFIX=":8080/api/"; }
-[[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/che-integration-tests/"; }
 
 MODE="grid"
 GRID_OPTIONS="-Dgrid.mode=true"
-RERUN=false
-readonly MAX_RERUN=2
+RERUN_ATTEMPTS=0
 BROWSER="GOOGLE_CHROME"
 WEBDRIVER_VERSION=$(curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 WEBDRIVER_PORT="9515"
@@ -98,14 +98,17 @@ checkParameters() {
     for var in "$@"; do
         if [[ "$var" =~ --web-driver-version=.* ]]; then :
         elif [[ "$var" =~ --web-driver-port=[0-9]+$ ]]; then :
-        elif [[ "$var" == "--http" ]]; then :
-        elif [[ "$var" == "--https" ]]; then  :
-        elif [[ "$var" == "--che" ]]; then :
+        elif [[ "$var" == --http ]]; then :
+        elif [[ "$var" == --https ]]; then :
+        elif [[ "$var" == --che ]]; then :
         elif [[ "$var" =~ --host=.* ]]; then :
         elif [[ "$var" =~ --threads=[0-9]+$ ]]; then :
-        elif [[ "$var" == "--rerun" ]]; then :
-        elif [[ "$var" == "--debug" ]]; then :
-        elif [[ "$var" == "--all-tests" ]]; then
+
+        elif [[ "$var" == --rerun ]]; then :
+        elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --rerun[[:space:]]$var ]]; then :
+
+        elif [[ "$var" == --debug ]]; then :
+        elif [[ "$var" == --all-tests ]]; then
             echo "[WARN] '--all-tests' parameter is outdated and is being ignored"
 
         elif [[ "$var" =~ --test=.* ]]; then
@@ -130,17 +133,20 @@ checkParameters() {
                 exit 1;
             }
 
-        elif [[ "$var" == "--failed-tests" ]]; then :
-        elif [[ "$var" == "--regression-tests" ]]; then :
+        elif [[ "$var" == --failed-tests ]]; then :
+        elif [[ "$var" == --regression-tests ]]; then :
         elif [[ "$var" =~ -M.* ]]; then :
         elif [[ "$var" =~ -P.* ]]; then :
-        elif [[ "$var" == "--help" ]]; then :
-        elif [[ "$var" == "--compare-with-ci" ]]; then :
-        elif [[ "$var" =~ ^--workspace-pool-size=(auto|[0-9]+)$ ]]; then :
+        elif [[ "$var" == --help ]]; then :
+
+        elif [[ "$var" == --compare-with-ci ]]; then :
         elif [[ "$var" =~ ^[0-9]+$ ]] && [[ $@ =~ --compare-with-ci[[:space:]]$var ]]; then :
+
+        elif [[ "$var" =~ ^--workspace-pool-size=(auto|[0-9]+)$ ]]; then :
         elif [[ "$var" =~ ^-D.* ]]; then :
         elif [[ "$var" =~ ^-[[:alpha:]]$ ]]; then :
-        elif [[ "$var" == "--skip-sources-validation" ]]; then :
+        elif [[ "$var" == --skip-sources-validation ]]; then :
+        elif [[ "$var" == --multiuser ]]; then :
         else
             printHelp
             echo "[TEST] Unrecognized or misused parameter "${var}
@@ -161,10 +167,10 @@ applyCustomOptions() {
                 WEBDRIVER_PORT=$(echo "$var" | sed -e "s/--web-driver-port=//g")
             fi
 
-        elif [[ "$var" == "--http" ]]; then
+        elif [[ "$var" == --http ]]; then
             PRODUCT_PROTOCOL="http"
 
-        elif [[ "$var" == "--https" ]]; then
+        elif [[ "$var" == --https ]]; then
             PRODUCT_PROTOCOL="https"
 
         elif [[ "$var" =~ --host=.* ]]; then
@@ -176,15 +182,23 @@ applyCustomOptions() {
         elif [[ "$var" =~ --workspace-pool-size=.* ]]; then
             WORKSPACE_POOL_SIZE=$(echo "$var" | sed -e "s/--workspace-pool-size=//g")
 
-        elif [[ "$var" == "--rerun" ]]; then
-            RERUN=true
+        elif [[ "$var" =~ --rerun ]]; then
+            local rerunAttempts=$(echo $@ | sed 's/.*--rerun\W\+\([0-9]\+\).*/\1/')
+            if [[ "$rerunAttempts" =~ ^[0-9]+$ ]]; then
+              RERUN_ATTEMPTS=$rerunAttempts
+            else
+              RERUN_ATTEMPTS=1
+            fi
 
-        elif [[ "$var" == "--debug" ]]; then
+        elif [[ "$var" == --debug ]]; then
             DEBUG_OPTIONS="-Dmaven.failsafe.debug"
             NODE_CHROME_DEBUG_SUFFIX="-debug"
 
-        elif [[ "$var" == "--compare-with-ci" ]]; then
+        elif [[ "$var" == --compare-with-ci ]]; then
             COMPARE_WITH_CI=true
+
+        elif [[ "$var" == --multiuser ]]; then
+            CHE_MULTIUSER=true
 
         fi
     done
@@ -212,11 +226,11 @@ defineTestsScope() {
         elif [[ "$var" =~ --suite=.* ]]; then
             TESTS_SCOPE="-DrunSuite=src/test/resources/suites/"$(echo "$var" | sed -e "s/--suite=//g")
 
-        elif [[ "$var" == "--failed-tests" ]]; then
+        elif [[ "$var" == --failed-tests ]]; then
             generateTestNgFailedReport $(fetchFailedTests)
             TESTS_SCOPE="-DrunSuite=${TESTNG_FAILED_SUITE}"
 
-        elif [[ "$var" == "--regression-tests" ]]; then
+        elif [[ "$var" == --regression-tests ]]; then
             generateTestNgFailedReport $(findRegressions)
             TESTS_SCOPE="-DrunSuite=${TESTNG_FAILED_SUITE}"
         fi
@@ -366,7 +380,7 @@ Modes (defines environment to run tests):
                                         Web browsers will be opened on the developer machine.
                                         Default value is in range [2,5] and depends on available RAM.
 
-    -Mgrid (default)                    All tests will be run in parallel on several docker containers.
+    -Mgrid (default)                    All tests will be run in parallel among several docker containers.
                                         One container per thread. Recommended to run test suite.
 
         Options that go with 'grid' mode:
@@ -381,8 +395,10 @@ Define tests scope:
 Handle failing tests:
     --failed-tests                      Rerun failed tests that left after the previous try
     --regression-tests                  Rerun regression tests that left after the previous try
-    --rerun                             Automatically rerun failing tests
-    --compare-with-ci                   Compare failed tests with results on CI server
+    --rerun [ATTEMPTS]                  Automatically rerun failing tests.
+                                        Default attempts number is 1.
+    --compare-with-ci [BUILD NUMBER]    Compare failed tests with results on CI server.
+                                        Default build is the latest.
 
 Other options:
     --debug                             Run tests in debug mode
@@ -398,7 +414,7 @@ HOW TO of usage:
         ${CALLER} --multiuser
 
     Test Eclipse Che assembly and automatically rerun failing tests:
-        ${CALLER} --rerun
+        ${CALLER} --rerun [ATTEMPTS]
 
     Run single test or package of tests:
         ${CALLER} <...> --test=<TEST>
@@ -408,13 +424,13 @@ HOW TO of usage:
 
     Rerun failed tests:
         ${CALLER} <...> --failed-tests
-        ${CALLER} <...> --failed-tests --rerun
+        ${CALLER} <...> --failed-tests --rerun [ATTEMPTS]
 
     Debug selenium test:
         ${CALLER} -Mlocal --test=<TEST> --debug
 
     Analyse tests results:
-        ${CALLER} --compare-with-ci [CI job number]
+        ${CALLER} --compare-with-ci [BUILD NUMBER]
 "
 
     printf "%s" "${usage}"
@@ -424,7 +440,7 @@ printRunOptions() {
     echo "[TEST]"
     echo "[TEST] =========== RUN OPTIONS ==========================="
     echo "[TEST] Mode                : "${MODE}
-    echo "[TEST] Rerun failing tests : "${RERUN}
+    echo "[TEST] Rerun attempts      : "${RERUN_ATTEMPTS}
     echo "[TEST] ==================================================="
     echo "[TEST] Product Protocol    : "${PRODUCT_PROTOCOL}
     echo "[TEST] Product Host        : "${PRODUCT_HOST}
@@ -487,8 +503,8 @@ fetchFailedTestsNumber() {
 }
 
 detectLatestResultsUrl() {
-    local job=$(curl -s ${BASE_ACTUAL_RESULTS_URL} | tr '\n' ' ' | sed 's/.*Last build (#\([0-9]\+\)).*/\1/')
-    echo ${BASE_ACTUAL_RESULTS_URL}${job}"/testReport/"
+    local build=$(curl -s ${BASE_ACTUAL_RESULTS_URL} | tr '\n' ' ' | sed 's/.*Last build (#\([0-9]\+\)).*/\1/')
+    echo ${BASE_ACTUAL_RESULTS_URL}${build}"/testReport/"
 }
 
 # Fetches list of failed tests and failed configurations.
@@ -497,11 +513,20 @@ fetchActualResults() {
     unset ACTUAL_RESULTS
     unset ACTUAL_RESULTS_URL
 
-    local job=$(echo $@ | sed 's/.*--compare-with-ci\W\+\([0-9]\+\).*/\1/')
-    if [[ ! ${job} =~ ^[0-9]+$ ]]; then
+    # define the URL of CI job to compare result with result on it
+    if [[ ${CHE_MULTIUSER} == true ]]; then
+      local nameOfCIJob=che-multiuser-integration-tests
+    else
+      local nameOfCIJob=che-integration-tests
+    fi
+
+    [[ -z ${BASE_ACTUAL_RESULTS_URL+x} ]] && { BASE_ACTUAL_RESULTS_URL="https://ci.codenvycorp.com/view/qa/job/$nameOfCIJob/"; }
+
+    local build=$(echo $@ | sed 's/.*--compare-with-ci\W\+\([0-9]\+\).*/\1/')
+    if [[ ! ${build} =~ ^[0-9]+$ ]]; then
         ACTUAL_RESULTS_URL=$(detectLatestResultsUrl)
     else
-        ACTUAL_RESULTS_URL=${BASE_ACTUAL_RESULTS_URL}${job}"/testReport/"
+        ACTUAL_RESULTS_URL=${BASE_ACTUAL_RESULTS_URL}${build}"/testReport/"
     fi
 
     # get list of failed tests from CI server, remove duplicates from it and sort
@@ -599,7 +624,7 @@ analyseTestsResults() {
 
 printProposals() {
     echo -e "[TEST] "${YELLOW}"PROPOSALS:"${NO_COLOUR}
-    local cmd=$(echo $@ | sed -e "s/--rerun//g" | \
+    local cmd=$(echo $@ | sed -e "s/--rerun\W*[0-9]*//g" | \
                           sed -e "s/-M[^ ]*//g" | \
                           sed -e "s/--failed-tests//g" | \
                           sed -e "s/--regression-tests//g" | \
@@ -631,11 +656,11 @@ printProposals() {
     fi
 
     echo "[TEST]"
-    echo "[TEST] To compare tests results with the latest CI job"
+    echo "[TEST] To compare tests results with the latest results on CI job"
     echo -e "[TEST] \t${BLUE}${CUR_DIR}/${CALLER} ${cmd} --compare-with-ci${NO_COLOUR}"
     echo "[TEST]"
-    echo "[TEST] To compare tests results with results of the specific CI job"
-    echo -e "[TEST] \t${BLUE}${CUR_DIR}/${CALLER} ${cmd} --compare-with-ci CI_JOB_NUMBER${NO_COLOUR}"
+    echo "[TEST] To compare local tests results with certain build on CI job"
+    echo -e "[TEST] \t${BLUE}${CUR_DIR}/${CALLER} ${cmd} --compare-with-ci [BUILD NUMBER]${NO_COLOUR}"
     echo "[TEST]"
     echo "[TEST]"
 }
@@ -674,7 +699,7 @@ rerunTests() {
     local total=$(echo ${regressions[@]} | wc -w)
 
     if [[ ! ${total} -eq 0 ]]; then
-        local rerun=$1 && shift
+        local rerunCounter=$1 && shift
 
         analyseTestsResults $@
         generateFailSafeReport
@@ -684,14 +709,14 @@ rerunTests() {
 
         echo -e "[TEST]"
         echo -e "[TEST] ${YELLOW}---------------------------------------------------${NO_COLOUR}"
-        echo -e "[TEST] ${YELLOW}RERUNNING FAILED TESTS IN ONE THREAD: ATTEMPT #${rerun}${NO_COLOUR}"
+        echo -e "[TEST] ${YELLOW}RERUNNING FAILED TESTS IN ONE THREAD: ATTEMPT #${rerunCounter}${NO_COLOUR}"
         echo -e "[TEST] ${YELLOW}---------------------------------------------------${NO_COLOUR}"
 
         defineTestsScope "--failed-tests"
         runTests
 
-        if [[ ${rerun} < ${MAX_RERUN} ]]; then
-            rerunTests $(($rerun+1)) $@
+        if [[ ${rerunCounter} < ${RERUN_ATTEMPTS} ]]; then
+            rerunTests $(($rerunCounter+1)) $@
         fi
     fi
 }
@@ -797,7 +822,7 @@ prepareToFirstRun() {
 testProduct() {
     runTests
 
-    if [[ ${RERUN} == true ]]; then
+    if [[ ${RERUN_ATTEMPTS} > 0 ]]; then
         MAVEN_OPTIONS="${MAVEN_OPTIONS} -o"
         rerunTests 1 $@
     fi

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -84,8 +84,10 @@ Define tests scope:
 Handle failing tests:
     --failed-tests                      Rerun failed tests that left after the previous try
     --regression-tests                  Rerun regression tests that left after the previous try
-    --rerun                             Automatically rerun failing tests
-    --compare-with-ci                   Compare failed tests with results on CI server
+    --rerun [ATTEMPTS]                  Automatically rerun failing tests.
+                                        Default attempts number is 1.
+    --compare-with-ci [BUILD NUMBER]    Compare failed tests with results on CI server.
+                                        Default build is the latest.
 
 Other options:
     --debug                             Run tests in debug mode
@@ -101,7 +103,7 @@ HOW TO of usage:
         ./selenium-tests.sh --multiuser
 
     Test Eclipse Che assembly and automatically rerun failing tests:
-        ./selenium-tests.sh --rerun
+        ./selenium-tests.sh --rerun [ATTEMPTS]
 
     Run single test or package of tests:
         ./selenium-tests.sh <...> --test=<TEST>
@@ -111,13 +113,13 @@ HOW TO of usage:
 
     Rerun failed tests:
         ./selenium-tests.sh <...> --failed-tests
-        ./selenium-tests.sh <...> --failed-tests --rerun
+        ./selenium-tests.sh <...> --failed-tests --rerun [ATTEMPTS]
 
     Debug selenium test:
         ./selenium-tests.sh -Mlocal --test=<TEST> --debug
 
     Analyse tests results:
-        ./selenium-tests.sh --compare-with-ci [CI job number]
+        ./selenium-tests.sh --compare-with-ci [BUILD NUMBER]
 ```
 
 

--- a/selenium/che-selenium-test/selenium-tests.sh
+++ b/selenium/che-selenium-test/selenium-tests.sh
@@ -31,22 +31,6 @@ for var in "$@"; do
     fi
 done
 
-index=0
-params=($*)
-cheMultiuserValue=${CHE_MULTIUSER:-false}
-for var in "$@"; do
-    if [[ "$var" =~ --multiuser ]]; then
-        cheMultiuserValue=true
-        unset params[$index]                     # remove "--multiuser" from parameters
-        break
-    fi
-    let "index+=1"
-done
-
-export CHE_MULTIUSER=$cheMultiuserValue
-
-set -- "${params[@]}"
-
 mvn $CLEAN_GOAL dependency:unpack-dependencies \
     -DincludeArtifactIds=che-selenium-core \
     -DincludeGroupIds=org.eclipse.che.selenium \


### PR DESCRIPTION
### What does this PR do?
- moves `--multiuser` parameter from **selenium-test.sh** to **webdriver.sh**;
- fixed **webdriver.sh** script to compare selenium testing results with multiuser CI job;
- makes it clear the difference between 'CI job' from 'build' in terms of comparison of test results;
- adds an ability to set exact number of rerun of selenium tests.

### What issues does this PR fix or reference?
- issues: #7511, #7512
- PR into che6: https://github.com/eclipse/che/pull/7823

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

#### Docs PR
https://github.com/eclipse/che-docs/pull/324