### PR TITLE
Remove redundant event firing

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/context/AppContextImpl.java
@@ -58,7 +58,6 @@ import org.eclipse.che.ide.api.workspace.model.ServerImpl;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.eclipse.che.ide.project.node.SyntheticNode;
 import org.eclipse.che.ide.resource.Path;
-import org.eclipse.che.ide.resources.impl.ResourceDeltaImpl;
 import org.eclipse.che.ide.resources.impl.ResourceManager;
 import org.eclipse.che.ide.statepersistance.AppStateManager;
 import org.eclipse.che.ide.ui.smartTree.data.HasDataObject;
@@ -414,10 +413,6 @@ public class AppContextImpl implements AppContext, SelectionChangedHandler, Reso
 
   private void clearProjects() {
     if (!rootProjects.isEmpty()) {
-      rootProjects.forEach(
-          project ->
-              eventBus.fireEvent(
-                  new ResourceChangedEvent(new ResourceDeltaImpl(project, REMOVED))));
       rootProjects.clear();
     }
   }


### PR DESCRIPTION
### What does this PR do?
Remove redundant event firing due to few reasons. 1) there is no reason to duplicate event fire for removed resource; 2) it causes NPE when lambda process event fire.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#7647 

#### Release Notes
N/A

#### Docs PR
N/A