### PR TITLE
Use trash icon from FontAwesome for delete command operation

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsTreeRenderer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsTreeRenderer.java
@@ -151,7 +151,7 @@ class CommandsTreeRenderer extends DefaultPresentationRenderer<Node> {
       SpanElement element = Document.get().createSpanElement();
       element.getStyle().setFontSize(11., Style.Unit.PT);
       element.getStyle().setMarginTop(2., Style.Unit.PT);
-      element.setInnerHTML((String)icon);
+      element.setInnerHTML((String) icon);
       return element;
     }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsTreeRenderer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/explorer/CommandsTreeRenderer.java
@@ -14,7 +14,10 @@ import static com.google.gwt.user.client.Event.ONCLICK;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.Event;
+import org.eclipse.che.ide.FontAwesome;
 import org.eclipse.che.ide.command.CommandResources;
 import org.eclipse.che.ide.command.explorer.CommandsExplorerView.ActionDelegate;
 import org.eclipse.che.ide.command.node.CommandFileNode;
@@ -81,7 +84,7 @@ class CommandsTreeRenderer extends DefaultPresentationRenderer<Node> {
   private void renderCommandNode(CommandFileNode node, Element nodeContainerElement) {
     nodeContainerElement.addClassName(resources.commandsExplorerCss().commandNode());
 
-    final Element removeCommandButton = createButton(resources.removeCommand());
+    final Element removeCommandButton = createButton(FontAwesome.TRASH);
     Event.setEventListener(
         removeCommandButton,
         event -> {
@@ -132,12 +135,26 @@ class CommandsTreeRenderer extends DefaultPresentationRenderer<Node> {
     addCommandButton.setId("commands_tree-button-add");
   }
 
-  private Element createButton(SVGResource icon) {
+  private Element createButton(Object icon) {
     final Element button = Document.get().createSpanElement();
-    button.appendChild(icon.getSvg().getElement());
+    button.appendChild(getIconElement(icon));
 
     Event.sinkEvents(button, ONCLICK);
 
     return button;
+  }
+
+  private Element getIconElement(Object icon) {
+    if (icon instanceof SVGResource) {
+      return ((SVGResource) icon).getSvg().getElement();
+    } else if (icon instanceof String) {
+      SpanElement element = Document.get().createSpanElement();
+      element.getStyle().setFontSize(11., Style.Unit.PT);
+      element.getStyle().setMarginTop(2., Style.Unit.PT);
+      element.setInnerHTML((String)icon);
+      return element;
+    }
+
+    throw new IllegalArgumentException("Icon type is undefined");
   }
 }


### PR DESCRIPTION
### What does this PR do?
This changes proposal replaces current icon for delete command button with the new one used from Font Awesome:

![image](https://user-images.githubusercontent.com/1968177/34153464-d0b08fb6-e4ba-11e7-9c33-a89c6cdb307d.png)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/openshiftio/openshift.io/issues/1502

#### Release Notes
N/A

#### Docs PR
N/A
