### PR TITLE
[cli] stop action Use messagebus instead of json rpc bus for system calls.

### DIFF
--- a/dockerfiles/lib/src/api/wsmaster/system/system-stop-event-promise-subscriber.ts
+++ b/dockerfiles/lib/src/api/wsmaster/system/system-stop-event-promise-subscriber.ts
@@ -11,8 +11,8 @@
 
 import {org} from "../../../api/dto/che-dto"
 import {MessageBusSubscriber} from "../../../spi/websocket/messagebus-subscriber";
+import {MessageBus} from "../../../spi/websocket/messagebus";
 import {Log} from "../../../spi/log/log";
-import {JsonRpcBus} from "../../../spi/websocket/json-rpc-bus";
 /**
  * Handle a promise that will be resolved when system is stopped.
  * If system has error, promise will be rejected
@@ -20,52 +20,52 @@ import {JsonRpcBus} from "../../../spi/websocket/json-rpc-bus";
  */
 export class SystemStopEventPromiseMessageBusSubscriber implements MessageBusSubscriber {
 
-    /**
-     * Bus used to collect events
-     */
-    messageBus : JsonRpcBus;
+  /**
+   * Bus used to collect events
+   */
+  messageBus : MessageBus;
 
-    /**
-     * Resolve method to call when we're ready to shutdown the system.
-     */
-    resolve : any;
+  /**
+   * Resolve method to call when we're ready to shutdown the system.
+   */
+  resolve : any;
 
-    /**
-     * Reject method on the promise if we need to abort the current process.
-     */
-    reject : any;
+  /**
+   * Reject method on the promise if we need to abort the current process.
+   */
+  reject : any;
 
-    /**
-     * The promise used to defer the resolution.
-     */
-    promise: Promise<string>;
+  /**
+   * The promise used to defer the resolution.
+   */
+  promise: Promise<string>;
 
-    constructor(messageBus : JsonRpcBus) {
-        this.messageBus = messageBus;
-        this.promise = new Promise<string>((resolve, reject) => {
-            this.resolve = resolve;
-            this.reject = reject;
-        });
+  constructor(messageBus : MessageBus) {
+    this.messageBus = messageBus;
+    this.promise = new Promise<string>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  handleMessage(message: any) {
+    // Ready to shutdown, it means we have finished the graceful stop and we can resolve the promise
+    if ('READY_TO_SHUTDOWN' === message.status) {
+      this.resolve();
+      this.messageBus.close();
+    } else if ('ERROR' === message.status) {
+      try {
+        let stringify: any = JSON.stringify(message);
+        this.reject('Error when stopping the system ' + stringify);
+      } catch (error) {
+        this.reject('Error when stopping the system ' + message.toString());
+      }
+      this.messageBus.close();
+    } else {
+      // Changing the status, displaying it to the user
+      Log.getLogger().info("System going into status '" + message.status + "' (was '" + message.prevStatus + "')");
     }
 
-    handleMessage(message: any) {
-        // Ready to shutdown, it means we have finished the graceful stop and we can resolve the promise
-        if ('READY_TO_SHUTDOWN' === message.status) {
-            this.resolve();
-            this.messageBus.close();
-        } else if ('ERROR' === message.status) {
-            try {
-                let stringify: any = JSON.stringify(message);
-                this.reject('Error when stopping the system ' + stringify);
-            } catch (error) {
-                this.reject('Error when stopping the system ' + message.toString());
-            }
-            this.messageBus.close();
-        } else {
-            // Changing the status, displaying it to the user
-            Log.getLogger().info("System going into status '" + message.status + "' (was '" + message.prevStatus + "')");
-        }
-
-    }
+  }
 
 }

--- a/dockerfiles/lib/src/api/wsmaster/system/system.ts
+++ b/dockerfiles/lib/src/api/wsmaster/system/system.ts
@@ -15,8 +15,8 @@ import {Websocket} from "../../../spi/websocket/websocket";
 import {HttpJsonRequest} from "../../../spi/http/default-http-json-request";
 import {DefaultHttpJsonRequest} from "../../../spi/http/default-http-json-request";
 import {HttpJsonResponse} from "../../../spi/http/default-http-json-request";
+import {MessageBus} from "../../../spi/websocket/messagebus";
 import {SystemStopEventPromiseMessageBusSubscriber} from "./system-stop-event-promise-subscriber";
-import {JsonRpcBus} from "../../../spi/websocket/json-rpc-bus";
 
 /**
  * System class allowing to get state of system and perform graceful stop, etc.
@@ -24,110 +24,110 @@ import {JsonRpcBus} from "../../../spi/websocket/json-rpc-bus";
  */
 export class System {
 
-    /**
-     * Authentication data
-     */
-    authData:AuthData;
+  /**
+   * Authentication data
+   */
+  authData:AuthData;
 
-    /**
-     * websocket.
-     */
-    websocket:Websocket;
+  /**
+   * websocket.
+   */
+  websocket:Websocket;
 
-    constructor(authData:AuthData) {
-        this.authData = authData;
-        this.websocket = new Websocket();
-    }
+  constructor(authData:AuthData) {
+    this.authData = authData;
+    this.websocket = new Websocket();
+  }
 
-    /**
-     * Get state of the system
-     */
-    getState():Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
-        let jsonRequest: HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, null, '/api/system/state', 200);
-        return jsonRequest.request().then((jsonResponse:HttpJsonResponse) => {
-            return jsonResponse.asDto(org.eclipse.che.api.system.shared.dto.SystemStateDtoImpl);
+  /**
+   * Get state of the system
+   */
+  getState():Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
+    let jsonRequest: HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, null, '/api/system/state', 200);
+    return jsonRequest.request().then((jsonResponse:HttpJsonResponse) => {
+      return jsonResponse.asDto(org.eclipse.che.api.system.shared.dto.SystemStateDtoImpl);
+    });
+  }
+
+  /**
+   * Get the message bus for the given System state DTO.
+   * @param systemStateDto the current DTO
+   * @returns {Promise<MessageBus>}
+   */
+  getMessageBus(systemStateDto : org.eclipse.che.api.system.shared.dto.SystemStateDto): Promise<MessageBus> {
+
+    // get link for websocket
+    let websocketLink: string;
+    systemStateDto.getLinks().forEach(stateLink => {
+      if ('system.state.channel' === stateLink.getRel()) {
+        websocketLink = stateLink.getHref();
+      }
+    });
+    return this.websocket.getMessageBus(websocketLink + '?token=' + this.authData.getToken());
+  }
+
+
+  /**
+   * Stop the server and return a promise that will wait for the ready to shutdown event
+   */
+  gracefulStop():Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
+    // get workspace DTO
+    return this.getState().then((systemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
+      if ('READY_TO_SHUTDOWN' === systemStateDto.getStatus()) {
+        return this.readyTobeShutdown(systemStateDto);
+      } else if ('RUNNING' === systemStateDto.getStatus()) {
+        // call stop and wait
+        return this.shutdown(systemStateDto, true);
+      } else {
+        // only wait as stop has been called
+        return this.shutdown(systemStateDto, false);
+      }
+    });
+  }
+
+
+
+  /**
+   * In that case, system is already in a state ready to be shutdown so we do nothing
+   * @returns {Promise<string>}
+   */
+  readyTobeShutdown(currentSystemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto) : Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
+    return Promise.resolve(currentSystemStateDto);
+  }
+
+  /**
+   * We want or we're already in a shutdown process so we need to wait the end of the action
+   * @param systemStateDto the current state
+   * @param callStop if true, we need to call the stop action, else we only listen to the stop process event
+   * @returns {Promise<string>}
+   */
+  shutdown(systemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto, callStop: boolean) : Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
+    let callbackSubscriber : SystemStopEventPromiseMessageBusSubscriber;
+    return this.getMessageBus(systemStateDto).then((messageBus: MessageBus) => {
+      callbackSubscriber = new SystemStopEventPromiseMessageBusSubscriber(messageBus);
+      let channelToListen : string;
+      systemStateDto.getLinks().forEach(stateLink => {
+        if ('system.state.channel' === stateLink.getRel()) {
+          channelToListen = stateLink.getParameters()[0].getDefaultValue();
+        }
+      });
+      return messageBus.subscribeAsync(channelToListen, callbackSubscriber);
+    }).then((subscribed: string) => {
+      if (callStop) {
+        let jsonRequest: HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, null, '/api/system/stop', 204).setMethod('POST');
+        return jsonRequest.request().then((jsonResponse: HttpJsonResponse) => {
+          return;
+        }).then(() => {
+          return callbackSubscriber.promise;
+        }).then(() => {
+          return this.getState();
         });
-    }
-
-    /**
-     * Get the message bus for the given System state DTO.
-     * @param systemStateDto the current DTO
-     * @returns {Promise<MessageBus>}
-     */
-    getMessageBus(systemStateDto : org.eclipse.che.api.system.shared.dto.SystemStateDto): Promise<JsonRpcBus> {
-
-        // get link for websocket
-        let websocketLink: string;
-        systemStateDto.getLinks().forEach(stateLink => {
-            if ('system.state.channel' === stateLink.getRel()) {
-                websocketLink = stateLink.getHref();
-            }
+      } else {
+        return callbackSubscriber.promise.then(() => {
+          return this.getState();
         });
-        return this.websocket.getJsonRpcBus(websocketLink + '?token=' + this.authData.getToken());
-    }
-
-
-    /**
-     * Stop the server and return a promise that will wait for the ready to shutdown event
-     */
-    gracefulStop():Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
-        // get workspace DTO
-        return this.getState().then((systemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto) => {
-            if ('READY_TO_SHUTDOWN' === systemStateDto.getStatus()) {
-                return this.readyTobeShutdown(systemStateDto);
-            } else if ('RUNNING' === systemStateDto.getStatus()) {
-                // call stop and wait
-                return this.shutdown(systemStateDto, true);
-            } else {
-                // only wait as stop has been called
-                return this.shutdown(systemStateDto, false);
-            }
-        });
-    }
-
-
-
-    /**
-     * In that case, system is already in a state ready to be shutdown so we do nothing
-     * @returns {Promise<string>}
-     */
-    readyTobeShutdown(currentSystemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto) : Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
-        return Promise.resolve(currentSystemStateDto);
-    }
-
-    /**
-     * We want or we're already in a shutdown process so we need to wait the end of the action
-     * @param systemStateDto the current state
-     * @param callStop if true, we need to call the stop action, else we only listen to the stop process event
-     * @returns {Promise<string>}
-     */
-    shutdown(systemStateDto: org.eclipse.che.api.system.shared.dto.SystemStateDto, callStop: boolean) : Promise<org.eclipse.che.api.system.shared.dto.SystemStateDto> {
-        let callbackSubscriber : SystemStopEventPromiseMessageBusSubscriber;
-        return this.getMessageBus(systemStateDto).then((messageBus: JsonRpcBus) => {
-            callbackSubscriber = new SystemStopEventPromiseMessageBusSubscriber(messageBus);
-            let channelToListen : string;
-            systemStateDto.getLinks().forEach(stateLink => {
-                if ('system.state.channel' === stateLink.getRel()) {
-                    channelToListen = stateLink.getParameters()[0].getDefaultValue();
-                }
-            });
-            return messageBus.subscribeAsync(channelToListen, callbackSubscriber);
-        }).then((subscribed: string) => {
-            if (callStop) {
-                let jsonRequest: HttpJsonRequest = new DefaultHttpJsonRequest(this.authData, null, '/api/system/stop', 204).setMethod('POST');
-                return jsonRequest.request().then((jsonResponse: HttpJsonResponse) => {
-                    return;
-                }).then(() => {
-                    return callbackSubscriber.promise;
-                }).then(() => {
-                    return this.getState();
-                });
-            } else {
-                return callbackSubscriber.promise.then(() => {
-                    return this.getState();
-                });
-            }
-        });
-    }
+      }
+    });
+  }
 
 }

