### PR TITLE
Provide machine logs volume and configuration of logs root path

### DIFF
--- a/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
+++ b/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
@@ -218,4 +218,13 @@ fi
 
 EXEC_AGENT_PORT=${CHE_SERVER_EXEC_AGENT_HTTP_PORT:-4412}
 
-$HOME/che/exec-agent/che-exec-agent -addr :${EXEC_AGENT_PORT} -cmd ${SHELL_INTERPRETER} -logs-dir $HOME/che/exec-agent/logs
+
+LOGS_DIR=''
+## Checks whether workspace logs root exists if it does override exec-agent logs directory otherwise default folder would be used
+if [ -d "${CHE_WORKSPACE_LOGS_ROOT__DIR}" ]; then
+   LOGS_DIR=$CHE_WORKSPACE_LOGS_ROOT__DIR/exec-agent
+else
+   LOGS_DIR=$HOME/che/exec-agent/logs
+fi
+
+$HOME/che/exec-agent/che-exec-agent -addr :${EXEC_AGENT_PORT} -cmd ${SHELL_INTERPRETER} -logs-dir $LOGS_DIR

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -28,6 +28,11 @@ che.workspace.storage=${che.home}/workspaces
 # workspace. This is the directory in the machine where your projects are placed.
 che.workspace.projects.storage=/projects
 
+#Defines the directory inside the machine where all the workspace logs are placed.
+#The value of this folder should be provided into machine e.g. like environment variable
+#so agents developers can use this directory for backup agents logs.
+che.workspace.logs.root_dir=/workspace_logs
+
 # Configures proxies used by runtimes powering workspaces
 che.workspace.http_proxy=
 che.workspace.https_proxy=

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -122,6 +122,11 @@
 #     agents within the workspace when it boots, then the workspace will not be started.
 #CHE_WORKSPACE_AGENT_DEV_MAX__START__TIME__MS=300000
 
