### PR TITLE
Rework default memory limit setting

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/MachineConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/MachineConfig.java
@@ -21,9 +21,9 @@ import java.util.Map;
 public interface MachineConfig {
 
   /**
-   * Name of the attribute from {@link #getAttributes()} which if present sets memory limit of the
-   * machine in bytes. If memory limit is set in environment specific recipe this attribute should
-   * override value from recipe.
+   * Name of the attribute from {@link #getAttributes()} which if present defines memory limit of
+   * the machine in bytes. If memory limit is set in environment specific recipe this attribute used
+   * in {@code MachineConfig} should override value from recipe.
    */
   String MEMORY_LIMIT_ATTRIBUTE = "memoryLimitBytes";
 

--- a/infrastructures/docker/environment/pom.xml
+++ b/infrastructures/docker/environment/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>che-core-api-workspace-shared</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/ComposeEnvironmentFactory.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/ComposeEnvironmentFactory.java
@@ -50,6 +50,7 @@ public class ComposeEnvironmentFactory extends InternalEnvironmentFactory<Compos
 
   private final ComposeServicesStartStrategy startStrategy;
   private final ComposeEnvironmentValidator composeValidator;
+  private final String defaultMachineMemorySizeAttribute;
 
   @Inject
   public ComposeEnvironmentFactory(
@@ -59,9 +60,11 @@ public class ComposeEnvironmentFactory extends InternalEnvironmentFactory<Compos
       ComposeEnvironmentValidator composeValidator,
       ComposeServicesStartStrategy startStrategy,
       @Named("che.workspace.default_memory_mb") long defaultMachineMemorySizeMB) {
-    super(installerRegistry, recipeRetriever, machinesValidator, defaultMachineMemorySizeMB);
+    super(installerRegistry, recipeRetriever, machinesValidator);
     this.startStrategy = startStrategy;
     this.composeValidator = composeValidator;
+    this.defaultMachineMemorySizeAttribute =
+        String.valueOf(defaultMachineMemorySizeMB * 1024 * 1024);
   }
 
   @Override
@@ -117,6 +120,8 @@ public class ComposeEnvironmentFactory extends InternalEnvironmentFactory<Compos
         final Long ramLimit = entry.getValue().getMemLimit();
         if (ramLimit != null && ramLimit > 0) {
           attributes.put(MEMORY_LIMIT_ATTRIBUTE, String.valueOf(ramLimit));
+        } else {
+          attributes.put(MEMORY_LIMIT_ATTRIBUTE, defaultMachineMemorySizeAttribute);
         }
       }
     }

--- a/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerfile/DockerfileEnvironmentFactoryTest.java
+++ b/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerfile/DockerfileEnvironmentFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.environment.dockerfile;
+
+import static java.util.Arrays.fill;
+import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.installer.server.InstallerRegistry;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
+import org.eclipse.che.api.workspace.server.spi.environment.MachineConfigsValidator;
+import org.eclipse.che.api.workspace.server.spi.environment.RecipeRetriever;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class DockerfileEnvironmentFactoryTest {
+
+  private static final long DEFAULT_RAM_LIMIT_MB = 2048;
+  private static final long BYTES_IN_MB = 1024 * 1024;
+  private static final String MACHINE_NAME = "machine";
+
+  @Mock private InternalRecipe recipe;
+  @Mock private InstallerRegistry installerRegistry;
+  @Mock private RecipeRetriever recipeRetriever;
+  @Mock private MachineConfigsValidator machinesValidator;
+
+  private DockerfileEnvironmentFactory factory;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    factory =
+        new DockerfileEnvironmentFactory(
+            installerRegistry, recipeRetriever, machinesValidator, DEFAULT_RAM_LIMIT_MB);
+
+    when(recipe.getType()).thenReturn(DockerfileEnvironment.TYPE);
+    when(recipe.getContent()).thenReturn("");
+  }
+
+  @Test
+  public void testSetRamLimitAttributeWhenRamLimitIsMissingInConfig() throws Exception {
+    final Map<String, InternalMachineConfig> machines =
+        ImmutableMap.of(MACHINE_NAME, mockInternalMachineConfig(new HashMap<>()));
+
+    factory.doCreate(recipe, machines, Collections.emptyList());
+
+    final long[] actual = machinesRam(machines.values());
+    final long[] expected = new long[actual.length];
+    fill(expected, DEFAULT_RAM_LIMIT_MB * BYTES_IN_MB);
+    assertTrue(Arrays.equals(actual, expected));
+  }
+
+  private static InternalMachineConfig mockInternalMachineConfig(Map<String, String> attributes) {
+    final InternalMachineConfig machineConfigMock = mock(InternalMachineConfig.class);
+    when(machineConfigMock.getAttributes()).thenReturn(attributes);
+    return machineConfigMock;
+  }
+
+  private static long[] machinesRam(Collection<InternalMachineConfig> configs) {
+    return configs
+        .stream()
+        .mapToLong(m -> Long.parseLong(m.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE)))
+        .toArray();
+  }
+}

