### PR TITLE
Selenium: move ServerRuntimeInfoTest selenium test to miscellaneous package

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/consoles/ServerRuntimeInfoTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.consoles;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import java.util.List;
@@ -17,6 +19,8 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
+import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -27,6 +31,8 @@ public class ServerRuntimeInfoTest {
   @Inject private Loader loader;
   @Inject private Consoles consoles;
   @Inject private Ide ide;
+  @Inject private ProjectExplorer projectExplorer;
+  @Inject private MachineTerminal terminal;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -35,7 +41,10 @@ public class ServerRuntimeInfoTest {
 
   @Test
   public void testShouldCheckServerList() throws Exception {
+    projectExplorer.waitProjectExplorer();
+    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
     loader.waitOnClosed();
+
     consoles.clickOnPlusMenuButton();
     consoles.clickOnServerItemInContextMenu();
     consoles.waitProcessInProcessConsoleTree("Servers");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ServerRuntimeInfoTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.selenium.consoles;
+package org.eclipse.che.selenium.miscellaneous;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -148,6 +148,7 @@
           <class name="org.eclipse.che.selenium.miscellaneous.ImplementationBaseOperationsTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.NavigateToFileTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.ResolveDependencyAfterRecreateProjectTest"/>
+          <class name="org.eclipse.che.selenium.miscellaneous.ServerRuntimeInfoTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.TerminalTypingTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithSplitPanelTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithTerminalTest"/>
@@ -246,7 +247,6 @@
           <class name="org.eclipse.che.selenium.workspaces.WorkingWithJavaMySqlStackTest"/>
           <class name="org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest"/>
           <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest"/>
-          <class name="org.eclipse.che.selenium.consoles.ServerRuntimeInfoTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
### What does this PR do?
This PR:
- move **ServerRuntimeInfoTest** from **consoles** package to **miscellaneous;**
- add checking that a test workspace is started before opening the **Servers** tab.
