### PR TITLE
Allow getting list of supported environment recipe types from Workspace API

### DIFF
--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -61,5 +61,7 @@ public final class Constants {
 
   public static final String WS_MACHINE_NAME = "default";
 
+  public static final String SUPPORTED_ENVIRONMENTS = "supported_environments";
+
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -61,7 +61,7 @@ public final class Constants {
 
   public static final String WS_MACHINE_NAME = "default";
 
-  public static final String SUPPORTED_ENVIRONMENTS = "supportedEnvironments";
+  public static final String SUPPORTED_RECIPE_TYPES = "supportedRecipeTypes";
 
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -61,7 +61,7 @@ public final class Constants {
 
   public static final String WS_MACHINE_NAME = "default";
 
-  public static final String SUPPORTED_ENVIRONMENTS = "supported_environments";
+  public static final String SUPPORTED_ENVIRONMENTS = "supportedEnvironments";
 
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -22,6 +22,7 @@ import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.inject.Singleton;
 import org.eclipse.che.account.api.AccountManager;
 import org.eclipse.che.account.shared.model.Account;
@@ -339,6 +340,10 @@ public class WorkspaceManager {
                 removeWorkspaceQuietly(workspace);
               }
             });
+  }
+
+  public Set<String> getSupportedRecipes() {
+    return runtimes.getSupportedRecipes();
   }
 
   /** Asynchronously starts given workspace. */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -553,6 +553,10 @@ public class WorkspaceRuntimes {
     return Optional.of(state.runtime.getContext());
   }
 
+  public Set<String> getSupportedRecipes() {
+    return environmentFactories.keySet();
+  }
+
   private InternalEnvironment createInternalEnvironment(Environment environment)
       throws InfrastructureException, ValidationException, NotFoundException {
     String recipeType = environment.getRecipe().getType();

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -679,7 +679,7 @@ public class WorkspaceService extends Service {
   @ApiResponses({@ApiResponse(code = 200, message = "The response contains server settings")})
   public Map<String, String> getSettings() {
     return ImmutableMap.of(
-        Constants.SUPPORTED_ENVIRONMENTS,
+        Constants.SUPPORTED_RECIPE_TYPES,
         Joiner.on(",").join(workspaceManager.getSupportedRecipes()));
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -17,6 +17,8 @@ import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -56,6 +58,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.token.MachineTokenException;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
+import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.api.workspace.shared.dto.CommandDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.MachineDto;
@@ -675,7 +678,9 @@ public class WorkspaceService extends Service {
   @ApiOperation(value = "Get workspace server configuration values")
   @ApiResponses({@ApiResponse(code = 200, message = "The response contains server settings")})
   public Map<String, String> getSettings() {
-    return new HashMap<>();
+    return ImmutableMap.of(
+        Constants.SUPPORTED_ENVIRONMENTS,
+        Joiner.on(",").join(workspaceManager.getSupportedRecipes()));
   }
 
   private static Map<String, String> parseAttrs(List<String> attributes)

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -34,6 +34,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.jayway.restassured.response.Response;
@@ -62,6 +63,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
+import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.api.workspace.shared.dto.CommandDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.MachineDto;
@@ -1101,6 +1103,8 @@ public class WorkspaceServiceTest {
 
   @Test
   public void shouldBeAbleToGetSettings() throws Exception {
+    when(wsManager.getSupportedRecipes()).thenReturn(ImmutableSet.of("dockerimage", "dockerfile"));
+
     final Response response =
         given()
             .auth()
@@ -1111,7 +1115,8 @@ public class WorkspaceServiceTest {
     assertEquals(response.getStatusCode(), 200);
     final Map<String, String> settings =
         new Gson().fromJson(response.print(), new TypeToken<Map<String, String>>() {}.getType());
-    assertEquals(settings, emptyMap());
+    assertEquals(
+        settings, singletonMap(Constants.SUPPORTED_ENVIRONMENTS, "dockerimage,dockerfile"));
   }
 
   private static String unwrapError(Response response) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -1116,7 +1116,7 @@ public class WorkspaceServiceTest {
     final Map<String, String> settings =
         new Gson().fromJson(response.print(), new TypeToken<Map<String, String>>() {}.getType());
     assertEquals(
-        settings, singletonMap(Constants.SUPPORTED_ENVIRONMENTS, "dockerimage,dockerfile"));
+        settings, singletonMap(Constants.SUPPORTED_RECIPE_TYPES, "dockerimage,dockerfile"));
   }
 
   private static String unwrapError(Response response) {


### PR DESCRIPTION
### What does this PR do?
Adds a list of environment recipe types supported in a running Che instance. 
To get it cal `GET /api/workspace/settings`. The response is an object with next field:
`supported_environments` and value such as `"dockerimage,dockerfile"`.
Recipe types are separated by the comma sign.

### What issues does this PR fix or reference?
Fixes #7530 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
