### PR TITLE
Openshift ocp fails due to livenessProbe.

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/keycloak/deployment-config.yaml
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/keycloak/deployment-config.yaml
@@ -39,7 +39,7 @@ spec:
         image: ' '
         name: keycloak
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 11
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1


### PR DESCRIPTION
### What does this PR do?
The livenessProbe's failureThreshold is set to low. This causes the livenessProbe having to short a period of probing before it fails and removes the container. The failureThreshold is set to 4, the initialDelaySeconds is set to 5 and the periodSeconds is 5. This means 5s+4x5s=25s before the container fails. This patch set failureThreshold higher to 11 allowing for a more reasonable overall probe time of 60s (5s+11x5s=60s) before fails and removes the container.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7799

#### Release Notes
N/A

Signed-off-by: James Drummond <james@devcomb.com>
