### PR TITLE
Also allow configuring the `OkHttpClient` connnection pool.

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -375,7 +375,7 @@ che.openshift.server.http.connection_pool.max_idle=5
 
 # Keep-alive timeout of the http client connection pool
 # in minutes
-che.openshift.server.http.connection_pool.keep_alive=5
+che.openshift.server.http.connection_pool.keep_alive.mins=5
 
 #
 #

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -360,14 +360,22 @@ che.openshift.workspace.memory.override=NULL
 # this length of time.
 che.openshift.server.inactive.stop.timeout.ms=1800000
 
-# Number of maximum concurrent web requests
+# Number of maximum concurrent async web requests
 # (http requests or ongoing  web socket calls)
-# Default values are 64 and 5 per-host, which 
+# Default values are 64, and 5 per-host, which 
 # doesn't seem correct for multi-user scenarios
 # knowing that Che keeps a number of connections
 # opened (e.g. for command or ws-agent logs)
-che.openshift.server.concurrent.requests.total=1000
-che.openshift.server.concurrent.requests.perhost=1000
+che.openshift.server.http.async_requests.max=1000
+che.openshift.server.http.async_requests.max_per_host=1000
+
+# Max number of idle connections in the http
+# client connection pool
+che.openshift.server.http.connection_pool.max_idle=5
+
+# Keep-alive timeout of the http client connection pool
+# in minutes
+che.openshift.server.http.connection_pool.keep_alive=5
 
 #
 #

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftClientFactory.java
@@ -42,7 +42,7 @@ public class OpenShiftClientFactory {
       @Named("che.openshift.server.http.async_requests.max") int maxConcurrentRequests,
       @Named("che.openshift.server.http.async_requests.max_per_host") int maxConcurrentRequestsPerHost,
       @Named("che.openshift.server.http.connection_pool.max_idle") int maxIdleConnections,
-      @Named("che.openshift.server.http.connection_pool.keep_alive") int connectionPoolKeepAlive) {
+      @Named("che.openshift.server.http.connection_pool.keep_alive.mins") int connectionPoolKeepAlive) {
     Config defaultOpenshiftConfig = workspaceEnvironmentProvider.getDefaultOpenshiftConfig();
     OkHttpClient temporary = HttpClientUtils.createHttpClient(defaultOpenshiftConfig);
     OkHttpClient.Builder builder = temporary.newBuilder();


### PR DESCRIPTION
### What does this PR do?

This PR allows configuring the connection of the single shared `OkHttpClient` instance.

This might be necessary, in the future, to increase the max number of idle connections in the pool in the multi-tenant Che, according to the number of concurrent users / workspaces.
