### PR TITLE
Selenium: Remove logging of preferences from "CheckRestoringSplitEditorTest" selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -39,8 +39,6 @@ import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.PopupDialogsBrowser;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,7 +55,6 @@ public class CheckRestoringSplitEditorTest {
   private Pair<Integer, Integer> cursorPositionForReadMeFile = new Pair<>(1, 10);
   private Pair<Integer, Integer> cursorPositionForPomFile = new Pair<>(31, 1);
   private List<String> expectedTextFromEditor;
-  private static final Logger LOG = LoggerFactory.getLogger(CheckRestoringSplitEditorTest.class);
 
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
@@ -103,7 +100,6 @@ public class CheckRestoringSplitEditorTest {
       projectExplorer.waitItemInVisibleArea(javaClassName);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      LOG.info(getPreferences());
       fail("Known issue https://github.com/eclipse/che/issues/7551", ex);
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Remove logging of preferences from "CheckRestoringSplitEditorTest" selenium test

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/7551
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
