### PR TITLE
Selenium: add checking that a machine name is clickable in the Consoles page object

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.selenium.pageobject;
 
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
@@ -29,10 +31,14 @@ import java.util.List;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.action.ActionsFactory;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 /** @author Aleksandr Shmaraev */
@@ -393,10 +399,15 @@ public class Consoles {
   }
 
   public void openServersTabFromContextMenu(String machineName) {
+    Wait<WebDriver> wait =
+        new FluentWait<WebDriver>(seleniumWebDriver)
+            .withTimeout(ELEMENT_TIMEOUT_SEC, SECONDS)
+            .pollingEvery(500, MILLISECONDS)
+            .ignoring(WebDriverException.class);
+
     WebElement machine =
-        redrawDriverWait.until(
-            visibilityOfElementLocated(By.xpath(format(MACHINE_NAME, machineName))));
-    machine.click();
+        wait.until(visibilityOfElementLocated(By.xpath(format(MACHINE_NAME, machineName))));
+    wait.until(visibilityOf(machine)).click();
 
     actionsFactory.createAction(seleniumWebDriver).moveToElement(machine).contextClick().perform();
     redrawDriverWait.until(visibilityOf(serversMenuItem)).click();


### PR DESCRIPTION
### What does this PR do?
This PR adds checking that a machine name in the **Processes** area is clickable before opening the **Servers** list. Sometimes the **Loader** can be opened and it will receive the click.

**Failed selenium test:** WorkspaceDetailsSingleMachineTest

**Log:**
```
org.openqa.selenium.WebDriverException: 
unknown error: Element <span class="GIWAMGHBPT">...</span> is not clickable at point (336, 743). Other element would receive the click: <div id="gwt-debug-glass-panel" class="GIWAMGHBBCB">...</div>
Session ID: 087777f0-4192-4d18-9984-a360e20c9c4d
	at org.eclipse.che.selenium.dashboard.WorkspaceDetailsSingleMachineTest.checkServerInServersList(WorkspaceDetailsSingleMachineTest.java:255)
	at org.eclipse.che.selenium.dashboard.WorkspaceDetailsSingleMachineTest.startWorkspaceAndCheckChanges(WorkspaceDetailsSingleMachineTest.java:226)
Caused by: org.openqa.selenium.remote.ScreenshotException: 
```
**Screenshot:**
![org eclipse che selenium dashboard workspacedetailssinglemachinetest startworkspaceandcheckchanges_htjthkg3](https://user-images.githubusercontent.com/7760565/34939079-3e7f2dc0-f9f3-11e7-9744-a0e34d8c0cb6.png)
