### PR TITLE
Sync JAVA_OPTS of workspace master between docker and openshift config

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/che-config
+++ b/dockerfiles/init/modules/openshift/files/scripts/che-config
@@ -29,6 +29,5 @@ CHE_MULTIUSER: ${CHE_MULTIUSER}
 CHE_OAUTH_GITHUB_CLIENTID: ${CHE_OAUTH_GITHUB_CLIENTID}
 CHE_OAUTH_GITHUB_CLIENTSECRET: ${CHE_OAUTH_GITHUB_CLIENTSECRET}
 CHE_PREDEFINED_STACKS_RELOAD__ON__START: ${CHE_PREDEFINED_STACKS_RELOAD}
-CHE_SERVER_JAVA_OPTS: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
+JAVA_OPTS: "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m "
 CHE_WORKSPACE_AUTO_START: "false"
-CHE_WORKSPACE_JAVA_OPTIONS: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"


### PR DESCRIPTION
### What does this PR do?
1. Sync JAVA_OPTS of workspace master between docker and openshift config.
2. Fixed master crashes, since CHE_SERVER_JAVA_OPTS was not used default memory limit was set to 2G with a limit on container 1G.
3. Used default jvm for ws-agent JVM configs.


#### Release Notes
Sync JAVA_OPTS of workspace master between docker and openshift config.

#### Docs PR
n/a
