### PR TITLE
Selenium: add info about known issue into unstable FileStructureNodesTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureNodesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureNodesTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.selenium.miscellaneous;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FILE_STRUCTURE;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SIMPLE;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -24,6 +25,7 @@ import org.eclipse.che.selenium.pageobject.FileStructure;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.openqa.selenium.WebDriverException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -124,7 +126,14 @@ public class FileStructureNodesTest {
     // check work nodes in the 'file structure' by double click
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
-    fileStructure.waitExpectedTextInFileStructure(ITEMS_CLASS);
+
+    try {
+      fileStructure.waitExpectedTextInFileStructure(ITEMS_CLASS);
+    } catch (WebDriverException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8294");
+    }
+
     fileStructure.waitExpectedTextInFileStructure(ITEMS_INNER_CLASS);
     fileStructure.selectItemInFileStructureByDoubleClick(INNER_CLASS_NAME);
     fileStructure.waitExpectedTextIsNotPresentInFileStructure(ITEMS_INNER_CLASS);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureNodesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureNodesTest.java
@@ -131,7 +131,7 @@ public class FileStructureNodesTest {
       fileStructure.waitExpectedTextInFileStructure(ITEMS_CLASS);
     } catch (WebDriverException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8294");
+      fail("Known issue https://github.com/eclipse/che/issues/8300");
     }
 
     fileStructure.waitExpectedTextInFileStructure(ITEMS_INNER_CLASS);


### PR DESCRIPTION
### What does this PR do?
This PR adds info about known issue into unstable **FileStructureNodesTest** selenium test.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8300