### PR TITLE
Support of headers to 'HttpJsonRequest'. Adding 'Connection: close' header while checking server availability

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequest.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequest.java
@@ -111,6 +111,16 @@ public interface HttpJsonRequest {
   HttpJsonRequest addQueryParam(@NotNull String name, @NotNull Object value);
 
   /**
+   * Adds header to the request.
+   *
+   * @param name header name
+   * @param value header value
+   * @return this request instance
+   * @throws NullPointerException when either header name or value is null
+   */
+  HttpJsonRequest addHeader(@NotNull String name, @NotNull String value);
+
+  /**
    * Adds authorization header to the request.
    *
    * @param value authorization header value
@@ -204,6 +214,18 @@ public interface HttpJsonRequest {
   default HttpJsonRequest addQueryParams(@NotNull Map<String, ?> params) {
     Objects.requireNonNull(params, "Required non-null query parameters");
     params.forEach(this::addQueryParam);
+    return this;
+  }
+
+  /**
+   * Adds set of headers to this request.
+   *
+   * @param headers map with headers
+   * @return this request instance
+   */
+  default HttpJsonRequest addHeaders(@NotNull Map<String, String> headers) {
+    Objects.requireNonNull(headers, "Required non-null headers");
+    headers.forEach(this::addHeader);
     return this;
   }
 }

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequestTest.java
@@ -103,10 +103,11 @@ public class DefaultHttpJsonRequestTest {
             anyString(),
             nullable(Object.class),
             nullable(List.class),
-            nullable(String.class));
+            nullable(String.class),
+            nullable(List.class));
     request.request();
 
-    verify(request).doRequest(0, DEFAULT_URL, "POST", null, null, null);
+    verify(request).doRequest(0, DEFAULT_URL, "POST", null, null, null, null);
   }
 
   @Test
@@ -119,6 +120,7 @@ public class DefaultHttpJsonRequestTest {
         .setTimeout(10_000_000)
         .addQueryParam("name", "value")
         .addQueryParam("name2", "value2")
+        .addHeader("Connection", "close")
         .request();
 
     verify(request)
@@ -128,7 +130,8 @@ public class DefaultHttpJsonRequestTest {
             "PUT",
             body,
             asList(Pair.of("name", "value"), Pair.of("name2", "value2")),
-            null);
+            null,
+            asList(Pair.of("Connection", "close")));
   }
 
   @Test
@@ -145,6 +148,7 @@ public class DefaultHttpJsonRequestTest {
             eq("http://localhost:8080"),
             eq("POST"),
             mapCaptor.capture(),
+            eq(null),
             eq(null),
             eq(null));
     assertTrue(mapCaptor.getValue() instanceof JsonStringMap);
@@ -164,6 +168,7 @@ public class DefaultHttpJsonRequestTest {
             eq("POST"),
             listCaptor.capture(),
             eq(null),
+            eq(null),
             eq(null));
     assertTrue(listCaptor.getValue() instanceof JsonArray);
     assertEquals(listCaptor.getValue(), body);
@@ -172,7 +177,7 @@ public class DefaultHttpJsonRequestTest {
   @Test
   public void defaultMethodIsGet() throws Exception {
     request.request();
-    verify(request).doRequest(0, DEFAULT_URL, HttpMethod.GET, null, null, null);
+    verify(request).doRequest(0, DEFAULT_URL, HttpMethod.GET, null, null, null, null);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -214,6 +219,21 @@ public class DefaultHttpJsonRequestTest {
   @Test(expectedExceptions = NullPointerException.class)
   public void shouldThrowNullPointerExceptionWhenQueryParamsAreNull() throws Exception {
     new DefaultHttpJsonRequest("http://localhost:8080").addQueryParams(null);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionWhenHeaderNameIsNull() throws Exception {
+    new DefaultHttpJsonRequest("http://localhost:8080").addHeader(null, "close");
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionWhenHeaderValueIsNull() throws Exception {
+    new DefaultHttpJsonRequest("http://localhost:8080").addHeader("Connection", null);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionWhenHeadersAreNull() throws Exception {
+    new DefaultHttpJsonRequest("http://localhost:8080").addHeaders(null);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -375,6 +395,7 @@ public class DefaultHttpJsonRequestTest {
             anyString(),
             nullable(Object.class),
             nullable(List.class),
-            nullable(String.class));
+            nullable(String.class),
+            nullable(List.class));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/HttpConnectionServerChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/HttpConnectionServerChecker.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
  * @author Alexander Garagatyi
  */
 public class HttpConnectionServerChecker extends ServerChecker {
+  private static final String CONNECTION_HEADER = "Connection";
+  private static final String CONNECTION_CLOSE = "close";
   private final URL url;
 
   public HttpConnectionServerChecker(
@@ -46,6 +48,7 @@ public class HttpConnectionServerChecker extends ServerChecker {
       // TODO consider how much time we should use as a limit
       httpURLConnection.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(3));
       httpURLConnection.setReadTimeout((int) TimeUnit.SECONDS.toMillis(3));
+      httpURLConnection.setRequestProperty(CONNECTION_HEADER, CONNECTION_CLOSE);
       return isConnectionSuccessful(httpURLConnection);
     } catch (IOException e) {
       return false;


### PR DESCRIPTION
### What does this PR do?
Support of headers to 'HttpJsonRequest'. Adding 'Connection: close' header while checking server availability
Cherry-picking https://github.com/eclipse/che/pull/7898

### What issues does this PR fix or reference?

redhat-developer/rh-che#479

#### Release Notes
Adding support of headers to 'HttpJsonRequest'

