### PR TITLE
Fix servers probes on https powered deployment

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/TcpProbeConfig.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/TcpProbeConfig.java
@@ -34,9 +34,9 @@ public class TcpProbeConfig extends ProbeConfig {
       int port,
       String host) {
     super(successThreshold, failureThreshold, timeoutSeconds, periodSeconds, initialDelaySeconds);
-    if (port < 0) {
+    if (port < 1) {
       throw new IllegalArgumentException(
-          "Port '" + port + "' is illegal. Port should not be less than 0");
+          "Port '" + port + "' is illegal. Port should not be less than 1");
     }
     this.port = port;
     if (isNullOrEmpty(host)) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/ExecServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/ExecServerLivenessProbeConfigFactory.java
@@ -29,7 +29,7 @@ public class ExecServerLivenessProbeConfigFactory implements HttpProbeConfigFact
     try {
       URL url = new URL(server.getUrl());
       return new HttpProbeConfig(
-          url.getPort() == -1 ? 80 : url.getPort(),
+          url.getPort() == -1 ? url.getDefaultPort() : url.getPort(),
           url.getHost(),
           url.getProtocol(),
           "/liveness",

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/TerminalServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/TerminalServerLivenessProbeConfigFactory.java
@@ -39,17 +39,17 @@ public class TerminalServerLivenessProbeConfigFactory implements HttpProbeConfig
     } else {
       protocol = "http";
     }
+    int port;
+    if (uri.getPort() == -1) {
+      if ("http".equals(protocol)) {
+        port = 80;
+      } else {
+        port = 443;
+      }
+    } else {
+      port = uri.getPort();
+    }
 
-    return new HttpProbeConfig(
-        uri.getPort() == -1 ? 80 : uri.getPort(),
-        uri.getHost(),
-        protocol,
-        "/liveness",
-        null,
-        1,
-        3,
-        120,
-        10,
-        10);
+    return new HttpProbeConfig(port, uri.getHost(), protocol, "/liveness", null, 1, 3, 120, 10, 10);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
@@ -42,8 +42,19 @@ public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigF
       // add trailing slash
       URI uri = UriBuilder.fromUri(server.getUrl()).path("/").build();
 
+      int port;
+      if (uri.getPort() == -1) {
+        if ("http".equals(uri.getScheme())) {
+          port = 80;
+        } else {
+          port = 443;
+        }
+      } else {
+        port = uri.getPort();
+      }
+
       return new HttpProbeConfig(
-          uri.getPort() == -1 ? 80 : uri.getPort(),
+          port,
           uri.getHost(),
           uri.getScheme(),
           uri.getPath(),


### PR DESCRIPTION
### What does this PR do?
Fixes possibility to use server probes on an OpenShift deployment where https is enabled for routes.
Also, disallow server probes with port 0.

### What issues does this PR fix or reference?
Fixes #8378 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
