### PR TITLE
Fix oauth login to GitHub with keycloak

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
@@ -205,7 +205,7 @@ export class ImportGithubProjectController {
    * Shows authentication popup window.
    */
   authenticateWithGitHub(): void {
-    if (!this.importGithubProjectService.getIsGitHubOAuthProviderAvailable()) {
+    if (!this.keycloakAuth.isPresent && !this.importGithubProjectService.getIsGitHubOAuthProviderAvailable()) {
       this.$mdDialog.show({
         controller: 'NoGithubOauthDialogController',
         controllerAs: 'noGithubOauthDialogController',
@@ -240,13 +240,14 @@ export class ImportGithubProjectController {
       + this.$location.port()
       + (this.$browser as any).baseHref()
       + 'gitHubCallback.html';
-    this.githubPopup.open('/api/oauth/authenticate'
+    let link = '/api/oauth/authenticate'
       + '?oauth_provider=github'
       + '&scope=' + ['user', 'repo', 'write:public_key'].join(',')
       + '&userId=' + this.importGithubProjectService.getCurrentUserId()
       + token
       + '&redirect_after_login='
-      + redirectUrl,
+      + redirectUrl;
+    this.githubPopup.open(link,
       {
         width: 1020,
         height: 618

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
@@ -162,7 +162,6 @@ export class ImportGithubProjectService implements IEditingProgress {
    */
   getOrFetchOAuthProvider(): ng.IPromise<any> {
     const defer = this.$q.defer();
-
     this.isGitHubOAuthProviderAvailable = this.cheAPI.getOAuthProvider().isOAuthProviderRegistered('github');
     if (this.isGitHubOAuthProviderAvailable) {
       defer.resolve(this.isGitHubOAuthProviderAvailable);
@@ -313,7 +312,7 @@ export class ImportGithubProjectService implements IEditingProgress {
    * @return {boolean}
    */
   getIsGitHubOAuthProviderAvailable(): boolean {
-    return this.isGitHubOAuthProviderAvailable;
+    return this.cheAPI.getOAuthProvider().isOAuthProviderRegistered('github');
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes the detection - when to display message about not configured GitHub provider on project importing. If it's multi-user che and keycloak is configured - no need to show that message. Also the login to Gihub in multi-user Che was fixed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8022

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A
