### PR TITLE
Make bootstrapper use /bin/sh as an interpreter

### DIFF
--- a/agents/go-agents/bootstrapper/main.go
+++ b/agents/go-agents/bootstrapper/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eclipse/che/agents/go-agents/bootstrapper/cfg"
 	"github.com/eclipse/che/agents/go-agents/core/jsonrpc"
 	"github.com/eclipse/che/agents/go-agents/core/jsonrpc/jsonrpcws"
+	"github.com/eclipse/che/agents/go-agents/core/process"
 )
 
 func main() {
@@ -26,6 +27,8 @@ func main() {
 
 	cfg.Parse()
 	cfg.Print()
+
+	process.SetShellInterpreter("/bin/sh")
 
 	booter.Init(
 		cfg.RuntimeID,

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
@@ -179,7 +179,7 @@ export class DiagnosticsWorkspaceStartCheck {
               }
             },
             'recipe': {
-              'content': 'FROM openjdk:8-jre-alpine\nRUN apk add --update bash\nCMD tail -f /dev/null\n',
+              'content': 'FROM openjdk:8-jre-alpine\nCMD tail -f /dev/null\n',
               'contentType': 'text/x-dockerfile',
               'type': 'dockerfile'
             }


### PR DESCRIPTION
### What does this PR do?
Sets `/bin/sh` as a shell interpreter of processes that bootstrapper starts. 

### What issues does this PR fix or reference?
Fixes #7124 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
