### PR TITLE
Recompute diagnostics for pom.xml file

### DIFF
--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/JavaLanguageServerExtensionStub.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/JavaLanguageServerExtensionStub.java
@@ -17,7 +17,6 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.debug.shared.model.Location;
 import org.eclipse.che.api.debug.shared.model.impl.LocationImpl;
-import org.eclipse.che.api.languageserver.registry.CheLanguageClientFactory;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.plugin.java.languageserver.JavaLanguageServerExtensionService;
@@ -29,9 +28,6 @@ public class JavaLanguageServerExtensionStub extends JavaLanguageServerExtension
 
   public JavaLanguageServerExtensionStub() {
     super(
-        mock(
-            CheLanguageClientFactory.class,
-            Mockito.withSettings().defaultAnswer(RETURNS_DEEP_STUBS)),
         mock(
             LanguageServerRegistry.class, Mockito.withSettings().defaultAnswer(RETURNS_DEEP_STUBS)),
         mock(

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/JavaLanguageServerExtensionStub.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/JavaLanguageServerExtensionStub.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.debug.shared.model.Location;
 import org.eclipse.che.api.debug.shared.model.impl.LocationImpl;
+import org.eclipse.che.api.languageserver.registry.CheLanguageClientFactory;
 import org.eclipse.che.api.languageserver.registry.LanguageServerRegistry;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.plugin.java.languageserver.JavaLanguageServerExtensionService;
@@ -28,6 +29,9 @@ public class JavaLanguageServerExtensionStub extends JavaLanguageServerExtension
 
   public JavaLanguageServerExtensionStub() {
     super(
+        mock(
+            CheLanguageClientFactory.class,
+            Mockito.withSettings().defaultAnswer(RETURNS_DEEP_STUBS)),
         mock(
             LanguageServerRegistry.class, Mockito.withSettings().defaultAnswer(RETURNS_DEEP_STUBS)),
         mock(

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/diagnostics/PomDiagnosticsRequestor.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/diagnostics/PomDiagnosticsRequestor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.ext.java.client.diagnostics;
+
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+import org.eclipse.che.ide.api.editor.EditorOpenedEvent;
+import org.eclipse.che.ide.api.editor.EditorOpenedEventHandler;
+import org.eclipse.che.ide.ext.java.client.service.JavaLanguageExtensionServiceClient;
+import org.eclipse.che.ide.resource.Path;
+
+/**
+ * Asks JDT.LS to get diagnostics for opened pom.xml file.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class PomDiagnosticsRequestor {
+
+  private static final String POM_FILE = "pom.xml";
+
+  @Inject
+  public PomDiagnosticsRequestor(
+      final EventBus eventBus, final JavaLanguageExtensionServiceClient service) {
+    eventBus.addHandler(
+        EditorOpenedEvent.TYPE,
+        new EditorOpenedEventHandler() {
+          @Override
+          public void onEditorOpened(EditorOpenedEvent event) {
+            Path path = event.getFile().getLocation();
+            if (!POM_FILE.equals(path.lastSegment())) {
+              return;
+            }
+            new Timer() {
+              @Override
+              public void run() {
+                processEditorOpened(path);
+              }
+            }.schedule(300);
+          }
+
+          private void processEditorOpened(Path path) {
+            service.reComputePomDiagnostics(path.toString());
+          }
+        });
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/diagnostics/PomDiagnosticsRequestor.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/diagnostics/PomDiagnosticsRequestor.java
@@ -17,7 +17,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.api.editor.EditorOpenedEvent;
 import org.eclipse.che.ide.api.editor.EditorOpenedEventHandler;
 import org.eclipse.che.ide.ext.java.client.service.JavaLanguageExtensionServiceClient;
-import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 
 /**
  * Asks JDT.LS to get diagnostics for opened pom.xml file.
@@ -31,26 +31,28 @@ public class PomDiagnosticsRequestor {
 
   @Inject
   public PomDiagnosticsRequestor(
-      final EventBus eventBus, final JavaLanguageExtensionServiceClient service) {
+      final EventBus eventBus,
+      DtoBuildHelper buildHelper,
+      final JavaLanguageExtensionServiceClient service) {
     eventBus.addHandler(
         EditorOpenedEvent.TYPE,
         new EditorOpenedEventHandler() {
           @Override
           public void onEditorOpened(EditorOpenedEvent event) {
-            Path path = event.getFile().getLocation();
-            if (!POM_FILE.equals(path.lastSegment())) {
+            String uri = buildHelper.getUri(event.getFile());
+            if (uri.endsWith(POM_FILE)) {
               return;
             }
             new Timer() {
               @Override
               public void run() {
-                processEditorOpened(path);
+                processEditorOpened(uri);
               }
             }.schedule(300);
           }
 
-          private void processEditorOpened(Path path) {
-            service.reComputePomDiagnostics(path.toString());
+          private void processEditorOpened(String uri) {
+            service.reComputePomDiagnostics(uri);
           }
         });
   }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/inject/JavaGinModule.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/inject/JavaGinModule.java
@@ -37,6 +37,7 @@ import org.eclipse.che.ide.ext.java.client.command.valueproviders.ClasspathMacro
 import org.eclipse.che.ide.ext.java.client.command.valueproviders.MainClassMacro;
 import org.eclipse.che.ide.ext.java.client.command.valueproviders.OutputDirMacro;
 import org.eclipse.che.ide.ext.java.client.command.valueproviders.SourcepathMacro;
+import org.eclipse.che.ide.ext.java.client.diagnostics.PomDiagnosticsRequestor;
 import org.eclipse.che.ide.ext.java.client.documentation.QuickDocPresenter;
 import org.eclipse.che.ide.ext.java.client.documentation.QuickDocumentation;
 import org.eclipse.che.ide.ext.java.client.inject.factories.PropertyWidgetFactory;
@@ -85,6 +86,8 @@ public class JavaGinModule extends AbstractGinModule {
     bind(NewJavaSourceFileView.class).to(NewJavaSourceFileViewImpl.class).in(Singleton.class);
     bind(QuickDocumentation.class).to(QuickDocPresenter.class).in(Singleton.class);
     bind(JavaNavigationService.class).to(JavaNavigationServiceImpl.class);
+
+    bind(PomDiagnosticsRequestor.class).asEagerSingleton();
 
     GinMultibinder.newSetBinder(binder(), NodeInterceptor.class)
         .addBinding()

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
@@ -23,6 +23,7 @@ import static org.eclipse.che.ide.ext.java.shared.Constants.FILE_STRUCTURE;
 import static org.eclipse.che.ide.ext.java.shared.Constants.GET_JAVA_CORE_OPTIONS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.IMPLEMENTERS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.ORGANIZE_IMPORTS;
+import static org.eclipse.che.ide.ext.java.shared.Constants.RECOMPUTE_POM_DIAGNOSTICS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REIMPORT_MAVEN_PROJECTS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REIMPORT_MAVEN_PROJECTS_REQUEST_TIMEOUT;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REQUEST_TIMEOUT;
@@ -181,6 +182,17 @@ public class JavaLanguageExtensionServiceClient {
                 .onSuccess(resolve::apply)
                 .onTimeout(() -> onTimeout(reject))
                 .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));
+  }
+
+  public Promise<Void> reComputePomDiagnostics(String pomPath) {
+    return Promises.create(
+        (resolve, reject) ->
+            requestTransmitter
+                .newRequest()
+                .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
+                .methodName(RECOMPUTE_POM_DIAGNOSTICS)
+                .paramsAsString(pomPath)
+                .sendAndSkipResult());
   }
 
   /**

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
@@ -50,6 +50,7 @@ public final class Constants {
   public static final String UPDATE_JAVA_CORE_OPTIONS = "java/updateJavaCoreOptions";
   public static final String GET_PREFERENCES = "java/getPreferences";
   public static final String UPDATE_PREFERENCES = "java/updatePreferences";
+  public static final String RECOMPUTE_POM_DIAGNOSTICS = "java/recomputePomDiagnostics";
 
   private Constants() {
     throw new UnsupportedOperationException("Unused constructor.");

--- a/plugins/plugin-java/che-plugin-java-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-server/pom.xml
@@ -67,10 +67,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-languageserver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-languageserver-shared</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
@@ -573,12 +573,12 @@ public class JavaLanguageServerExtensionService {
     Type type = new TypeToken<PublishDiagnosticsParams>() {}.getType();
     PublishDiagnosticsParams diagnostics =
         doGetOne(Commands.RECOMPUTE_POM_DIAGNOSTICS, singletonList(pomUri), type);
-    Optional<InitializedLanguageServer> lServer = findInitializedLanguageServer();
-    if (!lServer.isPresent()) {
+    Optional<InitializedLanguageServer> languageServer = findInitializedLanguageServer();
+    if (!languageServer.isPresent()) {
       LOG.error("Language server not initialized.");
       return;
     }
-    String serverId = lServer.get().getId();
+    String serverId = languageServer.get().getId();
     eventService.publish(new ExtendedPublishDiagnosticsParams(serverId, diagnostics));
   }
 


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Executes a command to recompute pom's diagnostics when editor was opened.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8470