### PR TITLE
allow fast search by pressing enter on search field

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchPresenter.java
@@ -150,14 +150,6 @@ public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegat
 
   @Override
   public void onEnterClicked() {
-    if (view.isAcceptButtonInFocus()) {
-      String searchText = view.getSearchText();
-      if (!searchText.isEmpty()) {
-        search(searchText);
-      }
-      return;
-    }
-
     if (view.isCancelButtonInFocus()) {
       view.close();
       return;
@@ -165,6 +157,13 @@ public class FullTextSearchPresenter implements FullTextSearchView.ActionDelegat
 
     if (view.isSelectPathButtonInFocus()) {
       view.showSelectPathDialog();
+      return;
+    }
+
+    // start search if Enter is pressed anywhere else in the dialog
+    String searchText = view.getSearchText();
+    if (!searchText.isEmpty()) {
+      search(searchText);
     }
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.search;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -236,6 +237,19 @@ public class FullTextSearchViewImpl extends Window implements FullTextSearchView
           @Override
           public void onClick(ClickEvent event) {
             showSelectPathDialog();
+          }
+        });
+
+    text.addKeyUpHandler(
+        new KeyUpHandler() {
+          @Override
+          public void onKeyUp(KeyUpEvent event) {
+            acceptButton.setEnabled(!text.getValue().isEmpty());
+            if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+              if (!text.getValue().isEmpty()) {
+                delegate.search(text.getText());
+              }
+            }
           }
         });
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.java
@@ -229,6 +229,9 @@ public class FullTextSearchViewImpl extends Window implements FullTextSearchView
           @Override
           public void onKeyUp(KeyUpEvent event) {
             acceptButton.setEnabled(!text.getValue().isEmpty());
+            if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+              delegate.onEnterClicked();
+            }
           }
         });
 
@@ -237,19 +240,6 @@ public class FullTextSearchViewImpl extends Window implements FullTextSearchView
           @Override
           public void onClick(ClickEvent event) {
             showSelectPathDialog();
-          }
-        });
-
-    text.addKeyUpHandler(
-        new KeyUpHandler() {
-          @Override
-          public void onKeyUp(KeyUpEvent event) {
-            acceptButton.setEnabled(!text.getValue().isEmpty());
-            if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
-              if (!text.getValue().isEmpty()) {
-                delegate.search(text.getText());
-              }
-            }
           }
         });
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/search/FullTextSearchViewImpl.java
@@ -12,7 +12,6 @@ package org.eclipse.che.ide.search;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -229,9 +228,6 @@ public class FullTextSearchViewImpl extends Window implements FullTextSearchView
           @Override
           public void onKeyUp(KeyUpEvent event) {
             acceptButton.setEnabled(!text.getValue().isEmpty());
-            if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
-              delegate.onEnterClicked();
-            }
           }
         });
 


### PR DESCRIPTION
Signed-off-by: Hanno Kolvenbach <kolvenbach@silexica.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This allows to press enter inside the search box to start the global search immediately.

### What issues does this PR fix or reference?
Fixing https://github.com/eclipse/che/issues/7863
First step of https://github.com/eclipse/che/issues/7858
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
