### PR TITLE
Remove unnecessary item from the check list in the ServerRuntimeInfoTest

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
@@ -51,8 +51,7 @@ public class ServerRuntimeInfoTest {
             "exec-agent/ws",
             "wsagent/http",
             "exec-agent/http",
-            "wsagent-debug",
-            "terminal");
+            "wsagent-debug");
 
     for (int i = 0; i < expectedReferenceList.size(); i++) {
       String referenceId = "gwt-debug-runtime-info-reference-" + i;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
@@ -53,8 +53,6 @@ public class ServerRuntimeInfoTest {
             "exec-agent/http",
             "wsagent-debug");
 
-
-
     for (int i = 0; i < expectedReferenceList.size(); i++) {
       String referenceId = "gwt-debug-runtime-info-reference-" + i;
       consoles.checkReferenceList(referenceId, expectedReferenceList.get(i));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
@@ -51,8 +51,8 @@ public class ServerRuntimeInfoTest {
             "exec-agent/ws",
             "wsagent/http",
             "exec-agent/http",
-            "wsagent-debug",
-            "terminal");
+            "wsagent-debug"
+            );
 
     for (int i = 0; i < expectedReferenceList.size(); i++) {
       String referenceId = "gwt-debug-runtime-info-reference-" + i;


### PR DESCRIPTION
### Description
After changing servers list in the IDE the 'terminal' item in runtime info widget is not visible on this moment. (We should resize or scroll this one to make it visible ). 
@vparfonov, @tolusha 