### PR TITLE
CHE-7661: Clear active debugger on connection error

### DIFF
--- a/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
+++ b/plugins/plugin-debugger/che-plugin-debugger-ide/src/main/java/org/eclipse/che/plugin/debugger/ide/debug/AbstractDebugger.java
@@ -494,6 +494,7 @@ public abstract class AbstractDebugger implements Debugger, DebuggerObservable {
                 })
         .catchError(
             error -> {
+              debuggerManager.setActiveDebugger(null);
               notification.setTitle(
                   constant.failedToConnectToRemoteDebuggerDescription(
                       debuggerDescriptor.getAddress(), error.getMessage()));


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Clear active debugger on connection error

### What issues does this PR fix or reference?
#7671 

<!-- #### Changelog -->
Fix bug when 'Debugger is already connected' message was shown when reconnecting after connection error. 

<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A