### PR TITLE
che-8250: fix github redirect url, when no port is defined

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
@@ -235,9 +235,11 @@ export class ImportGithubProjectController {
    * @param {string} token
    */
   openGithubPopup(token: string): void {
+    // given URL http://example.com - returns port => 80, which causes wrong redirect URL value:
+    let port = this.$location.port() === 80 ? '' : ':' + this.$location.port();
     const redirectUrl = this.$location.protocol() + '://'
-      + this.$location.host() + ':'
-      + this.$location.port()
+      + this.$location.host()
+      + port
       + (this.$browser as any).baseHref()
       + 'gitHubCallback.html';
     let link = '/api/oauth/authenticate'


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

### What does this PR do?
There is the difference between the port detection in native JavaScript and angular for the following format of the URL: 

` http://example.com/#/some/path`

`var port = $location.port(); // => 80`
`var port = location.port; // => empty string`
so in this case the redirect URL used to have "80" port appended which is correct, but did not pass validation in keycloak, cause defined URLs have the following format:
![screenshot from 2018-01-12 14-15-08](https://user-images.githubusercontent.com/1611939/34874805-2dde5a2e-f7a3-11e7-8f0a-72986f4ea6a5.png)

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/8250

#### Release Notes
N/A

#### Docs PR
N/A
