### PR TITLE
Fix invalid API version from openshift yml

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -424,6 +424,7 @@ if [ "${OPENSHIFT_FLAVOR}" == "minishift" ]; then
   echo "[CHE] Deploying Che on minishift (image ${CHE_IMAGE})"
   curl -sSL http://central.maven.org/maven2/io/fabric8/tenant/apps/che/"${OSIO_VERSION}"/che-"${OSIO_VERSION}"-openshift.yml | \
     if [ ! -z "${OPENSHIFT_NAMESPACE_URL+x}" ]; then sed "s/    hostname-http:.*/    hostname-http: ${OPENSHIFT_NAMESPACE_URL}/" ; else cat -; fi | \
+    sed "s/apps.openshift.io\///" | \
     sed "s/          image:.*/          image: \"${CHE_IMAGE_SANITIZED}\"/" | \
     sed "s/          imagePullPolicy:.*/          imagePullPolicy: \"${IMAGE_PULL_POLICY}\"/" | \
     sed "s/    workspaces-memory-limit: 2300Mi/    workspaces-memory-limit: 1300Mi/" | \


### PR DESCRIPTION
### What does this PR do?
Quick sed fix for deployment to minishift.

Should probably be fixed in the `maven2/io/fabric8/tenant/apps/che` repo.

### What issues does this PR fix or reference?
Closes #7803

#### Changelog
sed apps.openshift.io/ out of the version as its invalid when running `deploy_che.sh`

#### Release Notes
N/A