### PR TITLE
Selenium: add waiting that the Loader is closed in WorkspaceDetailsSingleMachineTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -251,6 +251,7 @@ public class WorkspaceDetailsSingleMachineTest {
   }
 
   private void checkServerInServersList(String serverName) {
+    loader.waitOnClosed();
     consoles.openServersTabFromContextMenu("dev-machine");
     consoles.waitProcessInProcessConsoleTree("Servers");
     consoles.waitTabNameProcessIsPresent("Servers");


### PR DESCRIPTION
### What does this PR do?
This PR  add waiting that the **Loader** is closed in the unstable **WorkspaceDetailsSingleMachineTest** selenium test.

Test report: https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-docker/135/Selenium_tests_report/

![org eclipse che selenium dashboard workspacedetailssinglemachinetest startworkspaceandcheckchanges_ya74h2jw 1](https://user-images.githubusercontent.com/7760565/34514338-b98cf1fa-f075-11e7-880c-00b0899e6a0a.png)