--- a/dockerfiles/lib/src/spi/websocket/messagebuilder.ts
+++ b/dockerfiles/lib/src/spi/websocket/messagebuilder.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc.- initial API and implementation
+ */
+import {UUID} from "../../utils/index";
+
+/**
+ * Generator of the messages to send with the {@link MessageBus} object.
+ * @author Florent Benoit
+ */
+export class MessageBuilder {
+
+  method: string;
+  path: string;
+  TYPE: string;
+  message : any;
+
+  constructor(method? : string, path? : string) {
+    this.TYPE = 'x-everrest-websocket-message-type';
+    if (method) {
+      this.method = method;
+    } else {
+      this.method = 'POST';
+    }
+    if (path) {
+      this.path = path;
+    } else {
+      this.path = null;
+    }
+
+
+    this.message = {};
+    // add uuid
+    this.message.uuid = UUID.build();
+
+    this.message.method = this.method;
+    this.message.path = this.path;
+    this.message.headers = [];
+    this.message.body;
+  }
+
+  subscribe(channel) {
+    var header = {name: this.TYPE, value: 'subscribe-channel'};
+    this.message.headers.push(header);
+    this.message.body = JSON.stringify({channel: channel});
+    return this;
+  }
+
+  unsubscribe(channel) {
+    var header = {name:this.TYPE, value: 'unsubscribe-channel'};
+    this.message.headers.push(header);
+    this.message.body = JSON.stringify({channel: channel});
+    return this;
+  }
+
+  /**
+   * Prepares ping frame for server.
+   *
+   * @returns {MessageBuilder}
+   */
+  ping() {
+    var header = {name:this.TYPE, value: 'ping'};
+    this.message.headers.push(header);
+    return this;
+  }
+
+  build() {
+    return this.message;
+  }
+
+}

