### PR TITLE
Remove read 'preferences' from try/catch block in CreateNewPackagesWithHelpCreationJavaClassTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewPackagesWithHelpCreationJavaClassTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewPackagesWithHelpCreationJavaClassTest.java
@@ -37,9 +37,6 @@ import org.testng.annotations.Test;
  * @author Andrey Chizhikov
  */
 public class CreateNewPackagesWithHelpCreationJavaClassTest {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(CreateNewPackagesWithHelpCreationJavaClassTest.class);
   private static final String PROJECT_NAME =
       CreateNewPackagesWithHelpCreationJavaClassTest.class.getSimpleName();
   private static final String NEW_PACKAGE_NAME1 = "tu";
@@ -102,17 +99,9 @@ public class CreateNewPackagesWithHelpCreationJavaClassTest {
     try {
       projectExplorer.waitItemInVisibleArea("TestClass2.java");
     } catch (TimeoutException ex) {
-      LOG.info(getPreferences());
       // remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/8122");
     }
   }
 
-  private String getPreferences() throws Exception {
-    return httpJsonRequestFactory
-        .fromUrl(testApiEndpointUrlProvider.get() + "preferences")
-        .useGetMethod()
-        .request()
-        .asString();
-  }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove read 'preferences' from try/catch block in CreateNewPackagesWithHelpCreationJavaClassTest selenium test

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
