### PR TITLE
add test for DNS providers in ocp.sh and use backup if default doesn't work

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
@@ -40,7 +40,7 @@ export OPENSHIFT_USERNAME=${OPENSHIFT_USERNAME:-${DEFAULT_OPENSHIFT_USERNAME}}
 DEFAULT_OPENSHIFT_PASSWORD="developer"
 export OPENSHIFT_PASSWORD=${OPENSHIFT_PASSWORD:-${DEFAULT_OPENSHIFT_PASSWORD}}
 
-BACKUP_DNS_PROVIDERS=(
+DNS_PROVIDERS=(
 xip.io
 nip.codenvy-stg.com
 )
@@ -82,22 +82,18 @@ export CONFIG_DIR=${CONFIG_DIR:-${DEFAULT_CONFIG_DIR}}
 }
 
 test_dns_provider() {
-    #Test  DNS_PROVIDER
-    if [[ $(dig +short 10.0.0.1.$DNS_PROVIDER) = "10.0.0.1" ]]; then
-        echo "$DNS_PROVIDER works - OK"
-    else
-        echo "$DNS_PROVIDER seems is not working, trying to use BACKUP_DNS_PROVIDERS"
-        for i in ${BACKUP_DNS_PROVIDERS[@]}
-            do
-            if [[ $(dig +short 10.0.0.1.$i) = "10.0.0.1" ]]; then
-                echo "$i - works OK, using it as DNS provider"
-                export DNS_PROVIDER="$i"
-                break;
-             else
-                echo "Test $i DNS provider failed, trying next one."
-            fi
-            done
-    fi
+    #add current $DNS_PROVIDER to the providers list to respect environment settings
+    DNS_PROVIDERS=("$DNS_PROVIDER" "${DNS_PROVIDERS[@]}")
+    for i in ${DNS_PROVIDERS[@]}
+        do
+        if [[ $(dig +short 10.0.0.1.$i) = "10.0.0.1" ]]; then
+            echo "Test $i - works OK, using it as DNS provider"
+            export DNS_PROVIDER="$i"
+            break;
+         else
+            echo "Test $i DNS provider failed, trying next one."
+        fi
+        done
 }
 
 get_tools() {

--- a/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
@@ -86,7 +86,7 @@ test_dns_provider() {
     DNS_PROVIDERS=("$DNS_PROVIDER" "${DNS_PROVIDERS[@]}")
     for i in ${DNS_PROVIDERS[@]}
         do
-        if [[ $(dig +short 10.0.0.1.$i) = "10.0.0.1" ]]; then
+        if [[ $(dig +short +time=5 +tries=1 10.0.0.1.$i) = "10.0.0.1" ]]; then
             echo "Test $i - works OK, using it as DNS provider"
             export DNS_PROVIDER="$i"
             break;


### PR DESCRIPTION
nip.io is down again... and we have failed tests on CI due to that.
So this PR adds the check for DNS provider and if default `nip.io` will fail test,  backup DNS provider will be used.

needed for: https://github.com/eclipse/che/issues/8326