### PR TITLE
Automatically set the CHE_INFRA_OPENSHIFT_OAUTH__TOKEN.

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -377,6 +377,10 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: che" | oc apply -f -
+  CHE_INFRA_OPENSHIFT_USERNAME=""
+  CHE_INFRA_OPENSHIFT_PASSWORD=""
+  oc create serviceaccount che -n ${CHE_OPENSHIFT_PROJECT}
+  CHE_INFRA_OPENSHIFT_OAUTH__TOKEN=$(oc sa get-token che -n ${CHE_OPENSHIFT_PROJECT})  
 fi
 
 # ----------------------------------------------


### PR DESCRIPTION
### What does this PR do?
Automatically set the CHE_INFRA_OPENSHIFT_OAUTH__TOKEN to the project's service account for minishift and ocp. 

CHE_INFRA_OPENSHIFT_[USERNAME|PASSWORD] are set to "" for minishift and ocp. 

_Additional conversation is now needed to determine if CHE_INFRA_OPENSHIFT_[USERNAME|PASSWORD] variables are even needed. 

### What issues does this PR fix or reference?
N/A

#### Release Notes
Automatically set Openshift's deployment configuration environment variable  CHE_INFRA_OPENSHIFT_OAUTH__TOKEN to project's service account.

Signed-off-by: James Drummond <james@devcomb.com>