### PR TITLE
Change PVC name provisioning to prefix + generating 8 chars

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -338,7 +338,7 @@ che.infra.openshift.pvc.enabled=true
 #        Existing PVC will be used or new one will be created if it doesn't exist.
 #
 # - 'unique'
-#        PVC with name that is evaluated as '{che.infra.openshift.pvc.name} + '-' + {WORKSPACE_ID}'
+#        PVC with name that is evaluated as '{che.infra.openshift.pvc.name} + '-' + {generated_8_chars}'
 #        will be used for storing of workspaces data.
 #        Existing PVC will be used or a new one will be created if it doesn't exist.
 che.infra.openshift.pvc.strategy=common

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -449,7 +449,7 @@ CHE_SINGLE_PORT=false
 #        Existing PVC will be used or new one will be created if it doesn't exist.
 #
 # - 'unique'
-#        PVC with name that is evaluated as '{che.infra.openshift.pvc.name} + '-' + {WORKSPACE_ID}'
+#        PVC with name that is evaluated as '{che.infra.openshift.pvc.name} + '-' + {generated_8_chars}'
 #        will be used for storing of workspaces data.
 #        Existing PVC will be used or a new one will be created if it doesn't exist.
 #CHE_INFRA_OPENSHIFT_PVC_STRATEGY=common

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Constants.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Constants.java
@@ -30,6 +30,9 @@ public final class Constants {
   /** The label that contains a value with workspace id to which object belongs to. */
   public static final String CHE_WORKSPACE_ID_LABEL = "che.workspace_id";
 
+  /** The label that contains a value with volume name. */
+  public static final String CHE_VOLUME_NAME_LABEL = "che.workspace.volume_name";
+
   /**
    * The annotation with the wildcard reserved for container name. Formatted annotation with the
    * real container name is used to get machine name.

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Names.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Names.java
@@ -28,8 +28,8 @@ public class Names {
 
   static final char WORKSPACE_ID_PREFIX_SEPARATOR = '.';
 
-  static final String ROUTE_PREFIX = "route";
-  static final int ROUTE_PREFIX_SIZE = 8;
+  public static final String ROUTE_NAME_PREFIX = "route";
+  static final int GENERATED_PART_SIZE = 8;
 
   /**
    * Returns machine name for the specified container in the specified pod.
@@ -67,8 +67,8 @@ public class Names {
     return workspaceId + WORKSPACE_ID_PREFIX_SEPARATOR + originalPodName;
   }
 
-  /** Returns route name that will be unique whole a namespace. */
-  public static String uniqueRouteName() {
-    return NameGenerator.generate(ROUTE_PREFIX, ROUTE_PREFIX_SIZE);
+  /** Returns randomly generated name with given prefix. */
+  public static String generateName(String prefix) {
+    return NameGenerator.generate(prefix, GENERATED_PART_SIZE);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPersistentVolumeClaims.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftPersistentVolumeClaims.java
@@ -69,6 +69,29 @@ public class OpenShiftPersistentVolumeClaims {
   }
 
   /**
+   * Returns all existing persistent volume claims with given label.
+   *
+   * @param labelName name of provided label
+   * @param labelValue value of provided label
+   * @return list of matched PVCs
+   * @throws InfrastructureException when any exception occurs while fetching the pvcs
+   */
+  public List<PersistentVolumeClaim> getByLabel(String labelName, String labelValue)
+      throws InfrastructureException {
+    try {
+      return clientFactory
+          .create()
+          .persistentVolumeClaims()
+          .inNamespace(namespace)
+          .withLabel(labelName, labelValue)
+          .list()
+          .getItems();
+    } catch (KubernetesClientException e) {
+      throw new InfrastructureException(e.getMessage(), e);
+    }
+  }
+
+  /**
    * Creates all PVCs which are not present in current OpenShift project.
    *
    * @param toCreate collection of PVCs to create

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/UniqueNamesProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/UniqueNamesProvisioner.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.provision;
 
+import static org.eclipse.che.workspace.infrastructure.openshift.Names.ROUTE_NAME_PREFIX;
 import static org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftObjectUtil.putLabel;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -32,7 +33,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftE
  *
  * @author Anton Korneta
  * @see Names#uniquePodName(String, String)
- * @see Names#uniqueRouteName()
+ * @see Names#generateName(String)
  */
 @Singleton
 public class UniqueNamesProvisioner implements ConfigurationProvisioner {
@@ -55,7 +56,7 @@ public class UniqueNamesProvisioner implements ConfigurationProvisioner {
     for (Route route : routes) {
       final ObjectMeta routeMeta = route.getMetadata();
       putLabel(route, Constants.CHE_ORIGINAL_NAME_LABEL, routeMeta.getName());
-      final String routeName = Names.uniqueRouteName();
+      final String routeName = Names.generateName(ROUTE_NAME_PREFIX);
       routeMeta.setName(routeName);
       osEnv.getRoutes().put(routeName, route);
     }


### PR DESCRIPTION
### What does this PR do?
Some of the OpenShift storage backends can use prefixes for objects names but the name length limit is equal to 63 characters, in such cases, the composite name(`prefix-workspaceId-volumeName`) that is used for `unique` PVC strategy does not fit the limitation. 
We proposing to change the naming to: `prefix-generated_chars_length_8` and put the volume name into PVC labels.

### What issues does this PR fix or reference?
fix #8439 
