### PR TITLE
Fix load user repo in sigle user mode

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitAuthActionPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitAuthActionPresenter.java
@@ -73,8 +73,10 @@ public class GitAuthActionPresenter {
                               Promises.resolve(new Credentials(token.getToken(), token.getToken())))
                       .thenPromise(operation::perform)
                       .catchError(
-                          (Operation<PromiseError>) err -> notificationManager
-                              .notify(locale.messagesNotAuthorizedContent(), FAIL, FLOAT_MODE));
+                          (Operation<PromiseError>)
+                              err ->
+                                  notificationManager.notify(
+                                      locale.messagesNotAuthorizedContent(), FAIL, FLOAT_MODE));
                 }
                 return Promises.reject(error);
               }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitAuthActionPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitAuthActionPresenter.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.ide.ext.git.client;
 
 import static org.eclipse.che.api.git.shared.ProviderInfo.PROVIDER_NAME;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.util.ExceptionUtils.getAttributes;
 import static org.eclipse.che.ide.util.ExceptionUtils.getErrorCode;
 
@@ -18,6 +20,7 @@ import java.util.Map;
 import org.eclipse.che.api.core.ErrorCodes;
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
+import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.promises.client.js.Promises;
@@ -68,7 +71,10 @@ public class GitAuthActionPresenter {
                       .thenPromise(
                           token ->
                               Promises.resolve(new Credentials(token.getToken(), token.getToken())))
-                      .thenPromise(operation::perform);
+                      .thenPromise(operation::perform)
+                      .catchError(
+                          (Operation<PromiseError>) err -> notificationManager
+                              .notify(locale.messagesNotAuthorizedContent(), FAIL, FLOAT_MODE));
                 }
                 return Promises.reject(error);
               }

--- a/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/OAuthAuthenticationServiceTest.java
+++ b/wsmaster/che-core-api-auth/src/test/java/org/eclipse/che/security/oauth/OAuthAuthenticationServiceTest.java
@@ -75,7 +75,7 @@ public class OAuthAuthenticationServiceTest {
             .queryParam("oauth_provider", "unknown")
             .get(SECURE_PATH + "/oauth/token");
 
-    assertEquals(response.getStatusCode(), 400);
+    assertEquals(response.getStatusCode(), 404);
     assertEquals(
         DtoFactory.getInstance()
             .createDtoFromJson(response.getBody().asInputStream(), ServiceError.class)


### PR DESCRIPTION
### What does this PR do?
Fixes Oauth window appear on loading repository if user not yet authorized in sigle user mode. (now it is just simply showing error message and fails.)
For this puprose, we made some changes in the exceptions model of `api/oauth/token?oauth_provider=<provider>` service.  
Previously, it was throwing `BadRequestException` if no such provider found, and `NotFoundException` when no token found for user (i.e. user not yet authenticated on GitHub or other provider).
Now it will be `NotFoundException` when there is no such provider, and `UnauthorizedException` when no token for user is present. This is closer to Keycloak model and requires less checks on the client side.