### PR TITLE
CHE-6923: Provide more space for committer fields in Preferences dialog.

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/preference/CommitterPreferenceViewImpl.ui.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/preference/CommitterPreferenceViewImpl.ui.xml
@@ -21,18 +21,22 @@
         .inherit {
             margin-top: 5px;
         }
+
+        .preferencesInputs {
+            width: 100%;
+        }
     </ui:style>
 
     <g:FlowPanel styleName="{style.main}">
 
         <g:FlowPanel styleName="{style.inherit}">
             <g:Label>Name:</g:Label>
-            <g:TextBox ui:field="name" debugId="committer-preferences-name"/>
+            <g:TextBox ui:field="name" debugId="committer-preferences-name" addStyleNames="{style.preferencesInputs}"/>
         </g:FlowPanel>
 
         <g:FlowPanel styleName="{style.inherit}">
             <g:Label>Email:</g:Label>
-            <g:TextBox ui:field="email" debugId="committer-preferences-email"/>
+            <g:TextBox ui:field="email" debugId="committer-preferences-email" addStyleNames="{style.preferencesInputs}"/>
         </g:FlowPanel>
 
     </g:FlowPanel>


### PR DESCRIPTION
### What does this PR do?
Provide more space for committer fields in Preferences dialog.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6923

#### Release Notes
Provide more space for committer fields in Preferences dialog.

#### Docs PR
Don't need.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
