### PR TITLE
Selenium: change an image name from 'location' to 'content' in default.json recipe

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
@@ -27,7 +27,7 @@
         }
       },
       "recipe":{
-        "location":"eclipse/ubuntu_jdk8",
+        "content":"eclipse/ubuntu_jdk8",
         "type":"dockerimage"
       }
     }


### PR DESCRIPTION
### What does this PR do?
This PR change an image name from 'location' to 'content' in **default.json** dockerimage recipe according to https://github.com/eclipse/che/pull/8076.