### PR TITLE
Dashboard: prevent to start and open in IDE a workspace with unsupported recipe type

### DIFF
--- a/dashboard/e2e/projects/create-project/create-project-samples/create-project-samples.spec.js
+++ b/dashboard/e2e/projects/create-project/create-project-samples/create-project-samples.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/projects/create-project/create-project.mock.js
+++ b/dashboard/e2e/projects/create-project/create-project.mock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/projects/create-project/create-project.po.js
+++ b/dashboard/e2e/projects/create-project/create-project.po.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/list-stacks/list-stack.mock.js
+++ b/dashboard/e2e/stacks/list-stacks/list-stack.mock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/list-stacks/list-stack.po.js
+++ b/dashboard/e2e/stacks/list-stacks/list-stack.po.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/list-stacks/list-stack.spec.js
+++ b/dashboard/e2e/stacks/list-stacks/list-stack.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/stack-details/change-machine-source/change-machine-source.spec.js
+++ b/dashboard/e2e/stacks/stack-details/change-machine-source/change-machine-source.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/stack-details/delete-dev-machine/delete-dev-machine.spec.js
+++ b/dashboard/e2e/stacks/stack-details/delete-dev-machine/delete-dev-machine.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/stack-details/rename-machine/rename-machine.spec.js
+++ b/dashboard/e2e/stacks/stack-details/rename-machine/rename-machine.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/stack-details/stack-details.mock.js
+++ b/dashboard/e2e/stacks/stack-details/stack-details.mock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/stacks/stack-details/stack-details.po.js
+++ b/dashboard/e2e/stacks/stack-details/stack-details.po.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/utils.js
+++ b/dashboard/e2e/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/widgets/che-notification/che-notification.po.js
+++ b/dashboard/e2e/widgets/che-notification/che-notification.po.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/widgets/che-popup/che-popup.po.js
+++ b/dashboard/e2e/widgets/che-popup/che-popup.po.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/workspaces/list-workspaces/list-workspaces.mock.js
+++ b/dashboard/e2e/workspaces/list-workspaces/list-workspaces.mock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/workspaces/list-workspaces/list-workspaces.po.js
+++ b/dashboard/e2e/workspaces/list-workspaces/list-workspaces.po.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/e2e/workspaces/list-workspaces/list-workspaces.spec.js
+++ b/dashboard/e2e/workspaces/list-workspaces/list-workspaces.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/all.js
+++ b/dashboard/gulp/all.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/build.js
+++ b/dashboard/gulp/build.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/conf.js
+++ b/dashboard/gulp/conf.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/e2e-tests.js
+++ b/dashboard/gulp/e2e-tests.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/inject.js
+++ b/dashboard/gulp/inject.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/material-design-svgfont.js
+++ b/dashboard/gulp/material-design-svgfont.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/proxy.js
+++ b/dashboard/gulp/proxy.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/scripts.js
+++ b/dashboard/gulp/scripts.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/server.js
+++ b/dashboard/gulp/server.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/styles.js
+++ b/dashboard/gulp/styles.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/svgfont.js
+++ b/dashboard/gulp/svgfont.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/unit-tests.js
+++ b/dashboard/gulp/unit-tests.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulp/watch.js
+++ b/dashboard/gulp/watch.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/gulpfile.js
+++ b/dashboard/gulpfile.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/404.html
+++ b/dashboard/src/404.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/admin/plugins/plugins.html
+++ b/dashboard/src/app/admin/plugins/plugins.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/administration/administration.html
+++ b/dashboard/src/app/administration/administration.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/colors/che-color.constant.ts.template
+++ b/dashboard/src/app/colors/che-color.constant.ts.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/app/colors/che-output-colors.constant.ts.template
+++ b/dashboard/src/app/colors/che-output-colors.constant.ts.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/app/dashboard/dashboard.html
+++ b/dashboard/src/app/dashboard/dashboard.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/demo-components/demo-components.html
+++ b/dashboard/src/app/demo-components/demo-components.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/diagnostics/diagnostics-widget.html
+++ b/dashboard/src/app/diagnostics/diagnostics-widget.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/diagnostics/diagnostics.html
+++ b/dashboard/src/app/diagnostics/diagnostics.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.html
+++ b/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/create-factory.html
+++ b/dashboard/src/app/factories/create-factory/create-factory.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/git/create-factory-git.html
+++ b/dashboard/src/app/factories/create-factory/git/create-factory-git.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.html
+++ b/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/create-factory/workspaces-tab/factory-from-workspace.html
+++ b/dashboard/src/app/factories/create-factory/workspaces-tab/factory-from-workspace.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/factory-details/factory-details.html
+++ b/dashboard/src/app/factories/factory-details/factory-details.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/last-factories/last-factories.html
+++ b/dashboard/src/app/factories/last-factories/last-factories.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/list-factories/factory-item/factory-item.html
+++ b/dashboard/src/app/factories/list-factories/factory-item/factory-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/list-factories/list-factories.html
+++ b/dashboard/src/app/factories/list-factories/list-factories.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/factories/load-factory/load-factory.html
+++ b/dashboard/src/app/factories/load-factory/load-factory.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/ide/ide.html
+++ b/dashboard/src/app/ide/ide.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/navbar/navbar.html
+++ b/dashboard/src/app/navbar/navbar.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/navbar/navbar.styl
+++ b/dashboard/src/app/navbar/navbar.styl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.spec.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.spec.ts
@@ -14,6 +14,7 @@ import {CheAPIBuilder} from '../../../components/api/builder/che-api-builder.fac
 import {CheHttpBackend} from '../../../components/api/test/che-http-backend';
 import IdeSvc from '../../ide/ide.service';
 import {CheBranding} from '../../../components/branding/che-branding.factory';
