### PR TITLE
Prompt to generate ssh key at import private repo from github

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/presenter/ImportProjectWizardPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projectimport/wizard/presenter/ImportProjectWizardPresenter.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.ide.projectimport.wizard.presenter;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.HashMap;
@@ -18,7 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.project.shared.dto.ProjectImporterDescriptor;
-import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.project.wizard.ImportWizardRegistrar;
 import org.eclipse.che.ide.api.wizard.Wizard;
@@ -27,7 +28,7 @@ import org.eclipse.che.ide.projectimport.wizard.ImportWizard;
 import org.eclipse.che.ide.projectimport.wizard.ImportWizardFactory;
 import org.eclipse.che.ide.projectimport.wizard.ImportWizardRegistry;
 import org.eclipse.che.ide.projectimport.wizard.mainpage.MainPagePresenter;
-import org.eclipse.che.ide.ui.dialogs.DialogFactory;
+import org.eclipse.che.ide.util.loging.Log;
 
 /**
  * Presenter for import project wizard dialog.
@@ -41,12 +42,11 @@ public class ImportProjectWizardPresenter
         ImportProjectWizardView.EnterPressedDelegate,
         MainPagePresenter.ImporterSelectionListener {
 
-  private final DialogFactory dialogFactory;
-  private final ImportWizardFactory importWizardFactory;
-  private final ImportProjectWizardView view;
-  private final Provider<MainPagePresenter> mainPageProvider;
-  private final CoreLocalizationConstant locale;
-  private final ImportWizardRegistry wizardRegistry;
+  private ImportWizardFactory importWizardFactory;
+  private ImportProjectWizardView view;
+  private Provider<MainPagePresenter> mainPageProvider;
+  private ImportWizardRegistry wizardRegistry;
+
   private final Map<ProjectImporterDescriptor, ImportWizard> wizardsCache;
 
   private MainPagePresenter mainPage;
@@ -57,17 +57,13 @@ public class ImportProjectWizardPresenter
   public ImportProjectWizardPresenter(
       ImportProjectWizardView view,
       MainPagePresenter mainPage,
-      CoreLocalizationConstant locale,
       Provider<MainPagePresenter> mainPageProvider,
       ImportWizardRegistry wizardRegistry,
-      DialogFactory dialogFactory,
       ImportWizardFactory importWizardFactory) {
     this.view = view;
-    this.locale = locale;
     this.wizardRegistry = wizardRegistry;
     this.mainPage = mainPage;
     this.mainPageProvider = mainPageProvider;
-    this.dialogFactory = dialogFactory;
     this.importWizardFactory = importWizardFactory;
     wizardsCache = new HashMap<>();
     view.setDelegate(this);
@@ -102,9 +98,10 @@ public class ImportProjectWizardPresenter
           @Override
           public void onFailure(Throwable e) {
             view.setLoaderVisibility(false);
-            dialogFactory
-                .createMessageDialog(locale.importProjectViewTitle(), e.getMessage(), null)
-                .show();
+
+            if (e != null && !isNullOrEmpty(e.getLocalizedMessage())) {
+              Log.error(getClass(), e.getLocalizedMessage());
+            }
           }
         });
   }

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/GitHubLocalizationConstant.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/GitHubLocalizationConstant.java
@@ -55,6 +55,9 @@ public interface GitHubLocalizationConstant extends Messages {
   @Key("authorization.message.keyUploadSuccess")
   String authMessageKeyUploadSuccess();
 
+  @Key("message.sshKey.generation.promt")
+  String messageSshKeyGenerationPromt();
+
   /*
    * SamplesListGrid
    */

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/authenticator/GitHubAuthenticatorImpl.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/authenticator/GitHubAuthenticatorImpl.java
@@ -16,25 +16,16 @@ import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUC
 import com.google.common.collect.Lists;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
-import java.util.List;
 import javax.validation.constraints.NotNull;
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper;
-import org.eclipse.che.api.ssh.shared.dto.SshPairDto;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.oauth.OAuth2Authenticator;
 import org.eclipse.che.ide.api.oauth.OAuth2AuthenticatorUrlProvider;
-import org.eclipse.che.ide.api.ssh.SshServiceClient;
 import org.eclipse.che.ide.ui.dialogs.DialogFactory;
