### PR TITLE
Fixes machine row when there are no installers

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/loading/WorkspaceLoadingTrackerViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/loading/WorkspaceLoadingTrackerViewImpl.java
@@ -368,6 +368,8 @@ public class WorkspaceLoadingTrackerViewImpl extends Composite
 
       // Update `rowspan` attribute of machine icon cell
       icon.setAttribute("rowspan", "" + (2 + installers.size()));
+
+      inlineDelimiter.getStyle().setProperty("height", "10px");
     }
 
     void setInstallerFailed(String installerId, String errorMessage) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/loading/WorkspaceLoadingTrackerViewImpl.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/loading/WorkspaceLoadingTrackerViewImpl.ui.xml
@@ -292,7 +292,7 @@
                         <td class="{style.machineState}" rel="stopped" id="machine-state">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
                     </tr>
 
-                    <tr ui:field="machineInlineDelimiterTemplate"><td colspan="7" style="height: 10px;"></td></tr>
+                    <tr ui:field="machineInlineDelimiterTemplate" style="height: 20px;"><td colspan="7"></td></tr>
 
                     <tr ui:field="installerTemplate" class="{style.installerRow}">
                         <td class="{style.list}">•</td>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Makes visible `Outputs` hyperlink for machine without installers.

![machine wo installers](https://user-images.githubusercontent.com/1655894/35848966-abe2460e-0b28-11e8-82f1-32f374c022aa.png)

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
