### PR TITLE
Selenium: Fix unexpected fails in the "FormatterTest", "CheckRestoringSplitEditorTest", "CheckIntelligenceCommandFromToolbarTest" selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/FormatterTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/FormatterTest.java
@@ -34,7 +34,7 @@ public class FormatterTest {
       NameGenerator.generate(FormatterTest.class.getSimpleName(), 4);
   private static final String FORMATTED_TEXT =
       "/*\n"
-          + " * Copyright (c) 2012-2017 Red Hat, Inc.\n"
+          + " * Copyright (c) 2012-2018 Red Hat, Inc.\n"
           + " * All rights reserved. This program and the accompanying materials\n"
           + " * are made available under the terms of the Eclipse Public License v1.0\n"
           + " * which accompanies this distribution, and is available at\n"

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.W
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MULTIPLE;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
@@ -107,7 +108,13 @@ public class CheckIntelligenceCommandFromToolbarTest {
 
     waitOnAvailablePreviewPage(currentWindow, "Enter your name:");
     Assert.assertTrue(commandsToolbar.getTimerValue().matches("\\d\\d:\\d\\d"));
-    Assert.assertTrue(commandsToolbar.getNumOfProcessCounter().equals("#2"));
+
+    try {
+      Assert.assertTrue(commandsToolbar.getNumOfProcessCounter().equals("#2"));
+    } catch (AssertionError ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8277");
+    }
 
     commandsToolbar.clickOnPreviewCommandBtnAndSelectUrl("dev-machine:tomcat8");
     checkTestAppAndReturnToIde(currentWindow, "Enter your name:");

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/editor/split-editor-restore-exp-text.txt
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/editor/split-editor-restore-exp-text.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 Red Hat, Inc.
+ * Copyright (c) 2012-2018 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix unexpected fails in the "FormatterTest", "CheckRestoringSplitEditorTest", "CheckIntelligenceCommandFromToolbarTest" selenium tests

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/8270
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
