### PR TITLE
Complement unstable parts of the selenium tests with info about known issues

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/NodeJsDebugTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/NodeJsDebugTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.debugger;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -33,6 +34,7 @@ import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.debug.DebugPanel;
 import org.eclipse.che.selenium.pageobject.debug.NodeJsDebugConfig;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
@@ -127,7 +129,12 @@ public class NodeJsDebugTest {
     debugPanel.clickOnButton(DebugPanel.DebuggerActionButtons.EVALUATE_EXPRESSIONS);
     debugPanel.typeEvaluateExpression("c.length");
     debugPanel.clickEvaluateBtn();
-    debugPanel.waitExpectedResultInEvaluateExpression("19");
+    try {
+      debugPanel.waitExpectedResultInEvaluateExpression("19");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/4720", ex);
+    }
     debugPanel.clickCloseEvaluateBtn();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolder.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolder.java
@@ -88,7 +88,7 @@ public class DirectUrlFactoryWithRootFolder {
       testFactoryWithRootFolder.authenticateAndOpen();
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7555");
+      fail("Known issue https://github.com/eclipse/che/issues/7555", ex);
     }
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(EXPECTED_PROJECT);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolder.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolder.java
@@ -84,7 +84,12 @@ public class DirectUrlFactoryWithRootFolder {
             "tslint.json",
             "typings.json",
             "wallaby.js");
-    testFactoryWithRootFolder.authenticateAndOpen();
+    try {
+      testFactoryWithRootFolder.authenticateAndOpen();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7555");
+    }
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(EXPECTED_PROJECT);
     notificationsPopupPanel.waitProgressPopupPanelClose();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranch.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranch.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -27,6 +28,7 @@ import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -64,7 +66,13 @@ public class DirectUrlFactoryWithSpecificBranch {
 
   @Test
   public void factoryWithDirectUrlWithSpecificBranch() throws Exception {
-    testFactoryWithSpecificBranch.authenticateAndOpen();
+    try {
+
+      testFactoryWithSpecificBranch.authenticateAndOpen();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7555");
+    }
     projectExplorer.waitProjectExplorer();
     notificationsPopupPanel.waitProgressPopupPanelClose();
     events.clickEventLogBtn();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranch.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranch.java
@@ -67,11 +67,10 @@ public class DirectUrlFactoryWithSpecificBranch {
   @Test
   public void factoryWithDirectUrlWithSpecificBranch() throws Exception {
     try {
-
       testFactoryWithSpecificBranch.authenticateAndOpen();
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7555");
+      fail("Known issue https://github.com/eclipse/che/issues/7555", ex);
     }
     projectExplorer.waitProjectExplorer();
     notificationsPopupPanel.waitProgressPopupPanelClose();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.T
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.FAILED;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.PASSED;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -38,6 +39,7 @@ import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -105,7 +107,7 @@ public class JavaTestPluginTestNgTest {
   }
 
   @Test
-  public void shouldExecuteTestClassSuccessfully() throws InterruptedException {
+  public void shouldExecuteTestClassSuccessfully() {
     // given
     projectExplorer.quickRevealToItemWithJavaScript(PATH_TO_ANOTHER_TEST_CLASS);
     projectExplorer.openItemByPath(PATH_TO_TEST_CLASS);
@@ -127,7 +129,7 @@ public class JavaTestPluginTestNgTest {
   }
 
   @Test(priority = 1)
-  public void shouldExecuteTestMethodsSuccessfully() throws InterruptedException {
+  public void shouldExecuteTestMethodsSuccessfully() {
     // given
     projectExplorer.openItemByPath(PATH_TO_ANOTHER_TEST_CLASS);
 
@@ -140,7 +142,13 @@ public class JavaTestPluginTestNgTest {
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     editor.goToCursorPositionVisible(30, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
-    pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppAnother");
+    try {
+
+      pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppAnother");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7338");
+    }
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(FAILED).size() == 1);
     String testErrorMessage = pluginConsole.getTestErrorMessage();
     assertTrue(
@@ -151,7 +159,7 @@ public class JavaTestPluginTestNgTest {
   }
 
   @Test(priority = 2)
-  public void shouldExecuteAlltests() throws InterruptedException {
+  public void shouldExecuteAlltests() {
     // given
     projectExplorer.openItemByPath(PATH_TO_ANOTHER_TEST_CLASS);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -143,11 +143,10 @@ public class JavaTestPluginTestNgTest {
     editor.goToCursorPositionVisible(30, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
     try {
-
       pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppAnother");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7338");
+      fail("Known issue https://github.com/eclipse/che/issues/7338", ex);
     }
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(FAILED).size() == 1);
     String testErrorMessage = pluginConsole.getTestErrorMessage();


### PR DESCRIPTION
### What does this PR do?
* We have the selenium tests with unstable parts with dependent issues. In this PR has been aggregated information with typical fails in last 10 jobs on CI and added info  about issues in assertions.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7888
@tolusha @vparfonov @dmytro-ndp 