### PR TITLE
Add field 'status' into runtime machine object

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/runtime/Machine.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/runtime/Machine.java
@@ -37,4 +37,6 @@ public interface Machine {
    * </pre>
    */
   Map<String, ? extends Server> getServers();
+
+  MachineStatus getStatus();
 }

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/runtime/MachineStatus.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/runtime/MachineStatus.java
@@ -26,5 +26,5 @@ public enum MachineStatus {
   STOPPED,
 
   /** Machine failed */
-  FAILED;
+  FAILED
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/MachineImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/MachineImpl.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 
 /** Data object for {@link Machine}. */
@@ -23,11 +24,16 @@ public class MachineImpl implements Machine {
   private String name;
   private Map<String, String> attributes;
   private Map<String, ServerImpl> servers;
+  private MachineStatus status;
 
   public MachineImpl(
-      String name, Map<String, String> attributes, Map<String, ? extends Server> servers) {
+      String name,
+      Map<String, String> attributes,
+      Map<String, ? extends Server> servers,
+      MachineStatus status) {
     this.name = name;
     this.attributes = new HashMap<>(attributes);
+    this.status = status;
     if (servers != null) {
       this.servers =
           servers
@@ -42,7 +48,7 @@ public class MachineImpl implements Machine {
   }
 
   public MachineImpl(String name, Machine machine) {
-    this(name, machine.getAttributes(), machine.getServers());
+    this(name, machine.getAttributes(), machine.getServers(), machine.getStatus());
   }
 
   public String getName() {
@@ -65,26 +71,47 @@ public class MachineImpl implements Machine {
     return servers;
   }
 
+  @Override
+  public MachineStatus getStatus() {
+    return status;
+  }
+
   public Optional<ServerImpl> getServerByName(String name) {
     return Optional.ofNullable(getServers().get(name));
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof MachineImpl)) return false;
-    MachineImpl that = (MachineImpl) o;
-    return Objects.equals(getAttributes(), that.getAttributes())
-        && Objects.equals(getServers(), that.getServers());
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MachineImpl)) {
+      return false;
+    }
+    MachineImpl machine = (MachineImpl) o;
+    return Objects.equals(getName(), machine.getName())
+        && Objects.equals(getAttributes(), machine.getAttributes())
+        && Objects.equals(getServers(), machine.getServers())
+        && getStatus() == machine.getStatus();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getAttributes(), getServers());
+    return Objects.hash(getName(), getAttributes(), getServers(), getStatus());
   }
 
   @Override
   public String toString() {
-    return "MachineImpl{" + "attributes=" + attributes + ", servers=" + servers + '}';
+    return "MachineImpl{"
+        + "name='"
+        + name
+        + '\''
+        + ", attributes="
+        + attributes
+        + ", servers="
+        + servers
+        + ", status="
+        + status
+        + '}';
   }
 }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/RuntimeImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/RuntimeImpl.java
@@ -47,11 +47,7 @@ public class RuntimeImpl implements Runtime {
               .collect(
                   toMap(
                       Map.Entry::getKey,
-                      entry ->
-                          new MachineImpl(
-                              entry.getKey(),
-                              entry.getValue().getAttributes(),
-                              entry.getValue().getServers())));
+                      entry -> new MachineImpl(entry.getKey(), entry.getValue())));
     }
     this.owner = owner;
     this.machineToken = machineToken;

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -277,6 +277,8 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         serverCheckerFactory.create(getContext().getIdentity(), name, machine.getServers());
     readinessChecker.startAsync(new ServerReadinessHandler(name));
     readinessChecker.await();
