### PR TITLE
Selenium: add checking that workspace has stopping status after renaming

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.selenium.core.constant.TestWorkspaceConstants.RUNNING_WORKSPACE_MESS;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
+import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
@@ -96,6 +97,7 @@ public class ProjectStateAfterRenameWorkspaceTest {
     workspaces.selectWorkspaceItemName(testWorkspace.getName());
     workspaceOverview.enterNameWorkspace(WORKSPACE_NEW_NAME);
     workspaceDetails.clickOnSaveChangesBtn();
+    workspaceDetails.checkStateOfWorkspace(STOPPING);
     workspaceDetails.checkStateOfWorkspace(RUNNING);
     workspaceOverview.checkNameWorkspace(WORKSPACE_NEW_NAME);
 


### PR DESCRIPTION
### What does this PR do?
This PR add waiting that a test workspace has stopping status after it renaming in unstable **ProjectStateAfterRenameWorkspaceTest** selenium test. 