### PR TITLE
Fix github-specific selenium tests after adding support of Identity brokering mechanism of Keycloak

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/user/TestUserImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/user/TestUserImpl.java
@@ -91,7 +91,7 @@ public class TestUserImpl implements TestUser {
     this.userServiceClient.create(name, email, password);
     this.authToken = authServiceClient.login(name, password);
     this.id = userServiceClient.findByEmail(email).getId();
-    LOG.info("User name='{}', id='{}' has been created", name, id);
+    LOG.info("User name='{}', id='{}' is being used for testing", name, id);
     this.workspaceServiceClient = wsServiceClientFactory.create(email, password);
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
@@ -23,11 +23,11 @@ import java.util.Arrays;
 import java.util.List;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.action.ActionsFactory;
-import org.eclipse.che.selenium.core.client.TestGitHubKeyUploader;
 import org.eclipse.che.selenium.core.client.TestSshServiceClient;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 /** @autor by mmusienko on 9/19/14. */
 @Singleton
 public class Preferences {
+
+  private static final String GITHUB_COM = "github.com";
   private final Loader loader;
   private final ActionsFactory actionsFactory;
   private final AskDialog askDialog;
@@ -258,24 +260,20 @@ public class Preferences {
         .click();
   }
 
-  public boolean isSshKeyTableIsEmpty(String expText) {
-    loader.waitOnClosed();
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
-        .until(ExpectedConditions.presenceOfElementLocated(By.xpath(Locators.SSH_KEYS_TABLE)));
-    return sshKeysTable.getAttribute("style").contains(expText);
-  }
-
   public boolean isSshKeyIsPresent(String host) {
-    loader.waitOnClosed();
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(Locators.SSH_KEYS_TABLE)));
-    return sshKeysTable.getText().contains(host);
+    try {
+      new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+          .until(ExpectedConditions.presenceOfElementLocated(By.xpath(Locators.SSH_KEYS_TABLE)));
+      return sshKeysTable.getText().contains(host);
+    } catch (TimeoutException e) {
+      return false;
+    }
   }
 
   // timeout is changed to 40 sec, is related to running tests on che6-ocp platform
   public void waitSshKeyIsPresent(final String host) {
     new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
-        .until((ExpectedCondition<Boolean>) driver -> sshKeysTable.getText().contains(host));
+        .until((ExpectedCondition<Boolean>) driver -> isSshKeyIsPresent(host));
   }
 
   public void deleteSshKeyByHost(String host) {
@@ -535,20 +533,32 @@ public class Preferences {
     waitSshKeyIsPresent(titleOfKey);
   }
 
-  public void regenerateAndUploadSshKeyOnGithub(String githubUsername, String githubPassword)
+  public void generateAndUploadSshKeyOnGithub(String githubUsername, String githubPassword)
       throws Exception {
-    testSshServiceClient.deleteVCSKey(TestGitHubKeyUploader.GITHUB_COM);
-
     waitMenuInCollapsedDropdown(Preferences.DropDownSshKeysMenu.VCS);
     selectDroppedMenuByName(Preferences.DropDownSshKeysMenu.VCS);
 
     loader.waitOnClosed();
+
+    if (isSshKeyIsPresent(GITHUB_COM)) {
+      clickOnCloseBtn();
+      waitPreferencesFormIsClosed();
+      return;
+    }
 
     String ideWin = seleniumWebDriver.getWindowHandle();
 
     // regenerate key and upload it on the gitHub
     clickOnGenerateAndUploadToGitHub();
 
+    // check if github key has been uploaded without authorization on github.com
+    if (isSshKeyIsPresent(GITHUB_COM)) {
+      clickOnCloseBtn();
+      waitPreferencesFormIsClosed();
+      return;
+    }
+
+    // authorize on github.com
     askDialog.waitFormToOpen(25);
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
@@ -570,7 +580,7 @@ public class Preferences {
 
     seleniumWebDriver.switchTo().window(ideWin);
     loader.waitOnClosed();
-    waitSshKeyIsPresent("github.com");
+    waitSshKeyIsPresent(GITHUB_COM);
     loader.waitOnClosed();
     clickOnCloseBtn();
     waitPreferencesFormIsClosed();

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
@@ -290,6 +290,9 @@ public class Preferences {
           .until(ExpectedConditions.visibilityOf(element))
           .click();
     }
+
+    askDialog.clickOkBtn();
+    askDialog.waitFormToClose();
   }
 
   /**
@@ -540,16 +543,17 @@ public class Preferences {
 
     loader.waitOnClosed();
 
+    // delete github keu if it exists
     if (isSshKeyIsPresent(GITHUB_COM)) {
-      clickOnCloseBtn();
-      waitPreferencesFormIsClosed();
-      return;
+      deleteSshKeyByHost(GITHUB_COM);
     }
 
     String ideWin = seleniumWebDriver.getWindowHandle();
 
     // regenerate key and upload it on the gitHub
     clickOnGenerateAndUploadToGitHub();
+
+    loader.waitOnClosed();
 
     // check if github key has been uploaded without authorization on github.com
     if (isSshKeyIsPresent(GITHUB_COM)) {
@@ -558,7 +562,7 @@ public class Preferences {
       return;
     }
 
-    // authorize on github.com
+    // login to github
     askDialog.waitFormToOpen(25);
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
@@ -571,6 +575,7 @@ public class Preferences {
 
     loader.waitOnClosed();
 
+    // authorize on github.com
     if (seleniumWebDriver.getWindowHandles().size() > 1) {
       loader.waitOnClosed();
       gitHub.waitAuthorizeBtn();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportProjectIntoSpecifiedBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportProjectIntoSpecifiedBranchTest.java
@@ -68,8 +68,7 @@ public class ImportProjectIntoSpecifiedBranchTest {
         TestMenuCommandsConstants.Profile.PROFILE_MENU,
         TestMenuCommandsConstants.Profile.PREFERENCES);
     preferences.waitPreferencesForm();
-    gitHubClientService.deleteAllGrants(gitHubUsername, gitHubPassword);
-    preferences.regenerateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
+    preferences.generateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
   }
 
   @AfterMethod

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportRecursiveSubmoduleTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportRecursiveSubmoduleTest.java
@@ -65,8 +65,7 @@ public class ImportRecursiveSubmoduleTest {
         TestMenuCommandsConstants.Profile.PROFILE_MENU,
         TestMenuCommandsConstants.Profile.PREFERENCES);
     preferences.waitPreferencesForm();
-    gitHubClientService.deleteAllGrants(gitHubUsername, gitHubPassword);
-    preferences.regenerateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
+    preferences.generateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
   }
 
   @AfterMethod

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/KeepDirectoryGitImportTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/KeepDirectoryGitImportTest.java
@@ -78,8 +78,7 @@ public class KeepDirectoryGitImportTest {
         TestMenuCommandsConstants.Profile.PROFILE_MENU,
         TestMenuCommandsConstants.Profile.PREFERENCES);
     preferences.waitPreferencesForm();
-    gitHubClientService.deleteAllGrants(gitHubUsername, gitHubPassword);
-    preferences.regenerateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
+    preferences.generateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
   }
 
   @AfterMethod

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
@@ -117,9 +117,12 @@ public class PullRequestPluginTest {
     List<String> listPullRequest =
         gitHubClientService.getNumbersOfOpenedPullRequests(
             NAME_REPO, gitHubUsername, gitHubPassword);
-    gitHubClientService.closePullRequest(
-        NAME_REPO, Collections.max(listPullRequest), gitHubUsername, gitHubPassword);
-    gitHubClientService.deleteBranch(NAME_REPO, NEW_BRANCH, gitHubUsername, gitHubPassword);
+
+    if (!listPullRequest.isEmpty()) {
+      gitHubClientService.closePullRequest(
+          NAME_REPO, Collections.max(listPullRequest), gitHubUsername, gitHubPassword);
+      gitHubClientService.deleteBranch(NAME_REPO, NEW_BRANCH, gitHubUsername, gitHubPassword);
+    }
   }
 
   @Test(priority = 0)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
@@ -107,8 +107,7 @@ public class PullRequestPluginTest {
         TestMenuCommandsConstants.Profile.PROFILE_MENU,
         TestMenuCommandsConstants.Profile.PREFERENCES);
     preferences.waitPreferencesForm();
-    gitHubClientService.deleteAllGrants(gitHubUsername, gitHubPassword);
-    preferences.regenerateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
+    preferences.generateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
   }
 
   @AfterClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginWithForkTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginWithForkTest.java
@@ -11,12 +11,14 @@
 package org.eclipse.che.selenium.git;
 
 import static org.eclipse.che.selenium.pageobject.PullRequestPanel.Status;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.selenium.core.client.TestGitHubServiceClient;
 import org.eclipse.che.selenium.core.client.TestUserPreferencesServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
@@ -31,12 +33,15 @@ import org.eclipse.che.selenium.pageobject.Preferences;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.PullRequestPanel;
 import org.eclipse.che.selenium.pageobject.Wizard;
+import org.slf4j.Logger;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
 public class PullRequestPluginWithForkTest {
+  private static final Logger LOG = getLogger(PullRequestPluginWithForkTest.class);
+
   private static final String PROJECT_NAME = "pull-request-plugin-fork-test";
   private static final String PROJECT_URL =
       "https://github.com/iedexmain1/pull-request-plugin-fork-test.git";
@@ -98,12 +103,25 @@ public class PullRequestPluginWithForkTest {
 
   @AfterClass
   public void tearDown() throws Exception {
-    gitHubClientService.deleteRepo(FORK_NAME_REPO, gitHubUsername, gitHubPassword);
+    try {
+      gitHubClientService.deleteRepo(FORK_NAME_REPO, gitHubUsername, gitHubPassword);
+    } catch (NotFoundException e) {
+      // ignore absent repo to delete
+      LOG.debug("Repo {} is not found.", FORK_NAME_REPO);
+      return;
+    }
+
     List<String> listPullRequest =
         gitHubClientService.getNumbersOfOpenedPullRequests(
             NAME_REPO, githubUserCloneName, githubUserClonePassword);
-    gitHubClientService.closePullRequest(
-        NAME_REPO, Collections.max(listPullRequest), githubUserCloneName, githubUserClonePassword);
+
+    if (!listPullRequest.isEmpty()) {
+      gitHubClientService.closePullRequest(
+          NAME_REPO,
+          Collections.max(listPullRequest),
+          githubUserCloneName,
+          githubUserClonePassword);
+    }
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginWithForkTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginWithForkTest.java
@@ -93,8 +93,7 @@ public class PullRequestPluginWithForkTest {
         TestMenuCommandsConstants.Profile.PROFILE_MENU,
         TestMenuCommandsConstants.Profile.PREFERENCES);
     preferences.waitPreferencesForm();
-    gitHubClientService.deleteAllGrants(gitHubUsername, gitHubPassword);
-    preferences.regenerateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
+    preferences.generateAndUploadSshKeyOnGithub(gitHubUsername, gitHubPassword);
   }
 
   @AfterClass


### PR DESCRIPTION
### What does this PR do?
It fixes github-specific selenium tests to work correctly with Eclipse Che with support of Identity brokering mechanism of Keycloak.
Also it implements removal of test user which selenium tests launcher has created, to clean up Github identity provider link.

### What issues does this PR fix or reference?
#7930