### PR TITLE
Increase CHE boot timeout in deploy_che.sh

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/deploy_che.sh
@@ -62,7 +62,7 @@ wait_until_che_is_available() {
     available=$(oc get dc che -o json | jq '.status.conditions[] | select(.type == "Available") | .status')
     progressing=$(oc get dc che -o json | jq '.status.conditions[] | select(.type == "Progressing") | .status')
 
-    DEPLOYMENT_TIMEOUT_SEC=120
+    DEPLOYMENT_TIMEOUT_SEC=300
     POLLING_INTERVAL_SEC=5
     end=$((SECONDS+DEPLOYMENT_TIMEOUT_SEC))
     while [ "${available}" != "\"True\"" ] && [ ${SECONDS} -lt ${end} ]; do


### PR DESCRIPTION
it seems 120s is not enough to start CHE on CI. 
Before moving wait method from `ocp.sh` to `deploy_che.sh` we had 300s of a timeout. 

needed for: https://github.com/eclipse/che/issues/8603