### PR TITLE
CHE-8304: Support DTO generating for new LSP4J constructs

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -193,6 +193,7 @@
                     <excludes>
                         <exclude>**/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/LatestCompletionResult.java</exclude>
                         <exclude>**/Either.java</exclude>
+                        <exclude>**/Either3.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/lsp4j/jsonrpc/messages/Either.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/lsp4j/jsonrpc/messages/Either.java
@@ -1,14 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.messages;
+
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 /**
  * An either type maps union types in protocol specifications.
- *
- * @param <L>
- * @param <R>
  */
 public class Either<L, R> {
+
+    public static <L, R> Either<L, R> forLeft(@NonNull L left) {
+        return new Either<L, R>(left, null);
+    }
+
+    public static <L, R> Either<L, R> forRight(@NonNull R right) {
+        return new Either<L, R>(null, right);
+    }
 
     private final L left;
     private final R right;
@@ -17,14 +30,6 @@ public class Either<L, R> {
         super();
         this.left = left;
         this.right = right;
-    }
-
-    public static <L, R> Either<L, R> forLeft(@NonNull L left) {
-        return new Either<L, R>(left, null);
-    }
-
-    public static <L, R> Either<L, R> forRight(@NonNull R right) {
-        return new Either<L, R>(null, right);
     }
 
     public L getLeft() {
@@ -41,6 +46,25 @@ public class Either<L, R> {
 
     public boolean isRight() {
         return right != null;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Either<?, ?>) {
+            Either<?, ?> other = (Either<?, ?>) obj;
+            return this.left != null && other.left != null && this.left.equals(other.left)
+                    || this.right != null && other.right != null && this.right.equals(other.right);
+        }
+        return false;
+    }
+    
+    @Override
+    public int hashCode() {
+        if (this.left != null)
+            return this.left.hashCode();
+        if (this.right != null)
+            return this.right.hashCode();
+        return 0;
     }
 
     public String toString() {

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/lsp4j/jsonrpc/messages/Either3.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/resources/org/eclipse/lsp4j/jsonrpc/messages/Either3.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.messages;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+/**
+ * Union type for three types.
+ */
+public class Either3<T1, T2, T3> extends Either<T1, Either<T2, T3>> {
+    
+    public static <T1, T2, T3> Either3<T1, T2, T3> forFirst(@NonNull T1 first) {
+        return new Either3<T1, T2, T3>(first, null);
+    }
+
+    public static <T1, T2, T3> Either3<T1, T2, T3> forSecond(@NonNull T2 second) {
+        return new Either3<T1, T2, T3>(null, new Either<T2, T3>(second, null));
+    }
+    
+    public static <T1, T2, T3> Either3<T1, T2, T3> forThird(@NonNull T3 third) {
+        return new Either3<T1, T2, T3>(null, new Either<T2, T3>(null, third));
+    }
+    
+    public static <T1, T2, T3> Either3<T1, T2, T3> forLeft3(@NonNull T1 first) {
+        return new Either3<T1, T2, T3>(first, null);
+    }
+    
+    public static <T1, T2, T3> Either3<T1, T2, T3> forRight3(@NonNull Either<T2, T3> right) {
+        return new Either3<T1, T2, T3>(null, right);
+    }
+
+    protected Either3(T1 left, Either<T2, T3> right) {
+        super(left, right);
+    }
+    
+    public T1 getFirst() {
+        return getLeft();
+    }
+    
+    public T2 getSecond() {
+        Either<T2, T3> right = getRight();
+        if (right == null)
+            return null;
+        else
+            return right.getLeft();
+    }
+    
+    public T3 getThird() {
+        Either<T2, T3> right = getRight();
+        if (right == null)
+            return null;
+        else
+            return right.getRight();
+    }
+    
+    public boolean isFirst() {
+        return isLeft();
+    }
+    
+    public boolean isSecond() {
+        return isRight() && getRight().isLeft();
+    }
+    
+    public boolean isThird() {
+        return isRight() && getRight().isRight();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("Either3 [").append("\n");
+        builder.append("  first = ").append(getFirst()).append("\n");
+        builder.append("  second = ").append(getSecond()).append("\n");
+        builder.append("  third = ").append(getThird()).append("\n");
+        return builder.append("]").toString();
+    }
+
+}

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/DtoGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/DtoGenerator.java
@@ -161,6 +161,7 @@ public abstract class DtoGenerator {
       out.println("import java.util.ArrayList;");
       out.println("import java.util.HashMap;");
       out.println("import org.eclipse.lsp4j.jsonrpc.messages.Either;");
+      out.println("import org.eclipse.lsp4j.jsonrpc.messages.Either3;");
       out.println("import org.eclipse.che.api.languageserver.util.EitherUtil;");
       out.println("import org.eclipse.che.api.languageserver.util.JsonUtil;");
       out.println("import org.eclipse.che.api.languageserver.shared.util.JsonDecision;");

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/EitherUtil.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/EitherUtil.java
@@ -29,6 +29,18 @@ public class EitherUtil {
     return getDisjointType(type, 1);
   }
 
+  static Type getFirstDisjointType(Type type) {
+    return getDisjointType(type, 0);
+  }
+
+  static Type getSecondDisjointType(Type type) {
+    return getDisjointType(type, 1);
+  }
+
+  static Type getThirdDisjointType(Type type) {
+    return getDisjointType(type, 2);
+  }
+
   private static Type getDisjointType(Type type, int index) {
     if (type instanceof ParameterizedType) {
       final ParameterizedType parameterizedType = (ParameterizedType) type;

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ToDtoGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/ToDtoGenerator.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 
 /**
  * This class generates property conversions from regular lsp4j classes to dto classes. Used to
@@ -90,6 +91,8 @@ public class ToDtoGenerator extends ConversionGenerator {
       generateListConversion(indent + INDENT, out, varName, valueAccess, paramType);
     } else if (Map.class.isAssignableFrom(rawClass)) {
       generateMapConversion(indent + INDENT, out, varName, valueAccess, paramType);
+    } else if (Either3.class.isAssignableFrom(getRawClass(paramType))) {
+      generateEither3Conversion(indent + INDENT, out, varName, valueAccess, paramType);
     } else if (Either.class.isAssignableFrom(rawClass)) {
       generateEitherConversion(indent + INDENT, out, varName, valueAccess, paramType);
     } else {
@@ -100,6 +103,41 @@ public class ToDtoGenerator extends ConversionGenerator {
               varName,
               dtoValueExpression(rawClass, valueAccess)));
     }
+  }
+
+  private void generateEither3Conversion(
+      String indent, PrintWriter out, String varName, String valueAccess, Type paramType) {
+    String innerName = varName + "e";
+
+    out.println(indent + String.format("%1$s %2$s;", paramType.getTypeName(), varName));
+    out.println(indent + String.format("if (%1$s.isFirst()) {", valueAccess));
+    generateToDto(
+        indent + INDENT,
+        out,
+        innerName,
+        valueAccess + ".getFirst()",
+        EitherUtil.getFirstDisjointType(paramType));
+    out.println(
+        indent + INDENT + String.format("%1$s= Either3.forFirst(%2$s);", varName, innerName));
+    out.println(indent + String.format("} else if (%1$s.isSecond()) {", valueAccess));
+    generateToDto(
+        indent + INDENT,
+        out,
+        innerName,
+        valueAccess + ".getSecond()",
+        EitherUtil.getSecondDisjointType(paramType));
+    out.println(
+        indent + INDENT + String.format("%1$s= Either3.forSecond(%2$s);", varName, innerName));
+    out.println(indent + "} else  {");
+    generateToDto(
+        indent + INDENT,
+        out,
+        innerName,
+        valueAccess + ".getThird()",
+        EitherUtil.getThirdDisjointType(paramType));
+    out.println(
+        indent + INDENT + String.format("%1$s= Either3.forThird(%2$s);", varName, innerName));
+    out.println(indent + "}");
   }
 
   private void generateEitherConversion(
@@ -129,6 +167,9 @@ public class ToDtoGenerator extends ConversionGenerator {
 
   private void generateMapConversion(
       String indent, PrintWriter out, String varName, String valueAccess, Type paramType) {
+    if (!(paramType instanceof ParameterizedType)) {
+      paramType = ((Class<?>) paramType).getGenericSuperclass();
+    }
     ParameterizedType genericType = (ParameterizedType) paramType;
     Type containedType = genericType.getActualTypeArguments()[1];
     Type valueType = genericType.getActualTypeArguments()[1];


### PR DESCRIPTION
Support for classes that extend a Map type and Either3.
See org.eclipse.lsp4j.FormattingOptions

### What does this PR do?

Fixes #8304: Adds support for Dto generation in new cases exposed by LSP4J 0.3.0+. Two specific cases are catered for, both exposed by the rewriting of [FormattingOptions](https://github.com/eclipse/lsp4j/blob/026cb14c2218f6e8a9fb1d8464f38b49a9d7177a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java#L22) in https://github.com/eclipse/lsp4j/issues/99#issuecomment-313330347.

The new signature for the class is:
```java
public class FormattingOptions extends LinkedHashMap<String, Either3<String, Number, Boolean>> {}
```
The first issue is that FormattingOptions is of type Map, but does not have generics itself. This is resolved with a little heuristic that attempts to get the generic types from the superclass.

The second issue is the new Either3 type. New support has been written for Either3.

This allows, but also requires, Lsp4j to be upgraded to 0.3.0 or later (when Either3 was introduced). The upgrade is useful for new features, but more importantly, Debug Protocol implementation in #5508 requires it. As such a PR for che-dependencies is also included, see https://github.com/eclipse/che-dependencies/pull/93

### What issues does this PR fix or reference?

Fixes #8304 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

The version of LSP4J has been upgraded to 0.3.0.


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
