### PR TITLE
Remove stopping test workspace

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -14,6 +14,7 @@ import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPING;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil.containsWsAgentServer;
 
@@ -137,7 +138,9 @@ public class TestWorkspaceServiceClient {
     }
 
     Workspace workspace = getByName(workspaceName, userName);
-    if (workspace.getStatus() != STOPPED) {
+    if (workspace.getStatus() == STOPPING) {
+      waitStatus(workspaceName, userName, STOPPED);
+    } else if (workspace.getStatus() != STOPPED) {
       stop(workspaceName, userName);
     }
 


### PR DESCRIPTION
### What does this PR do?
It fixes `TestWorkspaceServiceClient::delete()` method to make it possible to remove stopping test workspace, to avoid an error like the following:
```
[ERROR] tearDown(org.eclipse.che.selenium.dashboard.WorkspacesListTest)  Time elapsed: 21.535 s  <<< FAILURE!
org.eclipse.che.api.core.ConflictException: Could not stop the workspace 'che/wksp-mil0n' because its status is 'STOPPING'.
	at org.eclipse.che.selenium.dashboard.WorkspacesListTest.tearDown(WorkspacesListTest.java:68)
```