### PR TITLE
Changed back recreate update in che deployment config

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/che-openshift.yml
+++ b/dockerfiles/init/modules/openshift/files/scripts/che-openshift.yml
@@ -58,7 +58,9 @@ items:
     selector:
       app: che
     strategy:
-      type: Rolling
+      type: Recreate
+      recreateParams:
+        timeoutSeconds: 10000
     template:
       metadata:
         labels:


### PR DESCRIPTION
### What does this PR do?
Fixes updating of Che application by deployment config.
The `rolling` update strategy doesn't work
- for the single-user Che on local OCP where `H2` database is used: 
*because* file database is occupied by previous Che pod;
- for both (single and multi-user) on OCP instances where nodes number is more than 1: 
*because* while we're using `ReadWriteOnce` PVC access mode new Che Pod can't be started because PVC is already mounted to old Che Pod.

### What issues does this PR fix or reference?
-

#### Release Notes
N/A


#### Docs PR
N/A