### PR TITLE
CHE7856: Fix parsing path when getting Git Status on file creation

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitColorsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitColorsTest.java
@@ -20,7 +20,6 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.G
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Project.New.FILE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Project.New.NEW;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Project.PROJECT;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -37,7 +36,6 @@ import org.eclipse.che.selenium.pageobject.*;
 import org.eclipse.che.selenium.pageobject.git.Git;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -151,13 +149,7 @@ public class GitColorsTest {
     askForValueDialog.typeAndWaitText("newFile");
     askForValueDialog.clickOkBtn();
     askForValueDialog.waitFormToClose();
-
-    try {
-      editor.waitYellowTab("newFile");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7856", ex);
-    }
+    editor.waitYellowTab("newFile");
 
     // check that the file color is yellow
     projectExplorer.waitYellowNode(PROJECT_NAME + "/newFile");

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitStatusProvider.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitStatusProvider.java
@@ -12,7 +12,6 @@ package org.eclipse.che.api.git;
 
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.fs.server.WsPathUtils.SEPARATOR;
-import static org.eclipse.che.api.fs.server.WsPathUtils.nameOf;
 import static org.eclipse.che.api.fs.server.WsPathUtils.resolve;
 import static org.eclipse.che.api.project.server.VcsStatusProvider.VcsStatus.ADDED;
 import static org.eclipse.che.api.project.server.VcsStatusProvider.VcsStatus.MODIFIED;
@@ -66,8 +65,8 @@ public class GitStatusProvider implements VcsStatusProvider {
               .getClosest(wsPath)
               .orElseThrow(() -> new NotFoundException("Can't find project"));
       String projectFsPath = pathTransformer.transform(project.getPath()).toString();
-      String projectName = nameOf(project.getPath());
-      String itemPath = wsPath.substring(wsPath.indexOf(projectName + SEPARATOR));
+      wsPath = wsPath.substring(wsPath.startsWith(SEPARATOR) ? 1 : 0);
+      String itemPath = wsPath.substring(wsPath.indexOf(SEPARATOR) + 1);
       Status status =
           gitConnectionFactory.getConnection(projectFsPath).status(singletonList(itemPath));
       if (status.getUntracked().contains(itemPath)) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix parsing path when getting Git Status on file creation

### What issues does this PR fix or reference?
#7856 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Fix bug when sometimes new files are not colored in yellow on Git project. 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A