### PR TITLE
Use URIs in Language Server API calls

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/smartTree/NodeLoader.java
@@ -131,7 +131,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
       }
 
       // Iterate on nested descendants to make additional load request
-      if (childRequested.remove(parent)) {
+      if (Boolean.TRUE.equals(childRequested.remove(parent))) {
         for (Node node : tree.getNodeStorage().getChildren(parent)) {
           if (tree.isExpanded(node) && !tree.getNodeDescriptor(node).getChildren().isEmpty()) {
             loadChildren(node, true);
@@ -366,6 +366,7 @@ public class NodeLoader implements LoaderHandler.HasLoaderHandlers {
     return children -> {
       if (nodeInterceptors.isEmpty()) {
         onLoadSuccess(parent, children);
+        return;
       }
 
       LinkedList<NodeInterceptor> sortedByPriorityQueue = new LinkedList<>(nodeInterceptors);

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/OpenDeclarationFinder.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/editor/OpenDeclarationFinder.java
@@ -38,6 +38,7 @@ import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExternalLibrariesParameters;
 import org.eclipse.che.jdt.ls.extension.api.dto.JarEntry;
+import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 
 /**
  * @author Evgen Vidolob
@@ -49,7 +50,8 @@ public class OpenDeclarationFinder {
   private final EditorAgent editorAgent;
   private DtoFactory dtoFactory;
   private final JavaNavigationService navigationService;
-  private JavaLanguageExtensionServiceClient extensionService;
+  private final JavaLanguageExtensionServiceClient extensionService;
+  private final TextDocumentServiceClient textDocumentService;
   private final AppContext appContext;
   private JavaNodeFactory javaNodeFactory;
 
@@ -59,12 +61,14 @@ public class OpenDeclarationFinder {
       DtoFactory dtoFactory,
       JavaNavigationService navigationService,
       JavaLanguageExtensionServiceClient extensionService,
+      TextDocumentServiceClient textDocumentService,
       AppContext appContext,
       JavaNodeFactory javaNodeFactory) {
     this.editorAgent = editorAgent;
     this.dtoFactory = dtoFactory;
     this.navigationService = navigationService;
     this.extensionService = extensionService;
+    this.textDocumentService = textDocumentService;
     this.appContext = appContext;
     this.javaNodeFactory = javaNodeFactory;
   }
@@ -205,8 +209,8 @@ public class OpenDeclarationFinder {
     params.setNodeId(descriptor.getLibId());
     params.setNodePath(entry.getPath());
     params.setProjectUri(projectPath.toString());
-    extensionService
-        .libraryNodeContentByPath(params)
+    textDocumentService
+        .getFileContent(entry.getUri())
         .then(
             content -> {
               final VirtualFile file =

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructurePresenter2.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructurePresenter2.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
 import org.eclipse.che.jdt.ls.extension.api.dto.FileStructureCommandParameters;
 import org.eclipse.che.plugin.languageserver.ide.filestructure.ElementSelectionDelegate;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.che.plugin.languageserver.ide.util.OpenFileInEditorHelper;
 
 /**
@@ -36,6 +37,7 @@ public class FileStructurePresenter2
   private final FileStructureWindow view;
   private final JavaLanguageExtensionServiceClient javaExtensionService;
   private final OpenFileInEditorHelper openHelper;
+  private final DtoBuildHelper dtoHelper;
   private final MessageLoader loader;
 
   private TextEditor activeEditor;
@@ -46,10 +48,12 @@ public class FileStructurePresenter2
       FileStructureWindow view,
       JavaLanguageExtensionServiceClient javaExtensionService,
       OpenFileInEditorHelper openHelper,
+      DtoBuildHelper dtoHelper,
       LoaderFactory loaderFactory) {
     this.view = view;
     this.javaExtensionService = javaExtensionService;
     this.openHelper = openHelper;
+    this.dtoHelper = dtoHelper;
     this.loader = loaderFactory.newLoader();
     this.view.setDelegate(this);
   }
@@ -68,8 +72,7 @@ public class FileStructurePresenter2
       javaExtensionService
           .fileStructure(
               new DtoClientImpls.FileStructureCommandParametersDto(
-                  new FileStructureCommandParameters(
-                      file.getLocation().toString(), showInheritedMembers)))
+                  new FileStructureCommandParameters(dtoHelper.getUri(file), showInheritedMembers)))
           .then(
               result -> {
                 loader.hide();
@@ -94,8 +97,7 @@ public class FileStructurePresenter2
       javaExtensionService
           .fileStructure(
               new DtoClientImpls.FileStructureCommandParametersDto(
-                  new FileStructureCommandParameters(
-                      file.getLocation().toString(), showInheritedMembers)))
+                  new FileStructureCommandParameters(dtoHelper.getUri(file), showInheritedMembers)))
           .then(
               result -> {
                 loader.hide();

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/PackageNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/PackageNode.java
@@ -19,8 +19,6 @@ import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.api.promises.client.js.Executor;
 import org.eclipse.che.api.promises.client.js.JsPromiseError;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
-import org.eclipse.che.ide.resource.Path;
-import org.eclipse.che.ide.rest.UrlBuilder;
 import org.eclipse.che.ide.ui.smartTree.data.AbstractTreeNode;
 import org.eclipse.che.ide.ui.smartTree.data.Node;
 import org.eclipse.che.ide.ui.smartTree.presentation.HasNewPresentation;
@@ -60,10 +58,7 @@ public class PackageNode extends AbstractTreeNode implements HasNewPresentation 
   @Override
   public NewNodePresentation getPresentation() {
     String container =
-        new Path(new UrlBuilder(pkg.getUri()).getPath())
-            .removeFirstSegments(1)
-            .makeRelative()
-            .toString();
+        UsagesNode.toPath(pkg.getUri()).removeFirstSegments(1).makeRelative().toString();
     return new NewNodePresentation.Builder()
         .withIcon(resources.packageItem())
         .withNodeText(pkg.getName())

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/UsagesNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/UsagesNode.java
@@ -128,7 +128,7 @@ public class UsagesNode extends AbstractTreeNode implements HasNewPresentation {
     }
   }
 
-  private static Path toPath(String uri) {
-    return new Path(new UrlBuilder(uri).getPath());
+  static Path toPath(String uri) {
+    return uri.startsWith("/") ? new Path(uri) : new Path(new UrlBuilder(uri).getPath());
   }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
@@ -19,7 +19,6 @@ import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARIES;
 import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARIES_CHILDREN;
 import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARY_CHILDREN;
 import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARY_ENTRY;
-import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_NODE_CONTENT;
 import static org.eclipse.che.ide.ext.java.shared.Constants.FILE_STRUCTURE;
 import static org.eclipse.che.ide.ext.java.shared.Constants.GET_JAVA_CORE_OPTIONS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.IMPLEMENTERS;
@@ -259,26 +258,6 @@ public class JavaLanguageExtensionServiceClient {
                 .methodName(EXTERNAL_LIBRARY_ENTRY)
                 .paramsAsDto(params)
                 .sendAndReceiveResultAsDto(JarEntry.class, REQUEST_TIMEOUT)
-                .onSuccess(resolve::apply)
-                .onTimeout(() -> onTimeout(reject))
-                .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));
-  }
-
-  /**
-   * Gets content of the file from the library by file path.
-   *
-   * @param params external libraries parameters {@link ExternalLibrariesParameters}
-   * @return content of the file
-   */
-  public Promise<String> libraryNodeContentByPath(ExternalLibrariesParameters params) {
-    return Promises.create(
-        (resolve, reject) ->
-            requestTransmitter
-                .newRequest()
-                .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
-                .methodName(EXTERNAL_NODE_CONTENT)
-                .paramsAsDto(params)
-                .sendAndReceiveResultAsString(REQUEST_TIMEOUT)
                 .onSuccess(resolve::apply)
                 .onTimeout(() -> onTimeout(reject))
                 .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/JarFileNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/JarFileNode.java
@@ -38,7 +38,6 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.api.theme.Style;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
-import org.eclipse.che.ide.ext.java.client.service.JavaLanguageExtensionServiceClient;
 import org.eclipse.che.ide.project.node.SyntheticNode;
 import org.eclipse.che.ide.project.shared.NodesResources;
 import org.eclipse.che.ide.resource.Path;
@@ -48,6 +47,8 @@ import org.eclipse.che.ide.ui.smartTree.data.settings.NodeSettings;
 import org.eclipse.che.ide.ui.smartTree.presentation.NodePresentation;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExternalLibrariesParameters;
 import org.eclipse.che.jdt.ls.extension.api.dto.JarEntry;
+import org.eclipse.che.plugin.languageserver.ide.location.HasURI;
+import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 
 /**
  * It might be used for any jar content.
@@ -56,11 +57,16 @@ import org.eclipse.che.jdt.ls.extension.api.dto.JarEntry;
  */
 @Beta
 public class JarFileNode extends SyntheticNode<JarEntry>
-    implements VirtualFile, HasAction, FileEventHandler, ResourceChangedHandler, HasLocation {
+    implements VirtualFile,
+        HasAction,
+        FileEventHandler,
+        ResourceChangedHandler,
+        HasLocation,
+        HasURI {
 
   private final String libId;
   private final Path project;
-  private final JavaLanguageExtensionServiceClient service;
+  private final TextDocumentServiceClient service;
   private final DtoFactory dtoFactory;
   private final JavaResources javaResources;
   private final NodesResources nodesResources;
@@ -77,7 +83,7 @@ public class JarFileNode extends SyntheticNode<JarEntry>
       @Assisted String libId,
       @Assisted Path project,
       @Assisted NodeSettings nodeSettings,
-      JavaLanguageExtensionServiceClient service,
+      TextDocumentServiceClient service,
       DtoFactory dtoFactory,
       JavaResources javaResources,
       NodesResources nodesResources,
@@ -139,7 +145,7 @@ public class JarFileNode extends SyntheticNode<JarEntry>
 
   @Override
   public Path getLocation() {
-    return Path.valueOf(getData().getPath());
+    return Path.valueOf(getData().getUri());
   }
 
   /** {@inheritDoc} */
@@ -176,7 +182,7 @@ public class JarFileNode extends SyntheticNode<JarEntry>
     params.setNodePath(getData().getPath());
     params.setNodeId(libId);
     return service
-        .libraryNodeContentByPath(params)
+        .getFileContent(getData().getUri())
         .then((Function<String, String>) result -> result);
   }
 
@@ -261,5 +267,10 @@ public class JarFileNode extends SyntheticNode<JarEntry>
   public Location toLocation(int lineNumber) {
     return new LocationImpl(
         getLocation().toString(), lineNumber, true, libId, getProject().toString());
+  }
+
+  @Override
+  public String getURI() {
+    return getData().getUri();
   }
 }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
@@ -39,7 +39,6 @@ public final class Constants {
   public static final String EXTERNAL_LIBRARIES_CHILDREN = "java/externalLibrariesChildren";
   public static final String EXTERNAL_LIBRARY_CHILDREN = "java/libraryChildren";
   public static final String EXTERNAL_LIBRARY_ENTRY = "java/libraryEntry";
-  public static final String EXTERNAL_NODE_CONTENT = "java/libraryNodeContentByPath";
   public static final String CLASS_PATH_TREE = "java/classpathTree";
   public static final String ORGANIZE_IMPORTS = "java/organizeImports";
   public static final String EFFECTIVE_POM = "java/effective-pom";

--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
@@ -22,7 +22,6 @@ import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARIES;
 import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARIES_CHILDREN;
 import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARY_CHILDREN;
 import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_LIBRARY_ENTRY;
-import static org.eclipse.che.ide.ext.java.shared.Constants.EXTERNAL_NODE_CONTENT;
 import static org.eclipse.che.ide.ext.java.shared.Constants.FILE_STRUCTURE;
 import static org.eclipse.che.ide.ext.java.shared.Constants.GET_JAVA_CORE_OPTIONS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.IMPLEMENTERS;
@@ -46,7 +45,6 @@ import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_EXTERNAL_LIBRARI
 import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_EXTERNAL_LIBRARIES_COMMAND;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_LIBRARY_CHILDREN_COMMAND;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_LIBRARY_ENTRY_COMMAND;
-import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_LIBRARY_NODE_CONTENT_BY_PATH_COMMAND;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_OUTPUT_DIR_COMMAND;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_SOURCE_FOLDERS;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.REIMPORT_MAVEN_PROJECTS_COMMAND;
@@ -206,13 +204,6 @@ public class JavaLanguageServerExtensionService {
         .paramsAsDto(ExternalLibrariesParameters.class)
         .resultAsDto(JarEntry.class)
         .withFunction(this::getLibraryEntry);
-
-    requestHandler
-        .newConfiguration()
-        .methodName(EXTERNAL_NODE_CONTENT)
-        .paramsAsDto(ExternalLibrariesParameters.class)
-        .resultAsString()
-        .withFunction(this::getLibraryNodeContentByPath);
 
     requestHandler
         .newConfiguration()
@@ -590,12 +581,6 @@ public class JavaLanguageServerExtensionService {
     params.setProjectUri(prefixURI(params.getProjectUri()));
     Type type = new TypeToken<JarEntry>() {}.getType();
     return doGetOne(GET_LIBRARY_ENTRY_COMMAND, singletonList(params), type);
-  }
-
-  private String getLibraryNodeContentByPath(ExternalLibrariesParameters params) {
-    params.setProjectUri(prefixURI(params.getProjectUri()));
-    Type type = new TypeToken<String>() {}.getType();
-    return doGetOne(GET_LIBRARY_NODE_CONTENT_BY_PATH_COMMAND, singletonList(params), type);
   }
 
   private List<String> executeFindTestsCommand(

--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerLauncher.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerLauncher.java
@@ -110,7 +110,8 @@ public class JavaLanguageServerLauncher extends LanguageServerLauncherTemplate
         new LanguageServerDescription(
             "org.eclipse.che.plugin.java.languageserver",
             Arrays.asList("javaSource", "javaClass"),
-            Collections.singletonList(new DocumentFilter(null, null, "jdt")),
+            Arrays.asList(
+                new DocumentFilter(null, null, "jdt"), new DocumentFilter(null, null, "chelib")),
             Arrays.asList(
                 "glob:**/*.java",
                 "glob:**/pom.xml",

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -33,6 +33,7 @@ import org.eclipse.che.ide.editor.preferences.EditorPreferencesManager;
 import org.eclipse.che.ide.editor.preferences.editorproperties.EditorProperties;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
@@ -48,6 +49,7 @@ public class LanguageServerFormatter implements ContentFormatter {
 
   private final TextDocumentServiceClient client;
   private final DtoFactory dtoFactory;
+  private DtoBuildHelper dtoHelper;
   private final NotificationManager manager;
   private final ServerCapabilities capabilities;
   private final EditorPreferencesManager editorPreferencesManager;
@@ -57,11 +59,13 @@ public class LanguageServerFormatter implements ContentFormatter {
   public LanguageServerFormatter(
       TextDocumentServiceClient client,
       DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper,
       NotificationManager manager,
       @Assisted ServerCapabilities capabilities,
       EditorPreferencesManager editorPreferencesManager) {
     this.client = client;
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     this.manager = manager;
     this.capabilities = capabilities;
     this.editorPreferencesManager = editorPreferencesManager;
@@ -104,9 +108,7 @@ public class LanguageServerFormatter implements ContentFormatter {
 
                     DocumentOnTypeFormattingParams params =
                         dtoFactory.createDto(DocumentOnTypeFormattingParams.class);
-                    TextDocumentIdentifier identifier =
-                        dtoFactory.createDto(TextDocumentIdentifier.class);
-                    identifier.setUri(document.getFile().getLocation().toString());
+                    TextDocumentIdentifier identifier = dtoHelper.createTDI(document.getFile());
                     params.setTextDocument(identifier);
                     params.setOptions(getFormattingOptions());
                     params.setCh(event.getText());
@@ -129,8 +131,7 @@ public class LanguageServerFormatter implements ContentFormatter {
   private void formatFullDocument(Document document) {
     DocumentFormattingParams params = dtoFactory.createDto(DocumentFormattingParams.class);
 
-    TextDocumentIdentifier identifier = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifier.setUri(document.getFile().getLocation().toString());
+    TextDocumentIdentifier identifier = dtoHelper.createTDI(document.getFile());
 
     params.setTextDocument(identifier);
     params.setOptions(getFormattingOptions());
@@ -202,8 +203,7 @@ public class LanguageServerFormatter implements ContentFormatter {
     DocumentRangeFormattingParams params =
         dtoFactory.createDto(DocumentRangeFormattingParams.class);
 
-    TextDocumentIdentifier identifier = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifier.setUri(document.getFile().getLocation().toString());
+    TextDocumentIdentifier identifier = dtoHelper.createTDI(document.getFile());
 
     params.setTextDocument(identifier);
     params.setOptions(getFormattingOptions());

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/FullTextDocumentSynchronize.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/FullTextDocumentSynchronize.java
@@ -17,6 +17,7 @@ import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
@@ -30,12 +31,16 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 class FullTextDocumentSynchronize implements TextDocumentSynchronize {
 
   private final DtoFactory dtoFactory;
+  private final DtoBuildHelper dtoHelper;
   private final TextDocumentServiceClient textDocumentService;
 
   @Inject
   public FullTextDocumentSynchronize(
-      DtoFactory dtoFactory, TextDocumentServiceClient textDocumentService) {
+      DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper,
+      TextDocumentServiceClient textDocumentService) {
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     this.textDocumentService = textDocumentService;
   }
 
@@ -49,7 +54,7 @@ class FullTextDocumentSynchronize implements TextDocumentSynchronize {
       int version) {
 
     DidChangeTextDocumentParams changeDTO = dtoFactory.createDto(DidChangeTextDocumentParams.class);
-    String uri = document.getFile().getLocation().toString();
+    String uri = dtoHelper.getUri(document.getFile());
     changeDTO.setUri(uri);
     VersionedTextDocumentIdentifier versionedDocId =
         dtoFactory.createDto(VersionedTextDocumentIdentifier.class);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/IncrementalTextDocumentSynchronize.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/sync/IncrementalTextDocumentSynchronize.java
@@ -17,6 +17,7 @@ import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -32,12 +33,16 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 class IncrementalTextDocumentSynchronize implements TextDocumentSynchronize {
 
   private final DtoFactory dtoFactory;
+  private final DtoBuildHelper dtoHelper;
   private final TextDocumentServiceClient textDocumentService;
 
   @Inject
   public IncrementalTextDocumentSynchronize(
-      DtoFactory dtoFactory, TextDocumentServiceClient textDocumentService) {
+      DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper,
+      TextDocumentServiceClient textDocumentService) {
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     this.textDocumentService = textDocumentService;
   }
 
@@ -50,7 +55,7 @@ class IncrementalTextDocumentSynchronize implements TextDocumentSynchronize {
       String insertedText,
       int version) {
     DidChangeTextDocumentParams changeDTO = dtoFactory.createDto(DidChangeTextDocumentParams.class);
-    String uri = document.getFile().getLocation().toString();
+    String uri = dtoHelper.getUri(document.getFile());
     changeDTO.setUri(uri);
     VersionedTextDocumentIdentifier versionedDocId =
         dtoFactory.createDto(VersionedTextDocumentIdentifier.class);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/HasURI.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/HasURI.java
@@ -8,8 +8,13 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.api.languageserver.shared.util;
+package org.eclipse.che.plugin.languageserver.ide.location;
 
-public class Constants {
-  public static final String CHE_WKSP_SCHEME = "chewsfile://";
+/**
+ * Objects that can be identified with a LSP URI.
+ *
+ * @author Thomas Mäder
+ */
+public interface HasURI {
+  String getURI();
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/LanguageServerFile.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/LanguageServerFile.java
@@ -31,7 +31,6 @@ public class LanguageServerFile implements VirtualFile, HasURI {
 
   private String extractName(String uri) {
     String path = new UrlBuilder(uri).getPath();
-    path = path.substring(1, path.length() - 1);
     return new Path(path).lastSegment();
   }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/LanguageServerFile.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/LanguageServerFile.java
@@ -13,17 +13,26 @@ package org.eclipse.che.plugin.languageserver.ide.location;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.ide.rest.UrlBuilder;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 
-public class LanguageServerFile implements VirtualFile {
-  private String uri;
+public class LanguageServerFile implements VirtualFile, HasURI {
+  private final String uri;
   private final Path path;
   private final TextDocumentServiceClient textDocumentService;
+  private String name;
 
   public LanguageServerFile(TextDocumentServiceClient textDocumentService, String uri) {
     this.textDocumentService = textDocumentService;
     this.uri = uri;
-    this.path = new Path(uri.substring("file://".length()));
+    this.path = new Path(uri);
+    this.name = extractName(uri);
+  }
+
+  private String extractName(String uri) {
+    String path = new UrlBuilder(uri).getPath();
+    path = path.substring(1, path.length() - 1);
+    return new Path(path).lastSegment();
   }
 
   @Override
@@ -33,12 +42,12 @@ public class LanguageServerFile implements VirtualFile {
 
   @Override
   public String getName() {
-    return path.lastSegment();
+    return name;
   }
 
   @Override
   public String getDisplayName() {
-    return path.lastSegment();
+    return name;
   }
 
   @Override
@@ -54,6 +63,10 @@ public class LanguageServerFile implements VirtualFile {
   @Override
   public Promise<String> getContent() {
     return textDocumentService.getFileContent(uri);
+  }
+
+  public String getURI() {
+    return uri;
   }
 
   @Override

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/references/FindReferencesAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/references/FindReferencesAction.java
@@ -28,6 +28,7 @@ import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConf
 import org.eclipse.che.plugin.languageserver.ide.location.OpenLocationPresenter;
 import org.eclipse.che.plugin.languageserver.ide.location.OpenLocationPresenterFactory;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ReferenceContext;
@@ -41,6 +42,7 @@ public class FindReferencesAction extends AbstractPerspectiveAction {
   private final EditorAgent editorAgent;
   private final TextDocumentServiceClient client;
   private final DtoFactory dtoFactory;
+  private final DtoBuildHelper dtoHelper;
   private final OpenLocationPresenter presenter;
 
   @Inject
@@ -48,11 +50,13 @@ public class FindReferencesAction extends AbstractPerspectiveAction {
       EditorAgent editorAgent,
       OpenLocationPresenterFactory presenterFactory,
       TextDocumentServiceClient client,
-      DtoFactory dtoFactory) {
+      DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper) {
     super(singletonList(PROJECT_PERSPECTIVE_ID), "Find References", "Find References");
     this.editorAgent = editorAgent;
     this.client = client;
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     presenter = presenterFactory.create("Find References");
   }
 
@@ -84,20 +88,19 @@ public class FindReferencesAction extends AbstractPerspectiveAction {
       return;
     }
     TextEditor textEditor = ((TextEditor) activeEditor);
-    String path = activeEditor.getEditorInput().getFile().getLocation().toString();
     ReferenceParams paramsDTO = dtoFactory.createDto(ReferenceParams.class);
 
     Position Position = dtoFactory.createDto(Position.class);
     Position.setLine(textEditor.getCursorPosition().getLine());
     Position.setCharacter(textEditor.getCursorPosition().getCharacter());
 
-    TextDocumentIdentifier identifierDTO = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifierDTO.setUri(path);
+    TextDocumentIdentifier identifierDTO =
+        dtoHelper.createTDI(activeEditor.getEditorInput().getFile());
 
     ReferenceContext contextDTO = dtoFactory.createDto(ReferenceContext.class);
     contextDTO.setIncludeDeclaration(true);
 
-    paramsDTO.setUri(path);
+    paramsDTO.setUri(identifierDTO.getUri());
     paramsDTO.setPosition(Position);
     paramsDTO.setTextDocument(identifierDTO);
     paramsDTO.setContext(contextDTO);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/symbol/GoToSymbolAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/symbol/GoToSymbolAction.java
@@ -41,6 +41,7 @@ import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConf
 import org.eclipse.che.plugin.languageserver.ide.quickopen.QuickOpenModel;
 import org.eclipse.che.plugin.languageserver.ide.quickopen.QuickOpenPresenter;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
@@ -61,6 +62,7 @@ public class GoToSymbolAction extends AbstractPerspectiveAction
   private final TextDocumentServiceClient client;
   private final EditorAgent editorAgent;
   private final DtoFactory dtoFactory;
+  private final DtoBuildHelper dtoHelper;
   private final NotificationManager notificationManager;
   private final FuzzyMatches fuzzyMatches;
   private final SymbolKindHelper symbolKindHelper;
@@ -78,6 +80,7 @@ public class GoToSymbolAction extends AbstractPerspectiveAction
       TextDocumentServiceClient client,
       EditorAgent editorAgent,
       DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper,
       NotificationManager notificationManager,
       FuzzyMatches fuzzyMatches,
       SymbolKindHelper symbolKindHelper,
@@ -91,6 +94,7 @@ public class GoToSymbolAction extends AbstractPerspectiveAction
     this.client = client;
     this.editorAgent = editorAgent;
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     this.notificationManager = notificationManager;
     this.fuzzyMatches = fuzzyMatches;
     this.symbolKindHelper = symbolKindHelper;
@@ -100,9 +104,8 @@ public class GoToSymbolAction extends AbstractPerspectiveAction
   @Override
   public void actionPerformed(ActionEvent e) {
     DocumentSymbolParams paramsDTO = dtoFactory.createDto(DocumentSymbolParams.class);
-    TextDocumentIdentifier identifierDTO = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifierDTO.setUri(
-        editorAgent.getActiveEditor().getEditorInput().getFile().getLocation().toString());
+    TextDocumentIdentifier identifierDTO =
+        dtoHelper.createTDI(editorAgent.getActiveEditor().getEditorInput().getFile());
     paramsDTO.setTextDocument(identifierDTO);
     activeEditor = (TextEditor) editorAgent.getActiveEditor();
     cursorPosition = activeEditor.getDocument().getCursorPosition();

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/workspace/FindSymbolAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/navigation/workspace/FindSymbolAction.java
@@ -46,6 +46,7 @@ import org.eclipse.che.plugin.languageserver.ide.navigation.symbol.SymbolKindHel
 import org.eclipse.che.plugin.languageserver.ide.quickopen.QuickOpenModel;
 import org.eclipse.che.plugin.languageserver.ide.quickopen.QuickOpenPresenter;
 import org.eclipse.che.plugin.languageserver.ide.service.WorkspaceServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.che.plugin.languageserver.ide.util.OpenFileInEditorHelper;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
@@ -70,6 +71,7 @@ public class FindSymbolAction extends AbstractPerspectiveAction
   private final FuzzyMatches fuzzyMatches;
   private PromiseProvider promiseProvider;
   private final ThrottledDelayer<List<SymbolEntry>> delayer;
+  private DtoBuildHelper dtoHelper;
 
   @Inject
   public FindSymbolAction(
@@ -78,6 +80,7 @@ public class FindSymbolAction extends AbstractPerspectiveAction
       QuickOpenPresenter presenter,
       WorkspaceServiceClient workspaceServiceClient,
       DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper,
       EditorAgent editorAgent,
       SymbolKindHelper symbolKindHelper,
       FuzzyMatches fuzzyMatches,
@@ -90,6 +93,7 @@ public class FindSymbolAction extends AbstractPerspectiveAction
     this.presenter = presenter;
     this.workspaceServiceClient = workspaceServiceClient;
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     this.editorAgent = editorAgent;
     this.symbolKindHelper = symbolKindHelper;
     this.fuzzyMatches = fuzzyMatches;
@@ -143,8 +147,7 @@ public class FindSymbolAction extends AbstractPerspectiveAction
     ExtendedWorkspaceSymbolParams params =
         dtoFactory.createDto(ExtendedWorkspaceSymbolParams.class);
     params.setQuery(value);
-    params.setFileUri(
-        editorAgent.getActiveEditor().getEditorInput().getFile().getLocation().toString());
+    params.setFileUri(dtoHelper.getUri(editorAgent.getActiveEditor().getEditorInput().getFile()));
     return workspaceServiceClient
         .symbol(params)
         .then(

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/registry/LanguageServerRegistry.java
@@ -28,6 +28,7 @@ import org.eclipse.che.ide.ui.loaders.request.LoaderFactory;
 import org.eclipse.che.ide.ui.loaders.request.MessageLoader;
 import org.eclipse.che.plugin.languageserver.ide.service.LanguageServerRegistryJsonRpcClient;
 import org.eclipse.che.plugin.languageserver.ide.service.LanguageServerRegistryServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.ServerCapabilities;
 
 /** @author Anatoliy Bazko */
@@ -39,6 +40,7 @@ public class LanguageServerRegistry {
 
   private final Map<FileType, LanguageDescription> registeredFileTypes = new ConcurrentHashMap<>();
   private final FileTypeRegistry fileTypeRegistry;
+  private final DtoBuildHelper dtoHelper;
 
   @Inject
   public LanguageServerRegistry(
@@ -47,12 +49,14 @@ public class LanguageServerRegistry {
       NotificationManager notificationManager,
       LanguageServerRegistryJsonRpcClient jsonRpcClient,
       LanguageServerRegistryServiceClient client,
-      FileTypeRegistry fileTypeRegistry) {
+      FileTypeRegistry fileTypeRegistry,
+      DtoBuildHelper dtoHelper) {
 
     this.loaderFactory = loaderFactory;
     this.notificationManager = notificationManager;
     this.jsonRpcClient = jsonRpcClient;
     this.fileTypeRegistry = fileTypeRegistry;
+    this.dtoHelper = dtoHelper;
   }
 
   public Promise<ServerCapabilities> getOrInitializeServer(VirtualFile file) {
@@ -61,7 +65,7 @@ public class LanguageServerRegistry {
         loaderFactory.newLoader("Initializing Language Server for " + file.getName());
     loader.show();
     return jsonRpcClient
-        .initializeServer(file.getLocation().toString())
+        .initializeServer(dtoHelper.getUri(file))
         .then(
             (ServerCapabilities arg) -> {
               loader.hide();

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/RenamePresenter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/RenamePresenter.java
@@ -45,6 +45,7 @@ import org.eclipse.che.plugin.languageserver.ide.rename.model.RenameFile;
 import org.eclipse.che.plugin.languageserver.ide.rename.model.RenameFolder;
 import org.eclipse.che.plugin.languageserver.ide.rename.model.RenameProject;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -60,6 +61,7 @@ public class RenamePresenter extends BasePresenter implements ActionDelegate {
   private final LanguageServerLocalization localization;
   private final TextDocumentServiceClient client;
   private final DtoFactory dtoFactory;
+  private final DtoBuildHelper dtoHelper;
   private final Provider<RenameInputBox> renameInputBoxProvider;
   private final RenameView view;
   private final WorkspaceAgent workspaceAgent;
@@ -77,6 +79,7 @@ public class RenamePresenter extends BasePresenter implements ActionDelegate {
       LanguageServerLocalization localization,
       TextDocumentServiceClient client,
       DtoFactory dtoFactory,
+      DtoBuildHelper dtoHelper,
       Provider<RenameInputBox> renameInputBoxProvider,
       RenameView view,
       WorkspaceAgent workspaceAgent,
@@ -86,6 +89,7 @@ public class RenamePresenter extends BasePresenter implements ActionDelegate {
     this.localization = localization;
     this.client = client;
     this.dtoFactory = dtoFactory;
+    this.dtoHelper = dtoHelper;
     this.renameInputBoxProvider = renameInputBoxProvider;
     this.view = view;
     this.workspaceAgent = workspaceAgent;
@@ -187,8 +191,7 @@ public class RenamePresenter extends BasePresenter implements ActionDelegate {
   private void callRename(String newName, TextPosition cursorPosition, TextEditor editor) {
     RenameParams dto = dtoFactory.createDto(RenameParams.class);
 
-    TextDocumentIdentifier identifier = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifier.setUri(editor.getEditorInput().getFile().getLocation().toString());
+    TextDocumentIdentifier identifier = dtoHelper.createTDI(editor.getEditorInput().getFile());
 
     dto.setNewName(newName);
     dto.setTextDocument(identifier);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/DtoBuildHelper.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/DtoBuildHelper.java
@@ -14,7 +14,9 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
+import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.plugin.languageserver.ide.location.HasURI;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -34,31 +36,37 @@ public class DtoBuildHelper {
   }
 
   public TextDocumentPositionParams createTDPP(Document document, int cursorOffset) {
-    TextDocumentPositionParams paramsDTO = dtoFactory.createDto(TextDocumentPositionParams.class);
-    TextDocumentIdentifier identifierDTO = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifierDTO.setUri(document.getFile().getLocation().toString());
-
-    Position Position = dtoFactory.createDto(Position.class);
     TextPosition position = document.getPositionFromIndex(cursorOffset);
-    Position.setCharacter(position.getCharacter());
-    Position.setLine(position.getLine());
+    return createTDPP(document.getFile(), position);
+  }
 
-    paramsDTO.setUri(document.getFile().getLocation().toString());
-    paramsDTO.setTextDocument(identifierDTO);
-    paramsDTO.setPosition(Position);
-    return paramsDTO;
+  public TextDocumentIdentifier createTDI(VirtualFile file) {
+    TextDocumentIdentifier identifierDTO = dtoFactory.createDto(TextDocumentIdentifier.class);
+    identifierDTO.setUri(getUri(file));
+    return identifierDTO;
+  }
+
+  public String getUri(VirtualFile file) {
+    if (file instanceof HasURI) {
+      return ((HasURI) file).getURI();
+    } else {
+      return file.getLocation().toString();
+    }
   }
 
   public TextDocumentPositionParams createTDPP(Document document, TextPosition position) {
-    TextDocumentPositionParams paramsDTO = dtoFactory.createDto(TextDocumentPositionParams.class);
-    TextDocumentIdentifier identifierDTO = dtoFactory.createDto(TextDocumentIdentifier.class);
-    identifierDTO.setUri(document.getFile().getLocation().toString());
+    VirtualFile file = document.getFile();
+    return createTDPP(file, position);
+  }
 
+  private TextDocumentPositionParams createTDPP(VirtualFile file, TextPosition position) {
+    TextDocumentPositionParams paramsDTO = dtoFactory.createDto(TextDocumentPositionParams.class);
+    TextDocumentIdentifier identifierDTO = createTDI(file);
     Position Position = dtoFactory.createDto(Position.class);
     Position.setCharacter(position.getCharacter());
     Position.setLine(position.getLine());
 
-    paramsDTO.setUri(document.getFile().getLocation().toString());
+    paramsDTO.setUri(identifierDTO.getUri());
     paramsDTO.setTextDocument(identifierDTO);
     paramsDTO.setPosition(Position);
     return paramsDTO;

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/OpenFileInEditorHelper.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/OpenFileInEditorHelper.java
@@ -15,7 +15,6 @@ import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.function.Consumer;
-import org.eclipse.che.api.languageserver.shared.util.Constants;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.api.promises.client.js.Executor;
@@ -165,8 +164,8 @@ public class OpenFileInEditorHelper {
 
   public void openLocation(String uri, LinearRange range) {
     Consumer<TextEditor> selectRange = selectRange(range);
-    if (uri.startsWith(Constants.CHE_WKSP_SCHEME)) {
-      openPath(uri.substring(Constants.CHE_WKSP_SCHEME.length()), selectRange);
+    if (uri.startsWith("/")) {
+      openPath(uri, selectRange);
     } else {
       openFile(new LanguageServerFile(textDocumentService, uri), selectRange);
     }
@@ -175,17 +174,14 @@ public class OpenFileInEditorHelper {
   public void openLocation(Location location) {
     Range range = location.getRange();
     String uri = location.getUri();
-    TextRange selectionRange = toTextRange(range);
-    if (uri.startsWith(Constants.CHE_WKSP_SCHEME)) {
-      openPath(location.getUri().substring(Constants.CHE_WKSP_SCHEME.length()), selectionRange);
+    TextRange selectionRange =
+        new TextRange(
+            new TextPosition(range.getStart().getLine(), range.getStart().getCharacter()),
+            new TextPosition(range.getEnd().getLine(), range.getEnd().getCharacter()));
+    if (uri.startsWith("/")) {
+      openPath(location.getUri(), selectionRange);
     } else {
       openFile(new LanguageServerFile(textDocumentService, location.getUri()), selectionRange);
     }
-  }
-
-  private TextRange toTextRange(Range range) {
-    return new TextRange(
-        new TextPosition(range.getStart().getLine(), range.getStart().getCharacter()),
-        new TextPosition(range.getEnd().getLine(), range.getEnd().getCharacter()));
   }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServiceUtils.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServiceUtils.java
@@ -15,7 +15,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
-import org.eclipse.che.api.languageserver.shared.util.Constants;
 import org.eclipse.lsp4j.Location;
 
 /** Language service service utilities */
@@ -24,8 +23,8 @@ public class LanguageServiceUtils {
   private static final String PROJECTS = "/projects";
   private static final String FILE_PROJECTS = "file:///projects";
 
-  public static String prefixURI(String relativePath) {
-    return FILE_PROJECTS + relativePath;
+  public static String prefixURI(String uri) {
+    return uri.startsWith("/") ? FILE_PROJECTS + uri : uri;
   }
 
   public static String removePrefixUri(String uri) {
@@ -64,9 +63,7 @@ public class LanguageServiceUtils {
   }
 
   public static Location fixLocation(Location o) {
-    if (isProjectUri(o.getUri())) {
-      o.setUri(Constants.CHE_WKSP_SCHEME + removePrefixUri(o.getUri()));
-    }
+    o.setUri(removePrefixUri(o.getUri()));
     return o;
   }
 

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServiceUtils.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/service/LanguageServiceUtils.java
@@ -68,7 +68,7 @@ public class LanguageServiceUtils {
   }
 
   public static boolean isWorkspaceUri(String uri) {
-    return uri.startsWith(Constants.CHE_WKSP_SCHEME);
+    return uri.startsWith("/");
   }
 
   public static String workspaceURIToFileURI(String uri) throws LanguageServerException {
@@ -80,6 +80,6 @@ public class LanguageServiceUtils {
   }
 
   public static String fixUri(String uri) {
-    return isProjectUri(uri) ? Constants.CHE_WKSP_SCHEME + removePrefixUri(uri) : uri;
+    return isProjectUri(uri) ? removePrefixUri(uri) : uri;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes Che LSP support to use paths for Che workspace resources and uri's for everything else (class file contents, etc.). The main reason for this PR is to allow supporting LSP functionality (hover help, etc.) via jdt.ls.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7852

#### Release Notes
Enbable LSP functionality in class files 

