### PR TITLE
Make machine present in workspace runtime when starting event is sent

### DIFF
--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -149,7 +149,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
       DockerMachine machine = machineCreator.create(container);
       String name = Labels.newDeserializer(container.getLabels()).machineName();
 
-      runtimeMachines.addMachine(name, machine);
+      runtimeMachines.putMachine(name, machine);
       stopDetector.startDetection(container.getId(), name, new AbnormalMachineStopHandlerImpl());
       streamLogsAsync(name, container.getId());
     }
@@ -193,7 +193,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
         checkInterruption();
         String machineName = containerEntry.getKey();
 
-        runtimeMachines.addMachine(machineName, new DockerMachine.StartingDockerMachine());
+        runtimeMachines.putMachine(machineName, new DockerMachine.StartingDockerMachine());
         sendStartingEvent(machineName);
 
         try {
@@ -302,7 +302,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
             identity,
             new AbnormalMachineStopHandlerImpl());
     try {
-      runtimeMachines.replaceMachine(name, machine);
+      runtimeMachines.putMachine(name, machine);
 
       return machine;
     } catch (InfrastructureException e) {

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
@@ -58,11 +57,16 @@ import org.eclipse.che.workspace.infrastructure.docker.network.NetworkLifecycle;
 import org.eclipse.che.workspace.infrastructure.docker.server.mapping.ExternalIpURLRewriter;
 import org.slf4j.Logger;
 
-/** @author Alexander Garagatyi */
+/**
+ * Represents {@link InternalRuntime} for Docker infrastructure.
+ *
+ * @author Alexander Garagatyi
+ */
 public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext> {
 
   private static final Logger LOG = getLogger(DockerInternalRuntime.class);
 
+  private final RuntimeMachines runtimeMachines;
   private final StartSynchronizer startSynchronizer;
   private final Map<String, String> properties;
   private final NetworkLifecycle networks;
@@ -145,7 +149,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
       DockerMachine machine = machineCreator.create(container);
       String name = Labels.newDeserializer(container.getLabels()).machineName();
 
-      startSynchronizer.addMachine(name, machine);
+      runtimeMachines.addMachine(name, machine);
       stopDetector.startDetection(container.getId(), name, new AbnormalMachineStopHandlerImpl());
       streamLogsAsync(name, container.getId());
     }
@@ -173,6 +177,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     this.probesFactory = probesFactory;
     this.properties = new HashMap<>();
     this.startSynchronizer = new StartSynchronizer();
+    this.runtimeMachines = new RuntimeMachines();
     this.loggers = loggers;
     this.probeScheduler = probeScheduler;
   }
