### PR TITLE
Selenium: increase timeout for checking that a workspace name is not visible in the Workspaces list after deleting

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/Workspaces.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/Workspaces.java
@@ -228,7 +228,7 @@ public class Workspaces {
 
   /** wait the workspace is not present on dashboard */
   public void waitWorkspaceIsNotPresent(String workspaceName) {
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC)
         .until(
             invisibilityOfElementLocated(
                 By.xpath(format(Locators.WORKSPACE_ITEM_NAME, workspaceName))));


### PR DESCRIPTION
### What does this PR do?
This PR increases timeout for checking that a workspace name is not visible in the **Workspaces** list after deleting. 


