### PR TITLE
CHE-6330: Line should appear in the middle of the editor after setCursorPosition()

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.ide.editor.orion.client;
 
+import static org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewShowOptionsOverlay.CENTER_VIEW_ANCHOR;
+
 import com.google.web.bindery.event.shared.HandlerRegistration;
 import org.eclipse.che.ide.api.editor.document.AbstractDocument;
 import org.eclipse.che.ide.api.editor.document.Document;
@@ -30,6 +32,7 @@ import org.eclipse.che.ide.editor.orion.client.jso.OrionSelectionOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextModelOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextModelOverlay.EventHandler;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewShowOptionsOverlay;
 
 /**
  * The implementation of {@link Document} for Orion.
@@ -160,7 +163,9 @@ public class OrionDocument extends AbstractDocument {
 
   @Override
   public void setCursorPosition(final TextPosition position) {
-    this.editorOverlay.setCaretOffset(getIndexFromPosition(position));
+    OrionTextViewShowOptionsOverlay showOptionsOverlay = OrionTextViewShowOptionsOverlay.create();
+    showOptionsOverlay.setViewAnchor(CENTER_VIEW_ANCHOR);
+    this.editorOverlay.setCaretOffset(getIndexFromPosition(position), showOptionsOverlay);
   }
 
   public int getCursorOffset() {

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.ide.editor.orion.client;
 
-import static org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewShowOptionsOverlay.CENTER_VIEW_ANCHOR;
+import static org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewShowOptionsOverlay.ViewAnchorValue.CENTER;
 
 import com.google.web.bindery.event.shared.HandlerRegistration;
 import org.eclipse.che.ide.api.editor.document.AbstractDocument;
@@ -164,7 +164,7 @@ public class OrionDocument extends AbstractDocument {
   @Override
   public void setCursorPosition(final TextPosition position) {
     OrionTextViewShowOptionsOverlay showOptionsOverlay = OrionTextViewShowOptionsOverlay.create();
-    showOptionsOverlay.setViewAnchor(CENTER_VIEW_ANCHOR);
+    showOptionsOverlay.setViewAnchor(CENTER.getValue());
     this.editorOverlay.setCaretOffset(getIndexFromPosition(position), showOptionsOverlay);
   }
 

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionEditorOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionEditorOverlay.java
@@ -60,6 +60,10 @@ public class OrionEditorOverlay extends JavaScriptObject {
         this.setCaretOffset(offset, true);
     }-*/;
 
+  public final native void setCaretOffset(int offset, OrionTextViewShowOptionsOverlay show) /*-{
+        this.setCaretOffset(offset, show);
+    }-*/;
+
   public final native int getCaretOffset() /*-{
         return this.getCaretOffset();
     }-*/;

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewShowOptionsOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewShowOptionsOverlay.java
@@ -14,6 +14,8 @@ import com.google.gwt.core.client.JavaScriptObject;
 
 public class OrionTextViewShowOptionsOverlay extends JavaScriptObject {
 
+  public static final String CENTER_VIEW_ANCHOR = "center";
+
   protected OrionTextViewShowOptionsOverlay() {}
 
   public final native String getScrollPolicy() /*-{
@@ -46,5 +48,9 @@ public class OrionTextViewShowOptionsOverlay extends JavaScriptObject {
 
   public final native void setViewAnchorOffset(final String newValue) /*-{
         this.viewAnchorOffset = newValue;
+    }-*/;
+
+  public static native OrionTextViewShowOptionsOverlay create() /*-{
+        return {};
     }-*/;
 }

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewShowOptionsOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionTextViewShowOptionsOverlay.java
@@ -14,7 +14,21 @@ import com.google.gwt.core.client.JavaScriptObject;
 
 public class OrionTextViewShowOptionsOverlay extends JavaScriptObject {
 
-  public static final String CENTER_VIEW_ANCHOR = "center";
+  public enum ViewAnchorValue {
+    TOP("top"),
+    BOTTOM("bottom"),
+    CENTER("center");
+
+    private final String value;
+
+    ViewAnchorValue(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
 
   protected OrionTextViewShowOptionsOverlay() {}
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When navigating to line opened in the new editor line appears in the middle of the editor after `setCursorPosition()` method.

### What issues does this PR fix or reference?
#6330
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
When navigating to line opened in the new editor, line appears in the middle of the editor after `setCursorPosition()` method.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A