### PR TITLE
Selenium: Delete the 'loader.waitOnClosed()' from the page object 'Preferences'

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
@@ -573,8 +573,6 @@ public class Preferences {
     gitHub.typePass(githubPassword);
     gitHub.clickOnSignInButton();
 
-    loader.waitOnClosed();
-
     // authorize on github.com
     if (seleniumWebDriver.getWindowHandles().size() > 1) {
       loader.waitOnClosed();


### PR DESCRIPTION

### What does this PR do?
* Delete the 'loader.waitOnClosed()' from the page object 'Preferences'
* Wait of closing loader is not needed in this place and can produce to failing of the selenium test

### What issues does this PR fix or reference?
#8529
