### PR TITLE
Selenium: Add the 'Assert.fail()' to the tests from the 'opendeclaration' package 

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.opendeclaration;
 
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.WARNING_MARKER;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -23,6 +24,7 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,7 +59,14 @@ public class Eclipse0093Test {
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByPath(PROJECT_NAME + PATH_TO_PACKAGE_PREFIX + "Test.java");
     editor.waitActive();
-    editor.waitMarkerInPosition(WARNING_MARKER, 12);
+
+    try {
+      editor.waitMarkerInPosition(WARNING_MARKER, 12);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
+    }
+
     editor.goToCursorPositionVisible(17, 26);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("MyEnum");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.opendeclaration;
 
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkersType.WARNING_MARKER;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -23,6 +24,7 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,7 +59,14 @@ public class Eclipse0115Test {
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByPath(PROJECT_NAME + PATH_TO_PACKAGE_PREFIX + "X.java");
     editor.waitActive();
-    editor.waitMarkerInPosition(WARNING_MARKER, 14);
+
+    try {
+      editor.waitMarkerInPosition(WARNING_MARKER, 14);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
+    }
+
     editor.goToCursorPositionVisible(32, 14);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitSpecifiedValueForLineAndChar(35, 24);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0121Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0121Test.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.opendeclaration;
 
+import static org.testng.Assert.fail;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -21,6 +23,7 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,7 +60,14 @@ public class Eclipse0121Test {
     editor.waitActive();
     editor.goToCursorPositionVisible(15, 43);
     editor.typeTextIntoEditor(Keys.F4.toString());
-    editor.waitTabIsPresent("Collections");
+
+    try {
+      editor.waitTabIsPresent("Collections");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
+    }
+
     editor.waitSpecifiedValueForLineAndChar(14, 35);
   }
 }


### PR DESCRIPTION

### What does this PR do?
* Add the 'Assert.fail()' to the selenium tests from the 'opendeclaration' package related to known issue #7161 
* Related selenium tests: _Eclipse0093Test_, _Eclipse0115Test_, _Eclipse0121Test_
### What issues does this PR fix or reference?
#8292  

