### PR TITLE
Add consumers to language server's file watcher

### DIFF
--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerModule.java
@@ -10,9 +10,18 @@
  */
 package org.eclipse.che.api.languageserver;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
 import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.eclipse.che.api.languageserver.consumers.LanguageServerFileChangeConsumer;
+import org.eclipse.che.api.languageserver.consumers.LanguageServerFileCreateConsumer;
+import org.eclipse.che.api.languageserver.consumers.LanguageServerFileDeleteConsumer;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
 import org.eclipse.che.api.languageserver.messager.PublishDiagnosticsParamsJsonRpcTransmitter;
 import org.eclipse.che.api.languageserver.messager.ShowMessageJsonRpcTransmitter;
@@ -50,5 +59,19 @@ public class LanguageServerModule extends AbstractModule {
     bind(LanguageServerFileWatcher.class).asEagerSingleton();
     bind(LanguageServerInitializationHandler.class).asEagerSingleton();
     install(new FactoryModuleBuilder().build(CheLanguageClientFactory.class));
+
+    configureFileWatcher();
+  }
+
+  private void configureFileWatcher() {
+    newSetBinder(binder(), new TypeLiteral<Consumer<Path>>() {}, Names.named("che.fs.file.create"))
+        .addBinding()
+        .to(LanguageServerFileCreateConsumer.class);
+    newSetBinder(binder(), new TypeLiteral<Consumer<Path>>() {}, Names.named("che.fs.file.delete"))
+        .addBinding()
+        .to(LanguageServerFileDeleteConsumer.class);
+    newSetBinder(binder(), new TypeLiteral<Consumer<Path>>() {}, Names.named("che.fs.file.update"))
+        .addBinding()
+        .to(LanguageServerFileChangeConsumer.class);
   }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/consumers/LanguageServerFileChangeConsumer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/consumers/LanguageServerFileChangeConsumer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.consumers;
