### PR TITLE
Fixed start of workspaces on OpenShift 3.7 by adding redirecting of error from exec

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPods.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPods.java
@@ -324,6 +324,8 @@ public class OpenShiftPods {
             .inNamespace(namespace)
             .withName(podName)
             .inContainer(containerName)
+            // redirecting error output to exec watch out stream
+            .redirectingError()
             .usingListener(watchdog)
             .exec(encode(command))) {
       try {


### PR DESCRIPTION
### What does this PR do?
OpenShift 3.7 requires specified at least one of stdin, stdout, stderr while exec performing. This pull request fixes start of workspaces by adding redirecting of error from exec.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7839