### PR TITLE
Avoid removal of non-test workspaces at the cleanup environment stage of selenium testing

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -876,6 +876,9 @@ prepareTestUsersForMultiuserChe() {
     export CHE_ADMIN_PASSWORD=${CHE_ADMIN_PASSWORD:-admin}
     export CHE_ADMIN_OFFLINE__TOKEN=${CHE_ADMIN_OFFLINE__TOKEN}
 
+    export CHE_TESTUSER_OFFLINE__TOKEN=${CHE_TESTUSER_OFFLINE__TOKEN}
+    export CHE_SECOND_TESTUSER_OFFLINE__TOKEN=${CHE_SECOND_TESTUSER_OFFLINE__TOKEN}
+
     if [[ -n ${CHE_TESTUSER_EMAIL+x} ]] && [[ -n ${CHE_TESTUSER_PASSWORD+x} ]]; then
         return
     fi
@@ -898,8 +901,6 @@ prepareTestUsersForMultiuserChe() {
            CHE_TESTUSER_PASSWORD=${CHE_ADMIN_PASSWORD}
         fi
 
-        export CHE_TESTUSER_OFFLINE__TOKEN=${CHE_TESTUSER_OFFLINE__TOKEN}
-
         # create second test user
         time=$(date +%s)
         export CHE_SECOND_TESTUSER_NAME=${CHE_SECOND_TESTUSER_NAME:-user${time}}
@@ -916,7 +917,6 @@ prepareTestUsersForMultiuserChe() {
            CHE_SECOND_TESTUSER_PASSWORD=${CHE_ADMIN_PASSWORD}
         fi
 
-        export CHE_SECOND_TESTUSER_OFFLINE__TOKEN=${CHE_SECOND_TESTUSER_OFFLINE__TOKEN}
     fi
 }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -42,7 +42,6 @@ import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.workspace.MemoryMeasure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 
 /**
  * @author Musienko Maxim
@@ -217,13 +216,7 @@ public class TestWorkspaceServiceClient {
   public void start(String workspaceId, String workspaceName, TestUser workspaceOwner)
       throws Exception {
     sendStartRequest(workspaceId, workspaceName);
-
-    try {
-      waitStatus(workspaceName, workspaceOwner.getName(), RUNNING);
-    } catch (IllegalStateException ex) {
-      // Remove try-catch block after issue has been resolved
-      Assert.fail("Known issue https://github.com/eclipse/che/issues/8031", ex);
-    }
+    waitStatus(workspaceName, workspaceOwner.getName(), RUNNING);
   }
 
   /** Gets workspace by its id. */

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -82,6 +82,7 @@ public abstract class SeleniumTestHandler
 
   private static final Logger LOG = LoggerFactory.getLogger(SeleniumTestHandler.class);
   private static final AtomicBoolean isCleanUpCompleted = new AtomicBoolean();
+  private static final AtomicBoolean isWebDriverSessionCreationChecked = new AtomicBoolean();
 
   @Inject
   @Named("tests.screenshot_dir")
@@ -170,18 +171,23 @@ public abstract class SeleniumTestHandler
 
   @Override
   public void onStart(ISuite suite) {
-    runningTests.clear();
     suite.setParentInjector(injector);
   }
 
   /** Check if webdriver session can be created without errors. */
   private void checkWebDriverSessionCreation() {
+    if (isWebDriverSessionCreationChecked.get()) {
+      return;
+    }
+
     SeleniumWebDriver seleniumWebDriver = null;
     try {
       seleniumWebDriver = new SeleniumWebDriver(browser, webDriverPort, gridMode, webDriverVersion);
     } finally {
       Optional.ofNullable(seleniumWebDriver)
           .ifPresent(SeleniumWebDriver::quit); // finish webdriver session
+
+      isWebDriverSessionCreationChecked.set(true);
     }
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -82,7 +82,6 @@ public abstract class SeleniumTestHandler
 
   private static final Logger LOG = LoggerFactory.getLogger(SeleniumTestHandler.class);
   private static final AtomicBoolean isCleanUpCompleted = new AtomicBoolean();
-  private static final AtomicBoolean isWebDriverSessionCreationChecked = new AtomicBoolean();
 
   @Inject
   @Named("tests.screenshot_dir")
@@ -128,6 +127,7 @@ public abstract class SeleniumTestHandler
     getRuntime().addShutdownHook(new Thread(this::shutdown));
 
     revokeGithubOauthToken();
+    checkWebDriverSessionCreation();
   }
 
   private void revokeGithubOauthToken() {
@@ -176,18 +176,12 @@ public abstract class SeleniumTestHandler
 
   /** Check if webdriver session can be created without errors. */
   private void checkWebDriverSessionCreation() {
-    if (isWebDriverSessionCreationChecked.get()) {
-      return;
-    }
-
     SeleniumWebDriver seleniumWebDriver = null;
     try {
       seleniumWebDriver = new SeleniumWebDriver(browser, webDriverPort, gridMode, webDriverVersion);
     } finally {
       Optional.ofNullable(seleniumWebDriver)
           .ifPresent(SeleniumWebDriver::quit); // finish webdriver session
-
-      isWebDriverSessionCreationChecked.set(true);
     }
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/user/TestUserImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/user/TestUserImpl.java
@@ -14,8 +14,6 @@ import static java.lang.String.format;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.PreDestroy;
 import org.eclipse.che.selenium.core.client.TestAuthServiceClient;
 import org.eclipse.che.selenium.core.client.TestUserServiceClient;
@@ -97,23 +95,7 @@ public class TestUserImpl implements TestUser {
 
   @Override
   @PreDestroy
-  public void cleanUp() {
-    List<String> workspaces = new ArrayList<>();
-    try {
-      workspaces = workspaceServiceClient.getAll();
-    } catch (Exception e) {
-      LOG.error("Failed to get all workspaces.", e);
-    }
-
-    for (String workspace : workspaces) {
-      try {
-        workspaceServiceClient.delete(workspace, name);
-      } catch (Exception e) {
-        LOG.error(
-            format("User name='%s' failed to remove workspace name='%s'", workspace, name), e);
-      }
-    }
-  }
+  public void cleanUp() {}
 
   @Override
   public String toString() {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 
 /** @author Anatolii Bazko */
 public class TestWorkspaceImpl implements TestWorkspace {
@@ -74,7 +75,11 @@ public class TestWorkspaceImpl implements TestWorkspace {
                       e);
                 }
 
-                throw new IllegalStateException(errorMessage, e);
+                if (e instanceof IllegalStateException) {
+                  Assert.fail("Known issue https://github.com/eclipse/che/issues/8031", e);
+                } else {
+                  throw new IllegalStateException(errorMessage, e);
+                }
               }
             });
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java
@@ -41,6 +41,7 @@ import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -143,5 +144,10 @@ public class CheckSimpleGwtAppTest {
         .until(
             ExpectedConditions.textToBePresentInElementLocated(
                 By.tagName("body"), expectedTextOnCodeServerPage));
+  }
+
+  @AfterClass
+  public void tearDown() {
+    testWorkspace.delete();
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR get rid of code which removes all user's worskspaces after the all test executions. 
Also it restores removal of test workspaces in the next cases:
- removal of test workspace linked to field [CheckSimpleGwtAppTest::testWorkspace](https://github.com/eclipse/che/blob/6.0.0-M4/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java#L58);
- removal of test workspace linked to some test which being executed in the _CheOneThreadTestsSuite.xml_ suite when _CheSuite.xml_ suite starts execution, removes that test from [SeleniumTestHandler::runningTests](https://github.com/eclipse/che/blob/6.0.0-M4/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java#L173) list and so prevents removal of test workspace which belongs to that test when [SeleniumTestHandler::shutdown()](https://github.com/eclipse/che/blob/6.0.0-M4/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java#L418) method is executed;
- removal of test workspaces which startup failed, and they weren't removed after that because of removal were hidden by [Assert.fail()](https://github.com/eclipse/che/commit/2c299254768e49f6082106b7331dc67a25831e28) command.

### What issues does this PR fix or reference?
#6829