### PR TITLE
Selenium: change timeout for waiting that a workspace is started

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceDetails.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceDetails.java
@@ -128,6 +128,11 @@ public class WorkspaceDetails {
         .until(textToBePresentInElement(workspaceState, stateWorkspace.getStatus()));
   }
 
+  public void checkStateOfWorkspace(StateWorkspace stateWorkspace, int timeout) {
+    new WebDriverWait(seleniumWebDriver, timeout)
+        .until(textToBePresentInElement(workspaceState, stateWorkspace.getStatus()));
+  }
+
   /** click on 'RUN' button in 'Workspace Information' */
   public void clickOnRunWorkspace() {
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
@@ -11,7 +11,8 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STARTING;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
+import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.OVERVIEW;
 import static org.testng.Assert.assertFalse;
@@ -102,7 +103,7 @@ public class RenameWorkspaceTest {
   private void saveAndWaitWorkspaceRestarted() {
     workspaceDetails.clickOnSaveChangesBtn();
     workspaceDetails.checkStateOfWorkspace(STOPPING);
-    workspaceDetails.checkStateOfWorkspace(STARTING);
+    workspaceDetails.checkStateOfWorkspace(RUNNING, EXPECTED_MESS_IN_CONSOLE_SEC);
     dashboard.waitNotificationMessage("Workspace updated");
     dashboard.waitNotificationIsClosed();
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
 import static org.testng.Assert.fail;
@@ -97,7 +98,7 @@ public class ProjectStateAfterRenameWorkspaceTest {
     workspaceOverview.enterNameWorkspace(WORKSPACE_NEW_NAME);
     workspaceDetails.clickOnSaveChangesBtn();
     workspaceDetails.checkStateOfWorkspace(STOPPING);
-    workspaceDetails.checkStateOfWorkspace(RUNNING);
+    workspaceDetails.checkStateOfWorkspace(RUNNING, EXPECTED_MESS_IN_CONSOLE_SEC);
     workspaceOverview.checkNameWorkspace(WORKSPACE_NEW_NAME);
 
     // open the IDE, check state of the project


### PR DESCRIPTION
### What does this PR do?
This PR increased timeout for checking that a workspace is started(status is **RUNNING**). 

**Failed tests:** RenameWorkspaceTest, ProjectStateAfterRenameWorkspaceTest.

Sometimes existed timeout for 60 sec is not enough.
https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-docker/128/Selenium_tests_report/
![org eclipse che selenium workspaces projectstateafterrenameworkspacetest checkprojectafterrenamews_0w6e47rf](https://user-images.githubusercontent.com/7760565/34408930-669607ac-ebcf-11e7-8535-5b2c76ca36e2.png)
