### PR TITLE
Remove unused parameter from IDE link

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
@@ -215,7 +215,6 @@ export class CreateWorkspaceSvc {
   redirectToIde(namespaceId: string, workspace: che.IWorkspace): void {
     const path = `/ide/${namespaceId}/${workspace.config.name}`;
     this.$location.path(path);
-    this.$location.search({'init': 'true'});
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

Remove unused init parameter, when workspace creation page redirects to the IDE.
