### PR TITLE
CHE-7220: Fix Git add to index when deleted files are present

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -342,27 +342,25 @@ class JGitConnection implements GitConnection {
     try {
       addCommand.call();
 
-      addDeletedFilesToIndex(filePatterns);
+      addDeletedFilesToIndexIfNeeded(filePatterns);
     } catch (GitAPIException exception) {
       throw new GitException(exception.getMessage(), exception);
     }
   }
 
   /** To add deleted files in index it is required to perform git rm on them */
-  private void addDeletedFilesToIndex(List<String> filePatterns) throws GitAPIException {
+  private void addDeletedFilesToIndexIfNeeded(List<String> filePatterns) throws GitAPIException {
     Set<String> deletedFiles = getGit().status().call().getMissing();
+    if (deletedFiles.isEmpty()) {
+      return;
+    }
+    if (!filePatterns.isEmpty() && !filePatterns.contains(".")) {
+      deletedFiles =
+          deletedFiles.stream().filter(filePatterns::contains).collect(Collectors.toSet());
+    }
     if (!deletedFiles.isEmpty()) {
       RmCommand rmCommand = getGit().rm();
-      if (filePatterns.contains(".")) {
-        deletedFiles.forEach(rmCommand::addFilepattern);
-      } else {
-        filePatterns.forEach(
-            filePattern ->
-                deletedFiles
-                    .stream()
-                    .filter(deletedFile -> deletedFile.startsWith(filePattern))
-                    .forEach(rmCommand::addFilepattern));
-      }
+      deletedFiles.forEach(rmCommand::addFilepattern);
       rmCommand.call();
     }
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix Git add to index specified file when deleted files are present.

### What issues does this PR fix or reference?
#7220 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Fix Git add to index specified file when deleted files are present.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A