### PR TITLE
Selenium: Add steps for switch focus to another element in the CheckRestoringSplitEditorTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -94,6 +94,9 @@ public class CheckRestoringSplitEditorTest {
       popupDialogsBrowser.acceptAlert();
     }
 
+    projectExplorer.selectItem(PROJECT_NAME);
+    projectExplorer.waitItemIsSelected(PROJECT_NAME);
+
     seleniumWebDriver.navigate().refresh();
     projectExplorer.waitItem(PROJECT_NAME);
     try {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add steps for switch focus to another element in the CheckRestoringSplitEditorTest selenium test

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/7551
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
