### PR TITLE
Added resolving of conflicts between installers servers for OpenShift infra

### DIFF
--- a/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.json
+++ b/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.json
@@ -1,0 +1,20 @@
+{
+  "id": "org.eclipse.che.exec",
+  "version": "1.0.1",
+  "name": "Exec",
+  "description": "Agent for command execution",
+  "dependencies": [],
+  "properties": {},
+  "servers": {
+    "exec-agent/http": {
+      "port": "4412/tcp",
+      "protocol": "http",
+      "path" : "/process"
+    },
+    "exec-agent/ws": {
+      "port": "4412/tcp",
+      "protocol": "ws",
+      "path": "/connect"
+    }
+  }
+}

--- a/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
+++ b/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
@@ -1,0 +1,221 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+
+is_current_user_root() {
+    test "$(id -u)" = 0
+}
+
+is_current_user_sudoer() {
+    sudo -n true > /dev/null 2>&1
+}
+
+set_sudo_command() {
+    if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
+}
+
+set_sudo_command
+unset PACKAGES
+command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
+CURL_INSTALLED=false
+WGET_INSTALLED=false
+command -v curl >/dev/null 2>&1 && CURL_INSTALLED=true
+command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
+
+# no curl, no wget, install curl
+if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
+  PACKAGES=${PACKAGES}" curl";
+  CURL_INSTALLED=true
+fi
+
+CHE_DIR=$HOME/che
+LOCAL_AGENT_BINARIES_URI='/mnt/che/exec-agent/exec-agent-${PREFIX}.tar.gz'
+DOWNLOAD_AGENT_BINARIES_URI='${WORKSPACE_MASTER_URI}/agent-binaries/${PREFIX}/exec/exec-agent-${PREFIX}.tar.gz'
+TARGET_AGENT_BINARIES_URI='file://${CHE_DIR}/exec-agent-${PREFIX}.tar.gz'
+
+if [ -f /etc/centos-release ]; then
+    FILE="/etc/centos-release"
+    LINUX_TYPE=$(cat $FILE | awk '{print $1}')
+ elif [ -f /etc/redhat-release ]; then
+    FILE="/etc/redhat-release"
+    LINUX_TYPE=$(cat $FILE | cut -c 1-8)
+ else
+    FILE="/etc/os-release"
+    LINUX_TYPE=$(cat $FILE | grep ^ID= | tr '[:upper:]' '[:lower:]')
+    LINUX_VERSION=$(cat $FILE | grep ^VERSION_ID=)
+fi
+MACHINE_TYPE=$(uname -m)
+SHELL_INTERPRETER="/bin/sh"
+
+mkdir -p ${CHE_DIR}
+${SUDO} mkdir -p /projects
+if is_current_user_sudoer; then
+  ${SUDO} sh -c "chown $(id -u -n) /projects"
+fi
+
+########################
+### Install packages ###
+########################
+
+# Red Hat Enterprise Linux 7
+############################
+if echo ${LINUX_TYPE} | grep -qi "rhel"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum install ${PACKAGES};
+    }
+
+# Ubuntu 14.04 16.04 / Linux Mint 17
+####################################
+elif echo ${LINUX_TYPE} | grep -qi "ubuntu"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apt-get update;
+        ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+# Debian 8
+##########
+elif echo ${LINUX_TYPE} | grep -qi "debian"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apt-get update;
+        ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+# Fedora 23
+###########
+elif echo ${LINUX_TYPE} | grep -qi "fedora"; then
+    command -v ps >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" procps-ng"; }
+    test "${PACKAGES}" = "" || {
+        ${SUDO} dnf -y install ${PACKAGES};
+    }
+
+# CentOS 7.1 & Oracle Linux 7.1
+###############################
+elif echo ${LINUX_TYPE} | grep -qi "centos"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# openSUSE 13.2
+###############
+elif echo ${LINUX_TYPE} | grep -qi "opensuse"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} zypper install -y ${PACKAGES};
+    }
+
+# Alpine 3.3
+############
+elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apk update
+        ${SUDO} apk add ${PACKAGES};
+    }
+
+# Centos 6.6, 6.7, 6.8
+############
+elif echo ${LINUX_TYPE} | grep -qi "CentOS"; then
+     test "${PACKAGES}" = "" || {
+         ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# Red Hat Enterprise Linux 6
+############################
+
+elif echo ${LINUX_TYPE} | grep -qi "Red Hat"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum install ${PACKAGES};
+    }
+
+else
+    >&2 echo "Unrecognized Linux Type"
+    >&2 cat $FILE
+    exit 1
+fi
+
+
+########################
+### Install Exec agent ###
+########################
+if echo ${MACHINE_TYPE} | grep -qi "x86_64"; then
+    PREFIX=linux_amd64
+elif echo ${MACHINE_TYPE} | grep -qi "arm5"; then
+    PREFIX=linux_arm7
+elif echo ${MACHINE_TYPE} | grep -qi "arm6"; then
+    PREFIX=linux_arm7
+elif echo ${MACHINE_TYPE} | grep -qi "arm7"; then
+    PREFIX=linux_arm7
+elif echo ${MACHINE_TYPE} | grep -qi "armv7l"; then
+    PREFIX=linux_arm7
+else
+    >&2 echo "Unrecognized Machine Type"
+    >&2 uname -a
+    exit 1
+fi
+
+# Compute URI of workspace master
+WORKSPACE_MASTER_URI=$(echo $CHE_API | cut -d / -f 1-3)
+
+## Evaluate variables now that prefix is defined
+eval "LOCAL_AGENT_BINARIES_URI=${LOCAL_AGENT_BINARIES_URI}"
+eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
+eval "TARGET_AGENT_BINARIES_URI=${TARGET_AGENT_BINARIES_URI}"
+
+LOCAL_AGENT_PATH=
+if [ -f "${LOCAL_AGENT_BINARIES_URI}" ]; then
+    AGENT_BINARIES_URI="file://${LOCAL_AGENT_BINARIES_URI}"
+    LOCAL_AGENT_PATH=${LOCAL_AGENT_BINARIES_URI}
+elif [ -f $(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g") ]; then
+    AGENT_BINARIES_URI="file://"$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
+    LOCAL_AGENT_PATH=$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
+else
+    AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
+fi
+
+# If file is already on the filesystem, use it
+if [ ! -z ${LOCAL_AGENT_PATH} ]; then
+  tar zxf ${LOCAL_AGENT_PATH} -C ${CHE_DIR}
+else
+  echo "Exec Agent binary is downloaded remotely"
+  # Use curl
+  if [ ${CURL_INSTALLED} = true ]; then
+    if curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+  else
+    # replace https by http as wget may not be able to handle ssl
+    AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')
+
+    # use wget
+    WGET_SPIDER="wget --spider"
+    if wget  2>&1 | grep -q BusyBox; then
+      WGET_SPIDER="wget -s"
+    fi
+    LOCAL_DOWNLOAD=$(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g')
+    if ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') >/dev/null; then
+      wget -qO ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      wget -qO- ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    tar xzf ${LOCAL_DOWNLOAD} -C ${CHE_DIR}
+  fi
+fi
+
+
+
+if [ -f /bin/bash ]; then
+    SHELL_INTERPRETER="/bin/bash"
+fi
+
+EXEC_AGENT_PORT=${CHE_SERVER_EXEC_AGENT_HTTP_PORT:-4412}
+
+$HOME/che/exec-agent/che-exec-agent -addr :${EXEC_AGENT_PORT} -cmd ${SHELL_INTERPRETER} -logs-dir $HOME/che/exec-agent/logs

--- a/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.json
+++ b/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.json
@@ -1,0 +1,15 @@
+{
+  "id": "org.eclipse.che.terminal",
+  "version": "1.0.1",
+  "name": "Terminal",
+  "description": "Embedded web terminal",
+  "dependencies": [],
+  "properties": {},
+  "servers": {
+    "terminal": {
+      "port": "4411/tcp",
+      "protocol": "ws",
+      "path" : "/pty"
+    }
+  }
+}

--- a/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.script.sh
@@ -1,0 +1,216 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+is_current_user_root() {
+    test "$(id -u)" = 0
+}
+
+is_current_user_sudoer() {
+    sudo -n true > /dev/null 2>&1
+}
+
+set_sudo_command() {
+    if is_current_user_sudoer && ! is_current_user_root; then SUDO="sudo -E"; else unset SUDO; fi
+}
+
+set_sudo_command
+unset PACKAGES
+command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
+CURL_INSTALLED=false
+WGET_INSTALLED=false
+command -v curl >/dev/null 2>&1 && CURL_INSTALLED=true
+command -v wget >/dev/null 2>&1 && WGET_INSTALLED=true
+
+# no curl, no wget, install curl
+if [ ${CURL_INSTALLED} = false ] && [ ${WGET_INSTALLED} = false ]; then
+  PACKAGES=${PACKAGES}" curl";
+  CURL_INSTALLED=true
+fi
+
+CHE_DIR=$HOME/che
+LOCAL_AGENT_BINARIES_URI='/mnt/che/terminal/websocket-terminal-${PREFIX}.tar.gz'
+DOWNLOAD_AGENT_BINARIES_URI='${WORKSPACE_MASTER_URI}/agent-binaries/${PREFIX}/terminal/websocket-terminal-${PREFIX}.tar.gz'
+TARGET_AGENT_BINARIES_URI='file://${CHE_DIR}/websocket-terminal-${PREFIX}.tar.gz'
+
+if [ -f /etc/centos-release ]; then
+    FILE="/etc/centos-release"
+    LINUX_TYPE=$(cat $FILE | awk '{print $1}')
+ elif [ -f /etc/redhat-release ]; then
+    FILE="/etc/redhat-release"
+    LINUX_TYPE=$(cat $FILE | cut -c 1-8)
+ else
+    FILE="/etc/os-release"
+    LINUX_TYPE=$(cat $FILE | grep ^ID= | tr '[:upper:]' '[:lower:]')
+    LINUX_VERSION=$(cat $FILE | grep ^VERSION_ID=)
+fi
+MACHINE_TYPE=$(uname -m)
+SHELL_INTERPRETER="/bin/sh"
+
+
+mkdir -p ${CHE_DIR}
+
+########################
+### Install packages ###
+########################
+
+# Red Hat Enterprise Linux 7 
+############################
+if echo ${LINUX_TYPE} | grep -qi "rhel"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum install ${PACKAGES};
+    }
+
+# Ubuntu 14.04 16.04 / Linux Mint 17 
+####################################
+elif echo ${LINUX_TYPE} | grep -qi "ubuntu"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apt-get update;
+        ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+# Debian 8
+##########
+elif echo ${LINUX_TYPE} | grep -qi "debian"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apt-get update;
+        ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+# Fedora 23 
+###########
+elif echo ${LINUX_TYPE} | grep -qi "fedora"; then
+    command -v ps >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" procps-ng"; }
+    test "${PACKAGES}" = "" || {
+        ${SUDO} dnf -y install ${PACKAGES};
+    }
+
+# CentOS 7.1 & Oracle Linux 7.1
+###############################
+elif echo ${LINUX_TYPE} | grep -qi "centos"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# openSUSE 13.2
+###############
+elif echo ${LINUX_TYPE} | grep -qi "opensuse"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} zypper install -y ${PACKAGES};
+    }
+
+# Alpine 3.3
+############
+elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apk update
+        ${SUDO} apk add ${PACKAGES};
+    }
+
+# Centos 6.6, 6.7, 6.8
+############
+elif echo ${LINUX_TYPE} | grep -qi "CentOS"; then
+     test "${PACKAGES}" = "" || {
+         ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# Red Hat Enterprise Linux 6 
+############################
+
+elif echo ${LINUX_TYPE} | grep -qi "Red Hat"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum install ${PACKAGES};
+    }
+
+else
+    >&2 echo "Unrecognized Linux Type"
+    >&2 cat $FILE
+    exit 1
+fi
+
+########################
+### Install Terminal ###
+########################
+if echo ${MACHINE_TYPE} | grep -qi "x86_64"; then
+    PREFIX=linux_amd64
+elif echo ${MACHINE_TYPE} | grep -qi "arm5"; then
+    PREFIX=linux_arm7
+elif echo ${MACHINE_TYPE} | grep -qi "arm6"; then
+    PREFIX=linux_arm7
+elif echo ${MACHINE_TYPE} | grep -qi "arm7"; then
+    PREFIX=linux_arm7
+elif echo ${MACHINE_TYPE} | grep -qi "armv7l"; then
+    PREFIX=linux_arm7
+else
+    >&2 echo "Unrecognized Machine Type"
+    >&2 uname -a
+    exit 1
+fi
+
+# Compute URI of workspace master
+WORKSPACE_MASTER_URI=$(echo $CHE_API | cut -d / -f 1-3)
+
+## Evaluate variables now that prefix is defined
+eval "LOCAL_AGENT_BINARIES_URI=${LOCAL_AGENT_BINARIES_URI}"
+eval "DOWNLOAD_AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}"
+eval "TARGET_AGENT_BINARIES_URI=${TARGET_AGENT_BINARIES_URI}"
+
+LOCAL_AGENT_PATH=
+if [ -f "${LOCAL_AGENT_BINARIES_URI}" ]; then
+    AGENT_BINARIES_URI="file://${LOCAL_AGENT_BINARIES_URI}"
+    LOCAL_AGENT_PATH=${LOCAL_AGENT_BINARIES_URI}
+elif [ -f $(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g") ]; then
+    AGENT_BINARIES_URI="file://"$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
+    LOCAL_AGENT_PATH=$(echo "${LOCAL_AGENT_BINARIES_URI}" | sed "s/-${PREFIX}//g")
+else
+    AGENT_BINARIES_URI=${DOWNLOAD_AGENT_BINARIES_URI}
+fi
+
+# If file is already on the filesystem, use it
+if [ ! -z ${LOCAL_AGENT_PATH} ]; then
+  tar zxf ${LOCAL_AGENT_PATH} -C ${CHE_DIR}
+else
+  echo "Terminal Agent binary is downloaded remotely"
+  # Use curl
+  if [ ${CURL_INSTALLED} = true ]; then
+    if curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif curl -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      curl -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+  else
+    # replace https by http as wget may not be able to handle ssl
+    AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')
+
+    # use wget
+    WGET_SPIDER="wget --spider"
+    if wget  2>&1 | grep -q BusyBox; then
+      WGET_SPIDER="wget -s"
+    fi
+    LOCAL_DOWNLOAD=$(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g')
+    if ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') >/dev/null; then
+      wget -qO ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+    elif ${WGET_SPIDER} -q $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
+      wget -qO- ${LOCAL_DOWNLOAD} $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    fi
+    tar xzf ${LOCAL_DOWNLOAD} -C ${CHE_DIR}
+  fi
+fi
+
+
+
+if [ -f /bin/bash ]; then
+    SHELL_INTERPRETER="/bin/bash"
+fi
+
+TERMINAL_PORT=${CHE_SERVER_TERMINAL_PORT:-4411}
+
+$HOME/che/terminal/che-websocket-terminal -addr :${TERMINAL_PORT} -cmd ${SHELL_INTERPRETER}

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -372,3 +372,10 @@ che.infra.openshift.pvc.jobs.memorylimit=250Mi
 # Detailed information about access mode is described here:
 # https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/storage.html#pv-access-modes
 che.infra.openshift.pvc.access_mode=ReadWriteOnce
+
+# Defined range of ports for installers servers
+#
+# By default, installer will use own port, but if it conflicts with another installer servers
+# then OpenShift infrastructure will reconfigure installer to use first available from this range
+che.infra.openshift.installer_server_min_port=10000
+che.infra.openshift.installer_server_max_port=20000

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/bootstrap/DockerBootstrapper.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/bootstrap/DockerBootstrapper.java
@@ -48,7 +48,7 @@ public class DockerBootstrapper extends AbstractBootstrapper {
   private final String machineName;
   private final RuntimeIdentity runtimeIdentity;
   private final DockerMachine dockerMachine;
-  private final List<Installer> installers;
+  private final List<? extends Installer> installers;
   private final int serverCheckPeriodSeconds;
   private final int installerTimeoutSeconds;
 
@@ -57,7 +57,7 @@ public class DockerBootstrapper extends AbstractBootstrapper {
       @Assisted String machineName,
       @Assisted RuntimeIdentity runtimeIdentity,
       @Assisted DockerMachine dockerMachine,
-      @Assisted List<Installer> installers,
+      @Assisted List<? extends Installer> installers,
       EventService eventService,
       @Named("che.infra.docker.master_websocket_endpoint") String cheWebsocketEndpoint,
       @Named("che.infra.docker.bootstrapper.timeout_min") int bootstrappingTimeoutMinutes,

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/bootstrap/DockerBootstrapperFactory.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/bootstrap/DockerBootstrapperFactory.java
@@ -21,6 +21,6 @@ public interface DockerBootstrapperFactory {
   DockerBootstrapper create(
       @Assisted String machineName,
       @Assisted RuntimeIdentity runtimeIdentity,
-      @Assisted List<Installer> installers,
+      @Assisted List<? extends Installer> installers,
       @Assisted DockerMachine dockerMachine);
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.InstallerServersPortProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.limits.ram.RamLimitProvisioner;
@@ -42,6 +43,7 @@ public class OpenShiftEnvironmentProvisioner {
   private final EnvVarsConverter envVarsConverter;
   private final RestartPolicyRewriter restartPolicyRewriter;
   private final RamLimitProvisioner ramLimitProvisioner;
+  private final InstallerServersPortProvisioner installerServersPortProvisioner;
 
   @Inject
   public OpenShiftEnvironmentProvisioner(
@@ -52,7 +54,8 @@ public class OpenShiftEnvironmentProvisioner {
       EnvVarsConverter envVarsConverter,
       RestartPolicyRewriter restartPolicyRewriter,
       WorkspaceVolumesStrategy volumesStrategy,
-      RamLimitProvisioner ramLimitProvisioner) {
+      RamLimitProvisioner ramLimitProvisioner,
+      InstallerServersPortProvisioner installerServersPortProvisioner) {
     this.pvcEnabled = pvcEnabled;
     this.volumesStrategy = volumesStrategy;
     this.uniqueNamesProvisioner = uniqueNamesProvisioner;
@@ -61,10 +64,14 @@ public class OpenShiftEnvironmentProvisioner {
     this.envVarsConverter = envVarsConverter;
     this.restartPolicyRewriter = restartPolicyRewriter;
     this.ramLimitProvisioner = ramLimitProvisioner;
+    this.installerServersPortProvisioner = installerServersPortProvisioner;
   }
 
   public void provision(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
       throws InfrastructureException {
+    // update environment according Infrastructure specific
+    installerServersPortProvisioner.provision(osEnv, identity);
+
     // 1 stage - converting Che model env to OpenShift env
     serversConverter.provision(osEnv, identity);
     envVarsConverter.provision(osEnv, identity);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
@@ -42,7 +42,7 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
   private static final String CONFIG_FILE = "config.json";
 
   private final RuntimeIdentity runtimeIdentity;
-  private final List<Installer> installers;
+  private final List<? extends Installer> installers;
   private final int serverCheckPeriodSeconds;
   private final int installerTimeoutSeconds;
   private final OpenShiftMachine openShiftMachine;
@@ -51,7 +51,7 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
   @Inject
   public OpenShiftBootstrapper(
       @Assisted RuntimeIdentity runtimeIdentity,
-      @Assisted List<Installer> installers,
+      @Assisted List<? extends Installer> installers,
       @Assisted OpenShiftMachine openShiftMachine,
       @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
       @Named("che.infra.openshift.bootstrapper.binary_url") String bootstrapperBinaryUrl,

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapperFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapperFactory.java
@@ -20,6 +20,6 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftMachine;
 public interface OpenShiftBootstrapperFactory {
   OpenShiftBootstrapper create(
       @Assisted RuntimeIdentity runtimeIdentity,
-      @Assisted List<Installer> agents,
+      @Assisted List<? extends Installer> agents,
       @Assisted OpenShiftMachine openShiftMachine);
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/InstallerServersPortProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/InstallerServersPortProvisioner.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import io.fabric8.kubernetes.api.model.Pod;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
+import org.eclipse.che.api.installer.server.model.impl.InstallerServerConfigImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.workspace.infrastructure.openshift.Names;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+
+/**
+ * Fixes installers servers ports if conflicts are present.
+ *
+ * <p>Installers fail to start if they provide servers which should be running on the same port.
+ * Installers in different machines can conflict too since containers in a pod use shared ports. To
+ * resolve such conflicts Infrastructure provides a free port for installer server by injection
+ * environment variable.
+ *
+ * <p>The environment variable name has the following format
+ * `CHE_SERVER_{NORMALISED_SERVER_NAME}_PORT`. Where `NORMALISED_SERVER_NAME` is a server name in
+ * the upper case where all characters which are not Latin letters or digits replaced with `_`
+ * symbol. So installers must respect the corresponding environment variables with the recommended
+ * value for server port.
+ *
+ * @author Sergii Leshchenko
+ */
+public class InstallerServersPortProvisioner implements ConfigurationProvisioner {
+
+  public static final String SERVER_PORT_ENV_FMT = "CHE_SERVER_%s_PORT";
+
+  private final int minPort;
+  private final int maxPort;
+
+  @Inject
+  public InstallerServersPortProvisioner(
+      @Named("che.infra.openshift.installer_server_min_port") int minPort,
+      @Named("che.infra.openshift.installer_server_max_port") int maxPort) {
+    this.minPort = minPort;
+    this.maxPort = maxPort;
+  }
+
+  @Override
+  public void provision(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+
+    for (Pod pod : osEnv.getPods().values()) {
+      // it is needed to detect conflicts between all containers in a pod
+      // because they use the same ports
+      List<InternalMachineConfig> podMachines =
+          pod.getSpec()
+              .getContainers()
+              .stream()
+              .map(container -> osEnv.getMachines().get(Names.machineName(pod, container)))
+              .collect(toList());
+
+      fixInstallersPortsConflicts(podMachines);
+    }
+  }
+
+  @VisibleForTesting
+  void fixInstallersPortsConflicts(List<InternalMachineConfig> machinesConfigs)
+      throws InfrastructureException {
+    ServersPorts ports = new ServersPorts();
+
+    for (InternalMachineConfig machineConfig : machinesConfigs) {
+      for (InstallerImpl installer : machineConfig.getInstallers()) {
+        Map<Integer, Collection<String>> port2ServerRefs = getServersRefsGroupedByPorts(installer);
+
+        for (Entry<Integer, Collection<String>> portServersEntry : port2ServerRefs.entrySet()) {
+          Integer port = portServersEntry.getKey();
+
+          if (!ports.occupy(port)) {
+            int newPort = ports.findFreePort();
+            assignNewPort(portServersEntry.getValue(), newPort, machineConfig, installer);
+          }
+        }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  void assignNewPort(
+      Collection<String> serversRefs,
+      int newPort,
+      InternalMachineConfig machineConfig,
+      InstallerImpl installer) {
+
+    for (String serverName : serversRefs) {
+      ServerConfig serverConfig = installer.getServers().get(serverName);
+      String protocol = getPortProtocol(serverConfig.getPort()).second;
+
+      InstallerServerConfigImpl newServerConfig = new InstallerServerConfigImpl(serverConfig);
+
+      newServerConfig.setPort(newPort + "/" + protocol);
+
+      installer.getServers().put(serverName, newServerConfig);
+
+      machineConfig.getServers().put(serverName, newServerConfig);
+
+      // put environment variable for installer
+      machineConfig.getEnv().put(getEnvName(serverName), Integer.toString(newPort));
+    }
+  }
+
+  @VisibleForTesting
+  Map<Integer, Collection<String>> getServersRefsGroupedByPorts(InstallerImpl installer) {
+    Multimap<Integer, String> portToServerNames = ArrayListMultimap.create();
+
+    for (Entry<String, ? extends ServerConfig> serverEntry : installer.getServers().entrySet()) {
+      String serverName = serverEntry.getKey();
+      ServerConfig serverConfig = serverEntry.getValue();
+
+      Pair<Integer, String> portProtocol = getPortProtocol(serverConfig.getPort());
+
+      portToServerNames.put(portProtocol.first, serverName);
+    }
+
+    return portToServerNames.asMap();
+  }
+
+  @VisibleForTesting
+  String getEnvName(String serverName) {
+    String serverNameEnv = serverName.replaceAll("\\W", "_");
+    return String.format(SERVER_PORT_ENV_FMT, serverNameEnv.toUpperCase());
+  }
+
+  private Pair<Integer, String> getPortProtocol(String port) {
+    String[] dividedPort = port.split("/");
+    Integer portValue = Integer.parseInt(dividedPort[0]);
+    String protocol = dividedPort[1];
+    return Pair.of(portValue, protocol);
+  }
+
+  class ServersPorts {
+    private Set<Integer> occupiedPorts;
+    private int freePort;
+
+    private ServersPorts() {
+      this.occupiedPorts = new HashSet<>();
+      this.freePort = minPort;
+    }
+
+    @VisibleForTesting
+    ServersPorts(int initPortValue, Set<Integer> occupiedPorts) {
+      this.occupiedPorts = occupiedPorts;
+      this.freePort = initPortValue;
+    }
+
+    /**
+     * Marks the specified port as occupied.
+     *
+     * <p>If the specified port is not already occupied <tt>true</tt> will be returned,
+     * <tt>false</tt> otherwise.
+     *
+     * @return <tt>true</tt> if this set did not already contain the specified element
+     */
+    @VisibleForTesting
+    boolean occupy(int port) {
+      return occupiedPorts.add(port);
+    }
+
+    @VisibleForTesting
+    int findFreePort() throws InternalInfrastructureException {
+      int newPort;
+      do {
+        newPort = freePort++;
+        if (newPort > maxPort) {
+          throw new InternalInfrastructureException(
+              String.format(
+                  "There is no available port in configured ports range [%s, %s].",
+                  minPort, maxPort));
+        }
+      } while (!occupiedPorts.add(newPort));
+
+      return newPort;
+    }
+
+    @VisibleForTesting
+    Set<Integer> getOccupiedPorts() {
+      return occupiedPorts;
+    }
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.inOrder;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.InstallerServersPortProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.limits.ram.RamLimitProvisioner;
@@ -38,6 +39,7 @@ import org.testng.annotations.Test;
 public class OpenShiftEnvironmentProvisionerTest {
 
   @Mock private WorkspaceVolumesStrategy volumesStrategy;
+  @Mock private InstallerServersPortProvisioner installerServersPortProvisioner;
   @Mock private UniqueNamesProvisioner uniqueNamesProvisioner;
   @Mock private OpenShiftEnvironment osEnv;
   @Mock private RuntimeIdentity runtimeIdentity;
@@ -62,9 +64,11 @@ public class OpenShiftEnvironmentProvisionerTest {
             envVarsProvisioner,
             restartPolicyRewriter,
             volumesStrategy,
-            ramLimitProvisioner);
+            ramLimitProvisioner,
+            installerServersPortProvisioner);
     provisionOrder =
         inOrder(
+            installerServersPortProvisioner,
             volumesStrategy,
             uniqueNamesProvisioner,
             tlsRouteProvisioner,
@@ -78,6 +82,9 @@ public class OpenShiftEnvironmentProvisionerTest {
   public void performsOrderedProvisioning() throws Exception {
     osInfraProvisioner.provision(osEnv, runtimeIdentity);
 
+    provisionOrder
+        .verify(installerServersPortProvisioner)
+        .provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(serversProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(envVarsProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(volumesStrategy).provision(eq(osEnv), eq(runtimeIdentity));

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/InstallerServersPortProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/InstallerServersPortProvisionerTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.InstallerServersPortProvisioner.ServersPorts;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link InstallerServersPortProvisioner}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class InstallerServersPortProvisionerTest {
+
+  @Mock private OpenShiftEnvironment osEnv;
+
+  private InstallerServersPortProvisioner portProvisioner;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    portProvisioner = spy(new InstallerServersPortProvisioner(10_000, 20_000));
+  }
+
+  @Test
+  public void shouldGroupMachinesByPodsAndLaunchPortsConflictResolvingOnProvisioning()
+      throws Exception {
+    // given
+    doNothing().when(portProvisioner).fixInstallersPortsConflicts(anyList());
+    when(osEnv.getPods())
+        .thenReturn(
+            ImmutableMap.of(
+                "pod1",
+                createPod("pod1", "container1", "container2"),
+                "pod2",
+                createPod("pod2", "container3")));
+
+    InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
+    InternalMachineConfig machine2 = mock(InternalMachineConfig.class);
+    InternalMachineConfig machine3 = mock(InternalMachineConfig.class);
+
+    when(osEnv.getMachines())
+        .thenReturn(
+            ImmutableMap.of(
+                "pod1/container1",
+                machine1,
+                "pod1/container2",
+                machine2,
+                "pod2/container3",
+                machine3));
+
+    // when
+    portProvisioner.provision(osEnv, mock(RuntimeIdentity.class));
+
+    // then
+    verify(portProvisioner).fixInstallersPortsConflicts(asList(machine1, machine2));
+    verify(portProvisioner).fixInstallersPortsConflicts(singletonList(machine3));
+  }
+
+  @Test
+  public void shouldFixInstallerPortsConflicts() throws Exception {
+    Map<String, ServerConfigImpl> servers1 = new HashMap<>();
+    servers1.put("server1", new ServerConfigImpl("8080/tcp", "http", "/api", emptyMap()));
+
+    InstallerImpl installer1 =
+        new InstallerImpl(
+            "installer1", "name", "v1", "description", emptyList(), emptyMap(), "script", servers1);
+
+    InternalMachineConfig machine1 =
+        new InternalMachineConfig(
+            singletonList(installer1), servers1, new HashMap<>(), emptyMap(), emptyMap());
+
+    Map<String, ServerConfigImpl> servers2 = new HashMap<>();
+    servers2.put("server2-http", new ServerConfigImpl("8080/tcp", "http", "/api", emptyMap()));
+    servers2.put("server2-ws", new ServerConfigImpl("8080/tcp", "ws", "/api", emptyMap()));
+
+    InstallerImpl installer2 =
+        new InstallerImpl(
+            "installer2", "name", "v1", "description", emptyList(), emptyMap(), "script", servers2);
+
+    InternalMachineConfig machine2 =
+        new InternalMachineConfig(
+            singletonList(installer2), servers2, new HashMap<>(), emptyMap(), emptyMap());
+
+    portProvisioner.fixInstallersPortsConflicts(asList(machine1, machine2));
+
+    assertTrue(machine1.getEnv().isEmpty());
+    assertEquals(machine1.getServers().get("server1").getPort(), "8080/tcp");
+    assertEquals(machine1.getInstallers().get(0).getServers().get("server1").getPort(), "8080/tcp");
+
+    assertEquals(machine2.getEnv().get("CHE_SERVER_SERVER2_HTTP_PORT"), "10000");
+
+    String newHttpServerPort = machine2.getServers().get("server2-http").getPort();
+    String newWsServerPort = machine2.getServers().get("server2-ws").getPort();
+    assertEquals(newHttpServerPort, "10000/tcp");
+    assertEquals(newWsServerPort, "10000/tcp");
+
+    String newInstallerHttpServerPort =
+        machine2.getInstallers().get(0).getServers().get("server2-http").getPort();
+
+    String newInstallerWsServerPort =
+        machine2.getInstallers().get(0).getServers().get("server2-ws").getPort();
+    assertEquals(newInstallerHttpServerPort, "10000/tcp");
+    assertEquals(newInstallerWsServerPort, "10000/tcp");
+
+    assertEquals(newHttpServerPort, newInstallerHttpServerPort);
+    assertEquals(newWsServerPort, newInstallerWsServerPort);
+  }
+
+  @Test
+  public void shouldReturnGroupedServersByPort() {
+    // given
+    Map<String, ServerConfigImpl> installerServers = new HashMap<>();
+    installerServers.put(
+        "server1-http", new ServerConfigImpl("8080/tcp", "http", "/api", emptyMap()));
+    installerServers.put("server1-ws", new ServerConfigImpl("8080/tcp", "ws", "/api", emptyMap()));
+    installerServers.put("server1-udp", new ServerConfigImpl("8080/udp", "udp", "", emptyMap()));
+    installerServers.put("server2", new ServerConfigImpl("8081/tcp", "http", "/api", emptyMap()));
+
+    InstallerImpl installer =
+        new InstallerImpl(
+            "installer1",
+            "name",
+            "v1",
+            "description",
+            emptyList(),
+            emptyMap(),
+            "script",
+            installerServers);
+
+    // when
+    Map<Integer, Collection<String>> portToServersRefs =
+        portProvisioner.getServersRefsGroupedByPorts(installer);
+
+    // then
+    Collection<String> servers8080 = portToServersRefs.get(8080);
+    assertEquals(servers8080.size(), 3);
+    assertTrue(
+        servers8080.containsAll(ImmutableSet.of("server1-http", "server1-ws", "server1-udp")));
+
+    Collection<String> servers8081 = portToServersRefs.get(8081);
+    assertEquals(servers8081.size(), 1);
+    assertTrue(servers8081.contains("server2"));
+  }
+
+  @Test
+  public void shouldAssignNewPortToInstallerServer() throws Exception {
+    // given
+    Set<String> serversRefs = ImmutableSet.of("server1-http", "server1-ws");
+
+    Map<String, ServerConfigImpl> installerServers = new HashMap<>();
+    installerServers.put(
+        "server1-http", new ServerConfigImpl("8080/tcp", "http", "/api", emptyMap()));
+    installerServers.put("server1-ws", new ServerConfigImpl("8080/tcp", "ws", "/api", emptyMap()));
+
+    Map<String, ServerConfigImpl> machineServers = new HashMap<>();
+    machineServers.put("server2", new ServerConfigImpl("8080/tcp", "http", "/api", emptyMap()));
+    machineServers.putAll(installerServers);
+
+    InstallerImpl installer =
+        new InstallerImpl(
+            "installer1",
+            "name",
+            "v1",
+            "description",
+            emptyList(),
+            emptyMap(),
+            "script",
+            installerServers);
+
+    InternalMachineConfig machineConfig =
+        new InternalMachineConfig(
+            singletonList(installer), machineServers, new HashMap<>(), emptyMap(), emptyMap());
+
+    // when
+    portProvisioner.assignNewPort(
+        serversRefs, 10007, machineConfig, machineConfig.getInstallers().get(0));
+
+    // then
+    assertEquals(machineConfig.getEnv().size(), 2);
+
+    assertEquals(machineConfig.getEnv().get("CHE_SERVER_SERVER1_WS_PORT"), "10007");
+    assertEquals(machineConfig.getServers().get("server1-ws").getPort(), "10007/tcp");
+    assertEquals(
+        machineConfig.getInstallers().get(0).getServers().get("server1-ws").getPort(), "10007/tcp");
+
+    assertEquals(machineConfig.getEnv().get("CHE_SERVER_SERVER1_HTTP_PORT"), "10007");
+    assertEquals(machineConfig.getServers().get("server1-http").getPort(), "10007/tcp");
+    assertEquals(
+        machineConfig.getInstallers().get(0).getServers().get("server1-http").getPort(),
+        "10007/tcp");
+  }
+
+  @Test(dataProvider = "serverToEnvVar")
+  public void shouldReturnEnvironmentVariableNameByServerName(String serverName, String envVar) {
+    // when
+    String envName = portProvisioner.getEnvName(serverName);
+
+    // then
+    assertEquals(envName, envVar);
+  }
+
+  @DataProvider
+  public Object[][] serverToEnvVar() {
+    return new Object[][] {
+      {"terminal|pty", "CHE_SERVER_TERMINAL_PTY_PORT"},
+      {"wsagent/http", "CHE_SERVER_WSAGENT_HTTP_PORT"},
+      {"tomcat-8080", "CHE_SERVER_TOMCAT_8080_PORT"},
+      {"tomcat@8080", "CHE_SERVER_TOMCAT_8080_PORT"}
+    };
+  }
+
+  @Test(dataProvider = "occupiedPorts")
+  public void shouldFindFirstAvailableFreePort(ServersPorts ports, Integer result)
+      throws Exception {
+    // given
+    int originalOccupiedPortsNumber = ports.getOccupiedPorts().size();
+
+    // when
+    Integer availablePort = ports.findFreePort();
+
+    // then
+    assertEquals(availablePort, result);
+    assertTrue(ports.getOccupiedPorts().contains(result));
+    assertEquals(ports.getOccupiedPorts().size(), originalOccupiedPortsNumber + 1);
+  }
+
+  @DataProvider
+  public Object[][] occupiedPorts() {
+    return new Object[][] {
+      {portProvisioner.new ServersPorts(10_000, Sets.newHashSet(10_000, 10_001, 10_002)), 10_003},
+      {portProvisioner.new ServersPorts(10_000, Sets.newHashSet(10_000, 10_002)), 10_001},
+    };
+  }
+
+  @Test(
+    expectedExceptions = InternalInfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "There is no available port in configured ports range \\[10000, 20000\\]."
+  )
+  public void shouldThrowExceptionIfThereIsNotFreePort() throws Exception {
+    // given
+    ServersPorts ports = portProvisioner.new ServersPorts(20_001, emptySet());
+
+    // when
+    ports.findFreePort();
+  }
+
+  private Pod createPod(String podName, String... containersNames) {
+    List<Container> containers =
+        Arrays.stream(containersNames)
+            .map(name -> new ContainerBuilder().withName(name).build())
+            .collect(Collectors.toList());
+    return new PodBuilder()
+        .withNewMetadata()
+        .withName(podName)
+        .endMetadata()
+        .withNewSpec()
+        .withContainers(containers)
+        .endSpec()
+        .build();
+  }
+}

--- a/wsmaster/che-core-api-installer/src/main/java/org/eclipse/che/api/installer/server/model/impl/InstallerImpl.java
+++ b/wsmaster/che-core-api-installer/src/main/java/org/eclipse/che/api/installer/server/model/impl/InstallerImpl.java
@@ -234,7 +234,7 @@ public class InstallerImpl implements Installer {
   }
 
   @Override
-  public Map<String, ? extends ServerConfig> getServers() {
+  public Map<String, InstallerServerConfigImpl> getServers() {
     if (servers == null) {
       servers = new HashMap<>();
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
@@ -11,12 +11,12 @@
 package org.eclipse.che.api.workspace.server.spi.environment;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
 import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
@@ -33,7 +33,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
  * @author gazarenkov
  */
 public class InternalMachineConfig {
-  private final List<Installer> installers;
+  private final List<InstallerImpl> installers;
   private final Map<String, ServerConfig> servers;
   private final Map<String, String> env;
   private final Map<String, String> attributes;
@@ -59,7 +59,7 @@ public class InternalMachineConfig {
       this.servers.putAll(servers);
     }
     if (installers != null) {
-      this.installers.addAll(installers);
+      installers.forEach(i -> this.installers.add(new InstallerImpl(i)));
     }
     if (env != null) {
       this.env.putAll(env);
@@ -72,9 +72,9 @@ public class InternalMachineConfig {
     }
   }
 
-  /** Returns unmodifiable ordered list of installers configs of the machine. */
-  public List<Installer> getInstallers() {
-    return Collections.unmodifiableList(installers);
+  /** Returns modifiable ordered list of installers configs of the machine. */
+  public List<InstallerImpl> getInstallers() {
+    return installers;
   }
 
   /** Returns modifiable map of servers configured in the machine. */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisioner.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
 import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
@@ -60,7 +61,7 @@ public class InstallerConfigProvisioner implements InternalEnvironmentProvisione
    * @param env map to fill
    * @param installers installers to retrieve env
    */
-  private void fillEnv(Map<String, String> env, List<Installer> installers) {
+  private void fillEnv(Map<String, String> env, List<InstallerImpl> installers) {
     for (Installer installer : installers) {
       String envVars = installer.getProperties().get(Installer.ENVIRONMENT_PROPERTY);
       if (isNullOrEmpty(envVars)) {
@@ -89,9 +90,9 @@ public class InstallerConfigProvisioner implements InternalEnvironmentProvisione
    * @throws InfrastructureException if any installer has server that conflicts with already
    *     configured one
    */
-  private void fillServers(Map<String, ServerConfig> servers, List<Installer> installers)
+  private void fillServers(Map<String, ServerConfig> servers, List<InstallerImpl> installers)
       throws InfrastructureException {
-    for (Installer installer : installers) {
+    for (InstallerImpl installer : installers) {
       for (Map.Entry<String, ? extends ServerConfig> serverEntry :
           installer.getServers().entrySet()) {
         if (servers.putIfAbsent(serverEntry.getKey(), serverEntry.getValue()) != null

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.api.workspace.server.spi.environment;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
@@ -25,6 +27,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +37,7 @@ import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.installer.server.InstallerRegistry;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
 import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
@@ -95,10 +99,11 @@ public class InternalEnvironmentFactoryTest {
   @Test
   public void shouldUseRetrievedInstallerWhileInternalEnvironmentCreation() throws Exception {
     // given
-    List<Installer> installersToRetrieve = singletonList(mock(Installer.class));
+    List<Installer> installersToRetrieve =
+        ImmutableList.of(createInstaller("org.eclipse.che.terminal", "script"));
     doReturn(installersToRetrieve).when(installerRegistry).getOrderedInstallers(anyList());
 
-    List<String> sourceInstallers = singletonList("ws-agent");
+    List<String> sourceInstallers = singletonList("org.eclipse.che.terminal");
     MachineConfigImpl machineConfig = new MachineConfigImpl().withInstallers(sourceInstallers);
     EnvironmentImpl env = new EnvironmentImpl(null, ImmutableMap.of("machine", machineConfig));
 
@@ -198,6 +203,10 @@ public class InternalEnvironmentFactoryTest {
     environmentFactory.create(mock(Environment.class));
 
     assertEquals(machine.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE), ramLimit);
+  }
+
+  private InstallerImpl createInstaller(String id, String script) {
+    return new InstallerImpl(id, "any", "any", "any", emptyList(), emptyMap(), script, emptyMap());
   }
 
   private static class TestEnvironmentFactory

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/MachineConfigsValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/MachineConfigsValidatorTest.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
-import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.shared.Constants;
@@ -211,7 +210,7 @@ public class MachineConfigsValidatorTest {
     return machineConfig;
   }
 
-  private static List<Installer> createInstallers(String... installers) {
+  private static List<InstallerImpl> createInstallers(String... installers) {
     return Arrays.stream(installers)
         .map(s -> new InstallerImpl().withId(s))
         .collect(Collectors.toList());

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisionerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisionerTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
 import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
@@ -45,8 +46,8 @@ public class InstallerConfigProvisionerTest {
   @Mock private InternalMachineConfig machine1;
   @Mock private InternalMachineConfig machine2;
 
-  @Mock private Installer installer1;
-  @Mock private Installer installer2;
+  @Mock private InstallerImpl installer1;
+  @Mock private InstallerImpl installer2;
 
   private InstallerConfigProvisioner installerConfigProvisioner;
 


### PR DESCRIPTION
### What does this PR do?
Adds resolving of conflicts between installers servers for OpenShift infra.

So, If different installers (in one machine or different machine but in one pod) declare servers with the same port then servers of one installer will be reconfigured to use the first available port from configured range. Reconfiguring will be performed in the following way: server port will be updated in machine and installers configuration, also `CHE_SERVER_${NORMALISED_SERVER_NAME}_PORT` environment variable will be injected into the corresponding machine. Where `NORMALISED_SERVER_NAME` is a server name in the upper case where all characters which are not Latin letters or digit replaced with `_` symbol. 

Installers must respect the corresponding environment variables with the recommended value for server port.

`Exec` and `terminal` installers are adapted to use environment variable with the port for their servers.
While we must add new installers script instead of editing existing ones it's difficult to review changes, so I prepared changes that are made in installers scripts:
<details>
<summary>terminal changes</summary>

![terminal_diff](https://user-images.githubusercontent.com/5887312/35087879-5c822db0-fc3a-11e7-846b-736e5f4e9574.png)

</details>

<details>
<summary>exec agent changes</summary>

![exec_agent_diff](https://user-images.githubusercontent.com/5887312/35043147-2669075e-fb94-11e7-918b-172d3cc46dec.png)

</details>


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7927

#### Release Notes
Added resolving of conflicts between installers servers for OpenShift infra.

#### Docs PR
Will add docs for installers developers and section about new environment variables.