### PR TITLE
Add permissions for default admin to manage his profile

### DIFF
--- a/dockerfiles/init/modules/keycloak/templates/che-users-0.json.erb
+++ b/dockerfiles/init/modules/keycloak/templates/che-users-0.json.erb
@@ -28,6 +28,10 @@
     <% else -%>
     "requiredActions" : [ ],
     <% end -%>
+    "realmRoles" : ["uma_authorization", "offline_access" ],
+    "clientRoles" : {
+       "account" : [ "manage-account", "view-profile" ]
+     },
     "groups" : [ ]
   } ]
 }


### PR DESCRIPTION
### What does this PR do?
Add permissions for default admin to manage his profile. This will be automatically done in new installations. Existing installations should manually add `manage-account` and `view-profile` roles to the admin user.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7125

#### Release Notes
N/A


#### Docs PR
N/A