### PR TITLE
Selenium: Add timeout to the 'PhpProjectDebuggingTest' related to run on the oc…

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/PhpProjectDebuggingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/PhpProjectDebuggingTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
@@ -203,6 +204,12 @@ public class PhpProjectDebuggingTest {
    */
   private void startWebPhpScriptInDebugMode() {
     final String previewUrl = consoles.getPreviewUrl() + START_DEBUG_PARAMETERS;
+
+    // it needs when the test is running on the che6-ocp platform
+    if (previewUrl.contains("route")) {
+      WaitUtils.sleepQuietly(10);
+    }
+
     new Thread(
             () -> {
               try {

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/eclipse_php.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/eclipse_php.json
@@ -54,7 +54,7 @@
       "type": "custom"
     },
     {
-      "commandLine": "sudo service apache2 start && sudo tail -f /var/log/apache2/access.log -f /var/log/apache2/error.log",
+      "commandLine": "service apache2 start && tail -f /var/log/apache2/access.log -f /var/log/apache2/error.log",
       "name": "start apache",
       "attributes": {
         "previewUrl": "${server.80/tcp}/${current.project.relpath}"
@@ -62,7 +62,7 @@
       "type": "custom"
     },
     {
-      "commandLine": "sudo service apache2 stop",
+      "commandLine": "service apache2 stop",
       "name": "stop apache",
       "attributes": {
         "previewUrl": ""
@@ -70,7 +70,7 @@
       "type": "custom"
     },
     {
-      "commandLine": "sudo service apache2 restart",
+      "commandLine": "service apache2 restart",
       "name": "restart apache",
       "attributes": {
         "previewUrl": "${server.80/tcp}/${current.project.relpath}"


### PR DESCRIPTION
### What does this PR do?
* Add timeout to the 'PhpProjectDebuggingTest' related to run selenium test on the ocp platform
* Delete 'sudo' from the template php.json stack on the ocp platform in the resources

### What issues does this PR fix or reference?
#7942