--- a/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerimage/DockerImageEnvironmentFactoryTest.java
+++ b/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerimage/DockerImageEnvironmentFactoryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage;
+
+import static java.util.Arrays.fill;
+import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.installer.server.InstallerRegistry;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
+import org.eclipse.che.api.workspace.server.spi.environment.MachineConfigsValidator;
+import org.eclipse.che.api.workspace.server.spi.environment.RecipeRetriever;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class DockerImageEnvironmentFactoryTest {
+  private static final long DEFAULT_RAM_LIMIT_MB = 2048;
+  private static final long BYTES_IN_MB = 1024 * 1024;
+  private static final String MACHINE_NAME = "machine";
+
+  @Mock private InternalRecipe recipe;
+  @Mock private InstallerRegistry installerRegistry;
+  @Mock private RecipeRetriever recipeRetriever;
+  @Mock private MachineConfigsValidator machinesValidator;
+
+  private DockerImageEnvironmentFactory factory;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    factory =
+        new DockerImageEnvironmentFactory(
+            installerRegistry, recipeRetriever, machinesValidator, DEFAULT_RAM_LIMIT_MB);
+
+    when(recipe.getType()).thenReturn(DockerImageEnvironment.TYPE);
+    when(recipe.getContent()).thenReturn("");
+  }
+
+  @Test
+  public void testSetRamLimitAttributeWhenRamLimitIsMissingInConfig() throws Exception {
+    final Map<String, InternalMachineConfig> machines =
+        ImmutableMap.of(MACHINE_NAME, mockInternalMachineConfig(new HashMap<>()));
+
+    factory.doCreate(recipe, machines, Collections.emptyList());
+
+    final long[] actual = machinesRam(machines.values());
+    final long[] expected = new long[actual.length];
+    fill(expected, DEFAULT_RAM_LIMIT_MB * BYTES_IN_MB);
+    assertTrue(Arrays.equals(actual, expected));
+  }
+
+  private static InternalMachineConfig mockInternalMachineConfig(Map<String, String> attributes) {
+    final InternalMachineConfig machineConfigMock = mock(InternalMachineConfig.class);
+    when(machineConfigMock.getAttributes()).thenReturn(attributes);
+    return machineConfigMock;
+  }
+
+  private static long[] machinesRam(Collection<InternalMachineConfig> configs) {
+    return configs
+        .stream()
+        .mapToLong(m -> Long.parseLong(m.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE)))
+        .toArray();
+  }
+}

--- a/infrastructures/docker/environment/src/test/resources/logback-test.xml
+++ b/infrastructures/docker/environment/src/test/resources/logback-test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<configuration>
+
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <File>target/log/log.log</File>
+        <encoder>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <root level="INFO">
+        <appender-ref ref="stdout"/>
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -64,6 +64,7 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
 
   private final OpenShiftClientFactory clientFactory;
   private final OpenShiftEnvironmentValidator envValidator;
+  private final String defaultMachineMemorySizeAttribute;
 
   @Inject
   public OpenShiftEnvironmentFactory(
@@ -73,9 +74,11 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
       OpenShiftClientFactory clientFactory,
       OpenShiftEnvironmentValidator envValidator,
       @Named("che.workspace.default_memory_mb") long defaultMachineMemorySizeMB) {
-    super(installerRegistry, recipeRetriever, machinesValidator, defaultMachineMemorySizeMB);
+    super(installerRegistry, recipeRetriever, machinesValidator);
     this.clientFactory = clientFactory;
     this.envValidator = envValidator;
+    this.defaultMachineMemorySizeAttribute =
+        String.valueOf(defaultMachineMemorySizeMB * 1024 * 1024);
   }
 
   @Override
