### PR TITLE
Change content of field in the 'WorkingWithTerminalTest' according to che6-ocp

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -59,7 +59,7 @@ public class WorkingWithTerminalTest {
   private static final String MC_HELP_DIALOG =
       "This is the main help screen for GNU Midnight Commander.";
   private static final String MC_USER_MENU_DIALOG = "User menu";
-  private static final String[] VIEW_BIN_FOLDER = {"bash", "bunzip2", "bzcat"};
+  private static final String[] VIEW_BIN_FOLDER = {"bash", "chmod", "date"};
 
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
@@ -342,6 +342,7 @@ public class WorkingWithTerminalTest {
 
   @Test(priority = 12)
   public void closeTerminalByExitCommand() {
+    terminal.waitTerminalConsole();
     terminal.typeIntoTerminal("exit" + Keys.ENTER);
     terminal.waitTerminalIsNotPresent(1);
   }


### PR DESCRIPTION

### What does this PR do?
* Change the content of 'VIEW_BIN_FOLDER' field in the selenium test 'WorkingWithTerminalTest' according to che-6 ocp platform
* Add the 'waitTerminalConsole()' to the test method to increase stability

**Related selenium test:** _WorkingWithTerminalTest_
