### PR TITLE
Allow Openshift deploy_che.sh script to detect if project deletion is completed and new project successfully created.

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -308,27 +308,11 @@ if ! oc get project "${CHE_OPENSHIFT_PROJECT}" &> /dev/null; then
         sleep $POLLING_INTERVAL_SEC
     }
     done
+    echo "Project \"${CHE_OPENSHIFT_PROJECT}\" creation done!"
+else
+    echo "Project \"${CHE_OPENSHIFT_PROJECT}\" already exists. Please remove project before running this script."
+    exit 1
 fi
-echo "Project \"${CHE_OPENSHIFT_PROJECT}\" creation done!"
-
-echo -n "[CHE] Switching to \"${CHE_OPENSHIFT_PROJECT}\"..."
-WAIT_TO_SWITCH_TO_PROJECT=true
-timeout_in=$((POLLING_INTERVAL_SEC+DEPLOYMENT_TIMEOUT_SEC))
-while $WAIT_TO_SWITCH_TO_PROJECT
-do
-{ # try
-    timeout_in=$((timeout_in-POLLING_INTERVAL_SEC))
-    if [ "$timeout_in" -le "0" ] ; then
-        echo "[CHE] **ERROR**: Timeout of $DEPLOYMENT_TIMEOUT_SEC waiting to switch to project \"${CHE_OPENSHIFT_PROJECT}\"."
-        exit 1
-    fi  
-    oc project "${CHE_OPENSHIFT_PROJECT}" &> /dev/null && \
-    WAIT_TO_SWITCH_TO_PROJECT=false # Only excutes after project creation is successfully
-} || { # catch
-    echo -n "."
-}
-done
-echo "done!"
 
 # -------------------------------------------------------------
 # Deploying secondary servers

--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -278,27 +278,32 @@ echo "done!"
 # --------------------------
 echo -n "[CHE] Checking if project \"${CHE_OPENSHIFT_PROJECT}\" exists..."
 if ! oc get project "${CHE_OPENSHIFT_PROJECT}" &> /dev/null; then
+    if [ "${COMMAND}" == "cleanup" ] || [ "${COMMAND}" == "rollupdate" ]; then echo "**ERROR** project doesn't exist. Aborting"; exit 1; fi
+    if [ "${OPENSHIFT_FLAVOR}" == "osio" ]; then echo "**ERROR** project doesn't exist on OSIO. Aborting"; exit 1; fi
 
-  if [ "${COMMAND}" == "cleanup" ] || [ "${COMMAND}" == "rollupdate" ]; then echo "**ERROR** project doesn't exist. Aborting"; exit 1; fi
-  if [ "${OPENSHIFT_FLAVOR}" == "osio" ]; then echo "**ERROR** project doesn't exist on OSIO. Aborting"; exit 1; fi
+    # OpenShift will not get project but project still exists for a period after being deleted.
+    # The following will loop until it can create successfully.
 
-  # OpenShift will not get project but project still exists for for a period after being deleted.
-  # The following will loop until it can create successfully.
+    WAIT_FOR_PROJECT_TO_DELETE=true
+    WAIT_FOR_PROJECT_TO_DELETE_MESSAGE="Waiting for project to be deleted fully(~15 seconds)..."
 
-  WAIT_FOR_PROJECT_TO_DELETE=true
-  WAIT_FOR_PROJECT_TO_DELETE_MESSAGE="Waiting for project to be deleted fully(~15 seconds)..."
-
-  echo "Project \"${CHE_OPENSHIFT_PROJECT}\" does not exist...trying to creating it."
-  while $WAIT_FOR_PROJECT_TO_DELETE
-  do
-  { # try
-
-      oc new-project "${CHE_OPENSHIFT_PROJECT}" &> /dev/null && \
-      WAIT_FOR_PROJECT_TO_DELETE=false # Only excutes if project creation is successfully
-  } || { # catch
-      echo -n $WAIT_FOR_PROJECT_TO_DELETE_MESSAGE
-      WAIT_FOR_PROJECT_TO_DELETE_MESSAGE="."
-      sleep 2
+    echo "Project \"${CHE_OPENSHIFT_PROJECT}\" does not exist...trying to creating it."
+    DEPLOYMENT_TIMEOUT_SEC=120
+    POLLING_INTERVAL_SEC=2
+    end=$((POLLING_INTERVAL_SEC+DEPLOYMENT_TIMEOUT_SEC))  
+    while $WAIT_FOR_PROJECT_TO_DELETE
+    do
+    { # try
+        timeout_in=$((end-POLLING_INTERVAL_SEC))
+        if [ "$timeout_in" -le "0" ] ; then
+            WAIT_FOR_PROJECT_TO_DELETE=false
+        fi  
+        oc new-project "${CHE_OPENSHIFT_PROJECT}" &> /dev/null && \
+        WAIT_FOR_PROJECT_TO_DELETE=false # Only excutes if project creation is successfully
+    } || { # catch
+        echo -n $WAIT_FOR_PROJECT_TO_DELETE_MESSAGE
+        WAIT_FOR_PROJECT_TO_DELETE_MESSAGE="."
+        sleep $POLLING_INTERVAL_SEC
   }
   done
 fi

--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -278,6 +278,7 @@ echo "done!"
 # --------------------------
 echo -n "[CHE] Checking if project \"${CHE_OPENSHIFT_PROJECT}\" exists..."
 if ! oc get project "${CHE_OPENSHIFT_PROJECT}" &> /dev/null; then
+
     if [ "${COMMAND}" == "cleanup" ] || [ "${COMMAND}" == "rollupdate" ]; then echo "**ERROR** project doesn't exist. Aborting"; exit 1; fi
     if [ "${OPENSHIFT_FLAVOR}" == "osio" ]; then echo "**ERROR** project doesn't exist on OSIO. Aborting"; exit 1; fi
 


### PR DESCRIPTION
### What does this PR do?
Allow Openshift deploy_che.sh script to detect if project deletion is completed and new project successfully created.

### What issues does this PR fix or reference?
N/A

#### Release Notes
Allow Openshift deploy_che.sh script to detect if project deletion is completed and new project successfully created.

Signed-off-by: James Drummond <james@devcomb.com>
