### PR TITLE
CHE-7377 improve workspace config tab for UD

### DIFF
--- a/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.html
+++ b/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.html
@@ -37,7 +37,7 @@
         <div ng-message="maxlength">Component's version should be less than 256 characters long.</div>
       </che-input>
     </div>
-    <che-button-primary che-button-title="{{editComponentDialogController.index === -1 ? 'Add' : 'Edit'}}"
+    <che-button-primary che-button-title="{{editComponentDialogController.index === -1 ? 'Add' : 'Save'}}"
                         ng-click="editComponentDialogController.updateComponent()"
                         ng-disabled="editComponentForm.$invalid">
     </che-button-primary>

--- a/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.html
+++ b/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.html
@@ -1,33 +1,36 @@
 <div layout="column" class="config-import">
-  <ng-form name="workspaceConfigImportForm">
-    <div class="config-editor">
-      <che-editor editor-content="workspaceConfigImportController.importWorkspaceJson"
-                  editor-state="editorState"
-                  validator="workspaceConfigImportController.workspaceConfigValidation()"
-                  on-content-change="workspaceConfigImportController.onChange()"
-                  editor-mode="{{workspaceConfigImportController.editorOptions.mode}}"></che-editor>
-    </div>
-    <div layout="column">
-      <!-- Other errors -->
-      <div ng-if="workspaceConfigImportController.configValidationMessages.length===0">
-        <!-- Settings tab errors -->
-        <div ng-if="workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeSettings].length>0">
-          <div>Settings tab contains error(s):</div>
-          <div class="error-message"
-               ng-repeat="settingsValidationMessage in workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeSettings]">
-            {{settingsValidationMessage}}
-          </div>
+  <div class="config-editor">
+    <che-editor editor-content="workspaceConfigImportController.importWorkspaceJson"
+                editor-state="editorState"
+                validator="workspaceConfigImportController.workspaceConfigValidation()"
+                on-content-change="workspaceConfigImportController.onChange()"
+                editor-mode="application/json"
+                required>
+      <div ng-message="required">A reference is required.</div>
+    </che-editor>
+  </div>
+  <div layout="column">
+    <!-- Other errors -->
+    <div ng-if="workspaceConfigImportController.configValidationMessages.length===0">
+      <!-- Settings tab errors -->
+      <div
+        ng-if="workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeSettings].length>0">
+        <div>Settings tab contains error(s):</div>
+        <div class="error-message"
+             ng-repeat="settingsValidationMessage in workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeSettings]">
+          {{settingsValidationMessage}}
         </div>
-        <!-- Runtime tab errors -->
-        <div ng-if="workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeEnvironment].length>0">
-          <div>Runtime tab contains error(s):</div>
-          <div class="error-message"
-               ng-repeat="envValidationMessage in workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeEnvironment]">
-            {{envValidationMessage}}
-          </div>
+      </div>
+      <!-- Runtime tab errors -->
+      <div
+        ng-if="workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeEnvironment].length>0">
+        <div>Runtime tab contains error(s):</div>
+        <div class="error-message"
+             ng-repeat="envValidationMessage in workspaceConfigImportController.otherValidationMessages[workspaceConfigImportController.errorsScopeEnvironment]">
+          {{envValidationMessage}}
         </div>
       </div>
     </div>
-  </ng-form>
+  </div>
 </div>
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/edit-machine-dialog/edit-machine-dialog.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/edit-machine-dialog/edit-machine-dialog.html
@@ -55,7 +55,7 @@
     <che-button-notice che-button-title="Close"
                        ng-click="editMachineDialogController.cancel()">
     </che-button-notice>
-    <che-button-primary che-button-title="{{editMachineDialogController.isAdd ? 'Add' : 'Edit'}}"
+    <che-button-primary che-button-title="{{editMachineDialogController.isAdd ? 'Add' : 'Save'}}"
                         ng-click="editMachineDialogController.updateMachine()"
                         ng-disabled="editMachineForm.$invalid || !editMachineDialogController.isChange() || !editorState.isValid">
     </che-button-primary>

