### PR TITLE
Theia stacks from Florent's theia  prototype 

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks-images/type-theia.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks-images/type-theia.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<svg
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="200"
+   height="200"
+   viewBox="0 0 200 200"
+   id="svg2"
+   version="1.1">
+  <defs
+     id="defs4" />
+  <g
+     id="layer1"
+     transform="translate(0,-852.36216)">
+    <g
+       id="text4144"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         id="path4215"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         d="m 17.303642,935.20844 33.59375,0 0,7.10449 -12.084961,0 0,29.3457 -9.399414,0 0,-29.3457 -12.109375,0 0,-7.10449 z" />
+      <path
+         id="path4217"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         d="m 55.731377,935.20844 9.399414,0 0,13.8916 13.867187,0 0,-13.8916 9.399414,0 0,36.45019 -9.399414,0 0,-15.4541 -13.867187,0 0,15.4541 -9.399414,0 0,-36.45019 z" />
+      <path
+         id="path4219"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         d="m 97.528252,935.20844 25.366208,0 0,7.10449 -15.96679,0 0,6.78711 15.01464,0 0,7.10449 -15.01464,0 0,8.34961 16.5039,0 0,7.10449 -25.903318,0 0,-36.45019 z" />
+      <path
+         id="path4221"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         d="m 131.70794,935.20844 9.39941,0 0,36.45019 -9.39941,0 0,-36.45019 z" />
+      <path
+         id="path4223"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         d="m 172.38177,965.01801 -14.69727,0 -2.31933,6.64062 -9.44825,0 13.50098,-36.45019 11.20605,0 13.50098,36.45019 -9.44824,0 -2.29492,-6.64062 z m -12.35352,-6.7627 9.98535,0 -4.98047,-14.50195 -5.00488,14.50195 z" />
+    </g>
+  </g>
+</svg>

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -62,7 +62,7 @@
       "commands": []
     },
     "stackIcon": {
-      "name": "type-java.svg",
+      "name": "type-theia.svg",
       "mediaType": "image/svg+xml"
     }
   },
@@ -129,7 +129,7 @@
       "commands": []
     },
     "stackIcon": {
-      "name": "type-java.svg",
+      "name": "type-theia.svg",
       "mediaType": "image/svg+xml"
     }
   },

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -3,7 +3,7 @@
     "id": "java-theia-docker",
     "creator": "ide",
     "name": "Java Theia (docker)",
-    "description": "Java + Theia in a sidecar container (docker)",
+    "description": "Che development + Theia in a sidecar container (docker)",
     "scope": "general",
     "tags": [
       "Java 1.8, Theia"
@@ -70,7 +70,7 @@
     "id": "java-theia-openshift",
     "creator": "ide",
     "name": "Java Theia (openshift)",
-    "description": "Java + Theia in a sidecar container (openshift)",
+    "description": "Che development + Theia in a sidecar container (openshift)",
     "scope": "general",
     "tags": [
       "Java 1.8, Theia"

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -83,7 +83,7 @@
               "attributes": {},
 
               "servers": {
-                "theia": {
+                "ws/theia": {
                   "protocol": "http",
                   "port": "3000",
                   "attributes": {
@@ -99,7 +99,7 @@
               "installers": [],
               "env": {}
             },
-            "dev-machine": {
+            "ws/dev": {
               "attributes": {},
               "servers": {
                 "theia-dev": {

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1,5 +1,72 @@
 [
   {
+    "id": "java-theia-docker",
+    "creator": "ide",
+    "name": "Java Theia (docker)",
+    "description": "Java + Theia in a sidecar container (docker)",
+    "scope": "general",
+    "tags": [
+      "Java 1.8, Theia"
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "theia": {
+              "attributes": {},
+
+              "servers": {
+                "theia": {
+                  "protocol": "http",
+                  "port": "3000",
+                  "attributes": {
+                    "type": "ide"
+                  }
+                }
+              },
+              "volumes": {
+                "projects": {
+                  "path": "/projects"
+                }
+              },
+              "installers": [],
+              "env": {}
+            },
+            "dev-machine": {
+              "attributes": {},
+              "servers": {
+                "theia-dev": {
+                  "protocol": "http",
+                  "port": "3030"
+                }
+              },
+              "volumes": {
+                "projects": {
+                  "path": "/projects"
+                }
+              },
+              "installers": [],
+              "env": {}
+            }
+          },
+          "recipe": {
+            "type": "compose",
+            "content": "services:\n theia:\n  image: theiaide/theia\n  entrypoint:\n  - yarn\n  - theia\n  - start\n  - /projects\n  - --hostname=0.0.0.0\n  mem_limit: 1073741824\n dev-machine:\n  image: eclipse/che-dev:nightly\n  mem_limit: 2147483648\n  depends_on:\n    - theia",
+            "contentType": "application/x-yaml"
+          }
+        }
+      },
+      "defaultEnv": "default",
+      "name": "theia",
+      "projects": [],
+      "commands": []
+    },
+    "stackIcon": {
+      "name": "type-java.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
     "id": "java-centos-mysql",
     "creator": "ide",
     "name": "Java-MySQL CentOS",

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -79,11 +79,11 @@
       "environments": {
         "default": {
           "machines": {
-            "theia": {
+            "ws/theia": {
               "attributes": {},
 
               "servers": {
-                "ws/theia": {
+                "theia": {
                   "protocol": "http",
                   "port": "3000",
                   "attributes": {

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -67,6 +67,73 @@
     }
   },
   {
+    "id": "java-theia-openshift",
+    "creator": "ide",
+    "name": "Java Theia (openshift)",
+    "description": "Java + Theia in a sidecar container (openshift)",
+    "scope": "general",
+    "tags": [
+      "Java 1.8, Theia"
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "theia": {
+              "attributes": {},
+
+              "servers": {
+                "theia": {
+                  "protocol": "http",
+                  "port": "3000",
+                  "attributes": {
+                    "type": "ide"
+                  }
+                }
+              },
+              "volumes": {
+                "projects": {
+                  "path": "/projects"
+                }
+              },
+              "installers": [],
+              "env": {}
+            },
+            "dev-machine": {
+              "attributes": {},
+              "servers": {
+                "theia-dev": {
+                  "protocol": "http",
+                  "port": "3030"
+                }
+              },
+              "volumes": {
+                "projects": {
+                  "path": "/projects"
+                }
+              },
+              "installers": [],
+              "env": {}
+            }
+          },
+          "recipe": {
+            "type": "openshift",
+            "content": "---\nkind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    containers:\n      -\n        image: theiaide/theia\n        command:\n          - yarn\n        args:\n          - theia\n          - start\n          - /projects\n          - --hostname=0.0.0.0\n        name: theia\n      -\n        image: eclipse/che-dev:nightly\n        name: dev",
+            "contentType": "application/x-yaml"
+          }
+        }
+      },
+      "defaultEnv": "default",
+      "name": "theia",
+      "projects": [],
+      "commands": []
+    },
+    "stackIcon": {
+      "name": "type-java.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
     "id": "java-centos-mysql",
     "creator": "ide",
     "name": "Java-MySQL CentOS",


### PR DESCRIPTION
### What does this PR do?
Adding two stacks. One for docker other for Openshift.
1. Both stacks have two machines. One with ```theiaide/theia``` other is base ```eclipse/che-dev:nightly```. 
2. theia configred to start from ```/projects``` volume
3. theia has 3030 port exposed, dev  - 3000

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8267

#### Release Notes
n/a


#### Docs PR
n/a