### PR TITLE
Fix displaying of list of organizations for GitHub account

### DIFF
--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPageViewImpl.ui.xml
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPageViewImpl.ui.xml
@@ -80,10 +80,10 @@
                           debugId="githubImporter-loadRepo"/>
             </g:FlowPanel>
         </g:north>
-        <g:north size="205">
+        <g:north size="215">
             <g:FlowPanel ui:field="bottomPanel">
                 <g:DockLayoutPanel ui:field="githubPanel" debugId="file-importProject-githubPanel">
-                    <g:north size="25">
+                    <g:north size="45">
                         <g:FlowPanel addStyleNames="{style.bottomSpace}">
                             <g:Label text="{locale.importFromGithubAccount}"
                                      addStyleNames="{style.alignLeft} {style.textPosition} {style.rightSpace}"/>


### PR DESCRIPTION
### What does this PR do?
Fix displaying of list of organizations for GitHub account

### What issues does this PR fix or reference?
#8537
![org_list](https://user-images.githubusercontent.com/5676062/35622744-93beaf22-0691-11e8-9a49-fc1c1e96752a.png)
