### PR TITLE
Selenium: Add the 'Assert.fail() to the 'CommitFilesTest' related to known issue

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/Git.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/Git.java
@@ -363,7 +363,7 @@ public class Git {
   }
 
   /**
-   * check open state of commit form
+   * check opened state of commit form
    *
    * @return true if widget is open
    */

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/Git.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/Git.java
@@ -362,8 +362,17 @@ public class Git {
     gitCommit.waitMainFormCommit();
   }
 
+  /**
+   * check open state of commit form
+   *
+   * @return true if widget is open
+   */
+  public boolean isCommitWidgetOpened() {
+    return gitCommit.isWidgetOpened();
+  }
+
   /** click on the "Cancel' button in tne 'Commit' main form wait the main form is closed */
-  public void clickOnCancelBtnComitForm() {
+  public void clickOnCancelBtnCommitForm() {
     gitCommit.clickOnCancelBtn();
     gitCommit.waitMainFormCommitIsClosed();
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitCommit.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitCommit.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -74,6 +75,14 @@ public class GitCommit {
   public void waitMainFormCommitIsClosed() {
     new WebDriverWait(seleniumWebDriver, 5)
         .until(ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.MAIN_FORM_COMMIT)));
+  }
+
+  public boolean isWidgetOpened() {
+    try {
+      return btnCancel.isDisplayed();
+    } catch (NoSuchElementException ex) {
+      return false;
+    }
   }
 
   public void typeCommitMsg(String text) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesByMultiSelectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesByMultiSelectTest.java
@@ -129,7 +129,7 @@ public class CommitFilesByMultiSelectTest {
     // Check the 'Cancel' button
     menu.runCommand(TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.COMMIT);
     git.waitCommitMainFormIsOpened();
-    git.clickOnCancelBtnComitForm();
+    git.clickOnCancelBtnCommitForm();
 
     // perform init commit
     projectExplorer.selectItem(PROJECT_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.git;
 
+import static org.testng.Assert.fail;
+
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import java.net.URL;
@@ -31,6 +33,8 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -87,6 +91,13 @@ public class CommitFilesTest {
     ide.open(ws);
   }
 
+  @AfterMethod
+  public void closeForm() {
+    if (git.isCommitWidgetOpened()) {
+      git.clickOnCancelBtnCommitForm();
+    }
+  }
+
   @Test
   public void testCheckBoxSelections() {
     projectExplorer.waitProjectExplorer();
@@ -140,7 +151,7 @@ public class CommitFilesTest {
     git.waitItemCheckBoxToBeUnSelectedInCommitWindow("jsp", "guess_num.jsp");
     git.waitItemCheckBoxToBeSelectedInCommitWindow("web.xml", "spring-servlet.xml", "index.jsp");
 
-    git.clickOnCancelBtnComitForm();
+    git.clickOnCancelBtnCommitForm();
     git.waitCommitFormClosed();
   }
 
@@ -165,19 +176,26 @@ public class CommitFilesTest {
     projectExplorer.selectItem(PROJECT_NAME);
     menu.runCommand(TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.COMMIT);
     git.waitCommitMainFormIsOpened();
-    git.waitItemCheckBoxToBeSelectedInCommitWindow(
-        "src/main",
-        "java/org/eclipse/dev/examples",
-        "AppController.java",
-        "webapp",
-        "WEB-INF",
-        "jsp",
-        "guess_num.jsp",
-        "web.xml",
-        "spring-servlet.xml",
-        "index.jsp",
-        "pom.xml");
-    git.clickOnCancelBtnComitForm();
+
+    try {
+      git.waitItemCheckBoxToBeSelectedInCommitWindow(
+          "src/main",
+          "java/org/eclipse/dev/examples",
+          "AppController.java",
+          "webapp",
+          "WEB-INF",
+          "jsp",
+          "guess_num.jsp",
+          "web.xml",
+          "spring-servlet.xml",
+          "index.jsp",
+          "pom.xml");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8042", ex);
+    }
+
+    git.clickOnCancelBtnCommitForm();
     git.waitCommitFormClosed();
   }
 
@@ -186,7 +204,14 @@ public class CommitFilesTest {
     // perform init commit without one folder
     projectExplorer.selectItem(PROJECT_NAME);
     menu.runCommand(TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.COMMIT);
-    git.clickItemCheckBoxInCommitWindow("java/org/eclipse/dev/examples");
+
+    try {
+      git.clickItemCheckBoxInCommitWindow("java/org/eclipse/dev/examples");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8042", ex);
+    }
+
     git.waitAndRunCommit("init");
     loader.waitOnClosed();
 


### PR DESCRIPTION
### What does this PR do?
* Add the 'Assert.fail() to the selenium test 'CommitFilesTest' related to known issue
* Add the deletion of commit form in the test 'CommitFilesTest'
* Add the 'isWidgetOpen' method in the page objects 'GitCommit' and 'Git'
* Correct the name of method 'clickOnCancelBtnComitForm' in the page object 'Git'

### What issues does this PR fix or reference?
#8043
#8042
