### PR TITLE
Sync how CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS and CHE_WORKSPACE_MAVEN__SERVER__JAVA__OPTIONS looks like for end user

### DIFF
--- a/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.json
+++ b/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.json
@@ -1,0 +1,27 @@
+{
+  "id": "org.eclipse.che.ws-agent",
+  "version": "1.0.3",
+  "name": "Workspace API",
+  "description": "Workspace API support",
+  "dependencies": [
+    "org.eclipse.che.exec",
+    "org.eclipse.che.terminal"
+  ],
+  "properties": {},
+  "servers": {
+    "wsagent/http": {
+      "port": "4401/tcp",
+      "protocol": "http",
+      "path" : "/api"
+    },
+    "wsagent/ws": {
+      "port": "4401/tcp",
+      "protocol": "ws",
+      "path" : "/wsagent"
+    },
+    "wsagent-debug": {
+      "port": "4403/tcp",
+      "protocol": "tcp"
+    }
+  }
+}

--- a/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.script.sh
@@ -1,0 +1,286 @@
+#
+# Copyright (c) 2012-2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+is_current_user_root() {
+    test "$(id -u)" = 0
+}
+
+is_current_user_sudoer() {
+    sudo -n true > /dev/null 2>&1
+}
+
+set_sudo_command() {
+    if is_current_user_sudoer && ! is_current_user_root; then
+        SUDO="sudo -E"
+    else
+        unset SUDO;
+    fi
+}
+
+set_sudo_command
+unset PACKAGES
+command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
+CURL_INSTALLED=false
+WGET_INSTALLED=false
+command -v curl >/dev/null 2>&1 && CURL_INSTALLED=true
+command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
+
+# no curl, no wget, install curl
+if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
+  PACKAGES=${PACKAGES}" curl";
+  CURL_INSTALLED=true
+fi
+
+LOCAL_AGENT_BINARIES_URI="/mnt/che/ws-agent.tar.gz"
+DOWNLOAD_AGENT_BINARIES_URI='${WORKSPACE_MASTER_URI}/agent-binaries/ws-agent.tar.gz'
+
+CHE_DIR=$HOME/che
+
+if [ -f /etc/centos-release ]; then
+    FILE="/etc/centos-release"
+    LINUX_TYPE=$(cat $FILE | awk '{print $1}')
+ elif [ -f /etc/redhat-release ]; then
+    FILE="/etc/redhat-release"
+    LINUX_TYPE=$(cat $FILE | cut -c 1-8)
+ else
+    FILE="/etc/os-release"
+    LINUX_TYPE=$(cat $FILE | grep ^ID= | tr '[:upper:]' '[:lower:]')
+    LINUX_VERSION=$(cat $FILE | grep ^VERSION_ID=)
+fi
+MACHINE_TYPE=$(uname -m)
+
+mkdir -p ${CHE_DIR}
+
+if is_current_user_sudoer; then
+    ${SUDO} mkdir -p /projects
+    ${SUDO} sh -c "chown -R $(id -u -n) /projects"
+fi
+
+INSTALL_JDK=false
+command -v ${JAVA_HOME}/bin/java >/dev/null 2>&1 || {
+    INSTALL_JDK=true;
+} && {
+    java_version=$(${JAVA_HOME}/bin/java -version 2>&1 | grep version  | awk '{print $NF}' | sed 's/"//g' | cut -d '.' -f2)
+    if [ -z ${java_version} ] || [ ! "${java_version}" -eq "8" ]; then
+        INSTALL_JDK=true;
+    fi
+}
+
+if [ ${INSTALL_JDK} = true ]; then
+    export JAVA_HOME=${CHE_DIR}/jdk1.8
+fi
+
+
+########################
+### Install packages ###
+########################
+
+# Red Hat Enterprise Linux 7
+############################
+if echo ${LINUX_TYPE} | grep -qi "rhel"; then
+
+    if [ ${INSTALL_JDK} = true ]; then
+      PACKAGES=${PACKAGES}" java-1.8.0-openjdk-devel.x86_64"
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum install -y ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk $JAVA_HOME
+    fi
+
+# Ubuntu 14.04 16.04 / Linux Mint 17
+####################################
+elif echo ${LINUX_TYPE} | grep -qi "ubuntu"; then
+
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" openjdk-8-jdk-headless"
+        ${SUDO} apt-get install -y software-properties-common;
+        ${SUDO} add-apt-repository ppa:openjdk-r/ppa;
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apt-get update;
+        ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk-amd64 $JAVA_HOME
+    fi
+
+# Debian 8
+##########
+elif echo ${LINUX_TYPE} | grep -qi "debian"; then
+
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" -t jessie-backports openjdk-8-jdk-headless";
+        echo "deb http://httpredir.debian.org/debian jessie-backports main" | ${SUDO} tee --append /etc/apt/sources.list
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apt-get update;
+        ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk-amd64 $JAVA_HOME
+    fi
+
+
+# Fedora 23
+###########
+elif echo ${LINUX_TYPE} | grep -qi "fedora"; then
+
+    command -v ps >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" procps-ng"; }
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" java-1.8.0-openjdk-devel.x86_64";
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} dnf -y install ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk $JAVA_HOME
+    fi
+
+# CentOS 7.1 & Oracle Linux 7.1
+###############################
+elif echo ${LINUX_TYPE} | grep -qi "centos"; then
+
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" java-1.8.0-openjdk-devel";
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum -y install ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk $JAVA_HOME
+    fi
+
+# openSUSE 13.2
+###############
+elif echo ${LINUX_TYPE} | grep -qi "opensuse"; then
+
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" java-1_8_0-openjdk-devel";
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} zypper install -y ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk $JAVA_HOME
+    fi
+
+
+# Alpine 3.3
+############$$
+elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
+
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" openjdk8";
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apk update
+        ${SUDO} apk add ${PACKAGES};
+    }
+
+    # Link OpenJDK to JAVA_HOME
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8-openjdk $JAVA_HOME
+    fi
+
+# Centos 6.6, 6.7, 6.8
+############
+elif echo ${LINUX_TYPE} | grep -qi "CentOS"; then
+
+     if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" java-1.8.0-openjdk-devel";
+     fi
+
+     test "${PACKAGES}" = "" || {
+         ${SUDO} yum -y install ${PACKAGES};
+     }
+
+     if [ ${INSTALL_JDK} = true ]; then
+         ln -s /usr/lib/jvm/java-1.8.0-openjdk $JAVA_HOME
+     fi
+
+# Red Hat Enterprise Linux 6
+############################
+elif echo ${LINUX_TYPE} | grep -qi "Red Hat"; then
+    if [ ${INSTALL_JDK} = true ]; then
+        PACKAGES=${PACKAGES}" java-1.8.0-openjdk-devel.x86_64";
+    fi
+
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum install -y ${PACKAGES};
+    }
+
+    if [ ${INSTALL_JDK} = true ]; then
+        ln -s /usr/lib/jvm/java-1.8.0-openjdk $JAVA_HOME
+    fi
+
+else
+    >&2 echo "Unrecognized Linux Type"
+    >&2 cat $FILE
+    exit 1
+fi
+
+########################
+### Install ws-agent ###
+########################
+
+rm -rf ${CHE_DIR}/ws-agent
+mkdir -p ${CHE_DIR}/ws-agent
+
+
+# Compute URI of workspace master
+WORKSPACE_MASTER_URI=$(echo $CHE_API | cut -d / -f 1-3)
+
+## Evaluate variables now that prefix is defined
+eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
+
+
+if [ -f "${LOCAL_AGENT_BINARIES_URI}" ] && [ -s "${LOCAL_AGENT_BINARIES_URI}" ]
+then
+    tar zxf "${LOCAL_AGENT_BINARIES_URI}" -C ${CHE_DIR}/ws-agent
+else
+    echo "Workspace Agent will be downloaded from Workspace Master"
+    AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
+    if [ ${CURL_INSTALLED} = true ]; then
+      curl -s  ${AGENT_BINARIES_URI} | tar  xzf - -C ${CHE_DIR}/ws-agent
+    else
+      # replace https by http as wget may not be able to handle ssl
+      AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')
+
+      # use wget
+      wget -qO- ${AGENT_BINARIES_URI} | tar xzf - -C ${CHE_DIR}/ws-agent
+    fi
+
+fi
+
+if [ -z "${CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS}" ]; then
+    >&2 echo "Not able to find appropriate JAVA_OPTS for workspace agent JVM."
+    >&2 echo "Environment variable CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS has to be defined."
+    exit 1
+else
+   export JAVA_OPTS="${CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS}"
+fi
+
+export JPDA_ADDRESS="4403" && ~/che/ws-agent/bin/catalina.sh jpda run

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceAgentJavaOptsEnvVariableProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceAgentJavaOptsEnvVariableProvider.java
@@ -19,8 +19,8 @@ import org.eclipse.che.commons.lang.Pair;
 public class WorkspaceAgentJavaOptsEnvVariableProvider implements EnvVarProvider {
 
   /** Env variable for jvm settings */
-  public static final String CHE_WORKSPACE_WSAGENT_JAVA_OPTIONS =
-      "CHE_WORKSPACE_WSAGENT_JAVA_OPTIONS";
+  public static final String CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS =
+      "CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS";
 
   private String javaOpts;
 
@@ -33,6 +33,6 @@ public class WorkspaceAgentJavaOptsEnvVariableProvider implements EnvVarProvider
 
   @Override
   public Pair<String, String> get(RuntimeIdentity runtimeIdentity) {
-    return Pair.of(CHE_WORKSPACE_WSAGENT_JAVA_OPTIONS, javaOpts);
+    return Pair.of(CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS, javaOpts);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceAgentJavaOptsEnvVariableProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceAgentJavaOptsEnvVariableProvider.java
@@ -19,8 +19,7 @@ import org.eclipse.che.commons.lang.Pair;
 public class WorkspaceAgentJavaOptsEnvVariableProvider implements EnvVarProvider {
 
   /** Env variable for jvm settings */
-  public static final String CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS =
-      "CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS";
+  public static final String WSAGENT_JAVA_OPTIONS_ENV = "CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS";
 
   private String javaOpts;
 
@@ -33,6 +32,6 @@ public class WorkspaceAgentJavaOptsEnvVariableProvider implements EnvVarProvider
 
   @Override
   public Pair<String, String> get(RuntimeIdentity runtimeIdentity) {
-    return Pair.of(CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS, javaOpts);
+    return Pair.of(WSAGENT_JAVA_OPTIONS_ENV, javaOpts);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Sync how CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS and CHE_WORKSPACE_MAVEN__SERVER__JAVA__OPTIONS looks like for end user

It's a bit confusing for users that property ```CHE_WORKSPACE_MAVEN__SERVER__JAVA__OPTIONS``` configured similarly for admin and for users as env variable, but CHE_WORKSPACE_WSAGENT_JAVA_OPTIONS and CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS have different naming for the same thing.  
After this pr to setup ws-agent ram user have to configure ```CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS``` instead of ```CHE_WORKSPACE_WSAGENT_JAVA_OPTIONS```

### What issues does this PR fix or reference?
n/a

#### Release Notes
Sync how CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS and CHE_WORKSPACE_MAVEN__SERVER__JAVA__OPTIONS looks like for end user

#### Docs PR
https://github.com/codenvy/che-docs/pull/6

  
  