### PR TITLE
Fix of steps sequence for the DebuggerWatchExpressionTest

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebuggerWatchExpressionTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebuggerWatchExpressionTest.java
@@ -93,11 +93,11 @@ public class DebuggerWatchExpressionTest {
     cmdPalette.openCommandPalette();
     cmdPalette.startCommandByDoubleClick(START_DEBUG);
 
+    consoles.waitExpectedTextIntoConsole(TestBuildConstants.LISTENING_AT_ADDRESS_8000);
     menu.runCommandByXpath(
         TestMenuCommandsConstants.Run.RUN_MENU,
         TestMenuCommandsConstants.Run.DEBUG,
         debugConfig.getXpathToІRunDebugCommand(PROJECT));
-    consoles.waitExpectedTextIntoConsole(TestBuildConstants.LISTENING_AT_ADDRESS_8000);
   }
 
   @Test(priority = 1)


### PR DESCRIPTION
### What does this PR do?
Apply quick fix for the DebuggerWatchExpressionTest test (After applying a connection for debugger on this moment at first step the debugger widget is opened and overlaps the console with output. But the test still wait expected message from the console.)
@dmytro-ndp, @vparfonov