--- a/dockerfiles/lib/src/spi/websocket/messagebus.ts
+++ b/dockerfiles/lib/src/spi/websocket/messagebus.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2016-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc.- initial API and implementation
+ */
+import {MessageBuilder} from './messagebuilder';
+import {MessageBusSubscriber} from './messagebus-subscriber';
+import {Log} from "../log/log";
+import {Websocket} from "./websocket";
+import {ResolveSubscribePromiseSubscriber} from "./resolve-subscribe-promise-subscriber";
+
+
+/**
+ * Allow to handle calls to the MessageBus running inside Eclipse Che by sending and receiving the messages.
+ * It handles the UUID messages and subscribers that can subscribe/unsubscribe
+ * @author Florent Benoit
+ */
+export class MessageBus {
+
+  websocketConnection : any;
+  heartbeatPeriod : number;
+  subscribersByChannel : Map<string, Array<MessageBusSubscriber>>;
+  keepAlive : any;
+  delaySend: Array<string>;
+  websocketClient : any;
+  closed : boolean;
+  websocket : Websocket;
+
+  constructor(websocketClient : any, url: string, websocket: Websocket, resolve : any, reject : any) {
+
+    this.websocketClient = websocketClient;
+    this.websocket = websocket;
+
+    this.closed = false;
+    this.delaySend = [];
+
+    var client = websocketClient.on('connectFailed', (error) => {
+      Log.getLogger().error('Connect Error: ' + error.toString());
+      reject(error);
+    });
+
+
+    client.on('error', error => {
+      Log.getLogger().error('websocketclient error', error.toString());
+      reject(error);
+    });
+
+    client.on('connect', (connection) => {
+      // resolve the promise of connecting to the bus
+      resolve(true);
+      this.websocketConnection = connection;
+      // push all previous messages
+      this.delaySend.forEach((subscribeOrder) => this.send(subscribeOrder));
+
+      // remove them
+      this.delaySend.length = 0;
+
+      // init keep alive
+      this.setKeepAlive();
+
+      connection.on('error', (error) => {
+        if (!this.closed) {
+          Log.getLogger().error("Connection Error: " + error.toString());
+        }
+      });
+      connection.on('close', () => {
+        if (!this.closed) {
+          Log.getLogger().error('Websocket connection closed');
+        }
+      });
+      connection.on('message', (message) => {
+        if (message.type === 'utf8') {
+          this.handleMessage(message.utf8Data);
+        }
+      });
+
+    });
+
+    // now connect
+    websocketClient.connect(url);
+
+
+
+    this.heartbeatPeriod = 3000;//1000 * 50; //ping each 50 seconds
+
+    this.subscribersByChannel = new Map<string, Array<MessageBusSubscriber>>();
+    let subscribersChannels : Array<MessageBusSubscriber> = new Array<MessageBusSubscriber>();
+    this.subscribersByChannel.set("subscribe-channel", subscribersChannels)
+
+  }
+
+  close() {
+    this.closed = true;
+    this.websocketConnection.close();
+  }
+
+
+  /**
+   * Sets the keep alive interval, which sends
+   * ping frame to server to keep connection alive.
+   * */
+  setKeepAlive() {
+    this.keepAlive = setTimeout(this.ping, this.heartbeatPeriod, this);
+  }
+
+  /**
+   * Sends ping frame to server.
+   */
+  ping(instance) {
+    instance.send(new MessageBuilder().ping().build());
+  }
+
+  /**
+   * Restart ping timer (cancel previous and start again).
+   */
+  restartPing () {
+    if (this.keepAlive) {
+      clearTimeout(this.keepAlive);
+    }
+
+    this.setKeepAlive();
+  }
+
+  /**
+   * Subscribes a new callback which will listener for messages sent to the specified channel.
+   * Upon the first subscribe to a channel, a message is sent to the server to
+   * subscribe the client for that channel. Subsequent subscribes for a channel
+   * already previously subscribed to do not trigger a send of another message
+   * to the server because the client has already a subscription, and merely registers
+   * (client side) the additional handler to be fired for events received on the respective channel.
+   */
+  subscribe(channel, callback) {
+    // already subscribed ?
+    var existingSubscribers = this.subscribersByChannel.get(channel);
+    if (!existingSubscribers) {
+      // register callback
+
+      var subscribers = [];
+      subscribers.push(callback);
+      this.subscribersByChannel.set(channel, subscribers);
+
+      var subscribeOrder = new MessageBuilder().subscribe(channel).build();
+      // send subscribe order
+      if (!this.websocketConnection) {
+        this.delaySend.push(subscribeOrder);
+      } else {
+        this.send(subscribeOrder);
+      }
+
+    } else {
+      // existing there, add only callback
+      existingSubscribers.push(callback);
+    }
+  }
+
+  /**
+   * Asynchronous subscribe method that is returning  promise that will be resolved when subscribe callback has been sent from the remote side
+   * @param channel the channel on which we want to subscribe
+   * @param callback the callback subscriber
+   * @returns {any} promise
+   */
+  subscribeAsync(channel, callback) : Promise<string> {
+    // already subscribed ?
+    var existingSubscribers = this.subscribersByChannel.get(channel);
+    if (!existingSubscribers) {
+      // register callback
+
+      var subscribers = [];
+      subscribers.push(callback);
+      this.subscribersByChannel.set(channel, subscribers);
+
+
+      // handle this subscribe
+      let resolveSubscribePromiseSubscriber : ResolveSubscribePromiseSubscriber = new ResolveSubscribePromiseSubscriber(channel);
+      this.subscribersByChannel.get("subscribe-channel").push(resolveSubscribePromiseSubscriber);
+      var subscribeOrder = new MessageBuilder().subscribe(channel).build();
+
+      // send subscribe order
+      if (!this.websocketConnection) {
+        this.delaySend.push(subscribeOrder);
+      } else {
+        this.send(subscribeOrder);
+      }
+      return resolveSubscribePromiseSubscriber.promise;
+    } else {
+      // existing there, add only callback
+      existingSubscribers.push(callback);
+      return Promise.resolve("true");
+    }
+  }
+
+  /**
+   * Unsubscribes a previously subscribed handler listening on the specified channel.
+   * If it's the last unsubscribe to a channel, a message is sent to the server to
+   * unsubscribe the client for that channel.
+   */
+  unsubscribe(channel) {
+    // already subscribed ?
+    var existingSubscribers = this.subscribersByChannel.get(channel);
+    // unable to cancel if not existing channel
+    if (!existingSubscribers) {
+      return;
+    }
+
+    if (existingSubscribers.length > 1) {
+      // only remove callback
+      for(let i = 0; i < existingSubscribers.length; i++) {
+        delete existingSubscribers[i];
+      }
+    } else {
+      // only one element, remove and send server message
+      this.subscribersByChannel.delete(channel);
+
+      // send unsubscribe order
+      this.send(new MessageBuilder().unsubscribe(channel).build());
+    }
+  }
+
+
+  send(message) {
+    var stringified = JSON.stringify(message);
+    this.websocketConnection.sendUTF(stringified);
+  }
+
+
+  handleMessage(message) {
+
+    // handling the receive of a message
+    // needs to parse it
+    var jsonMessage = JSON.parse(message);
+
+    // get headers
+    var headers = jsonMessage.headers;
+
+    var channelHeaderMessageType;
+    var channelHeaderChannel;
+    // found channel headers
+    for(let i = 0; i < headers.length; i++) {
+      let header = headers[i];
+      if ('x-everrest-websocket-message-type' === header.name) {
+        channelHeaderMessageType = header;
+        continue;
+      }
+      if ('x-everrest-websocket-channel' === header.name) {
+        channelHeaderChannel = header;
+        continue;
+      }
+    }
+
+    // process messages
+    if (channelHeaderMessageType && channelHeaderMessageType.value && channelHeaderMessageType.value != 'none') {
+      this.processMessage(jsonMessage, channelHeaderMessageType);
+    }
+    if (channelHeaderChannel && channelHeaderChannel.value) {
+      this.processMessage(jsonMessage, channelHeaderChannel);
+    }
+
+    // restart ping after received message
+    this.restartPing();
+  }
+
+  /**
+   * Process the JSON given message by using the given channelHeader value
+   * @param jsonMessage the message to parse and then send to subscribers
+   * @param channelHeader the header containing the value to extrace
+   */
+  processMessage(jsonMessage : any, channelHeader : any) {
+    // message for a channel, look at current subscribers
+    var subscribers : Array<MessageBusSubscriber> = this.subscribersByChannel.get(channelHeader.value);
+    if (subscribers) {
+      subscribers.forEach((subscriber : MessageBusSubscriber) => {
+        // Convert to JSON object if it's a JSON body
+        var data;
+        try {
+          data = JSON.parse(jsonMessage.body);
+        } catch (error) {
+          // keep raw data
+          data = jsonMessage.body;
+        }
+        subscriber.handleMessage(data);
+      });
+    }
+  }
+
+}

