### PR TITLE
CHE-7156: Stop using SearchEngine in debugger for searching resources by FQN

### DIFF
--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
@@ -626,10 +626,13 @@ public class JavaLanguageServerExtensionService {
             ImmutableList.of(fqn, String.valueOf(lineNumber)),
             type);
 
-    Either<String, ResourceLocation> l = location.get(0);
+    if (location.isEmpty()) {
+      throw new RuntimeException("Type with fully qualified name: " + fqn + " was not found");
+    }
+    Either<String, ResourceLocation> l = location.get(0); // TODO let user choose sources
 
     if (l.isLeft()) {
-      return new LocationImpl(l.getLeft(), lineNumber, null);
+      return new LocationImpl(removePrefixUri(l.getLeft()), lineNumber, null);
     } else {
       return new LocationImpl(
           l.getRight().getFqn(), lineNumber, true, l.getRight().getLibId(), null);


### PR DESCRIPTION
### What does this PR do?
Adopts Che side to use updated in https://github.com/eclipse/che-ls-jdt/pull/28 search for resource by FQN.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7156