### PR TITLE
Selenium: apply try/catch blocks in failed selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
@@ -101,9 +101,9 @@ public class OrganizationMembersTest {
     // Delete the members from the members list
     try {
       organizationPage.deleteMember(testUser.getEmail());
-    } catch (TimeoutException e) {
+    } catch (TimeoutException ex) {
       // remove try-catch block after the issue has been resolved
-      fail("Known issue https://github.com/codenvy/codenvy/issues/2473", e);
+      fail("Known issue https://github.com/eclipse/che/issues/7897", ex);
     }
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -84,13 +84,7 @@ public class CheckRestoringSplitEditorTest {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     splitEditorAndOpenFiles();
-    try {
-      setPositionsForSplittedEditor();
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7729", ex);
-    }
-
+    setPositionsForSplittedEditor();
     editor.waitActive();
     if (popupDialogsBrowser.isAlertPresent()) {
       popupDialogsBrowser.acceptAlert();
@@ -98,7 +92,6 @@ public class CheckRestoringSplitEditorTest {
 
     seleniumWebDriver.navigate().refresh();
     projectExplorer.waitItem(PROJECT_NAME);
-
     try {
       projectExplorer.waitItemInVisibleArea(javaClassName);
     } catch (TimeoutException ex) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ConvertToProjectWithPomFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ConvertToProjectWithPomFileTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextM
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.NEW;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.SubMenuNew.XML_FILE;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -33,6 +34,7 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -130,7 +132,12 @@ public class ConvertToProjectWithPomFileTest {
     editor.waitTabIsPresent("new-qa-spring-sample");
 
     seleniumWebDriver.navigate().refresh();
-    projectExplorer.waitItem(PROJECT_NAME + "/pom.xml");
+    try {
+      projectExplorer.waitItem(PROJECT_NAME + "/pom.xml");
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7551");
+    }
     editor.waitTabIsPresent("new-qa-spring-sample");
 
     editor.closeAllTabsByContextMenu();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.STOP_WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -27,6 +28,7 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.ToastLoader;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -65,7 +67,12 @@ public class ProjectStateAfterRefreshTest {
     openFilesInEditor();
     checkFilesAreOpened();
     seleniumWebDriver.navigate().refresh();
-    checkFilesAreOpened();
+    try {
+      checkFilesAreOpened();
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7551");
+    }
     editor.closeAllTabsByContextMenu();
   }
 
@@ -101,7 +108,12 @@ public class ProjectStateAfterRefreshTest {
 
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    editor.waitTabIsPresent("qa-spring-sample");
+    try {
+      editor.waitTabIsPresent("qa-spring-sample");
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7551");
+    }
     projectExplorer.waitItem(PROJECT_NAME + "/pom.xml");
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/webapp/WEB-INF");
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/webapp/WEB-INF/jsp");


### PR DESCRIPTION
### What does this PR do?
We have failed selenium tests which related to bugs(known bugs with issue):
 - add try/catch blocks to places when project state after web page restoring is checked(https://github.com/eclipse/che/issues/7551) - **ProjectStateAfterRefreshTest**, **ConvertToProjectWithPomFileTest**;
- remove try/catch block(issue is fixed) - **CheckRestoringSplitEditorTest**(https://github.com/eclipse/che/issues/7729);
- change issue url in **OrganizationMembersTest**("https://github.com/codenvy/codenvy/issues/2473" to "https://github.com/eclipse/che/issues/7897') because issue moved from **Codenvy** to **Che**.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8038