### PR TITLE
Fix remove project.

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/ocp.sh
@@ -356,6 +356,9 @@ parse_args() {
            --update)
                shift
            ;;
+           --remove-che)
+               shift
+           ;;
            --help)
                echo -e "$HELP"
                exit 1


### PR DESCRIPTION
### What does this PR do?
Fix remove project. osh.sh script needs to find `--remove-che` in case search or script fails. Added it in and provided a shift.

#### Release Notes
N/A

Signed-off-by: James Drummond <james@devcomb.com>
