### PR TITLE
Selenium: adapt selenium test for testing workspace after workspace agent is shut down

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -157,12 +157,12 @@ public class TestWorkspaceServiceClient {
       throws Exception {
 
     WorkspaceStatus status = null;
-    for (int i = 0; i < 120; i++) {
+    for (int i = 0; i < 600; i++) {
       status = getByName(workspaceName, userName).getStatus();
       if (status == expectedStatus) {
         return;
       } else {
-        WaitUtils.sleepQuietly(5);
+        WaitUtils.sleepQuietly(1);
       }
     }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NotificationsPopupPanel.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NotificationsPopupPanel.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.pageobject;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
@@ -46,6 +47,8 @@ public class NotificationsPopupPanel {
   private static final String PROGRESS_POPUP_PANEL_ID = "gwt-debug-popup-container";
   private static final String CLOSE_POPUP_IMG_XPATH =
       "//div[@id='gwt-debug-popup-container']/descendant::*[local-name()='svg'][2]";
+  private static final String RESTART_WORKSPACE_BUTTON =
+      "//div[@id='gwt-debug-popupLoader']//button[text()='Restart']";
 
   @FindBy(id = PROGRESS_POPUP_PANEL_ID)
   private WebElement progressPopupPanel;
@@ -135,5 +138,17 @@ public class NotificationsPopupPanel {
   public void waitPopUpPanelsIsClosed() {
     new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
         .until(ExpectedConditions.invisibilityOfElementLocated(By.id(PROGRESS_POPUP_PANEL_ID)));
+  }
+
+  public void waitWorkspaceAgentIsNotRunning() {
+    new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(RESTART_WORKSPACE_BUTTON)));
+  }
+
+  /** click on the Restart workspace button */
+  public void clickOnRestartWorkspaceButton() {
+    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
+        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(RESTART_WORKSPACE_BUTTON)))
+        .click();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
@@ -11,30 +11,23 @@
 package org.eclipse.che.selenium.miscellaneous;
 
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
-import static org.testng.Assert.fail;
+import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
+import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
+import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.COMMON;
 
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
-import org.eclipse.che.selenium.core.constant.TestCommandsConstants;
-import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
-import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
+import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
-import org.openqa.selenium.By;
-import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -53,64 +46,38 @@ public class CheckRestoringWorkspaceAfterStoppingWsAgentProcess {
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private MachineTerminal terminal;
-  @Inject private Consoles consoles;
   @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private TestWorkspaceServiceClient testWorkspaceServiceClient;
-  @Inject private SeleniumWebDriver seleniumWebDriver;
+  @Inject private NotificationsPopupPanel notificationsPopupPanel;
 
   @BeforeClass
   public void setUp() throws Exception {
     URL resource = getClass().getResource("/projects/guess-project");
     testProjectServiceClient.importProject(
-        workspace.getId(),
-        Paths.get(resource.toURI()),
-        PROJECT_NAME,
-        ProjectTemplates.MAVEN_SPRING);
+        workspace.getId(), Paths.get(resource.toURI()), PROJECT_NAME, MAVEN_SPRING);
     testCommandServiceClient.createCommand(
-        killPIDWSAgentCommand,
-        nameCommandForKillWsAgent,
-        TestCommandsConstants.CUSTOM,
-        workspace.getId());
+        killPIDWSAgentCommand, nameCommandForKillWsAgent, CUSTOM, workspace.getId());
     ide.open(workspace);
   }
 
   @Test()
   public void checkRestoreWsAgentByApi() throws Exception {
-    String expectedMessageOInDialog =
-        "Workspace agent is no longer responding. To fix the problem, restart the workspace.";
     projectExplorer.waitProjectExplorer();
-    projectExplorer.waitItem(PROJECT_NAME);
     terminal.waitTerminalTab();
-    projectExplorer.invokeCommandWithContextMenu(
-        ProjectExplorer.CommandsGoal.COMMON, PROJECT_NAME, nameCommandForKillWsAgent);
+    projectExplorer.waitItem(PROJECT_NAME);
 
-    try {
-      new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
-          .until(
-              ExpectedConditions.visibilityOfElementLocated(
-                  By.xpath("//span[text()='" + expectedMessageOInDialog + "']")));
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/6329");
-    }
+    projectExplorer.invokeCommandWithContextMenu(COMMON, PROJECT_NAME, nameCommandForKillWsAgent);
 
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.id("ask-dialog-first")))
-        .click();
+    notificationsPopupPanel.waitWorkspaceAgentIsNotRunning();
+    notificationsPopupPanel.clickOnRestartWorkspaceButton();
+
     testWorkspaceServiceClient.waitStatus(workspace.getName(), defaultTestUser.getName(), RUNNING);
   }
 
   @Test(priority = 1)
   public void checkRestoreIdeItems() {
-    projectExplorer.waitItem(PROJECT_NAME);
     terminal.waitTerminalTab();
-
-    try {
-      consoles.waitExpectedTextIntoConsole("Server start up in");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/6329");
-    }
+    projectExplorer.waitItem(PROJECT_NAME);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.miscellaneous;
 
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPING;
 import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.CommandsGoal.COMMON;
@@ -71,7 +72,7 @@ public class CheckRestoringWorkspaceAfterStoppingWsAgentProcess {
 
     notificationsPopupPanel.waitWorkspaceAgentIsNotRunning();
     notificationsPopupPanel.clickOnRestartWorkspaceButton();
-
+    testWorkspaceServiceClient.waitStatus(workspace.getName(), defaultTestUser.getName(), STOPPING);
     testWorkspaceServiceClient.waitStatus(workspace.getName(), defaultTestUser.getName(), RUNNING);
   }
 


### PR DESCRIPTION
This PR adapt **CheckRestoringWorkspaceAfterStoppingWsAgentProcess**  selenium test for testing workspace after workspace agent is shut down.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8566