### PR TITLE
Selenium: add info about known issue into ProjectStateAfterRefreshTest selenium test 

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
@@ -87,7 +87,14 @@ public class ProjectStateAfterRefreshTest {
     toastLoader.waitExpectedTextInToastLoader("Workspace is not running");
     toastLoader.clickOnStartButton();
     projectExplorer.waitProjectExplorer();
-    checkFilesAreOpened();
+
+    try {
+      checkFilesAreOpened();
+    } catch (TimeoutException ex) {
+      // Remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7551");
+    }
+
     editor.closeAllTabsByContextMenu();
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds info about known issue into **ProjectStateAfterRefreshTest** selenium test(https://github.com/eclipse/che/issues/7551).