### PR TITLE
CHE-7872: Rework Git branch dialog filter to have focus from the whole window

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/View.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/View.java
@@ -17,11 +17,8 @@ import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.FocusHandler;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.dom.client.MouseMoveEvent;
@@ -138,38 +135,33 @@ class View extends Composite {
   }
 
   private void handleEvents() {
-    KeyDownHandler handler =
-        new KeyDownHandler() {
-
-          @Override
-          public void onKeyDown(KeyDownEvent event) {
-            if (KeyboardEvent.KeyCode.ESC == event.getNativeEvent().getKeyCode()) {
-              event.stopPropagation();
-              event.preventDefault();
-              if (delegate != null) {
-                delegate.onEscapeKey();
-              }
-            } else if (KeyboardEvent.KeyCode.ENTER == event.getNativeEvent().getKeyCode()) {
-              event.stopPropagation();
-              event.preventDefault();
-              if (delegate != null) {
-                delegate.onEnterKey();
-              }
+    focusPanel.addKeyDownHandler(
+        event -> {
+          if (KeyboardEvent.KeyCode.ESC == event.getNativeEvent().getKeyCode()) {
+            event.stopPropagation();
+            event.preventDefault();
+            if (delegate != null) {
+              delegate.onEscapeKey();
             }
+          } else if (KeyboardEvent.KeyCode.ENTER == event.getNativeEvent().getKeyCode()) {
+            event.stopPropagation();
+            event.preventDefault();
+            if (delegate != null) {
+              delegate.onEnterKey();
+            }
+          } else {
+            delegate.onKeyDownEvent(event);
           }
-        };
+        });
 
-    focusPanel.addDomHandler(handler, KeyDownEvent.getType());
+    focusPanel.addKeyPressHandler(event -> delegate.onKeyPressEvent(event));
 
     closeButton.addDomHandler(
-        new ClickHandler() {
-          @Override
-          public void onClick(ClickEvent event) {
-            if (delegate != null) {
-              delegate.onClose();
-            }
-            event.stopPropagation();
+        event -> {
+          if (delegate != null) {
+            delegate.onClose();
           }
+          event.stopPropagation();
         },
         ClickEvent.getType());
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/window/Window.java
@@ -15,6 +15,8 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.Timer;
@@ -278,9 +280,7 @@ public abstract class Window implements IsWidget {
         new ViewEvents() {
           @Override
           public void onEscapeKey() {
-            if (hideOnEscapeEnabled && !blocked) {
-              Window.this.onClose();
-            }
+            Window.this.onEscapeKey();
           }
 
           @Override
@@ -294,8 +294,31 @@ public abstract class Window implements IsWidget {
           public void onEnterKey() {
             onEnterClicked();
           }
+
+          @Override
+          public void onKeyDownEvent(KeyDownEvent event) {
+            Window.this.onKeyDownEvent(event);
+          }
+
+          @Override
+          public void onKeyPressEvent(KeyPressEvent event) {
+            Window.this.onKeyPressEvent(event);
+          }
         });
   }
+
+  /** @see ViewEvents#onEscapeKey() */
+  protected void onEscapeKey() {
+    if (hideOnEscapeEnabled && !blocked) {
+      Window.this.onClose();
+    }
+  }
+
+  /** @see ViewEvents#onKeyDownEvent(KeyDownEvent) */
+  protected void onKeyDownEvent(KeyDownEvent event) {}
+
+  /** @see ViewEvents#onKeyPressEvent(KeyPressEvent) */
+  protected void onKeyPressEvent(KeyPressEvent event) {}
 
   /** Is called when user closes the Window. */
   protected void onClose() {
@@ -372,10 +395,22 @@ public abstract class Window implements IsWidget {
 
   /** The events sources by the View. */
   public interface ViewEvents {
+    /** Is called when ESCAPE key is pressed. */
     void onEscapeKey();
 
     void onClose();
 
+    /** Is called when ENTER key is pressed. */
     void onEnterKey();
+
+    /**
+     * Is called when {@link KeyDownEvent} is fired except events from ESCAPE and ENTER keys. In
+     * those cases {@link ViewEvents#onEscapeKey()} or {@link ViewEvents#onEnterKey()} will be
+     * fired.
+     */
+    void onKeyDownEvent(KeyDownEvent event);
+
+    /** Is called when {@link KeyPressEvent} is fired. */
+    void onKeyPressEvent(KeyPressEvent event);
   }
 }

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/list/FilterableSimpleList.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/list/FilterableSimpleList.java
@@ -57,8 +57,8 @@ public class FilterableSimpleList<M> extends SimpleList<M> {
     doFilter();
   }
 
-  /** Add Backspace to the filter and update items according to new filter value. */
-  public void addBackspaceToFilter() {
+  /** Remove last character from the filter and update items according to new filter value. */
+  public void removeLastCharacter() {
     filter.deleteCharAt(filter.length() - 1);
     filterChangedHandler.onFilterChanged(filter.toString());
     doFilter();

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/list/FilterableSimpleList.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/ui/list/FilterableSimpleList.java
@@ -7,10 +7,6 @@
  */
 package org.eclipse.che.ide.ui.list;
 
-import static com.google.gwt.event.dom.client.KeyCodes.KEY_BACKSPACE;
-import static com.google.gwt.event.dom.client.KeyCodes.KEY_ESCAPE;
-
-import com.google.gwt.user.client.ui.FocusPanel;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -18,9 +14,9 @@ import java.util.stream.Collectors;
  * A focus panel witch contain {@link SimpleList} widget. Supports filtering items according to
  * typed from keyboard symbols.
  */
-public class FilterableSimpleList<M> extends FocusPanel {
+public class FilterableSimpleList<M> extends SimpleList<M> {
+  private final FilterChangedHandler filterChangedHandler;
   private Map<String, M> filterableItems;
-  private SimpleList<M> simpleList;
   private StringBuilder filter;
 
   public interface FilterChangedHandler {
@@ -34,35 +30,9 @@ public class FilterableSimpleList<M> extends FocusPanel {
       SimpleList.ListItemRenderer<M> itemRenderer,
       SimpleList.ListEventDelegate<M> eventDelegate,
       FilterChangedHandler filterChangedHandler) {
-    super();
-    simpleList = SimpleList.create(view, css, itemRenderer, eventDelegate);
-    this.getElement().setAttribute("style", "outline: 0");
-
-    addKeyDownHandler(
-        keyDownEvent -> {
-          int keyCode = keyDownEvent.getNativeEvent().getKeyCode();
-          if (keyCode == KEY_BACKSPACE) {
-            filter.deleteCharAt(filter.length() - 1);
-            filterChangedHandler.onFilterChanged(filter.toString());
-          } else if (keyCode == KEY_ESCAPE && !filter.toString().isEmpty()) {
-            clearFilter();
-            keyDownEvent.stopPropagation();
-            filterChangedHandler.onFilterChanged("");
-          } else {
-            return;
-          }
-          doFilter();
-        });
-
-    addKeyPressHandler(
-        keyPressEvent -> {
-          filter.append(String.valueOf(keyPressEvent.getCharCode()));
-          filterChangedHandler.onFilterChanged(filter.toString());
-          doFilter();
-        });
-
-    add(simpleList);
-    filter = new StringBuilder();
+    super(view, view, view, css, itemRenderer, eventDelegate);
+    this.filterChangedHandler = filterChangedHandler;
+    this.filter = new StringBuilder();
   }
 
   public static <M> FilterableSimpleList<M> create(
@@ -75,6 +45,32 @@ public class FilterableSimpleList<M> extends FocusPanel {
         view, simpleListCss, itemRenderer, eventDelegate, filterChangedHandler);
   }
 
+  /** Clear the filter. */
+  public void clearFilter() {
+    filter.delete(0, filter.length() + 1);
+  }
+
+  /** Clear the filter and show all items. */
+  public void resetFilter() {
+    clearFilter();
+    filterChangedHandler.onFilterChanged("");
+    doFilter();
+  }
+
+  /** Add Backspace to the filter and update items according to new filter value. */
+  public void addBackspaceToFilter() {
+    filter.deleteCharAt(filter.length() - 1);
+    filterChangedHandler.onFilterChanged(filter.toString());
+    doFilter();
+  }
+
+  /** Add character to the filter and update items according to new filter value. */
+  public void addCharacterToFilter(String character) {
+    filter.append(character);
+    filterChangedHandler.onFilterChanged(filter.toString());
+    doFilter();
+  }
+
   /**
    * Render the list with given items.
    *
@@ -85,22 +81,17 @@ public class FilterableSimpleList<M> extends FocusPanel {
     doFilter();
   }
 
-  /** Reset the filter. */
-  public void clearFilter() {
-    filter.delete(0, filter.length() + 1);
-  }
-
-  /** Returns the selection model from parent {@link SimpleList} widget. */
-  public HasSelection<M> getSelectionModel() {
-    return simpleList.getSelectionModel();
+  /** Returns the filter's value. */
+  public String getFilter() {
+    return filter.toString();
   }
 
   private void doFilter() {
-    simpleList.render(
+    render(
         filterableItems
             .keySet()
             .stream()
-            .filter(name -> name.contains(filter.toString()))
+            .filter(name -> name.toLowerCase().contains(filter.toString().toLowerCase()))
             .map(name -> filterableItems.get(name))
             .collect(Collectors.toList()));
   }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchPresenter.java
@@ -128,6 +128,7 @@ public class BranchPresenter implements BranchView.ActionDelegate {
         .then(
             ignored -> {
               getBranches();
+              view.setFocus();
             })
         .catchError(
             error -> {
@@ -146,17 +147,24 @@ public class BranchPresenter implements BranchView.ActionDelegate {
 
   @Override
   public void onDeleteClicked() {
-
-    service
-        .branchDelete(project.getLocation(), selectedBranch.getName(), true)
-        .then(
-            ignored -> {
-              getBranches();
-            })
-        .catchError(
-            error -> {
-              handleError(error.getCause(), BRANCH_DELETE_COMMAND_NAME);
-            });
+    dialogFactory
+        .createConfirmDialog(
+            constant.branchDelete(),
+            constant.branchDeleteAsk(getSelectedBranchName()),
+            () ->
+                service
+                    .branchDelete(project.getLocation(), selectedBranch.getName(), true)
+                    .then(
+                        ignored -> {
+                          getBranches();
+                          view.setFocus();
+                        })
+                    .catchError(
+                        error -> {
+                          handleError(error.getCause(), BRANCH_DELETE_COMMAND_NAME);
+                        }),
+            null)
+        .show();
   }
 
   @Override
@@ -218,6 +226,7 @@ public class BranchPresenter implements BranchView.ActionDelegate {
                   .then(
                       branch -> {
                         getBranches();
+                        view.setFocus();
                       })
                   .catchError(
                       error -> {

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchView.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchView.java
@@ -111,4 +111,7 @@ public interface BranchView extends View<BranchView.ActionDelegate> {
 
   /** Clear search filter. */
   void clearSearchFilter();
+
+  /** Set focus to current window. */
+  void setFocus();
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchViewImpl.java
@@ -193,7 +193,7 @@ public class BranchViewImpl extends Window implements BranchView {
   @Override
   protected void onKeyDownEvent(KeyDownEvent event) {
     if (event.getNativeEvent().getKeyCode() == KEY_BACKSPACE) {
-      branchesList.addBackspaceToFilter();
+      branchesList.removeLastCharacter();
     }
   }
 

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/branch/BranchViewImpl.java
@@ -10,9 +10,12 @@
  */
 package org.eclipse.che.ide.ext.git.client.branch;
 
+import static com.google.gwt.event.dom.client.KeyCodes.KEY_BACKSPACE;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -35,7 +38,6 @@ import org.eclipse.che.api.git.shared.Branch;
 import org.eclipse.che.ide.FontAwesome;
 import org.eclipse.che.ide.ext.git.client.GitLocalizationConstant;
 import org.eclipse.che.ide.ext.git.client.GitResources;
-import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 import org.eclipse.che.ide.ui.list.FilterableSimpleList;
 import org.eclipse.che.ide.ui.list.SimpleList;
 import org.eclipse.che.ide.ui.window.Window;
@@ -70,7 +72,6 @@ public class BranchViewImpl extends Window implements BranchView {
   @UiField(provided = true)
   final GitLocalizationConstant locale;
 
-  private final DialogFactory dialogFactory;
   private FilterableSimpleList<Branch> branchesList;
   private ActionDelegate delegate;
 
@@ -78,11 +79,9 @@ public class BranchViewImpl extends Window implements BranchView {
   protected BranchViewImpl(
       GitResources resources,
       GitLocalizationConstant locale,
-      org.eclipse.che.ide.Resources coreRes,
-      DialogFactory dialogFactory) {
+      org.eclipse.che.ide.Resources coreRes) {
     this.res = resources;
     this.locale = locale;
-    this.dialogFactory = dialogFactory;
     this.ensureDebugId("git-branches-window");
 
     setTitle(locale.branchTitle());
@@ -149,7 +148,6 @@ public class BranchViewImpl extends Window implements BranchView {
     this.localRemoteFilter.addItem("Remote", "remote");
 
     createButtons();
-    addHandlers();
   }
 
   private void onFilterChanged(String filter) {
@@ -162,14 +160,6 @@ public class BranchViewImpl extends Window implements BranchView {
   @UiHandler("localRemoteFilter")
   public void onLocalRemoteFilterChanged(ChangeEvent event) {
     delegate.onLocalRemoteFilterChanged();
-    branchesList.setFocus(true);
-  }
-
-  private void addHandlers() {
-    ClickHandler clickHandler = event -> branchesList.setFocus(true);
-    localRemoteFilter.addClickHandler(clickHandler);
-    searchFilterLabel.addClickHandler(clickHandler);
-    searchFilterIcon.addClickHandler(clickHandler);
   }
 
   private void createButtons() {
@@ -183,7 +173,8 @@ public class BranchViewImpl extends Window implements BranchView {
     addButtonToFooter(btnRename);
 
     btnDelete =
-        createButton(locale.buttonDelete(), "git-branches-delete", event -> onDeleteClicked());
+        createButton(
+            locale.buttonDelete(), "git-branches-delete", event -> delegate.onDeleteClicked());
     addButtonToFooter(btnDelete);
 
     btnCreate =
@@ -199,15 +190,25 @@ public class BranchViewImpl extends Window implements BranchView {
     addButtonToFooter(btnCheckout);
   }
 
-  private void onDeleteClicked() {
-    dialogFactory
-        .createConfirmDialog(
-            locale.branchDelete(),
-            locale.branchDeleteAsk(
-                branchesList.getSelectionModel().getSelectedItem().getDisplayName()),
-            () -> delegate.onDeleteClicked(),
-            null)
-        .show();
+  @Override
+  protected void onKeyDownEvent(KeyDownEvent event) {
+    if (event.getNativeEvent().getKeyCode() == KEY_BACKSPACE) {
+      branchesList.addBackspaceToFilter();
+    }
+  }
+
+  @Override
+  protected void onKeyPressEvent(KeyPressEvent event) {
+    branchesList.addCharacterToFilter(String.valueOf(event.getCharCode()));
+  }
+
+  @Override
+  protected void onEscapeKey() {
+    if (branchesList.getFilter().isEmpty()) {
+      super.onEscapeKey();
+    } else {
+      branchesList.resetFilter();
+    }
   }
 
   @Override
@@ -223,7 +224,7 @@ public class BranchViewImpl extends Window implements BranchView {
     }
 
     if (isWidgetFocused(btnDelete)) {
-      onDeleteClicked();
+      delegate.onDeleteClicked();
       return;
     }
 
@@ -274,13 +275,13 @@ public class BranchViewImpl extends Window implements BranchView {
   @Override
   public void close() {
     this.hide();
+    delegate.onClose();
   }
 
   @Override
   public void showDialogIfClosed() {
     if (!super.isShowing()) {
       this.show(btnCreate);
-      branchesList.setFocus(true);
     }
   }
 
@@ -295,7 +296,12 @@ public class BranchViewImpl extends Window implements BranchView {
   }
 
   @Override
+  public void setFocus() {
+    super.focus();
+  }
+
+  @Override
   public void onClose() {
-    delegate.onClose();
+    close();
   }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchlist/BranchListPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchlist/BranchListPresenter.java
@@ -99,7 +99,6 @@ public class BranchListPresenter implements BranchListView.ActionDelegate {
 
   @Override
   public void onClose() {
-    view.close();
     view.updateSearchFilterLabel("");
     view.clearSearchFilter();
   }
@@ -140,14 +139,13 @@ public class BranchListPresenter implements BranchListView.ActionDelegate {
                 } else {
                   changesListPresenter.show(alteredFiles, selectedBranch.getName(), null);
                 }
+                view.close();
               }
             })
         .catchError(
             error -> {
               notificationManager.notify(locale.diffFailed(), FAIL, NOT_EMERGE_MODE);
             });
-
-    view.close();
   }
 
   @Override

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchlist/BranchListViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchlist/BranchListViewImpl.java
@@ -10,7 +10,11 @@
  */
 package org.eclipse.che.ide.ext.git.client.compare.branchlist;
 
+import static com.google.gwt.event.dom.client.KeyCodes.KEY_BACKSPACE;
+
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -132,7 +136,6 @@ public class BranchListViewImpl extends Window implements BranchListView {
             listBranchesDelegate,
             this::onFilterChanged);
     branchesPanel.add(branchesList);
-    searchFilterLabel.addClickHandler(event -> branchesList.setFocus(true));
 
     createButtons();
   }
@@ -166,12 +169,34 @@ public class BranchListViewImpl extends Window implements BranchListView {
   @Override
   public void close() {
     this.hide();
+    delegate.onClose();
   }
 
   @Override
   public void showDialog() {
     this.show();
-    branchesList.setFocus(true);
+    super.focus();
+  }
+
+  @Override
+  protected void onKeyDownEvent(KeyDownEvent event) {
+    if (event.getNativeEvent().getKeyCode() == KEY_BACKSPACE) {
+      branchesList.addBackspaceToFilter();
+    }
+  }
+
+  @Override
+  protected void onKeyPressEvent(KeyPressEvent event) {
+    branchesList.addCharacterToFilter(String.valueOf(event.getCharCode()));
+  }
+
+  @Override
+  protected void onEscapeKey() {
+    if (branchesList.getFilter().isEmpty()) {
+      super.onEscapeKey();
+    } else {
+      branchesList.resetFilter();
+    }
   }
 
   @Override
@@ -187,12 +212,11 @@ public class BranchListViewImpl extends Window implements BranchListView {
 
   @Override
   public void onClose() {
-    delegate.onClose();
+    close();
   }
 
   private void createButtons() {
-    btnClose =
-        createButton(locale.buttonClose(), "git-compare-branch-close", event -> delegate.onClose());
+    btnClose = createButton(locale.buttonClose(), "git-compare-branch-close", event -> close());
     addButtonToFooter(btnClose);
 
     btnCompare =

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchlist/BranchListViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/branchlist/BranchListViewImpl.java
@@ -181,7 +181,7 @@ public class BranchListViewImpl extends Window implements BranchListView {
   @Override
   protected void onKeyDownEvent(KeyDownEvent event) {
     if (event.getNativeEvent().getKeyCode() == KEY_BACKSPACE) {
-      branchesList.addBackspaceToFilter();
+      branchesList.removeLastCharacter();
     }
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Rework Git branch dialog filter to have focus from the whole window. This fixes bug when filter doesn't work after opening filter drop-down and after create, delete and rename branches.

### What issues does this PR fix or reference?
#7872 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Reworked Git branch dialog filter to have focus from the whole window.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A