### PR TITLE
Fix port retrieving for probes on OpenShift

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/TcpProbeConfig.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/TcpProbeConfig.java
@@ -36,7 +36,7 @@ public class TcpProbeConfig extends ProbeConfig {
     super(successThreshold, failureThreshold, timeoutSeconds, periodSeconds, initialDelaySeconds);
     if (port < 0) {
       throw new IllegalArgumentException(
-          "Port '" + timeoutSeconds + "' is illegal. Port should not be less than 0");
+          "Port '" + port + "' is illegal. Port should not be less than 0");
     }
     this.port = port;
     if (isNullOrEmpty(host)) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/ExecServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/ExecServerLivenessProbeConfigFactory.java
@@ -29,7 +29,16 @@ public class ExecServerLivenessProbeConfigFactory implements HttpProbeConfigFact
     try {
       URL url = new URL(server.getUrl());
       return new HttpProbeConfig(
-          url.getPort(), url.getHost(), url.getProtocol(), "/liveness", null, 1, 3, 120, 10, 10);
+          url.getPort() == -1 ? 80 : url.getPort(),
+          url.getHost(),
+          url.getProtocol(),
+          "/liveness",
+          null,
+          1,
+          3,
+          120,
+          10,
+          10);
     } catch (MalformedURLException e) {
       throw new InternalInfrastructureException(
           "Exec agent server liveness probe url is invalid. Error: " + e.getMessage());

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/TerminalServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/TerminalServerLivenessProbeConfigFactory.java
@@ -41,6 +41,15 @@ public class TerminalServerLivenessProbeConfigFactory implements HttpProbeConfig
     }
 
     return new HttpProbeConfig(
-        uri.getPort(), uri.getHost(), protocol, "/liveness", null, 1, 3, 120, 10, 10);
+        uri.getPort() == -1 ? 80 : uri.getPort(),
+        uri.getHost(),
+        protocol,
+        "/liveness",
+        null,
+        1,
+        3,
+        120,
+        10,
+        10);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
@@ -43,7 +43,7 @@ public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigF
       URI uri = UriBuilder.fromUri(server.getUrl()).path("/").build();
 
       return new HttpProbeConfig(
-          uri.getPort(),
+          uri.getPort() == -1 ? 80 : uri.getPort(),
           uri.getHost(),
           uri.getScheme(),
           uri.getPath(),


### PR DESCRIPTION
### What does this PR do?
Fix port retrieving for probes on OpenShift. Because of usage of URI and URL which return `-1` as a port when the port is not specified in the URL.

### What issues does this PR fix or reference?
Related to #7550 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