@@ -172,6 +175,8 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
           final long ramLimit = Containers.getRamLimit(container);
           if (ramLimit > 0) {
             attributes.put(MEMORY_LIMIT_ATTRIBUTE, String.valueOf(ramLimit));
+          } else {
+            attributes.put(MEMORY_LIMIT_ATTRIBUTE, defaultMachineMemorySizeAttribute);
           }
         }
       }

--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/usage/tracker/EnvironmentRamCalculator.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/usage/tracker/EnvironmentRamCalculator.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.Runtime;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
@@ -50,7 +51,8 @@ public class EnvironmentRamCalculator {
               .getMachines()
               .values()
               .stream()
-              .mapToLong(m -> Long.parseLong(m.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE)))
+              .mapToLong(
+                  m -> parseMemoryAttributeValue(m.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE)))
               .sum()
           / BYTES_TO_MEGABYTES_DIVIDER;
     } catch (InfrastructureException | ValidationException | NotFoundException ex) {
@@ -68,9 +70,29 @@ public class EnvironmentRamCalculator {
             .getMachines()
             .values()
             .stream()
-            .mapToLong(m -> Long.parseLong(m.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE)))
+            .mapToLong(
+                m -> parseMemoryAttributeValue(m.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE)))
             .sum()
         / BYTES_TO_MEGABYTES_DIVIDER;
+  }
+
+  /**
+   * Parse {@link MachineConfig#MEMORY_LIMIT_ATTRIBUTE} value to {@code Long}.
+   *
+   * @param attributeValue value of {@link MachineConfig#MEMORY_LIMIT_ATTRIBUTE} attribute from
+   *     machine config or runtime
+   * @return long value parsed from provided string attribute value or {@code 0} if {@code null} is
+   *     provided
+   * @throws NumberFormatException if provided value is neither {@code null} nor valid stringified
+   *     long
+   * @see Long#parseLong(String)
+   */
+  private long parseMemoryAttributeValue(String attributeValue) {
+    if (attributeValue == null) {
+      return 0;
+    } else {
+      return Long.parseLong(attributeValue);
+    }
   }
 
   private InternalEnvironment getInternalEnvironment(Environment environment)

--- a/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/usage/tracker/EnvironmentRamCalculatorTest.java
+++ b/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/usage/tracker/EnvironmentRamCalculatorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.Runtime;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
@@ -84,6 +85,18 @@ public class EnvironmentRamCalculatorTest {
     assertEquals(ram, 2560);
   }
 
