### PR TITLE
Fixed resolving of servers of an OpenShift multi-container workspace

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Annotations.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Annotations.java
@@ -22,8 +22,8 @@ import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 
 /**
- * Helps to convert {@link ServerConfig} objects to OpenShift infrastructure annotations and
- * vise-versa.
+ * Helps to convert servers related entities (like {@link ServerConfig} and machine name) to
+ * OpenShift annotations and vise-versa.
  *
  * @author Sergii Leshchenko
  */
@@ -36,6 +36,8 @@ public class Annotations {
   public static final String SERVER_PATH_ANNOTATION_FMT = ANNOTATION_PREFIX + "server.%s.path";
   public static final String SERVER_ATTR_ANNOTATION_FMT =
       ANNOTATION_PREFIX + "server.%s.attributes";
+
+  public static final String MACHINE_NAME_ANNOTATION = ANNOTATION_PREFIX + "machine.name";
 
   /** Pattern that matches server annotations e.g. "org.eclipse.che.server.exec-agent.port". */
   private static final Pattern SERVER_ANNOTATION_PATTERN =
@@ -86,6 +88,11 @@ public class Annotations {
       return this;
     }
 
+    public Serializer machineName(String machineName) {
+      annotations.put(MACHINE_NAME_ANNOTATION, machineName);
+      return this;
+    }
+
     public Map<String, String> annotations() {
       return annotations;
     }
@@ -120,6 +127,10 @@ public class Annotations {
         }
       }
       return servers;
