### PR TITLE
Dashboard: switch to the opened workspace without reloading the IDE

### DIFF
--- a/dashboard/src/app/ide/ide.controller.ts
+++ b/dashboard/src/app/ide/ide.controller.ts
@@ -147,7 +147,13 @@ class IdeCtrl {
 
     this.$rootScope.hideLoader = true;
 
-    if (this.selectedWorkspace) {
+    if (!this.selectedWorkspace) {
+      return;
+    }
+
+    if (this.ideSvc.openedWorkspace && this.selectedWorkspace.id === this.ideSvc.openedWorkspace.id) {
+      this.ideSvc.displayIDE();
+    } else {
       this.ideSvc.openIde(this.selectedWorkspace.id);
     }
   }


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This allows an end user to switch between any dashboard page and previously opened workspace without reloading the IDE.

### What issues does this PR fix or reference?
resolves https://github.com/eclipse/che/issues/6457

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>