### PR TITLE
Support of headers to 'HttpJsonRequest'. Adding 'Connection: close' header while pinging workspace agent

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequest.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequest.java
@@ -111,6 +111,16 @@ public interface HttpJsonRequest {
   HttpJsonRequest addQueryParam(@NotNull String name, @NotNull Object value);
 
   /**
+   * Adds header to the request.
+   *
+   * @param name header name
+   * @param value header value
+   * @return this request instance
+   * @throws NullPointerException when either header name or value is null
+   */
+  HttpJsonRequest addHeader(@NotNull String name, @NotNull String value);
+
+  /**
    * Adds authorization header to the request.
    *
    * @param value authorization header value
@@ -204,6 +214,18 @@ public interface HttpJsonRequest {
   default HttpJsonRequest addQueryParams(@NotNull Map<String, ?> params) {
     Objects.requireNonNull(params, "Required non-null query parameters");
     params.forEach(this::addQueryParam);
+    return this;
+  }
+
+  /**
+   * Adds set of headers to this request.
+   *
+   * @param headers map with headers
+   * @return this request instance
+   */
+  default HttpJsonRequest addHeaders(@NotNull Map<String, String> headers) {
+    Objects.requireNonNull(headers, "Required non-null headers");
+    headers.forEach(this::addHeader);
     return this;
   }
 }

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
@@ -103,10 +103,11 @@ public class DefaultHttpJsonRequestTest {
             anyString(),
             nullable(Object.class),
             nullable(List.class),
-            nullable(String.class));
+            nullable(String.class),
+            nullable(List.class));
     request.request();
 
-    verify(request).doRequest(0, DEFAULT_URL, "POST", null, null, null);
+    verify(request).doRequest(0, DEFAULT_URL, "POST", null, null, null, null);
   }
 
   @Test
@@ -119,6 +120,7 @@ public class DefaultHttpJsonRequestTest {
         .setTimeout(10_000_000)
         .addQueryParam("name", "value")
         .addQueryParam("name2", "value2")
+        .addHeader("Connection", "close")
         .request();
 
     verify(request)
@@ -128,7 +130,8 @@ public class DefaultHttpJsonRequestTest {
             "PUT",
             body,
             asList(Pair.of("name", "value"), Pair.of("name2", "value2")),
-            null);
+            null,
+            asList(Pair.of("Connection", "close")));
   }
 
   @Test
@@ -145,6 +148,7 @@ public class DefaultHttpJsonRequestTest {
             eq("http://localhost:8080"),
             eq("POST"),
             mapCaptor.capture(),
+            eq(null),
             eq(null),
             eq(null));
     assertTrue(mapCaptor.getValue() instanceof JsonStringMap);
@@ -164,6 +168,7 @@ public class DefaultHttpJsonRequestTest {
             eq("POST"),
             listCaptor.capture(),
             eq(null),
+            eq(null),
             eq(null));
     assertTrue(listCaptor.getValue() instanceof JsonArray);
     assertEquals(listCaptor.getValue(), body);