+
+    machine.setStatus(MachineStatus.RUNNING);
   }
 
   private void checkInterruption() throws InterruptedException {

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -54,6 +55,8 @@ public class DockerMachine implements Machine {
   private final String registry;
   private final Map<String, ServerImpl> servers;
 
+  private MachineStatus status;
+
   public DockerMachine(
       String containerId,
       String image,
@@ -67,6 +70,7 @@ public class DockerMachine implements Machine {
     this.registry = registry;
     this.dockerMachineStopDetector = dockerMachineStopDetector;
     this.servers = servers;
+    this.status = MachineStatus.STARTING;
   }
 
   @Override
@@ -77,6 +81,15 @@ public class DockerMachine implements Machine {
   @Override
   public Map<String, ServerImpl> getServers() {
     return servers;
+  }
+
+  @Override
+  public MachineStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(MachineStatus status) {
+    this.status = status;
   }
 
   void setServerStatus(String serverRef, ServerStatus status) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -126,6 +126,7 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
           machine.waitRunning(machineStartTimeoutMin);
           bootstrapMachine(machine);
           checkMachineServers(machine);
+          machine.setStatus(MachineStatus.RUNNING);
           sendRunningEvent(machine.getName());
         } catch (InfrastructureException rethrow) {
           sendFailedEvent(machine.getName(), rethrow.getMessage());
@@ -245,7 +246,7 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
         return;
       }
 
-      machine.setStatus(serverRef, ServerStatus.RUNNING);
+      machine.setServerStatus(serverRef, ServerStatus.RUNNING);
 
       eventService.publish(
           DtoFactory.newDto(ServerStatusEvent.class)

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftMachine.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftMachine.java
@@ -15,6 +15,7 @@ import static java.util.Collections.emptyMap;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
@@ -33,6 +34,8 @@ public class OpenShiftMachine implements Machine {
   private final Map<String, ServerImpl> ref2Server;
   private final OpenShiftProject project;
 
+  private MachineStatus status;
+
   public OpenShiftMachine(
       String machineName,
       String podName,
@@ -47,6 +50,7 @@ public class OpenShiftMachine implements Machine {
       this.ref2Server.putAll(ref2Server);
     }
     this.project = project;
+    this.status = MachineStatus.STARTING;
   }
 
   public String getName() {
@@ -71,7 +75,16 @@ public class OpenShiftMachine implements Machine {
     return ref2Server;
   }
 
-  void setStatus(String serverRef, ServerStatus status) {
+  @Override
+  public MachineStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(MachineStatus status) {
+    this.status = status;
+  }
+
+  void setServerStatus(String serverRef, ServerStatus status) {
     ServerImpl server = ref2Server.get(serverRef);
     if (server == null) {
       throw new IllegalArgumentException(

--- a/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenter.java
+++ b/plugins/plugin-gdb/che-plugin-gdb-ide/src/main/java/org/eclipse/che/plugin/gdb/ide/configuration/GdbConfigurationPagePresenter.java
@@ -109,6 +109,7 @@ public class GdbConfigurationPagePresenter
   private void setHosts(List<MachineImpl> machines) {
     Map<String, String> hosts = new HashMap<>();
     for (MachineImpl machine : machines) {
+      // TODO this attribute is not provided anymore
       String host = machine.getAttributes().get("network.ipAddress");
       if (host == null) {
         continue;

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/MachineDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/MachineDto.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.workspace.shared.dto;
 
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.dto.shared.DTO;
 
 /** @author Alexander Garagatyi */
@@ -27,4 +28,9 @@ public interface MachineDto extends Machine {
   Map<String, ServerDto> getServers();
 
   MachineDto withServers(Map<String, ServerDto> servers);
+
+  @Override
+  MachineStatus getStatus();
+
+  MachineDto withStatus(MachineStatus status);
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -279,7 +279,10 @@ public final class DtoConverter {
 
   /** Converts {@link Machine} to {@link MachineDto}. */
   public static MachineDto asDto(Machine machine) {
-    MachineDto machineDto = newDto(MachineDto.class).withAttributes(machine.getAttributes());
+    MachineDto machineDto =
+        newDto(MachineDto.class)
+            .withAttributes(machine.getAttributes())
+            .withStatus(machine.getStatus());
     if (machine.getServers() != null) {
       machineDto.withServers(
           machine

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/MachineImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/MachineImpl.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 
 /**
@@ -25,14 +26,17 @@ public class MachineImpl implements Machine {
 
   private Map<String, String> attributes;
   private Map<String, ServerImpl> servers;
+  private MachineStatus status;
 
   public MachineImpl(Machine machineRuntime) {
-    this(machineRuntime.getAttributes(), machineRuntime.getServers());
+    this(machineRuntime.getAttributes(), machineRuntime.getServers(), machineRuntime.getStatus());
   }
 
-  public MachineImpl(Map<String, String> attributes, Map<String, ? extends Server> servers) {
+  public MachineImpl(
+      Map<String, String> attributes, Map<String, ? extends Server> servers, MachineStatus status) {
     this(servers);
     this.attributes = new HashMap<>(attributes);
+    this.status = status;
   }
 
   public MachineImpl(Map<String, ? extends Server> servers) {
@@ -65,21 +69,38 @@ public class MachineImpl implements Machine {
   }
 
   @Override
+  public MachineStatus getStatus() {
+    return status;
+  }
+
+  @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof MachineImpl)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MachineImpl)) {
+      return false;
+    }
     MachineImpl machine = (MachineImpl) o;
     return Objects.equals(getAttributes(), machine.getAttributes())
-        && Objects.equals(getServers(), machine.getServers());
+        && Objects.equals(getServers(), machine.getServers())
+        && getStatus() == machine.getStatus();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getAttributes(), getServers());
+    return Objects.hash(getAttributes(), getServers(), getStatus());
   }
 
   @Override
   public String toString() {
-    return "MachineImpl{" + "attributes=" + attributes + ", servers=" + servers + '}';
+    return "MachineImpl{"
+        + "attributes="
+        + attributes
+        + ", servers="
+        + servers
+        + ", status="
+        + status
+        + '}';
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -79,7 +79,8 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
                 e ->
                     new MachineImpl(
                         e.getValue().getAttributes(),
-                        rewriteExternalServers(e.getValue().getServers()))));
+                        rewriteExternalServers(e.getValue().getServers()),
+                        e.getValue().getStatus())));
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -52,6 +52,7 @@ import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
@@ -571,7 +572,7 @@ public class WorkspaceManagerTest {
   }
 
   private MachineImpl createMachine() {
-    return new MachineImpl(emptyMap(), emptyMap());
+    return new MachineImpl(emptyMap(), emptyMap(), MachineStatus.RUNNING);
   }
 
   private RuntimeContext mockContext(RuntimeIdentity identity) throws Exception {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.RUNNING;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
@@ -329,7 +330,7 @@ public class WorkspaceServiceTest {
     Map<String, Server> servers =
         ImmutableMap.of("server1", createInternalServer(), externalServerKey, externalServer);
     Map<String, Machine> machines =
-        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers));
+        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers, RUNNING));
     workspace.setRuntime(new RuntimeImpl("activeEnv", machines, "user123"));
     when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
     Map<String, MachineDto> expected =
@@ -337,6 +338,7 @@ public class WorkspaceServiceTest {
             "machine1",
             newDto(MachineDto.class)
                 .withAttributes(singletonMap("key", "value"))
+                .withStatus(RUNNING)
                 .withServers(
                     singletonMap(
                         externalServerKey,
@@ -372,7 +374,7 @@ public class WorkspaceServiceTest {
     Map<String, Server> servers =
         ImmutableMap.of("server1", createInternalServer(), externalServerKey, externalServer);
     Map<String, Machine> machines =
-        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers));
+        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers, RUNNING));
     workspace.setRuntime(new RuntimeImpl("activeEnv", machines, "user123"));
     when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
     Map<String, MachineDto> expected =
@@ -380,6 +382,7 @@ public class WorkspaceServiceTest {
             "machine1",
             newDto(MachineDto.class)
                 .withAttributes(singletonMap("key", "value"))
+                .withStatus(RUNNING)
                 .withServers(
                     singletonMap(
                         externalServerKey,
@@ -415,7 +418,7 @@ public class WorkspaceServiceTest {
         ImmutableMap.of(
             internalServerKey, createInternalServer(), externalServerKey, externalServer);
     Map<String, Machine> machines =
-        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers));
+        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers, RUNNING));
     workspace.setRuntime(new RuntimeImpl("activeEnv", machines, "user123"));
     when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
 
@@ -424,6 +427,7 @@ public class WorkspaceServiceTest {
             "machine1",
             newDto(MachineDto.class)
                 .withAttributes(singletonMap("key", "value"))
+                .withStatus(RUNNING)
                 .withServers(
                     ImmutableMap.of(
                         externalServerKey,
@@ -466,7 +470,7 @@ public class WorkspaceServiceTest {
         ImmutableMap.of(
             internalServerKey, createInternalServer(), externalServerKey, externalServer);
     Map<String, Machine> machines =
-        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers));
+        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers, RUNNING));
     workspace.setRuntime(new RuntimeImpl("activeEnv", machines, "user123"));
     when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
 
@@ -475,6 +479,7 @@ public class WorkspaceServiceTest {
             "machine1",
             newDto(MachineDto.class)
                 .withAttributes(singletonMap("key", "value"))
+                .withStatus(RUNNING)
                 .withServers(
                     ImmutableMap.of(
                         externalServerKey,
@@ -517,7 +522,7 @@ public class WorkspaceServiceTest {
         ImmutableMap.of(
             internalServerKey, createInternalServer(), externalServerKey, externalServer);
     Map<String, Machine> machines =
-        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers));
+        singletonMap("machine1", new MachineImpl(singletonMap("key", "value"), servers, RUNNING));
     workspace.setRuntime(new RuntimeImpl("activeEnv", machines, "user123"));
     when(wsManager.getWorkspace(workspace.getId())).thenReturn(workspace);
 
@@ -526,6 +531,7 @@ public class WorkspaceServiceTest {
             "machine1",
             newDto(MachineDto.class)
                 .withAttributes(singletonMap("key", "value"))
+                .withStatus(RUNNING)
                 .withServers(
                     ImmutableMap.of(
                         externalServerKey,

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -41,6 +41,7 @@ import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.URLRewriter;
@@ -325,7 +326,8 @@ public class InternalRuntimeTest {
     MachineImpl machineWithInternalServer =
         new MachineImpl(
             createAttributes(),
-            ImmutableMap.of("server1", regularServer, "server2", internalServer));
+            ImmutableMap.of("server1", regularServer, "server2", internalServer),
+            MachineStatus.RUNNING);
     ImmutableMap<String, MachineImpl> internalMachines =
         ImmutableMap.of("m1", createMachine(), "m2", machineWithInternalServer);
     ImmutableMap<String, MachineImpl> expected =
@@ -335,7 +337,8 @@ public class InternalRuntimeTest {
             "m2",
             new MachineImpl(
                 createAttributes(),
-                ImmutableMap.of("server1", rewriteURL(regularServer), "server2", internalServer)));
+                ImmutableMap.of("server1", rewriteURL(regularServer), "server2", internalServer),
+                MachineStatus.RUNNING));
     setRunningRuntime();
     doReturn(internalMachines).when(internalRuntime).getInternalMachines();
 
@@ -410,7 +413,8 @@ public class InternalRuntimeTest {
             expectedProps,
             singletonMap(
                 expectedServerName,
-                new ServerImpl().withUrl(expectedServerUrl).withStatus(expectedServerStatus)));
+                new ServerImpl().withUrl(expectedServerUrl).withStatus(expectedServerStatus)),
+            MachineStatus.RUNNING);
     HashMap<String, MachineImpl> result = new HashMap<>();
     result.put("m1", createMachine());
     result.put("m2", createMachine());
@@ -476,7 +480,8 @@ public class InternalRuntimeTest {
     machine1.getServers().put(badServerName, failingRewritingServer);
     internalMachines.put("m1", machine1);
     internalMachines.put("m2", machine2);
-    expectedMachines.put("m1", new MachineImpl(machine1.getAttributes(), expectedServers));
+    expectedMachines.put(
+        "m1", new MachineImpl(machine1.getAttributes(), expectedServers, machine1.getStatus()));
     expectedMachines.put("m2", machine2);
     List<WarningImpl> expectedWarnings = new ArrayList<>();
     expectedWarnings.add(
@@ -497,7 +502,7 @@ public class InternalRuntimeTest {
   }
 
   private static MachineImpl createMachine() throws Exception {
-    return new MachineImpl(createAttributes(), createServers());
+    return new MachineImpl(createAttributes(), createServers(), MachineStatus.RUNNING);
   }
 
   private static Map<String, String> createAttributes() {


### PR DESCRIPTION
### What does this PR do?
Adds field `status` to runtime machine object which contains the status of a machine. 
When a machine starts status contains "STARTING" when it is running ''RUNNING".

### What issues does this PR fix or reference?
Fixes #7834 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
