### PR TITLE
Increase workspace attributes values field length in database for abnormal shutdown error saving.

### DIFF
--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.0.0/11__increase_workspace_attributes_values_length.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.0.0/11__increase_workspace_attributes_values_length.sql
@@ -1,0 +1,12 @@
+--
+-- Copyright (c) 2012-2017 Red Hat, Inc.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+ALTER TABLE workspace_attributes ALTER COLUMN attributes TYPE TEXT;


### PR DESCRIPTION
### What does this PR do?
Since we're added workspace abnormal shutdown error saving, 255 symbols length of  workspace attributes now not always enough.This PR changes attributes value field type to `TEXT`

### What issues does this PR fix or reference?
fixes #8090

#### Release Notes
Increase workspace attributes values field length in database for abnormal shutdown error saving.


#### Docs PR
N/A
