### PR TITLE
Selenium: change timeouts in unstable selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ToastLoader.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ToastLoader.java
@@ -12,7 +12,7 @@ package org.eclipse.che.selenium.pageobject;
 
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLocated;
@@ -72,7 +72,7 @@ public class ToastLoader {
    * @param expText
    */
   public void waitExpectedTextInToastLoader(String expText) {
-    new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, EXPECTED_MESS_IN_CONSOLE_SEC)
         .until(
             visibilityOfElementLocated(
                 By.xpath(format(Locators.MAINFORM_WITH_TEXT_CONTAINER, expText))));

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceOverview.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceOverview.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.pageobject.dashboard.workspaces;
 
 import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
@@ -78,7 +79,7 @@ public class WorkspaceOverview {
    * @param nameWorkspace expected name of workspace
    */
   public void checkNameWorkspace(String nameWorkspace) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
         .until(
             visibilityOfElementLocated(By.xpath(format(Locators.WORKSPACE_TITLE, nameWorkspace))));
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/machineperspective/MachineTerminal.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.selenium.pageobject.machineperspective;
 
 import static java.lang.String.format;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
 import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLocated;
@@ -73,7 +73,7 @@ public class MachineTerminal {
 
   /** waits default terminal tab */
   public void waitTerminalTab() {
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC).until(visibilityOf(defaultTermTab));
+    new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC).until(visibilityOf(defaultTermTab));
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsComposeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsComposeTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.selenium.core.constant.TestStacksConstants.JAVA_MYSQL;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPED;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.ENV_VARIABLES;
@@ -154,7 +154,7 @@ public class WorkspaceDetailsComposeTest {
     seleniumWebDriver.switchFromDashboardIframeToIde();
     projectExplorer.waitProjectExplorer();
 
-    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
+    terminal.waitTerminalTab(PREPARING_WS_TIMEOUT_SEC);
     consoles.waitProcessInProcessConsoleTree("machine");
     consoles.waitTabNameProcessIsPresent("machine");
   }
@@ -180,7 +180,7 @@ public class WorkspaceDetailsComposeTest {
 
     seleniumWebDriver.switchFromDashboardIframeToIde(60);
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
+    terminal.waitTerminalTab(PREPARING_WS_TIMEOUT_SEC);
 
     dashboard.open();
     dashboard.waitDashboardToolbarTitle();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsComposeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsComposeTest.java
@@ -141,6 +141,7 @@ public class WorkspaceDetailsComposeTest {
     workspaceMachines.clickOnEditMachineButton(machineName);
     workspaceMachines.checkEditTheMachineDialogIsOpen();
     workspaceMachines.setMachineNameInDialog("machine");
+    WaitUtils.sleepQuietly(2);
     workspaceMachines.clickOnSaveNameDialogButton();
     workspaceMachines.checkMachineExists("machine");
     clickOnSaveButton();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.selenium.dashboard;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
@@ -216,7 +216,7 @@ public class WorkspaceDetailsSingleMachineTest {
     workspaceDetails.clickOpenInIdeWsBtn();
     seleniumWebDriver.switchFromDashboardIframeToIde();
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
+    terminal.waitTerminalTab(PREPARING_WS_TIMEOUT_SEC);
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.waitFolderDefinedTypeOfFolderByPath(PROJECT_NAME, PROJECT_FOLDER);
     projectExplorer.waitFolderDefinedTypeOfFolderByPath(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);


### PR DESCRIPTION
### What does this PR do?
This PR: 
1. increases timeout for waiting that the **Terminal** tab is visible
(**WorkspaceDetailsComposeTest** failed test - https://ci.codenvycorp.com/view/qa/job/che-integration-tests-multiuser-master-docker/87/Selenium_tests_report/);

2. increases timeout for waiting a message in the **Toast Loader** that a test workspace is started or stopped
(**ProjectStateAfterWorkspaceRestartTest** failed test - https://ci.codenvycorp.com/job/che-pullrequests-test/340/Selenium_tests_report/);

3. increases timeout for waiting that a workspace name in **workspace detail** toolbar changed after workspace renaming();

4. adds timeout before clicking on the **Save** button in the **Edit Machine** form
(**WorkspaceDetailsComposeTest** failed test - https://ci.codenvycorp.com/job/che-pullrequests-test/340/Selenium_tests_report/).

