### PR TITLE
CHE-7001: Fix Git status of untracked files in Git diff

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/FileStatus.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/FileStatus.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status.DELET
 import static org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status.MODIFIED;
 import static org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status.RENAMED;
 import static org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status.UNMODIFIED;
+import static org.eclipse.che.ide.ext.git.client.compare.FileStatus.Status.UNTRACKED;
 
 /**
  * Class for determining git status of given changed file.
@@ -52,6 +53,8 @@ public class FileStatus {
         return RENAMED;
       case "C":
         return COPIED;
+      case "U":
+        return UNTRACKED;
     }
     return UNMODIFIED;
   }

--- a/wsagent/che-core-api-git/src/test/java/org/eclipse/che/git/impl/DiffTest.java
+++ b/wsagent/che-core-api-git/src/test/java/org/eclipse/che/git/impl/DiffTest.java
@@ -63,13 +63,15 @@ public class DiffTest {
     // given
     GitConnection connection = connectToInitializedGitRepository(connectionFactory, repository);
     makeCommitInMaster(connection);
+    addFile(connection, "Untracked", "Content\n");
 
     // when
     List<String> diff =
         readDiff(DiffParams.create().withType(DiffType.NAME_STATUS).withRenameLimit(0), connection);
     // then
-    assertEquals(diff.size(), 1);
+    assertEquals(diff.size(), 2);
     assertTrue(diff.contains("M\taaa"));
+    assertTrue(diff.contains("U\tUntracked"));
   }
 
   @Test(

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -797,7 +797,7 @@ class JGitConnection implements GitConnection {
 
   @Override
   public DiffPage diff(DiffParams params) throws GitException {
-    return new JGitDiffPage(params, repository);
+    return new JGitDiffPage(params, repository, this);
   }
 
   @Override

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitDiffPage.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitDiffPage.java
@@ -352,17 +352,11 @@ class JGitDiffPage extends DiffPage {
     for (DiffEntry de : diff) {
       switch (de.getChangeType()) {
         case ADD:
-          if (status.getUntracked().contains(de.getNewPath())) {
-            writer.print(
-                "U\t"
-                    + de.getNewPath()
-                    + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
-          } else {
-            writer.print(
-                "A\t"
-                    + de.getNewPath()
-                    + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
-          }
+          writer.print(
+              (status.getUntracked().contains(de.getNewPath()) ? "U" : "A")
+                  + "\t"
+                  + de.getNewPath()
+                  + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
           break;
         case DELETE:
           writer.print(

--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitDiffPage.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitDiffPage.java
@@ -21,9 +21,13 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.eclipse.che.api.git.DiffPage;
+import org.eclipse.che.api.git.GitConnection;
+import org.eclipse.che.api.git.exception.GitException;
 import org.eclipse.che.api.git.params.DiffParams;
 import org.eclipse.che.api.git.shared.DiffType;
+import org.eclipse.che.api.git.shared.Status;
 import org.eclipse.jgit.diff.ContentSource;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffEntry.ChangeType;
@@ -44,6 +48,8 @@ import org.eclipse.jgit.treewalk.FileTreeIterator;
 import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
 import org.eclipse.jgit.treewalk.filter.PathFilterGroup;
 import org.eclipse.jgit.treewalk.filter.TreeFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains information about difference between two commits, commit and working tree, working tree
@@ -54,10 +60,14 @@ import org.eclipse.jgit.treewalk.filter.TreeFilter;
 class JGitDiffPage extends DiffPage {
   private final DiffParams params;
   private final Repository repository;
+  private final GitConnection gitConnection;
 
-  JGitDiffPage(DiffParams params, Repository repository) {
+  private static final Logger LOG = LoggerFactory.getLogger(JGitDiffPage.class);
+
+  JGitDiffPage(DiffParams params, Repository repository, GitConnection gitConnection) {
     this.params = params;
     this.repository = repository;
+    this.gitConnection = gitConnection;
   }
 
   @Override
@@ -97,6 +107,8 @@ class JGitDiffPage extends DiffPage {
       } else {
         writeRawDiff(diff, formatter);
       }
+    } catch (GitException e) {
+      LOG.error(e.getMessage());
     } finally {
       formatter.close();
       repository.close();
@@ -329,33 +341,53 @@ class JGitDiffPage extends DiffPage {
     writer.flush();
   }
 
-  private void writeNamesAndStatus(List<DiffEntry> diff, OutputStream out) throws IOException {
+  private void writeNamesAndStatus(List<DiffEntry> diff, OutputStream out)
+      throws IOException, GitException {
     PrintWriter writer = new PrintWriter(out);
     int diffSize = diff.size();
+
+    Status status =
+        gitConnection.status(diff.stream().map(DiffEntry::getNewPath).collect(Collectors.toList()));
+
     for (DiffEntry de : diff) {
-      if (de.getChangeType() == ChangeType.ADD) {
-        writer.print(
-            "A\t" + de.getNewPath() + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
-      } else if (de.getChangeType() == ChangeType.DELETE) {
-        writer.print(
-            "D\t" + de.getOldPath() + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
-      } else if (de.getChangeType() == ChangeType.MODIFY) {
-        writer.print(
-            "M\t" + de.getNewPath() + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
-      } else if (de.getChangeType() == ChangeType.COPY) {
-        writer.print(
-            "C\t"
-                + de.getOldPath()
-                + '\t'
-                + de.getNewPath()
-                + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
-      } else if (de.getChangeType() == ChangeType.RENAME) {
-        writer.print(
-            "R\t"
-                + de.getOldPath()
-                + '\t'
-                + de.getNewPath()
-                + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+      switch (de.getChangeType()) {
+        case ADD:
+          if (status.getUntracked().contains(de.getNewPath())) {
+            writer.print(
+                "U\t"
+                    + de.getNewPath()
+                    + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+          } else {
+            writer.print(
+                "A\t"
+                    + de.getNewPath()
+                    + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+          }
+          break;
+        case DELETE:
+          writer.print(
+              "D\t" + de.getOldPath() + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+          break;
+        case MODIFY:
+          writer.print(
+              "M\t" + de.getNewPath() + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+          break;
+        case COPY:
+          writer.print(
+              "C\t"
+                  + de.getOldPath()
+                  + '\t'
+                  + de.getNewPath()
+                  + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+          break;
+        case RENAME:
+          writer.print(
+              "R\t"
+                  + de.getOldPath()
+                  + '\t'
+                  + de.getNewPath()
+                  + (diffSize != diff.indexOf(de) + 1 ? lineSeparator() : ""));
+          break;
       }
     }
     writer.flush();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
JGit diff request returns a list of diff items. Those items don't have 'Untracked' status. So if untracked file is present in the project, the diff command will return related diff item with status 'ADDED'. In this PR I compare added files from diff request with Git Status to set Untracked status if needed.
![compare_with_latest](https://user-images.githubusercontent.com/7668752/34163614-ddd888d6-e4df-11e7-86d8-74a6a8ca9246.png)

### What issues does this PR fix or reference?
#7001
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Fix Git status of untracked files in Git diff

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A