+
+import com.google.inject.Inject;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import javax.inject.Singleton;
+import org.eclipse.che.api.fs.server.PathTransformer;
+
+/**
+ * Consumer for the file changing operation.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class LanguageServerFileChangeConsumer implements Consumer<Path> {
+  private final Map<Consumer<String>, Set<PathMatcher>> consumers = new ConcurrentHashMap<>();
+
+  private PathTransformer pathTransformer;
+
+  @Inject
+  public LanguageServerFileChangeConsumer(PathTransformer pathTransformer) {
+    this.pathTransformer = pathTransformer;
+  }
+
+  @Override
+  public void accept(Path path) {
+    for (Entry<Consumer<String>, Set<PathMatcher>> entry : consumers.entrySet()) {
+      for (PathMatcher matcher : entry.getValue()) {
+        if (matcher.matches(path)) {
+          entry.getKey().accept(pathTransformer.transform(path));
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds registered consumer and set of matchers for matching files by path
+   *
+   * @param create registered consumer
+   * @param matcher set of matchers for matching file's path
+   */
+  public void watch(Consumer<String> create, Set<PathMatcher> matcher) {
+    consumers.putIfAbsent(create, matcher);
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/consumers/LanguageServerFileCreateConsumer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/consumers/LanguageServerFileCreateConsumer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.consumers;
+
+import com.google.inject.Inject;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import javax.inject.Singleton;
+import org.eclipse.che.api.fs.server.PathTransformer;
+
+/**
+ * Consumer for the file creating operation.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class LanguageServerFileCreateConsumer implements Consumer<Path> {
+
+  private final Map<Consumer<String>, Set<PathMatcher>> consumers = new ConcurrentHashMap<>();
+
+  private PathTransformer pathTransformer;
+
+  @Inject
+  public LanguageServerFileCreateConsumer(PathTransformer pathTransformer) {
+    this.pathTransformer = pathTransformer;
+  }
+
+  @Override
+  public void accept(Path path) {
+    for (Entry<Consumer<String>, Set<PathMatcher>> entry : consumers.entrySet()) {
+      for (PathMatcher matcher : entry.getValue()) {
+        if (matcher.matches(path)) {
+          entry.getKey().accept(pathTransformer.transform(path));
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds registered consumer and set of matchers for matching files by path
+   *
+   * @param create registered consumer
+   * @param matcher set of matchers for matching file's path
+   */
+  public void watch(Consumer<String> create, Set<PathMatcher> matcher) {
+    consumers.putIfAbsent(create, matcher);
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/consumers/LanguageServerFileDeleteConsumer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/consumers/LanguageServerFileDeleteConsumer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.consumers;
+
+import com.google.inject.Inject;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import javax.inject.Singleton;
+import org.eclipse.che.api.fs.server.PathTransformer;
+
+/**
+ * Consumer for the file deleting operation.
+ *
+ * @author Valeriy Svydenko
+ */
+@Singleton
+public class LanguageServerFileDeleteConsumer implements Consumer<Path> {
+
+  private final Map<Consumer<String>, Set<PathMatcher>> consumers = new ConcurrentHashMap<>();
+
+  private PathTransformer pathTransformer;
+
+  @Inject
+  public LanguageServerFileDeleteConsumer(PathTransformer pathTransformer) {
+    this.pathTransformer = pathTransformer;
+  }
+
+  @Override
+  public void accept(Path path) {
+    for (Entry<Consumer<String>, Set<PathMatcher>> entry : consumers.entrySet()) {
+      for (PathMatcher matcher : entry.getValue()) {
+        if (matcher.matches(path)) {
+          entry.getKey().accept(pathTransformer.transform(path));
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds registered consumer and set of matchers for matching files by path
+   *
+   * @param create registered consumer
+   * @param matcher set of matchers for matching file's path
+   */
+  public void watch(Consumer<String> create, Set<PathMatcher> matcher) {
+    consumers.putIfAbsent(create, matcher);
+  }
+}

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerFileWatcher.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerFileWatcher.java
@@ -11,19 +11,23 @@
 package org.eclipse.che.api.languageserver.registry;
 
 import static org.eclipse.che.api.languageserver.service.LanguageServiceUtils.prefixURI;
+import static org.eclipse.lsp4j.FileChangeType.Changed;
+import static org.eclipse.lsp4j.FileChangeType.Created;
+import static org.eclipse.lsp4j.FileChangeType.Deleted;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.util.Collections;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.PreDestroy;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.che.api.languageserver.consumers.LanguageServerFileChangeConsumer;
+import org.eclipse.che.api.languageserver.consumers.LanguageServerFileCreateConsumer;
+import org.eclipse.che.api.languageserver.consumers.LanguageServerFileDeleteConsumer;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncher;
-import org.eclipse.che.api.watcher.server.FileWatcherManager;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
@@ -37,15 +41,20 @@ import org.eclipse.lsp4j.services.LanguageServer;
  */
 @Singleton
 public class LanguageServerFileWatcher {
-
-  private final FileWatcherManager watcherManager;
-
-  private CopyOnWriteArrayList<Integer> watcherIds = new CopyOnWriteArrayList<>();
+  private final LanguageServerFileCreateConsumer fileCreateConsumer;
+  private final LanguageServerFileChangeConsumer fileUpdateConsumer;
+  private final LanguageServerFileDeleteConsumer fileDeleteConsumer;
 
   @Inject
   public LanguageServerFileWatcher(
-      FileWatcherManager watcherManager, LanguageServerRegistry serverInitializer) {
-    this.watcherManager = watcherManager;
+      LanguageServerFileCreateConsumer fileCreateConsumer,
+      LanguageServerFileChangeConsumer fileUpdateConsumer,
+      LanguageServerFileDeleteConsumer fileDeleteConsumer,
+      LanguageServerRegistry serverInitializer) {
+    this.fileCreateConsumer = fileCreateConsumer;
+    this.fileUpdateConsumer = fileUpdateConsumer;
+    this.fileDeleteConsumer = fileDeleteConsumer;
+
     serverInitializer.addObserver(this::onServerInitialized);
   }
 
@@ -56,39 +65,26 @@ public class LanguageServerFileWatcher {
     server.getWorkspaceService().didChangeWatchedFiles(params);
   }
 
-  @PreDestroy
-  @VisibleForTesting
-  public void removeAllWatchers() {
-    for (Integer watcherId : watcherIds) {
-      watcherManager.unRegisterByMatcher(watcherId);
-    }
-  }
-
   private void onServerInitialized(
       LanguageServerLauncher launcher,
       LanguageServer server,
       ServerCapabilities capabilities,
       String projectPath) {
     LanguageServerDescription description = launcher.getDescription();
-    description
-        .getFileWatchPatterns()
-        .stream()
-        .map(patternToMatcher())
-        .forEach(
-            matcher -> {
-              int watcherId =
-                  watcherManager.registerByMatcher(
-                      matcher,
-                      s -> send(server, s, FileChangeType.Created),
-                      s -> send(server, s, FileChangeType.Changed),
-                      s -> send(server, s, FileChangeType.Deleted));
+    Set<PathMatcher> matchers =
+        description
+            .getFileWatchPatterns()
+            .stream()
+            .map(patternToMatcher())
+            .collect(Collectors.toSet());
 
-              watcherIds.add(watcherId);
-            });
+    fileCreateConsumer.watch(s -> send(server, s, Created), matchers);
+    fileUpdateConsumer.watch(s -> send(server, s, Changed), matchers);
+    fileDeleteConsumer.watch(s -> send(server, s, Deleted), matchers);
   }
 
-  public static Function<String, PathMatcher> patternToMatcher() {
+  static Function<String, PathMatcher> patternToMatcher() {
     FileSystem fileSystem = FileSystems.getDefault();
-    return (fileWatchPattern) -> fileSystem.getPathMatcher(fileWatchPattern);
+    return fileSystem::getPathMatcher;
   }
 }

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/registry/LanguageServerRegistryImpl.java
@@ -51,7 +51,6 @@ import org.eclipse.che.api.languageserver.remote.RemoteLsLauncherProvider;
 import org.eclipse.che.api.languageserver.service.LanguageServiceUtils;
 import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
 import org.eclipse.che.api.project.server.ProjectManager;
-import org.eclipse.che.api.project.server.impl.RegisteredProject;
 import org.eclipse.che.api.workspace.server.WorkspaceService;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
 import org.eclipse.lsp4j.ClientCapabilities;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The problem was here because file watcher skipped files which were created before workspace initialization. The pr provides new consumers which will track all files.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8399