### PR TITLE
Move GitCompareTest to one thread tests suite

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -60,6 +60,7 @@
             <class name="org.eclipse.che.selenium.git.CheckoutToRemoteBranchWhichAlreadyHasLinkedLocalBranchTest"/>
             <class name="org.eclipse.che.selenium.git.FetchUpdatesAndMergeRemoteBranchIntoLocalTest"/>
             <class name="org.eclipse.che.selenium.git.GitPullTest"/>
+            <class name="org.eclipse.che.selenium.git.GitCompareTest"/>
             <class name="org.eclipse.che.selenium.git.ImportProjectIntoSpecifiedBranchTest"/>
             <class name="org.eclipse.che.selenium.git.ImportRecursiveSubmoduleTest"/>
             <class name="org.eclipse.che.selenium.git.KeepDirectoryGitImportTest"/>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -120,7 +120,6 @@
           <class name="org.eclipse.che.selenium.git.CreateAndDeleteLocalBranchTest"/>
           <class name="org.eclipse.che.selenium.git.GitChangeMarkersTest"/>
           <class name="org.eclipse.che.selenium.git.GitColorsTest"/>
-          <class name="org.eclipse.che.selenium.git.GitCompareTest"/>
           <class name="org.eclipse.che.selenium.git.InitializeAndDeleteLocalRepositoryTest"/>
           <class name="org.eclipse.che.selenium.git.SetGitCommitterTest"/>
           <class name="org.eclipse.che.selenium.gwt.CheckSimpleGwtAppTest"/>


### PR DESCRIPTION
### What does this PR do?
It moves **GitCompareTest** to one thread tests suite to avoid server error in time of uploading ssh key for github:
```
[ERROR] prepare(org.eclipse.che.selenium.git.GitCompareTest)  Time elapsed: 6.769 s  <<< FAILURE!
org.eclipse.che.api.core.ServerException: Server Error
    at org.eclipse.che.selenium.git.GitCompareTest.prepare(GitCompareTest.java:69)
```