### PR TITLE
Add default language descriptions set

### DIFF
--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
@@ -17,6 +17,8 @@ import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
 import org.eclipse.che.api.languageserver.messager.PublishDiagnosticsParamsJsonRpcTransmitter;
 import org.eclipse.che.api.languageserver.messager.ShowMessageJsonRpcTransmitter;
 import org.eclipse.che.api.languageserver.registry.CheLanguageClientFactory;
+import org.eclipse.che.api.languageserver.registry.DefaultLanguageRecognizer;
+import org.eclipse.che.api.languageserver.registry.LanguageRecognizer;
 import org.eclipse.che.api.languageserver.registry.LanguageServerFileWatcher;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistryImpl;
@@ -35,6 +37,7 @@ public class LanguageServerModule extends AbstractModule {
   protected void configure() {
     install(new LsRemoteModule());
 
+    bind(LanguageRecognizer.class).to(DefaultLanguageRecognizer.class);
     bind(LanguageServerRegistry.class).to(LanguageServerRegistryImpl.class);
     bind(ServerInitializer.class).to(ServerInitializerImpl.class);
     bind(LanguageRegistryService.class);

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 Red Hat, Inc.
+ * Copyright (c) 2012-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.registry;
+
+import static org.eclipse.che.api.fs.server.WsPathUtils.nameOf;
+
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+
+/**
+ * Language recognizer based on default language set. Custom language descriptions created that are
+ * injected by guice are taken into account prior to default language set. Language recognition is
+ * based on file name or file extension, so may be improved further in future.
+ */
+@Singleton
+public class DefaultLanguageRecognizer implements LanguageRecognizer {
+
+  private final Set<LanguageDescription> languages;
+  private final DefaultLanguages defaultLanguages;
+
+  @Inject
+  public DefaultLanguageRecognizer(
+      Set<LanguageDescription> languages, DefaultLanguages defaultLanguages) {
+    this.languages = languages;
+    this.defaultLanguages = defaultLanguages;
+  }
+
+  @Override
+  public LanguageDescription recognizeByPath(String wsPath) {
+    Name name = new Name(wsPath);
+    Extension extension = new Extension(wsPath);
+
+    for (LanguageDescription language : languages) {
+      if (name.matches(language) || extension.matches(language)) {
+        return language;
+      }
+    }
+
+    for (LanguageDescription language : defaultLanguages.getAll()) {
+      if (name.matches(language) || extension.matches(language)) {
+        return language;
+      }
+    }
+
+    return UNIDENTIFIED;
+  }
+
+  @Override
+  public LanguageDescription recognizeById(String id) {
+    for (LanguageDescription language : languages) {
+      if (language.getLanguageId().equals(id)) {
+        return language;
+      }
+    }
+
+    for (LanguageDescription language : defaultLanguages.getAll()) {
+      if (language.getLanguageId().equals(id)) {
+        return language;
+      }
+    }
+
+    return UNIDENTIFIED;
+  }
+
+  private static class Name {
+    private final String name;
+
+    private Name(String wsPath) {
+      String nameAndExtension = nameOf(wsPath);
+      int lastDotIndex = nameAndExtension.lastIndexOf('.');
+
+      this.name = lastDotIndex < 0 ? nameAndExtension : nameAndExtension.substring(0, lastDotIndex);
+    }
+
+    private boolean matches(LanguageDescription languageDescription) {
+      return languageDescription.getFileNames().contains(name);
+    }
+  }
+
+  private static class Extension {
+    private final String extension;
+
+    private Extension(String wsPath) {
+      String nameAndExtension = nameOf(wsPath);
+      int lastDotIndex = nameAndExtension.lastIndexOf('.');
+
+      this.extension = lastDotIndex < 0 ? "" : nameAndExtension.substring(lastDotIndex + 1);
+    }
+
+    private boolean matches(LanguageDescription languageDescription) {
+      return languageDescription.getFileExtensions().contains(extension);
+    }
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguages.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 Red Hat, Inc.
+ * Copyright (c) 2012-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguages.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/DefaultLanguages.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.registry;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Singleton;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+
+/** Contains set of default language descriptions */
+@Singleton
+public class DefaultLanguages {
+
+  private final Set<LanguageDescription> languages = new HashSet<>();
+
+  public DefaultLanguages() {
+    register("bat", "bat", "text/plain");
+    register("bibtex", "bib", "text/plain");
+    register("clojure", "clj", "text/x-clojure");
+    register("coffeescript", "coffee", "text/x-coffeescript");
+    register("c", "c", "text/x-csrc");
+    register("cpp", "cpp", "text/x-c++src");
+    register("csharp", "cs", "text/x-csharp");
+    register("css", "css", "text/css");
+    register("diff", "diff", "text/x-diff");
+    register("fsharp", "fs", "text/x-fsharp");
+    register("go", "go", "text/x-go");
+    register("groovy", "groovy", "text/x-groovy");
+    register("handlebars", "hbs", "text/plain");
+    register("html", "html", "text/html");
+    register("ini", "ini", "text/plain");
+    register("jade", "jade", "text/x-jade");
+    register("java", "java", "text/x-java");
+    register("javascript", "js", "text/javascript");
+    register("json", "json", "application/json");
+    register("scala", "scala", "text/x-scala");
+    register("kt", "kotlin", "text/x-kotlin");
+    register("latex", "tex", "text/x-latex");
+    register("lisp", "lisp", "text/x-commonlisp");
+    register("lua", "lua", "text/x-lua");
+    register("makefile", "Makefile", "text/plain");
+    register("markdown", "markdown", "text/x-markdown");
+    register("objective-c", "m", "text/x-objective-c");
+    register("objective-cpp", "mm", "text/x-objective-cpp");
+    register("perl", "pl", "text/x-perl");
+    register("php", "php", "text/x-php");
+    register("powershell", "ps1", "text/plain");
+    register("pascal", "pas", "text/x-pascal");
+    register("python", "py", "text/x-python");
+    register("r", "r", "text/x-rsrc");
+    register("ruby", "rb", "text/x-ruby");
+    register("rust", "rs", "text/x-rustsrc");
+    register("shellscript", "sh", "text/x-sh");
+    register("sql", "sql", "text/x-sql");
+    register("swift", "swift", "text/x-swift");
+    register("typescript", "ts", "application/typescript");
+    register("xml", "xml", "application/xml");
+    register("xsl", "xsl", "text/plain");
+    register("yaml", "yaml", "text/x-yaml");
+
+    registerWithName("dockerfile", "Dockerfile", "text/x-dockerfile");
+  }
+
+  public Set<LanguageDescription> getAll() {
+    return Collections.unmodifiableSet(languages);
+  }
+
+  private void register(String id, String extension, String mimeType) {
+    LanguageDescription languageDescription = new LanguageDescription();
+    languageDescription.setLanguageId(id);
+    languageDescription.setMimeType(mimeType);
+    languageDescription.setFileExtensions(Collections.singletonList(extension));
+    languages.add(languageDescription);
+  }
+
+  private void registerWithName(String id, String fileName, String mimeType) {
+    LanguageDescription languageDescription = new LanguageDescription();
+    languageDescription.setLanguageId(id);
+    languageDescription.setMimeType(mimeType);
+    languageDescription.setFileNames(Collections.singletonList(fileName));
+    languages.add(languageDescription);
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageRecognizer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 Red Hat, Inc.
+ * Copyright (c) 2012-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageRecognizer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageRecognizer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.registry;
+
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+
+/**
+ * The implementations of this interface are responsible for language recognition of a file under
+ * defined path.
+ */
+public interface LanguageRecognizer {
+  LanguageDescription UNIDENTIFIED =
+      new LanguageDescription() {
+        @Override
+        public String getLanguageId() {
+          return "unidentified";
+        }
+
+        @Override
+        public String getMimeType() {
+          return "";
+        }
+
+        @Override
+        public String getHighlightingConfiguration() {
+          return "";
+        }
+      };
+
+  /**
+   * Recognize a language by file path. If language cannot be recognized for any reason than the
+   * implementation must return {@link LanguageRecognizer#UNIDENTIFIED}.
+   *
+   * @param wsPath workspace path of a file
+   * @return description of language that was recognized
+   */
+  LanguageDescription recognizeByPath(String wsPath);
+
+  /**
+   * Recognize a language by it's identifier. If language cannot be recognized for any reason than
+   * the implementation must return {@link LanguageRecognizer#UNIDENTIFIED}.
+   *
+   * @param id language identifier
+   * @return description of language that was recognized
+   */
+  LanguageDescription recognizeById(String id);
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/remote/LsConfigurationExtractor.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/remote/LsConfigurationExtractor.java
@@ -47,6 +47,10 @@ class LsConfigurationExtractor {
     List<String> fileWatchPatterns = getFileWatchPatterns(configJsonObject);
     List<DocumentFilter> documentFilters = getDocumentFilters(configJsonObject);
 
+    if (languageIds.isEmpty()) {
+      throw new IllegalStateException(
+          "Language server is not properly configured in workspace configuration: language ids list is empty");
+    }
     return new LanguageServerDescription(id, languageIds, documentFilters, fileWatchPatterns);
   }
 

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizerTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 Red Hat, Inc.
+ * Copyright (c) 2012-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizerTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/DefaultLanguageRecognizerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.registry;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.languageserver.registry.LanguageRecognizer.UNIDENTIFIED;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** Tests for {@link DefaultLanguageRecognizer} */
+@Listeners(MockitoTestNGListener.class)
+public class DefaultLanguageRecognizerTest {
+
+  @Spy private Set<LanguageDescription> languages = new HashSet<>();
+  @Mock private DefaultLanguages defaultLanguages;
+
+  @InjectMocks private DefaultLanguageRecognizer recognizer;
+
+  @BeforeMethod
+  public void setUp() {
+    languages.clear();
+  }
+
+  @Test
+  public void shouldRecognizeDefaultByName() throws Exception {
+    LanguageDescription expected = new LanguageDescription();
+    expected.setFileNames(singletonList("Dockerfile"));
+    when(defaultLanguages.getAll()).thenReturn(Collections.singleton(expected));
+
+    LanguageDescription language = recognizer.recognizeByPath("/project/Dockerfile");
+
+    assertEquals(language, expected);
+  }
+
+  @Test
+  public void shouldRecognizeDefaultByExtension() throws Exception {
+    LanguageDescription expected = new LanguageDescription();
+    expected.setFileExtensions(singletonList("java"));
+    when(defaultLanguages.getAll()).thenReturn(Collections.singleton(expected));
+
+    LanguageDescription language = recognizer.recognizeByPath("/project/Main.java");
+
+    assertEquals(language, expected);
+  }
+
+  @Test
+  public void shouldRecognizeOverriddenByName() throws Exception {
+    LanguageDescription expected = new LanguageDescription();
+    expected.setFileNames(singletonList("Dockerfile"));
+    languages.add(expected);
+
+    LanguageDescription language = recognizer.recognizeByPath("/project/Dockerfile");
+
+    assertEquals(language, expected);
+  }
+
+  @Test
+  public void shouldRecognizeOverriddenByExtension() throws Exception {
+    LanguageDescription expected = new LanguageDescription();
+    expected.setFileExtensions(singletonList("java"));
+    languages.add(expected);
+
+    LanguageDescription language = recognizer.recognizeByPath("/project/Main.java");
+
+    assertEquals(language, expected);
+  }
+
+  @Test
+  public void shouldNotRecognizeByNameWhenNoLanguageSet() throws Exception {
+    LanguageDescription language = recognizer.recognizeByPath("/project/Dockerfile");
+
+    assertEquals(language, UNIDENTIFIED);
+  }
+
+  @Test
+  public void shouldNotRecognizeByExtensionWhenNoLanguageSet() throws Exception {
+    LanguageDescription language = recognizer.recognizeByPath("/project/Main.java");
+
+    assertEquals(language, UNIDENTIFIED);
+  }
+
+  @Test
+  public void shouldRecognizeOverriddenPriorToDefaultByName() throws Exception {
+    LanguageDescription notExpected = new LanguageDescription();
+    notExpected.setFileNames(singletonList("Dockerfile"));
+    notExpected.setLanguageId("expectedId");
+    when(defaultLanguages.getAll()).thenReturn(Collections.singleton(notExpected));
+
+    LanguageDescription expected = new LanguageDescription();
+    expected.setFileNames(singletonList("Dockerfile"));
+    expected.setLanguageId("notExpectedId");
+    languages.add(expected);
+
+    LanguageDescription language = recognizer.recognizeByPath("/project/Dockerfile");
+
+    assertEquals(language, expected);
+    assertNotEquals(language, notExpected);
+  }
+
+  @Test
+  public void shouldRecognizeOverriddenPriorToDefaultByExtension() throws Exception {
+    LanguageDescription notExpected = new LanguageDescription();
+    notExpected.setFileExtensions(singletonList("java"));
+    notExpected.setLanguageId("expectedId");
+    when(defaultLanguages.getAll()).thenReturn(Collections.singleton(notExpected));
+
+    LanguageDescription expected = new LanguageDescription();
+    expected.setFileExtensions(singletonList("java"));
+    expected.setLanguageId("notExpectedId");
+    languages.add(expected);
+
+    LanguageDescription language = recognizer.recognizeByPath("/project/Main.java");
+
+    assertEquals(language, expected);
+    assertNotEquals(language, notExpected);
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImplTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImplTest.java
@@ -95,7 +95,8 @@ public class LanguageServerRegistryImplTest {
     when(languageServer.getTextDocumentService()).thenReturn(mock(TextDocumentService.class));
     when(languageServer.initialize(any(InitializeParams.class))).thenReturn(completableFuture);
 
-    when(languageRecognizer.recognizeByPath(PREFIX + FILE_PATH)).thenReturn(languageDescription);
+    when(languageRecognizer.recognizeByPath(anyString())).thenReturn(languageDescription);
+    when(languageRecognizer.recognizeById(anyString())).thenReturn(languageDescription);
 
     when(pmp.get()).thenReturn(pm);
 

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImplTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImplTest.java
@@ -66,6 +66,7 @@ public class LanguageServerRegistryImplTest {
   @Mock private HttpJsonRequest httpJsonRequest;
   @Mock private HttpJsonResponse httpJsonResponse;
   @Mock private Workspace workspace;
+  @Mock private LanguageRecognizer languageRecognizer;
 
   private LanguageServerRegistryImpl registry;
   private LanguageServerDescription serverDescription;
@@ -94,6 +95,8 @@ public class LanguageServerRegistryImplTest {
     when(languageServer.getTextDocumentService()).thenReturn(mock(TextDocumentService.class));
     when(languageServer.initialize(any(InitializeParams.class))).thenReturn(completableFuture);
 
+    when(languageRecognizer.recognizeByPath(PREFIX + FILE_PATH)).thenReturn(languageDescription);
+
     when(pmp.get()).thenReturn(pm);
 
     when(clientFactory.create(anyString())).thenReturn(languageClient);
@@ -115,7 +118,8 @@ public class LanguageServerRegistryImplTest {
                 pmp,
                 initializer,
                 null,
-                clientFactory) {
+                clientFactory,
+                languageRecognizer) {
               @Override
               protected String extractProjectPath(String filePath) throws LanguageServerException {
                 return PROJECT_PATH;

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/remote/LsConfigurationExtractorTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/remote/LsConfigurationExtractorTest.java
@@ -34,7 +34,9 @@ public class LsConfigurationExtractorTest {
 
   @Test
   public void shouldExtractId() throws Exception {
-    Map<String, String> attributes = Collections.singletonMap("config", "{\"id\":\"testId\"}");
+    Map<String, String> attributes =
+        Collections.singletonMap(
+            "config", "{\"id\":\"testId\" ,\"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -44,7 +46,8 @@ public class LsConfigurationExtractorTest {
 
   @Test
   public void shouldExtractNullWhenIdIsNotMentioned() throws Exception {
-    Map<String, String> attributes = Collections.singletonMap("config", "{}");
+    Map<String, String> attributes =
+        Collections.singletonMap("config", "{\"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -64,8 +67,8 @@ public class LsConfigurationExtractorTest {
         languageServerDescription.getLanguageIds(), Collections.singletonList("languageId"));
   }
 
-  @Test
-  public void shouldExtractEmptyLanguageIdsForEmptyArray() throws Exception {
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void shouldThrowExceptionWhenExtractEmptyLanguageIdsForEmptyArray() throws Exception {
     Map<String, String> attributes = Collections.singletonMap("config", "{\"languageIds\": [] }");
 
     LanguageServerDescription languageServerDescription =
@@ -74,8 +77,9 @@ public class LsConfigurationExtractorTest {
     assertTrue(languageServerDescription.getLanguageIds().isEmpty());
   }
 
-  @Test
-  public void shouldExtractEmptyLanguageIdsWhenLanguageIdsAreNotMentioned() throws Exception {
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void shouldThrowExceptionWhenExtractEmptyLanguageIdsWhenLanguageIdsAreNotMentioned()
+      throws Exception {
     Map<String, String> attributes = Collections.singletonMap("config", "{ }");
 
     LanguageServerDescription languageServerDescription =
@@ -87,7 +91,9 @@ public class LsConfigurationExtractorTest {
   @Test
   public void shouldExtractFileWatchPatterns() throws Exception {
     Map<String, String> attributes =
-        Collections.singletonMap("config", "{\"fileWatchPatterns\": [\"fileWatchPattern\"] }");
+        Collections.singletonMap(
+            "config",
+            "{\"fileWatchPatterns\": [\"fileWatchPattern\"], \"languageIds\": [\"languageId\"] }");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -100,7 +106,8 @@ public class LsConfigurationExtractorTest {
   @Test
   public void shouldExtractEmptyFileWatchPatternsForEmptyArray() throws Exception {
     Map<String, String> attributes =
-        Collections.singletonMap("config", "{\"fileWatchPatterns\": [] }");
+        Collections.singletonMap(
+            "config", "{\"fileWatchPatterns\": [] , \"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -109,9 +116,10 @@ public class LsConfigurationExtractorTest {
   }
 
   @Test
-  public void shouldExtractEmptyFileWatchPatternsWhenfileWatchPatternsAreNotMentioned()
+  public void shouldExtractEmptyFileWatchPatternsWhenFileWatchPatternsAreNotMentioned()
       throws Exception {
-    Map<String, String> attributes = Collections.singletonMap("config", "{ }");
+    Map<String, String> attributes =
+        Collections.singletonMap("config", "{\"languageIds\": [\"languageId\"] }");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -122,7 +130,8 @@ public class LsConfigurationExtractorTest {
   @Test
   public void shouldExtractDocumentFilter() throws Exception {
     Map<String, String> attributes =
-        Collections.singletonMap("config", "{\"documentFilters\": [{}] }");
+        Collections.singletonMap(
+            "config", "{\"documentFilters\": [{}],\"languageIds\": [\"languageId\"] }");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -133,7 +142,8 @@ public class LsConfigurationExtractorTest {
   @Test
   public void shouldExtractEmptyDocumentFilterForEmptyArray() throws Exception {
     Map<String, String> attributes =
-        Collections.singletonMap("config", "{\"documentFilters\": [] }");
+        Collections.singletonMap(
+            "config", "{\"documentFilters\": [] ,\"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -143,7 +153,8 @@ public class LsConfigurationExtractorTest {
 
   @Test
   public void shouldExtractDocumentFilterWhenDocumentFilterAreNotMentioned() throws Exception {
-    Map<String, String> attributes = Collections.singletonMap("config", "{ }");
+    Map<String, String> attributes =
+        Collections.singletonMap("config", "{ \"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -154,7 +165,9 @@ public class LsConfigurationExtractorTest {
   @Test
   public void shouldExtractDocumentFilterLanguageId() throws Exception {
     Map<String, String> attributes =
-        Collections.singletonMap("config", "{\"documentFilters\": [{\"languageId\":\"testId\"}] }");
+        Collections.singletonMap(
+            "config",
+            "{\"documentFilters\": [{\"languageId\":\"testId\"}] ,\"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -166,7 +179,9 @@ public class LsConfigurationExtractorTest {
   @Test
   public void shouldExtractDocumentFilterScheme() throws Exception {
     Map<String, String> attributes =
-        Collections.singletonMap("config", "{\"documentFilters\": [{\"scheme\":\"testScheme\"}] }");
+        Collections.singletonMap(
+            "config",
+            "{\"documentFilters\": [{\"scheme\":\"testScheme\"}],\"languageIds\": [\"languageId\"] }");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);
@@ -179,7 +194,8 @@ public class LsConfigurationExtractorTest {
   public void shouldExtractDocumentFilterPathRegex() throws Exception {
     Map<String, String> attributes =
         Collections.singletonMap(
-            "config", "{\"documentFilters\": [{\"pathRegex\":\"testPathRegex\"}] }");
+            "config",
+            "{\"documentFilters\": [{\"pathRegex\":\"testPathRegex\"}] ,\"languageIds\": [\"languageId\"]}");
 
     LanguageServerDescription languageServerDescription =
         lsConfigurationExtractor.extract(attributes);


### PR DESCRIPTION
Signed-off-by: Dmytro Kulieshov <dkuliesh@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
After a deep and long analysis the decision is to add standard set of language descriptions while more appropriate and more complex solution is yet to come under a separate issue (issues). The way the new languages are added stays the same (via guice configuration of `LanguageDescreption`) and if no match is found then additional default set of languages is taken in consideration.

Example of a definition of a language server in a workspace configuration (not changed)
```json
"servers":{
   "ls":{
      "attributes":{
         "internal":"true",
         "type":"ls",
         "config":"{\"id\":\"github.com/sourcegraph/go-langserver\", \"languageIds\":[go]}"
      },
      "protocol":"tcp",
      "port":"4417"
   }
}
```
Where `languageIds` is a list of language that this server is to be associated with.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7790

<!-- #### Changelog -->
Added default set of language descriptions.
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