+# Workspace logs root
+#     Defines the directory inside the machine where all the workspace logs are placed.
+#     The value of this folder should be provided into machine e.g. like environment variable
+#     so agents developers can use this directory for backup agents logs.
+#CHE_WORKSPACE_LOGS_ROOT__DIR=/workspace_logs
 
 
 # Workspace Java Options

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -16,9 +16,11 @@ import static org.eclipse.che.workspace.infrastructure.openshift.project.pvc.Uni
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.multibindings.Multibinder;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiEnvVarProvider;
+import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.bootstrapper.OpenShiftBootstrapperFactory;
@@ -31,6 +33,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceP
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumeStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftCheApiEnvVarProvider;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.env.LogsRootEnvVariableProvider;
 
 /** @author Sergii Leshchenko */
 public class OpenShiftInfraModule extends AbstractModule {
@@ -57,5 +60,9 @@ public class OpenShiftInfraModule extends AbstractModule {
     volumesStrategies.addBinding(COMMON_STRATEGY).to(CommonPVCStrategy.class);
     volumesStrategies.addBinding(UNIQUE_STRATEGY).to(UniqueWorkspacePVCStrategy.class);
     bind(WorkspaceVolumesStrategy.class).toProvider(WorkspaceVolumeStrategyProvider.class);
+
+    Multibinder<EnvVarProvider> envVarProviders =
+        Multibinder.newSetBinder(binder(), EnvVarProvider.class);
+    envVarProviders.addBinding().to(LogsRootEnvVariableProvider.class);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/bootstrapper/OpenShiftBootstrapper.java
@@ -38,7 +38,6 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
   private static final String BOOTSTRAPPER_BASE_DIR = "/tmp/";
   private static final String BOOTSTRAPPER_DIR = BOOTSTRAPPER_BASE_DIR + "bootstrapper/";
   private static final String BOOTSTRAPPER_FILE = "bootstrapper";
-  private static final String BOOTSTRAPPER_LOG_FILE = "bootstrapper.log";
   private static final String CONFIG_FILE = "config.json";
 
   private final RuntimeIdentity runtimeIdentity;
@@ -47,6 +46,8 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
   private final int installerTimeoutSeconds;
   private final OpenShiftMachine openShiftMachine;
   private final String bootstrapperBinaryUrl;
+  private final String bootstrapperLogsFolder;
+  private final String bootstrapperLogsFile;
 
   @Inject
   public OpenShiftBootstrapper(
@@ -59,6 +60,7 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
       @Named("che.infra.openshift.bootstrapper.installer_timeout_sec") int installerTimeoutSeconds,
       @Named("che.infra.openshift.bootstrapper.server_check_period_sec")
           int serverCheckPeriodSeconds,
+      @Named("che.workspace.logs.root_dir") String logsRootPath,
       EventService eventService) {
     super(
         openShiftMachine.getName(),
@@ -73,6 +75,8 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
     this.serverCheckPeriodSeconds = serverCheckPeriodSeconds;
     this.installerTimeoutSeconds = installerTimeoutSeconds;
     this.openShiftMachine = openShiftMachine;
+    this.bootstrapperLogsFolder = logsRootPath + "/bootstrapper";
+    this.bootstrapperLogsFile = bootstrapperLogsFolder + "/bootstrapper.log";
   }
 
   @Override
@@ -108,8 +112,7 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
             // redirects command output and makes the bootstrapping process detached,
             // to avoid the holding of the socket connection for exec watcher.
             + " > "
-            + BOOTSTRAPPER_DIR
-            + BOOTSTRAPPER_LOG_FILE
+            + bootstrapperLogsFile
             + " 2>&1 &");
   }
 
@@ -117,7 +120,7 @@ public class OpenShiftBootstrapper extends AbstractBootstrapper {
     String machineName = openShiftMachine.getName();
     LOG.debug(
         "Bootstrapping {}:{}. Creating folder for bootstrapper", runtimeIdentity, machineName);
-    openShiftMachine.exec("mkdir", "-p", BOOTSTRAPPER_DIR);
+    openShiftMachine.exec("mkdir", "-p", BOOTSTRAPPER_DIR, bootstrapperLogsFolder);
     LOG.debug("Bootstrapping {}:{}. Downloading bootstrapper binary", runtimeIdentity, machineName);
     openShiftMachine.exec(
         "curl", "-o", BOOTSTRAPPER_DIR + BOOTSTRAPPER_FILE, bootstrapperBinaryUrl);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/LogsVolumeMachineProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/LogsVolumeMachineProvisioner.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import com.google.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+
+/**
+ * Adds to each machine inside environment volume with logs root.
+ *
+ * @author Anton Korneta
+ */
+public class LogsVolumeMachineProvisioner implements ConfigurationProvisioner {
+  public static final String LOGS_VOLUME_NAME = "che-logs";
+
+  private final String logsRootPath;
+
+  @Inject
+  public LogsVolumeMachineProvisioner(@Named("che.workspace.logs.root_dir") String logsRootPath) {
+    this.logsRootPath = logsRootPath;
+  }
+
+  @Override
+  public void provision(OpenShiftEnvironment environment, RuntimeIdentity identity)
+      throws InfrastructureException {
+    for (InternalMachineConfig machine : environment.getMachines().values()) {
+      machine.getVolumes().put(LOGS_VOLUME_NAME, new VolumeImpl().withPath(logsRootPath));
+    }
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/env/LogsRootEnvVariableProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/env/LogsRootEnvVariableProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision.env;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
+import org.eclipse.che.commons.lang.Pair;
+
+/**
+ * Add env variable to machines with path to root folder of workspace logs.
+ *
+ * @author Anton Korneta
+ */
+public class LogsRootEnvVariableProvider implements EnvVarProvider {
+
+  /** Environment variable that points to root folder of projects inside machine */
+  public static final String WORKSPACE_LOGS_ROOT_ENV_VAR = "CHE_WORKSPACE_LOGS_ROOT__DIR";
+
+  private String logsRootPath;
+
+  @Inject
+  public LogsRootEnvVariableProvider(@Named("che.workspace.logs.root_dir") String logsRootPath) {
+    this.logsRootPath = logsRootPath;
+  }
+
+  @Override
+  public Pair<String, String> get(RuntimeIdentity identity) throws InfrastructureException {
+    return Pair.of(WORKSPACE_LOGS_ROOT_ENV_VAR, logsRootPath);
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.project.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.InstallerServersPortProvisioner;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.LogsVolumeMachineProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.limits.ram.RamLimitProvisioner;
@@ -48,6 +49,7 @@ public class OpenShiftEnvironmentProvisionerTest {
   @Mock private ServersConverter serversProvisioner;
   @Mock private RestartPolicyRewriter restartPolicyRewriter;
   @Mock private RamLimitProvisioner ramLimitProvisioner;
+  @Mock private LogsVolumeMachineProvisioner logsVolumeMachineProvisioner;
 
   private OpenShiftEnvironmentProvisioner osInfraProvisioner;
 
@@ -65,15 +67,17 @@ public class OpenShiftEnvironmentProvisionerTest {
             restartPolicyRewriter,
             volumesStrategy,
             ramLimitProvisioner,
-            installerServersPortProvisioner);
+            installerServersPortProvisioner,
+            logsVolumeMachineProvisioner);
     provisionOrder =
         inOrder(
             installerServersPortProvisioner,
+            logsVolumeMachineProvisioner,
+            serversProvisioner,
+            envVarsProvisioner,
             volumesStrategy,
             uniqueNamesProvisioner,
             tlsRouteProvisioner,
-            serversProvisioner,
-            envVarsProvisioner,
             restartPolicyRewriter,
             ramLimitProvisioner);
   }
@@ -85,6 +89,7 @@ public class OpenShiftEnvironmentProvisionerTest {
     provisionOrder
         .verify(installerServersPortProvisioner)
         .provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(logsVolumeMachineProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(serversProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(envVarsProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(volumesStrategy).provision(eq(osEnv), eq(runtimeIdentity));

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/LogsVolumeMachineProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/LogsVolumeMachineProvisionerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link LogsVolumeMachineProvisioner}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class LogsVolumeMachineProvisionerTest {
+
+  private static final String WORKSPACE_LOGS_ROOT_PATH = "/workspace_logs";
+  private static final String MACHINE_NAME_1 = "web/main";
+  private static final String MACHINE_NAME_2 = "db/main";
+
+  @Mock private OpenShiftEnvironment openShiftEnvironment;
+  @Mock private RuntimeIdentity identity;
+  @Mock private InternalMachineConfig machine1;
+  @Mock private InternalMachineConfig machine2;
+
+  private LogsVolumeMachineProvisioner logsVolumeProvisioner;
+
+  @BeforeMethod
+  public void setup() {
+    logsVolumeProvisioner = new LogsVolumeMachineProvisioner(WORKSPACE_LOGS_ROOT_PATH);
+    when(machine1.getVolumes()).thenReturn(new HashMap<>());
+    when(machine2.getVolumes()).thenReturn(new HashMap<>());
+    when(openShiftEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of(MACHINE_NAME_1, machine1, MACHINE_NAME_2, machine2));
+  }
+
+  @Test
+  public void testProvisionLogsVolumeToAllMachineInEnvironment() throws Exception {
+    logsVolumeProvisioner.provision(openShiftEnvironment, identity);
+
+    InternalMachineConfig m1 = openShiftEnvironment.getMachines().get(MACHINE_NAME_1);
+    InternalMachineConfig m2 = openShiftEnvironment.getMachines().get(MACHINE_NAME_2);
+    assertTrue(m1.getVolumes().containsKey(LOGS_VOLUME_NAME));
+    assertEquals(m1.getVolumes().get(LOGS_VOLUME_NAME).getPath(), WORKSPACE_LOGS_ROOT_PATH);
+    assertTrue(m2.getVolumes().containsKey(LOGS_VOLUME_NAME));
+    assertEquals(m2.getVolumes().get(LOGS_VOLUME_NAME).getPath(), WORKSPACE_LOGS_ROOT_PATH);
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/env/LogsRootEnvVariableProviderTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/env/LogsRootEnvVariableProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision.env;
+
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.env.LogsRootEnvVariableProvider.WORKSPACE_LOGS_ROOT_ENV_VAR;
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.commons.lang.Pair;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link LogsRootEnvVariableProvider}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class LogsRootEnvVariableProviderTest {
+
+  private static final String WORKSPACE_LOGS_ROOT_PATH = "/workspace_logs";
+
+  @Mock private RuntimeIdentity identity;
+
+  private LogsRootEnvVariableProvider logsRootEnvVariableProvider;
+
+  @BeforeMethod
+  public void setup() {
+    logsRootEnvVariableProvider = new LogsRootEnvVariableProvider(WORKSPACE_LOGS_ROOT_PATH);
+  }
+
+  @Test
+  public void testProviderReturnsLogsEnvironmentVariable() throws Exception {
+    final Pair<String, String> eVar = logsRootEnvVariableProvider.get(identity);
+
+    assertEquals(eVar.first, WORKSPACE_LOGS_ROOT_ENV_VAR);
+    assertEquals(eVar.second, WORKSPACE_LOGS_ROOT_PATH);
+  }
+}

--- a/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.script.sh
@@ -283,4 +283,9 @@ else
    export JAVA_OPTS="${CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS}"
 fi
 
+## Checks whether workspace logs root exists if it does then overrides ws-agent logs directory
+if [ -d "${CHE_WORKSPACE_LOGS_ROOT__DIR}" ]; then
+  export CHE_LOGS_DIR=$CHE_WORKSPACE_LOGS_ROOT__DIR/ws-agent
+fi
+
 export JPDA_ADDRESS="4403" && ~/che/ws-agent/bin/catalina.sh jpda run


### PR DESCRIPTION
### What does this PR do?
Adds configuration of workspace logs root directory;
Provides environment variable for each OpenShift machine that contains value of logs root directory;
Adds logs volume into all OpenShift machines and make distinct subpaths for logs with machine name.
Modifies installation scripts of ws-agent and exec-agent with a logic that defines the logs folder for this agents and redirects bootstrapper logs to workspace logs root.

file structure on host for different strategies:

One PV will be used for storing logs of machines that are placed in the same pod.
**unique:** 
![unique_strategy](https://user-images.githubusercontent.com/12269156/35618103-9c66d2da-0682-11e8-94c5-0abbf5631bda.png)

One PV will be used for storing logs and projects data of workspace with two machines.
**common:**
![common_strategy](https://user-images.githubusercontent.com/12269156/35618120-a65bb9a4-0682-11e8-997d-bda6cd914993.png)

### What issues does this PR fix or reference?
#7807 
partially solves this issue(for OpenShift only): #7386 

#### Docs PR
n/a