### PR TITLE
Selenium: unexpected fail of WorkingWithJavaMySqlStackTest and RenameWorkspaceTest selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -818,16 +818,8 @@ public class ProjectExplorer {
 
   public void invokeCommandWithContextMenu(
       String commandsGoal, String pathToItem, String commandName, String machineName) {
-    selectItem(pathToItem);
-    openContextMenuByPathSelectedItem(pathToItem);
-    clickOnItemInContextMenu(COMMANDS);
-    clickOnItemInContextMenu(commandsGoal);
+    invokeCommandWithContextMenu(commandsGoal, pathToItem, commandName);
 
-    redrawUiElementsWait
-        .until(
-            visibilityOfElementLocated(
-                By.xpath(String.format("//tr[@id[contains(.,'%s')]]", commandName))))
-        .click();
     loader.waitOnClosed();
     actionsFactory
         .createAction(seleniumWebDriver)

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceDetails.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceDetails.java
@@ -12,7 +12,6 @@ package org.eclipse.che.selenium.pageobject.dashboard.workspaces;
 
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
@@ -124,7 +123,7 @@ public class WorkspaceDetails {
    * @param stateWorkspace expected state of workspace
    */
   public void checkStateOfWorkspace(StateWorkspace stateWorkspace) {
-    new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, EXPECTED_MESS_IN_CONSOLE_SEC)
         .until(textToBePresentInElement(workspaceState, stateWorkspace.getStatus()));
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.OVERVIEW;
@@ -103,8 +103,6 @@ public class RenameWorkspaceTest {
   private void saveAndWaitWorkspaceRestarted() {
     workspaceDetails.clickOnSaveChangesBtn();
     workspaceDetails.checkStateOfWorkspace(STOPPING);
-    workspaceDetails.checkStateOfWorkspace(RUNNING, EXPECTED_MESS_IN_CONSOLE_SEC);
-    dashboard.waitNotificationMessage("Workspace updated");
-    dashboard.waitNotificationIsClosed();
+    workspaceDetails.checkStateOfWorkspace(RUNNING, UPDATING_PROJECT_TIMEOUT_SEC);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
 import static org.testng.Assert.fail;
@@ -98,7 +98,7 @@ public class ProjectStateAfterRenameWorkspaceTest {
     workspaceOverview.enterNameWorkspace(WORKSPACE_NEW_NAME);
     workspaceDetails.clickOnSaveChangesBtn();
     workspaceDetails.checkStateOfWorkspace(STOPPING);
-    workspaceDetails.checkStateOfWorkspace(RUNNING, EXPECTED_MESS_IN_CONSOLE_SEC);
+    workspaceDetails.checkStateOfWorkspace(RUNNING, UPDATING_PROJECT_TIMEOUT_SEC);
     workspaceOverview.checkNameWorkspace(WORKSPACE_NEW_NAME);
 
     // open the IDE, check state of the project


### PR DESCRIPTION
### What does this PR do?
This PR:
- increase timeouts for waiting statuses of workspace( it will fix **ProjectStateAfterRenameWorkspaceTest** and **RenameWorkspaceTest** tests);
- change **invokeCommandWithContextMenu** method of the **ProjectExplorer** selenium page object(it will fix **WorkingWithJavaMySqlStackTest** test).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8214
