### PR TITLE
Dashboard: fix editor styles in "Build stack from recipe" widget 

### DIFF
--- a/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.controller.ts
@@ -90,6 +90,9 @@ export class RecipeEditorController implements IRecipeEditorControllerScope {
       onLoad: (editor: any) => {
         this.setEditor(editor);
         editor.focus();
+        $timeout(() => {
+          editor.refresh();
+        }, 100);
       }
     };
 

--- a/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.styl
+++ b/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.styl
@@ -18,12 +18,14 @@
       .CodeMirror-sizer
         margin-left 26px
 
-      .CodeMirror-gutter-wrapper
-        left 0 !important
+        &:first-child
+          margin-left 55px !important
 
-      .CodeMirror-gutter-elt,
-      .CodeMirror-linenumber
-        margin-left -55px
+      .CodeMirror-gutter.CodeMirror-lint-markers
+        width 16px !important
+
+      .CodeMirror-gutter.CodeMirror-linenumbers
+        width 29px !important
 
       .CodeMirror-scroll
         margin-left -20px


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
It fixes styles of the editor that is shown when creating a stack from a custom recipe.

![editor](https://user-images.githubusercontent.com/16220722/35795114-cf46be54-0a60-11e8-9df2-4adb59b1aa94.gif)

### What issues does this PR fix or reference?
fix https://github.com/eclipse/che/issues/8297

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix