### PR TITLE
Fixed recipe in the che-in-che stack

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -68,7 +68,7 @@
             }
           },
           "recipe": {
-            "location": "eclipse/che-dev:nightly",
+            "content": "eclipse/che-dev:nightly",
             "type": "dockerimage"
           }
         }


### PR DESCRIPTION
### What does this PR do?
`Che-in-che` stack still has docker image in location field. As result, it is impossible to edit `Che-in-che` workspace json via the dashboard. See sceenshot

![screenshot_20180104_105549](https://user-images.githubusercontent.com/5887312/34556231-34fc5722-f13e-11e7-84c5-ca70c20c8e6a.png)

So, this PR fixes recipe in the `che-in-che` stack.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6006