### PR TITLE
change way how to wipe config dir to not break running che on docker

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
@@ -152,7 +152,8 @@ deploy_che_to_ocp() {
     if [ $IMAGE_PULL_POLICY == "Always" ]; then
         docker pull "$IMAGE_INIT"
     fi
-    docker run -t --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${CONFIG_DIR}":/data -e IMAGE_INIT="$IMAGE_INIT" -e CHE_MULTIUSER="$CHE_MULTIUSER" eclipse/che-cli:${CHE_IMAGE_TAG} destroy --quiet --skip:pull --skip:nightly
+    #wipeout config folder
+    docker run -v "${CONFIG_DIR}":/to_remove alpine sh -c "rm -rf /to_remove/" || true
     docker run -t --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${CONFIG_DIR}":/data -e IMAGE_INIT="$IMAGE_INIT" -e CHE_MULTIUSER="$CHE_MULTIUSER" eclipse/che-cli:${CHE_IMAGE_TAG} config --skip:pull --skip:nightly
     cd "${CONFIG_DIR}/instance/config/openshift/scripts/"
     bash deploy_che.sh ${DEPLOY_SCRIPT_ARGS}


### PR DESCRIPTION
do not call CHE CLI destroy command in ocp.sh to avoid killing running che on docker

fixes: https://github.com/eclipse/che/issues/8117