### PR TITLE
Add handling in the CheckMainFeatureForCSharpLanguageTest for possible failing after first initialization

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.languageserver;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.ERROR_MARKER;
 
 import com.google.inject.Inject;
@@ -19,7 +20,6 @@ import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
-import org.eclipse.che.selenium.core.constant.TestTimeoutsConstants;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
@@ -113,7 +113,7 @@ public class CheckMainFeatureForCSharpLanguageTest {
     String xpathLocatorForEventMessages =
         "//div[contains(@id,'gwt-debug-notification-wrappergwt-uid')]";
     List<WebElement> textMessages =
-        new WebDriverWait(seleniumWebDriver, TestTimeoutsConstants.MINIMUM_SEC)
+        new WebDriverWait(seleniumWebDriver, MINIMUM_SEC)
             .until(
                 ExpectedConditions.presenceOfAllElementsLocatedBy(
                     By.xpath(xpathLocatorForEventMessages)));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
@@ -10,21 +10,32 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.ERROR_MARKER;
 
 import com.google.inject.Inject;
+import java.util.List;
 import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
+import org.eclipse.che.selenium.core.constant.TestTimeoutsConstants;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
+import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -32,6 +43,7 @@ import org.testng.annotations.Test;
 public class CheckMainFeatureForCSharpLanguageTest {
 
   private final String PROJECT_NAME = NameGenerator.generate("AspProject", 4);
+  private final String COMMAND_NAME_FOR_RESTORE_LS = PROJECT_NAME + ": update dependencies";
 
   @InjectTestWorkspace(template = WorkspaceTemplate.UBUNTU_LSP)
   private TestWorkspace workspace;
@@ -42,6 +54,11 @@ public class CheckMainFeatureForCSharpLanguageTest {
   @Inject private CodenvyEditor editor;
   @Inject private Menu menu;
   @Inject private Wizard wizard;
+  @Inject private SeleniumWebDriver seleniumWebDriver;
+  @Inject private TestCommandServiceClient testCommandServiceClient;
+  @Inject private CommandsPalette commandsPalette;
+
+  @Inject private Consoles consoles;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -49,7 +66,7 @@ public class CheckMainFeatureForCSharpLanguageTest {
   }
 
   @Test
-  public void checkLaunchingCodeserver() throws Exception {
+  public void checkLaunchingCodeserver() {
     projectExplorer.waitProjectExplorer();
     menu.runCommand(
         TestMenuCommandsConstants.Workspace.WORKSPACE,
@@ -62,6 +79,7 @@ public class CheckMainFeatureForCSharpLanguageTest {
     projectExplorer.waitItem(PROJECT_NAME + "/Program.cs", 240);
     projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
     loader.waitOnClosed();
+    checkInitStateAndLaunchLanguageServer();
     editor.goToCursorPositionVisible(24, 12);
     for (int i = 0; i < 9; i++) {
       editor.typeTextIntoEditor(Keys.BACK_SPACE.toString());
@@ -74,5 +92,36 @@ public class CheckMainFeatureForCSharpLanguageTest {
     editor.enterAutocompleteProposal("Build() ");
     editor.typeTextIntoEditor(";");
     editor.waitAllMarkersDisappear(ERROR_MARKER);
+  }
+
+  private void checkInitStateAndLaunchLanguageServer() {
+    if (isInitLanguageServerFail()) {
+      reInitLanguageServer();
+    }
+  }
+
+  private void reInitLanguageServer() {
+    commandsPalette.openCommandPalette();
+    commandsPalette.startCommandByDoubleClick(COMMAND_NAME_FOR_RESTORE_LS);
+    consoles.waitExpectedTextIntoConsole("Restore completed");
+    editor.closeAllTabs();
+    projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
+    loader.waitOnClosed();
+  }
+
+  private boolean isInitLanguageServerFail() {
+    String xpathLocatorForEventMessages =
+        "//div[contains(@id,'gwt-debug-notification-wrappergwt-uid')]";
+    List<WebElement> textMessages =
+        new WebDriverWait(seleniumWebDriver, TestTimeoutsConstants.MINIMUM_SEC)
+            .until(
+                ExpectedConditions.presenceOfAllElementsLocatedBy(
+                    By.xpath(xpathLocatorForEventMessages)));
+    StringBuilder allMessagesBuilder = new StringBuilder();
+    textMessages.forEach(message -> allMessagesBuilder.append(message.getAttribute("textContent")));
+    String agrigatedMessages = allMessagesBuilder.toString();
+    return (isNullOrEmpty(agrigatedMessages))
+        ? false
+        : (agrigatedMessages.contains("Timeout initializing error"));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.ERROR_MARKER;
 
@@ -79,7 +78,7 @@ public class CheckMainFeatureForCSharpLanguageTest {
     projectExplorer.waitItem(PROJECT_NAME + "/Program.cs", 240);
     projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
     loader.waitOnClosed();
-    checkInitStateAndLaunchLanguageServer();
+    checkLanguageServerInitStateAndLaunch();
     editor.goToCursorPositionVisible(24, 12);
     for (int i = 0; i < 9; i++) {
       editor.typeTextIntoEditor(Keys.BACK_SPACE.toString());
@@ -94,8 +93,8 @@ public class CheckMainFeatureForCSharpLanguageTest {
     editor.waitAllMarkersDisappear(ERROR_MARKER);
   }
 
-  private void checkInitStateAndLaunchLanguageServer() {
-    if (isInitLanguageServerFail()) {
+  private void checkLanguageServerInitStateAndLaunch() {
+    if (isLanguageServerInitFailed()) {
       reInitLanguageServer();
     }
   }
@@ -109,7 +108,7 @@ public class CheckMainFeatureForCSharpLanguageTest {
     loader.waitOnClosed();
   }
 
-  private boolean isInitLanguageServerFail() {
+  private boolean isLanguageServerInitFailed() {
     String xpathLocatorForEventMessages =
         "//div[contains(@id,'gwt-debug-notification-wrappergwt-uid')]";
     List<WebElement> textMessages =
@@ -117,11 +116,9 @@ public class CheckMainFeatureForCSharpLanguageTest {
             .until(
                 ExpectedConditions.presenceOfAllElementsLocatedBy(
                     By.xpath(xpathLocatorForEventMessages)));
-    StringBuilder allMessagesBuilder = new StringBuilder();
-    textMessages.forEach(message -> allMessagesBuilder.append(message.getAttribute("textContent")));
-    String aggregatedMessages = allMessagesBuilder.toString();
-    return (isNullOrEmpty(aggregatedMessages))
-        ? false
-        : (aggregatedMessages.contains("Timeout initializing error"));
+    return textMessages
+        .stream()
+        .anyMatch(
+            message -> message.getAttribute("textContent").contains("Timeout initializing error"));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CheckMainFeatureForCSharpLanguageTest.java
@@ -119,9 +119,9 @@ public class CheckMainFeatureForCSharpLanguageTest {
                     By.xpath(xpathLocatorForEventMessages)));
     StringBuilder allMessagesBuilder = new StringBuilder();
     textMessages.forEach(message -> allMessagesBuilder.append(message.getAttribute("textContent")));
-    String agrigatedMessages = allMessagesBuilder.toString();
-    return (isNullOrEmpty(agrigatedMessages))
+    String aggregatedMessages = allMessagesBuilder.toString();
+    return (isNullOrEmpty(aggregatedMessages))
         ? false
-        : (agrigatedMessages.contains("Timeout initializing error"));
+        : (aggregatedMessages.contains("Timeout initializing error"));
   }
 }


### PR DESCRIPTION
### What does this PR do?
Sometimes for first LS. initialization the default timeout is not enough. For this - in the test has been added handle that invokes command for getting dependencies by terminal command and checks main of LS. features again

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7952
@tolusha @dmytro-ndp @vparfonov 