### PR TITLE
Update the images for Debian, Ubuntu and Rails runtime stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1138,7 +1138,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "eclipse/ubuntu_rails"
+      "origin": "eclipse/ruby_rails"
     },
     "workspaceConfig": {
       "environments": {
@@ -1160,7 +1160,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/ubuntu_rails",
+            "location": "eclipse/ruby_rails",
             "type": "dockerimage"
           }
         }
@@ -1211,7 +1211,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "eclipse/debian_jre"
+      "origin": "eclipse/debian_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -1228,7 +1228,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/debian_jre",
+            "location": "eclipse/debian_jdk8",
             "type": "dockerimage"
           }
         }
@@ -1256,7 +1256,7 @@
     ],
     "source": {
       "type": "image",
-      "origin": "eclipse/debian_jre"
+      "origin": "eclipse/debian_jdk8"
     },
     "workspaceConfig": {
       "environments": {
@@ -1278,7 +1278,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/debian_jre",
+            "location": "eclipse/debian_jdk8",
             "type": "dockerimage"
           }
         }
@@ -1878,7 +1878,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/ubuntu_jre",
+            "location": "eclipse/ubuntu_jdk8",
             "type": "dockerimage"
           }
         }
@@ -1889,7 +1889,7 @@
     },
     "source": {
       "type": "image",
-      "origin": "eclipse/ubuntu_jre"
+      "origin": "eclipse/ubuntu_jdk8"
     }
   },
   {
@@ -2703,7 +2703,7 @@
     "name": "Ceylon with Java JavaScript Dart on CentOS",
     "id": "ceylon-java-javascript-dart-centos",
     "source": {
-      "origin": "eclipse/centos_ceylon_nodejs_dart",
+      "origin": "registry.centos.org/che-stacks/centos-ceylon-nodejs-dart",
       "type": "image"
     },
     "components": [
@@ -2779,7 +2779,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/centos_ceylon_nodejs_dart",
+            "location": "registry.centos.org/che-stacks/centos-ceylon-nodejs-dart",
             "type": "dockerimage"
           }
         }


### PR DESCRIPTION
### What does this PR do?
Updates the following stacks:

- `rails-default`: was [eclipse/ubuntu_rails](https://hub.docker.com/r/eclipse/ubuntu_rails/)(1 year old) replaced with [eclipse/ruby_rails](https://hub.docker.com/r/eclipse/ruby_rails)
- ` debian`: was [eclipse/debian_jre](https://hub.docker.com/r/eclipse/debian_jre/)(1 year old) replaced with [eclipse/debian_jdk8](https://hub.docker.com/r/eclipse/debian_jdk8/)
- ` debianlsp`: was [eclipse/debian_jre](https://hub.docker.com/r/eclipse/debian_jre/)(1 year old) replaced with [eclipse/debian_jdk8](https://hub.docker.com/r/eclipse/debian_jdk8/)
- ` ubuntu `: was [eclipse/ubuntu_jre](https://hub.docker.com/r/eclipse/ubuntu_jre/)(1 year old) replaced with [eclipse/ubuntu_jdk8](https://hub.docker.com/r/eclipse/ubuntu_jdk8/)
- ` ceylon-java-javascript-dart-centos `: was [eclipse/centos_ceylon_nodejs_dart](https://hub.docker.com/r/eclipse/centos_ceylon_nodejs_dart/) replaced with [registry.centos.org/che-stacks/centos-ceylon-nodejs-dart](https://registry.centos.org/tag/che-stacks/centos-ceylon-nodejs-dart/latest/)

@eivantsov @riuvshin we may want to remove [eclipse/ubuntu_rails](https://hub.docker.com/r/eclipse/ubuntu_rails/), [eclipse/debian_jre](https://hub.docker.com/r/eclipse/debian_jre/), [eclipse/ubuntu_jre](https://hub.docker.com/r/eclipse/ubuntu_jre/), [eclipse/centos_ceylon_nodejs_dart](https://hub.docker.com/r/eclipse/centos_ceylon_nodejs_dart/) from dockerhub or maybe someone is still using them?

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6097#issuecomment-351062777
