### PR TITLE
Remove redundant check if webdriver session can be created

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -162,9 +162,7 @@ public abstract class SeleniumTestHandler
   }
 
   @Override
-  public void onStart(ITestContext context) {
-    checkWebDriverSessionCreation();
-  }
+  public void onStart(ITestContext context) {}
 
   @Override
   public void onFinish(ITestContext context) {}


### PR DESCRIPTION
### What does this PR do?
This PR removes redundant [call of SeleniumTestHandler::checkWebDriverSessionCreation()](https://github.com/eclipse/che/blob/master/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java#L166) method which remains untouched after adding another call of this method into constructor ([commit e7a5e977dadc57730e9d1c9c432f2fdaa9f9406c](https://github.com/eclipse/che/commit/e7a5e977dadc57730e9d1c9c432f2fdaa9f9406c#diff-d3fc6a71dbfe0aa46e07d4ee23118dfb). 