--- a/dashboard/src/components/api/environment/openshift-environment-manager.ts
+++ b/dashboard/src/components/api/environment/openshift-environment-manager.ts
@@ -163,7 +163,7 @@ export class OpenshiftEnvironmentManager extends EnvironmentManager {
    */
   getEnvironment(environment: che.IWorkspaceEnvironment, machines: IEnvironmentManagerMachine[]): che.IWorkspaceEnvironment {
     const newEnvironment = super.getEnvironment(environment, machines);
-    if (environment && environment.recipe && environment.recipe.content) {
+    if (!environment || !environment.recipe || !environment.recipe.content) {
       return newEnvironment;
     }
     let recipe: IPodList;

--- a/dashboard/src/components/widget/editor/che-editor.directive.ts
+++ b/dashboard/src/components/widget/editor/che-editor.directive.ts
@@ -31,13 +31,48 @@ export class CheEditor implements ng.IDirective {
   templateUrl: string = 'components/widget/editor/che-editor.html';
   controller: string = 'CheEditorController';
   controllerAs: string = 'cheEditorController';
+  transclude: boolean = true;
   bindToController: boolean = true;
 
-  scope: any = {
+  // scope values
+  scope = {
     editorContent: '=',
     editorState: '=?',
     editorMode: '@?',
     validator: '&?',
     onContentChange: '&?'
   };
+
+  compile(element: ng.IRootElementService, attrs: ng.IAttributes): ng.IDirectiveCompileFn {
+    const avoidAttrs = ['ng-model', 'editor-content', 'editor-state', 'editor-mode', 'validator', 'on-content-change'];
+    const avoidStartWithAttrs: Array<string> = ['$'];
+
+    const keys = Object.keys(attrs.$attr);
+    // search the input field
+    const inputJqEl = element.find('.custom-checks che-input');
+
+    keys.forEach((key: string) => {
+      const attr = attrs.$attr[key];
+      if (!attr) {
+        return;
+      }
+      if (avoidStartWithAttrs.find((avoidStartWithAttr: string) => {
+          return attr.indexOf(avoidStartWithAttr) === 0;
+        })) {
+        return;
+      }
+      if (avoidAttrs.indexOf(attr) !== -1) {
+        return;
+      }
+      let value = attrs[key];
+
+      // set the value of the attribute
+      inputJqEl.attr(attr, value);
+      // add also the material version of max length (only one the first input which is the md-input)
+      element.removeAttr(attr);
+    });
+
+    return;
+  }
+
 }

--- a/dashboard/src/components/widget/editor/che-editor.html
+++ b/dashboard/src/components/widget/editor/che-editor.html
@@ -1,14 +1,23 @@
 <div class="che-codemirror-editor">
-  <ng-form name="codemirrorForm">
+  <ng-form name="editorForm">
     <textarea ui-codemirror="cheEditorController.editorOptions"
               aria-label="editor"
               ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 }, allowInvalid: true }"
-              ng-model="cheEditorController.editorContent"
-              name="editor"
-              required></textarea>
-    <div ng-messages="codemirrorForm.editor.$error || !cheEditorController.isEditorValid()">
-      <div ng-message="required">Editor's content is required.</div>
+              ng-model="cheEditorController.editorContent"></textarea>
+    <che-input type="hidden"
+               che-form="editorForm"
+               custom-validator="cheEditorController.isEditorValid()"
+               ng-model="cheEditorController.editorState.errors.toString()"></che-input>
+    <div ng-messages="editorForm.$invalid">
       <div ng-repeat="error in cheEditorController.editorState.errors">{{error}}</div>
+    </div>
+    <div class="custom-checks">
+      <che-input type="hidden"
+                 che-form="editorForm"
+                 ng-model-options="{ allowInvalid: true }"
+                 ng-model="cheEditorController.editorContent">
+        <ng-transclude></ng-transclude>
+      </che-input>
     </div>
   </ng-form>
 </div>

--- a/dashboard/src/components/widget/editor/che-editor.styl
+++ b/dashboard/src/components/widget/editor/che-editor.styl
@@ -1,5 +1,8 @@
-.che-codemirror-editor div[ng-messages]
-  min-height 20px
-  color $error-color
-  *:not(:first-child)
-    display none
+.che-codemirror-editor
+  *[ng-messages]
+    line-height 20px
+    color $error-color
+    *:not(:first-child)
+      display none
+  .che-input-desktop
+    margin-top 0


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Improve workspace config editor behavior by adding autosave for cursor position and turn it back after data refreshing.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7377
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
