### PR TITLE
Fix the `Pipe not connected` error so that we can use the shared `OkHttpClient` for all the calls

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -360,6 +360,15 @@ che.openshift.workspace.memory.override=NULL
 # this length of time.
 che.openshift.server.inactive.stop.timeout.ms=1800000
 
+# Number of maximum concurrent web requests
+# (http requests or ongoing  web socket calls)
+# Default values are 64 and 5 per-host, which 
+# doesn't seem correct for multi-user scenarios
+# knowing that Che keeps a number of connections
+# opened (e.g. for command or ws-agent logs)
+che.openshift.server.concurrent.requests.total=1000
+che.openshift.server.concurrent.requests.perhost=1000
+
 #
 #
 # Be aware that setting che.openshift.workspace.memory.override

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
@@ -66,6 +66,7 @@ public class OpenShiftClientFactory {
   }
 
   public CheKubernetesClient newKubeClient(Config config) {
+    config.setWebsocketPingInterval(0);
     OkHttpClient clientHttpClient =
         httpClient.newBuilder().authenticator(Authenticator.NONE).build();
     OkHttpClient.Builder builder = clientHttpClient.newBuilder();

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
@@ -20,6 +20,7 @@ import io.fabric8.openshift.client.internal.OpenShiftOAuthInterceptor;
 import java.io.IOException;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import okhttp3.Authenticator;
 import okhttp3.Interceptor;
@@ -34,9 +35,13 @@ public class OpenShiftClientFactory {
 
   @Inject
   public OpenShiftClientFactory(
-      OpenshiftWorkspaceEnvironmentProvider workspaceEnvironmentProvider) {
-    this.httpClient =
-        HttpClientUtils.createHttpClient(workspaceEnvironmentProvider.getDefaultOpenshiftConfig());
+      OpenshiftWorkspaceEnvironmentProvider workspaceEnvironmentProvider,
+      @Named("che.openshift.server.concurrent.requests.total") int maxConcurrentRequests,
+      @Named("che.openshift.server.concurrent.requests.perhost") int maxConcurrentRequestsPerHost) {
+    Config defaultOpenshiftConfig = workspaceEnvironmentProvider.getDefaultOpenshiftConfig();
+    this.httpClient = HttpClientUtils.createHttpClient(defaultOpenshiftConfig);
+    httpClient.dispatcher().setMaxRequests(maxConcurrentRequests);
+    httpClient.dispatcher().setMaxRequestsPerHost(maxConcurrentRequestsPerHost);
   }
 
   @PreDestroy
@@ -66,7 +71,6 @@ public class OpenShiftClientFactory {
   }
 
   public CheKubernetesClient newKubeClient(Config config) {
-    config.setWebsocketPingInterval(0);
     OkHttpClient clientHttpClient =
         httpClient.newBuilder().authenticator(Authenticator.NONE).build();
     OkHttpClient.Builder builder = clientHttpClient.newBuilder();


### PR DESCRIPTION
### What does this PR do?

Properly fix the [`Pipe not connected` error](https://issues.jboss.org/browse/CHE-180) so that we can use the shared `OkHttpClient` for all the calls.

This allows sharing a common base `OkHttpClient` instance when accessing to the `kubernetes-client` or `openshift-client` libraries, thus totally removing the waste of resource that was previoulsy involved.

In the previous PR https://github.com/eclipse/che/pull/7793, the shared `OkHttpClient` instance was still not used in the calls involving web sockets (mainly `OpenshiftConnector.startExec()` and similar methods), because doing so would have reintroduced various old issues described [here](https://issues.jboss.org/browse/CHE-180)   

This PR, as well as PR https://github.com/eclipse/che-dependencies/pull/84 which should be merged before this one, now fixes these old issues in a proper way, so that the shared `OkHttpClient` instance can be used everywhere in the `OpenshiftConnector`.

### What issues does this PR fix or reference?

This PR provides correct fixes for some issues described [here] (https://issues.jboss.org/browse/CHE-180). 

It also finally completes the implementation, on the CHE 5 branch, of issue https://github.com/redhat-developer/rh-che/issues/472.