--- a/dockerfiles/lib/src/spi/websocket/resolve-subscribe-promise-subscriber.ts
+++ b/dockerfiles/lib/src/spi/websocket/resolve-subscribe-promise-subscriber.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc.- initial API and implementation
+ */
+
+import {Log} from "../log/log";
+import {MessageBusSubscriber} from "./messagebus-subscriber";
+/**
+ * Handle a promise that will be resolved when system is stopped.
+ * If system has error, promise will be rejected
+ * @author Florent Benoit
+ */
+export class ResolveSubscribePromiseSubscriber implements MessageBusSubscriber {
+
+  resolve : any;
+  reject : any;
+  promise: Promise<string>;
+  channel : string;
+
+  constructor(channel : string) {
+    this.channel = channel;
+    this.promise = new Promise<string>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  handleMessage(message: any) {
+    if (this.channel === message.channel) {
+      this.resolve();
+    } else if ('ERROR' === message.eventType) {
+      try {
+        let stringify: any = JSON.stringify(message);
+        this.reject('Error when getting subscribe channel ' + stringify);
+      } catch (error) {
+        this.reject('Error when getting subscribe channel' + message.toString());
+      }
+    } else {
+      this.reject('Error when getting subscribe channel ' + message.toString());
+    }
+
+  }
+
+}

--- a/dockerfiles/lib/src/spi/websocket/websocket.ts
+++ b/dockerfiles/lib/src/spi/websocket/websocket.ts
@@ -10,6 +10,7 @@
  */
 
 import {JsonRpcBus} from "./json-rpc-bus";
+import {MessageBus} from "./messagebus";
 
 /**
  * This class is handling the websocket handling by providing a {@link MessageBus} object
@@ -24,12 +25,38 @@ export class Websocket {
 
 
     /**
+     * Instance of messagebus
+     */
+    messageBus : MessageBus;
+
+  /**
      * Default constructor initializing websocket.
      */
     constructor() {
         this.wsClient = require('websocket').client;
     }
 
+
+  /**
+   * Gets a MessageBus object for a remote workspace, by providing the remote URL to this websocket
+   * @param websocketURL the remote host base WS url
+   * @param workspaceId the workspaceID used as suffix for the URL
+   */
+  getMessageBus(websocketURL) : Promise<MessageBus> {
+    if (this.messageBus) {
+      return Promise.resolve(this.messageBus);
+    }
+    var webSocketClient: any = new this.wsClient();
+    var remoteWebsocketUrl: string = websocketURL;
+    let promise : Promise<MessageBus> = new Promise<MessageBus>((resolve, reject) => {
+      this.messageBus = new MessageBus(webSocketClient, remoteWebsocketUrl, this, resolve, reject);
+    });
+
+    return promise.then(() => {
+      return this.messageBus;
+    });
+
+  }
     /**
      * Gets a MessageBus object for a remote workspace, by providing the remote URL to this websocket
      * @param websocketURL the remote host base WS url


### PR DESCRIPTION
### What does this PR do?
perform graceful stop using messagebus listener and not json rpc bus

Fix https://github.com/eclipse/che/issues/7981

```
$ docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/dat6:/data eclipse/che:nightly stop --fast
INFO: (che cli): nightly - using docker 17.12.0-ce-rc2 / docker4mac
INFO: (che stop): Stopping workspaces...
INFO: (che stop): Stopping containers...
INFO: (che stop): Removing containers...
```

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I3e66b10708d9e72757fd424f587ff7e36c972d09
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
