### PR TITLE
Selenium: Delete the 'loader.waitOnClosed()' from the page object 'Preferences' 

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Preferences.java
@@ -575,7 +575,6 @@ public class Preferences {
 
     // authorize on github.com
     if (seleniumWebDriver.getWindowHandles().size() > 1) {
-      loader.waitOnClosed();
       gitHub.waitAuthorizeBtn();
       gitHub.clickOnAuthorizeBtn();
       seleniumWebDriver.switchTo().window(ideWin);


### PR DESCRIPTION
### What does this PR do?
* Delete the 'loader.waitOnClosed()' from the page object 'Preferences'
* Wait of closing loader is not needed in this place and can produce to failing of the selenium test

### What issues does this PR fix or reference?
#8529