### PR TITLE
Use tag version for `che-libs` and `che-docs`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <url>https://github.com/eclipse/che</url>
     </scm>
     <properties>
-        <che.docs.version>5.22.1-SNAPSHOT</che.docs.version>
-        <che.lib.version>5.22.1-SNAPSHOT</che.lib.version>
+        <che.docs.version>5.22.0</che.docs.version>
+        <che.lib.version>5.22.0</che.lib.version>
         <che.version>5.22.1-SNAPSHOT</che.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>


### PR DESCRIPTION
### What does this PR do?

It replaces SNAPSHOT version numbers with tag version numbers for `che-libs` and `che-docs`, so that they don't need to be built locally when building che on the `5.22.x` branch.

### What issues does this PR fix or reference?
 no issue. This chnage was recommended by @riuvshin 