### PR TITLE
Add all needed classes to the org-eclipse-search from original Eclipse artifact org.eclipse.search

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/pom.xml
@@ -133,10 +133,6 @@
             <artifactId>registry</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.search</groupId>
-            <artifactId>org.eclipse.search</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.text</groupId>
             <artifactId>org.eclipse.text</artifactId>
         </dependency>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/pom.xml
@@ -55,10 +55,6 @@
             <artifactId>contenttype</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.search</groupId>
-            <artifactId>org.eclipse.search</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.text</groupId>
             <artifactId>org.eclipse.text</artifactId>
             <exclusions>

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/InternalSearchUI.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/InternalSearchUI.java
@@ -23,7 +23,6 @@ import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.search.ui.IQueryListener;
 import org.eclipse.search.ui.ISearchQuery;
-import org.eclipse.search.ui.ISearchResultViewPart;
 
 public class InternalSearchUI {
 
@@ -85,7 +84,7 @@ public class InternalSearchUI {
     }
 
     public boolean belongsTo(Object family) {
-      return family == org.eclipse.search2.internal.ui.InternalSearchUI.FAMILY_SEARCH;
+      return family == new Object();
     }
   }
 
@@ -134,7 +133,7 @@ public class InternalSearchUI {
   //		return null;
   //	}
 
-  public boolean runSearchInBackground(ISearchQuery query, ISearchResultViewPart view) {
+  public boolean runSearchInBackground(ISearchQuery query, Object view) {
     if (isQueryRunning(query)) return false;
 
     //		// prepare view
@@ -169,7 +168,7 @@ public class InternalSearchUI {
   }
 
   public IStatus runSearchInForeground(
-      IRunnableContext context, final ISearchQuery query, ISearchResultViewPart view) {
+      IRunnableContext context, final ISearchQuery query, Object view) {
     if (isQueryRunning(query)) {
       return Status.CANCEL_STATUS;
     }

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/NewSearchUI.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/NewSearchUI.java
@@ -13,7 +13,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.search.ui.IQueryListener;
 import org.eclipse.search.ui.ISearchQuery;
-import org.eclipse.search.ui.ISearchResultViewPart;
 
 /**
  * A facade for access to the new search UI facilities.
@@ -110,7 +109,7 @@ public class NewSearchUI {
    * @throws IllegalArgumentException Thrown when the passed query is not able to run in background
    * @since 3.2
    */
-  public static void runQueryInBackground(ISearchQuery query, ISearchResultViewPart view)
+  public static void runQueryInBackground(ISearchQuery query, Object view)
       throws IllegalArgumentException {
     if (query == null) {
       throw new IllegalArgumentException("query must not be null"); // $NON-NLS-1$
@@ -158,7 +157,7 @@ public class NewSearchUI {
    * @since 3.2
    */
   public static IStatus runQueryInForeground(
-      IRunnableContext context, ISearchQuery query, ISearchResultViewPart view) {
+      IRunnableContext context, ISearchQuery query, Object view) {
     if (query == null) {
       throw new IllegalArgumentException("query must not be null"); // $NON-NLS-1$
     }

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/IQueryListener.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/IQueryListener.java
@@ -1,0 +1,54 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui;
+
+/**
+ * A listener for changes to the set of search queries. Queries are added by running them via {@link
+ * org.eclipse.search.ui.NewSearchUI#runQueryInBackground(ISearchQuery)
+ * NewSearchUI#runQueryInBackground(ISearchQuery)} or {@link
+ * org.eclipse.search.ui.NewSearchUI#runQueryInForeground(org.eclipse.jface.operation.IRunnableContext,ISearchQuery)
+ * NewSearchUI#runQueryInForeground(IRunnableContext,ISearchQuery)}
+ *
+ * <p>The search UI determines when queries are rerun, stopped or deleted (and will notify
+ * interested parties via this interface). Listeners can be added and removed in the {@link
+ * org.eclipse.search.ui.NewSearchUI NewSearchUI} class.
+ *
+ * <p>Clients may implement this interface.
+ *
+ * @since 3.0
+ */
+public interface IQueryListener {
+  /**
+   * Called when an query has been added to the system.
+   *
+   * @param query the query that has been added
+   */
+  void queryAdded(ISearchQuery query);
+  /**
+   * Called when a query has been removed.
+   *
+   * @param query the query that has been removed
+   */
+  void queryRemoved(ISearchQuery query);
+
+  /**
+   * Called before an <code>ISearchQuery</code> is starting.
+   *
+   * @param query the query about to start
+   */
+  void queryStarting(ISearchQuery query);
+
+  /**
+   * Called after an <code>ISearchQuery</code> has finished.
+   *
+   * @param query the query that has finished
+   */
+  void queryFinished(ISearchQuery query);
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/ISearchQuery.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/ISearchQuery.java
@@ -1,0 +1,66 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2011 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+/**
+ * Represents a particular search query (in a Java example, a query might be "find all occurrences
+ * of 'foo' in workspace"). When its run method is called, the query places any results it finds in
+ * the <code>ISearchResult</code> that can be accessed via getSearchResult(). Note that <code>
+ * getSearchResult</code> may be called at any time, even before the <code>run()</code> method has
+ * been called. An empty search result should be returned in that case.
+ *
+ * <p>Clients may implement this interface.
+ *
+ * @since 3.0
+ */
+public interface ISearchQuery {
+  /**
+   * This is the method that actually does the work, i.e. finds the results of the search query.
+   *
+   * @param monitor the progress monitor to be used
+   * @return the status after completion of the search job.
+   * @throws OperationCanceledException Thrown when the search query has been canceled.
+   */
+  IStatus run(IProgressMonitor monitor) throws OperationCanceledException;
+  /**
+   * Returns a user readable label for this query. This will be used, for example to set the <code>
+   * Job</code> name if this query is executed in the background. Note that progress notification
+   * (for example, the number of matches found) should be done via the progress monitor passed into
+   * the <code>run(IProgressMonitor)</code> method
+   *
+   * @return the user readable label of this query
+   */
+  String getLabel();
+  /**
+   * Returns whether the query can be run more than once. Some queries may depend on transient
+   * information and return <code>false</code>.
+   *
+   * @return whether this query can be run more than once
+   */
+  boolean canRerun();
+  /**
+   * Returns whether this query can be run in the background. Note that queries must do proper
+   * locking when they are run in the background (e.g. get the appropriate workspace locks).
+   *
+   * @return whether this query can be run in the background
+   */
+  boolean canRunInBackground();
+  /**
+   * Returns the search result associated with this query. This method can be called before run is
+   * called.
+   *
+   * @return this query's search result
+   */
+  ISearchResult getSearchResult();
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/ISearchResult.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/ISearchResult.java
@@ -1,0 +1,69 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+
+/**
+ * Implementors of this interface represent the result of a search. How the results of a search are
+ * structured is up to the implementor of this interface. The abstract base implementation provided
+ * with {@link org.eclipse.search.ui.text.AbstractTextSearchResult AbstractTextSearchResult} uses a
+ * flat list of matches to represent the result of a search. Subclasses of <code>SearchResultEvent
+ * </code> can be used in order to notify listeners of search result changes.
+ *
+ * <p>To present search results to the user implementors of this interface must also provide an
+ * extension for the extension point <code>org.eclipse.search.searchResultViewPage</code>.
+ *
+ * <p>Clients may implement this interface.
+ *
+ * @see org.eclipse.search.ui.ISearchResultPage
+ * @since 3.0
+ */
+public interface ISearchResult {
+  /**
+   * Adds a <code>ISearchResultListener</code>. Has no effect when the listener has already been
+   * added.
+   *
+   * @param l the listener to be added
+   */
+  void addListener(ISearchResultListener l);
+  /**
+   * Removes a <code>ISearchResultChangedListener</code>. Has no effect when the listener hasn't
+   * previously been added.
+   *
+   * @param l the listener to be removed
+   */
+  void removeListener(ISearchResultListener l);
+  /**
+   * Returns a user readable label for this search result. The label is typically used in the result
+   * view and should contain the search query string and number of matches.
+   *
+   * @return the label for this search result
+   */
+  String getLabel();
+  /**
+   * Returns a tooltip to be used when this search result is shown in the UI.
+   *
+   * @return a user readable String
+   */
+  String getTooltip();
+  /**
+   * Returns an image descriptor for the given ISearchResult.
+   *
+   * @return an image representing this search result or <code>null</code>
+   */
+  ImageDescriptor getImageDescriptor();
+  /**
+   * Returns the query that produced this search result.
+   *
+   * @return the query producing this result
+   */
+  ISearchQuery getQuery();
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/ISearchResultListener.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/ISearchResultListener.java
@@ -1,0 +1,31 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui;
+/**
+ * Listener interface for changes to an <code>ISearchResult</code>. Implementers of <code>
+ * ISearchResult</code> should define subclasses of <code>SearchResultEvent</code> and send those to
+ * registered listeners. Implementers of <code>ISearchResultListener</code> will in general know the
+ * concrete class of search result they are listening to, and therefore the kind of events they have
+ * to handle.
+ *
+ * <p>Clients may implement this interface.
+ *
+ * @since 3.0
+ */
+public interface ISearchResultListener {
+  /**
+   * Called to notify listeners of changes in a <code>ISearchResult</code>. The event object <code>e
+   * </code> is only guaranteed to be valid for the duration of the call.
+   *
+   * @param e the event object describing the change. Note that implementers of <code>ISearchResult
+   *     </code> will be sending subclasses of <code>SearchResultEvent</code>
+   */
+  void searchResultChanged(SearchResultEvent e);
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/SearchResultEvent.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/SearchResultEvent.java
@@ -1,0 +1,42 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui;
+
+import java.util.EventObject;
+
+/**
+ * The common superclass of all events sent from <code>ISearchResults</code>. This class is supposed
+ * to be subclassed to provide more specific notification.
+ *
+ * @see ISearchResultListener#searchResultChanged(SearchResultEvent)
+ * @since 3.0
+ */
+public abstract class SearchResultEvent extends EventObject {
+
+  private static final long serialVersionUID = -4877459368182725252L;
+
+  /**
+   * Creates a new search result event for the given search result.
+   *
+   * @param searchResult the source of the event
+   */
+  protected SearchResultEvent(ISearchResult searchResult) {
+    super(searchResult);
+  }
+
+  /**
+   * Gets the <code>ISearchResult</code> for this event.
+   *
+   * @return the source of this event
+   */
+  public ISearchResult getSearchResult() {
+    return (ISearchResult) getSource();
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/AbstractTextSearchResult.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/AbstractTextSearchResult.java
@@ -1,0 +1,385 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.search.ui.ISearchResult;
+import org.eclipse.search.ui.ISearchResultListener;
+import org.eclipse.search.ui.SearchResultEvent;
+
+/**
+ * An abstract base implementation for text-match based search results. This search result
+ * implementation consists of a list of {@link Match matches}. No assumptions are made about the
+ * kind of elements these matches are reported against.
+ *
+ * @since 3.0
+ */
+public abstract class AbstractTextSearchResult implements ISearchResult {
+
+  private static final Match[] EMPTY_ARRAY = new Match[0];
+
+  private final Map fElementsToMatches;
+  private final List fListeners;
+  private final MatchEvent fMatchEvent;
+
+  private MatchFilter[] fMatchFilters;
+
+  /** Constructs a new <code>AbstractTextSearchResult</code> */
+  protected AbstractTextSearchResult() {
+    fElementsToMatches = new HashMap();
+    fListeners = new ArrayList();
+    fMatchEvent = new MatchEvent(this);
+
+    fMatchFilters = null; // filtering disabled by default
+  }
+
+  /**
+   * Returns an array with all matches reported against the given element. Note that all matches of
+   * the given element are returned. The filter state of the matches is not relevant.
+   *
+   * @param element the element to report matches for
+   * @return all matches reported for this element
+   * @see Match#getElement()
+   */
+  public Match[] getMatches(Object element) {
+    synchronized (fElementsToMatches) {
+      List matches = (List) fElementsToMatches.get(element);
+      if (matches != null) return (Match[]) matches.toArray(new Match[matches.size()]);
+      return EMPTY_ARRAY;
+    }
+  }
+
+  /**
+   * Adds a <code>Match</code> to this search result. This method does nothing if the match is
+   * already present.
+   *
+   * <p>Subclasses may extend this method.
+   *
+   * @param match the match to add
+   */
+  public void addMatch(Match match) {
+    boolean hasAdded = false;
+    synchronized (fElementsToMatches) {
+      hasAdded = doAddMatch(match);
+    }
+    if (hasAdded) fireChange(getSearchResultEvent(match, MatchEvent.ADDED));
+  }
+
+  /**
+   * Adds a number of Matches to this search result. This method does nothing for matches that are
+   * already present.
+   *
+   * <p>Subclasses may extend this method.
+   *
+   * @param matches the matches to add
+   */
+  public void addMatches(Match[] matches) {
+    Collection reallyAdded = new ArrayList();
+    synchronized (fElementsToMatches) {
+      for (int i = 0; i < matches.length; i++) {
+        if (doAddMatch(matches[i])) reallyAdded.add(matches[i]);
+      }
+    }
+    if (!reallyAdded.isEmpty()) fireChange(getSearchResultEvent(reallyAdded, MatchEvent.ADDED));
+  }
+
+  private MatchEvent getSearchResultEvent(Match match, int eventKind) {
+    fMatchEvent.setKind(eventKind);
+    fMatchEvent.setMatch(match);
+    return fMatchEvent;
+  }
+
+  private MatchEvent getSearchResultEvent(Collection matches, int eventKind) {
+    fMatchEvent.setKind(eventKind);
+    Match[] matchArray = (Match[]) matches.toArray(new Match[matches.size()]);
+    fMatchEvent.setMatches(matchArray);
+    return fMatchEvent;
+  }
+
+  private boolean doAddMatch(Match match) {
+    updateFilterState(match);
+
+    List matches = (List) fElementsToMatches.get(match.getElement());
+    if (matches == null) {
+      matches = new ArrayList();
+      fElementsToMatches.put(match.getElement(), matches);
+      matches.add(match);
+      return true;
+    }
+    if (!matches.contains(match)) {
+      insertSorted(matches, match);
+      return true;
+    }
+    return false;
+  }
+
+  private static void insertSorted(List matches, Match match) {
+    int insertIndex = getInsertIndex(matches, match);
+    matches.add(insertIndex, match);
+  }
+
+  private static int getInsertIndex(List matches, Match match) {
+    int count = matches.size();
+    int min = 0, max = count - 1;
+    while (min <= max) {
+      int mid = (min + max) / 2;
+      Match data = (Match) matches.get(mid);
+      int compare = compare(match, data);
+      if (compare > 0) max = mid - 1;
+      else min = mid + 1;
+    }
+    return min;
+  }
+
+  private static int compare(Match match1, Match match2) {
+    int diff = match2.getOffset() - match1.getOffset();
+    if (diff != 0) return diff;
+    return match2.getLength() - match1.getLength();
+  }
+
+  /**
+   * Removes all matches from this search result.
+   *
+   * <p>Subclasses may extend this method.
+   */
+  public void removeAll() {
+    synchronized (fElementsToMatches) {
+      doRemoveAll();
+    }
+    fireChange(new RemoveAllEvent(this));
+  }
+
+  private void doRemoveAll() {
+    fElementsToMatches.clear();
+  }
+
+  /**
+   * Removes the given match from this search result. This method has no effect if the match is not
+   * found.
+   *
+   * <p>Subclasses may extend this method.
+   *
+   * @param match the match to remove
+   */
+  public void removeMatch(Match match) {
+    boolean existed = false;
+    synchronized (fElementsToMatches) {
+      existed = doRemoveMatch(match);
+    }
+    if (existed) fireChange(getSearchResultEvent(match, MatchEvent.REMOVED));
+  }
+
+  /**
+   * Removes the given matches from this search result. This method has no effect for matches that
+   * are not found
+   *
+   * <p>Subclasses may extend this method.
+   *
+   * @param matches the matches to remove
+   */
+  public void removeMatches(Match[] matches) {
+    Collection existing = new ArrayList();
+    synchronized (fElementsToMatches) {
+      for (int i = 0; i < matches.length; i++) {
+        if (doRemoveMatch(matches[i]))
+          existing.add(matches[i]); // no duplicate matches at this point
+      }
+    }
+    if (!existing.isEmpty()) fireChange(getSearchResultEvent(existing, MatchEvent.REMOVED));
+  }
+
+  private boolean doRemoveMatch(Match match) {
+    boolean existed = false;
+    List matches = (List) fElementsToMatches.get(match.getElement());
+    if (matches != null) {
+      existed = matches.remove(match);
+      if (matches.isEmpty()) fElementsToMatches.remove(match.getElement());
+    }
+    return existed;
+  }
+
+  /** {@inheritDoc} */
+  public void addListener(ISearchResultListener l) {
+    synchronized (fListeners) {
+      fListeners.add(l);
+    }
+  }
+
+  /** {@inheritDoc} */
+  public void removeListener(ISearchResultListener l) {
+    synchronized (fListeners) {
+      fListeners.remove(l);
+    }
+  }
+
+  /**
+   * Send the given <code>SearchResultEvent</code> to all registered search result listeners.
+   *
+   * @param e the event to be sent
+   * @see ISearchResultListener
+   */
+  protected void fireChange(SearchResultEvent e) {
+    HashSet copiedListeners = new HashSet();
+    synchronized (fListeners) {
+      copiedListeners.addAll(fListeners);
+    }
+    Iterator listeners = copiedListeners.iterator();
+    while (listeners.hasNext()) {
+      ((ISearchResultListener) listeners.next()).searchResultChanged(e);
+    }
+  }
+
+  private void updateFilterStateForAllMatches() {
+    boolean disableFiltering = getActiveMatchFilters() == null;
+    ArrayList changed = new ArrayList();
+    Object[] elements = getElements();
+    for (int i = 0; i < elements.length; i++) {
+      Match[] matches = getMatches(elements[i]);
+      for (int k = 0; k < matches.length; k++) {
+        if (disableFiltering || updateFilterState(matches[k])) {
+          changed.add(matches[k]);
+        }
+      }
+    }
+    Match[] allChanges = (Match[]) changed.toArray(new Match[changed.size()]);
+    fireChange(new FilterUpdateEvent(this, allChanges, getActiveMatchFilters()));
+  }
+
+  /*
+   * Evaluates the filter for the match and updates it. Return true if the filter changed.
+   */
+  private boolean updateFilterState(Match match) {
+    MatchFilter[] matchFilters = getActiveMatchFilters();
+    if (matchFilters == null) {
+      return false; // do nothing, no change
+    }
+
+    boolean oldState = match.isFiltered();
+    for (int i = 0; i < matchFilters.length; i++) {
+      if (matchFilters[i].filters(match)) {
+        match.setFiltered(true);
+        return !oldState;
+      }
+    }
+    match.setFiltered(false);
+    return oldState;
+  }
+
+  /**
+   * Returns the total number of matches contained in this search result. The filter state of the
+   * matches is not relevant when counting matches. All matches are counted.
+   *
+   * @return total number of matches
+   */
+  public int getMatchCount() {
+    int count = 0;
+    synchronized (fElementsToMatches) {
+      for (Iterator elements = fElementsToMatches.values().iterator(); elements.hasNext(); ) {
+        List element = (List) elements.next();
+        if (element != null) count += element.size();
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Returns the number of matches reported against a given element. This is equivalent to calling
+   * <code>getMatches(element).length</code> The filter state of the matches is not relevant when
+   * counting matches. All matches are counted.
+   *
+   * @param element the element to get the match count for
+   * @return the number of matches reported against the element
+   */
+  public int getMatchCount(Object element) {
+    List matches = (List) fElementsToMatches.get(element);
+    if (matches != null) return matches.size();
+    return 0;
+  }
+
+  /**
+   * Returns an array containing the set of all elements that matches are reported against in this
+   * search result. Note that all elements that contain matches are returned. The filter state of
+   * the matches is not relevant.
+   *
+   * @return the set of elements in this search result
+   */
+  public Object[] getElements() {
+    synchronized (fElementsToMatches) {
+      return fElementsToMatches.keySet().toArray();
+    }
+  }
+
+  /**
+   * Sets the active match filters for this result. If set to non-null, the match filters will be
+   * used to update the filter state ({@link Match#isFiltered()} of matches and the {@link
+   * AbstractTextSearchViewPage} will only show non-filtered matches. If <code>null</code> is set
+   * the filter state of the match is ignored by the {@link AbstractTextSearchViewPage} and all
+   * matches are shown. Note the model contains all matches, regardless if the filter state of a
+   * match.
+   *
+   * @param filters the match filters to set or <code>null</code> if the filter state of the match
+   *     should be ignored.
+   * @since 3.3
+   */
+  public void setActiveMatchFilters(MatchFilter[] filters) {
+    fMatchFilters = filters;
+    updateFilterStateForAllMatches();
+  }
+
+  /**
+   * Returns the active match filters for this result. If not null is returned, the match filters
+   * will be used to update the filter state ({@link Match#isFiltered()} of matches and the {@link
+   * AbstractTextSearchViewPage} will only show non-filtered matches. If <code>null</code> is set
+   * the filter state of the match is ignored by the {@link AbstractTextSearchViewPage} and all
+   * matches are shown.
+   *
+   * @return the match filters to be used or <code>null</code> if the filter state of the match
+   *     should be ignored.
+   * @since 3.3
+   */
+  public MatchFilter[] getActiveMatchFilters() {
+    return fMatchFilters;
+  }
+
+  /**
+   * Returns all applicable filters for this result or null if match filters are not supported. If
+   * match filters are returned, the {@link AbstractTextSearchViewPage} will contain menu entries in
+   * the view menu.
+   *
+   * @return all applicable filters for this result.
+   * @since 3.3
+   */
+  public MatchFilter[] getAllMatchFilters() {
+    return null;
+  }
+
+  /**
+   * Returns an implementation of <code>IEditorMatchAdapter</code> appropriate for this search
+   * result.
+   *
+   * @return an appropriate adapter or <code>null</code> if none has been implemented
+   * @see IEditorMatchAdapter
+   */
+  public abstract IEditorMatchAdapter getEditorMatchAdapter();
+
+  /**
+   * Returns an implementation of <code>IFileMatchAdapter</code> appropriate for this search result.
+   *
+   * @return an appropriate adapter or <code>null</code> if none has been implemented
+   * @see IFileMatchAdapter
+   */
+  public abstract IFileMatchAdapter getFileMatchAdapter();
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/FilterUpdateEvent.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/FilterUpdateEvent.java
@@ -1,0 +1,60 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+import org.eclipse.search.ui.ISearchResult;
+import org.eclipse.search.ui.SearchResultEvent;
+
+/**
+ * An event object describing that the filter state of the given {@link Match matches} has been
+ * updated or {@link MatchFilter match filters} have been reconfigured.
+ *
+ * <p>Clients may instantiate or subclass this class.
+ *
+ * @since 3.3
+ */
+public class FilterUpdateEvent extends SearchResultEvent {
+
+  private static final long serialVersionUID = 6009335074727417443L;
+
+  private final Match[] fMatches;
+  private final MatchFilter[] fFilters;
+
+  /**
+   * Constructs a new {@link FilterUpdateEvent}.
+   *
+   * @param searchResult the search result concerned
+   * @param matches the matches updated by the filter change
+   * @param filters the currently activated filters
+   */
+  public FilterUpdateEvent(ISearchResult searchResult, Match[] matches, MatchFilter[] filters) {
+    super(searchResult);
+    fMatches = matches;
+    fFilters = filters;
+  }
+
+  /**
+   * Returns the matches updated by the filter update.
+   *
+   * @return the matches updated by the filter update
+   */
+  public Match[] getUpdatedMatches() {
+    return fMatches;
+  }
+
+  /**
+   * Returns the the filters currently set, or <code>null</code> if filters have been disabled.
+   *
+   * @return the filters currently set
+   */
+  public MatchFilter[] getActiveFilters() {
+    return fFilters;
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/IEditorMatchAdapter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/IEditorMatchAdapter.java
@@ -1,0 +1,44 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+/**
+ * This interface serves as an adapter between matches and editors. It is used to highlight matches
+ * in editors. Search implementors who want their matches highlighted must return an implementation
+ * of <code>IEditorMatchAdapter</code> from the <code>getEditorMatchAdapter()</code> method in their
+ * search result subclass. It is assumed that the match adapters are stateless, and no lifecycle
+ * management is provided.
+ *
+ * <p>Clients may implement this interface.
+ *
+ * @see AbstractTextSearchResult
+ * @since 3.0
+ */
+public interface IEditorMatchAdapter {
+  /**
+   * Determines whether a match should be displayed in the given editor. For example, if a match is
+   * reported in a file, This method should return <code>true</code>, if the given editor displays
+   * the file.
+   *
+   * @param match The match
+   * @param editor The editor that possibly contains the matches element
+   * @return whether the given match should be displayed in the editor
+   */
+  public abstract boolean isShownInEditor(Match match, Object editor);
+  /**
+   * Returns all matches that are contained in the element shown in the given editor. For example,
+   * if the editor shows a particular file, all matches in that file should be returned.
+   *
+   * @param result the result to search for matches
+   * @param editor The editor.
+   * @return All matches that are contained in the element that is shown in the given editor.
+   */
+  public abstract Match[] computeContainedMatches(AbstractTextSearchResult result, Object editor);
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/IFileMatchAdapter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/IFileMatchAdapter.java
@@ -1,0 +1,46 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+import org.eclipse.core.resources.IFile;
+
+/**
+ * This interface serves to map matches to <code>IFile</code> instances. Changes to those files are
+ * then tracked (via the platforms file buffer mechanism) and matches updated when changes are
+ * saved. Clients who want their match positions automatically updated should return an
+ * implementation of <code>IFileMatchAdapter</code> from the <code>getFileMatchAdapter()</code>
+ * method in their search result implementation. It is assumed that the match adapters are
+ * stateless, and no lifecycle management is provided.
+ *
+ * <p>Clients may implement this interface.
+ *
+ * @see AbstractTextSearchResult
+ * @since 3.0
+ */
+public interface IFileMatchAdapter {
+  /**
+   * Returns an array with all matches contained in the given file in the given search result. If
+   * the matches are not contained within an <code>IFile</code>, this method must return an empty
+   * array.
+   *
+   * @param result the search result to find matches in
+   * @param file the file to find matches in
+   * @return an array of matches (possibly empty)
+   */
+  public abstract Match[] computeContainedMatches(AbstractTextSearchResult result, IFile file);
+  /**
+   * Returns the file associated with the given element (usually the file the element is contained
+   * in). If the element is not associated with a file, this method should return <code>null</code>.
+   *
+   * @param element an element associated with a match
+   * @return the file associated with the element or <code>null</code>
+   */
+  public abstract IFile getFile(Object element);
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/Match.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/Match.java
@@ -1,0 +1,144 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+import org.eclipse.core.runtime.Assert;
+
+/**
+ * A textual match in a given object. This class may be instantiated and also subclassed (to add
+ * additional match state like accuracy, etc). The element a match is reported against is assumed to
+ * contain the match, and the UI will group matches against the same element together. A match has
+ * an offset and a length which may be specified in characters or in lines.
+ *
+ * @since 3.0
+ */
+public class Match {
+
+  /** A constant expressing that offset and length of this match are specified in lines */
+  public static final int UNIT_LINE = 1;
+
+  /** A constant expressing that offset and length of this match are specified in characters */
+  public static final int UNIT_CHARACTER = 2;
+
+  private static final int IS_FILTERED = 1 << 2;
+
+  private Object fElement;
+  private int fOffset;
+  private int fLength;
+  private int fFlags;
+
+  /**
+   * Constructs a new Match object.
+   *
+   * @param element the element that contains the match
+   * @param unit the unit offset and length are based on
+   * @param offset the offset the match starts at
+   * @param length the length of the match
+   */
+  public Match(Object element, int unit, int offset, int length) {
+    Assert.isTrue(unit == UNIT_CHARACTER || unit == UNIT_LINE);
+    fElement = element;
+    fOffset = offset;
+    fLength = length;
+    fFlags = unit;
+  }
+
+  /**
+   * Constructs a new Match object. The offset and length will be based on characters.
+   *
+   * @param element the element that contains the match
+   * @param offset the offset the match starts at
+   * @param length the length of the match
+   */
+  public Match(Object element, int offset, int length) {
+    this(element, UNIT_CHARACTER, offset, length);
+  }
+
+  /**
+   * Returns the offset of this match.
+   *
+   * @return the offset
+   */
+  public int getOffset() {
+    return fOffset;
+  }
+
+  /**
+   * Sets the offset of this match.
+   *
+   * @param offset the offset to set
+   */
+  public void setOffset(int offset) {
+    fOffset = offset;
+  }
+
+  /**
+   * Returns the length of this match.
+   *
+   * @return the length
+   */
+  public int getLength() {
+    return fLength;
+  }
+
+  /**
+   * Sets the length.
+   *
+   * @param length the length to set
+   */
+  public void setLength(int length) {
+    fLength = length;
+  }
+
+  /**
+   * Returns the element that contains this match. The element is used to group the match.
+   *
+   * @return the element that contains this match
+   */
+  public Object getElement() {
+    return fElement;
+  }
+
+  /**
+   * Returns whether match length and offset are expressed in lines or characters.
+   *
+   * @return either UNIT_LINE or UNIT_CHARACTER;
+   */
+  public int getBaseUnit() {
+    if ((fFlags & UNIT_LINE) != 0) return UNIT_LINE;
+    return UNIT_CHARACTER;
+  }
+
+  /**
+   * Marks this match as filtered or not.
+   *
+   * @param value <code>true</code> if the match is filtered; otherwise <code>false</code>
+   * @since 3.1
+   */
+  public void setFiltered(boolean value) {
+    if (value) {
+      fFlags |= IS_FILTERED;
+    } else {
+      fFlags &= (~IS_FILTERED);
+    }
+  }
+
+  /**
+   * Returns whether this match is filtered or not.
+   *
+   * @return <code>true<code> if the match is filtered;
+   *  otherwise <code>false</code>
+   *
+   * @since 3.1
+   */
+  public boolean isFiltered() {
+    return (fFlags & IS_FILTERED) != 0;
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/MatchEvent.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/MatchEvent.java
@@ -1,0 +1,98 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+import org.eclipse.search.ui.ISearchResult;
+import org.eclipse.search.ui.SearchResultEvent;
+
+/**
+ * An event object describing addition and removal of matches. Events of this class are sent when
+ * <code>Match</code>es are added or removed from an <code>AbstractTextSearchResult</code>.
+ *
+ * <p>Clients may instantiate or subclass this class.
+ *
+ * @since 3.0
+ */
+public class MatchEvent extends SearchResultEvent {
+  private static final long serialVersionUID = 6009335074727417445L;
+  private int fKind;
+  private Match[] fMatches;
+  private Match[] fMatchContainer = new Match[1];
+  /**
+   * Constant for a matches being added.
+   *
+   * @see MatchEvent#getKind()
+   */
+  public static final int ADDED = 1;
+  /**
+   * Constant for a matches being removed.
+   *
+   * @see MatchEvent#getKind()
+   */
+  public static final int REMOVED = 2;
+
+  private static final Match[] fgEmtpyMatches = new Match[0];
+
+  /**
+   * Constructs a new <code>MatchEvent</code>.
+   *
+   * @param searchResult the search result concerned
+   */
+  public MatchEvent(ISearchResult searchResult) {
+    super(searchResult);
+  }
+
+  /**
+   * Tells whether this is a remove or an add.
+   *
+   * @return one of <code>ADDED</code> or <code>REMOVED</code>
+   */
+  public int getKind() {
+    return fKind;
+  }
+  /**
+   * Returns the concerned matches.
+   *
+   * @return the matches this event is about
+   */
+  public Match[] getMatches() {
+    if (fMatches != null) return fMatches;
+    else if (fMatchContainer[0] != null) return fMatchContainer;
+    else return fgEmtpyMatches;
+  }
+
+  /**
+   * Sets the kind of event this is.
+   *
+   * @param kind the kind to set; either <code>ADDED</code> or <code>REMOVED</code>
+   */
+  protected void setKind(int kind) {
+    fKind = kind;
+  }
+  /**
+   * Sets the match for the change this event reports.
+   *
+   * @param match the match to set
+   */
+  protected void setMatch(Match match) {
+    fMatchContainer[0] = match;
+    fMatches = null;
+  }
+
+  /**
+   * Sets the matches for the change this event reports.
+   *
+   * @param matches the matches to set
+   */
+  protected void setMatches(Match[] matches) {
+    fMatchContainer[0] = null;
+    fMatches = matches;
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/MatchFilter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/MatchFilter.java
@@ -1,0 +1,56 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+/**
+ * A match filter is used to evaluate the filter state of a match ({@link Match#isFiltered()}.
+ * Filters are managed by the ({@link AbstractTextSearchResult}.
+ *
+ * @since 3.3
+ */
+public abstract class MatchFilter {
+
+  /**
+   * Returns whether the given match is filtered by this filter.
+   *
+   * @param match the match to look at
+   * @return returns <code>true</code> if the given match should be filtered or <code>false</code>
+   *     if not.
+   */
+  public abstract boolean filters(Match match);
+
+  /**
+   * Returns the name of the filter as shown in the match filter selection dialog.
+   *
+   * @return the name of the filter as shown in the match filter selection dialog.
+   */
+  public abstract String getName();
+
+  /**
+   * Returns the description of the filter as shown in the match filter selection dialog.
+   *
+   * @return the description of the filter as shown in the match filter selection dialog.
+   */
+  public abstract String getDescription();
+
+  /**
+   * Returns the label of the filter as shown by the filter action.
+   *
+   * @return the label of the filter as shown by the filter action.
+   */
+  public abstract String getActionLabel();
+
+  /**
+   * Returns an ID of this filter.
+   *
+   * @return the id of the filter to be used when persisting this filter.
+   */
+  public abstract String getID();
+}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/RemoveAllEvent.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-search/src/main/java/org/eclipse/search/ui/text/RemoveAllEvent.java
@@ -1,0 +1,33 @@
+/**
+ * ***************************************************************************** Copyright (c) 2000,
+ * 2008 IBM Corporation and others. All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * <p>Contributors: IBM Corporation - initial API and implementation
+ * *****************************************************************************
+ */
+package org.eclipse.search.ui.text;
+
+import org.eclipse.search.ui.ISearchResult;
+import org.eclipse.search.ui.SearchResultEvent;
+
+/**
+ * An event indicating that all matches have been removed from a <code>AbstractTextSearchResult
+ * </code>.
+ *
+ * <p>Clients may instantiate or subclass this class.
+ *
+ * @since 3.0
+ */
+public class RemoveAllEvent extends SearchResultEvent {
+  private static final long serialVersionUID = 6009335074727417445L;
+  /**
+   * A constructor
+   *
+   * @param searchResult the search result this event is about
+   */
+  public RemoveAllEvent(ISearchResult searchResult) {
+    super(searchResult);
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
@@ -133,10 +133,6 @@
             <artifactId>org.eclipse.search</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.search</groupId>
-            <artifactId>org.eclipse.search</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.text</groupId>
             <artifactId>org.eclipse.text</artifactId>
             <exclusions>


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?
Add all needed classes to the org-eclipse-search from original Eclipse artifact org.eclipse.search.
Exclude original artifact form ws-agent assembly to avoid  ClassNotFoundException of Eclipse UI Elements

### What issues does this PR fix or reference?
#7688

