### PR TITLE
rh-che #500:  Adding 'che.workspace.server.ping_success_threshold' property for server checker and liveness probe configuration.

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -112,6 +112,9 @@ che.installer.registry.remote=NULL
 #     not interacted with the workspace. Leaving a browser window open counts as idleness time.
 che.workspace.agent.dev.inactive_stop_timeout_ms=3600000
 che.workspace.activity_check_scheduler_period_s=60
+# Number of sequential successful pings to server after which it is treated as available.
+# Note: the property is common for all servers e.g. workspace agent, terminal, exec etc.
+che.workspace.server.ping_success_threshold=1
 
 ### TEMPLATES
 # Folder that contains JSON files with code templates and samples

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/HttpConnectionServerChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/HttpConnectionServerChecker.java
@@ -34,9 +34,10 @@ public class HttpConnectionServerChecker extends ServerChecker {
       String serverRef,
       long period,
       long timeout,
+      int successThreshold,
       TimeUnit timeUnit,
       Timer timer) {
-    super(machineName, serverRef, period, timeout, timeUnit, timer);
+    super(machineName, serverRef, period, timeout, successThreshold, timeUnit, timer);
     this.url = url;
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/TerminalHttpConnectionServerChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/TerminalHttpConnectionServerChecker.java
@@ -30,9 +30,10 @@ class TerminalHttpConnectionServerChecker extends HttpConnectionServerChecker {
       String serverRef,
       long period,
       long timeout,
+      int successThreshold,
       TimeUnit timeUnit,
       Timer timer) {
-    super(url, machineName, serverRef, period, timeout, timeUnit, timer);
+    super(url, machineName, serverRef, period, timeout, successThreshold, timeUnit, timer);
   }
 
   @Override

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactory.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Runtime;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
@@ -41,15 +42,18 @@ public class WorkspaceProbesFactory {
   private final Map<String, HttpProbeConfigFactory> probeConfigFactories;
 
   @Inject
-  public WorkspaceProbesFactory(MachineTokenProvider machineTokenProvider) {
+  public WorkspaceProbesFactory(
+      MachineTokenProvider machineTokenProvider,
+      @Named("che.workspace.server.ping_success_threshold") int serverPingSuccessThreshold) {
     probeConfigFactories =
         ImmutableMap.of(
             Constants.SERVER_WS_AGENT_HTTP_REFERENCE,
-            new WsAgentServerLivenessProbeConfigFactory(machineTokenProvider),
+            new WsAgentServerLivenessProbeConfigFactory(
+                machineTokenProvider, serverPingSuccessThreshold),
             Constants.SERVER_EXEC_AGENT_HTTP_REFERENCE,
-            new ExecServerLivenessProbeConfigFactory(),
+            new ExecServerLivenessProbeConfigFactory(serverPingSuccessThreshold),
             Constants.SERVER_TERMINAL_REFERENCE,
-            new TerminalServerLivenessProbeConfigFactory());
+            new TerminalServerLivenessProbeConfigFactory(serverPingSuccessThreshold));
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/ExecServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/ExecServerLivenessProbeConfigFactory.java
@@ -22,6 +22,11 @@ import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
  * @author Alexander Garagatyi
  */
 public class ExecServerLivenessProbeConfigFactory implements HttpProbeConfigFactory {
+  private final int successThreshold;
+
+  public ExecServerLivenessProbeConfigFactory(int successThreshold) {
+    this.successThreshold = successThreshold;
+  }
 
   @Override
   public HttpProbeConfig get(String workspaceId, Server server)
@@ -34,7 +39,7 @@ public class ExecServerLivenessProbeConfigFactory implements HttpProbeConfigFact
           url.getProtocol(),
           "/liveness",
           null,
-          1,
+          successThreshold,
           3,
           120,
           10,

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/TerminalServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/TerminalServerLivenessProbeConfigFactory.java
@@ -22,6 +22,11 @@ import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
  * @author Alexander Garagatyi
  */
 public class TerminalServerLivenessProbeConfigFactory implements HttpProbeConfigFactory {
+  private final int successThreshold;
+
+  public TerminalServerLivenessProbeConfigFactory(int successThreshold) {
+    this.successThreshold = successThreshold;
+  }
 
   @Override
   public HttpProbeConfig get(String workspaceId, Server server)
@@ -50,6 +55,7 @@ public class TerminalServerLivenessProbeConfigFactory implements HttpProbeConfig
       port = uri.getPort();
     }
 
-    return new HttpProbeConfig(port, uri.getHost(), protocol, "/liveness", null, 1, 3, 120, 10, 10);
+    return new HttpProbeConfig(
+        port, uri.getHost(), protocol, "/liveness", null, successThreshold, 3, 120, 10, 10);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.server.hc.probe.server;
 import static java.util.Collections.singletonMap;
 
 import java.net.URI;
+import javax.inject.Inject;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriBuilderException;
@@ -29,9 +30,13 @@ import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
  */
 public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigFactory {
   private final MachineTokenProvider machineTokenProvider;
+  private final int successThreshold;
 
-  public WsAgentServerLivenessProbeConfigFactory(MachineTokenProvider machineTokenProvider) {
+  @Inject
+  public WsAgentServerLivenessProbeConfigFactory(
+      MachineTokenProvider machineTokenProvider, int successThreshold) {
     this.machineTokenProvider = machineTokenProvider;
+    this.successThreshold = successThreshold;
   }
 
   @Override
@@ -59,7 +64,7 @@ public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigF
           uri.getScheme(),
           uri.getPath(),
           singletonMap(HttpHeaders.AUTHORIZATION, machineTokenProvider.getToken(workspaceId)),
-          1,
+          successThreshold,
           3,
           120,
           10,

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/HttpConnectionServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/HttpConnectionServerCheckerTest.java
@@ -50,7 +50,7 @@ public class HttpConnectionServerCheckerTest {
     checker =
         spy(
             new HttpConnectionServerChecker(
-                SERVER_URL, MACHINE_NAME, SERVER_REF, 1, 10, TimeUnit.SECONDS, timer));
+                SERVER_URL, MACHINE_NAME, SERVER_REF, 1, 10, 1, TimeUnit.SECONDS, timer));
 
     doReturn(conn).when(checker).createConnection(nullable(URL.class));
     when(conn.getResponseCode()).thenReturn(200);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -36,6 +36,7 @@ public class ServerCheckerTest {
   private static final String SERVER_REF = "ref1";
   private static final long PERIOD_MS = 10;
   private static final long TIMEOUT_MS = 500;
+  private static final int SUCCESS_THRESHOLD = 1;
 
   private Timer timer;
   private TestServerChecker checker;
@@ -46,7 +47,13 @@ public class ServerCheckerTest {
     checker =
         spy(
             new TestServerChecker(
-                MACHINE_NAME, SERVER_REF, PERIOD_MS, TIMEOUT_MS, TimeUnit.MILLISECONDS, timer));
+                MACHINE_NAME,
+                SERVER_REF,
+                PERIOD_MS,
+                TIMEOUT_MS,
+                SUCCESS_THRESHOLD,
+                TimeUnit.MILLISECONDS,
+                timer));
   }
 
   @AfterMethod
@@ -80,7 +87,13 @@ public class ServerCheckerTest {
     checker =
         spy(
             new TestServerChecker(
-                MACHINE_NAME, SERVER_REF, PERIOD_MS, PERIOD_MS * 2, TimeUnit.MILLISECONDS, timer));
+                MACHINE_NAME,
+                SERVER_REF,
+                PERIOD_MS,
+                PERIOD_MS * 2,
+                SUCCESS_THRESHOLD,
+                TimeUnit.MILLISECONDS,
+                timer));
 
     // ensure server not available before start
     when(checker.isAvailable()).thenReturn(false);
@@ -100,7 +113,7 @@ public class ServerCheckerTest {
 
   @Test(expectedExceptions = InfrastructureException.class)
   public void checkOnceThrowsExceptionIfServerIsNotAvailable() throws InfrastructureException {
-    new TestServerChecker("test", "test", 1, 1, TimeUnit.SECONDS, null).checkOnce(ref -> {});
+    new TestServerChecker("test", "test", 1, 1, 1, TimeUnit.SECONDS, null).checkOnce(ref -> {});
   }
 
   private static class TestServerChecker extends ServerChecker {
@@ -109,9 +122,10 @@ public class ServerCheckerTest {
         String serverRef,
         long period,
         long timeout,
+        int successThreshold,
         TimeUnit timeUnit,
         Timer timer) {
-      super(machineName, serverRef, period, timeout, timeUnit, timer);
+      super(machineName, serverRef, period, timeout, successThreshold, timeUnit, timer);
     }
 
     @Override

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
@@ -49,6 +49,7 @@ public class ServersCheckerTest {
   private static final String MACHINE_NAME = "mach1";
   private static final String MACHINE_TOKEN = "machineToken";
   private static final String WORKSPACE_ID = "ws123";
+  private static final int SERVER_PING_SUCCESS_THRESHOLD = 1;
 
   @Mock private Consumer<String> readinessHandler;
   @Mock private MachineTokenProvider machineTokenProvider;
@@ -74,7 +75,14 @@ public class ServersCheckerTest {
 
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
 
-    checker = spy(new ServersChecker(runtimeIdentity, MACHINE_NAME, servers, machineTokenProvider));
+    checker =
+        spy(
+            new ServersChecker(
+                runtimeIdentity,
+                MACHINE_NAME,
+                servers,
+                machineTokenProvider,
+                SERVER_PING_SUCCESS_THRESHOLD));
     when(checker.doCreateChecker(any(URL.class), anyString())).thenReturn(connectionChecker);
     when(machineTokenProvider.getToken(anyString())).thenReturn(MACHINE_TOKEN);
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/TerminalHttpConnectionServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/TerminalHttpConnectionServerCheckerTest.java
@@ -39,7 +39,14 @@ public class TerminalHttpConnectionServerCheckerTest {
   public void setUp() throws Exception {
     checker =
         new TerminalHttpConnectionServerChecker(
-            new URL("http://localhost"), MACHINE_NAME, SERVER_REF, 1, 10, TimeUnit.SECONDS, timer);
+            new URL("http://localhost"),
+            MACHINE_NAME,
+            SERVER_REF,
+            1,
+            10,
+            1,
+            TimeUnit.SECONDS,
+            timer);
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactoryTest.java
@@ -37,6 +37,7 @@ public class WorkspaceProbesFactoryTest {
   private static final String WORKSPACE_ID = "wsId";
   private static final String MACHINE_NAME = "machine1";
   private static final String TOKEN = "token1";
+  private static final int SERVER_PING_SUCCESS_THRESHOLD = 1;
   private static final ServerImpl SERVER = new ServerImpl().withUrl("https://localhost:4040/path1");
 
   @Mock private MachineTokenProvider tokenProvider;
@@ -47,7 +48,7 @@ public class WorkspaceProbesFactoryTest {
   public void setUp() throws Exception {
     when(tokenProvider.getToken(WORKSPACE_ID)).thenReturn(TOKEN);
 
-    probesFactory = new WorkspaceProbesFactory(tokenProvider);
+    probesFactory = new WorkspaceProbesFactory(tokenProvider, SERVER_PING_SUCCESS_THRESHOLD);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Adding 'che.workspace.server.ping_success_threshold' property for server checker and liveness probe configuration.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/500
Porting https://github.com/eclipse/che/commit/a54f1caa53e2da640685dc3620fd9d6f9fdfeb56 to master

#### Release Notes
Adding 'che.workspace.server.ping_success_threshold' property for server checker and liveness probe configuration.

#### Docs PR
N/A