+    }
+
+    public String machineName() {
+      return annotations.get(MACHINE_NAME_ANNOTATION);
     }
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -240,12 +240,13 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
       final Pod createdPod = project.pods().create(toCreate);
       final ObjectMeta podMetadata = createdPod.getMetadata();
       for (Container container : createdPod.getSpec().getContainers()) {
+        String machineName = Names.machineName(toCreate, container);
         OpenShiftMachine machine =
             new OpenShiftMachine(
-                Names.machineName(toCreate, container),
+                machineName,
                 podMetadata.getName(),
                 container.getName(),
-                serverResolver.resolve(createdPod, container),
+                serverResolver.resolve(machineName),
                 project);
         machines.put(machine.getName(), machine);
         sendStartingEvent(machine.getName());

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
@@ -114,14 +114,16 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
   }
 
   private void injectBootstrapper() throws InfrastructureException {
-    LOG.debug("Creating folder for bootstrapper");
+    String machineName = openShiftMachine.getName();
+    LOG.debug(
+        "Bootstrapping {}:{}. Creating folder for bootstrapper", runtimeIdentity, machineName);
     openShiftMachine.exec("mkdir", "-p", BOOTSTRAPPER_DIR);
-    LOG.debug("Downloading bootstrapper binary");
+    LOG.debug("Bootstrapping {}:{}. Downloading bootstrapper binary", runtimeIdentity, machineName);
     openShiftMachine.exec(
         "curl", "-o", BOOTSTRAPPER_DIR + BOOTSTRAPPER_FILE, bootstrapperBinaryUrl);
     openShiftMachine.exec("chmod", "+x", BOOTSTRAPPER_DIR + BOOTSTRAPPER_FILE);
 
-    LOG.debug("Creating bootstrapper config file");
+    LOG.debug("Bootstrapping {}:{}. Creating config file", runtimeIdentity, machineName);
     openShiftMachine.exec(
         "sh",
         "-c",

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AnnotationsTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AnnotationsTest.java
@@ -43,6 +43,7 @@ public class AnnotationsTest {
             .servers(
                 ImmutableMap.of(
                     "my-server2", new ServerConfigImpl("8080/tcp", "ws", "/connect", emptyMap())))
+            .machineName("test-machine")
             .annotations();
     Map<String, String> expected =
         ImmutableMap.<String, String>builder()
@@ -54,6 +55,7 @@ public class AnnotationsTest {
             .put("org.eclipse.che.server.my-server2.protocol", "ws")
             .put("org.eclipse.che.server.my-server2.path", "/connect")
             .put("org.eclipse.che.server.my-server2.attributes", stringEmptyAttributes)
+            .put("org.eclipse.che.machine.name", "test-machine")
             .build();
 
     assertEquals(serialized, expected);
@@ -74,11 +76,14 @@ public class AnnotationsTest {
             .put("org.eclipse.che.server.my-server3.port", "7070/tcp")
             .put("org.eclipse.che.server.my-server3.protocol", "http")
             .put("org.eclipse.che.server.my-server3.attributes", stringEmptyAttributes)
+            .put("org.eclipse.che.machine.name", "test-machine")
             .build();
 
     Annotations.Deserializer deserializer = Annotations.newDeserializer(annotations);
 
     Map<String, ServerConfigImpl> servers = deserializer.servers();
+
+    assertEquals(deserializer.machineName(), "test-machine");
 
     Map<String, ServerConfigImpl> expected = new HashMap<>();
     expected.put("my-server1/http", new ServerConfigImpl("8000/tcp", "http", "/api/info", null));

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/ServerResolverTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.runtime.ServerStatus.UNKNOWN;
@@ -18,11 +18,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -31,6 +26,7 @@ import io.fabric8.openshift.api.model.RouteBuilder;
 import java.util.Map;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.workspace.infrastructure.openshift.Annotations.Serializer;
 import org.testng.annotations.Test;
 
 /**
@@ -39,20 +35,21 @@ import org.testng.annotations.Test;
  * @author Sergii Leshchenko
  */
 public class ServerResolverTest {
+
   private static final Map<String, String> ATTRIBUTES_MAP = singletonMap("key", "value");
   private static final int CONTAINER_PORT = 3054;
   private static final String ROUTE_HOST = "localhost";
 
   @Test
-  public void testResolvingServersWhenThereIsNoMatchedServiceByPodLabels() {
+  public void
+      testResolvingServersWhenThereIsNoTheCorrespondingServiceAndRouteForTheSpecifiedMachine() {
     // given
-    Container container = createContainer();
-    Pod pod = createPod(ImmutableMap.of("kind", "web-app"));
     Service nonMatchedByPodService =
-        createService("nonMatched", CONTAINER_PORT, ImmutableMap.of("kind", "db"), null);
+        createService("nonMatched", "foreignMachine", CONTAINER_PORT, null);
     Route route =
         createRoute(
             "nonMatched",
+            "foreignMachine",
             ImmutableMap.of(
                 "http-server", new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP)));
 
@@ -60,83 +57,46 @@ public class ServerResolverTest {
         ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
 
     // when
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
     // then
     assertTrue(resolved.isEmpty());
   }
 
   @Test
-  public void testResolvingServersWhenThereIsNoMatchedServiceByContainerPort() {
-    Container container = createContainer();
-    Pod pod = createPod(ImmutableMap.of("kind", "web-app"));
-    Service nonMatchedByPodService =
-        createService("nonMatched", 7777, ImmutableMap.of("kind", "web-app"), null);
-    Route route =
-        createRoute(
-            "nonMatched",
-            ImmutableMap.of(
-                "http-server", new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP)));
-
-    ServerResolver serverResolver =
-        ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
-
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
-
-    assertTrue(resolved.isEmpty());
-  }
-
-  @Test
-  public void testResolvingServersWhenThereIsMatchedServiceForContainer() {
-    Container container = createContainer();
-    Pod pod = createPod(ImmutableMap.of("kind", "web-app"));
-    Service nonMatchedByPodService =
-        createService("matched", CONTAINER_PORT, ImmutableMap.of("kind", "web-app"), null);
+  public void testResolvingServersWhenThereIsMatchedRouteForTheSpecifiedMachine() {
     Route route =
         createRoute(
             "matched",
+            "machine",
             ImmutableMap.of(
-                "http-server",
-                new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP),
-                "ws-server",
-                new ServerConfigImpl("3054", "ws", "/connect", ATTRIBUTES_MAP)));
+                "http-server", new ServerConfigImpl("3054", "http", "/api", ATTRIBUTES_MAP)));
 
-    ServerResolver serverResolver =
-        ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
+    ServerResolver serverResolver = ServerResolver.of(emptyList(), singletonList(route));
 
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
-    assertEquals(resolved.size(), 2);
+    assertEquals(resolved.size(), 1);
     assertEquals(
         resolved.get("http-server"),
         new ServerImpl()
             .withUrl("http://localhost/api")
             .withStatus(UNKNOWN)
             .withAttributes(ATTRIBUTES_MAP));
-    assertEquals(
-        resolved.get("ws-server"),
-        new ServerImpl()
-            .withUrl("ws://localhost/connect")
-            .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
   }
 
   @Test
-  public void testResolvingServersWhenThereIsMatchedServiceForContainerAndServerPathIsNull() {
-    Container container = createContainer();
-    Pod pod = createPod(singletonMap("kind", "web-app"));
-    Service nonMatchedByPodService =
-        createService("matched", CONTAINER_PORT, singletonMap("kind", "web-app"), null);
+  public void testResolvingServersWhenThereIsMatchedRouteForMachineAndServerPathIsNull() {
     Route route =
         createRoute(
             "matched",
+            "machine",
             singletonMap(
                 "http-server", new ServerConfigImpl("3054", "http", null, ATTRIBUTES_MAP)));
 
-    ServerResolver serverResolver =
-        ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
+    ServerResolver serverResolver = ServerResolver.of(emptyList(), singletonList(route));
 
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
     assertEquals(resolved.size(), 1);
     assertEquals(
@@ -148,20 +108,16 @@ public class ServerResolverTest {
   }
 
   @Test
-  public void testResolvingServersWhenThereIsMatchedServiceForContainerAndServerPathIsEmpty() {
-    Container container = createContainer();
-    Pod pod = createPod(singletonMap("kind", "web-app"));
-    Service nonMatchedByPodService =
-        createService("matched", CONTAINER_PORT, singletonMap("kind", "web-app"), null);
+  public void testResolvingServersWhenThereIsMatchedRouteForMachineAndServerPathIsEmpty() {
     Route route =
         createRoute(
             "matched",
+            "machine",
             singletonMap("http-server", new ServerConfigImpl("3054", "http", "", ATTRIBUTES_MAP)));
 
-    ServerResolver serverResolver =
-        ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
+    ServerResolver serverResolver = ServerResolver.of(emptyList(), singletonList(route));
 
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
     assertEquals(resolved.size(), 1);
     assertEquals(
@@ -173,21 +129,17 @@ public class ServerResolverTest {
   }
 
   @Test
-  public void testResolvingServersWhenThereIsMatchedServiceForContainerAndServerPathIsRelative() {
-    Container container = createContainer();
-    Pod pod = createPod(singletonMap("kind", "web-app"));
-    Service nonMatchedByPodService =
-        createService("matched", CONTAINER_PORT, singletonMap("kind", "web-app"), null);
+  public void testResolvingServersWhenThereIsMatchedRouteForMachineAndServerPathIsRelative() {
     Route route =
         createRoute(
             "matched",
+            "machine",
             singletonMap(
                 "http-server", new ServerConfigImpl("3054", "http", "api", ATTRIBUTES_MAP)));
 
-    ServerResolver serverResolver =
-        ServerResolver.of(singletonList(nonMatchedByPodService), singletonList(route));
+    ServerResolver serverResolver = ServerResolver.of(emptyList(), singletonList(route));
 
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
     assertEquals(resolved.size(), 1);
     assertEquals(
@@ -200,20 +152,18 @@ public class ServerResolverTest {
 
   @Test
   public void testResolvingInternalServers() {
-    Container container = createContainer();
-    Pod pod = createPod(singletonMap("kind", "web-app"));
     Service service =
         createService(
             "service11",
+            "machine",
             CONTAINER_PORT,
-            singletonMap("kind", "web-app"),
             singletonMap(
                 "http-server", new ServerConfigImpl("3054", "http", "api", ATTRIBUTES_MAP)));
-    Route route = createRoute("matched", null);
+    Route route = createRoute("matched", "machine", null);
 
     ServerResolver serverResolver = ServerResolver.of(singletonList(service), singletonList(route));
 
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
     assertEquals(resolved.size(), 1);
     assertEquals(
@@ -226,20 +176,18 @@ public class ServerResolverTest {
 
   @Test
   public void testResolvingInternalServersWithPortWithTransportProtocol() {
-    Container container = createContainer();
-    Pod pod = createPod(singletonMap("kind", "web-app"));
     Service service =
         createService(
             "service11",
+            "machine",
             CONTAINER_PORT,
-            singletonMap("kind", "web-app"),
             singletonMap(
                 "http-server", new ServerConfigImpl("3054/udp", "xxx", "api", ATTRIBUTES_MAP)));
-    Route route = createRoute("matched", null);
+    Route route = createRoute("matched", "machine", null);
 
     ServerResolver serverResolver = ServerResolver.of(singletonList(service), singletonList(route));
 
-    Map<String, ServerImpl> resolved = serverResolver.resolve(pod, container);
+    Map<String, ServerImpl> resolved = serverResolver.resolve("machine");
 
     assertEquals(resolved.size(), 1);
     assertEquals(
@@ -250,32 +198,20 @@ public class ServerResolverTest {
             .withAttributes(ATTRIBUTES_MAP));
   }
 
-  private Pod createPod(Map<String, String> labels) {
-    return new PodBuilder().withNewMetadata().withLabels(labels).endMetadata().build();
-  }
-
-  private Container createContainer() {
-    return new ContainerBuilder()
-        .withPorts(new ContainerPortBuilder().withContainerPort(CONTAINER_PORT).build())
-        .build();
-  }
-
   private Service createService(
-      String name,
-      Integer port,
-      Map<String, String> selector,
-      Map<String, ServerConfigImpl> servers) {
-    Map<String, String> annotations = emptyMap();
+      String name, String machineName, Integer port, Map<String, ServerConfigImpl> servers) {
+    Serializer serializer = Annotations.newSerializer();
+    serializer.machineName(machineName);
     if (servers != null) {
-      annotations = Annotations.newSerializer().servers(servers).annotations();
+      serializer.servers(servers);
     }
+
     return new ServiceBuilder()
         .withNewMetadata()
         .withName(name)
-        .withAnnotations(annotations)
+        .withAnnotations(serializer.annotations())
         .endMetadata()
         .withNewSpec()
-        .withSelector(selector)
         .withPorts(
             new ServicePortBuilder()
                 .withPort(port)
@@ -287,16 +223,17 @@ public class ServerResolverTest {
         .build();
   }
 
-  // TODO Think about common builders
-  private Route createRoute(String name, Map<String, ServerConfigImpl> servers) {
-    Map<String, String> annotations = emptyMap();
+  private Route createRoute(
+      String name, String machineName, Map<String, ServerConfigImpl> servers) {
+    Serializer serializer = Annotations.newSerializer();
+    serializer.machineName(machineName);
     if (servers != null) {
-      annotations = Annotations.newSerializer().servers(servers).annotations();
+      serializer.servers(servers);
     }
     return new RouteBuilder()
         .withNewMetadata()
         .withName(name)
-        .withAnnotations(annotations)
+        .withAnnotations(serializer.annotations())
         .endMetadata()
         .withNewSpec()
         .withHost(ROUTE_HOST)

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -211,13 +211,8 @@ public class WorkspaceRuntimes {
     try {
       InternalEnvironment internalEnv = createInternalEnvironment(environment);
       RuntimeContext runtimeContext = infrastructure.prepare(runtimeId, internalEnv);
-
       InternalRuntime runtime = runtimeContext.getRuntime();
-      if (runtime == null) {
-        throw new IllegalStateException(
-            "SPI contract violated. RuntimeInfrastructure.start(...) must not return null: "
-                + RuntimeInfrastructure.class);
-      }
+
       RuntimeState state = new RuntimeState(runtime, STARTING);
       if (isStartRefused.get()) {
         throw new ConflictException(

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeInfrastructure.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeInfrastructure.java
@@ -79,9 +79,15 @@ public abstract class RuntimeInfrastructure {
   }
 
   /**
-   * Making Runtime is a two phase process. On the first phase implementation MUST prepare
-   * RuntimeContext, this is supposedly "fast" method On the second phase Runtime is created with
-   * RuntimeContext.start() which is supposedly "long" method.
+   * Starting the Runtime is a two phase process:
+   *
+   * <pre>
+   * <ul>
+   *   <li>On the first phase implementation MUST prepare RuntimeContext;</li>
+   *   <li>On the second phase the Runtime that can be fetched from RuntimeContext
+   *   should be started with InternalRuntime.start().</li>
+   * </ul>
+   * </pre>
    *
    * @param id the RuntimeIdentity
    * @param environment incoming internal environment


### PR DESCRIPTION
### What does this PR do?
Previously ServerResolver analyzed servers of a machine (container) by real OpenShift object connections. But it works wrong while Service is linked with Pod but not a particular container (service expose all containers in one Pod at the same time).
While OpenShift infrastructure creates Services and Routes for Che Servers, it would be simpler to serialize machine name into Route/Service annotations and use it while servers resolving instead of analyzing real OpenShift objects connections. So in this PR, it is implemented in the described way and it fixes resolving of servers of an OpenShift multi-container workspace.

This PR also contains the following minor changes:
- Added more information to bootstrapper debug logging;
- Since RuntimeContext **MUST** return non-null value checking Runtime on null is redundant. So it is removed;
- Fixed java doc for RuntimeInfrastructure#prepare.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7922
  
  
  