### PR TITLE
Selenium: apply try/catch block to ProjectStateAfterRenameWorkspaceTest test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -31,6 +32,7 @@ import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceOverview;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -105,7 +107,14 @@ public class ProjectStateAfterRenameWorkspaceTest {
 
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    projectExplorer.waitItem(PROJECT_NAME + "/src/main/webapp/index.jsp");
+
+    try {
+      projectExplorer.waitItem(PROJECT_NAME + "/src/main/webapp/index.jsp");
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7551");
+    }
+
     projectExplorer.waitItem(
         PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/AppController.java");
     editor.waitTabIsPresent("index.jsp");


### PR DESCRIPTION
### What does this PR do?
This PR adds try/catch block to **ProjectStateAfterRenameWorkspaceTest** selenium test in place when a project state after a workspace restarting is checked.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8038