### PR TITLE
CHE-8000: Fix Git commit window sizes

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/commit/CommitViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/commit/CommitViewImpl.java
@@ -87,6 +87,7 @@ public class CommitViewImpl extends Window implements CommitView {
 
     remoteBranches = new ListBox();
     remoteBranches.setEnabled(false);
+    remoteBranches.getElement().setAttribute("style", "width: 230px");
 
     pushAfterCommit = new CheckBox();
     pushAfterCommit.setHTML(locale.commitPushCheckboxTitle());

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/commit/CommitViewImpl.ui.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/commit/CommitViewImpl.ui.xml
@@ -25,11 +25,13 @@
         <g:north size="350" addStyleNames="{style.emptyBorder}">
             <g:FlowPanel ui:field="changesPanel" debugId="git-commit-changed-files"/>
         </g:north>
-        <g:center size="50" addStyleNames="{style.emptyBorder}">
-            <g:CheckBox ui:field="amend" HTML="{locale.commitAmendFieldTitle}" debugId="git-commit-amend"/>
-        </g:center>
-        <g:south size="130" addStyleNames="{style.emptyBorder}">
-            <g:TextArea ui:field="message" width="588px" height="118px" addStyleNames="{res.gitCSS.textFont}" debugId="git-commit-message"/>
+        <g:south size="146" addStyleNames="{style.emptyBorder}">
+            <g:FlowPanel>
+                <g:CheckBox ui:field="amend" HTML="{locale.commitAmendFieldTitle}"
+                            debugId="git-commit-amend"/>
+                <g:TextArea ui:field="message" width="588px" height="116px" addStyleNames="{res.gitCSS.textFont}"
+                            debugId="git-commit-message"/>
+            </g:FlowPanel>
         </g:south>
 
     </g:DockLayoutPanel>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix widget's sizes in Git commit dialog.

### What issues does this PR fix or reference?
#8000

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Fix window sizes of Git commit dialog.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A