@@ -172,7 +177,7 @@ public class DefaultHttpJsonRequestTest {
   @Test
   public void defaultMethodIsGet() throws Exception {
     request.request();
-    verify(request).doRequest(0, DEFAULT_URL, HttpMethod.GET, null, null, null);
+    verify(request).doRequest(0, DEFAULT_URL, HttpMethod.GET, null, null, null, null);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -214,6 +219,21 @@ public class DefaultHttpJsonRequestTest {
   @Test(expectedExceptions = NullPointerException.class)
   public void shouldThrowNullPointerExceptionWhenQueryParamsAreNull() throws Exception {
     new DefaultHttpJsonRequest("http://localhost:8080").addQueryParams(null);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionWhenHeaderNameIsNull() throws Exception {
+    new DefaultHttpJsonRequest("http://localhost:8080").addHeader(null, "close");
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionWhenHeaderValueIsNull() throws Exception {
+    new DefaultHttpJsonRequest("http://localhost:8080").addHeader("Connection", null);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionWhenHeadersAreNull() throws Exception {
+    new DefaultHttpJsonRequest("http://localhost:8080").addHeaders(null);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -375,6 +395,7 @@ public class DefaultHttpJsonRequestTest {
             anyString(),
             nullable(Object.class),
             nullable(List.class),
-            nullable(String.class));
+            nullable(String.class),
+            nullable(List.class));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactory.java
@@ -39,6 +39,8 @@ public class WsAgentPingRequestFactory {
       "Workspace agent server not found in dev machine.";
   private static final String WS_AGENT_URL_IS_NULL_OR_EMPTY_ERROR =
       "URL of Workspace Agent is null or empty.";
+  private static final String CONNECTION_HEADER = "Connection";
+  private static final String CONNECTION_CLOSE = "close";
 
   private final HttpJsonRequestFactory httpJsonRequestFactory;
   private final int wsAgentPingConnectionTimeoutMs;
@@ -80,9 +82,11 @@ public class WsAgentPingRequestFactory {
     if (!wsAgentPingUrl.endsWith("/")) {
       wsAgentPingUrl = wsAgentPingUrl.concat("/");
     }
+
     return httpJsonRequestFactory
         .fromUrl(wsAgentPingUrl)
         .setMethod(HttpMethod.GET)
-        .setTimeout(wsAgentPingConnectionTimeoutMs);
+        .setTimeout(wsAgentPingConnectionTimeoutMs)
+        .addHeader(CONNECTION_HEADER, CONNECTION_CLOSE);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/agent/server/WsAgentPingRequestFactoryTest.java
@@ -40,6 +40,8 @@ public class WsAgentPingRequestFactoryTest {
   private static final String WS_AGENT_SERVER_NOT_FOUND_ERROR =
       "Workspace agent server not found in dev machine.";
   private static final String WS_AGENT_SERVER_URL = "ws_agent";
+  private static final String CONNECTION_HEADER = "Connection";
+  private static final String CONNECTION_CLOSE = "close";
 
   @Mock private HttpJsonRequestFactory httpJsonRequestFactory;
   @Mock private HttpJsonRequest httpJsonRequest;
@@ -62,6 +64,10 @@ public class WsAgentPingRequestFactoryTest {
 
     when(httpJsonRequestFactory.fromUrl(anyString())).thenReturn(httpJsonRequest);
     when(httpJsonRequest.setMethod(HttpMethod.GET)).thenReturn(httpJsonRequest);
+    when(httpJsonRequest.setTimeout(WS_AGENT_PING_CONNECTION_TIMEOUT_MS))
+        .thenReturn(httpJsonRequest);
+    when(httpJsonRequest.addHeader(CONNECTION_HEADER, CONNECTION_CLOSE))
+        .thenReturn(httpJsonRequest);
     when(server.getProperties()).thenReturn(serverProperties);
     when(serverProperties.getInternalUrl()).thenReturn(WS_AGENT_SERVER_URL);
     when(devMachine.getRuntime()).thenReturn(machineRuntimeInfo);
@@ -105,5 +111,6 @@ public class WsAgentPingRequestFactoryTest {
     verify(httpJsonRequestFactory).fromUrl(WS_AGENT_SERVER_URL + '/');
     verify(httpJsonRequest).setMethod(javax.ws.rs.HttpMethod.GET);
     verify(httpJsonRequest).setTimeout(WS_AGENT_PING_CONNECTION_TIMEOUT_MS);
+    verify(httpJsonRequest).addHeader(CONNECTION_HEADER, CONNECTION_CLOSE);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adding support of headers to 'HttpJsonRequest'
Adding 'Connection: close' header while pinging workspace agent
Details in https://github.com/redhat-developer/rh-che/issues/479#issuecomment-351482507

Image used for verification on osio - `ibuziuk/che-server:connection-close`

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/479

<!-- #### Changelog -->
Adding support of headers to 'HttpJsonRequest'

#### Release Notes
Adding support of headers to 'HttpJsonRequest'