-import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.plugin.github.ide.GitHubLocalizationConstant;
-import org.eclipse.che.plugin.ssh.key.client.SshKeyUploader;
-import org.eclipse.che.plugin.ssh.key.client.SshKeyUploaderRegistry;
-import org.eclipse.che.plugin.ssh.key.client.manage.SshKeyManagerPresenter;
+import org.eclipse.che.plugin.ssh.key.client.SshKeyManager;
 import org.eclipse.che.security.oauth.JsOAuthWindow;
 import org.eclipse.che.security.oauth.OAuthCallback;
 import org.eclipse.che.security.oauth.OAuthStatus;
@@ -48,8 +39,7 @@ public class GitHubAuthenticatorImpl
 
   AsyncCallback<OAuthStatus> callback;
 
-  private final SshKeyUploaderRegistry registry;
-  private final SshServiceClient sshServiceClient;
+  private final SshKeyManager sshKeyManager;
   private final DialogFactory dialogFactory;
   private final GitHubAuthenticatorView view;
   private final NotificationManager notificationManager;
@@ -61,16 +51,14 @@ public class GitHubAuthenticatorImpl
 
   @Inject
   public GitHubAuthenticatorImpl(
-      SshKeyUploaderRegistry registry,
-      SshServiceClient sshServiceClient,
+      SshKeyManager sshKeyManager,
       GitHubAuthenticatorView view,
       DialogFactory dialogFactory,
       GitHubLocalizationConstant locale,
       NotificationManager notificationManager,
       AppContext appContext,
       SecurityTokenProvider securityTokenProvider) {
-    this.registry = registry;
-    this.sshServiceClient = sshServiceClient;
+    this.sshKeyManager = sshKeyManager;
     this.view = view;
     this.securityTokenProvider = securityTokenProvider;
     this.view.setDelegate(this);
@@ -147,20 +135,15 @@ public class GitHubAuthenticatorImpl
   }
 
   private void generateSshKeys(final OAuthStatus authStatus) {
-    final SshKeyUploader githubKeyUploader = registry.getUploader(GITHUB_HOST);
-    if (githubKeyUploader != null) {
-      String userId = appContext.getCurrentUser().getId();
-      githubKeyUploader.uploadKey(
-          userId,
-          new AsyncCallback<Void>() {
-            @Override
-            public void onSuccess(Void result) {
+    sshKeyManager
+        .generateSshKey(appContext.getCurrentUser().getId(), GITHUB_HOST)
+        .then(
+            arg -> {
               callback.onSuccess(authStatus);
               notificationManager.notify(locale.authMessageKeyUploadSuccess(), SUCCESS, FLOAT_MODE);
-            }
-
-            @Override
-            public void onFailure(Throwable exception) {
+            })
+        .catchError(
+            arg -> {
               dialogFactory
                   .createMessageDialog(
                       locale.authorizationDialogTitle(),
@@ -168,57 +151,6 @@ public class GitHubAuthenticatorImpl
                       null)
                   .show();
               callback.onFailure(new Exception(locale.authMessageUnableCreateSshKey()));
-              getFailedKey();
-            }
-          });
-    } else {
-      dialogFactory
-          .createMessageDialog(
-              locale.authorizationDialogTitle(), locale.authMessageUnableCreateSshKey(), null)
-          .show();
-      callback.onFailure(new Exception(locale.authMessageUnableCreateSshKey()));
-    }
-  }
-
-  /** Need to remove failed uploaded pair from local storage if they can't be uploaded to github */
-  private void getFailedKey() {
-    sshServiceClient
-        .getPairs(SshKeyManagerPresenter.VCS_SSH_SERVICE)
-        .then(
-            new Operation<List<SshPairDto>>() {
-              @Override
-              public void apply(List<SshPairDto> result) throws OperationException {
-                for (SshPairDto key : result) {
-                  if (key.getName().equals(GITHUB_HOST)) {
-                    removeFailedKey(key);
-                    return;
-                  }
-                }
-              }
-            })
-        .catchError(
-            new Operation<PromiseError>() {
-              @Override
-              public void apply(PromiseError arg) throws OperationException {
-                Log.error(OAuth2Authenticator.class, arg.getCause());
-              }
-            });
-  }
-
-  /**
-   * Remove failed pair.
-   *
-   * @param pair failed pair
-   */
-  private void removeFailedKey(@NotNull final SshPairDto pair) {
-    sshServiceClient
-        .deletePair(pair.getService(), pair.getName())
-        .catchError(
-            new Operation<PromiseError>() {
-              @Override
-              public void apply(PromiseError arg) throws OperationException {
-                Log.error(OAuth2Authenticator.class, arg.getCause());
-              }
             });
   }
 }

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPageViewImpl.ui.xml
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPageViewImpl.ui.xml
@@ -80,10 +80,10 @@
                           debugId="githubImporter-loadRepo"/>
             </g:FlowPanel>
         </g:north>
-        <g:north size="205">
+        <g:north size="215">
             <g:FlowPanel ui:field="bottomPanel">
                 <g:DockLayoutPanel ui:field="githubPanel" debugId="file-importProject-githubPanel">
-                    <g:north size="25">
+                    <g:north size="45">
                         <g:FlowPanel addStyleNames="{style.bottomSpace}">
                             <g:Label text="{locale.importFromGithubAccount}"
                                      addStyleNames="{style.alignLeft} {style.textPosition} {style.rightSpace}"/>

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/load/ProjectData.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/java/org/eclipse/che/plugin/github/ide/load/ProjectData.java
@@ -26,6 +26,9 @@ public class ProjectData {
   /** Url to clone from GitHub (readOnly). */
   private String readOnlyUrl;
 
+  private String httpTransportUrl;
+  private boolean isPrivateRepo;
+
   private List<String> targets;
 
   public ProjectData(
@@ -34,13 +37,17 @@ public class ProjectData {
       String type,
       List<String> targets,
       String repositoryUrl,
-      String readOnlyUrl) {
+      String readOnlyUrl,
+      String httpTransportUrl,
+      boolean isPrivateRepo) {
     this.name = name;
     this.description = description;
     this.type = type;
     this.repositoryUrl = repositoryUrl;
     this.targets = targets;
     this.readOnlyUrl = readOnlyUrl;
+    this.httpTransportUrl = httpTransportUrl;
+    this.isPrivateRepo = isPrivateRepo;
   }
 
   /**
@@ -105,5 +112,37 @@ public class ProjectData {
 
   public void setReadOnlyUrl(String readOnlyUrl) {
     this.readOnlyUrl = readOnlyUrl;
+  }
+
+  /**
+   * Gets the HTTPS URL to the repository, such as "https://github.com/eclipse/che.git" This URL is
+   * read-only.
+   */
+  public String getHttpTransportUrl() {
+    return httpTransportUrl;
+  }
+
+  /** Sets the HTTPS URL to the repository, such as "https://github.com/eclipse/che.git" */
+  public void setHttpTransportUrl(String httpTransportUrl) {
+    this.httpTransportUrl = httpTransportUrl;
+  }
+
+  /**
+   * Gets state of the repository.
+   *
+   * @return {@code true} when the repository is private, {@code false} otherwise
+   */
+  public boolean isPrivateRepo() {
+    return isPrivateRepo;
+  }
+
+  /**
+   * Sets state of the repository.
+   *
+   * @param isPrivateRepo should be {@code true} when the repository is private, {@code false}
+   *     otherwise
+   */
+  void setPrivateRepo(boolean isPrivateRepo) {
+    this.isPrivateRepo = isPrivateRepo;
   }
 }

--- a/plugins/plugin-github/che-plugin-github-ide/src/main/resources/org/eclipse/che/plugin/github/ide/GitHubLocalizationConstant.properties
+++ b/plugins/plugin-github/che-plugin-github-ide/src/main/resources/org/eclipse/che/plugin/github/ide/GitHubLocalizationConstant.properties
@@ -17,6 +17,7 @@ authorization.dialog.text = {0} requests authorization through OAuth2 protocol
 authorization.generateKeyLabel = generate ssh key and upload it on GitHub
 authorization.message.unableCreateSshKey = Unable create private ssh key. \
   You can create a new SSH key pair in Profile->Preferences->SSH->VCS.
+message.sshKey.generation.promt = Selected Repo is private. Would you like to generate ssh key and upload it on GitHub?
 authorization.message.keyUploadSuccess = Ssh key uploaded
 ############### SamplesListGrid ###############
 samplesListGrid.column.name=Project

--- a/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
+++ b/plugins/plugin-github/che-plugin-github-ide/src/test/java/org/eclipse/che/plugin/github/ide/importer/page/GithubImporterPagePresenterTest.java
@@ -44,10 +44,12 @@ import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.wizard.Wizard;
 import org.eclipse.che.ide.commons.exception.UnauthorizedException;
 import org.eclipse.che.ide.dto.DtoFactory;
+import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 import org.eclipse.che.plugin.github.ide.GitHubLocalizationConstant;
 import org.eclipse.che.plugin.github.ide.GitHubServiceClient;
 import org.eclipse.che.plugin.github.ide.load.ProjectData;
 import org.eclipse.che.plugin.github.shared.GitHubUser;
+import org.eclipse.che.plugin.ssh.key.client.SshKeyManager;
 import org.eclipse.che.security.oauth.OAuthStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,6 +83,8 @@ public class GithubImporterPagePresenterTest {
   @Mock private AppContext appContext;
   @Mock private OAuthServiceClient oAuthServiceClient;
   @Mock private NotificationManager notificationManager;
+  @Mock private DialogFactory dialogFactory;
+  @Mock private SshKeyManager sshKeyManager;
 
   private GithubImporterPagePresenter presenter;
 
@@ -99,8 +103,10 @@ public class GithubImporterPagePresenterTest {
                 gitHubAuthenticatorRegistry,
                 gitHubClientService,
                 dtoFactory,
+                dialogFactory,
                 appContext,
                 locale,
+                sshKeyManager,
                 oAuthServiceClient,
                 notificationManager));
     doReturn(Collections.singletonList(gitHubUser))
@@ -172,7 +178,14 @@ public class GithubImporterPagePresenterTest {
   public void onRepositorySelectedTest() {
     ProjectData projectData =
         new ProjectData(
-            "name", "description", "type", Collections.emptyList(), "repoUrl", "readOnlyUrl");
+            "name",
+            "description",
+            "type",
+            Collections.emptyList(),
+            "repoUrl",
+            "readOnlyUrl",
+            "httpTransportUrl",
+            false);
 
     presenter.onRepositorySelected(projectData);
 

--- a/wsagent/che-core-ssh-key-ide/src/main/java/org/eclipse/che/plugin/ssh/key/client/SshKeyGenerationInfo.java
+++ b/wsagent/che-core-ssh-key-ide/src/main/java/org/eclipse/che/plugin/ssh/key/client/SshKeyGenerationInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.ssh.key.client;
+
+import org.eclipse.che.ide.api.app.AppContext;
+
+/**
+ * Data object to keep cached info about generation ssh keys for {@link AppContext#getCurrentUser()}
+ *
+ * @author Roman Nikitenko
+ */
+public class SshKeyGenerationInfo {
+  private String host;
+  private boolean isSshAvailable;
+  private boolean isCanceled;
+
+  public SshKeyGenerationInfo(String host, boolean isSshAvailable, boolean isCanceled) {
+    this.host = host;
+    this.isSshAvailable = isSshAvailable;
+    this.isCanceled = isCanceled;
+  }
+  /** Gets the host to generate ssh key, such as "github.com" */
+  public String getHost() {
+    return host;
+  }
+
+  /** Sets the host to generate ssh key, such as "github.com" */
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  /**
+   * Gets current user's cached state of ssh keys for the host. Use {@link
+   * SshKeyManager#isSshKeyAvailable(String)} to get not cached info
+   *
+   * @return {@code true} when ssh key is available for the host, {@code false} otherwise
+   */
+  public boolean isSshAvailable() {
+    return isSshAvailable;
+  }
+
+  /**
+   * Sets current user's state of ssh keys for the host.
+   *
+   * @param isSshAvailable should be {@code true} when ssh key is available for the host, {@code
+   *     false} otherwise
+   */
+  public void setSshAvailable(boolean isSshAvailable) {
+    this.isSshAvailable = isSshAvailable;
+  }
+
+  /**
+   * Gets info if current user has canceled a prompt to generate ssh key for the host.
+   *
+   * @return {@code true} when current user has canceled a prompt to generate ssh key for the host,
+   *     {@code false} otherwise
+   */
+  public boolean isCanceled() {
+    return isCanceled;
+  }
+
+  /**
+   * Sets info if current user has canceled a prompt to generate ssh key for the host.
+   *
+   * @param isCanceled should be {@code true} when current user has canceled a prompt to generate
+   *     ssh key for the host, {@code false} otherwise
+   */
+  public void setCanceled(boolean isCanceled) {
+    this.isCanceled = isCanceled;
+  }
+}

--- a/wsagent/che-core-ssh-key-ide/src/main/java/org/eclipse/che/plugin/ssh/key/client/SshKeyManager.java
+++ b/wsagent/che-core-ssh-key-ide/src/main/java/org/eclipse/che/plugin/ssh/key/client/SshKeyManager.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.ssh.key.client;
+
+import static org.eclipse.che.plugin.ssh.key.client.manage.SshKeyManagerPresenter.VCS_SSH_SERVICE;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.api.ssh.SshServiceClient;
+import org.eclipse.che.ide.util.loging.Log;
+
+/**
+ * Provides business logic for Ssh related operations.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class SshKeyManager {
+
+  private PromiseProvider promiseProvider;
+  private SshServiceClient sshServiceClient;
+  private SshKeyUploaderRegistry sshKeyUploaderRegistry;
+
+  @Inject
+  public SshKeyManager(
+      PromiseProvider promiseProvider,
+      SshKeyUploaderRegistry sshKeyUploaderRegistry,
+      SshServiceClient sshServiceClient) {
+    this.promiseProvider = promiseProvider;
+    this.sshServiceClient = sshServiceClient;
+    this.sshKeyUploaderRegistry = sshKeyUploaderRegistry;
+  }
+
+  /**
+   * Generates and uploads new public key for specified host. Removes the key when an exception is
+   * happen at uploading the key
+   *
+   * @param userId the id of the user who will be the owner of the ssh pair
+   * @param host host to generate the key
+   */
+  public Promise<Void> generateSshKey(String userId, String host) {
+    SshKeyUploader sshKeyUploader = sshKeyUploaderRegistry.getUploader(host);
+    if (sshKeyUploader == null) {
+      return promiseProvider.reject("Can not find ssh keys uploader for " + host);
+    }
+
+    return promiseProvider.create(
+        callback ->
+            sshKeyUploader.uploadKey(
+                userId,
+                new AsyncCallback<Void>() {
+                  @Override
+                  public void onSuccess(Void result) {
+                    callback.onSuccess(result);
+                  }
+
+                  @Override
+                  public void onFailure(Throwable exception) {
+                    callback.onFailure(exception);
+
+                    removeSshKey(host);
+                  }
+                }));
+  }
+
+  /**
+   * Removes the key for the specified host.
+   *
+   * @param host host to remove the key
+   */
+  public void removeSshKey(String host) {
+    sshServiceClient
+        .getPair(VCS_SSH_SERVICE, host)
+        .thenPromise(pair -> sshServiceClient.deletePair(pair.getService(), pair.getName()))
+        .catchError(
+            arg -> {
+              Log.error(getClass(), arg.getCause());
+            });
+  }
+
+  /**
+   * Checks if current user has ssh keys for the specified host.
+   *
+   * @return {@link Promise} with {@code true} when ssh key is available for the host, {@code false}
+   *     otherwise
+   */
+  public Promise<Boolean> isSshKeyAvailable(String host) {
+    return promiseProvider.create(
+        callback ->
+            sshServiceClient
+                .getPair(VCS_SSH_SERVICE, host)
+                .then(
+                    arg -> {
+                      callback.onSuccess(true);
+                    })
+                .catchError(
+                    arg -> {
+                      callback.onSuccess(false);
+
+                      Log.info(getClass(), "Ssh key is not available for " + host);
+                    }));
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Change behavior at importing repo from github.

**Current behavior:**
We try to import repo by ssh regardless if user has ssh key 

**New behavior:**
We check if user has ssh key when user click 'Load repo' button:

Ssh key is available -> we import repo by ssh regardless if repo public or private 

Ssh key is not available and repo is public -> we import repo by http

Ssh key is not available and repo is private ->
- We display prompt to generate ssh key 
- We generate ssh key and import repo by ssh when user accept this operation
- We remember user's rejection to generate key to don't disturb user anymore and do not display the dialog again when user click on a private repo
- We set **http** url (not **ssh** url) in corresponding field when user reject key generation 



### What issues does this PR fix or reference?
#6765 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>