### PR TITLE
Selenium: add changes to the unstable WorkspaceDetailsSingleMachineTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -561,6 +561,7 @@ public class ProjectExplorer {
    *     javaSource folder. We can use this types from ProjectExlorer.FolderTypes public interface.
    */
   public void waitFolderDefinedTypeOfFolderByPath(String pathToFolder, String typeFolder) {
+    loader.waitOnClosed();
     loadPageTimeout.until(
         visibilityOfElementLocated(
             By.xpath(

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceInstallers.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceInstallers.java
@@ -76,44 +76,12 @@ public class WorkspaceInstallers {
     return Boolean.parseBoolean(state);
   }
 
-  public Boolean isInstallerStateTurnedOn(String installerName, String installerVersion) {
-    String state =
-        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-            .until(
-                ExpectedConditions.visibilityOfElementLocated(
-                    By.xpath(
-                        format(
-                            Locators.INSTALLER_VERSION_STATE,
-                            installerName,
-                            installerVersion,
-                            installerName))))
-            .getAttribute("aria-checked");
-
-    return Boolean.parseBoolean(state);
-  }
-
   public Boolean isInstallerStateNotChangeable(String installerName) {
     String state =
         new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
             .until(
                 ExpectedConditions.visibilityOfElementLocated(
                     By.xpath(format(Locators.INSTALLER_STATE, installerName))))
-            .getAttribute("aria-disabled");
-
-    return Boolean.parseBoolean(state);
-  }
-
-  public Boolean isInstallerStateNotChangeable(String installerName, String installerVersion) {
-    String state =
-        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-            .until(
-                ExpectedConditions.visibilityOfElementLocated(
-                    By.xpath(
-                        format(
-                            Locators.INSTALLER_VERSION_STATE,
-                            installerName,
-                            installerVersion,
-                            installerName))))
             .getAttribute("aria-disabled");
 
     return Boolean.parseBoolean(state);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspace
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.PROJECTS;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.SERVERS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -131,6 +132,10 @@ public class WorkspaceDetailsSingleMachineTest {
   @Test
   public void checkWorkingWithInstallers() {
     workspaceDetails.selectTabInWorkspaceMenu(INSTALLERS);
+
+    // check the 'Workspace API' installer
+    assertFalse(workspaceInstallers.isInstallerStateTurnedOn("Workspace API", "1.0.0"));
+    assertTrue(workspaceInstallers.isInstallerStateNotChangeable("Workspace API", "1.0.0"));
 
     // check all needed installers in dev-machine exist
     workspaceMachines.selectMachine("Workspace Installers", "dev-machine");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -22,7 +22,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspace
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.PROJECTS;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.SERVERS;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -69,6 +68,7 @@ public class WorkspaceDetailsSingleMachineTest {
           .put("SSH", false)
           .put("Terminal", true)
           .put("TypeScript language server", false)
+          .put("Workspace API", true)
           .put("Yaml language server", false)
           .build();
 
@@ -132,10 +132,7 @@ public class WorkspaceDetailsSingleMachineTest {
   @Test
   public void checkWorkingWithInstallers() {
     workspaceDetails.selectTabInWorkspaceMenu(INSTALLERS);
-
-    // check the 'Workspace API' installer
-    assertFalse(workspaceInstallers.isInstallerStateTurnedOn("Workspace API", "1.0.0"));
-    assertTrue(workspaceInstallers.isInstallerStateNotChangeable("Workspace API", "1.0.0"));
+    assertTrue(workspaceInstallers.isInstallerStateNotChangeable("Workspace API"));
 
     // check all needed installers in dev-machine exist
     workspaceMachines.selectMachine("Workspace Installers", "dev-machine");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -22,7 +22,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspace
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.PROJECTS;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.SERVERS;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -132,12 +131,6 @@ public class WorkspaceDetailsSingleMachineTest {
   @Test
   public void checkWorkingWithInstallers() {
     workspaceDetails.selectTabInWorkspaceMenu(INSTALLERS);
-
-    // check both versions of the 'Workspace API' installer
-    assertTrue(workspaceInstallers.isInstallerStateTurnedOn("Workspace API", "1.0.1"));
-    assertFalse(workspaceInstallers.isInstallerStateTurnedOn("Workspace API", "1.0.0"));
-    assertTrue(workspaceInstallers.isInstallerStateNotChangeable("Workspace API", "1.0.1"));
-    assertTrue(workspaceInstallers.isInstallerStateNotChangeable("Workspace API", "1.0.0"));
 
     // check all needed installers in dev-machine exist
     workspaceMachines.selectMachine("Workspace Installers", "dev-machine");


### PR DESCRIPTION
### What does this PR do?
This PR:
- remove redundant checking of the **Workspace API** installers in the Installers tab;
![selection_107](https://user-images.githubusercontent.com/7760565/34408470-cfbaf1b4-ebcc-11e7-82b4-af50ac688fea.png)

- add checking that the **Loader** is closed in waitFolderDefinedTypeOfFolderByPath() method of the **ProjectExplorer** page object. 
https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-docker/128/Selenium_tests_report/
![org eclipse che selenium dashboard workspacedetailssinglemachinetest startworkspaceandcheckchanges_zv6a3xgm](https://user-images.githubusercontent.com/7760565/34408344-f20c2e8c-ebcb-11e7-8bbe-89d163df1e8b.png)

