### PR TITLE
Change shm size in a container for fixing problem with unexpected crashing of browser tabs

### DIFF
--- a/selenium/che-selenium-test/docker-compose.yml
+++ b/selenium/che-selenium-test/docker-compose.yml
@@ -43,6 +43,7 @@ services:
         soft: 163840
         hard: 163840
     restart: always
+    shm_size: 1g
 
 networks:
     selenium_grid_internal:


### PR DESCRIPTION
### What does this PR do?
Increase of size shm memory for chrome node. This prevent problem with overflowing of shm memory in the container and unexpected crashing of browser tabs and terminating sessions

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7887
@vparfonov @riuvshin @tolusha 