### PR TITLE
Selenium: unexpected fail of CreateWorkspaceOnDashboardTest and ServerRuntimeInfoTest tests 

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/CreateWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/CreateWorkspace.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.pageobject.dashboard;
 
 import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
@@ -196,7 +197,8 @@ public class CreateWorkspace {
   }
 
   public void waitToolbar() {
-    redrawUiElementsTimeout.until(visibilityOfElementLocated(By.id(Locators.TOOLBAR_TITLE_ID)));
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(visibilityOfElementLocated(By.id(Locators.TOOLBAR_TITLE_ID)));
   }
 
   public String getTextFromSearchInput() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ServerRuntimeInfoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ServerRuntimeInfoTest.java
@@ -27,6 +27,17 @@ import org.testng.annotations.Test;
 /** @author Vlad Zhukovskyi */
 public class ServerRuntimeInfoTest {
 
+  private List<String> expectedReferenceList =
+      Lists.newArrayList(
+          "codeserver",
+          "tomcat8",
+          "tomcat8-debug",
+          "wsagent/ws",
+          "exec-agent/ws",
+          "wsagent/http",
+          "exec-agent/http",
+          "wsagent-debug");
+
   @Inject private TestWorkspace testWorkspace;
   @Inject private Loader loader;
   @Inject private Consoles consoles;
@@ -51,20 +62,8 @@ public class ServerRuntimeInfoTest {
     consoles.waitTabNameProcessIsPresent("Servers");
     consoles.waitExpectedTextIntoServerTableCation("Servers of dev-machine:");
 
-    List<String> expectedReferenceList =
-        Lists.newArrayList(
-            "codeserver",
-            "tomcat8",
-            "tomcat8-debug",
-            "wsagent/ws",
-            "exec-agent/ws",
-            "wsagent/http",
-            "exec-agent/http",
-            "wsagent-debug");
-
-    for (int i = 0; i < expectedReferenceList.size(); i++) {
-      String referenceId = "gwt-debug-runtime-info-reference-" + i;
-      consoles.checkReferenceList(referenceId, expectedReferenceList.get(i));
+    for (String server : expectedReferenceList) {
+      consoles.checkThatServerExists(server);
     }
 
     consoles.clickOnHideInternalServers();


### PR DESCRIPTION
### What does this PR do?
This PR:
- in **CreateWorkspace** page object increases timeout for waiting that the **Create New Workspace page** is opened after clicking on the **Add Workspace** button (sometimes existed 5 sec is not enough to opening this page)(CreateWorkspaceOnDashboardTest);
- in **ServerRuntimeInfoTest** selenium test changes a way for checking a servers list in the **Servers** tab. It is need because the servers list in not always shows in particular order and the test fails.
![selection_132](https://user-images.githubusercontent.com/7760565/34875690-ff6bb89a-f7a6-11e7-8eb7-fa3445a7d456.png)
