### PR TITLE
Allow to use JSInterop on export

### DIFF
--- a/ide/che-ide-gwt-app/pom.xml
+++ b/ide/che-ide-gwt-app/pom.xml
@@ -50,6 +50,9 @@
                         <arg>${gwt.compiler.jvmArgs.Xss}</arg>
                         <arg>${gwt.compiler.jvmArgs.Xmx}</arg>
                     </jvmArgs>
+                    <compilerArgs>
+                        <arg>-generateJsInteropExports</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1877,7 +1877,11 @@
                     <codeserverArgs>
                         <arg>-noprecompile</arg>
                         <arg>-noincremental</arg>
+                        <arg>-generateJsInteropExports</arg>
                     </codeserverArgs>
+                    <compilerArgs>
+                        <arg>-generateJsInteropExports</arg>
+                    </compilerArgs>
                     <jvmArgs>
                         <arg>${gwt.compiler.jvmArgs.Xss}</arg>
                         <arg>${gwt.compiler.jvmArgs.Xmx}</arg>


### PR DESCRIPTION
### What does this PR do?
Add the arguments for GWT compiler to enable JSInterop export.

Change-Id: I37664554064cbe87ec68a8e062e78f34b45d745f
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

