### PR TITLE
Create test user at start of selenium tests execution

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -50,6 +50,7 @@ initVariables() {
     readonly FAILSAFE_REPORT="target/site/failsafe-report.html"
 
     readonly SINGLE_TEST_MSG="single test/package"
+
     export CHE_MULTIUSER=${CHE_MULTIUSER:-false}
 
     # CALLER variable contains parent caller script name
@@ -820,6 +821,65 @@ prepareToFirstRun() {
     checkIfProductIsRun
     cleanUpEnvironment
     initRunMode
+
+    if [[ ${CHE_MULTIUSER} == false ]]; then
+      prepareTestUserForSingleuserChe
+    else
+      prepareTestUserForMultiuserChe
+    fi
+}
+
+prepareTestUserForSingleuserChe() {
+    export CHE_ADMIN_EMAIL=
+    export CHE_ADMIN_PASSWORD=
+
+    export CHE_TESTUSER_EMAIL=che@eclipse.org
+    export CHE_TESTUSER_PASSWORD=secret
+}
+
+prepareTestUserForMultiuserChe() {
+    export CHE_ADMIN_NAME=${CHE_ADMIN_NAME:-admin}
+    export CHE_ADMIN_EMAIL=${CHE_ADMIN_EMAIL:-admin@admin.com}
+    export CHE_ADMIN_PASSWORD=${CHE_ADMIN_PASSWORD:-admin}
+
+    if [[ -n ${CHE_TESTUSER_EMAIL+x} ]] && [[ -n ${CHE_TESTUSER_PASSWORD+x} ]]; then
+        return
+    fi
+
+    # create test user by executing kcadm.sh commands inside keycloak docker container if there are no its credentials among environment variables
+    if [[ "${PRODUCT_HOST}" == "$(detectDockerInterfaceIp)" ]] || [[ "${CHE_SELENIUM_INFRASTRUCTURE}" == "openshift" ]]; then
+        local time=$(date +%s)
+        export CHE_TESTUSER_NAME=${CHE_TESTUSER_NAME:-user${time}}
+        export CHE_TESTUSER_EMAIL=${CHE_TESTUSER_EMAIL:-${CHE_TESTUSER_NAME}@1.com}
+        export CHE_TESTUSER_PASSWORD=${CHE_TESTUSER_PASSWORD:-${time}}
+
+        if [[ "${CHE_SELENIUM_INFRASTRUCTURE}" == "openshift" ]]; then
+            local kc_container_id=$(docker ps | grep keycloak_keycloak-1 | cut -d ' ' -f1)
+        else
+            local kc_container_id=$(docker ps | grep che_keycloak_1 | cut -d ' ' -f1)
+        fi
+
+        local cli_auth="--no-config --server http://localhost:8080/auth --user ${CHE_ADMIN_NAME} --password ${CHE_ADMIN_PASSWORD} --realm master"
+        local response=$(docker exec -i $kc_container_id sh -c "keycloak/bin/kcadm.sh create users -r che -s username=${CHE_TESTUSER_NAME} -s enabled=true $cli_auth 2>&1")
+        if [[ "$response" =~ "Created new user with id" ]]; then
+           userId=$(echo "$response" | grep "Created new user with id" | sed -e "s#Created new user with id ##" | sed -e "s#'##g")
+           # set test user's permanent password
+           docker exec -i $kc_container_id sh -c "keycloak/bin/kcadm.sh set-password -r che --username ${CHE_TESTUSER_NAME} --new-password ${CHE_TESTUSER_PASSWORD} $cli_auth"
+           # set email of test user to ${cheTestUserEmail}
+           docker exec -i $kc_container_id sh -c "keycloak/bin/kcadm.sh update users/$userId -r che --set email=${CHE_TESTUSER_EMAIL} $cli_auth"
+           # add realm role "user" test user
+           docker exec -i $kc_container_id sh -c "keycloak/bin/kcadm.sh add-roles -r che --uusername ${CHE_TESTUSER_NAME} --rolename user $cli_auth"
+           # add role "read-token" of client "broker" to test user
+           docker exec -i $kc_container_id sh -c "keycloak/bin/kcadm.sh add-roles -r che --uusername ${CHE_TESTUSER_NAME} --cclientid broker --rolename read-token $cli_auth"
+        else
+           # set test user credentials to be equal to admin ones in case of problem with creation of user
+           echo -e "${RED}[WARN] There is a problem with creation of test user in Keycloak server: '${response}'.${NO_COLOUR}"
+           echo -e "Admin user will be used as a test user."
+           CHE_TESTUSER_NAME=${CHE_ADMIN_NAME}
+           CHE_TESTUSER_EMAIL=${CHE_ADMIN_EMAIL}
+           CHE_TESTUSER_PASSWORD=${CHE_ADMIN_PASSWORD}
+        fi
+    fi
 }
 
 testProduct() {

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -52,6 +52,7 @@ initVariables() {
     readonly SINGLE_TEST_MSG="single test/package"
 
     export CHE_MULTIUSER=${CHE_MULTIUSER:-false}
+    export CHE_INFRASTRUCTURE=${CHE_INFRASTRUCTURE:-docker}
 
     # CALLER variable contains parent caller script name
     # CUR_DIR variable contains the current directory where CALLER is executed
@@ -847,13 +848,15 @@ prepareTestUserForMultiuserChe() {
     fi
 
     # create test user by executing kcadm.sh commands inside keycloak docker container if there are no its credentials among environment variables
-    if [[ "${PRODUCT_HOST}" == "$(detectDockerInterfaceIp)" ]] || [[ "${CHE_SELENIUM_INFRASTRUCTURE}" == "openshift" ]]; then
+    if [[ "${PRODUCT_HOST}" == "$(detectDockerInterfaceIp)" ]] || [[ "${CHE_INFRASTRUCTURE}" == "openshift" ]]; then
+
+        echo "[TEST] Creating test user..."
         local time=$(date +%s)
         export CHE_TESTUSER_NAME=${CHE_TESTUSER_NAME:-user${time}}
         export CHE_TESTUSER_EMAIL=${CHE_TESTUSER_EMAIL:-${CHE_TESTUSER_NAME}@1.com}
         export CHE_TESTUSER_PASSWORD=${CHE_TESTUSER_PASSWORD:-${time}}
 
-        if [[ "${CHE_SELENIUM_INFRASTRUCTURE}" == "openshift" ]]; then
+        if [[ "${CHE_INFRASTRUCTURE}" == "openshift" ]]; then
             local kc_container_id=$(docker ps | grep keycloak_keycloak-1 | cut -d ' ' -f1)
         else
             local kc_container_id=$(docker ps | grep che_keycloak_1 | cut -d ' ' -f1)

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactoryInitializer.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactoryInitializer.java
@@ -57,7 +57,7 @@ public class TestFactoryInitializer {
   @Inject private SeleniumWebDriver seleniumWebDriver;
 
   @Inject
-  @Named("che.selenium.infrastructure")
+  @Named("che.infrastructure")
   private String infrastructure;
 
   /**

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/WorkspaceDtoDeserializer.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/WorkspaceDtoDeserializer.java
@@ -37,7 +37,7 @@ public class WorkspaceDtoDeserializer {
   private static final Logger LOG = LoggerFactory.getLogger(WorkspaceDtoDeserializer.class);
 
   @Inject
-  @Named("che.selenium.infrastructure")
+  @Named("che.infrastructure")
   private String infrastructure;
 
   public WorkspaceConfigDto deserializeWorkspaceTemplate(String templateName) {

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -50,15 +50,9 @@ Follow the guide: [https://github.com/eclipse/che](https://github.com/eclipse/ch
 Simply launch `./selenium-tests.sh`
 
 ### How to run tests on OpenShift
-#### Che in container case
-##### 1. Set workspace runtime infrastructure implementation
-export CHE_SELENIUM_INFRASTRUCTURE=openshift
-##### 2. Run tests in the default way
-Simply launch `./selenium-tests.sh`
-#### Che inside of OpenShift case
-##### 1. Set workspace runtime infrastructure implementation
-export CHE_SELENIUM_INFRASTRUCTURE=openshift
-##### 2. Run tests and specify host and port of Che deployed to OpenShift
+#### 1. Set workspace runtime infrastructure implementation
+export CHE_INFRASTRUCTURE=openshift
+#### 2. Run tests and specify host and port of Che deployed to OpenShift
 Launch `./selenium-tests.sh --host=<Che host on openshift> --port=80`
 
 Example: `./selenium-tests.sh --host=che-spi.192.168.99.100.nip.io --port=80`

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -17,13 +17,6 @@ newly created [OAuth application](https://github.com/settings/developers).
 Set `CHE_LOCAL_CONF_DIR` environment variable and point to the folder where selenium tests configuration will be stored.
 Create file `selenium.properties` in that folder with the following content:
 ```
-# Credentials of Eclipse Che multiuser assemblies
-che.admin_user.email=<CHE_ADMIN_EMAIL>
-che.admin_user.password=<CHE_ADMIN_PASSWORD>
-
-che.test_user.email=<CHE_USER_EMAIL>
-che.test_user.password=<CHE_USER_PASSWORD>
-
 # GitHub account credentials
 github.username=<MAIN_GITHUB_USERNAME>
 github.password=<MAIN_GITHUB_PASSWORD>
@@ -34,6 +27,15 @@ github.auxiliary.password=<AUXILIARY_GITHUB_PASSWORD>
 google.user=<GOOGLE_USER>
 google.password=<GOOGLE_PASSWORD>
 ```
+
+In case of running of tests for Eclipse Che in Multi User mode you can set your own credentials of test user or admin instead of default ones
+export CHE_ADMIN_NAME=<che_admin_name>
+export CHE_ADMIN_EMAIL=<che_admin_email>
+export CHE_ADMIN_PASSWORD=<che_admin_password>
+
+export CHE_TESTUSER_NAME=<che_test_user_name>
+export CHE_TESTUSER_EMAIL=<che_test_user_email>
+export CHE_TESTUSER_PASSWORD=<che_test_user_password>
 
 #### 3. Prepare repository 
 Fork all repositories from [https://github.com/idexmai?tab=repositories](https://github.com/idexmai?tab=repositories) into the main GitHub account.

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/CheTestDefaultUserHttpJsonRequestFactory.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/CheTestDefaultUserHttpJsonRequestFactory.java
@@ -20,8 +20,8 @@ public class CheTestDefaultUserHttpJsonRequestFactory extends TestUserHttpJsonRe
   @Inject
   public CheTestDefaultUserHttpJsonRequestFactory(
       TestAuthServiceClient authServiceClient,
-      @Named("che.test_user.email") String email,
-      @Named("che.test_user.password") String password) {
+      @Named("che.testuser.email") String email,
+      @Named("che.testuser.password") String password) {
     super(authServiceClient, email, password);
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/TestCheAdminHttpJsonRequestFactory.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/TestCheAdminHttpJsonRequestFactory.java
@@ -20,8 +20,8 @@ public class TestCheAdminHttpJsonRequestFactory extends TestUserHttpJsonRequestF
   @Inject
   public TestCheAdminHttpJsonRequestFactory(
       TestAuthServiceClient authServiceClient,
-      @Named("che.admin_user.email") String adminEmail,
-      @Named("che.admin_user.password") String adminPassword) {
+      @Named("che.admin.email") String adminEmail,
+      @Named("che.admin.password") String adminPassword) {
     super(authServiceClient, adminEmail, adminPassword);
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/user/CheAdminTestUser.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/user/CheAdminTestUser.java
@@ -23,8 +23,8 @@ public class CheAdminTestUser implements AdminTestUser {
   @Inject
   public CheAdminTestUser(
       TestUserFactory userFactory,
-      @Named("che.admin_user.email") String email,
-      @Named("che.admin_user.password") String password)
+      @Named("che.admin.email") String email,
+      @Named("che.admin.password") String password)
       throws Exception {
     this.delegate = userFactory.create(email, password);
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/user/CheDefaultTestUser.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/user/CheDefaultTestUser.java
@@ -31,8 +31,8 @@ public class CheDefaultTestUser implements TestUser {
   @Inject
   public CheDefaultTestUser(
       TestUserFactory userFactory,
-      @Named("che.test_user.email") String email,
-      @Named("che.test_user.password") String password)
+      @Named("che.testuser.email") String email,
+      @Named("che.testuser.password") String password)
       throws Exception {
     this.delegate = userFactory.create(email, password);
   }

--- a/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
+++ b/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
@@ -27,15 +27,3 @@ google.password=
 
 # Workspace infrastructure implementation
 che.selenium.infrastructure=docker
-
-# Define configuration for che default test user.
-# For che single user assembly, the default values will be enough.
-# For che multiuser assembly, user must be already created on identity provider service.
-che.test_user.email=che@eclipse.org
-che.test_user.password=secret
-
-# Define configuration for admin test user.
-# Note that admin user needs only for multiuser assembly and
-# must be already created on identity provider service
-che.admin_user.email=
-che.admin_user.password=

--- a/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
+++ b/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
@@ -25,5 +25,3 @@ github.auxiliary.password=
 google.user=
 google.password=
 
-# Workspace infrastructure implementation
-che.selenium.infrastructure=docker


### PR DESCRIPTION
### What does this PR do?
Implements creation of test user into `webdriver.sh` script of selenium tests.

### What issues does this PR fix or reference?
#7816

#### Docs PR
https://github.com/eclipse/che-docs/pull/328