### PR TITLE
Selenium: add checking that a project is visible in projects list before selecting it in the Add or Import Project form

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/ProjectSourcePage.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/ProjectSourcePage.java
@@ -162,7 +162,8 @@ public class ProjectSourcePage {
    */
   public void selectSample(String name) {
     WebElement sample =
-        seleniumWebDriver.findElement(By.xpath(format(Locators.SAMPLE_CHECKBOX, name)));
+        new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
+            .until(visibilityOfElementLocated(By.xpath(format(Locators.SAMPLE_CHECKBOX, name))));
     sample.click();
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds waiting that a project is visible in projects list before selecting it. 

**Failed selenium test:** WorkspaceDetailsSingleMachineTest

**Report with reproduced bug:**
https://ci.codenvycorp.com/view/qa/job/che-integration-tests-multiuser-master-ocp/84/Selenium_tests_report/

**Screenshot:**
![org eclipse che selenium dashboard workspacedetailssinglemachinetest checkworkingwithprojects_w6ohavg1 1](https://user-images.githubusercontent.com/7760565/34994784-478e2764-fadd-11e7-837b-0cf4ee5d9a48.png)
