### PR TITLE
Removed reference of Kedge from properties file

### DIFF
--- a/plugins/plugin-yaml/che-plugin-yaml-ide/src/main/resources/org/eclipse/che/plugin/yaml/ide/YamlLocalizationConstant.properties
+++ b/plugins/plugin-yaml/che-plugin-yaml-ide/src/main/resources/org/eclipse/che/plugin/yaml/ide/YamlLocalizationConstant.properties
@@ -11,7 +11,7 @@
 
 addUrlText=Add Schema Url
 deleteUrlText=Delete Url
-headerUiMessage=Enter a schema which can be either the url, kedge, or kubernetes. If you specify kedge or kubernetes the languageserver will specify the schema url for you.
+headerUiMessage=Enter a schema which can either be the url or kubernetes. If you specify kubernetes the languageserver will specify the schema url for you.
 addUrlLabel=Add Schema url
 addSchemaButtonText=Add
 deleteUrlLabel=Delete url


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Removes references of kedge from YAML localization constants properties file

### What issues does this PR fix or reference?
You can no longer specify kedge directly through the YAML language server so kedge is no longer needed in the text

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

