### PR TITLE
CHE-7885: Throw exception on Git Status if checkout is in progress

### DIFF
--- a/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Constants.java
+++ b/wsagent/che-core-api-git-shared/src/main/java/org/eclipse/che/api/git/shared/Constants.java
@@ -16,6 +16,7 @@ public class Constants {
   public static final String DEFAULT_PAGE_SIZE_QUERY_PARAM = "20";
   public static final String EVENT_GIT_FILE_CHANGED = "event/git-change";
   public static final String COMMIT_IN_PROGRESS_ERROR = "Commit in progress";
+  public static final String CHECKOUT_IN_PROGRESS_ERROR = "Checkout in progress";
   public static final String NOT_A_GIT_REPOSITORY_ERROR = "Not a git repository";
 
   private Constants() {}

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitStatusChangedDetector.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitStatusChangedDetector.java
@@ -32,6 +32,7 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.fs.server.PathTransformer;
+import org.eclipse.che.api.git.exception.GitCheckoutInProgressException;
 import org.eclipse.che.api.git.exception.GitCommitInProgressException;
 import org.eclipse.che.api.git.exception.GitInvalidRepositoryException;
 import org.eclipse.che.api.git.shared.EditedRegion;
@@ -169,6 +170,9 @@ public class GitStatusChangedDetector implements EventSubscriber<StatusChangedEv
         for (String file : status.getChanged()) {
           modifiedFiles.put(file, connection.getEditedRegions(file));
         }
+        for (String file : status.getModified()) {
+          modifiedFiles.put(file, connection.getEditedRegions(file));
+        }
 
         StatusChangedEventDto statusChangeEventDto =
             newDto(StatusChangedEventDto.class)
@@ -177,7 +181,9 @@ public class GitStatusChangedDetector implements EventSubscriber<StatusChangedEv
                 .withModifiedFiles(modifiedFiles);
 
         transmit(statusChangeEventDto, id);
-      } catch (GitCommitInProgressException | GitInvalidRepositoryException e) {
+      } catch (GitCommitInProgressException
+          | GitCheckoutInProgressException
+          | GitInvalidRepositoryException e) {
         // Silent ignore
       } catch (ServerException | NotFoundException e) {
         LOG.error(e.getMessage());

--- a/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/exception/GitCheckoutInProgressException.java
+++ b/wsagent/che-core-api-git/src/main/java/org/eclipse/che/api/git/exception/GitCheckoutInProgressException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.git.exception;
+
+import java.util.Map;
+import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
+
+public class GitCheckoutInProgressException extends GitException {
+  public GitCheckoutInProgressException(String message) {
+    super(message);
+  }
+
+  public GitCheckoutInProgressException(
+      String message, int errorCode, Map<String, String> attributes) {
+    super(message, errorCode, attributes);
+  }
+
+  public GitCheckoutInProgressException(ServiceError serviceError) {
+    super(serviceError);
+  }
+
+  public GitCheckoutInProgressException(String message, int errorCode) {
+    super(message, errorCode);
+  }
+
+  public GitCheckoutInProgressException(Throwable cause) {
+    super(cause);
+  }
+
+  public GitCheckoutInProgressException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Throw exception on Git Status if checkout is in progress. This fixes a bug when file items in project explorer tree are marked as changed during checkout operation.  

### What issues does this PR fix or reference?
#7885 

<!-- #### Changelog -->
Throw exception on Git Status if checkout is in progress.

<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A