@@ -187,11 +192,17 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
           getContext().getEnvironment().getContainers().entrySet()) {
         checkInterruption();
         String machineName = containerEntry.getKey();
-        final DockerContainerConfig config = containerEntry.getValue();
+
+        runtimeMachines.addMachine(machineName, new DockerMachine.StartingDockerMachine());
         sendStartingEvent(machineName);
+
         try {
-          startMachine(machineName, config);
+          DockerMachine machine = startMachine(machineName, containerEntry.getValue());
           sendRunningEvent(machineName);
+
+          bootstrapInstallers(machineName, machine);
+
+          checkServers(machineName, machine);
         } catch (InfrastructureException e) {
           sendFailedEvent(machineName, e.getMessage());
           throw e;
@@ -250,7 +261,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
   @Override
   public Map<String, ? extends Machine> getInternalMachines() {
-    return startSynchronizer
+    return runtimeMachines
         .getMachines()
         .entrySet()
         .stream()
@@ -265,7 +276,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
   /** Checks servers availability on all the machines. */
   void checkServers() throws InfrastructureException {
     for (Map.Entry<String, ? extends DockerMachine> entry :
-        startSynchronizer.getMachines().entrySet()) {
+        runtimeMachines.getMachines().entrySet()) {
       String name = entry.getKey();
       DockerMachine machine = entry.getValue();
       ServersChecker checker =
@@ -279,10 +290,9 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     }
   }
 
-  private void startMachine(String name, DockerContainerConfig containerConfig)
+  private DockerMachine startMachine(String name, DockerContainerConfig containerConfig)
       throws InfrastructureException, InterruptedException {
     RuntimeIdentity identity = getContext().getIdentity();
-    InternalMachineConfig machineCfg = getContext().getEnvironment().getMachines().get(name);
 
     DockerMachine machine =
         containerStarter.startContainer(
@@ -292,27 +302,44 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
             identity,
             new AbnormalMachineStopHandlerImpl());
     try {
-      startSynchronizer.addMachine(name, machine);
+      runtimeMachines.replaceMachine(name, machine);
+
+      return machine;
     } catch (InfrastructureException e) {
       // destroy machine only in case its addition fails
       // in other cases cleanup of whole runtime will be performed
       destroyMachineQuietly(name, machine);
       throw e;
     }
-    if (machineCfg != null && !machineCfg.getInstallers().isEmpty()) {
-      bootstrapperFactory.create(name, identity, machineCfg.getInstallers(), machine).bootstrap();
-    }
+  }
+
+  private void checkServers(String name, DockerMachine machine)
+      throws InterruptedException, InfrastructureException {
+    RuntimeIdentity identity = getContext().getIdentity();
 
     checkInterruption();
+    // one-time check
     ServersChecker readinessChecker =
         serverCheckerFactory.create(identity, name, machine.getServers());
     readinessChecker.startAsync(new ServerReadinessHandler(name));
     readinessChecker.await();
 
-    machine.setStatus(MachineStatus.RUNNING);
+    checkInterruption();
+    // continuous checking
     probeScheduler.schedule(
         probesFactory.getProbes(identity.getWorkspaceId(), name, machine.getServers()),
         new ServerLivenessHandler());
+  }
+
+  private void bootstrapInstallers(String name, DockerMachine machine)
+      throws InfrastructureException, InterruptedException {
+    InternalMachineConfig machineCfg = getContext().getEnvironment().getMachines().get(name);
+    RuntimeIdentity identity = getContext().getIdentity();
+
+    if (machineCfg != null && !machineCfg.getInstallers().isEmpty()) {
+      checkInterruption();
+      bootstrapperFactory.create(name, identity, machineCfg.getInstallers(), machine).bootstrap();
+    }
   }
 
   private void checkInterruption() throws InterruptedException {
@@ -339,7 +366,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
 
     @Override
     public void accept(String serverRef) {
-      DockerMachine machine = startSynchronizer.getMachines().get(machineName);
+      DockerMachine machine = runtimeMachines.getMachine(machineName);
       if (machine == null) {
         // Probably machine was removed from the list during server check start due to some reason
         return;
@@ -360,7 +387,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     @Override
     public void accept(ProbeResult probeResult) {
       String machineName = probeResult.getMachineName();
-      DockerMachine machine = startSynchronizer.getMachines().get(machineName);
+      DockerMachine machine = runtimeMachines.getMachine(machineName);
       if (machine == null) {
         // Probably machine was removed from the list during server check start due to some reason
         return;
@@ -385,7 +412,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
   }
 
   private void destroyRuntime(Map<String, String> stopOptions) throws InfrastructureException {
-    Map<String, DockerMachine> machines = startSynchronizer.removeMachines();
+    Map<String, DockerMachine> machines = runtimeMachines.removeMachines();
     for (Map.Entry<String, DockerMachine> entry : machines.entrySet()) {
       destroyMachineQuietly(entry.getKey(), entry.getValue());
       sendStoppedEvent(entry.getKey());
@@ -401,8 +428,8 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
     } catch (InfrastructureException e) {
       LOG.error(
           format(
-              "Error occurs on destroying of docker machine '%s' in workspace '%s'. Container '%s'",
-              machineName, getContext().getIdentity().getWorkspaceId(), machine.getContainer()),
+              "Error occurs on destroying of docker machine '%s' in workspace '%s'. Error: %s",
+              machineName, getContext().getIdentity().getWorkspaceId(), e.getMessage()),
           e);
     }
   }
@@ -467,156 +494,5 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
             .withServerName(serverName)
             .withStatus(server.getStatus())
             .withServerUrl(server.getUrl()));
-  }
-
-  /**
-   * Controls the runtime start flow and helps to cancel it.
-   *
-   * <p>The runtime start with cancellation using the Start Synchronizer might look like:
-   *
-   * <pre>
-   * ...
-   *     public void startRuntime() {
-   *          startSynchronizer.setStartThread();
-   *          try {
-   *               // .....
-   *               startSynchronizer.complete();
-   *          } catch (Exception ex) {
-   *               startSynchronizer.completeExceptionally(ex);
-   *               throw ex;
-   *          }
-   *     }
-   * ...
-   * </pre>
-   *
-   * <p>At the same time stopping might look like:
-   *
-   * <pre>
-   * ...
-   *     public void stopRuntime() {
-   *          if (startSynchronizer.interrupt()) {
-   *               try {
-   *                  startSynchronizer.await();
-   *               } catch (RuntimeStartInterruptedException ex) {
-   *                  // normal stop
-   *               } catch (InterruptedException ex) {
-   *                  Thread.currentThread().interrupt();
-   *                  ...
-   *               }
-   *          }
-   *     }
-   * ...
-   * </pre>
-   */
-  static class StartSynchronizer {
-
-    private Exception exception;
-    private Thread startThread;
-    private Map<String, DockerMachine> machines;
-    private CountDownLatch completionLatch;
-
-    public StartSynchronizer() {
-      this.machines = new HashMap<>();
-      this.completionLatch = new CountDownLatch(1);
-    }
-
-    public synchronized Map<String, ? extends DockerMachine> getMachines() {
-      return machines != null ? machines : emptyMap();
-    }
-
-    public synchronized void addMachine(String name, DockerMachine machine)
-        throws InternalInfrastructureException {
-      if (machines != null) {
-        machines.put(name, machine);
-      } else {
-        throw new InternalInfrastructureException("Start of runtime is canceled.");
-      }
-    }
-
-    public synchronized Map<String, DockerMachine> removeMachines() throws InfrastructureException {
-      if (machines != null) {
-        Map<String, DockerMachine> machines = this.machines;
-        // unset to identify error if method called second time
-        this.machines = null;
-        return machines;
-      }
-      throw new InfrastructureException("Runtime doesn't have machines to remove");
-    }
-
-    /**
-     * Sets {@link Thread#currentThread()} as a {@link #startThread}.
-     *
-     * @throws InternalInfrastructureException when {@link #startThread} already setted.
-     */
-    public synchronized void setStartThread() throws InternalInfrastructureException {
-      if (startThread != null) {
-        throw new InternalInfrastructureException(
-            "Docker infrastructure context of workspace already started");
-      }
-      startThread = Thread.currentThread();
-    }
-
-    /**
-     * Releases waiting task and reset the starting thread.
-     *
-     * @throws InterruptedException when execution thread was interrupted just before this method
-     *     call
-     */
-    public synchronized void complete() throws InterruptedException {
-      if (Thread.currentThread().isInterrupted()) {
-        throw new InterruptedException();
-      }
-      startThread = null;
-      completionLatch.countDown();
-    }
-
-    /**
-     * Releases waiting task, reset the starting thread and sets an exception if it is not null.
-     *
-     * @param ex completion exception might be null
-     */
-    public synchronized void completeExceptionally(Exception ex) {
-      exception = ex;
-      startThread = null;
-      completionLatch.countDown();
-    }
-
-    /**
-     * Interrupts the {@link #startThread} if its value different to null.
-     *
-     * @return true if {@link #startThread} interruption flag setted, otherwise false will be
-     *     returned
-     */
-    public synchronized boolean interrupt() {
-      if (startThread != null) {
-        startThread.interrupt();
-        return true;
-      }
-      return false;
-    }
-
-    /**
-     * Waits until {@link #complete} is called and rethrow the {@link #exception} if it present.
-     * This call is blocking and it should be used with {@link #interrupt} method.
-     *
-     * @throws InterruptedException when this thread is interrupted while waiting for {@link
-     *     #complete}
-     * @throws RuntimeStartInterruptedException when {@link #startThread} successfully interrupted
-     * @throws InfrastructureException when any error occurs while waiting for {@link #complete}
-     */
-    public void await() throws InterruptedException, InfrastructureException {
-      completionLatch.await();
-      synchronized (this) {
-        if (exception != null) {
-          try {
-            throw exception;
-          } catch (InfrastructureException rethrow) {
-            throw rethrow;
-          } catch (Exception ex) {
-            throw new InternalInfrastructureException(ex);
-          }
-        }
-      }
-    }
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
@@ -37,15 +37,16 @@ import org.slf4j.Logger;
 /** @author Alexander Garagatyi */
 public class DockerMachine implements Machine {
 
+  private static final Logger LOG = getLogger(DockerMachine.class);
+
+  /** Name of the latest tag used in Docker image. */
+  public static final String LATEST_TAG = "latest";
+
   /**
    * Default HOSTNAME that will be added in all docker containers that are started. This host will
    * container the Docker host's ip reachable inside the container.
    */
   public static final String CHE_HOST = "che-host";
-  /** Name of the latest tag used in Docker image. */
-  public static final String LATEST_TAG = "latest";
-
-  private static final Logger LOG = getLogger(DockerMachine.class);
 
   private final String container;
   private final DockerConnector docker;

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
@@ -192,8 +192,9 @@ public class DockerMachine implements Machine {
 
     @Override
     public void destroy() throws InfrastructureException {
-      // Do nothing. May happen when runtime start is interrupted and the list of DockerMachines
-      // contains a StartingDockerMachine not yet replaced by the RunningDockerMachine
+      // Do nothing. May happen when runtime start is interrupted/failed and the list of
+      // DockerMachines contains a StartingDockerMachine not yet replaced by the
+      // RunningDockerMachine
     }
 
     @Override

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachine.java
@@ -37,16 +37,15 @@ import org.slf4j.Logger;
 /** @author Alexander Garagatyi */
 public class DockerMachine implements Machine {
 
-  private static final Logger LOG = getLogger(DockerMachine.class);
-
-  /** Name of the latest tag used in Docker image. */
-  public static final String LATEST_TAG = "latest";
-
   /**
    * Default HOSTNAME that will be added in all docker containers that are started. This host will
    * container the Docker host's ip reachable inside the container.
    */
   public static final String CHE_HOST = "che-host";
+  /** Name of the latest tag used in Docker image. */
+  public static final String LATEST_TAG = "latest";
+
+  private static final Logger LOG = getLogger(DockerMachine.class);
 
   private final String container;
   private final DockerConnector docker;
@@ -63,14 +62,15 @@ public class DockerMachine implements Machine {
       DockerConnector docker,
       Map<String, ServerImpl> servers,
       String registry,
-      DockerMachineStopDetector dockerMachineStopDetector) {
+      DockerMachineStopDetector dockerMachineStopDetector,
+      MachineStatus status) {
     this.container = containerId;
     this.docker = docker;
     this.image = image;
     this.registry = registry;
     this.dockerMachineStopDetector = dockerMachineStopDetector;
     this.servers = servers;
-    this.status = MachineStatus.STARTING;
+    this.status = status;
   }
 
   @Override
@@ -88,11 +88,7 @@ public class DockerMachine implements Machine {
     return status;
   }
 
-  public void setStatus(MachineStatus status) {
-    this.status = status;
-  }
-
-  void setServerStatus(String serverRef, ServerStatus status) {
+  public void setServerStatus(String serverRef, ServerStatus status) {
     if (servers == null) {
       throw new IllegalStateException("Servers are not initialized yet");
     }
@@ -132,18 +128,14 @@ public class DockerMachine implements Machine {
       docker.removeContainer(
           RemoveContainerParams.create(container).withRemoveVolumes(true).withForce(true));
     } catch (IOException e) {
-      throw new InternalInfrastructureException(e.getMessage(), e);
+      throw new InternalInfrastructureException(
+          "Error occurs on removing container '" + container + "'. Error: " + e.getMessage(), e);
     }
     try {
       docker.removeImage(RemoveImageParams.create(image).withForce(false));
     } catch (IOException e) {
       LOG.warn("IOException during destroy(). Ignoring.", e);
     }
-  }
-
-  /** Can be used for docker specific operations with machine */
-  public String getContainer() {
-    return container;
   }
 
   @Override
@@ -163,5 +155,59 @@ public class DockerMachine implements Machine {
         + ", container="
         + container
         + '}';
+  }
+
+  /**
+   * Represents {@link DockerMachine} in a starting state - aka fake state of the DockerMachine.
+   * This implementation returns empty map of servers and doesn't allow to change its own or any
+   * server status. This implementation is needed to represent Docker machine until we fetch
+   * information about Docker container and can create the real implementation of Docker machine.
+   */
+  static class StartingDockerMachine extends DockerMachine {
+
+    public StartingDockerMachine() {
+      super(null, null, null, null, null, null, MachineStatus.STARTING);
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, ServerImpl> getServers() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public MachineStatus getStatus() {
+      return MachineStatus.STARTING;
+    }
+
+    @Override
+    public void setServerStatus(String serverRef, ServerStatus status) {
+      throw new IllegalStateException(
+          "Starting Docker machine doesn't support server status change");
+    }
+
+    @Override
+    public void destroy() throws InfrastructureException {
+      // Do nothing. May happen when runtime start is interrupted and the list of DockerMachines
+      // contains a StartingDockerMachine not yet replaced by the RunningDockerMachine
+    }
+
+    @Override
+    public void putResource(String targetPath, InputStream sourceStream)
+        throws InfrastructureException {
+      throw new InternalInfrastructureException(
+          "Starting Docker machine doesn't support put resource operation");
+    }
+
+    @Override
+    public void exec(String script, MessageProcessor<LogMessage> messageProcessor)
+        throws InfrastructureException {
+      throw new InternalInfrastructureException(
+          "Starting Docker machine doesn't support exec operation");
+    }
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerMachineCreator.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.infrastructure.docker.client.DockerConnector;
@@ -75,6 +76,7 @@ public class DockerMachineCreator {
         new ServersMapper(hostname, deserializer.machineName())
             .map(networkSettings.getPorts(), configs),
         registry,
-        dockerMachineStopDetector);
+        dockerMachineStopDetector,
+        MachineStatus.RUNNING);
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeMachines.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeMachines.java
@@ -33,7 +33,7 @@ public class RuntimeMachines {
 
   /** Returns machines map. If runtime start is canceled returns empty map. */
   public synchronized Map<String, DockerMachine> getMachines() {
-    return machines != null ? machines : emptyMap();
+    return machines != null ? new HashMap<>(machines) : emptyMap();
   }
 
   /**

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeMachines.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeMachines.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.docker.DockerMachine.StartingDockerMachine;
+
+/**
+ * Holds machines during runtime lifecycle.
+ *
+ * @author Alexander Garagatyi
+ */
+public class RuntimeMachines {
+
+  private Map<String, DockerMachine> machines;
+
+  public RuntimeMachines() {
+    this.machines = new HashMap<>();
+  }
+
+  /** Returns machines map. If runtime start is canceled returns empty map. */
+  public synchronized Map<String, DockerMachine> getMachines() {
+    return machines != null ? machines : emptyMap();
+  }
+
+  /**
+   * Returns machine of the runtime by machine name. Returns {@code null} if there is no machine
+   * with such a name or machines lis was cleaned because of stop of the runtime.
+   */
+  @Nullable
+  public synchronized DockerMachine getMachine(String name) {
+    if (machines == null) {
+      return null;
+    }
+    return machines.get(name);
+  }
+
+  /**
+   * Adds a machine into the storage.
+   *
+   * @param name the name of a machine
+   * @param machine machine instance
+   * @throws InternalInfrastructureException if runtime start is cancelled which led to removal of
+   *     machines from this storage
+   */
+  public synchronized void addMachine(String name, DockerMachine machine)
+      throws InternalInfrastructureException {
+    if (machines == null) {
+      throw new InternalInfrastructureException("Start of runtime is canceled");
+    }
+    machines.put(name, machine);
+  }
+
+  /**
+   * Replaces existing machine with the provided one. Is supposed to be used to replace initial fake
+   * state of machine with the real one that returns all the information about machine.
+   *
+   * @param name name of the machine to replace
+   * @param machine replacement
+   * @throws InternalInfrastructureException if runtime start is cancelled which led to removal of
+   *     machines from this storage
+   * @throws InternalInfrastructureException if machine is not present in this storage which means
+   *     that correct runtime start flow is broken
+   */
+  public synchronized void replaceMachine(String name, DockerMachine machine)
+      throws InternalInfrastructureException {
+    if (machines == null) {
+      throw new InternalInfrastructureException("Start of runtime is canceled");
+    }
+    DockerMachine existingMachine = machines.get(name);
+    if (existingMachine == null || !(existingMachine instanceof StartingDockerMachine)) {
+      throw new InternalInfrastructureException("Machine is not in a STARTING state");
+    }
+    machines.replace(name, machine);
+  }
+
+  /**
+   * Removes all the machine and returns them. Is supposed to be called on normal/abnormal runtime
+   * stop.
+   *
+   * @throws InfrastructureException if there is no machines anymore. Might happen on concurrent
+   *     modification.
+   */
+  public synchronized Map<String, DockerMachine> removeMachines() throws InfrastructureException {
+    if (machines == null) {
+      throw new InfrastructureException("Runtime doesn't have machines to remove");
+    }
+    Map<String, DockerMachine> machines = this.machines;
+    // unset to identify error if method called second time
+    this.machines = null;
+    return machines;
+  }
+}

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeMachines.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeMachines.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.workspace.infrastructure.docker.DockerMachine.StartingDockerMachine;
 
 /**
  * Holds machines during runtime lifecycle.
@@ -50,42 +49,19 @@ public class RuntimeMachines {
   }
 
   /**
-   * Adds a machine into the storage.
+   * Puts a machine into the storage. Replaces machine if another instance is already present.
    *
    * @param name the name of a machine
    * @param machine machine instance
    * @throws InternalInfrastructureException if runtime start is cancelled which led to removal of
    *     machines from this storage
    */
-  public synchronized void addMachine(String name, DockerMachine machine)
+  public synchronized void putMachine(String name, DockerMachine machine)
       throws InternalInfrastructureException {
     if (machines == null) {
       throw new InternalInfrastructureException("Start of runtime is canceled");
     }
     machines.put(name, machine);
-  }
-
-  /**
-   * Replaces existing machine with the provided one. Is supposed to be used to replace initial fake
-   * state of machine with the real one that returns all the information about machine.
-   *
-   * @param name name of the machine to replace
-   * @param machine replacement
-   * @throws InternalInfrastructureException if runtime start is cancelled which led to removal of
-   *     machines from this storage
-   * @throws InternalInfrastructureException if machine is not present in this storage which means
-   *     that correct runtime start flow is broken
-   */
-  public synchronized void replaceMachine(String name, DockerMachine machine)
-      throws InternalInfrastructureException {
-    if (machines == null) {
-      throw new InternalInfrastructureException("Start of runtime is canceled");
-    }
-    DockerMachine existingMachine = machines.get(name);
-    if (existingMachine == null || !(existingMachine instanceof StartingDockerMachine)) {
-      throw new InternalInfrastructureException("Machine is not in a STARTING state");
-    }
-    machines.replace(name, machine);
   }
 
   /**

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/StartSynchronizer.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/StartSynchronizer.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker;
+
+import java.util.concurrent.CountDownLatch;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException;
+
+/**
+ * Controls the runtime start flow and helps to cancel it.
+ *
+ * <p>The runtime start with cancellation using the Start Synchronizer might look like:
+ *
+ * <pre>
+ * ...
+ *     public void startRuntime() {
+ *          startSynchronizer.setStartThread();
+ *          try {
+ *               // .....
+ *               startSynchronizer.complete();
+ *          } catch (Exception ex) {
+ *               startSynchronizer.completeExceptionally(ex);
+ *               throw ex;
+ *          }
+ *     }
+ * ...
+ * </pre>
+ *
+ * <p>At the same time stopping might look like:
+ *
+ * <pre>
+ * ...
+ *     public void stopRuntime() {
+ *          if (startSynchronizer.interrupt()) {
+ *               try {
+ *                  startSynchronizer.await();
+ *               } catch (RuntimeStartInterruptedException ex) {
+ *                  // normal stop
+ *               } catch (InterruptedException ex) {
+ *                  Thread.currentThread().interrupt();
+ *                  ...
+ *               }
+ *          }
+ *     }
+ * ...
+ * </pre>
+ *
+ * @author Alexander Garagatyi
+ */
+public class StartSynchronizer {
+
+  private Exception exception;
+  private Thread startThread;
+  private CountDownLatch completionLatch;
+
+  public StartSynchronizer() {
+    this.completionLatch = new CountDownLatch(1);
+  }
+
+  /**
+   * Sets {@link Thread#currentThread()} as a {@link #startThread}.
+   *
+   * @throws InternalInfrastructureException when {@link #startThread} is already set.
+   */
+  public synchronized void setStartThread() throws InternalInfrastructureException {
+    if (startThread != null) {
+      throw new InternalInfrastructureException(
+          "Docker infrastructure context of workspace already started");
+    }
+    startThread = Thread.currentThread();
+  }
+
+  /**
+   * Releases waiting task and reset the starting thread.
+   *
+   * @throws InterruptedException when execution thread was interrupted just before this method call
+   */
+  public synchronized void complete() throws InterruptedException {
+    if (Thread.currentThread().isInterrupted()) {
+      throw new InterruptedException();
+    }
+    startThread = null;
+    completionLatch.countDown();
+  }
+
+  /**
+   * Releases waiting task, reset the starting thread and sets an exception if it is not null.
+   *
+   * @param ex completion exception might be null
+   */
+  public synchronized void completeExceptionally(Exception ex) {
+    exception = ex;
+    startThread = null;
+    completionLatch.countDown();
+  }
+
+  /**
+   * Interrupts the {@link #startThread} if its value different to null.
+   *
+   * @return true if {@link #startThread} interruption flag set, otherwise false will be returned
+   */
+  public synchronized boolean interrupt() {
+    if (startThread != null) {
+      startThread.interrupt();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Waits until {@link #complete} is called and rethrow the {@link #exception} if it present. This
+   * call is blocking and it should be used with {@link #interrupt} method.
+   *
+   * @throws InterruptedException when this thread is interrupted while waiting for {@link
+   *     #complete}
+   * @throws RuntimeStartInterruptedException when {@link #startThread} successfully interrupted
+   * @throws InfrastructureException when any error occurs while waiting for {@link #complete}
+   */
+  public void await() throws InterruptedException, InfrastructureException {
+    completionLatch.await();
+    synchronized (this) {
+      if (exception != null) {
+        try {
+          throw exception;
+        } catch (InfrastructureException rethrow) {
+          throw rethrow;
+        } catch (Exception ex) {
+          throw new InternalInfrastructureException(ex);
+        }
+      }
+    }
+  }
+}

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntimeTest.java
@@ -175,8 +175,11 @@ public class DockerInternalRuntimeTest {
     } catch (InfrastructureException ex) {
       verify(starter, times(1))
           .startContainer(nullable(String.class), nullable(String.class), any(), any(), any());
-      verify(eventService, times(2)).publish(any(MachineStatusEvent.class));
-      verifyEventsOrder(newEvent(DEV_MACHINE, STARTING, null), newEvent(DEV_MACHINE, FAILED, msg));
+      verify(eventService, times(3)).publish(any(MachineStatusEvent.class));
+      verifyEventsOrder(
+          newEvent(DEV_MACHINE, STARTING, null),
+          newEvent(DEV_MACHINE, FAILED, msg),
+          newEvent(DEV_MACHINE, STOPPED, null));
       throw ex;
     }
   }
@@ -191,9 +194,10 @@ public class DockerInternalRuntimeTest {
       verify(starter, times(1))
           .startContainer(nullable(String.class), nullable(String.class), any(), any(), any());
       verify(bootstrapper, times(1)).bootstrap();
-      verify(eventService, times(3)).publish(any(MachineStatusEvent.class));
+      verify(eventService, times(4)).publish(any(MachineStatusEvent.class));
       verifyEventsOrder(
           newEvent(DEV_MACHINE, STARTING, null),
+          newEvent(DEV_MACHINE, RUNNING, null),
           newEvent(DEV_MACHINE, FAILED, "bootstrap failed"),
           newEvent(DEV_MACHINE, STOPPED, null));
       throw ex;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -137,10 +137,10 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
       for (OpenShiftMachine machine : machines.values()) {
         try {
           machine.waitRunning(machineStartTimeoutMin);
-          bootstrapMachine(machine);
-          checkMachineServers(machine);
           machine.setStatus(MachineStatus.RUNNING);
           sendRunningEvent(machine.getName());
+          bootstrapMachine(machine);
+          checkMachineServers(machine);
         } catch (InfrastructureException rethrow) {
           sendFailedEvent(machine.getName(), rethrow.getMessage());
           throw rethrow;
@@ -247,7 +247,8 @@ public class OpenShiftInternalRuntime extends InternalRuntime<OpenShiftRuntimeCo
                 podMetadata.getName(),
                 container.getName(),
                 serverResolver.resolve(machineName),
-                project);
+                project,
+                MachineStatus.STARTING);
         machines.put(machine.getName(), machine);
         sendStartingEvent(machine.getName());
       }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftMachine.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftMachine.java
@@ -41,7 +41,8 @@ public class OpenShiftMachine implements Machine {
       String podName,
       String containerName,
       Map<String, ServerImpl> ref2Server,
-      OpenShiftProject project) {
+      OpenShiftProject project,
+      MachineStatus status) {
     this.machineName = machineName;
     this.podName = podName;
     this.containerName = containerName;
@@ -50,7 +51,7 @@ public class OpenShiftMachine implements Machine {
       this.ref2Server.putAll(ref2Server);
     }
     this.project = project;
-    this.status = MachineStatus.STARTING;
+    this.status = status;
   }
 
   public String getName() {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -243,9 +243,12 @@ public class OpenShiftInternalRuntimeTest {
       verify(routes).create(any());
       verify(services).create(any());
       verify(bootstrapper).bootstrap();
-      verify(eventService, times(3)).publish(any());
+      verify(eventService, times(4)).publish(any());
       verifyEventsOrder(
-          newEvent(M1_NAME, STARTING), newEvent(M2_NAME, STARTING), newEvent(M1_NAME, FAILED));
+          newEvent(M1_NAME, STARTING),
+          newEvent(M2_NAME, STARTING),
+          newEvent(M1_NAME, RUNNING),
+          newEvent(M1_NAME, FAILED));
       throw rethrow;
     }
   }
@@ -280,7 +283,7 @@ public class OpenShiftInternalRuntimeTest {
       verify(routes).create(any());
       verify(services).create(any());
       verify(bootstrapper).bootstrap();
-      verifyEventsOrder(newEvent(M1_NAME, STARTING));
+      verifyEventsOrder(newEvent(M1_NAME, STARTING), newEvent(M1_NAME, RUNNING));
       throw rethrow;
     }
   }


### PR DESCRIPTION
### What does this PR do?
Make machine present in workspace runtime when starting event is sent.
Also set machine RUNNING status before bootstrapping installers and
checking servers statuses.


### What issues does this PR fix or reference?
Fixes #7900 
Fixes #8056 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
