### PR TITLE
Selenium: change the way to click the plus panel button in the Consoles page object

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -27,6 +27,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.action.ActionsFactory;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -80,13 +81,16 @@ public class Consoles {
   }
 
   protected final SeleniumWebDriver seleniumWebDriver;
+  private final ActionsFactory actionsFactory;
   private final Loader loader;
   private static final String CONSOLE_PANEL_DRUGGER_CSS = "div.gwt-SplitLayoutPanel-VDragger";
 
   @Inject
-  public Consoles(SeleniumWebDriver seleniumWebDriver, Loader loader) {
+  public Consoles(
+      SeleniumWebDriver seleniumWebDriver, Loader loader, ActionsFactory actionsFactory) {
     this.seleniumWebDriver = seleniumWebDriver;
     this.loader = loader;
+    this.actionsFactory = actionsFactory;
     redrawDriverWait = new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     loadPageDriverWait = new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC);
     updateProjDriverWait = new WebDriverWait(seleniumWebDriver, UPDATING_PROJECT_TIMEOUT_SEC);
@@ -161,7 +165,7 @@ public class Consoles {
 
   public void clickOnPlusMenuButton() {
     redrawDriverWait.until(visibilityOf(plusMenuBtn));
-    new Actions(seleniumWebDriver).moveToElement(plusMenuBtn).click().perform();
+    actionsFactory.createAction(seleniumWebDriver).moveToElement(plusMenuBtn).click().perform();
   }
 
   public void clickOnHideInternalServers() {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -160,7 +160,8 @@ public class Consoles {
   }
 
   public void clickOnPlusMenuButton() {
-    redrawDriverWait.until(visibilityOf(plusMenuBtn)).click();
+    redrawDriverWait.until(visibilityOf(plusMenuBtn));
+    new Actions(seleniumWebDriver).moveToElement(plusMenuBtn).click().perform();
   }
 
   public void clickOnHideInternalServers() {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/plugins/JavaTestRunnerPluginConsole.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/plugins/JavaTestRunnerPluginConsole.java
@@ -18,6 +18,7 @@ import com.google.inject.Singleton;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.action.ActionsFactory;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.openqa.selenium.By;
@@ -66,8 +67,9 @@ public class JavaTestRunnerPluginConsole extends Consoles {
   private WebElement resultTreeMainForm;
 
   @Inject
-  public JavaTestRunnerPluginConsole(SeleniumWebDriver seleniumWebDriver, Loader loader) {
-    super(seleniumWebDriver, loader);
+  public JavaTestRunnerPluginConsole(
+      SeleniumWebDriver seleniumWebDriver, Loader loader, ActionsFactory actionsFactory) {
+    super(seleniumWebDriver, loader, actionsFactory);
     PageFactory.initElements(seleniumWebDriver, this);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsComposeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsComposeTest.java
@@ -21,7 +21,6 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import java.util.Map;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
@@ -44,7 +43,7 @@ import org.testng.annotations.Test;
 /** @author Skoryk Serhii */
 public class WorkspaceDetailsComposeTest {
   private static final String WORKSPACE = NameGenerator.generate("java-mysql", 4);
-  private static final Map<String, String> EXPECTED_VARIABLES =
+  private static final ImmutableMap<String, String> EXPECTED_VARIABLES =
       ImmutableMap.of(
           "MYSQL_DATABASE", "petclinic",
           "MYSQL_PASSWORD", "password",

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.dashboard;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
@@ -28,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.Map;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
@@ -56,7 +56,7 @@ import org.testng.annotations.Test;
 /** @author Skoryk Serhii */
 public class WorkspaceDetailsSingleMachineTest {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 4);
-  private static final Map<String, Boolean> EXPECTED_INSTALLERS =
+  private static final ImmutableMap<String, Boolean> EXPECTED_INSTALLERS =
       ImmutableMap.<String, Boolean>builder()
           .put("C# language server", false)
           .put("Exec", false)
@@ -221,6 +221,7 @@ public class WorkspaceDetailsSingleMachineTest {
     workspaceDetails.clickOpenInIdeWsBtn();
     seleniumWebDriver.switchFromDashboardIframeToIde();
     projectExplorer.waitProjectExplorer();
+    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME, PROJECT_FOLDER);
     projectExplorer.waitFolderDefinedTypeOfFolderByPath(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);


### PR DESCRIPTION
### What does this PR do?
We have unexpected fail of **WorkspaceDetailsSingleMachineTest** selenium test. The context menu for adding new **Terminal** or opening the **Servers** list is not appeared after clicking button. 

*Log:*
```
Driver info: org.eclipse.che.selenium.core.SeleniumWebDriver
	at org.eclipse.che.selenium.dashboard.WorkspaceDetailsSingleMachineTest.checkServerInServersList(WorkspaceDetailsSingleMachineTest.java:259)
	at org.eclipse.che.selenium.dashboard.WorkspaceDetailsSingleMachineTest.startWorkspaceAndCheckChanges(WorkspaceDetailsSingleMachineTest.java:230)
Caused by: org.openqa.selenium.NoSuchElementException: 
no such element: Unable to locate element: {"method":"id","selector":"contextMenu/Servers"}
```
*Report with reproduced bug:*
https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-docker/122/Selenium_tests_report/

*Screenshot:*
![org eclipse che selenium dashboard workspacedetailssinglemachinetest startworkspaceandcheckchanges_zqqeheai](https://user-images.githubusercontent.com/7760565/34293200-86e82476-e70c-11e7-863b-126d691e193a.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8020