+import {IWorkspaceAttributes} from '../../../components/api/builder/che-workspace-builder';
 
 
 /**
@@ -67,7 +68,7 @@ describe('NavbarRecentWorkspacesController', () => {
       let wrkspName = 'testName' + i;
       let wrkspCreateDate = new Date(2001, 1, 1, i, 1).toString();
       let wrkspUpdateDate = new Date(2001, 1, 1, i, 2).toString();
-      let wrkspAttr = {'created': Date.parse(wrkspCreateDate), 'updated': Date.parse(wrkspUpdateDate)};
+      let wrkspAttr = {'created': Date.parse(wrkspCreateDate), 'updated': Date.parse(wrkspUpdateDate)} as IWorkspaceAttributes;
       let workspace = apiBuilder.getWorkspaceBuilder().withId(wrkspId).withAttributes(wrkspAttr).withName(wrkspName).build();
       workspaces.push(workspace);
     }

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -230,22 +230,33 @@ export class NavbarRecentWorkspacesController {
   }
 
   /**
-   * Returns IDE link
-   * @param workspaceId {String} workspace id
+   * @param {che.IWorkspace} workspace details
    * @returns {string}
    */
-  getIdeLink(workspaceId: string): string {
-    let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
+  getLink(workspace: che.IWorkspace): string {
+    if (this.workspacesService.isSupported(workspace)) {
+      return this.getIdeLink(workspace);
+    } else {
+      return this.getWorkspaceDetailsLink(workspace);
+    }
+  }
+
+  /**
+   * Returns IDE link
+   * @param {che.IWorkspace} workspace details
+   * @returns {string}
+   */
+  getIdeLink(workspace: che.IWorkspace): string {
     return '#/ide/' + (workspace ? (workspace.namespace + '/' + workspace.config.name) : 'unknown');
   }
 
   /**
-   * Opens new tab/window with IDE
-   * @param workspaceId {String} workspace id
+   * Returns link to page with workspace details
+   * @param {che.IWorkspace} workspace details
+   * @returns {string}
    */
-  openLinkInNewTab(workspaceId: string): void {
-    let url = this.getIdeLink(workspaceId);
-    this.$window.open(url, '_blank');
+  getWorkspaceDetailsLink(workspace: che.IWorkspace): string {
+    return '#/workspace/' + workspace.namespace + '/' + workspace.config.name;
   }
 
   /**
@@ -310,8 +321,7 @@ export class NavbarRecentWorkspacesController {
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
 
     this.updateRecentWorkspace(workspaceId);
-    this.cheWorkspace.startWorkspace(workspace.id, workspace.config.defaultEnv).then(() => {
-    }, (error: any) => {
+    this.cheWorkspace.startWorkspace(workspace.id, workspace.config.defaultEnv).catch((error: any) => {
       this.$log.error(error);
     });
   }

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.html
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.html
@@ -27,7 +27,8 @@
                               navbar-dropdown-external-class="recent-workspaces-menu"
                               navbar-dropdown-offset="30 22">
           <md-button nav-bar-selected flex che-reload-href
-                     ng-href="{{navbarRecentWorkspacesController.getIdeLink(workspace.id)}}" layout-align="left"
+                     ng-href="{{navbarRecentWorkspacesController.getLink(workspace)}}"
+                     layout-align="left"
                      target="_self">
             <div class="navbar-item" layout="row" layout-align="start center">
               <workspace-status-indicator

--- a/dashboard/src/app/profile/profile.html
+++ b/dashboard/src/app/profile/profile.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/proxy/proxy-settings.constant.ts.template
+++ b/dashboard/src/app/proxy/proxy-settings.constant.ts.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/build-stack/build-stack.html
+++ b/dashboard/src/app/stacks/list-stacks/build-stack/build-stack.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.html
+++ b/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/list-stacks.html
+++ b/dashboard/src/app/stacks/list-stacks/list-stacks.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.html
+++ b/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.html
+++ b/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/list-components/list-components.html
+++ b/dashboard/src/app/stacks/stack-details/list-components/list-components.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/select-template/select-template.html
+++ b/dashboard/src/app/stacks/stack-details/select-template/select-template.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/stacks/stack-details/stack.html
+++ b/dashboard/src/app/stacks/stack-details/stack.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
@@ -16,6 +16,7 @@ import {StackSelectorScope} from './stack-selector-scope.enum';
 import {StackSelectorSvc} from './stack-selector.service';
 import {CheBranding} from '../../../../components/branding/che-branding.factory';
 import {ConfirmDialogService} from '../../../../components/service/confirm-dialog/confirm-dialog.service';
+import {CheWorkspace} from '../../../../components/api/workspace/che-workspace.factory';
 
 /**
  * @ngdoc controller
@@ -132,14 +133,26 @@ export class StackSelectorController {
    * The priority stacks to be placed before others (comes from configuration).
    */
   private priorityStacks: Array<string>;
+  /**
+   * List of supported types of recipes.
+   */
+  private supportedRecipeTypes: string[];
 
   /**
    * Default constructor that is using resource injection
    * @ngInject for Dependency injection
    */
-  constructor($filter: ng.IFilterService, $mdDialog: ng.material.IDialogService, lodash: any, cheStack: CheStack,
-              confirmDialogService: ConfirmDialogService, $location: ng.ILocationService, cheBranding: CheBranding,
-              cheEnvironmentRegistry: CheEnvironmentRegistry, stackSelectorSvc: StackSelectorSvc) {
+  constructor($filter: ng.IFilterService,
+              $mdDialog: ng.material.IDialogService,
+              $q: ng.IQService,
+              lodash: any,
+              cheStack: CheStack,
+              cheWorkspace: CheWorkspace,
+              confirmDialogService: ConfirmDialogService,
+              $location: ng.ILocationService,
+              cheBranding: CheBranding,
+              cheEnvironmentRegistry: CheEnvironmentRegistry,
+              stackSelectorSvc: StackSelectorSvc) {
     this.$filter = $filter;
     this.$location = $location;
     this.$mdDialog = $mdDialog;
@@ -165,8 +178,20 @@ export class StackSelectorController {
 
     this.stacks = this.stackSelectorSvc.getStacks();
     this.updateMachines();
-    this.buildStacksListsByScope();
-    this.buildFilteredList();
+
+    $q.when().then(() => {
+      const types = cheWorkspace.getSupportedRecipeTypes();
+      if (types.length) {
+        return $q.when(types);
+      }
+      return cheWorkspace.fetchWorkspaceSettings().then(() => {
+        return $q.when(cheWorkspace.getSupportedRecipeTypes());
+      });
+    }).then((recipeTypes: string[]) => {
+      this.supportedRecipeTypes = recipeTypes;
+      this.buildStacksListsByScope();
+      this.buildFilteredList();
+    });
   }
 
   /**
@@ -196,19 +221,19 @@ export class StackSelectorController {
       this.stackMachines[stack.id] = [];
       if (stack.workspaceConfig) {
         // get machines memory limits
-              const defaultEnv = stack.workspaceConfig.defaultEnv,
-                    environment = stack.workspaceConfig.environments[defaultEnv],
-                    environmentManager = this.getEnvironmentManager(environment.recipe.type);
-              if (environmentManager) {
-                let machines = environmentManager.getMachines(environment);
+        const defaultEnv = stack.workspaceConfig.defaultEnv,
+          environment = stack.workspaceConfig.environments[defaultEnv],
+          environmentManager = this.getEnvironmentManager(environment.recipe.type);
+        if (environmentManager) {
+          let machines = environmentManager.getMachines(environment);
 
-                machines.forEach((machine: any) => {
-                  this.stackMachines[stack.id].push({
-                    name: machine.name,
-                    memoryLimitBytes: environmentManager.getMemoryLimit(machine)
-                  });
-                });
-              }
+          machines.forEach((machine: any) => {
+            this.stackMachines[stack.id].push({
+              name: machine.name,
+              memoryLimitBytes: environmentManager.getMemoryLimit(machine)
+            });
+          });
+        }
       }
     });
   }
@@ -221,6 +246,14 @@ export class StackSelectorController {
 
     scopes.forEach((scope: StackSelectorScope) => {
       this.stacksByScope[scope] = this.$filter('stackScopeFilter')(this.stacks, scope, this.stackMachines);
+    });
+
+    // for quickstart do not show stacks based on unsupported recipe types
+    this.stacksByScope[StackSelectorScope.QUICK_START] = this.stacksByScope[StackSelectorScope.QUICK_START].filter((stack: che.IStack) => {
+      const defaultEnvName = stack.workspaceConfig.defaultEnv,
+        defaultEnv = stack.workspaceConfig.environments[defaultEnvName],
+        recipeType = defaultEnv.recipe.type;
+      return this.supportedRecipeTypes.indexOf(recipeType) !== -1;
     });
   }
 

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-item/workspace-item.html
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-item/workspace-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/environments.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/environments.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.html
+++ b/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.html
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.html
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.spec.ts
@@ -14,6 +14,7 @@ import {WorkspaceStatus} from '../../../../components/api/workspace/che-workspac
 interface ITestScope extends ng.IRootScopeService {
   model: {
     workspaceStatus?: string;
+    buttonDisabled?: boolean;
     onStopWorkspace: Function;
     onRunWorkspace: Function;
   };
@@ -65,6 +66,7 @@ describe('WorkspaceStatusButton >', () => {
 
     const element = $compile(angular.element(
       `<workspace-status-button workspace-status="model.workspaceStatus"
+                                button-disabled="model.buttonDisabled"
                                 on-run-workspace="model.onRunWorkspace()"
                                 on-stop-workspace="model.onStopWorkspace()"></workspace-status-button>`
     ))($rootScope);
@@ -72,6 +74,30 @@ describe('WorkspaceStatusButton >', () => {
 
     return element;
   }
+
+  describe(`button is disabled >`, () => {
+    let jqRunButton: ng.IAugmentedJQuery;
+    let jqStopButton: ng.IAugmentedJQuery;
+
+    beforeEach(() => {
+      $rootScope.model.buttonDisabled = true;
+
+      const jqElement = getCompiledElement(WorkspaceStatus.STOPPED);
+      jqRunButton = jqElement.find('#run-workspace-button button');
+      jqStopButton = jqElement.find('#stop-workspace-button button');
+    });
+
+    it('should have "Run" button disabled', () => {
+      // timeout should be flashed
+      $timeout.flush();
+
+      expect(jqRunButton.get(0)).toBeTruthy();
+      expect(jqRunButton.attr('disabled')).toBeTruthy();
+
+      expect(jqStopButton.get(0)).toBeFalsy();
+    });
+
+  });
 
   describe('initially STOPPED >', () => {
     let jqRunButton: ng.IAugmentedJQuery;

--- a/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.ts
@@ -12,6 +12,7 @@
 import {CheWorkspace, WorkspaceStatus} from '../../../../components/api/workspace/che-workspace.factory';
 
 interface IWorkspaceStatusButtonScope extends ng.IScope {
+  buttonDisabled: boolean;
   isDisabled: boolean;
   showStopButton: boolean;
   workspaceStatus: string;
@@ -48,6 +49,7 @@ export class CheWorkspaceStatusButton {
   // scope values
   scope = {
     workspaceStatus: '=',
+    buttonDisabled: '=',
     onRunWorkspace: '&',
     onStopWorkspace: '&'
   };

--- a/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.html
+++ b/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.html
@@ -1,7 +1,7 @@
 <div class="che-workspace-button">
   <che-button-default ng-if="showStopButton===false"
                       id="run-workspace-button"
-                      ng-disabled="isDisabled"
+                      ng-disabled="buttonDisabled || isDisabled"
                       che-button-title="Run"
                       ng-click="onRunWorkspace()"></che-button-default>
   <che-button-default ng-if="showStopButton"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -2,14 +2,18 @@
   che-title="{{workspaceDetailsController.workspaceName}}"
   link-href="#/workspaces" link-title="Workspaces" class="workspace-details-toolbar">
   <div layout="row" layout-align="start center" class="toolbar-info">
-    <workspace-status che-status="workspaceDetailsController.getWorkspaceStatus()"></workspace-status>
+    <!-- is environment supported -->
+    <workspace-status che-status="workspaceDetailsController.getWorkspaceStatus()"
+                      che-is-supported="workspaceDetailsController.isSupported === true"></workspace-status>
     <workspace-warnings workspace="workspaceDetailsController.workspaceDetails"></workspace-warnings>
   </div>
   <div flex layout="row" layout-align="end center">
     <workspace-status-button workspace-status="workspaceDetailsController.getWorkspaceStatus()"
+                             button-disabled="workspaceDetailsController.isSupported===false"
                              on-stop-workspace="workspaceDetailsController.stopWorkspace()"
                              on-run-workspace="workspaceDetailsController.runWorkspace()"></workspace-status-button>
     <che-button-default ng-if="workspaceDetailsController.editMode === false"
+                        ng-disabled="workspaceDetailsController.isSupported===false"
                         id="open-in-ide-button"
                         che-button-title="Open"
                         href="#/ide/{{workspaceDetailsController.namespaceId}}/{{workspaceDetailsController.workspaceName}}"></che-button-default>
@@ -174,7 +178,7 @@
 
 <workspace-edit-mode-overlay ng-if="workspaceDetailsController.workspaceDetails && workspaceDetailsController.editMode && !workspaceDetailsController.saving"
                              workspace-edit-mode-message="{{workspaceDetailsController.editModeMessage}}"
-                             workspace-edit-mode-show-message="workspaceDetailsController.showApplyMessage"
-                             workspace-edit-disable-save-button="workspaceDetailsController.isSaveButtonDisabled()"
+                             workspace-edit-mode-show-message="workspaceDetailsController.showOverlayMessage"
+                             workspace-edit-disable-save-button="workspaceDetailsController.isSupported===false || workspaceDetailsController.isSaveButtonDisabled()"
                              workspace-edit-mode-on-save="workspaceDetailsController.saveWorkspace()"
                              workspace-edit-mode-on-cancel="workspaceDetailsController.cancelConfigChanges()"></workspace-edit-mode-overlay>

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-details/repository/project-repository.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-details/repository/project-repository.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-item/project-item.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-item/project-item.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/app/workspaces/workspace-status/workspace-status.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-status/workspace-status.directive.ts
@@ -15,21 +15,17 @@
  * both icon and text representation of current status
  * @author Oleksii Kurinnyi
  */
-export class WorkspaceStatus {
+export class WorkspaceStatus implements ng.IDirective {
 
-  /**
-   * Default constructor that is using resource
-   * @ngInject for Dependency injection
-   */
-  constructor () {
-    this.restrict = 'E';
+  restrict = 'E';
 
-    this.replace = true;
-    this.templateUrl = 'app/workspaces/workspace-status/workspace-status.html';
+  replace = true;
+  templateUrl = 'app/workspaces/workspace-status/workspace-status.html';
 
-    // scope values
-    this.scope = {
-      status : '=cheStatus'
-    };
-  }
+  // scope values
+  scope = {
+    status: '=cheStatus',
+    isSupported: '=cheIsSupported'
+  };
+
 }

--- a/dashboard/src/app/workspaces/workspace-status/workspace-status.html
+++ b/dashboard/src/app/workspaces/workspace-status/workspace-status.html
@@ -1,4 +1,9 @@
 <div class="workspace-status" flex layout="row" layout-align="start center">
-  <workspace-status-indicator che-status="status"></workspace-status-indicator>
-  <span class="workspace-status-text" id="workspace-status">{{status | lowercase}}</span>
+  <span ng-if="isSupported">
+    <workspace-status-indicator che-status="status"></workspace-status-indicator>
+    <span class="workspace-status-text" id="workspace-status">{{status | lowercase}}</span>
+  </span>
+  <span ng-if="isSupported===false">
+    <span class="workspace-status-text">Not supported</span>
+  </span>
 </div>

--- a/dashboard/src/components/widget/button/che-button-default.directive.spec.ts
+++ b/dashboard/src/components/widget/button/che-button-default.directive.spec.ts
@@ -131,34 +131,6 @@ describe(`cheButtonDefault >`, () => {
 
     });
 
-    describe(`ngClick directive >`, () => {
-      let buttonEl;
-
-      beforeEach(() => {
-        $scope.model.ngClick = jasmine.createSpy('ngClick');
-        $scope.model.cheButtonTitle = 'Test button title';
-        compileDirective();
-
-        buttonEl = compiledDirective.find('button');
-      });
-
-      it(`should be applied >`, () => {
-        expect(buttonEl.attr('ng-click')).toBeDefined();
-      });
-
-      it(`should be removed from top-level element >`, () => {
-        expect(compiledDirective.find('che-button-default').attr('ng-click')).toBeUndefined();
-      });
-
-      it(`should call a callback when clicked >`, () => {
-        buttonEl.click();
-        $scope.$digest();
-
-        expect($scope.model.ngClick).toHaveBeenCalled();
-      });
-
-    });
-
     describe(`ngDisable directive >`, () => {
       let buttonEl;
 
@@ -181,6 +153,52 @@ describe(`cheButtonDefault >`, () => {
         $scope.$digest();
 
         expect(buttonEl.attr('disabled')).toBeTruthy();
+      });
+
+    });
+
+    describe(`ngClick directive >`, () => {
+      let buttonEl;
+      let counter = 0;
+
+      beforeEach(() => {
+        $scope.model.ngClick = jasmine.createSpy('ngClick')
+          .and.callFake(() => {
+            // count number of calls
+            counter++;
+        });
+        $scope.model.ngDisabled = false;
+        $scope.model.cheButtonTitle = 'Test button title';
+        compileDirective();
+
+        buttonEl = compiledDirective.find('button');
+      });
+
+      it(`should call a callback when clicked >`, () => {
+        buttonEl.click();
+        $scope.$digest();
+
+        expect($scope.model.ngClick).toHaveBeenCalled();
+      });
+
+      it(`should call a callback exactly once >`, () => {
+        counter = 0;
+
+        buttonEl.click();
+        $scope.$digest();
+
+        expect(counter).toEqual(1);
+      });
+
+      describe(`when button is disabled >`, () => {
+
+        it(`shouldn't to call a callback when clicked >`, () => {
+          $scope.model.ngDisabled = true;
+          $scope.$digest();
+
+          expect($scope.model.ngClick).not.toHaveBeenCalled();
+        });
+
       });
 
     });

--- a/dashboard/src/components/widget/button/che-button-default.directive.spec.ts
+++ b/dashboard/src/components/widget/button/che-button-default.directive.spec.ts
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import {CheHttpBackend} from '../../api/test/che-http-backend';
+
+interface ITestScope extends ng.IScope {
+  model: {
+    href?: string;
+    target?: string;
+    tabindex?: number|string;
+    ngHref?: any;
+    ngClick?: any;
+    ngDisabled?: any;
+    cheButtonIcon?: string;
+    cheButtonTitle?: string;
+  };
+}
+
+describe(`cheButtonDefault >`, () => {
+
+  let $scope: ITestScope ;
+
+  let $compile: ng.ICompileService;
+
+  let $timeout: ng.ITimeoutService;
+
+  let compiledDirective;
+
+  /**
+   *  setup module
+   */
+  beforeEach(angular.mock.module('userDashboard'));
+
+  beforeEach(inject((_$compile_: ng.ICompileService,
+                     _$timeout_: ng.ITimeoutService,
+                     _$rootScope_: ng.IRootScopeService,
+                     _cheHttpBackend_: CheHttpBackend) => {
+    $scope = _$rootScope_.$new() as ITestScope;
+    $compile = _$compile_;
+    $timeout = _$timeout_;
+
+    const $httpBackend = _cheHttpBackend_.getHttpBackend();
+    // avoid tracking requests from branding controller
+    $httpBackend.whenGET(/.*/).respond(200, '');
+    $httpBackend.when('OPTIONS', '/api/').respond({});
+  }));
+
+  beforeEach(() => {
+    $scope.model = {};
+  });
+
+  afterEach(() => {
+    $timeout.verifyNoPendingTasks();
+  });
+
+  function compileDirective(): void {
+
+    let buttonTemplate = `<div><che-button-default`;
+    if ($scope.model.cheButtonTitle) {
+      buttonTemplate += ` che-button-title="{{model.cheButtonTitle}}" `;
+    }
+    if ($scope.model.cheButtonIcon) {
+      // fa fa-check-square
+      buttonTemplate += ` che-button-icon="{{model.cheButtonIcon}}" `;
+    }
+    if ($scope.model.href) {
+      buttonTemplate += ` href="{{model.href}}" `;
+    }
+    if ($scope.model.ngHref !== undefined) {
+      buttonTemplate += ` ng-href="model.ngHref" `;
+    }
+    if ($scope.model.ngClick !== undefined) {
+      buttonTemplate += ` ng-click="model.ngClick()" `;
+    }
+    if ($scope.model.tabindex) {
+      buttonTemplate += ` tabindex="{{model.tabindex}}" `;
+    }
+    if ($scope.model.target) {
+      buttonTemplate += ` target="{{model.target}}" `;
+    }
+    if ($scope.model.ngDisabled !== undefined) {
+      buttonTemplate += ` ng-disabled="model.ngDisabled" `;
+    }
+    buttonTemplate += `></che-button-default></div>`;
+
+    compiledDirective = $compile(angular.element( buttonTemplate ))($scope);
+    $timeout.flush();
+    $scope.$digest();
+  }
+
+  it(`directive compiled successfully >`, () => {
+    $scope.model.cheButtonTitle = 'Test button title';
+    compileDirective();
+
+    expect(compiledDirective.find('che-button-default').length).toEqual(1);
+  });
+
+  describe(`BUTTON >`, () => {
+
+    it(`should have correct title >`, () => {
+      $scope.model.cheButtonTitle = 'Test button title';
+      compileDirective();
+
+      expect(compiledDirective.find('button').html()).toContain('Test button title');
+    });
+
+    describe(`'tabindex' attribute >`, () => {
+
+      beforeEach(() => {
+        $scope.model.cheButtonTitle = 'Test button title';
+        $scope.model.tabindex = '3';
+        compileDirective();
+      });
+
+      it(`should be applied correctly >`, () => {
+        expect(compiledDirective.find('button').attr('tabindex')).toEqual($scope.model.tabindex);
+      });
+
+      it(`should be removed from top-level element >`, () => {
+        expect(compiledDirective.find('che-button-default').attr('tabindex')).toBeUndefined();
+      });
+
+    });
+
+    describe(`ngClick directive >`, () => {
+      let buttonEl;
+
+      beforeEach(() => {
+        $scope.model.ngClick = jasmine.createSpy('ngClick');
+        $scope.model.cheButtonTitle = 'Test button title';
+        compileDirective();
+
+        buttonEl = compiledDirective.find('button');
+      });
+
+      it(`should be applied >`, () => {
+        expect(buttonEl.attr('ng-click')).toBeDefined();
+      });
+
+      it(`should be removed from top-level element >`, () => {
+        expect(compiledDirective.find('che-button-default').attr('ng-click')).toBeUndefined();
+      });
+
+      it(`should call a callback when clicked >`, () => {
+        buttonEl.click();
+        $scope.$digest();
+
+        expect($scope.model.ngClick).toHaveBeenCalled();
+      });
+
+    });
+
+    describe(`ngDisable directive >`, () => {
+      let buttonEl;
+
+      beforeEach(() => {
+        $scope.model.cheButtonTitle = 'Test button title';
+        $scope.model.ngDisabled = false;
+
+        compileDirective();
+        buttonEl = compiledDirective.find('button');
+      });
+
+      it(`should be applied >`, () => {
+        expect(buttonEl.attr('ng-disabled')).toBeDefined();
+      });
+
+      it(`should add 'disable' attribute >`, () => {
+        expect(buttonEl.attr('disabled')).toBeFalsy();
+
+        $scope.model.ngDisabled = true;
+        $scope.$digest();
+
+        expect(buttonEl.attr('disabled')).toBeTruthy();
+      });
+
+    });
+
+  });
+
+  describe(`A >`, () => {
+
+    it(`should have correct title >`, () => {
+      $scope.model.cheButtonTitle = 'Test button title';
+      $scope.model.href = 'http://';
+      compileDirective();
+
+      expect(compiledDirective.find('a').html()).toContain('Test button title');
+    });
+
+    it(`should correctly apply 'href' attribute >`, () => {
+      $scope.model.cheButtonTitle = 'Test button title';
+      $scope.model.href = 'http://';
+      compileDirective();
+
+      expect(compiledDirective.find('a').attr('href')).toContain($scope.model.href);
+    });
+
+    it(`should correctly apply 'ng-href' attribute >`, () => {
+      $scope.model.cheButtonTitle = 'Test button title';
+      $scope.model.ngHref = () => { return 'http://'; };
+      compileDirective();
+
+      expect(compiledDirective.find('a').attr('ng-href')).toBeDefined();
+    });
+
+    it(`should correctly apply 'target' attribute >`, () => {
+      $scope.model.cheButtonTitle = 'Test button title';
+      $scope.model.ngHref = 'http://';
+      $scope.model.target = '_self';
+      compileDirective();
+
+      expect(compiledDirective.find('a').attr('target')).toEqual('_self');
+    });
+
+  });
+
+});

--- a/dashboard/src/components/widget/button/che-button-default.directive.spec.ts
+++ b/dashboard/src/components/widget/button/che-button-default.directive.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dashboard/src/components/widget/button/che-button.directive.ts
+++ b/dashboard/src/components/widget/button/che-button.directive.ts
@@ -51,7 +51,7 @@ export abstract class CheButton implements ng.IDirective {
   abstract getTemplateStart(): string;
 
   compile($element: ng.IAugmentedJQuery, $attrs: ICheButtonAttributes): ng.IDirectivePrePost {
-    const avoidAttrs = ['ng-model'];
+    const avoidAttrs = ['ng-model', 'ng-click'];
     const allowedAttrPrefixes = ['ng-'];
     const allowedAttributes = ['href', 'target', 'tabindex'];
 

--- a/dashboard/src/components/widget/button/che-button.directive.ts
+++ b/dashboard/src/components/widget/button/che-button.directive.ts
@@ -10,78 +10,83 @@
  */
 'use strict';
 
+export interface ICheButtonAttributes extends ng.IAttributes {
+  cheButtonIcon: string;
+  cheButtonTitle: string;
+  href: string;
+  target: string;
+  tabindex: string;
+  ngHref: string;
+  ngClick: string;
+  ngDisabled: string;
+}
 
 /**
  * Defines the super class for for all buttons
  * @author Florent Benoit
  */
-export abstract class CheButton {
+export abstract class CheButton implements ng.IDirective {
   restrict: string = 'E';
   bindToController: boolean = true;
 
   /**
-   * Template for the current toolbar
-   * @param element
-   * @param attrs
+   * Template for the current button
+   * @param $element
+   * @param $attrs
    * @returns {string} the template
    */
-  template(element: ng.IAugmentedJQuery, attrs: any) {
+  template($element: ng.IAugmentedJQuery, $attrs: ICheButtonAttributes) {
     let template: string = this.getTemplateStart();
-
-    if (attrs.href) {
-      template = template + ` href="${attrs.href}"`;
-    }
-
-    if (attrs.target) {
-      template = template + ` target="${attrs.target}"`;
-    }
-
-    if (attrs.ngClick) {
-      template = template + ` ng-click="${attrs.ngClick}"`;
-    }
-
-    if (attrs.ngHref) {
-      template = template + ` ng-href="${attrs.ngHref}"`;
-    }
-
-    if (attrs.ngDisabled) {
-      template = template + ` disabled="${attrs.ngHref}"`;
-    }
 
     template = template + '>';
 
-    if (attrs.cheButtonIcon) {
-      template = template + `<md-icon md-font-icon="${attrs.cheButtonIcon}" flex layout="column" layout-align="start center"></md-icon>`;
+    if ($attrs.cheButtonIcon) {
+      template = template + `<md-icon md-font-icon="${$attrs.cheButtonIcon}" flex layout="column" layout-align="start center"></md-icon>`;
     }
 
-
-    template = template + attrs.cheButtonTitle + '</md-button>';
+    template = template + $attrs.cheButtonTitle + '</md-button>';
     return template;
   }
 
   abstract getTemplateStart(): string;
 
-  compile(element: ng.IAugmentedJQuery, attrs: any) {
-    let button = element.find('button');
-    if (attrs && attrs.tabindex) {
-      button.attr('tabindex', attrs.tabindex);
-    } else {
-      button.attr('tabindex', 0);
-    }
-    // top level element doesn't have tabindex, only the button has
-    element.attr('tabindex', -1);
+  compile($element: ng.IAugmentedJQuery, $attrs: ICheButtonAttributes): ng.IDirectivePrePost {
+    const avoidAttrs = ['ng-model'];
+    const allowedAttrPrefixes = ['ng-'];
+    const allowedAttributes = ['href', 'target', 'tabindex'];
 
-    attrs.$set('ngClick', undefined);
-  }
+    const mdButtonEl = $element.find('md-button');
 
-  /**
-   * Re-apply ng-disabled on child
-   */
-  link($scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: any) {
-    $scope.$watch(attrs.ngDisabled, function (isDisabled: boolean) {
-      element.find('button').prop('disabled', isDisabled);
+    const keys = Object.keys($attrs.$attr);
+    keys.forEach((key: string) => {
+      const attr = $attrs.$attr[key];
+      if (!attr) {
+        return;
+      }
+      if (avoidAttrs.indexOf(attr) !== -1) {
+        return;
+      }
+
+      const isAllowedPrefix = allowedAttrPrefixes.some((prefix: string) => {
+        return attr.indexOf(prefix) === 0;
+      });
+      const isAllowedAttribute = allowedAttributes.some((_attr: string) => {
+        return attr === _attr;
+      });
+      if (!isAllowedAttribute && !isAllowedPrefix) {
+        return;
+      }
+
+      let value = $attrs[key];
+      if (attr === 'tabindex') {
+        value = value || 0;
+      }
+
+      mdButtonEl.attr(attr, value);
+      $attrs.$set(attr, null);
     });
 
+    return;
   }
 
 }

--- a/dashboard/src/components/widget/button/che-button.styl
+++ b/dashboard/src/components/widget/button/che-button.styl
@@ -72,3 +72,13 @@ che-button-save-flat:not([disabled]) .md-button:hover,
 che-button-cancel-flat:not([disabled]) .md-button:hover,
 che-button-primary:not([disabled]) .md-button:hover
   che-brightness(90%)
+
+che-button-danger,
+che-button-notice,
+che-button-warning,
+che-button-default,
+che-button-save-flat,
+che-button-cancel-flat,
+che-button-primary
+  button.md-button.che-button[disabled] span
+    pointer-events none

--- a/dashboard/src/components/widget/html-source/che-html-source.html
+++ b/dashboard/src/components/widget/html-source/che-html-source.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/components/widget/input/che-input-box.directive.ts
+++ b/dashboard/src/components/widget/input/che-input-box.directive.ts
@@ -50,7 +50,7 @@ export class CheInputBox {
   };
 
 
-  compile(element: ng.IRootElementService, attrs: ng.IAttributes) {
+  compile(element: ng.IAugmentedJQuery, attrs: ng.IAttributes): ng.IDirectivePrePost {
     const avoidAttrs = ['ng-model'];
     const avoidStartWithAttrs: Array<string> = ['$', 'che-'];
 
@@ -87,6 +87,8 @@ export class CheInputBox {
     if (!tabIndex) {
       inputJqEl.attr('tabindex', 0);
     }
+
+    return;
   }
 
   /**

--- a/dashboard/src/components/widget/input/che-input.directive.ts
+++ b/dashboard/src/components/widget/input/che-input.directive.ts
@@ -127,7 +127,7 @@ export class CheInput implements ng.IDirective {
     return template;
   }
 
-  compile(element: ng.IRootElementService, attrs: ng.IAttributes): ng.IDirectiveCompileFn {
+  compile(element: ng.IAugmentedJQuery, attrs: ng.IAttributes): ng.IDirectiveCompileFn {
     const tabindex = 'tabindex';
     const avoidAttrs = ['ng-model', 'ng-change'];
     const avoidStartWithAttrs: Array<string> = ['$', 'che-'];

--- a/dashboard/src/components/widget/popup/che-modal-popup.html
+++ b/dashboard/src/components/widget/popup/che-modal-popup.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/components/widget/popup/che-popup.html
+++ b/dashboard/src/components/widget/popup/che-popup.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/gitHubCallback.html
+++ b/dashboard/src/gitHubCallback.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015-2017 Red Hat, Inc.
+    Copyright (c) 2015-2018 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
For a workspace with unsupported recipe type, 
in navbar:
- prevents to open a workspace in IDE, opens Workspace Details page instead;

on Workspace Details page:
- prevents to start a workspace, open it in IDE or update its config;
- displays "Not supported" instead of current status;

![screenshot-localhost-3000-2018-01-11-16-50-29-920](https://user-images.githubusercontent.com/16220722/34831570-04f34f74-f6f0-11e7-9034-53b0c4c2dc2b.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8139

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