+  @Test
+  public void testCalculatesRamOfEnvironmentWhenSomeMachineConfigHasNoAttribute() throws Exception {
+    when(machineConfig1.getAttributes()).thenReturn(Collections.emptyMap());
+    when(machineConfig2.getAttributes())
+        .thenReturn(ImmutableMap.of(MEMORY_LIMIT_ATTRIBUTE, "536870912"));
+    when(recipeMock.getType()).thenReturn(RECIPE_TYPE);
+
+    final long ram = envRamCalculator.calculate(environment);
+
+    assertEquals(ram, 512);
+  }
+
   @Test(expectedExceptions = ServerException.class)
   public void testThrowServerExceptionWhenNoEnvFactoryForGivenRecipeTypeFound() throws Exception {
     when(recipeMock.getType()).thenReturn("unsupported");
@@ -99,5 +112,15 @@ public class EnvironmentRamCalculatorTest {
     final long ram = envRamCalculator.calculate(runtime);
 
     assertEquals(ram, 1536);
+  }
+
+  @Test
+  public void testCalculatesRamOfRuntimeWhenSomeMachineHasNoAttribute() throws Exception {
+    when(machine1.getAttributes()).thenReturn(ImmutableMap.of(MEMORY_LIMIT_ATTRIBUTE, "805306368"));
+    when(machine2.getAttributes()).thenReturn(Collections.emptyMap());
+
+    final long ram = envRamCalculator.calculate(runtime);
+
+    assertEquals(ram, 768);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -110,9 +110,12 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
   }
 
   /**
-   * Implementation validates downloaded recipe and creates specific InternalEnvironment. Returned
-   * InternalEnvironment must contains all machine that are defined in recipe and in source machine
-   * collection.
+   * Implementation validates downloaded recipe and creates specific InternalEnvironment.
+   *
+   * <p>Returned InternalEnvironment must contains all machine that are defined in recipe and in
+   * source machines collection. Also, if memory limitation is supported, it may add memory limit
+   * attribute {@link MachineConfig#MEMORY_LIMIT_ATTRIBUTE} from recipe or configured system-wide
+   * default value.
    *
    * @param recipe downloaded recipe
    * @param machines machines configuration

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -10,9 +10,6 @@
  */
 package org.eclipse.che.api.workspace.server.spi.environment;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
-
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,18 +47,14 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
   private final InstallerRegistry installerRegistry;
   private final RecipeRetriever recipeRetriever;
   private final MachineConfigsValidator machinesValidator;
-  private final String defaultMachineMemorySizeAttribute;
 
   public InternalEnvironmentFactory(
       InstallerRegistry installerRegistry,
       RecipeRetriever recipeRetriever,
-      MachineConfigsValidator machinesValidator,
-      long defaultMachineMemorySizeMB) {
+      MachineConfigsValidator machinesValidator) {
     this.installerRegistry = installerRegistry;
     this.recipeRetriever = recipeRetriever;
     this.machinesValidator = machinesValidator;
-    this.defaultMachineMemorySizeAttribute =
-        String.valueOf(defaultMachineMemorySizeMB * 1024 * 1024);
   }
 
   /**
@@ -113,17 +106,7 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
 
     machinesValidator.validate(machines);
 
-    final T environment = doCreate(recipe, machines, warnings);
-
-    // sets default ram limit attribute if not present
-    for (InternalMachineConfig machineConfig : environment.getMachines().values()) {
-      if (isNullOrEmpty(machineConfig.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE))) {
-        machineConfig
-            .getAttributes()
-            .put(MEMORY_LIMIT_ATTRIBUTE, defaultMachineMemorySizeAttribute);
-      }
-    }
-    return environment;
+    return doCreate(recipe, machines, warnings);
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -177,21 +176,6 @@ public class InternalEnvironmentFactoryTest {
   }
 
   @Test
-  public void testSetsDefaultRamLimitAttributeToMachineThatDoesNotContainIt() throws Exception {
-    final Map<String, String> attributes = new HashMap<>();
-    final InternalEnvironment internalEnv = mock(InternalEnvironment.class);
-    final InternalMachineConfig machine = mock(InternalMachineConfig.class);
-    when(environmentFactory.doCreate(any(), any(), any())).thenReturn(internalEnv);
-    when(internalEnv.getMachines()).thenReturn(ImmutableMap.of("testMachine", machine));
-    when(machine.getAttributes()).thenReturn(attributes);
-
-    environmentFactory.create(mock(Environment.class));
-
-    assertTrue(attributes.containsKey(MEMORY_LIMIT_ATTRIBUTE));
-    assertEquals(attributes.get(MEMORY_LIMIT_ATTRIBUTE), String.valueOf(RAM_LIMIT * 2 << 19));
-  }
-
-  @Test
   public void testDoNotOverrideRamLimitAttributeWhenMachineAlreadyContainsIt() throws Exception {
     final String ramLimit = "2147483648";
     final InternalEnvironment internalEnv = mock(InternalEnvironment.class);
@@ -216,7 +200,7 @@ public class InternalEnvironmentFactoryTest {
         InstallerRegistry installerRegistry,
         RecipeRetriever recipeRetriever,
         MachineConfigsValidator machinesValidator) {
-      super(installerRegistry, recipeRetriever, machinesValidator, RAM_LIMIT);
+      super(installerRegistry, recipeRetriever, machinesValidator);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Extract default machine memory limit setting from InternalEnvironmentFactory to recipe specific environment factories.
Make memory limit attribute optional by respecting it by resource API subsystem.

### What issues does this PR fix or reference?
Fixes #8377 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
